### PR TITLE
Ignore basic changes for model WXKG02LM

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -114,7 +114,7 @@ const devices = [
         vendor: 'Xiaomi',
         description: 'Aqara double key wireless wall switch',
         supports: 'left, right and both click',
-        fromZigbee: [fz.xiaomi_battery_3v, fz.WXKG02LM_click],
+        fromZigbee: [fz.xiaomi_battery_3v, fz.WXKG02LM_click, fz.ignore_basic_change],
         toZigbee: [],
         ep: {'left': 1, 'right': 2, 'both': 3},
     },


### PR DESCRIPTION
This will ignore missing converter warnings similar to those in PR #47:
```
2018-8-17 17:28:48 - warn: No converter available for 'WXKG02LM' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"65281":[null,3065,null,26,5032,77,[0,1],null,5125,null,0]}}'
2018-8-17 17:31:35 - warn: No converter available for 'WXKG02LM' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"65281":[null,3035,null,28,5032,26,[0,1],null,null,null,0]}}'
2018-8-17 19:11:47 - warn: No converter available for 'WXKG02LM' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"65281":[null,3025,null,27]}}'
2018-8-17 20:24:17 - warn: No converter available for 'WXKG02LM' with cid 'genBasic', type 'devChange' and data '{"cid":"genBasic","data":{"65281":[null,null,null,null,null,null,[null,2]]}}'
```
Disclaimer: I'm not quite sure if there is any useful information in these type of messages. Click events and battery reports continue to work, though.