### PR TITLE
Support Home Assistant flashing light bulbs

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -180,8 +180,7 @@ const converters = {
                 if (key === 'flash') {
                     if (value === 2) {
                         value = 'select';
-                    }
-                    else if (value === 10) {
+                    } else if (value === 10) {
                         value = 'lselect';
                     }
                 }


### PR DESCRIPTION
Home Assistant sends the "flash" key in the Zigbee message to tell
lightbulbs to flash. The value sent from Home Assistant is the
number of seconds for the bulb to flash. 2 for "short" and 10 for
"long".

See #157