### PR TITLE
Fix Typo for HEIMAN HS1CG-M

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3672,7 +3672,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['GASSensor-EN'],
+        zigbeeModel: ['GASSensor-EM'],
         model: 'HS1CG-M',
         vendor: 'HEIMAN',
         description: 'Combustible gas sensor',


### PR DESCRIPTION
Fix typo in zigbeeModel: GasSensor-EM
Tested with actual hardware