### PR TITLE
Support for AV2010/21A

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -375,6 +375,13 @@ const converters = {
             return result;
         },
     },
+    bitron_contact: {
+        cid: 'ssIasZone',
+        type: 'statusChange',
+        convert: (model, msg, publish, options) => {
+            return {contact: msg.data.zoneStatus === 20};
+        },
+    },
     nue_click: {
         cid: 'genScenes',
         type: 'cmdRecall',

--- a/devices.js
+++ b/devices.js
@@ -3400,6 +3400,15 @@ const devices = [
             execute(device, actions, callback);
         },
     },
+    {
+        zigbeeModel: ['902010/21A'],
+        model: 'AV2010/21A',
+        vendor: 'Bitron',
+        description: 'Multipurpose sensor',
+        supports: 'contact',
+        fromZigbee: [fz.bitron_contact],
+        toZigbee: [],
+    },
 
     // Iris
     {


### PR DESCRIPTION
Support for the Bitron Contact Sensor AV2010/21A
All npm tests passed successfully
![Bitron AV2010/21A](https://asset.conrad.com/media10/isa/160267/c1/-/de/1535659_BB_00_FB/bitron-video-funk-tuer-fensterkontakt-av2010-21a-902010-21a-1-kanal-1535659.jpg)