### PR TITLE
Setting system mode for Eurotronic thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1999,12 +1999,10 @@ const converters = {
             }
             if (typeof msg.data[0x4008] == 'number') {
                 result.eurotronic_system_mode = msg.data[0x4008];
-                if (result.eurotronic_system_mode == 0x11) {
-                    result.system_mode = common.thermostatSystemModes[0]; // off
-                } else if (result.eurotronic_system_mode == 0x05 || result.eurotronic_system_mode == 0x15 ) {
-                    // 0x05 = 5 from heat -> boost
-                    // 0x15 = 21 from off -> boost
+                if ((result.eurotronic_system_mode & 1 << 2) != 0) {
                     result.system_mode = common.thermostatSystemModes[1]; // boost => auto
+                } else if ((result.eurotronic_system_mode & (1 << 4)) != 0 ) {
+                    result.system_mode = common.thermostatSystemModes[0]; // off
                 } else {
                     result.system_mode = common.thermostatSystemModes[4]; // heat
                 }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1999,6 +1999,15 @@ const converters = {
             }
             if (typeof msg.data[0x4008] == 'number') {
                 result.eurotronic_system_mode = msg.data[0x4008];
+                if (result.eurotronic_system_mode == 0x11){
+                    result.system_mode = common.thermostatSystemModes[0]; // off
+                } else if (result.eurotronic_system_mode == 0x05 || result.eurotronic_system_mode == 0x15 ){
+                    // 0x05 = 5 from heat -> boost
+                    // 0x15 = 21 from off -> boost
+                    result.system_mode = common.thermostatSystemModes[1]; // boost => auto
+                } else {
+                    result.system_mode = common.thermostatSystemModes[4]; // heat
+                }
             }
             if (typeof msg.data[0x4002] == 'number') {
                 result.eurotronic_error_status = msg.data[0x4002];

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1999,9 +1999,9 @@ const converters = {
             }
             if (typeof msg.data[0x4008] == 'number') {
                 result.eurotronic_system_mode = msg.data[0x4008];
-                if (result.eurotronic_system_mode == 0x11){
+                if (result.eurotronic_system_mode == 0x11) {
                     result.system_mode = common.thermostatSystemModes[0]; // off
-                } else if (result.eurotronic_system_mode == 0x05 || result.eurotronic_system_mode == 0x15 ){
+                } else if (result.eurotronic_system_mode == 0x05 || result.eurotronic_system_mode == 0x15 ) {
                     // 0x05 = 5 from heat -> boost
                     // 0x15 = 21 from off -> boost
                     result.system_mode = common.thermostatSystemModes[1]; // boost => auto

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1931,6 +1931,7 @@ const converters = {
             const result = {};
             if (typeof msg.data['localTemp'] == 'number') {
                 result.local_temperature = precisionRound(msg.data['localTemp'], 2) / 100;
+                result.local_temperature = calibrateAndPrecisionRoundOptions(result.local_temperature, options, 'temperature')
             }
             if (typeof msg.data['localTemperatureCalibration'] == 'number') {
                 result.local_temperature_calibration =

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -728,6 +728,27 @@ const converters = {
             }
         },
     },
+    eurotronic_thermostat_system_mode: {
+        key: 'system_mode',
+        convertSet: async (entity, key, value, meta) => {
+            const systemMode = utils.getKeyByValue(common.thermostatSystemModes, value, value);
+            switch (systemMode) {
+                case 0: 
+                    value = 0x20; // off
+                    break;
+                case 1: 
+                    value = 0x05; // boost
+                    break;
+                default: 
+                    value = 0x11; // heat
+            }
+            const payload = {0x4008: {value, type: 0x22}};
+            await entity.write('hvacThermostat', payload, options.eurotronic);
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['systemMode']);
+        },
+    },
     eurotronic_system_mode: {
         key: 'eurotronic_system_mode',
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -733,14 +733,14 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const systemMode = utils.getKeyByValue(common.thermostatSystemModes, value, value);
             switch (systemMode) {
-                case 0: 
-                    value = 0x20; // off
-                    break;
-                case 1: 
-                    value = 0x05; // boost
-                    break;
-                default: 
-                    value = 0x11; // heat
+            case 0:
+                value = 0x20; // off
+                break;
+            case 1:
+                value = 0x05; // boost
+                break;
+            default:
+                value = 0x11; // heat
             }
             const payload = {0x4008: {value, type: 0x22}};
             await entity.write('hvacThermostat', payload, options.eurotronic);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -734,13 +734,13 @@ const converters = {
             const systemMode = utils.getKeyByValue(common.thermostatSystemModes, value, value);
             switch (systemMode) {
             case 0:
-                value = 0x20; // off
+                value |= 1 << 5; // off
                 break;
             case 1:
-                value = 0x05; // boost
+                value |= 1 << 2; // boost
                 break;
             default:
-                value = 0x11; // heat
+                value |= (2<<3) + 1; // heat
             }
             const payload = {0x4008: {value, type: 0x22}};
             await entity.write('hvacThermostat', payload, options.eurotronic);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -740,7 +740,7 @@ const converters = {
                 value |= 1 << 2; // boost
                 break;
             default:
-                value |= (2<<3) + 1; // heat
+                value |= 1 << 4 // heat
             }
             const payload = {0x4008: {value, type: 0x22}};
             await entity.write('hvacThermostat', payload, options.eurotronic);

--- a/devices.js
+++ b/devices.js
@@ -3991,6 +3991,7 @@ const devices = [
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
+            const options = {manufacturerCode: 4151,}
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
             await configureReporting.thermostatTemperature(endpoint);
             await endpoint.configureReporting('hvacThermostat', [{
@@ -3998,13 +3999,13 @@ const devices = [
                 minimumReportInterval: 0,
                 maximumReportInterval: repInterval.HOUR,
                 reportableChange: 25,
-            }], tz.options.eurotronic);
+            }], options);
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4008, type: 34},
                 minimumReportInterval: 0,
                 maximumReportInterval: repInterval.HOUR,
                 reportableChange: 1,
-            }], tz.options.eurotronic);
+            }], options);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -3983,14 +3983,15 @@ const devices = [
         ],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
+            tz.thermostat_local_temperature_calibration, tz.eurotronic_thermostat_system_mode,
             tz.eurotronic_system_mode, tz.eurotronic_error_status, tz.thermostat_setpoint_raise_lower,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_remote_sensing,
             tz.eurotronic_current_heating_setpoint, tz.eurotronic_trv_mode, tz.eurotronic_valve_position,
         ],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
+            const options = {manufacturerCode: 4151};
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
             await configureReporting.thermostatTemperature(endpoint);
             await endpoint.configureReporting('hvacThermostat', [{
@@ -3998,7 +3999,13 @@ const devices = [
                 minimumReportInterval: 0,
                 maximumReportInterval: repInterval.HOUR,
                 reportableChange: 25,
-            }]);
+            }], options);
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: {ID: 0x4008, type: 34},
+                minimumReportInterval: 0,
+                maximumReportInterval: repInterval.HOUR,
+                reportableChange: 1,
+            }], options);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -3991,7 +3991,6 @@ const devices = [
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 4151};
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
             await configureReporting.thermostatTemperature(endpoint);
             await endpoint.configureReporting('hvacThermostat', [{
@@ -3999,13 +3998,13 @@ const devices = [
                 minimumReportInterval: 0,
                 maximumReportInterval: repInterval.HOUR,
                 reportableChange: 25,
-            }], options);
+            }], tz.options.eurotronic);
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4008, type: 34},
                 minimumReportInterval: 0,
                 maximumReportInterval: repInterval.HOUR,
                 reportableChange: 1,
-            }], options);
+            }], tz.options.eurotronic);
         },
     },
 


### PR DESCRIPTION
Setting the system mode for Eurotronic thermostat based on the current temperature set point which is published on temperature input changes.

5°C        = off
6°C - 29°C = heat
30°C       = boost / auto

There is also some work to do in toZigbee.js to set the right mode.

Prose code:
  - if system mode = off then publish 32 to 0x4008
  - if system mode = auto then publish 5 to 0x4008
  - if system mode = heat then publish 17 (?) to 0x4008

=> key: 'system_mode' must be set on another way as it is on the generic implementation. Because there is already a eurotronic_system_mode which allows more than setting a state (also set child protection and mirror the display). I suggest to name it "eurotronic_thermostat_system_mode".

I've done some tests but I'm not getting any further. @Koenkk could you point me in a direction?


