### PR TITLE
Change behavior of MCT-340 SMA and XHS2-SE for temp, battery, etc.

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2679,7 +2679,7 @@ const converters = {
         type: 'cmdMoveToColorTemp',
         convert: (model, msg, publish, options) => null,
     },
-    visonic_contact: {
+    generic_contact: {
         cid: 'ssIasZone',
         type: 'statusChange',
         convert: (model, msg, publish, options) => {

--- a/devices.js
+++ b/devices.js
@@ -4794,7 +4794,7 @@ const devices = [
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact',
-        fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
+        fromZigbee: [fz.generic_contact, fz.ignore_power_change],
         toZigbee: [],
     },
     {
@@ -4803,7 +4803,7 @@ const devices = [
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact',
-        fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
+        fromZigbee: [fz.generic_contact, fz.ignore_power_change],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
@@ -4820,13 +4820,20 @@ const devices = [
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact',
-        fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
+        fromZigbee: [
+            fz.generic_temperature, fz.ignore_temperature_change, fz.generic_contact,
+            fz.generic_batteryvoltage_3000_2500, fz.ias_contact_dev_change,
+        ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
                 (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
-                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 0}, cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 30, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 0, 1000, 0, cb),
             ];
             execute(device, actions, callback);
         },
@@ -5110,13 +5117,20 @@ const devices = [
         vendor: 'Sercomm',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact',
-        fromZigbee: [fz.visonic_contact, fz.ignore_power_change],
+        fromZigbee: [
+            fz.generic_temperature, fz.ignore_temperature_change, fz.generic_contact,
+            fz.generic_batteryvoltage_3000_2500, fz.ias_contact_dev_change,
+        ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
                 (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
-                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 0}, cb),
+                (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
+                (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),
+                (cb) => device.report('msTemperatureMeasurement', 'measuredValue', 30, 600, 1, cb),
+                (cb) => device.bind('genPowerCfg', coordinator, cb),
+                (cb) => device.report('genPowerCfg', 'batteryVoltage', 0, 1000, 0, cb),
             ];
             execute(device, actions, callback);
         },

--- a/devices.js
+++ b/devices.js
@@ -4819,7 +4819,7 @@ const devices = [
         model: 'MCT-340 SMA',
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
-        supports: 'contact',
+        supports: 'contact, temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change, fz.generic_contact,
             fz.generic_batteryvoltage_3000_2500, fz.ias_contact_dev_change,
@@ -4828,6 +4828,7 @@ const devices = [
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
+                (cb) => device.bind('ssIasZone', coordinator, cb),
                 (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
                 (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
                 (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),

--- a/devices.js
+++ b/devices.js
@@ -5116,7 +5116,7 @@ const devices = [
         model: 'XHS2-SE',
         vendor: 'Sercomm',
         description: 'Magnetic door & window contact sensor',
-        supports: 'contact',
+        supports: 'contact, temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change, fz.generic_contact,
             fz.generic_batteryvoltage_3000_2500, fz.ias_contact_dev_change,
@@ -5125,6 +5125,7 @@ const devices = [
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
             const device = shepherd.find(ieeeAddr, 1);
             const actions = [
+                (cb) => device.bind('ssIasZone', coordinator, cb),
                 (cb) => device.write('ssIasZone', 'iasCieAddr', coordinator.device.getIeeeAddr(), cb),
                 (cb) => device.functional('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23}, cb),
                 (cb) => device.bind('msTemperatureMeasurement', coordinator, cb),

--- a/devices.js
+++ b/devices.js
@@ -4819,10 +4819,11 @@ const devices = [
         model: 'MCT-340 SMA',
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
-        supports: 'contact, temperature',
+        supports: 'contact, tem',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change, fz.generic_contact,
-            fz.generic_batteryvoltage_3000_2500, fz.ias_contact_dev_change,
+            fz.generic_batteryvoltage_3000_2500, fz.generic_change_batteryvoltage_3000_2500,
+            fz.ias_contact_dev_change,
         ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {
@@ -5120,7 +5121,8 @@ const devices = [
         supports: 'contact, temperature',
         fromZigbee: [
             fz.generic_temperature, fz.ignore_temperature_change, fz.generic_contact,
-            fz.generic_batteryvoltage_3000_2500, fz.ias_contact_dev_change,
+            fz.generic_batteryvoltage_3000_2500, fz.generic_change_batteryvoltage_3000_2500,
+            fz.ias_contact_dev_change,
         ],
         toZigbee: [],
         configure: (ieeeAddr, shepherd, coordinator, callback) => {


### PR DESCRIPTION
This should make a generic ias-style contact sensor that can be used more generically, and apply this to the MCT-340 SMA and XHS2-SE sensors to allow gathering of battery info, tamper, temperature, etc.