### PR TITLE
Improve support for MCT-340 E, MCT-340 SMA, XHS2-SE

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1489,6 +1489,17 @@ const converters = {
             };
         },
     },
+    battery_cr2032: {
+        cluster: 'genPowerCfg',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options) => {
+            const voltage = msg.data['batteryVoltage'] * 100;
+            return {
+                battery: toPercentageCR2032(voltage),
+                voltage: voltage / 1000.0,
+            };
+        },
+    },
     STS_PRS_251_beeping: {
         cluster: 'genIdentify',
         type: ['attributeReport', 'readResponse'],

--- a/devices.js
+++ b/devices.js
@@ -4461,9 +4461,16 @@ const devices = [
         model: 'MCT-340 SMA',
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
-        supports: 'contact',
-        fromZigbee: [fz.iaszone_contact],
+        supports: 'contact, temperature',
+        fromZigbee: [fz.iaszone_contact, fz.temperature, fz.battery_3V_2100],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await configureReporting.temperature(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
     },
 
     // Sunricher
@@ -4719,9 +4726,16 @@ const devices = [
         model: 'XHS2-SE',
         vendor: 'Sercomm',
         description: 'Magnetic door & window contact sensor',
-        supports: 'contact',
-        fromZigbee: [fz.iaszone_contact],
+        supports: 'contact, temperature',
+        fromZigbee: [fz.iaszone_contact, fz.temperature, fz.battery_3V_2100],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await configureReporting.temperature(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
     },
 
     // Leedarson

--- a/devices.js
+++ b/devices.js
@@ -4446,7 +4446,7 @@ const devices = [
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact, temperature',
-        fromZigbee: [fz.iaszone_contact, fz.temperature, fz.battery_3V_2100],
+        fromZigbee: [fz.iaszone_contact, fz.temperature, fz.battery_cr2032],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
@@ -4462,7 +4462,7 @@ const devices = [
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact, temperature',
-        fromZigbee: [fz.iaszone_contact, fz.temperature, fz.battery_3V_2100],
+        fromZigbee: [fz.iaszone_contact, fz.temperature, fz.battery_cr2032],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -4445,9 +4445,16 @@ const devices = [
         model: 'MCT-340 E',
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
-        supports: 'contact',
-        fromZigbee: [fz.iaszone_contact],
+        supports: 'contact, temperature',
+        fromZigbee: [fz.iaszone_contact, fz.temperature, fz.battery_3V_2100],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await configureReporting.temperature(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
     },
     {
         zigbeeModel: ['MCT-340 SMA'],


### PR DESCRIPTION
This PR is a combination of my work and #692 by @skandragon. It adds support for temperature and battery level reading from MCT-340 E, MCT-340 SMA, and XHS2-SE devices.

Some notes:
- I've only tested this on the MCT-340 E, though I believe the MCT-340 SMA is effectively identical.
- I switched the MCT devices to a CR2032 battery converter, but the XHS2-SE doesn't use CR2032 (it uses CR2450).
- I've been running a MCT-340 E at ≈1.9v for the past hour or two, but haven't yet been able to trip the low battery alarm. ¯\\\_(ツ)\_/¯

EDIT: I just saw the same MCT-340 E fail to start up until supplied with 2.1V.
EDIT2: The MCT-340 E low battery alarm was tripped while at 2.1V.