### PR TITLE
Fix bug

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1350,9 +1350,9 @@ const converters = {
 
             let ds18b20Id = null;
             let ds18b20Value = null;
-            if (msg.data.data['41368']) {
-                ds18b20Id = msg.data.data['41368'].split(':')[0];
-                ds18b20Value = precisionRound(msg.data.data['41368'].split(':')[1], 2);
+            if (msg.data['41368']) {
+                ds18b20Id = msg.data['41368'].split(':')[0];
+                ds18b20Value = precisionRound(msg.data['41368'].split(':')[1], 2);
             }
 
             return {


### PR DESCRIPTION
remove additional .data which is not supposed to be there.
See: https://github.com/formtapez/ZigUP/issues/13

Without this change z2m shows a lot of: `Failed to call 'DeviceReceive' 'onZigbeeEvent' (TypeError: Cannot read property '41368' of undefined` and does not proberly update values like link quality, cpu temp, etc.