### PR TITLE
Improve support for Centralite 4257050-ZHAC dimmable plug

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1754,6 +1754,13 @@ const converters = {
         },
     },
     generic_electrical_measurement: {
+        /**
+         * When using this converter also add the following to the configure method of the device:
+         * await endpoint.read('haElectricalMeasurement', [
+         *   'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier',
+         *   'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor',
+         * ]);
+         */
         cluster: 'haElectricalMeasurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1760,19 +1760,28 @@ const converters = {
             };
         },
     },
-    ZHAC_4257050_power: {
+    generic_electrical_measurement: {
         cluster: 'haElectricalMeasurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => {
             const payload = {};
             if (msg.data.hasOwnProperty('activePower')) {
-                payload.power = msg.data['activePower'] / 10.0;
+                const multiplier = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acPowerMultiplier');
+                const divisor = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acPowerDivisor');
+                const factor = multiplier && divisor ? multiplier / divisor : 1;
+                payload.power = precisionRound(msg.data['activePower'] * factor, 2);
             }
             if (msg.data.hasOwnProperty('rmsCurrent')) {
-                payload.current = msg.data['rmsCurrent'] / 1000.0;
+                const multiplier = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acCurrentMultiplier');
+                const divisor = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acCurrentDivisor');
+                const factor = multiplier && divisor ? multiplier / divisor : 1;
+                payload.current = precisionRound(msg.data['rmsCurrent'] * factor, 2);
             }
             if (msg.data.hasOwnProperty('rmsVoltage')) {
-                payload.voltage = msg.data['rmsVoltage'];
+                const multiplier = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acVoltageMultiplier');
+                const divisor = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acVoltageDivisor');
+                const factor = multiplier && divisor ? multiplier / divisor : 1;
+                payload.voltage = precisionRound(msg.data['rmsVoltage'] * factor, 2);
             }
             return payload;
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1850,6 +1850,19 @@ const converters = {
             }
         },
     },
+    restorable_brightness: {
+        cluster: 'genLevelCtrl',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options) => {
+            if (msg.data.hasOwnProperty('currentLevel')) {
+                // Ignore brightness = 0, which only happens when state is OFF
+                if (Number(msg.data['currentLevel']) > 0) {
+                    return {brightness: msg.data['currentLevel']};
+                }
+                return {};
+            }
+        },
+    },
     smartsense_multi: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1760,6 +1760,23 @@ const converters = {
             };
         },
     },
+    ZHAC_4257050_power: {
+        cluster: 'haElectricalMeasurement',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options) => {
+            const payload = {};
+            if (msg.data.hasOwnProperty('activePower')) {
+                payload.power = msg.data['activePower'] / 10.0;
+            }
+            if (msg.data.hasOwnProperty('rmsCurrent')) {
+                payload.current = msg.data['rmsCurrent'] / 1000.0;
+            }
+            if (msg.data.hasOwnProperty('rmsVoltage')) {
+                payload.voltage = msg.data['rmsVoltage'];
+            }
+            return payload;
+        },
+    },
     iaszone_occupancy_2: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1713,13 +1713,6 @@ const converters = {
             return {action: `rotate_${direction}_quick`, level: msg.data.level};
         },
     },
-    iris_3210L_power: {
-        cluster: 'haElectricalMeasurement',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options) => {
-            return {power: msg.data['activePower'] / 10.0};
-        },
-    },
     iris_3320L_contact: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1759,19 +1759,27 @@ const converters = {
         convert: (model, msg, publish, options) => {
             const payload = {};
             if (msg.data.hasOwnProperty('activePower')) {
-                const multiplier = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acPowerMultiplier');
-                const divisor = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acPowerDivisor');
+                const multiplier = msg.endpoint.getClusterAttributeValue(
+                    'haElectricalMeasurement', 'acPowerMultiplier'
+                );
+                const divisor = msg.endpoint.getClusterAttributeValue(
+                    'haElectricalMeasurement', 'acPowerDivisor'
+                );
                 const factor = multiplier && divisor ? multiplier / divisor : 1;
                 payload.power = precisionRound(msg.data['activePower'] * factor, 2);
             }
             if (msg.data.hasOwnProperty('rmsCurrent')) {
-                const multiplier = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acCurrentMultiplier');
+                const multiplier = msg.endpoint.getClusterAttributeValue(
+                    'haElectricalMeasurement', 'acCurrentMultiplier'
+                );
                 const divisor = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acCurrentDivisor');
                 const factor = multiplier && divisor ? multiplier / divisor : 1;
                 payload.current = precisionRound(msg.data['rmsCurrent'] * factor, 2);
             }
             if (msg.data.hasOwnProperty('rmsVoltage')) {
-                const multiplier = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acVoltageMultiplier');
+                const multiplier = msg.endpoint.getClusterAttributeValue(
+                    'haElectricalMeasurement', 'acVoltageMultiplier'
+                );
                 const divisor = msg.endpoint.getClusterAttributeValue('haElectricalMeasurement', 'acVoltageDivisor');
                 const factor = multiplier && divisor ? multiplier / divisor : 1;
                 payload.voltage = precisionRound(msg.data['rmsVoltage'] * factor, 2);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -288,6 +288,27 @@ const converters = {
             }
         },
     },
+    // Some devices reset brightness to 100% when turned on, even if previous brightness was different
+    // This uses the stored state of the device to restore to the previous brightness level when turning on
+    light_onoff_restorable_brightness: {
+        key: ['state', 'brightness', 'brightness_percent'],
+        convertSet: async (entity, key, value, meta) => {
+            const deviceState = meta.state || {};
+            const message = meta.message;
+            const state = message.hasOwnProperty('state') ? message.state.toLowerCase() : null;
+            const hasBrightness = message.hasOwnProperty('brightness') || message.hasOwnProperty('brightness_percent');
+
+            // Add brightness if command is 'on' and we can restore previous value
+            if (state === 'on' && !hasBrightness && deviceState.brightness > 0) {
+                message.brightness = deviceState.brightness;
+            }
+
+            return await converters.light_onoff_brightness.convertSet(entity, key, value, meta);
+        },
+        convertGet: async (entity, key, meta) => {
+            return await converters.light_onoff_brightness.convertGet(entity, key, meta);
+        },
+    },
     light_colortemp: {
         key: ['color_temp', 'color_temp_percent'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices.js
+++ b/devices.js
@@ -3537,7 +3537,7 @@ const devices = [
         zigbeeModel: ['4257050-ZHAC'],
         model: '4257050-ZHAC',
         vendor: 'Centralite',
-        description: '3-Series Smart Dimming Outlet',
+        description: '3-Series smart dimming outlet',
         supports: 'on/off, brightness, power meter',
         fromZigbee: [fz.restorable_brightness, fz.state, fz.generic_electrical_measurement],
         toZigbee: [tz.light_onoff_restorable_brightness],

--- a/devices.js
+++ b/devices.js
@@ -3400,13 +3400,16 @@ const devices = [
         vendor: 'Iris',
         description: 'Smart plug',
         supports: 'on/off',
-        fromZigbee: [fz.state, fz.iris_3210L_power],
+        fromZigbee: [fz.state, fz.generic_electrical_measurement],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 3},
+        meta: {configureKey: 4},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
+            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier', 'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor']);
             await configureReporting.onOff(endpoint);
+            await configureReporting.rmsVoltage(endpoint);
+            await configureReporting.rmsCurrent(endpoint);
             await configureReporting.activePower(endpoint);
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -3510,7 +3510,7 @@ const devices = [
 
     // Centralite Swiss Plug
     {
-        zigbeeModel: ['4256251-RZHAC', '4257050-RZHAC', '4257050-ZHAC'],
+        zigbeeModel: ['4256251-RZHAC', '4257050-RZHAC'],
         model: '4256251-RZHAC',
         vendor: 'Centralite',
         description: 'White Swiss power outlet switch with power meter',
@@ -3521,6 +3521,24 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await configureReporting.onOff(endpoint);
+            await configureReporting.rmsVoltage(endpoint);
+            await configureReporting.rmsCurrent(endpoint);
+            await configureReporting.activePower(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['4257050-ZHAC'],
+        model: '4257050-ZHAC',
+        vendor: 'Centralite',
+        description: '3-Series Smart Dimming Outlet',
+        supports: 'on/off, power meter',
+        fromZigbee: [fz.state, fz.ZHAC_4257050_power],
+        toZigbee: [tz.on_off],
+        meta: {configureKey: 3},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
             await configureReporting.onOff(endpoint);
             await configureReporting.rmsVoltage(endpoint);
             await configureReporting.rmsCurrent(endpoint);

--- a/devices.js
+++ b/devices.js
@@ -3532,13 +3532,13 @@ const devices = [
         model: '4257050-ZHAC',
         vendor: 'Centralite',
         description: '3-Series Smart Dimming Outlet',
-        supports: 'on/off, power meter',
-        fromZigbee: [fz.state, fz.ZHAC_4257050_power],
-        toZigbee: [tz.on_off],
+        supports: 'on/off, brightness, power meter',
+        fromZigbee: [fz.restorable_brightness, fz.state, fz.ZHAC_4257050_power],
+        toZigbee: [tz.light_onoff_restorable_brightness],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement']);
             await configureReporting.onOff(endpoint);
             await configureReporting.rmsVoltage(endpoint);
             await configureReporting.rmsCurrent(endpoint);

--- a/devices.js
+++ b/devices.js
@@ -3406,7 +3406,10 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
-            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier', 'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor']);
+            await endpoint.read('haElectricalMeasurement', [
+                'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier',
+                'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor',
+            ]);
             await configureReporting.onOff(endpoint);
             await configureReporting.rmsVoltage(endpoint);
             await configureReporting.rmsCurrent(endpoint);
@@ -3542,7 +3545,10 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement']);
-            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier', 'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor']);
+            await endpoint.read('haElectricalMeasurement', [
+                'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier',
+                'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor',
+            ]);
             await configureReporting.onOff(endpoint);
             await configureReporting.rmsVoltage(endpoint);
             await configureReporting.rmsCurrent(endpoint);

--- a/devices.js
+++ b/devices.js
@@ -3533,12 +3533,13 @@ const devices = [
         vendor: 'Centralite',
         description: '3-Series Smart Dimming Outlet',
         supports: 'on/off, brightness, power meter',
-        fromZigbee: [fz.restorable_brightness, fz.state, fz.ZHAC_4257050_power],
+        fromZigbee: [fz.restorable_brightness, fz.state, fz.generic_electrical_measurement],
         toZigbee: [tz.light_onoff_restorable_brightness],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement']);
+            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier', 'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor']);
             await configureReporting.onOff(endpoint);
             await configureReporting.rmsVoltage(endpoint);
             await configureReporting.rmsCurrent(endpoint);


### PR DESCRIPTION
This PR adds dimming and fixes power reporting for the Centralite 4257050-ZHAC dimmable plug.

There are a couple notes I want to make known before this is merged:
- The Centralite `4257050-ZHAC` does not automatically restore the previous dim level when powered off and back on. E.g. turn on, set dimmer to 50%, turn off, turn back on: dimmer is at 100% (I'd expect 50%). I added a workaround to support this using the existing z2m state mechanism. If this is not desired, I can certainly remove it; on the other hand, I believe my changes are generic enough that they might work for other dimmable devices with similar issues.
- I suspect that power reporting for `4256251-RZHAC` and `4257050-RZHAC` is broken (wrong powers of 10, doesn't take into account that different attributes info comes in different messages), but as I do not have these devices to test with, I don't want to mess with the code.

Please let me know if you have any concerns or want changes!