### PR TITLE
Add support for the IKEA SYMFONISK Sound Controller E1744

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -253,6 +253,25 @@ const converters = {
             return {click: 'brightness_stop'};
         },
     },
+    E1744_play_pause: {
+        cluster: 'genOnOff',
+        type: 'commandToggle',
+        convert: (model, msg, publish, options) => {
+            return {action: 'play_pause'};
+        },
+    },
+    E1744_skip: {
+        cluster: 'genLevelCtrl',
+        type: 'commandStep',
+        convert: (model, msg, publish, options) => {
+            const direction = msg.data.stepmode === 1 ? 'backward' : 'forward';
+            return {
+                action: `skip_${direction}`,
+                step_size: msg.data.stepsize,
+                transition_time: msg.data.transtime,
+            };
+        },
+    },
     AC0251100NJ_long_middle: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',

--- a/devices.js
+++ b/devices.js
@@ -963,6 +963,21 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['SYMFONISK Sound Controller'],
+        model: 'E1744',
+        vendor: 'IKEA',
+        description: 'SYMFONISK Sound Controller',
+        supports: 'volume up/down, play/pause, skip forward/backward',
+        fromZigbee: [fz.cmd_move, fz.cmd_stop, fz.E1744_play_pause, fz.E1744_skip, fz.generic_battery],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genLevelCtrl', 'genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['TRADFRI motion sensor'],
         model: 'E1525',
         vendor: 'IKEA',

--- a/devices.js
+++ b/devices.js
@@ -966,7 +966,7 @@ const devices = [
         zigbeeModel: ['SYMFONISK Sound Controller'],
         model: 'E1744',
         vendor: 'IKEA',
-        description: 'SYMFONISK Sound Controller',
+        description: 'SYMFONISK sound controller',
         supports: 'volume up/down, play/pause, skip forward/backward',
         fromZigbee: [fz.cmd_move, fz.cmd_stop, fz.E1744_play_pause, fz.E1744_skip, fz.generic_battery],
         toZigbee: [],


### PR DESCRIPTION
This is a rotary dimmer, disguised as audio controller.
It is somewhat similar to the rotary TRADFRI dimmer ICTC-G-1
with a push-button function added (single, double and triple click)
but without the quick-rotate feature.