### PR TITLE
Add  support for new devices (Gledopto GL-C-008S, Xiaomi Aqara TS0201)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2818,7 +2818,7 @@ const devices = [
         meta: {options: {disableDefaultResponse: true}},
         supports: 'on/off, brightness, color temperature, color',
     },
-        {
+    {
         zigbeeModel: ['GL-C-008S'],
         model: 'GL-C-008S',
         vendor: 'Gledopto',

--- a/devices.js
+++ b/devices.js
@@ -521,17 +521,6 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['TS0201'],
-        model: 'TS0201',
-        vendor: 'Xiaomi',
-        description: 'Aqara temperature, humidity with display',
-        supports: 'temperature and humidity',
-        fromZigbee: [
-            fz.xiaomi_battery_3v, fz.xiaomi_temperature, fz.humidity,
-        ],
-        toZigbee: [],
-    },
-    {
         zigbeeModel: ['lumi.sensor_motion'],
         model: 'RTCGQ01LM',
         vendor: 'Xiaomi',
@@ -2822,7 +2811,7 @@ const devices = [
         zigbeeModel: ['GL-C-008S'],
         model: 'GL-C-008S',
         vendor: 'Gledopto',
-        description: 'Zigbee LED controller RGB + CCT Plus model',
+        description: 'Zigbee LED controller RGB + CCT plus model',
         extend: gledopto.light,
         meta: {options: {disableDefaultResponse: true}},
         supports: 'on/off, brightness, color temperature, color',

--- a/devices.js
+++ b/devices.js
@@ -521,6 +521,17 @@ const devices = [
         toZigbee: [],
     },
     {
+        zigbeeModel: ['TS0201'],
+        model: 'TS0201',
+        vendor: 'Xiaomi',
+        description: 'Aqara temperature, humidity with display',
+        supports: 'temperature and humidity',
+        fromZigbee: [
+            fz.xiaomi_battery_3v, fz.xiaomi_temperature, fz.humidity,
+        ],
+        toZigbee: [],
+    },
+    {
         zigbeeModel: ['lumi.sensor_motion'],
         model: 'RTCGQ01LM',
         vendor: 'Xiaomi',
@@ -2803,6 +2814,15 @@ const devices = [
         model: 'GL-C-008',
         vendor: 'Gledopto',
         description: 'Zigbee LED controller RGB + CCT',
+        extend: gledopto.light,
+        meta: {options: {disableDefaultResponse: true}},
+        supports: 'on/off, brightness, color temperature, color',
+    },
+        {
+        zigbeeModel: ['GL-C-008S'],
+        model: 'GL-C-008S',
+        vendor: 'Gledopto',
+        description: 'Zigbee LED controller RGB + CCT Plus model',
         extend: gledopto.light,
         meta: {options: {disableDefaultResponse: true}},
         supports: 'on/off, brightness, color temperature, color',


### PR DESCRIPTION
Hi,
Hi I got two new devices that i added to my devices.js and homeassistant.js
Used pre-existing converters.

Gledopto RGB+CCT Plus controller (GL-C-008S),

![01c0d5d6-9ef9-4ad8-937e-ec96bd4f7d1a](https://user-images.githubusercontent.com/50028188/67619453-ca9e5b00-f7f3-11e9-9a01-d3cf64eb5757.jpg)

Xiaomi Aqara Temperature and Humidity sensor with display (TS0201).

![HTB1poCldlWD3KVjSZFsq6AqkpXaz](https://user-images.githubusercontent.com/50028188/67619475-1bae4f00-f7f4-11e9-9361-f66e8294ba38.jpg)
