### PR TITLE
Add support for NUE/3A HGZB-4D-UK

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2639,7 +2639,7 @@ const devices = [
     },
     {
         zigbeeModel: ['FB56+ZSC05HG1.0', 'FNB56-ZBW01LX1.2'],
-        model: 'HGZB-04D',
+        model: 'HGZB-04D / HGZB-4D-UK',
         vendor: 'Nue / 3A',
         description: 'Smart dimmer wall switch',
         supports: 'on/off, brightness',


### PR DESCRIPTION
The NUE/3A - Model HGZB-4D-UK reports as as FNB56-ZBW01LX1.2 so I added it under the existing support.