### PR TITLE
Added support for Philips Hue model LWO001

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1158,6 +1158,13 @@ const devices = [
         extend: hue.light_onoff_brightness,
     },
     {
+        zigbeeModel: ['LWO001'],
+        model: 'LWO001',
+        vendor: 'Philips',
+        description: 'Hue white Filament bulb G93 E27 bluetooth’,
+        extend: hue.light_onoff_brightness,
+    },
+    {
         zigbeeModel: ['LST001'],
         model: '7299355PH',
         vendor: 'Philips',

--- a/devices.js
+++ b/devices.js
@@ -1161,7 +1161,7 @@ const devices = [
         zigbeeModel: ['LWO001'],
         model: 'LWO001',
         vendor: 'Philips',
-        description: 'Hue white Filament bulb G93 E27 bluetooth’,
+        description: 'Hue white Filament bulb G93 E27 bluetooth',
         extend: hue.light_onoff_brightness,
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -1159,7 +1159,7 @@ const devices = [
     },
     {
         zigbeeModel: ['LWO001'],
-        model: 'LWO001',
+        model: '8718699688882',
         vendor: 'Philips',
         description: 'Hue white Filament bulb G93 E27 bluetooth',
         extend: hue.light_onoff_brightness,


### PR DESCRIPTION
Added support for Philips Hue Single Filament bulb - G93 E27 
Model : LWO001

