### PR TITLE
Add missing converter AIRAM-CTR.U

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3963,6 +3963,7 @@ const devices = [
         fromZigbee: [
             fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.CTR_U_brightness_updown_click,
             fz.CTR_U_brightness_updown_hold, fz.CTR_U_brightness_updown_release, fz.CTR_U_scene,
+            fz.ignore_basic_report,
         ],
         toZigbee: [],
     },


### PR DESCRIPTION
Add fz.ignore_basic_report to get rid of
No converter available for 'AIRAM-CTR.U' with cluster 'genBasic' and type 'readResponse' and data '{"modelId":"ZBT-Remote-EU-DIMV1A2","manufacturerName":"C046","powerSource":3}'
on pairing.