### PR TITLE
Add multiple misssing converters

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -318,7 +318,10 @@ const generic = {
     },
     light_onoff_brightness_colortemp_colorxy: {
         supports: 'on/off, brightness, color temperature, color xy',
-        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness],
+        fromZigbee: [
+            fz.color_colortemp, fz.on_off, fz.brightness,
+            fz.ignore_basic_report,
+        ],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition,
             tz.light_alert,
@@ -3303,7 +3306,10 @@ const devices = [
         vendor: 'Trust',
         description: 'Water leakage detector',
         supports: 'water leak',
-        fromZigbee: [fz.ias_water_leak_alarm_1],
+        fromZigbee: [
+            fz.ias_water_leak_alarm_1,
+            fz.ignore_basic_report,
+        ],
         toZigbee: [],
     },
     {
@@ -3352,7 +3358,10 @@ const devices = [
         vendor: 'Trust',
         description: 'Wireless contact sensor',
         supports: 'contact',
-        fromZigbee: [fz.iaszone_contact, fz.battery_percentage_remaining],
+        fromZigbee: [
+            fz.iaszone_contact, fz.battery_percentage_remaining,
+            fz.ignore_basic_report,
+        ],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
I encountered these messages when pairing different kind of devices with CC2652R:

```
Received Zigbee message from '0x00158d0001cd1ef3', type 'readResponse', cluster 'genBasic', data '{"modelId":"CSW_ADUROLIGHT","manufacturerName":"ADUROLIGHT","powerSource":3}' from endpoint 1 with groupID 0
No converter available for 'ZCTS-808' with cluster 'genBasic' and type 'readResponse' and data '{"modelId":"CSW_ADUROLIGHT","manufacturerName":"ADUROLIGHT","powerSource":3}'
```
```
Received Zigbee message from '0x005043c95f277c80', type 'readResponse', cluster 'genBasic', data '{"modelId":"WATER_TPV14","manufacturerName":"Heiman","powerSource":3}' from endpoint 1 with groupID 0
No converter available for 'ZWLD-100' with cluster 'genBasic' and type 'readResponse' and data '{"modelId":"WATER_TPV14","manufacturerName":"Heiman","powerSource":3}'
```
```
Received Zigbee message from '0x001788010278b40a', type 'readResponse', cluster 'genBasic', data '{"modelId":"LCT010","manufacturerName":"Philips","powerSource":1}' from endpoint 11 with groupID 0
No converter available for '9290012573A' with cluster 'genBasic' and type 'readResponse' and data '{"modelId":"LCT010","manufacturerName":"Philips","powerSource":1}'
```

Added fz.ignore_basic_report for all these. 