### PR TITLE
Added fz.ignore_basic_report to C2530.ROUTER

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1589,7 +1589,9 @@ const devices = [
         vendor: 'Custom devices (DiY)',
         description: '[CC2530 router](http://ptvo.info/cc2530-based-zigbee-coordinator-and-router-112/)',
         supports: 'state, description, type, rssi',
-        fromZigbee: [fz.CC2530ROUTER_state, fz.CC2530ROUTER_meta],
+        fromZigbee: [
+            fz.CC2530ROUTER_state, fz.CC2530ROUTER_meta, fz.ignore_basic_report,
+        ],
         toZigbee: [tz.ptvo_switch_trigger],
     },
     {


### PR DESCRIPTION
I met one of these again...
```
Device '0x00124b0014d9d7f3' announced itself
Received Zigbee message from '0x00124b0014d9d7f3', type 'readResponse', cluster 'genBasic', data '{"modelId":"lumi.router","manufacturerName":"LUMI","powerSource":1}' from endpoint 8 with groupID 0
No converter available for 'CC2530.ROUTER' with cluster 'genBasic' and type 'readResponse' and data '{"modelId":"lumi.router","manufacturerName":"LUMI","powerSource":1}'
``` 