### PR TITLE
battery_3V_2100 converter: guard against missing attributes when reporting battery percentage

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1582,13 +1582,13 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => {
             const result = {};
-            if (typeof msg.data['batteryVoltage'] == 'number') {
+            if (msg.data.hasOwnProperty('batteryVoltage')) {
                 const battery = {max: 3000, min: 2100};
                 const voltage = msg.data['batteryVoltage'] * 100;
                 result.battery = toPercentage(voltage, battery.min, battery.max);
                 result.voltage = voltage / 1000.0;
             }
-            if (typeof msg.data['batteryAlarmState'] == 'number') {
+            if (msg.data.hasOwnProperty('batteryAlarmState')) {
                 result.battery_alarm_state = msg.data['batteryAlarmState'];
             }
             return result;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1581,12 +1581,17 @@ const converters = {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => {
-            const battery = {max: 3000, min: 2100};
-            const voltage = msg.data['batteryVoltage'] * 100;
-            return {
-                battery: toPercentage(voltage, battery.min, battery.max),
-                voltage: voltage / 1000.0,
-            };
+            const result = {};
+            if (typeof msg.data['batteryVoltage'] == 'number') {
+                const battery = {max: 3000, min: 2100};
+                const voltage = msg.data['batteryVoltage'] * 100;
+                result.battery = toPercentage(voltage, battery.min, battery.max);
+                result.voltage = voltage / 1000.0;
+            }
+            if (typeof msg.data['batteryAlarmState'] == 'number') {
+                result.battery_alarm_state = msg.data['batteryAlarmState'];
+            }
+            return result;
         },
     },
     battery_cr2032: {


### PR DESCRIPTION
Both of my devices that use the `battery_3V_2100` converter have been reporting a lot of `null` battery percentages. After looking into it, I realized that sometimes the `genPowerCfg` report only included `batteryVoltage`, and other times it only included `batteryAlarmState`. When `batteryVoltage` isn't reported, the `toPercentage()` conversion fails and returns `null`.

This PR changes the converter to only report battery percentage when voltage is reported, so that it won't wipe out a previously-reported battery percentage when a report only includes battery alarm state. It also passes along `batteryAlarmState`, in case that is useful to anyone (I'm not sure if it even works on my devices).