### PR TITLE
No converter available for ...

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -303,7 +303,7 @@ const configureReporting = {
 const generic = {
     light_onoff_brightness: {
         supports: 'on/off, brightness',
-        fromZigbee: [fz.on_off, fz.brightness],
+        fromZigbee: [fz.on_off, fz.brightness, fz.ignore_basic_report,],
         toZigbee: [tz.light_onoff_brightness, tz.ignore_transition, tz.light_alert],
     },
     light_onoff_brightness_colortemp: {
@@ -929,7 +929,9 @@ const devices = [
         description: 'TRADFRI control outlet',
         supports: 'on/off',
         vendor: 'IKEA',
-        fromZigbee: [fz.on_off, fz.ignore_genLevelCtrl_report],
+        fromZigbee: [
+            fz.on_off, fz.ignore_genLevelCtrl_report, fz.ignore_basic_report,
+        ],
         toZigbee: [tz.on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -303,7 +303,7 @@ const configureReporting = {
 const generic = {
     light_onoff_brightness: {
         supports: 'on/off, brightness',
-        fromZigbee: [fz.on_off, fz.brightness, fz.ignore_basic_report,],
+        fromZigbee: [fz.on_off, fz.brightness, fz.ignore_basic_report],
         toZigbee: [tz.light_onoff_brightness, tz.ignore_transition, tz.light_alert],
     },
     light_onoff_brightness_colortemp: {


### PR DESCRIPTION
Yet again I noticed these:
```
Received Zigbee message from '0x000b57fffe8be58f', type 'readResponse', cluster 'genBasic', data '{"zclVersion":1}' from endpoint 1 with groupID 0
No converter available for 'LED1649C5' with cluster 'genBasic' and type 'readResponse' and data '{"zclVersion":1}'
...
Received Zigbee message from '0x000b57fffe4c2b78', type 'readResponse', cluster 'genBasic', data '{"zclVersion":1}' from endpoint 1 with groupID 0
No converter available for 'LED1623G12' with cluster 'genBasic' and type 'readResponse' and data '{"zclVersion":1}'
...
Received Zigbee message from '0x000b57fffeef4be3', type 'readResponse', cluster 'genBasic', data '{"zclVersion":3}' from endpoint 1 with groupID 0
No converter available for 'E1603/E1702' with cluster 'genBasic' and type 'readResponse' and data '{"zclVersion":3}'
```

LEDs were using ```generic.light_onoff_brightness``` - and I believe this solves these messages with all devices using this "set of converters". Should fz.ignore_basic_report be added to all of "generic sets"?
