### PR TITLE
Question - is this line needed?

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3999,7 +3999,6 @@ const devices = [
         vendor: 'Airam',
         description: 'LED OP A60 ZB 9W/827 E27',
         extend: generic.light_onoff_brightness,
-        fromZigbee: [fz.brightness, fz.on_off],
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
I believe we can remove
```
fromZigbee: [fz.brightness, fz.on_off],
```
and leave only 
```
extend: generic.light_onoff_brightness, 
```
since this is already included with generic.light_onoff_brightness
```
    light_onoff_brightness: {
        supports: 'on/off, brightness',
        fromZigbee: [fz.on_off, fz.brightness, fz.ignore_basic_report],
        toZigbee: [tz.light_onoff_brightness, tz.ignore_transition, tz.light_alert],
    },
```
If something gets defined in extend: generic-set any fromZigbee or toZigbee will overwrite settings defined in generic? I noticed once again "No converter available for '4713407' with cluster 'genBasic' and type 'readResponse' and data '{"zclVersion":2}"