### PR TITLE
Add additional model number for Konke sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5093,7 +5093,7 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['3AFE140103020000'],
+        zigbeeModel: ['3AFE140103020000', '3AFE220103020000'],
         model: '2AJZ4KPFT',
         vendor: 'Konke',
         description: 'Temperature and humidity sensor',


### PR DESCRIPTION
My Konke temperature/humidity sensor had a different model number.
Works fine.