### PR TITLE
Added support for device "tint Smart Switch"

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4143,7 +4143,15 @@ const devices = [
         ],
         toZigbee: [],
     },
-
+    {
+        zigbeeModel: ['tint Smart Switch'],
+        model: '404021',
+        description: 'Tint Smart Switch',
+        supports: 'on/off',
+        vendor: 'MÃ¼ller Licht',
+        fromZigbee: [fz.on_off],
+        toZigbee: [tz.on_off],
+    },
     // Salus
     {
         zigbeeModel: ['SP600'],

--- a/devices.js
+++ b/devices.js
@@ -4152,7 +4152,7 @@ const devices = [
         fromZigbee: [fz.on_off],
         toZigbee: [tz.on_off],
     },
-    
+
     // Salus
     {
         zigbeeModel: ['SP600'],

--- a/devices.js
+++ b/devices.js
@@ -4148,10 +4148,11 @@ const devices = [
         model: '404021',
         description: 'Tint Smart Switch',
         supports: 'on/off',
-        vendor: 'MÃ¼ller Licht',
+        vendor: 'Müller Licht',
         fromZigbee: [fz.on_off],
         toZigbee: [tz.on_off],
     },
+    
     // Salus
     {
         zigbeeModel: ['SP600'],

--- a/devices.js
+++ b/devices.js
@@ -4146,7 +4146,7 @@ const devices = [
     {
         zigbeeModel: ['tint Smart Switch'],
         model: '404021',
-        description: 'Tint Smart Switch',
+        description: 'Tint smart switch',
         supports: 'on/off',
         vendor: 'Müller Licht',
         fromZigbee: [fz.on_off],


### PR DESCRIPTION
New device added: "tint Smart Switch" from Mueller Licht.
Bought that device in Germany here: https://toom.de/p/tint-smart-switch-funkschalter/9240797
Looked as the same device as https://www.zigbee2mqtt.io/devices/ICZB-IW11SW.html
and I simply took over the config of that device.
Original manufacturer seems to be Sunricher: https://www.sunricher.com/zigbee-ac-in-wall-switch-sr-zg9101sac-hp-switch.html 

Pairing Issues:
I needed to reset the device a couple of times to fully pair. Often the message "Failed to interview '0x...', device has not successfully been paired" but after about 5 tries, it was finally successfull.