### PR TITLE
Support for Heiman HS1SA clone "FB56-SMF02HM1.4"

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3800,7 +3800,13 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['SMOK_V16', 'b5db59bfd81e4f1f95dc57fdbba17931', 'SMOK_YDLV10', 'SmokeSensor-EM', 'FB56-SMF02HM1.4'],
+        zigbeeModel: [
+            'SMOK_V16',
+            'b5db59bfd81e4f1f95dc57fdbba17931',
+            'SMOK_YDLV10',
+            'SmokeSensor-EM',
+            'FB56-SMF02HM1.4',
+        ],
         model: 'HS1SA',
         vendor: 'HEIMAN',
         description: 'Smoke detector',

--- a/devices.js
+++ b/devices.js
@@ -3800,7 +3800,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['SMOK_V16', 'b5db59bfd81e4f1f95dc57fdbba17931', 'SMOK_YDLV10', 'SmokeSensor-EM'],
+        zigbeeModel: ['SMOK_V16', 'b5db59bfd81e4f1f95dc57fdbba17931', 'SMOK_YDLV10', 'SmokeSensor-EM', 'FB56-SMF02HM1.4'],
         model: 'HS1SA',
         vendor: 'HEIMAN',
         description: 'Smoke detector',


### PR DESCRIPTION
I have a chinise clone of the HEIMAN HS1SA and this change make it working very well.
Its model number is `FB56-SMF02HM1.4`