### PR TITLE
Adds 'haElectricalMeasurement' bind to HS2SK device configuration

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3816,7 +3816,7 @@ const devices = [
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
             await configureReporting.onOff(endpoint);
             await configureReporting.rmsVoltage(endpoint);
             await configureReporting.rmsCurrent(endpoint);


### PR DESCRIPTION
This fixes https://github.com/Koenkk/zigbee2mqtt/issues/2310, ensuring that `activePower`, `rmsCurrent` and `rmsVoltage` are in exposed.