### PR TITLE
Added support for ZNCZ04LM

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -627,6 +627,17 @@ const devices = [
         toZigbee: [tz.on_off],
     },
     {
+        zigbeeModel: ['lumi.plug.mmeu01'],
+        model: 'ZNCZ04LM',
+        description: 'Mi power plug ZigBee EU',
+        supports: 'on/off, power measurement',
+        vendor: 'Xiaomi',
+        fromZigbee: [
+            fz.on_off, fz.xiaomi_power, fz.xiaomi_plug_state
+        ],
+        toZigbee: [tz.on_off],
+    },
+    {
         zigbeeModel: ['lumi.ctrl_86plug', 'lumi.ctrl_86plug.aq1'],
         model: 'QBCZ11LM',
         description: 'Aqara socket Zigbee',

--- a/devices.js
+++ b/devices.js
@@ -633,7 +633,7 @@ const devices = [
         supports: 'on/off, power measurement',
         vendor: 'Xiaomi',
         fromZigbee: [
-            fz.on_off, fz.xiaomi_power, fz.xiaomi_plug_state
+            fz.on_off, fz.xiaomi_power, fz.xiaomi_plug_state,
         ],
         toZigbee: [tz.on_off],
     },


### PR DESCRIPTION
zigbee2mqtt:info  2019-11-23T00:00:18: Device 'Computer' joined
zigbee2mqtt:info  2019-11-23T00:00:18: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"device_connected","message":{"friendly_name":"Computer"}}'
zigbee2mqtt:info  2019-11-23T00:00:18: Starting interview of 'Computer'
zigbee2mqtt:info  2019-11-23T00:00:18: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"pairing","message":"interview_started","meta":{"friendly_name":"Computer"}}'
zigbee2mqtt:info  2019-11-23T00:00:19: Successfully interviewed 'Computer', device has successfully been paired
zigbee2mqtt:info  2019-11-23T00:00:19: Device 'Computer' is supported, identified as: Xiaomi Mi power plug ZigBee EU (ZNCZ04LM)
zigbee2mqtt:info  2019-11-23T00:00:19: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"pairing","message":"interview_successful","meta":{"friendly_name":"Computer","model":"ZNCZ04LM","vendor":"Xiaomi","description":"Mi power plug ZigBee EU","supported":true}}'
zigbee2mqtt:info  2019-11-23T00:00:22: MQTT publish: topic 'zigbee2mqtt/Computer', payload '{"state":"OFF","linkquality":36,"power":4.67}'
zigbee2mqtt:info  2019-11-23T00:00:38: MQTT publish: topic 'zigbee2mqtt/Computer', payload '{"state":"ON","linkquality":2,"power":4.67}'
zigbee2mqtt:info  2019-11-23T00:00:47: MQTT publish: topic 'zigbee2mqtt/Computer', payload '{"state":"ON","linkquality":34,"power":4.75}'
zigbee2mqtt:info  2019-11-23T00:01:18: MQTT publish: topic 'zigbee2mqtt/Computer', payload '{"state":"ON","linkquality":23,"power":0}'
zigbee2mqtt:info  2019-11-23T00:01:32: MQTT publish: topic 'zigbee2mqtt/Computer', payload '{"state":"ON","linkquality":28,"power":4.67}'