### PR TITLE
[koenkk/zigbee2mqtt#2402] fromZigbee should handle currentHue in addition to currentSaturation

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -833,7 +833,7 @@ const converters = {
 
             if (
                 msg.data['currentX'] || msg.data['currentY'] || msg.data['currentSaturation'] ||
-                msg.data['enhancedCurrentHue']
+                msg.data['currentHue'] || msg.data['enhancedCurrentHue']
             ) {
                 result.color = {};
 
@@ -846,7 +846,11 @@ const converters = {
                 }
 
                 if (msg.data['currentSaturation']) {
-                    result.color.saturation = precisionRound(msg.data['currentSaturation'] / 2.54, 1);
+                    result.color.saturation = precisionRound(msg.data['currentSaturation'] / 2.54, 0);
+                }
+
+                if (msg.data['currentHue']) {
+                    result.color.hue = precisionRound((msg.data['currentHue'] * 360) / 254, 0);
                 }
 
                 if (msg.data['enhancedCurrentHue']) {


### PR DESCRIPTION
After this change we properly handle bulbs that do standard currentHue + currentSaturation,
according to the spec both should always be published.

```
5.2.2.2.1.1 CurrentHue Attribute

The CurrentHue attribute contains the current hue value of the light. It is updated
as fast as practical during commands that change the hue.
The hue in degrees shall be related to the CurrentHue attribute by the relationship
Hue = CurrentHue x 360 / 254 (CurrentHue in the range 0 - 254 inclusive)
If this attribute is implemented then the CurrentSaturation and ColorMode
attributes shall also be implemented.

5.2.2.2.1.2 CurrentSaturation Attribute

The CurrentSaturation attribute holds the current saturation value of the light. It is
updated as fast as practical during commands that change the saturation.
The saturation shall be related to the CurrentSaturation attribute by the
relationship
Saturation = CurrentSaturation/254 (CurrentSaturation in the range 0 - 254 inclusive)
If this attribute is implemented then the CurrentHue and ColorMode attributes
shall also be implemented.
```

In addition to handle currentHue, currentSaturation got update to round to the nearest whole number.

Using https://www.rapidtables.com/convert/color/hsv-to-rgb.html we can now convert the resulting values back, having V=100 set we get the color we configured.

This was tested with an Innr RB 250 C.