### PR TITLE
LZL4B_onoff: change to use 'action'

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2629,7 +2629,7 @@ const converters = {
         type: 'commandMoveToLevelWithOnOff',
         convert: (model, msg, publish, options) => {
             return {
-                level: msg.data.level,
+                action: msg.data.level,
                 transition_time: msg.data.transtime,
             };
         },


### PR DESCRIPTION
Use 'action' instead of 'level'.  Avoids persistence and allows for single handling of on/off and up/down events.