### PR TITLE
Add Paulmann 500.49 with new model name

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3544,6 +3544,13 @@ const devices = [
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
     {
+        zigbeeModel: ['500.49'],
+        model: '500.49',
+        vendor: 'Paulmann',
+        description: 'SmartHome Yourled RGB Controller',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
         zigbeeModel: ['CCT light'],
         model: '50064',
         vendor: 'Paulmann',

--- a/devices.js
+++ b/devices.js
@@ -3537,15 +3537,8 @@ const devices = [
         extend: generic.light_onoff_brightness,
     },
     {
-        zigbeeModel: ['RGBW light'],
+        zigbeeModel: ['RGBW light', '500.49'],
         model: '50049',
-        vendor: 'Paulmann',
-        description: 'SmartHome Yourled RGB Controller',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
-    },
-    {
-        zigbeeModel: ['500.49'],
-        model: '500.49',
         vendor: 'Paulmann',
         description: 'SmartHome Yourled RGB Controller',
         extend: generic.light_onoff_brightness_colortemp_colorxy,


### PR DESCRIPTION
The Paulmann YourLED RGB Controller I purchased registers itself with a different modelID than already supported: Device with modelID '500.49' is not supported.

Therefore I copied the already existing configuration but changed the IDs. The configuration works now for me. 