### PR TITLE
Fix E1744 command duplication (Koenkk/zigbee2mqtt#2434)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1049,7 +1049,7 @@ const devices = [
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genLevelCtrl', 'genPowerCfg']);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
     },


### PR DESCRIPTION
The device needs to be removed and rejoined to make this effective.