### PR TITLE
TRADFRI bulb E12 CWS opal 600lm

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -878,7 +878,8 @@ const devices = [
         zigbeeModel: [
             'TRADFRI bulb E27 CWS opal 600lm',
             'TRADFRI bulb E26 CWS opal 600lm',
-            'TRADFRI bulb E14 CWS opal 600lm'],
+            'TRADFRI bulb E14 CWS opal 600lm',
+            'TRADFRI bulb E12 CWS opal 600lm'],
         model: 'LED1624G9',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E14/E26/E27 600 lumen, dimmable, color, opal white',


### PR DESCRIPTION
As reported by @thefarelkid, this add support for the E12 variant.

koenkk/zigbee2mqtt#2455 