### PR TITLE
Pi Heating Demand  (valve position %)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2142,7 +2142,7 @@ const converters = {
                 result.running_state = common.thermostatRunningStates[state];
             }
             if (typeof msg.data['pIHeatingDemand'] == 'number') {
-                result.pi_heating_demand = msg.data['pIHeatingDemand'];
+                result.pi_heating_demand = precisionRound(msg.data['pIHeatingDemand'] / 255.0 * 100.0, 0);
             }
             return result;
         },


### PR DESCRIPTION
While working on #788 I noticed PIHeatingDemand is supose to indicate how far the valve is open in the manuals. Were 0 => closed, 255 => full open.

We simple convert this to a percentage here, which seems to work fine. Although I am not 100% sure if we should leave this as-is, the conversion is relatively trivial to do in things like node-red. But not all things consuming mqtt messages might have the luxery.

So feel free to just close the PR.

```
zigbee2mqtt:info  2019-12-06 08:51:08: MQTT publish: topic 'zigbee2mqtt/bedroom/radiator', payload '{"eurotronic_system_mode":1,"system_mode":"heat","linkquality":60,"local_temperature":18.5,"occupied_heating_setpoint":18.5,"unoccupied_heating_setpoint":16,"pi_heating_demand":0,"current_heating_setpoint":23,"eurotronic_error_status":0,"battery":100}'
zigbee2mqtt:info  2019-12-06 08:51:16: MQTT publish: topic 'zigbee2mqtt/bedroom/radiator', payload '{"eurotronic_system_mode":1,"system_mode":"heat","linkquality":60,"local_temperature":18.5,"occupied_heating_setpoint":23,"unoccupied_heating_setpoint":16,"pi_heating_demand":84,"current_heating_setpoint":23,"eurotronic_error_status":0,"battery":100}'
zigbee2mqtt:info  2019-12-06 08:51:40: MQTT publish: topic 'zigbee2mqtt/bedroom/radiator', payload '{"eurotronic_system_mode":1,"system_mode":"heat","linkquality":60,"local_temperature":18.5,"occupied_heating_setpoint":18,"unoccupied_heating_setpoint":16,"pi_heating_demand":0,"current_heating_setpoint":18,"eurotronic_error_status":0,"battery":100}'
```