### PR TITLE
EweLink OnOff

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1029,6 +1029,13 @@ const converters = {
                 };
             }
         },
+    },    
+    EWeLink_OnOff: {
+        cid: 'genOnOff',
+        type: ['attReport', 'devChange'],
+        convert: (model, msg, publish, options) => {
+            return {state: msg.data.data['onOff'] === 1 ? 'ON' : 'OFF'};
+        },
     },
     QBKG11LM_power: {
         cluster: 'genBasic',

--- a/devices.js
+++ b/devices.js
@@ -5029,6 +5029,16 @@ const devices = [
         toZigbee: [tz.on_off, tz.ignore_transition],
     },
 
+    //EweLink
+    {
+        zigbeeModel: ['SA-003-Zigbee'],
+        model: 'SA-003-Zigbee',
+        vendor: 'Ewelink',
+        description: 'Zigbee OnOff Controller',
+        supports: 'on/off',
+        fromZigbee: [fz.EWeLink_OnOff],
+        toZigbee: [tz.on_off],
+    },
     // Hampton Bay
     {
         zigbeeModel: ['HDC52EastwindFan', 'HBUniversalCFRemote'],


### PR DESCRIPTION
Device Zigbee OnOff Controller -> https://www.amazon.com/Zripool-Controller-Control-AC85-265V-Installation/dp/B07M6WNQ5F

PS: the procedure for add new device based on docker instance is not working with current docker latest image. I need to copy out from container zigbee-shepherd-converters ( not zigbee-herdsman-converters ) and modify that one. Doing this everything works well.