### PR TITLE
Added support for Lockwood keyless deadbolt

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5971,6 +5971,24 @@ const devices = [
         fromZigbee: [fz.ts0043_click],
         toZigbee: [],
     },
+
+    // Lockwood
+    {
+        zigbeeModel: ['YRD220/240 TSDB'],
+        model: 'YRD220/240 TSDB',
+        vendor: 'Yale',
+        description: 'Lockwood keyless push button deadbolt lock',
+        supports: 'lock/unlock, battery',
+        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery_200],
+        toZigbee: [tz.generic_lock],
+        meta: {options: {disableDefaultResponse: true}, configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await configureReporting.lockState(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>

--- a/devices.js
+++ b/devices.js
@@ -5979,7 +5979,7 @@ const devices = [
         vendor: 'Yale',
         description: 'Lockwood keyless push button deadbolt lock',
         supports: 'lock/unlock, battery',
-        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery_200],
+        fromZigbee: [fz.lock, fz.lock_operation_event, fz.generic_battery],
         toZigbee: [tz.generic_lock],
         meta: {options: {disableDefaultResponse: true}, configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -4608,6 +4608,22 @@ const devices = [
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
     },
+    {
+        zigbeeModel: ['YRD220/240 TSDB'],
+        model: 'YRD220/240 TSDB',
+        vendor: 'Yale',
+        description: 'Lockwood keyless push button deadbolt lock',
+        supports: 'lock/unlock, battery',
+        fromZigbee: [fz.lock, fz.lock_operation_event, fz.generic_battery],
+        toZigbee: [tz.generic_lock],
+        meta: {options: {disableDefaultResponse: true}, configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await configureReporting.lockState(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
 
     // Keen Home
     {
@@ -5970,24 +5986,6 @@ const devices = [
         supports: 'action',
         fromZigbee: [fz.ts0043_click],
         toZigbee: [],
-    },
-
-    // Lockwood
-    {
-        zigbeeModel: ['YRD220/240 TSDB'],
-        model: 'YRD220/240 TSDB',
-        vendor: 'Yale',
-        description: 'Lockwood keyless push button deadbolt lock',
-        supports: 'lock/unlock, battery',
-        fromZigbee: [fz.lock, fz.lock_operation_event, fz.generic_battery],
-        toZigbee: [tz.generic_lock],
-        meta: {options: {disableDefaultResponse: true}, configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
-            await configureReporting.lockState(endpoint);
-            await configureReporting.batteryPercentageRemaining(endpoint);
-        },
     },
 ];
 


### PR DESCRIPTION
This device came up as a Yale YRD220/240 which wasn't supported.  Had a look at the SmartThings code which does support it and discovered its similar to a YRD210 so copied that and came up with this.  It now works!  Also added a matching entry in homeassistant.js

Product link: [https://www.lockweb.com.au/en/lockwood-products/keyless-entry/lockwood-connected-digital-deadbolt/](url)