### PR TITLE
Support for Hive Thermostatic Radiator Valve

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2180,6 +2180,30 @@ const devices = [
         description: 'Active light, warm to cool white (GU10)',
         extend: generic.light_onoff_brightness_colortemp,
     },
+    {
+        zigbeeModel: ['TRV001'],
+        model: 'UK7004240',
+        vendor: 'Hive',
+        description: 'Radiator valve',
+        supports: 'temperature',
+        fromZigbee: [fz.thermostat_att_report, fz.battery_percentage_remaining],
+        toZigbee: [
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration,
+            tz.thermostat_setpoint_raise_lower, tz.thermostat_remote_sensing,
+            tz.thermostat_system_mode, tz.thermostat_running_state,
+        ],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, [
+                'genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'genPollCtrl', 'hvacThermostat',
+                'hvarUserInterfaceCfg',
+            ]);
+            await configureReporting.thermostatTemperature(endpoint);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await configureReporting.thermostatPIHeatingDemand(endpoint);
+        },
+    },
 
     // Innr
     {
@@ -6010,42 +6034,6 @@ const devices = [
         supports: 'action',
         fromZigbee: [fz.ts0043_click],
         toZigbee: [],
-    },
-
-    // Hive
-    {
-        zigbeeModel: ['TRV001'],
-        model: 'TRV001',
-        vendor: 'Danfoss',
-        description: 'Wireless Radiator Valve',
-        supports: 'temperature, thermostat',
-        fromZigbee: [
-            fz.thermostat_att_report,
-            fz.battery_percentage_remaining,
-        ],
-        toZigbee: [
-            tz.thermostat_occupied_heating_setpoint,
-            tz.thermostat_local_temperature_calibration,
-            tz.thermostat_setpoint_raise_lower,
-            tz.thermostat_remote_sensing,
-            tz.thermostat_system_mode,
-            tz.thermostat_running_state,
-        ],
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, [
-                'genBasic',
-                'genPowerCfg',
-                'genIdentify',
-                'genTime',
-                'genPollCtrl',
-                'hvacThermostat',
-                'hvarUserInterfaceCfg']);
-            await configureReporting.thermostatTemperature(endpoint);
-            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await configureReporting.thermostatPIHeatingDemand(endpoint);
-        },
     },
 ];
 

--- a/devices.js
+++ b/devices.js
@@ -6011,6 +6011,42 @@ const devices = [
         fromZigbee: [fz.ts0043_click],
         toZigbee: [],
     },
+
+    // Hive
+    {
+        zigbeeModel: ['TRV001'],
+        model: 'TRV001',
+        vendor: 'Danfoss',
+        description: 'Wireless Radiator Valve',
+        supports: 'temperature, thermostat',
+        fromZigbee: [
+            fz.thermostat_att_report,
+            fz.battery_percentage_remaining,
+        ],
+        toZigbee: [
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_local_temperature_calibration,
+            tz.thermostat_setpoint_raise_lower,
+            tz.thermostat_remote_sensing,
+            tz.thermostat_system_mode,
+            tz.thermostat_running_state,
+        ],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, [
+                'genBasic',
+                'genPowerCfg',
+                'genIdentify',
+                'genTime',
+                'genPollCtrl',
+                'hvacThermostat',
+                'hvarUserInterfaceCfg']);
+            await configureReporting.thermostatTemperature(endpoint);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await configureReporting.thermostatPIHeatingDemand(endpoint);
+        },
+    },
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
This adds support for the Hive TRVs for sale in the UK. Interestingly they report their vendor as Danfoss so I left that there.

I tested the basic functionality (set a heating point, see whether temperature is reported reasonably), so this support might not be complete yet. 

If anyone has a hive hub and sniffer  (and/or knows their way around zigbee better...)  this could be checked better.