### PR TITLE
Add GL-S-005Z Gledopto RGBW MR16 GU5.3

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3170,7 +3170,7 @@ const devices = [
         zigbeeModel: ['GL-S-005Z'],
         model: 'GL-S-005Z',
         vendor: 'Gledopto',
-        description: 'Smart RGBW MR16 ',
+        description: 'Smart RGBW MR16',
         extend: gledopto.light,
         supports: 'on/off, brightness, color, white',
     },

--- a/devices.js
+++ b/devices.js
@@ -3167,6 +3167,14 @@ const devices = [
         supports: 'on/off, brightness, color, white',
     },
     {
+        zigbeeModel: ['GL-S-005Z'],
+        model: 'GL-S-005Z',
+        vendor: 'Gledopto',
+        description: 'Smart RGBW MR16 ',
+        extend: gledopto.light,
+        supports: 'on/off, brightness, color, white',
+    },
+    {
         zigbeeModel: ['HOMA2023'],
         model: 'GD-CZ-006',
         vendor: 'Gledopto',


### PR DESCRIPTION
This is the same bulb as the GL-S-003Z with the identical features. The only difference is the socket: not GU10 but GU5.3 (MR16)