### PR TITLE
#788 improve Eurotronic SPZB0001 support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2157,10 +2157,10 @@ const converters = {
                     precisionRound(msg.data[0x4003], 2) / 100;
             }
             if (typeof msg.data[0x4008] == 'number') {
-                result.eurotronic_system_mode = msg.data[0x4008];
-                if ((result.eurotronic_system_mode & 1 << 2) != 0) {
+                result.eurotronic_host_flags = msg.data[0x4008];
+                if ((result.eurotronic_host_flags & 1 << 2) != 0) {
                     result.system_mode = common.thermostatSystemModes[1]; // boost => auto
-                } else if ((result.eurotronic_system_mode & (1 << 4)) != 0 ) {
+                } else if ((result.eurotronic_host_flags & (1 << 4)) != 0 ) {
                     result.system_mode = common.thermostatSystemModes[0]; // off
                 } else {
                     result.system_mode = common.thermostatSystemModes[4]; // heat

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2151,7 +2151,7 @@ const converters = {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => {
-            const result = {};
+            const result = converters.thermostat_att_report.convert(model, msg, publish, options);
             if (typeof msg.data[0x4003] == 'number') {
                 result.current_heating_setpoint =
                     precisionRound(msg.data[0x4003], 2) / 100;

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -806,8 +806,8 @@ const converters = {
             await entity.read('hvacThermostat', ['systemMode']);
         },
     },
-    eurotronic_system_mode: {
-        key: 'eurotronic_system_mode',
+    eurotronic_host_flags: {
+        key: 'eurotronic_host_flags',
         convertSet: async (entity, key, value, meta) => {
             const payload = {0x4008: {value, type: 0x22}};
             await entity.write('hvacThermostat', payload, options.eurotronic);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -793,22 +793,39 @@ const converters = {
             case 0:
                 value |= 1 << 5; // off
                 break;
-            case 1:
-                value |= 1 << 2; // boost
+            case 4:
+                value |= 1 << 2; // heat (boost for eurotronic)
                 break;
             default:
-                value |= 1 << 4; // heat
+                value |= 1 << 4; // auto
             }
             const payload = {0x4008: {value, type: 0x22}};
             await entity.write('hvacThermostat', payload, options.eurotronic);
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['systemMode']);
+            await entity.read('hvacThermostat', [0x4008], options.eurotronic);
         },
     },
     eurotronic_host_flags: {
-        key: 'eurotronic_host_flags',
+        key: ['eurotronic_host_flags', 'eurotronic_system_mode'],
         convertSet: async (entity, key, value, meta) => {
+            if (typeof value === 'object') {
+                let bitValue = 0;
+                if (value.mirror_display) {
+                    bitValue |= 1 << 1;
+                }
+                if (value.boost) {
+                    bitValue |= 1 << 2;
+                }
+                if (value.window_open) {
+                    bitValue |= 1 << 5;
+                }
+                if (value.child_protection) {
+                    bitValue |= 1 << 7;
+                }
+                meta.logger.debug(`eurotronic: host_flags object converted to ${bitValue}`);
+                value = bitValue;
+            }
             const payload = {0x4008: {value, type: 0x22}};
             await entity.write('hvacThermostat', payload, options.eurotronic);
         },

--- a/devices.js
+++ b/devices.js
@@ -4503,7 +4503,6 @@ const devices = [
         description: 'Spirit Zigbee wireless heater thermostat',
         supports: 'temperature, heating system control',
         fromZigbee: [
-            fz.thermostat_att_report,
             fz.eurotronic_thermostat,
             fz.battery_percentage_remaining,
         ],

--- a/devices.js
+++ b/devices.js
@@ -4509,7 +4509,7 @@ const devices = [
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_local_temperature_calibration, tz.eurotronic_thermostat_system_mode,
-            tz.eurotronic_system_mode, tz.eurotronic_error_status, tz.thermostat_setpoint_raise_lower,
+            tz.eurotronic_host_flags, tz.eurotronic_error_status, tz.thermostat_setpoint_raise_lower,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_remote_sensing,
             tz.eurotronic_current_heating_setpoint, tz.eurotronic_trv_mode, tz.eurotronic_valve_position,
         ],


### PR DESCRIPTION
- [X] switch to one fromZigbee convertor (so we can do the system_mode override)
- [X] ignore hvacThermostat's system_mode 
  - [x] system_mode == heat + eurotronic_system_mode == boost => heat
  - [x] system_mode == heat + eurotronic_system_mode == !boost => auto
  - [x] system_mode == heat + eurotronic_system_mode == window open => off
- [x] rename `fromZigbee.eurotronic_system_mode` to `fromZigbee.eurotronic_host_flags`
- [x] parse eurotronic_host_flags into a hash with items per flag
- [x] add toZigbee convertors for `eurotronic_host_flags` as hash
- [x] fix eurotronic_system_mode forgets other settings
