### PR TITLE
Add M-Elec Stitchy to device list.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1898,6 +1898,15 @@ const devices = [
         },
     },
 
+    // M-ELEC - https://melec.com.au/stitchy/
+    {
+        zigbeeModel: ['ML-ST-D200'],
+        model: 'ML-ST-D200',
+        vendor: 'M-ELEC',
+        description: 'Stitchy Dim switchable wall module',
+        extend: generic.light_onoff_brightness,
+    },
+
     // OSRAM
     {
         zigbeeModel: ['Outdoor Lantern W RGBW OSRAM'],


### PR DESCRIPTION
This is a pull request to support an M-Elec Stitchy Dimmer module.  See Issue #819 

It may be possible to use more than just the generic dimmer, but this works.