### PR TITLE
Zbt cct switch d0001

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3250,16 +3250,13 @@ const converters = {
             // map both "on" and "off" to a consistent "button_1"
             const deviceID = msg.device.ieeeAddr;
             if (!store[deviceID]) {
-                store[deviceID] = {last_cmd:null,last_seq:-10};
+                store[deviceID] = {lastCmd: null, last_seq: -10};
             }
-            const last_cmd = store[deviceID].last_cmd;
-            const last_seq = store[deviceID].last_seq;
 
-            let this_cmd = 'button_1';
-
-            store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
-            store[deviceID].last_cmd = this_cmd;
-            return {action: this_cmd}
+            const cmd = 'button_1';
+            store[deviceID].lastSeq = msg.meta.zclTransactionSequenceNumber;
+            store[deviceID].lastCmd = cmd;
+            return {action: cmd};
         },
     },
     ZBT_CCTSwitch_D0001_moveToLevel: {
@@ -3273,21 +3270,19 @@ const converters = {
 
             const deviceID = msg.device.ieeeAddr;
             if (!store[deviceID]) {
-                store[deviceID] = {last_cmd:null,last_seq:-10};
+                store[deviceID] = {lastCmd: null, lastSeq: -10};
             }
-            const last_cmd = store[deviceID].last_cmd;
-            const last_seq = store[deviceID].last_seq;
 
-            let this_cmd = null;
+            let cmd = null;
             if ( msg.type == 'commandMoveToLevel' ) {
-                this_cmd = 'button_2';
+                cmd = 'button_2';
             } else if ( msg.type == 'commandMoveToLevelWithOnOff' ) {
-                this_cmd = 'button_4';
+                cmd = 'button_4';
             }
 
-            store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
-            store[deviceID].last_cmd = this_cmd;
-            return {action: this_cmd}
+            store[deviceID].lastSeq = msg.meta.zclTransactionSequenceNumber;
+            store[deviceID].lastCmd = cmd;
+            return {action: cmd};
         },
     },
     ZBT_CCTSwitch_D0001_moveToColorTemp: {
@@ -3301,29 +3296,29 @@ const converters = {
             // and we can ignore it entirely
             const deviceID = msg.device.ieeeAddr;
             if (!store[deviceID]) {
-                store[deviceID] = {last_cmd:null,last_seq:-10};
+                store[deviceID] = {lastCmd: null, lastSeq: -10};
             }
-            let last_cmd = store[deviceID].last_cmd;
-            let last_seq = store[deviceID].last_seq;
+            const lastCmd = store[deviceID].lastCmd;
+            const lastSeq = store[deviceID].lastSeq;
 
-            let this_seq = msg.meta.zclTransactionSequenceNumber;
-            let this_cmd = 'button_3';
+            const seq = msg.meta.zclTransactionSequenceNumber;
+            let cmd = 'button_3';
 
-            // because the remote sends two commands for button4, we need to look at the previous command and see if it was
-            // the recognized start command for button4 - if so, ignore this second command, because it's not really button3,
-            // it's actually button4
-            if ( last_cmd == 'button_4' ) {
+            // because the remote sends two commands for button4, we need to look at the previous command and
+            // see if it was the recognized start command for button4 - if so, ignore this second command,
+            // because it's not really button3, it's actually button4
+            if ( lastCmd == 'button_4' ) {
                 // ensure the "last" message was really the message prior to this one
                 // accounts for missed messages (gap >1) and for the remote's rollover from 127 to 0
-                if ( (this_seq == 0 && last_seq == 127 ) || ( this_seq - last_seq ) == 1 ) {
-                    this_cmd = null;
+                if ( (seq == 0 && lastSeq == 127 ) || ( seq - lastSeq ) == 1 ) {
+                    cmd = null;
                 }
             }
 
-            if ( this_cmd != null ) {
-                store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
-                store[deviceID].last_cmd = this_cmd;
-                return {action: this_cmd}
+            if ( cmd != null ) {
+                store[deviceID].lastSeq = msg.meta.zclTransactionSequenceNumber;
+                store[deviceID].lastCmd = cmd;
+                return {action: cmd};
             }
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3242,6 +3242,91 @@ const converters = {
             };
         },
     },
+    ZBT_CCTSwitch_D0001_cmdOnOff: {
+        cluster: 'genOnOff',
+        type: ['commandOn', 'commandOff'],
+        convert: (model, msg, publish, options) => {
+            // the remote maintains state and sends two potential commands for the power button
+            // map both "on" and "off" to a consistent "button_1"
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {last_cmd:null,last_seq:-10};
+            }
+            const last_cmd = store[deviceID].last_cmd;
+            const last_seq = store[deviceID].last_seq;
+
+            let this_cmd = 'button_1';
+
+            store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
+            store[deviceID].last_cmd = this_cmd;
+            return {action: this_cmd}
+        },
+    },
+    ZBT_CCTSwitch_D0001_moveToLevel: {
+        cluster: 'genLevelCtrl',
+        type: ['commandMoveToLevel', 'commandMoveToLevelWithOnOff'],
+        convert: (model, msg, publish, options) => {
+            // wrap the messages from button2 and button4 into a single function
+            // button2 always sends "commandMoveToLevel"
+            // button4 sends two messages, with "commandMoveToLevelWithOnOff" coming first in the sequence
+            //         so that's the one we key off of to indicate "button4"
+
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {last_cmd:null,last_seq:-10};
+            }
+            const last_cmd = store[deviceID].last_cmd;
+            const last_seq = store[deviceID].last_seq;
+
+            let this_cmd = null;
+            if ( msg.type == 'commandMoveToLevel' ) {
+                this_cmd = 'button_2';
+            } else if ( msg.type == 'commandMoveToLevelWithOnOff' ) {
+                this_cmd = 'button_4';
+            }
+
+            store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
+            store[deviceID].last_cmd = this_cmd;
+            return {action: this_cmd}
+        },
+    },
+    ZBT_CCTSwitch_D0001_moveToColorTemp: {
+        cluster: 'lightingColorCtrl',
+        type: ['commandMoveToColorTemp'],
+        convert: (model, msg, publish, options) => {
+            // both button3 and button4 send the command "commandMoveToColorTemp"
+            // in order to distinguish between the buttons, use the sequence number and the previous command
+            // to determine if this message was immediately preceded by "commandMoveToLevelWithOnOff"
+            // if this command follows a "commandMoveToLevelWithOnOff", then it's actually button4's second message
+            // and we can ignore it entirely
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {last_cmd:null,last_seq:-10};
+            }
+            let last_cmd = store[deviceID].last_cmd;
+            let last_seq = store[deviceID].last_seq;
+
+            let this_seq = msg.meta.zclTransactionSequenceNumber;
+            let this_cmd = 'button_3';
+
+            // because the remote sends two commands for button4, we need to look at the previous command and see if it was
+            // the recognized start command for button4 - if so, ignore this second command, because it's not really button3,
+            // it's actually button4
+            if ( last_cmd == 'button_4' ) {
+                // ensure the "last" message was really the message prior to this one
+                // accounts for missed messages (gap >1) and for the remote's rollover from 127 to 0
+                if ( (this_seq == 0 && last_seq == 127 ) || ( this_seq - last_seq ) == 1 ) {
+                    this_cmd = null;
+                }
+            }
+
+            if ( this_cmd != null ) {
+                store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
+                store[deviceID].last_cmd = this_cmd;
+                return {action: this_cmd}
+            }
+        },
+    },
 
     // Ignore converters (these message dont need parsing).
     ignore_onoff_report: {
@@ -3363,97 +3448,7 @@ const converters = {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => null,
-    },    
-
-    // the remote maintains state and sends two potential commands for the power button
-    // map both "on" and "off" to a consistent "button1"
-    ZBT_CCTSwitch_D0001_cmdOnOff: {
-        cluster: 'genOnOff',
-        type: ['commandOn', 'commandOff'],
-        convert: (model, msg, publish, options) => {
-            const deviceID = msg.device.ieeeAddr;
-            if (!store[deviceID]) {
-                store[deviceID] = {last_cmd:null,last_seq:-10};
-            }
-            const last_cmd = store[deviceID].last_cmd;
-            const last_seq = store[deviceID].last_seq;
-
-            let this_cmd = 'button1';
-
-            store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
-            store[deviceID].last_cmd = this_cmd;
-            //return {action: this_cmd, last_cmd: last_cmd, last_seq: last_seq, this_seq: store[deviceID].last_seq};
-            return {action: this_cmd}
-        },
     },
-    
-    // wrap the messages from button2 and button4 into a single function
-    // button2 always sends "commandMoveToLevel"
-    // button4 sends two messages, with "commandMoveToLevelWithOnOff" coming first in the sequence
-    //         so that's the one we key off of to indicate "button4"
-    ZBT_CCTSwitch_D0001_moveToLevel: {
-        cluster: 'genLevelCtrl',
-        type: ['commandMoveToLevel', 'commandMoveToLevelWithOnOff'],
-        convert: (model, msg, publish, options) => {
-            const deviceID = msg.device.ieeeAddr;
-            if (!store[deviceID]) {
-                store[deviceID] = {last_cmd:null,last_seq:-10};
-            }
-            const last_cmd = store[deviceID].last_cmd;
-            const last_seq = store[deviceID].last_seq;
-
-            let this_cmd = null;
-            if ( msg.type == 'commandMoveToLevel' ) {
-                this_cmd = 'button2';
-            } else if ( msg.type == 'commandMoveToLevelWithOnOff' ) {
-                this_cmd = 'button4';
-            }
-
-            store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
-            store[deviceID].last_cmd = this_cmd;
-            //return {action: this_cmd, last_cmd: last_cmd, last_seq: last_seq, this_seq: store[deviceID].last_seq};
-            return {action: this_cmd}
-        },
-    },    
-    
-    // both button3 and button4 send the command "commandMoveToColorTemp"
-    // in order to distinguish between the buttons, use the sequence number and the previous command
-    // to determine if this message was immediately preceded by "commandMoveToLevelWithOnOff"
-    // if this command follows a "commandMoveToLevelWithOnOff", then it's actually button4's second message
-    // and we can ignore it entirely
-    ZBT_CCTSwitch_D0001_moveToColorTemp: {
-        cluster: 'lightingColorCtrl',
-        type: ['commandMoveToColorTemp'],
-        convert: (model, msg, publish, options) => {
-            const deviceID = msg.device.ieeeAddr;
-            if (!store[deviceID]) {
-                store[deviceID] = {last_cmd:null,last_seq:-10};
-            }
-            let last_cmd = store[deviceID].last_cmd;
-            let last_seq = store[deviceID].last_seq;
-
-            let this_seq = msg.meta.zclTransactionSequenceNumber;
-            let this_cmd = 'button3';
-
-            // because the remote sends two commands for button4, we need to look at the previous command and see if it was
-            // the recognized start command for button4 - if so, ignore this second command, because it's not really button3,
-            // it's actually button4
-            if ( last_cmd == 'button4' ) {
-                // ensure the "last" message was really the message prior to this one
-                // accounts for missed messages (gap >1) and for the remote's rollover from 127 to 0
-                if ( (this_seq == 0 && last_seq == 127 ) || ( this_seq - last_seq ) == 1 ) {
-                    this_cmd = null;
-                }
-            }
-
-            if ( this_cmd != null ) {
-                store[deviceID].last_seq = msg.meta.zclTransactionSequenceNumber;
-                store[deviceID].last_cmd = this_cmd;
-                //return {action: this_cmd, last_cmd: last_cmd, last_seq: last_seq, this_seq: store[deviceID].last_seq};
-                return {action: this_cmd}
-            }
-        },
-    },    
 };
 
 module.exports = converters;

--- a/devices.js
+++ b/devices.js
@@ -4307,6 +4307,17 @@ const devices = [
         description: 'GU10 adjustable white bulb',
         extend: generic.light_onoff_brightness_colortemp,
     },
+    {
+        zigbeeModel: ['ZBT-CCTSwitch-D0001'],
+        model: '6ARCZABZH',
+        vendor: 'EcoSmart',
+        description: 'Four button remote control (included with EcoSmart smart bulbs)',
+        supports: 'action',
+        fromZigbee: [
+            fz.ZBT_CCTSwitch_D0001_cmdOnOff, fz.ZBT_CCTSwitch_D0001_moveToLevel, fz.ZBT_CCTSwitch_D0001_moveToColorTemp,
+        ],
+        toZigbee: [],
+    },
 
     // Airam
     {
@@ -6170,17 +6181,6 @@ const devices = [
         description: 'Touch switch',
         supports: 'action',
         fromZigbee: [fz.ts0043_click],
-        toZigbee: [],
-    },
-    
-    // EcoSmart ZBT-CCTSwitch-D0001 4 button remote
-    {
-        zigbeeModel: [ 'ZBT-CCTSwitch-D0001' ],
-        model: 'ZBT-CCTSwitch-D0001',
-        vendor: 'EcoSmart',
-        description: 'Ecosmart four button remote control included with Ecosmart smart bulbs.',
-        supports: 'button pushes - 4 buttons',
-        fromZigbee: [ fz.ZBT_CCTSwitch_D0001_cmdOnOff, fz.ZBT_CCTSwitch_D0001_moveToLevel, fz.ZBT_CCTSwitch_D0001_moveToColorTemp ],
         toZigbee: [],
     },
 ];

--- a/devices.js
+++ b/devices.js
@@ -6172,6 +6172,17 @@ const devices = [
         fromZigbee: [fz.ts0043_click],
         toZigbee: [],
     },
+    
+    // EcoSmart ZBT-CCTSwitch-D0001 4 button remote
+    {
+        zigbeeModel: [ 'ZBT-CCTSwitch-D0001' ],
+        model: 'ZBT-CCTSwitch-D0001',
+        vendor: 'EcoSmart',
+        description: 'Ecosmart four button remote control included with Ecosmart smart bulbs.',
+        supports: 'button pushes - 4 buttons',
+        fromZigbee: [ fz.ZBT_CCTSwitch_D0001_cmdOnOff, fz.ZBT_CCTSwitch_D0001_moveToLevel, fz.ZBT_CCTSwitch_D0001_moveToColorTemp ],
+        toZigbee: [],
+    },
 ];
 
 module.exports = devices.map((device) =>


### PR DESCRIPTION
Related issue: https://github.com/Koenkk/zigbee2mqtt/issues/2544

**This requires this PR to be merged as well, or button2 does not function:**

https://github.com/Koenkk/zigbee-herdsman/pull/109

Not sure how closely this matches to the project standards - only submitting a PR without further review because a) there's a lot of interest in this device on various places given how cheap they were at Home Depot recently, and b) it works perfectly on my end with multiple remotes, and I'd like to get this in place for people to benefit from.

----
About the device: 

![image](https://user-images.githubusercontent.com/713813/71028130-b0d61180-20da-11ea-8012-4d332fc4436a.png)

ZBT-CCTSwitch-D0001 is a four button remote that came bundled with EcoSmart lightbulbs. It is designed to control the lightbulbs directly, so it maintains state and sends directed commands to the bulb group. For example, the power button cycles through on/off commands, the dim/color buttons cycle through specific levels, and the scene button sends two commands per button-press.

About the converter:

This converter maps the four buttons to single button commands named "button1", "button2", "button3", "button4", by mapping the multiple potential messages the remote will send to a single button output. It keeps track of the last command sent to allow the fourth (scene) button (which always sends two messages) to only broadcast out a single message ("button4"), despite the two incoming messages.