### PR TITLE
Add support for the EcoSmart D1533

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4339,7 +4339,7 @@ const devices = [
         vendor: 'EcoSmart',
         description: 'PAR20 bright white bulb',
         extend: generic.light_onoff_brightness,
-     },
+    },
 
     // Airam
     {

--- a/devices.js
+++ b/devices.js
@@ -4332,6 +4332,14 @@ const devices = [
         ],
         toZigbee: [],
     },
+    {
+        // eslint-disable-next-line
+        zigbeeModel: ['\u0000\u0002\u0000\u0004\u0000\f]�\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000e', '\u0000\u0002\u0000\u0004\"�T\u0004\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000e', '\u0000\u0002\u0000\u0004\u0000\f^�\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000e'],
+        model: 'D1533',
+        vendor: 'EcoSmart',
+        description: 'PAR20 bright white bulb',
+        extend: generic.light_onoff_brightness,
+     },
 
     // Airam
     {


### PR DESCRIPTION
Adds support for the EcoSmart D1533, which is a PAR20 bright white bulb. Supports light on/off, and brightness.