### PR TITLE
Fix issues with SmartThings Leak Sensor 2018, IM6001-WLP01

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1635,13 +1635,15 @@ const converters = {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => {
-            const battery = {max: 3000, min: 2500};
-            const voltage = msg.data['batteryVoltage'] * 100;
-            return {
-                battery: toPercentage(voltage, battery.min, battery.max),
-                voltage: voltage, // @deprecated
-                // voltage: voltage / 1000.0,
-            };
+            const result = {};
+            if (msg.data.hasOwnProperty('batteryVoltage')) {
+                const battery = {max: 3000, min: 2500};
+                const voltage = msg.data['batteryVoltage'] * 100;
+                result.battery = toPercentage(voltage, battery.min, battery.max);
+                result.voltage = voltage; // @deprecated
+                // result.voltage = voltage / 1000.0;
+            }
+            return result;
         },
     },
     battery_3V_2100: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1635,15 +1635,15 @@ const converters = {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options) => {
-            const result = {};
             if (msg.data.hasOwnProperty('batteryVoltage')) {
                 const battery = {max: 3000, min: 2500};
                 const voltage = msg.data['batteryVoltage'] * 100;
-                result.battery = toPercentage(voltage, battery.min, battery.max);
-                result.voltage = voltage; // @deprecated
-                // result.voltage = voltage / 1000.0;
+                return {
+                    battery: toPercentage(voltage, battery.min, battery.max),
+                    voltage: voltage, // @deprecated
+                    // voltage: voltage / 1000.0,
+                };
             }
-            return result;
         },
     },
     battery_3V_2100: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1994,7 +1994,7 @@ const converters = {
     },
     st_leak: {
         cluster: 'ssIasZone',
-        type: ['attributeReport', 'readResponse'],
+        type: ['attributeReport', 'commandStatusChangeNotification', 'readResponse'],
         convert: (model, msg, publish, options) => {
             const zoneStatus = msg.data.zonestatus;
             return {

--- a/devices.js
+++ b/devices.js
@@ -3551,18 +3551,6 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['IM6001-WLP01'],
-        model: 'IM6001-WLP01',
-        vendor: 'SmartThings',
-        description: 'Water leak sensor',
-        supports: 'water leak',
-        fromZigbee: [
-            fz.temperature,
-            fz.st_leak, fz.battery_3V,
-        ],
-        toZigbee: [],
-    },
-    {
         zigbeeModel: ['3315-S'],
         model: '3315-S',
         vendor: 'SmartThings',
@@ -3583,7 +3571,7 @@ const devices = [
     },
     {
         zigbeeModel: ['water'],
-        model: 'F-WTR-UK-V2',
+        model: 'IM6001-WLP01',
         vendor: 'SmartThings',
         description: 'Water leak sensor (2018 model)',
         supports: 'water leak and temperature',


### PR DESCRIPTION
As discussed in #749 , there are a few issues with the code regarding the newest SmartThings leak sensor:
- z2m identifies it as the wrong model
- for me (and others), leak reporting doesn't work

Based on the responses in that thread, I believe the below changes are appropriate. They make the following changes:
- Remove `IM6001-WLP01` as a Zigbee model ID that z2m is looking for. Based on my device, the `IM6001-WLP01` identifies itself as `water`.
- Add a listener for the `commandStatusChangeNotification` report type to fix leak reporting
- Protect against null battery values when the `genPowerCfg` cluster receives a report that doesn't include `batteryVoltage`.

There is a small possibility that this PR will break functionality for users with a device that reports as `IM6001-WLP01`, however I have been unable to find any evidence that any devices report that model ID.

Thanks!