### PR TITLE
Enhancements to CCTSwitch_D0001 and new functions

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3356,20 +3356,21 @@ const converters = {
             const stop = msg.type === 'commandStop' ? true : false;
             let direction = null;
             const clk = 'brightness';
-            const result = {click: clk};
+            const payload = {click: clk};
             if (stop) {
                 direction = store[deviceID].direction;
                 const duration = Date.now() - store[deviceID].start;
-                result.action = `${clk}_${direction}_release`;
-                result.duration = duration;
+                payload.action = `${clk}_${direction}_release`;
+                payload.duration = duration;
             } else {
                 direction = msg.data.movemode === 1 ? 'down' : 'up';
-                result.action = `${clk}_${direction}_hold`;
+                payload.action = `${clk}_${direction}_hold`;
                 // store button and start moment
                 store[deviceID].direction = direction;
+                payload.rate = msg.data.rate;
                 store[deviceID].start = Date.now();
             }
-            return result;
+            return payload;
         },
     },
     CCTSwitch_D0001_colortemp_updown_hold_release: {
@@ -3383,20 +3384,21 @@ const converters = {
             const stop = msg.data.movemode === 0;
             let direction = null;
             const clk = 'colortemp';
-            const result = {click: clk};
+            const payload = {click: clk, rate: msg.data.rate};
             if (stop) {
                 direction = store[deviceID].direction;
                 const duration = Date.now() - store[deviceID].start;
-                result.action = `${clk}_${direction}_release`;
-                result.duration = duration;
+                payload.action = `${clk}_${direction}_release`;
+                payload.duration = duration;
             } else {
                 direction = msg.data.movemode === 3 ? 'down' : 'up';
-                result.action = `${clk}_${direction}_hold`;
+                payload.action = `${clk}_${direction}_hold`;
+                payload.rate = msg.data.rate;
                 // store button and start moment
                 store[deviceID].direction = direction;
                 store[deviceID].start = Date.now();
             }
-            return result;
+            return payload;
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -4343,7 +4343,7 @@ const devices = [
     {
         zigbeeModel: ['Ecosmart-ZBT-A19-CCT-Bulb'],
         model: 'A9A19A60WESDZ02',
-        vendor: 'The Home Depot',
+        vendor: 'EcoSmart',
         description: 'Tuneable white (A19)',
         extend: generic.light_onoff_brightness_colortemp,
     },

--- a/devices.js
+++ b/devices.js
@@ -304,22 +304,25 @@ const generic = {
     light_onoff_brightness: {
         supports: 'on/off, brightness',
         fromZigbee: [fz.on_off, fz.brightness, fz.ignore_basic_report],
-        toZigbee: [tz.light_onoff_brightness, tz.ignore_transition, tz.light_alert, tz.light_brightness_move],
+        toZigbee: [
+            tz.light_onoff_brightness, tz.ignore_transition, tz.ignore_rate, tz.light_alert,
+            tz.light_brightness_move,
+        ],
     },
     light_onoff_brightness_colortemp: {
         supports: 'on/off, brightness, color temperature',
         fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.ignore_basic_report],
         toZigbee: [
-            tz.light_onoff_brightness, tz.light_colortemp, tz.ignore_transition, tz.light_alert,
-            tz.light_brightness_move,
+            tz.light_onoff_brightness, tz.light_colortemp, tz.ignore_transition, tz.ignore_rate, tz.light_alert,
+            tz.light_brightness_move, tz.light_colortemp_move,
         ],
     },
     light_onoff_brightness_colorxy: {
         supports: 'on/off, brightness, color xy',
         fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.ignore_basic_report],
         toZigbee: [
-            tz.light_onoff_brightness, tz.light_color, tz.ignore_transition, tz.light_alert,
-            tz.light_brightness_move,
+            tz.light_onoff_brightness, tz.light_color, tz.ignore_transition, tz.ignore_rate, tz.light_alert,
+            tz.light_brightness_move, tz.light_colortemp_move,
         ],
     },
     light_onoff_brightness_colortemp_colorxy: {
@@ -329,8 +332,8 @@ const generic = {
             fz.ignore_basic_report,
         ],
         toZigbee: [
-            tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition,
-            tz.light_alert, tz.light_brightness_move,
+            tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition, tz.ignore_rate,
+            tz.light_alert, tz.light_brightness_move, tz.light_colortemp_move,
         ],
     },
 };
@@ -4340,7 +4343,7 @@ const devices = [
     {
         zigbeeModel: ['Ecosmart-ZBT-A19-CCT-Bulb'],
         model: 'A9A19A60WESDZ02',
-        vendor: 'EcoSmart',
+        vendor: 'The Home Depot',
         description: 'Tuneable white (A19)',
         extend: generic.light_onoff_brightness_colortemp,
     },
@@ -4373,21 +4376,6 @@ const devices = [
         vendor: 'EcoSmart',
         description: 'GU10 adjustable white bulb',
         extend: generic.light_onoff_brightness_colortemp,
-    },
-    {
-        zigbeeModel: ['ZBT-CCTSwitch-D0001'],
-        model: '6ARCZABZH',
-        vendor: 'EcoSmart',
-        description: 'Four button remote control (included with EcoSmart smart bulbs)',
-        supports: 'action',
-        fromZigbee: [
-            fz.CCTSwitch_D0001_on_off,
-            fz.CCTSwitch_D0001_move_to_level_recall,
-            fz.CCTSwitch_D0001_move_to_colortemp_recall,
-            fz.CCTSwitch_D0001_colortemp_updown_hold_release,
-            fz.CCTSwitch_D0001_brightness_updown_hold_release,
-        ],
-        toZigbee: [],
     },
     {
         // eslint-disable-next-line
@@ -5515,6 +5503,28 @@ const devices = [
         vendor: 'Leedarson',
         description: 'LED E27 tunable white',
         extend: generic.light_onoff_brightness_colortemp,
+    },
+    {
+        zigbeeModel: ['ZBT-CCTSwitch-D0001'],
+        model: '6ARCZABZH',
+        vendor: 'Leedarson',
+        description: '4-Key Remote Controller',
+        supports: 'on/off, brightness up/down and click/hold/release, cct',
+        fromZigbee: [
+            fz.CCTSwitch_D0001_on_off,
+            fz.CCTSwitch_D0001_move_to_level_recall,
+            fz.CCTSwitch_D0001_move_to_colortemp_recall,
+            fz.CCTSwitch_D0001_colortemp_updown_hold_release,
+            fz.CCTSwitch_D0001_brightness_updown_hold_release,
+            fz.generic_battery,
+        ],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
     },
 
     // GMY


### PR DESCRIPTION
* CCTSwitch_D0001: use consistent variable `payload` for payload, not `result`
* CCTSwitch_D0001: include `rate` that's sent by the remote
* CCTSwitch-D0001: This is actually a Leedarson remote, and registered as such on FCC's listing.
				   renamed from 'EcoSmart'
* Ecosmart-ZBT-A19-CCT-Bulb: Another rename, this is "The Home Depot's" house brand. The remote
							 that comes with it just happens to be a different manufacturer.
* light_brightness_move: allow `stop`/`release` in payload for **stop** and allow '0' or 'up'
						 example (`brightness_move`: `brightness_up` or `up` or `0`)
						 example (`brightness_move`: `brightness_up_release` or `brightness_up_stop` etc)
* light_colortemp_move: **NEW** similar function to brightness. Originally developed for CCTSwitch_D0001,
					    but should allow other controllers same functionality.
* generic light controllers: Updated to allow use of the move color command. Various bulbs (Sengled/Osram/EcoSmart)
							 allow moving color temps, figured it should be added to the generic controllers.