### PR TITLE
Added support for Stelpro's thermostats

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2147,6 +2147,18 @@ const converters = {
             return result;
         },
     },
+    hvac_user_interface: {
+        cluster: 'hvacUserInterfaceCfg',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            const lockoutMode = msg.data['keypadLockout'];
+            if (typeof lockoutMode == 'number') {
+                result.keypad_lockout = lockoutMode;
+            }
+            return result;
+        },
+    },
     stelpro_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2100,7 +2100,12 @@ const converters = {
             }
             if (typeof msg.data['occupiedHeatingSetpoint'] == 'number') {
                 const ohs = precisionRound(msg.data['occupiedHeatingSetpoint'], 2) / 100;
-                result.occupied_heating_setpoint = ohs > -250 ? ohs : null;
+                if (ohs < -250) {
+                    // Stelpro will return -325.65 when set to off
+                    result.occupied_heating_setpoint = 0;
+                } else {
+                    result.occupied_heating_setpoint = ohs;
+                }
             }
             if (typeof msg.data['unoccupiedHeatingSetpoint'] == 'number') {
                 result.unoccupied_heating_setpoint =

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2173,10 +2173,10 @@ const converters = {
             if (mode == 'number') {
                 result.stelpro_mode = mode;
                 switch (mode) {
-                    case 5:
-                        // "Eco" mode is translated into "auto" here
-                        result.system_mode = common.thermostatSystemModes[1];
-                        break;
+                case 5:
+                    // "Eco" mode is translated into "auto" here
+                    result.system_mode = common.thermostatSystemModes[1];
+                    break;
                 }
             }
             const piHeatingDemand = msg.data['pIHeatingDemand'];

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2181,7 +2181,7 @@ const converters = {
             }
             const piHeatingDemand = msg.data['pIHeatingDemand'];
             if (typeof piHeatingDemand == 'number') {
-                result.operation = piHeatingDemand > 0 ? 'heating' : 'idle';
+                result.operation = piHeatingDemand >= 10 ? 'heating' : 'idle';
             }
             return result;
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2099,8 +2099,8 @@ const converters = {
                 result.occupancy = msg.data['occupancy'];
             }
             if (typeof msg.data['occupiedHeatingSetpoint'] == 'number') {
-                result.occupied_heating_setpoint =
-                    precisionRound(msg.data['occupiedHeatingSetpoint'], 2) / 100;
+                const ohs = precisionRound(msg.data['occupiedHeatingSetpoint'], 2) / 100;
+                result.occupied_heating_setpoint = ohs > -250 ? ohs : null;
             }
             if (typeof msg.data['unoccupiedHeatingSetpoint'] == 'number') {
                 result.unoccupied_heating_setpoint =
@@ -2143,6 +2143,24 @@ const converters = {
             }
             if (typeof msg.data['pIHeatingDemand'] == 'number') {
                 result.pi_heating_demand = precisionRound(msg.data['pIHeatingDemand'] / 255.0 * 100.0, 0);
+            }
+            return result;
+        },
+    },
+    stelpro_thermostat: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            const mode = msg.data['StelproSystemMode'];
+            if (mode == 'number') {
+                result.stelpro_mode = mode;
+                switch (mode) {
+                    case 5:
+                        // "Eco" mode is translated into "auto" here
+                        result.system_mode = common.thermostatSystemModes[1];
+                        break;
+                }
             }
             return result;
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2173,11 +2173,15 @@ const converters = {
             if (mode == 'number') {
                 result.stelpro_mode = mode;
                 switch (mode) {
-                case 5:
-                    // "Eco" mode is translated into "auto" here
-                    result.system_mode = common.thermostatSystemModes[1];
-                    break;
+                    case 5:
+                        // "Eco" mode is translated into "auto" here
+                        result.system_mode = common.thermostatSystemModes[1];
+                        break;
                 }
+            }
+            const piHeatingDemand = msg.data['pIHeatingDemand'];
+            if (typeof piHeatingDemand == 'number') {
+                result.operation = piHeatingDemand > 0 ? 'heating' : 'idle';
             }
             return result;
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2156,10 +2156,10 @@ const converters = {
             if (mode == 'number') {
                 result.stelpro_mode = mode;
                 switch (mode) {
-                    case 5:
-                        // "Eco" mode is translated into "auto" here
-                        result.system_mode = common.thermostatSystemModes[1];
-                        break;
+                case 5:
+                    // "Eco" mode is translated into "auto" here
+                    result.system_mode = common.thermostatSystemModes[1];
+                    break;
                 }
             }
             return result;

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1196,7 +1196,7 @@ const converters = {
         },
     },
     stelpro_thermostat_outdoor_temperature: {
-        key: 'thermostat_outdoor_temperature',
+        key: ['thermostat_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {
             if (value > -100 && value < 100) {
                 await entity.write('hvacThermostat', {StelproOutdoorTemp: value * 100});

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1197,7 +1197,7 @@ const converters = {
         key: 'thermostat_outdoor_temperature',
         convertSet: async (entity, key, value, meta) => {
             if (value > -100 && value < 100) {
-                await entity.write('hvacThermostat', { StelproOutdoorTemp: value * 100 });
+                await entity.write('hvacThermostat', {StelproOutdoorTemp: value * 100});
             }
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1193,6 +1193,14 @@ const converters = {
             }
         },
     },
+    stelpro_thermostat_outdoor_temperature: {
+        key: 'thermostat_outdoor_temperature',
+        convertSet: async (entity, key, value, meta) => {
+            if (value > -100 && value < 100) {
+                await entity.write('hvacThermostat', { StelproOutdoorTemp: value * 100 });
+            }
+        },
+    },
     DTB190502A1_LED: {
         key: ['LED'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices.js
+++ b/devices.js
@@ -145,6 +145,14 @@ const configureReporting = {
         }];
         await endpoint.configureReporting('seMetering', payload);
     },
+    thermostatSystemMode: async (endpoint, min=10, max=repInterval.HOUR) => {
+        const payload = [{
+            attribute: 'systemMode',
+            minimumReportInterval: min,
+            maximumReportInterval: max,
+        }];
+        await endpoint.configureReporting('hvacThermostat', payload);
+    },
     thermostatTemperature: async (endpoint, min=0, max=repInterval.HOUR, change=10) => {
         const payload = [{
             attribute: 'localTemp',

--- a/devices.js
+++ b/devices.js
@@ -171,21 +171,21 @@ const configureReporting = {
         }];
         await endpoint.configureReporting('hvacThermostat', payload);
     },
-    thermostatOccupiedHeatingSetpoint: async (endpoint) => {
+    thermostatOccupiedHeatingSetpoint: async (endpoint, min=0, max=repInterval.HOUR, change=10) => {
         const payload = [{
             attribute: 'occupiedHeatingSetpoint',
-            minimumReportInterval: 0,
-            maximumReportInterval: repInterval.HOUR,
-            reportableChange: 10,
+            minimumReportInterval: min,
+            maximumReportInterval: max,
+            reportableChange: change,
         }];
         await endpoint.configureReporting('hvacThermostat', payload);
     },
-    thermostatPIHeatingDemand: async (endpoint) => {
+    thermostatPIHeatingDemand: async (endpoint, min=0, max=repInterval.MINUTES_5, change=10) => {
         const payload = [{
             attribute: 'pIHeatingDemand',
-            minimumReportInterval: 0,
-            maximumReportInterval: repInterval.MINUTES_5,
-            reportableChange: 10,
+            minimumReportInterval: min,
+            maximumReportInterval: max,
+            reportableChange: change,
         }];
         await endpoint.configureReporting('hvacThermostat', payload);
     },

--- a/devices.js
+++ b/devices.js
@@ -5068,7 +5068,7 @@ const devices = [
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_temperature_display_mode,
             tz.thermostat_keypad_lockout,
-            tz.thermostat_stelpro_system_mode,
+            tz.thermostat_system_mode,
             tz.thermostat_running_state,
         ],
         meta: { configureKey: 1 },

--- a/devices.js
+++ b/devices.js
@@ -5088,7 +5088,7 @@ const devices = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tz.stelpro_thermostat_outdoor_temperature
+            tz.stelpro_thermostat_outdoor_temperature,
         ],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
@@ -5110,10 +5110,10 @@ const devices = [
             await configureReporting.thermostatPIHeatingDemand(endpoint, 1, 900, 5);
             await configureReporting.thermostatKeypadLockMode(endpoint, 1, 0);
 
-            await endpoint.configureReporting('hvacThermostat',[{
-                        attribute: 'StelproSystemMode', // cluster 0x0201 attribute 0x401c
-                        minimumReportInterval: 1,
-                        maximumReportInterval: 0,
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'StelproSystemMode', // cluster 0x0201 attribute 0x401c
+                minimumReportInterval: 1,
+                maximumReportInterval: 0,
             }]);
         },
     },
@@ -5127,7 +5127,7 @@ const devices = [
             fz.thermostat_att_report,
             fz.stelpro_thermostat,
             fz.hvac_user_interface,
-            fz.humidity
+            fz.humidity,
         ],
         toZigbee: [
             tz.thermostat_local_temperature,
@@ -5137,9 +5137,9 @@ const devices = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tz.stelpro_thermostat_outdoor_temperature
+            tz.stelpro_thermostat_outdoor_temperature,
         ],
-        meta: { configureKey: 1 },
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(25);
             const binds = [
@@ -5161,9 +5161,9 @@ const devices = [
             await configureReporting.thermostatKeypadLockMode(endpoint, 1, 0);
 
             await endpoint.configureReporting('hvacThermostat', [{
-                        attribute: 'StelproSystemMode', // cluster 0x0201 attribute 0x401c
-                        minimumReportInterval: 1,
-                        maximumReportInterval: 0,
+                attribute: 'StelproSystemMode', // cluster 0x0201 attribute 0x401c
+                minimumReportInterval: 1,
+                maximumReportInterval: 0,
             }]);
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -5079,6 +5079,7 @@ const devices = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
+            tz.stelpro_thermostat_outdoor_temperature
         ],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -5071,7 +5071,7 @@ const devices = [
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
         ],
-        meta: { configureKey: 1 },
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(25);
             const binds = [

--- a/devices.js
+++ b/devices.js
@@ -5052,6 +5052,51 @@ const devices = [
             await configureReporting.thermostatTemperature(endpoint);
         },
     },
+    {
+        zigbeeModel: ['STZB402+', 'STZB402'],
+        model: 'STZB402',
+        vendor: 'Stelpro',
+        description: 'Ki, line-voltage thermostat',
+        supports: 'temperature',
+        fromZigbee: [
+            fz.thermostat_att_report,
+            fz.stelpro_thermostat,
+        ],
+        toZigbee: [
+            tz.thermostat_local_temperature,
+            tz.thermostat_occupancy,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_temperature_display_mode,
+            tz.thermostat_keypad_lockout,
+            tz.thermostat_stelpro_system_mode,
+            tz.thermostat_running_state,
+        ],
+        meta: { configureKey: 1 },
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(25);
+            const binds = [
+                'genBasic',
+                'genIdentify',
+                'genGroups',
+                'hvacThermostat',
+                'hvacUserInterfaceCfg',
+                'msTemperatureMeasurement',
+            ];
+            await bind(endpoint, coordinatorEndpoint, binds);
+
+            // Those exact parameters (min/max/change) are required for reporting to work with Stelpro Ki
+            await configureReporting.thermostatTemperature(endpoint, 10, 60, 50);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, 1, 0, 50);
+            await configureReporting.thermostatSystemMode(endpoint, 1, 0);
+            await configureReporting.thermostatPIHeatingDemand(endpoint, 300, 900, 5);
+
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'StelproSystemMode', // cluster 0x0201 attribute 0x401c
+                minimumReportInterval: 1,
+                maximumReportInterval: 0,
+            }]);
+        },
+    },
 
     // Nyce
     {

--- a/devices.js
+++ b/devices.js
@@ -153,6 +153,14 @@ const configureReporting = {
         }];
         await endpoint.configureReporting('hvacThermostat', payload);
     },
+    thermostatKeypadLockMode: async (endpoint, min = 10, max = repInterval.HOUR) => {
+        const payload = [{
+            attribute: 'keypadLockout',
+            minimumReportInterval: min,
+            maximumReportInterval: max,
+        }];
+        await endpoint.configureReporting('hvacUserInterfaceCfg', payload);
+    },
     thermostatTemperature: async (endpoint, min=0, max=repInterval.HOUR, change=10) => {
         const payload = [{
             attribute: 'localTemp',
@@ -5061,6 +5069,7 @@ const devices = [
         fromZigbee: [
             fz.thermostat_att_report,
             fz.stelpro_thermostat,
+            fz.hvac_user_interface,
         ],
         toZigbee: [
             tz.thermostat_local_temperature,
@@ -5088,7 +5097,8 @@ const devices = [
             await configureReporting.thermostatTemperature(endpoint, 10, 60, 50);
             await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, 1, 0, 50);
             await configureReporting.thermostatSystemMode(endpoint, 1, 0);
-            await configureReporting.thermostatPIHeatingDemand(endpoint, 300, 900, 5);
+            await configureReporting.thermostatPIHeatingDemand(endpoint, 1, 900, 5);
+            await configureReporting.thermostatKeypadLockMode(endpoint, 1, 0);
 
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'StelproSystemMode', // cluster 0x0201 attribute 0x401c

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,7 +90,7 @@ describe('index.js', () => {
 
                 expect(Array.isArray(converter.key)).toBe(true);
 
-                if (converter.converSet && 4 != converter.convertSet.length) {
+                if (converter.convertSet && 4 != converter.convertSet.length) {
                     throw new Error(`${converterKey}: convert() invalid arguments length`)
                 }
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -62,6 +62,10 @@ describe('index.js', () => {
             Object.keys(device.fromZigbee).forEach((converterKey) => {
                 const converter = device.fromZigbee[converterKey];
 
+                if(!converter) {
+                    throw new Error(`fromZigbee[${converterKey}] not defined on device ${device.model}.`);
+                }
+
                 const keys = Object.keys(converter);
                 verifyKeys(['cluster', 'type', 'convert'], keys, converterKey);
 
@@ -73,6 +77,10 @@ describe('index.js', () => {
             // Verify toConverters
             Object.keys(device.toZigbee).forEach((converterKey) => {
                 const converter = device.toZigbee[converterKey];
+
+                if(!converter) {
+                    throw new Error(`toZigbee[${converterKey}] not defined on device ${device.model}.`);
+                }
 
                 verifyKeys(
                     ['key'],


### PR DESCRIPTION
Issues:
* https://github.com/Koenkk/zigbee2mqtt/issues/1678 (Stelpro Maestro thermostat)
* https://github.com/Koenkk/zigbee2mqtt/issues/2058 (Stelpro Ki Zigbee thermostat)

Added support for Stelpro's Line-voltage Zigbee thermostat:
* Support local temperature
* Support modes "Off", "Eco" and "Heating" ("eco" got translated as "auto" to fit existing APIs)
* Support display of outdoor temperature
* Support locking of keypad

## Still unsupported
* Support for configuration (backlight, C/F)
* Celcius-only operations for now
* Setting "eco" mode from MQTT (auto->eco)

> # Important - PR dependency
> This PR <https://github.com/Koenkk/zigbee-herdsman/pull/115> is required for the new converters to work properly.