### PR TITLE
Battery reporting for Trust devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3677,8 +3677,15 @@ const devices = [
         fromZigbee: [
             fz.ias_water_leak_alarm_1,
             fz.ignore_basic_report,
+            fz.battery_percentage_remaining,
         ],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
     },
     {
         zigbeeModel: ['\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'+
@@ -3717,8 +3724,17 @@ const devices = [
         vendor: 'Trust',
         description: 'Motion Sensor',
         supports: 'occupancy',
-        fromZigbee: [fz.iaszone_occupancy_2],
+        fromZigbee: [
+            fz.iaszone_occupancy_2, fz.battery_percentage_remaining,
+            fz.ignore_basic_report,
+        ],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
     },
     {
         zigbeeModel: ['CSW_ADUROLIGHT'],


### PR DESCRIPTION
Configure battery reporting to Trust Water leakage detector (ZWLD-100) and Trust Motion sensor (ZPIR-8000) and add appropriate converters for such messages:

```
Received Zigbee message from '0x005043c95f277514', type 'attributeReport', cluster 'genPowerCfg', data '{"batteryPercentageRemaining":200}' from endpoint 1 with groupID 0
No converter available for 'ZWLD-100' with cluster 'genPowerCfg' and type 'attributeReport' and data '{"batteryPercentageRemaining":200}'

Received Zigbee message from '0x00158d000202c235', type 'attributeReport', cluster 'genPowerCfg', data '{"batteryPercentageRemaining":200}' from endpoint 1 with groupID 0
No converter available for 'ZPIR-8000' with cluster 'genPowerCfg' and type 'attributeReport' and data '{"batteryPercentageRemaining":200}'
```