### PR TITLE
support GLEDOPTO GL-C-008 RGBW

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -976,8 +976,8 @@ const converters = {
                 entity = meta.state.white_value === -1 ? meta.device.getEndpoint(11) : meta.device.getEndpoint(15);
             }
 
-            if (meta.mapped.model === 'GL-C-008' && utils.hasEndpoints(meta.device, [10, 11, 13])) {
-                // GL-C-008 RGBW
+            if (meta.mapped.model === 'GL-C-007/GL-C-008' && utils.hasEndpoints(meta.device, [10, 11, 13])) {
+                // GL-C-007/GL-C-008 RGBW
                 if (key === 'state' && value.toUpperCase() === 'OFF') {
                     await converters.light_onoff_brightness.convertSet(meta.device.getEndpoint(13), key, value, meta);
                 }
@@ -1048,8 +1048,8 @@ const converters = {
                 }
             }
 
-            // GL-C-008 RGBW
-            if (meta.mapped.model === 'GL-C-008' && utils.hasEndpoints(meta.device, [10, 11, 13])) {
+            // GL-C-007/GL-C-008 RGBW
+            if (meta.mapped.model === 'GL-C-007/GL-C-008' && utils.hasEndpoints(meta.device, [10, 11, 13])) {
                 if (key === 'white_value') {
                     // Switch from RGB to white
                     await meta.device.getEndpoint(13).command('genOnOff', 'on', {});

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -976,6 +976,15 @@ const converters = {
                 entity = meta.state.white_value === -1 ? meta.device.getEndpoint(11) : meta.device.getEndpoint(15);
             }
 
+            if (meta.mapped.model === 'GL-C-008' && utils.hasEndpoints(meta.device, [10, 11, 13])) {
+                // GL-C-008 RGBW
+                if (key === 'state' && value.toUpperCase() === 'OFF') {
+                    await converters.light_onoff_brightness.convertSet(meta.device.getEndpoint(11), key, value, meta);
+                }
+
+                entity = meta.state.white_value === -1 ? meta.device.getEndpoint(11) : meta.device.getEndpoint(13);
+            }
+
             return await converters.light_onoff_brightness.convertSet(entity, key, value, meta);
         },
         convertGet: async (entity, key, meta) => {
@@ -1036,6 +1045,31 @@ const converters = {
                             readAfterWriteTime: 0,
                         };
                     }
+                }
+            }
+
+            // GL-C-008 RGBW
+            if (meta.mapped.model === 'GL-C-008' && utils.hasEndpoints(meta.device, [10, 11, 13])) {
+                if (key === 'white_value') {
+                    // Switch from RGB to white
+                    await meta.device.getEndpoint(13).command('genOnOff', 'on', {});
+                    await meta.device.getEndpoint(11).command('genOnOff', 'off', {});
+
+                    const result = await converters.light_brightness.convertSet(
+                        meta.device.getEndpoint(13), key, value, meta
+                    );
+                    return {
+                        state: {white_value: value, ...result.state, color: xyWhite},
+                        readAfterWriteTime: 0,
+                    };
+                } else {
+                    if (meta.state.white_value !== -1) {
+                        // Switch from white to RGB
+                        await meta.device.getEndpoint(11).command('genOnOff', 'on', {});
+                        await meta.device.getEndpoint(13).command('genOnOff', 'off', {});
+                        state.white_value = -1;
+                    }
+                    entity = meta.device.getEndpoint(11);
                 }
             }
 

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -979,7 +979,7 @@ const converters = {
             if (meta.mapped.model === 'GL-C-008' && utils.hasEndpoints(meta.device, [10, 11, 13])) {
                 // GL-C-008 RGBW
                 if (key === 'state' && value.toUpperCase() === 'OFF') {
-                    await converters.light_onoff_brightness.convertSet(meta.device.getEndpoint(11), key, value, meta);
+                    await converters.light_onoff_brightness.convertSet(meta.device.getEndpoint(13), key, value, meta);
                 }
 
                 entity = meta.state.white_value === -1 ? meta.device.getEndpoint(11) : meta.device.getEndpoint(13);

--- a/devices.js
+++ b/devices.js
@@ -3088,6 +3088,15 @@ const devices = [
 
     // Gledopto
     {
+        zigbeeModel: ['GLEDOPTO'],
+        model: 'GL-C-007/GL-C-008',
+        vendor: 'Gledopto',
+        description: 'Zigbee LED controller RGB + CCT or RGBW',
+        extend: gledopto.light,
+        meta: {options: {disableDefaultResponse: true}},
+        supports: 'on/off, brightness, color temperature or white, color',
+    },
+    {
         zigbeeModel: ['GL-C-006'],
         model: 'GL-C-006',
         vendor: 'Gledopto',
@@ -3104,7 +3113,7 @@ const devices = [
         supports: 'on/off, brightness, color, white',
     },
     {
-        zigbeeModel: ['GL-C-008', 'GLEDOPTO'],
+        zigbeeModel: ['GL-C-008'],
         model: 'GL-C-008',
         vendor: 'Gledopto',
         description: 'Zigbee LED controller RGB + CCT',


### PR DESCRIPTION
GLEDOPTO model GL-C-008 RGBW is currently not supported anymore due to different endpoint structure. Fixes https://github.com/Koenkk/zigbee2mqtt/issues/2604

NOTE 1
It reports itself as "GL-C-008" (meta.mapped.model) but during ZigBee pairing is entered into the database with modelId "GLEDOPTO".

NOTE 2
Endpoint 11 is definitely controlling RGB. I'm not sure though if endpoint 13 controls white channel as my LED strip is RGB only. Might need to be changed to endpoint 10 if white channel can't be controlled.