### PR TITLE
Add support for TRAFRI 2nd gen motion sensor (E1745)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -739,7 +739,7 @@ const converters = {
             return lookup[value] ? lookup[value] : null;
         },
     },
-    E1525_occupancy: {
+    tradfri_occupancy: {
         cluster: 'genOnOff',
         type: 'commandOnWithTimedOff',
         convert: (model, msg, publish, options) => {
@@ -761,6 +761,17 @@ const converters = {
 
             return {occupancy: true};
         },
+    },
+    E1745_requested_brightness: {
+        // Possible values are 76 (30%) or 254 (100%)
+        cluster: 'genLevelCtrl',
+        type: 'commandMoveToLevelWithOnOff',
+        convert: (model, msg, publush, options) => {
+            return {
+                "requested_brightness_level": msg.data.level,
+                "requested_brightness_percent": Math.round(msg.data.level / 254 * 100)
+            }
+        }
     },
     occupancy_with_timeout: {
         // This is for occupancy sensor that only send a message when motion detected,

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -768,10 +768,10 @@ const converters = {
         type: 'commandMoveToLevelWithOnOff',
         convert: (model, msg, publush, options) => {
             return {
-                "requested_brightness_level": msg.data.level,
-                "requested_brightness_percent": Math.round(msg.data.level / 254 * 100)
-            }
-        }
+                requested_brightness_level: msg.data.level,
+                requested_brightness_percent: Math.round(msg.data.level / 254 * 100),
+            };
+        },
     },
     occupancy_with_timeout: {
         // This is for occupancy sensor that only send a message when motion detected,

--- a/devices.js
+++ b/devices.js
@@ -1108,7 +1108,22 @@ const devices = [
         vendor: 'IKEA',
         description: 'TRADFRI motion sensor',
         supports: 'occupancy',
-        fromZigbee: [fz.generic_battery, fz.E1525_occupancy],
+        fromZigbee: [fz.generic_battery, fz.tradfri_occupancy],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['TRADFRI motion sensor'],
+        model: 'E1745',
+        vendor: 'IKEA',
+        description: 'TRADFRI motion sensor (2nd gen)',
+        supports: 'occupancy',
+        fromZigbee: [fz.generic_battery, fz.tradfri_occupancy, fz.E1745_requested_brightness],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -1104,24 +1104,9 @@ const devices = [
     },
     {
         zigbeeModel: ['TRADFRI motion sensor'],
-        model: 'E1525',
+        model: 'E1525/E1745',
         vendor: 'IKEA',
         description: 'TRADFRI motion sensor',
-        supports: 'occupancy',
-        fromZigbee: [fz.generic_battery, fz.tradfri_occupancy],
-        toZigbee: [],
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await configureReporting.batteryPercentageRemaining(endpoint);
-        },
-    },
-    {
-        zigbeeModel: ['TRADFRI motion sensor'],
-        model: 'E1745',
-        vendor: 'IKEA',
-        description: 'TRADFRI motion sensor (2nd gen)',
         supports: 'occupancy',
         fromZigbee: [fz.generic_battery, fz.tradfri_occupancy, fz.E1745_requested_brightness],
         toZigbee: [],


### PR DESCRIPTION
[E1745 motion sensor](https://www.ikea.com/gb/en/p/tradfri-wireless-motion-sensor-white-70429913/) is the successor of the E1525. Main differences are:
- Timeout is not adjustable, it's always 3 minutes
- New button that requests bulb brightness to be either 30% or 100%.

I added E1745 as a new device, however it has the same modelID as the E1525 (`TRADFRI motion sensor`). I realized this is a problem after running the tests. @Koenkk What do you recommend in this case? Should I just modify the E1525 device, and add a note that it also covers the E1745? The only difference in behavior is that E1745 sends the requested brightness, but only after it was changed.