### PR TITLE
Eurotronics host flags fixed

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -843,17 +843,19 @@ const converters = {
                 const hostFlags = {...currentHostFlags, ...value};
 
                 // calculate bit value
-                let bitValue = 0;
+                let bitValue = 1; // bit 0 always 1
                 if (hostFlags.mirror_display) {
                     bitValue |= 1 << 1;
                 }
                 if (hostFlags.boost) {
                     bitValue |= 1 << 2;
                 }
-                if (hostFlags.window_open) {
-                    bitValue |= 1 << 5;
-                } else {
-                    bitValue |= 1 << 4;
+                if (value.hasOwnProperty('window_open') && value.window_open != currentHostFlags.window_open) {
+                    if (hostFlags.window_open) {
+                        bitValue |= 1 << 5;
+                    } else {
+                        bitValue |= 1 << 4;
+                    }
                 }
                 if (hostFlags.child_protection) {
                     bitValue |= 1 << 7;


### PR DESCRIPTION
Small fix in addition to @sjorge https://github.com/Koenkk/zigbee-herdsman-converters/pull/682

- bit 0: must be always 1

- bit 4/5: window_open (reset) only fired if value set/changed. (reset-routine (bit 4) fired always before, even if only other setting was touched)