### PR TITLE
Support currentSummDelivered for SP600

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1541,7 +1541,12 @@ const converters = {
             if (msg.data.hasOwnProperty('instantaneousDemand')) {
                 result.power = msg.data['instantaneousDemand'];
             }
-
+            // Summation is reported in Watthours
+            if (msg.data.hasOwnProperty('currentSummDelivered')) {
+                const data = msg.data['currentSummDelivered'];
+                const value = (parseInt(data[0]) << 32) + parseInt(data[1]);
+                result.energy = value / 1000.0;
+            }
             return result;
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -4594,6 +4594,7 @@ const devices = [
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
             await configureReporting.onOff(endpoint);
             await configureReporting.instantaneousDemand(endpoint);
+            await configureReporting.currentSummDelivered(endpoint);
             await endpoint.read('seMetering', ['multiplier', 'divisor']);
         },
     },


### PR DESCRIPTION
The SP600 is capable of reporting `currSummDelivered`, it seems to do so in Watthours.

Slightly OffTopic: Is there a way to find out which attributes the plug supports other than trying to get it to report them? I see the device is advertising a `msTemperatureMeasurement` cluster, alas I have failed to get it to report any temperatures.