### PR TITLE
Support for Busch-Jaeger 6735, 6736, and 6737 together w/ 6710 U & 6711 U

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2682,6 +2682,56 @@ const converters = {
             return {fan_mode: key, fan_state: key === 'off' ? 'OFF' : 'ON'};
         },
     },
+    RM01_on_click: {
+        cluster: 'genOnOff',
+        type: 'commandOn',
+        convert: (model, msg, publish, options) => {
+            const button = getKey(model.endpoint(msg.device), msg.endpoint.ID);
+            return {action: `${button}_on`};
+        },
+    },
+    RM01_off_click: {
+        cluster: 'genOnOff',
+        type: 'commandOff',
+        convert: (model, msg, publish, options) => {
+            const button = getKey(model.endpoint(msg.device), msg.endpoint.ID);
+            return {action: `${button}_off`};
+        },
+    },
+    RM01_down_hold: {
+        cluster: 'genLevelCtrl',
+        type: 'commandStep',
+        convert: (model, msg, publish, options) => {
+            const button = getKey(model.endpoint(msg.device), msg.endpoint.ID);
+            return {
+                action: `${button}_down`,
+                step_mode: msg.data.stepmode,
+                step_size: msg.data.stepsize,
+                transition_time: msg.data.transtime,
+            };
+        },
+    },
+    RM01_up_hold: {
+        cluster: 'genLevelCtrl',
+        type: 'commandStepWithOnOff',
+        convert: (model, msg, publish, options) => {
+            const button = getKey(model.endpoint(msg.device), msg.endpoint.ID);
+            return {
+                action: `${button}_up`,
+                step_mode: msg.data.stepmode,
+                step_size: msg.data.stepsize,
+                transition_time: msg.data.transtime,
+            };
+        },
+    },
+    RM01_stop: {
+        cluster: 'genLevelCtrl',
+        type: 'commandStop',
+        convert: (model, msg, publish, options) => {
+            const button = getKey(model.endpoint(msg.device), msg.endpoint.ID);
+            return {action: `${button}_stop`};
+        },
+    },
     GIRA2430_scene_click: {
         cluster: 'genScenes',
         type: 'commandRecall',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1672,7 +1672,7 @@ const converters = {
                 },
                 {disableDefaultResponse: true},
             );
-        }
+        },
     },
     RM01_on_off: {
         key: ['state'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1680,12 +1680,16 @@ const converters = {
             if (utils.hasEndpoints(meta.device, [0x12])) {
                 const endpoint = meta.device.getEndpoint(0x12);
                 return await converters.on_off.convertSet(endpoint, key, value, meta);
+            } else {
+                throw new Error('OnOff not supported on this RM01 device.');
             }
         },
         convertGet: async (entity, key, meta) => {
             if (utils.hasEndpoints(meta.device, [0x12])) {
                 const endpoint = meta.device.getEndpoint(0x12);
                 return await converters.on_off.convertGet(endpoint, key, meta);
+            } else {
+                throw new Error('OnOff not supported on this RM01 device.');
             }
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1672,6 +1672,21 @@ const converters = {
                 },
                 {disableDefaultResponse: true},
             );
+        }
+    },
+    RM01_on_off: {
+        key: ['state'],
+        convertSet: async (entity, key, value, meta) => {
+            if (utils.hasEndpoints(meta.device, [0x12])) {
+                const endpoint = meta.device.getEndpoint(0x12);
+                await converters.on_off.convertSet(endpoint, key, value, meta);
+            }
+        },
+        convertGet: async (entity, key, meta) => {
+            if (utils.hasEndpoints(meta.device, [0x12])) {
+                const endpoint = meta.device.getEndpoint(0x12);
+                await converters.on_off.convertGet(endpoint, key, meta);
+            }
         },
     },
 

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1679,13 +1679,13 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             if (utils.hasEndpoints(meta.device, [0x12])) {
                 const endpoint = meta.device.getEndpoint(0x12);
-                await converters.on_off.convertSet(endpoint, key, value, meta);
+                return await converters.on_off.convertSet(endpoint, key, value, meta);
             }
         },
         convertGet: async (entity, key, meta) => {
             if (utils.hasEndpoints(meta.device, [0x12])) {
                 const endpoint = meta.device.getEndpoint(0x12);
-                await converters.on_off.convertGet(endpoint, key, meta);
+                return await converters.on_off.convertGet(endpoint, key, meta);
             }
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -4736,6 +4736,12 @@ const devices = [
             for (let i = firstEndpoint; i <= 0x0d; i++) {
                 const endpoint = device.getEndpoint(i);
                 if (endpoint != null) {
+                    // The total number of bindings seems to be severely limited with these devices.
+                    // In order to be able to toggle groups, we need to remove the scenes cluster
+                    const index = endpoint.outputClusters.indexOf(5);
+                    if (index > -1) {
+                        endpoint.outputClusters.splice(index, 1);
+                    }
                     await bind(endpoint, coordinatorEndpoint, ['genLevelCtrl']);
                 }
             }

--- a/devices.js
+++ b/devices.js
@@ -4715,7 +4715,7 @@ const devices = [
     },
     {
         // Busch-Jaeger 6735, 6736, and 6737 have been tested with the 6710 U (Power Adapter) and
-        // 6711 U (Relais) back-ends. The dimmer has not been verified to work yet, though it's
+        // 6711 U (Relay) back-ends. The dimmer has not been verified to work yet, though it's
         // safe to assume that it can at least been turned on or off with this integration.
         //
         // In order to manually capture scenes as described in the devices manual, the endpoint
@@ -4725,10 +4725,10 @@ const devices = [
         zigbeeModel: ['RM01'],
         model: '6735/6736/6737',
         vendor: 'Busch-Jaeger',
-        description: 'Busch-Jaeger 6735, 6736, 6737',
+        description: 'Zigbee Light Link power supply/relay/dimmer',
         supports: 'on/off',
         endpoint: (device) => {
-            return {'row_1': 0x0a, 'row_2': 0x0b, 'row_3': 0x0c, 'row_4': 0x0d, 'light': 0x12};
+            return {'row_1': 0x0a, 'row_2': 0x0b, 'row_3': 0x0c, 'row_4': 0x0d, 'relay': 0x12};
         },
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -4715,7 +4715,7 @@ const devices = [
     },
     {
         zigbeeModel: ['RM01'],
-        model: 'RM01',
+        model: '6735/6736/6737',
         vendor: 'Busch-Jaeger',
         description: 'Busch-Jaeger 6735, 6736, 6737',
         supports: 'on/off',

--- a/devices.js
+++ b/devices.js
@@ -4714,6 +4714,14 @@ const devices = [
         toZigbee: [tz.on_off],
     },
     {
+        // Busch-Jaeger 6735, 6736, and 6737 have been tested with the 6710 U (Power Adapter) and
+        // 6711 U (Relais) back-ends. The dimmer has not been verified to work yet, though it's
+        // safe to assume that it can at least been turned on or off with this integration.
+        //
+        // In order to manually capture scenes as described in the devices manual, the endpoint
+        // corresponding to the row needs to be unbound (https://www.zigbee2mqtt.io/information/binding.html)
+        // If that operation was successful, the switch will respond to button presses on that
+        // by blinking multiple times (vs. just blinking once if it's bound).
         zigbeeModel: ['RM01'],
         model: '6735/6736/6737',
         vendor: 'Busch-Jaeger',

--- a/devices.js
+++ b/devices.js
@@ -4722,7 +4722,7 @@ const devices = [
         endpoint: (device) => {
             return {'row_1': 0x0a, 'row_2': 0x0b, 'row_3': 0x0c, 'row_4': 0x0d, 'light': 0x12};
         },
-        meta: {configureKey: 3},
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             let firstEndpoint = 0x0a;
 
@@ -4736,7 +4736,7 @@ const devices = [
             for (let i = firstEndpoint; i <= 0x0d; i++) {
                 const endpoint = device.getEndpoint(i);
                 if (endpoint != null) {
-                    await bind(endpoint, coordinatorEndpoint, ['genLevelCtrl', 'genScenes']);
+                    await bind(endpoint, coordinatorEndpoint, ['genLevelCtrl']);
                 }
             }
         },
@@ -4744,7 +4744,7 @@ const devices = [
             fz.ignore_basic_report, fz.on_off, fz.RM01_on_click, fz.RM01_off_click,
             fz.RM01_up_hold, fz.RM01_down_hold, fz.RM01_stop,
         ],
-        toZigbee: [tz.on_off],
+        toZigbee: [tz.RM01_on_off],
         onEvent: async (type, data, device) => {
             const switchEndpoint = device.getEndpoint(0x12);
             if (switchEndpoint == null) {


### PR DESCRIPTION
Busch-Jaeger offers a set of Light Link devices that are not currently supported as e.g. reported in Koenkk/zigbee2mqtt#418. 

Offered are:
- 6710U: Power adapter only
- 6711U: Relais
- 6715U: LED Dimmer

Those are controlled by 6735, 6736, or 6737 devices which are either 1-switch, 2-switch, or 4-switch interfaces. Unless you put those devices onto the 6710U, the topmost switch always controls either relais or dimmer, while the other switches can be programmed to activate certain scenes.

At the moment, I only have a 6710U available, which exposes a 6736 via two endpoints: 10 & 11. According to my information and 6737 would expose the switch as endpoint 10-13. I should receive a 6711 later this week and I am pretty sure I have a 6715 lying around somewhere - I just have to find it.

From that perspective, I'd be okay with keeping this PR open for a while, though it might be useful to others as the information in Koenkk/zigbee2mqtt#418 seems to be outdated.

Now, I have to no idea if this is the right thing to expose such a devices, if there are better ways, perhaps conforming more to z2m handles things, please let me know. 