### PR TITLE
Add another zigbeeModel to Sunricher switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5495,7 +5495,7 @@ const devices = [
         extend: generic.light_onoff_brightness,
     },
     {
-        zigbeeModel: ['ON/OFF'],
+        zigbeeModel: ['ON/OFF', 'ZIGBEE-SWITCH'],
         model: 'ZG9101SAC-HP-Switch',
         vendor: 'Sunricher',
         description: 'ZigBee AC in-wall switch',


### PR DESCRIPTION
I bought two switches, and they had different model names and firmware versions. I believe they changed it in the firmware, since this device had `2.3.1_r21` and the other had `2.4.1_r33`. According to https://github.com/Koenkk/zigbee-herdsman/issues/60 OTA updates are not implemented, so I guess it should support both model names.

I verified it by building zigbee2mqtt 1.8.0-dev with this fork.