### PR TITLE
Fixed issue with illuminize 511.202

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5686,9 +5686,15 @@ const devices = [
         toZigbee: [tz.on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(3);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
-            await configureReporting.onOff(endpoint);
+            const ep1 = device.getEndpoint(1);
+            if (ep1 != null) {
+                await bind(ep1, coordinatorEndpoint, ['genOnOff']);
+                await configureReporting.onOff(ep1);
+            } else {
+                const ep3 = device.getEndpoint(3);
+                await bind(ep3, coordinatorEndpoint, ['genOnOff']);
+                await configureReporting.onOff(ep3);
+            }
         },
     },
 


### PR DESCRIPTION
Apparently, my illuminize 511.202 doesn't expose endpoint 3. Instead it exposes 1 and 242, with 1 being the switch. I've changed the existing code so that it checks for ep1 first, then falls back to ep3.