### PR TITLE
Add support for `lumi.ctrl_ln2`

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -575,7 +575,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['lumi.ctrl_ln2.aq1'],
+        zigbeeModel: ['lumi.ctrl_ln2.aq1', 'lumi.ctrl_ln2'],
         model: 'QBKG12LM',
         vendor: 'Xiaomi',
         description: 'Aqara double key wired wall switch',


### PR DESCRIPTION
This fixes the, where the `lumi.ctrl_ln2` is exactly the same as `lumi.ctrl_ln2.aq1`:

```
2020-01-08.09-59-19/log.txt:warn  2020-01-08 10:12:28: Received message from unsupported device with Zigbee model 'lumi.ctrl_ln2'
2020-01-08.09-59-19/log.txt-warn  2020-01-08 10:12:28: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
```