### PR TITLE
Fixes #897: SP600 now uses generic_power converter

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1571,25 +1571,6 @@ const converters = {
             };
         },
     },
-    SP600_power: {
-        cluster: 'seMetering',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options) => {
-            // Cannot use generic_power, divisor/multiplier is not according to ZCL.
-            // https://github.com/Koenkk/zigbee2mqtt/issues/2233
-            const result = {};
-            if (msg.data.hasOwnProperty('instantaneousDemand')) {
-                result.power = msg.data['instantaneousDemand'];
-            }
-            // Summation is reported in Watthours
-            if (msg.data.hasOwnProperty('currentSummDelivered')) {
-                const data = msg.data['currentSummDelivered'];
-                const value = (parseInt(data[0]) << 32) + parseInt(data[1]);
-                result.energy = value / 1000.0;
-            }
-            return result;
-        },
-    },
     SP120_power: {
         cluster: 'haElectricalMeasurement',
         type: ['attributeReport', 'readResponse'],

--- a/devices.js
+++ b/devices.js
@@ -4780,7 +4780,7 @@ const devices = [
         vendor: 'Salus',
         description: 'Smart plug',
         supports: 'on/off, power measurement',
-        fromZigbee: [fz.on_off, fz.SP600_power],
+        fromZigbee: [fz.on_off, fz.generic_power],
         toZigbee: [tz.on_off],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Removed the `SP600_power` converter and reverts back to the default `generic_power`.

The default converter started working properly when #849 was merged, so we don't need the "hacked" one any more!