### PR TITLE
add support for Philips LWA002/9290018215

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1353,6 +1353,13 @@ const devices = [
         extend: hue.light_onoff_brightness,
     },
     {
+        zigbeeModel: ['LWA002'],
+        model: '9290018215',
+        vendor: 'Philips',
+        description: 'Hue white A19 bulb E26 bluetooth',
+        extend: hue.light_onoff_brightness,
+    },
+    {
         zigbeeModel: ['LTA001'],
         model: '9290022169',
         vendor: 'Philips',


### PR DESCRIPTION
I bought this bulb that seems almost identical to LWA001/9290011370 (already supported).  It has the same shape and supports bluetooth as well.  I'm guessing it might be the North American model, as the box does say E26 instead of E27.  Since it isn't supported yet, I've added it in.