### PR TITLE
Rounds energy value in the generic_power converter

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1474,17 +1474,18 @@ const converters = {
 
             if (factor != null && (msg.data.hasOwnProperty('currentSummDelivered') ||
                 msg.data.hasOwnProperty('currentSummReceived'))) {
-                result.energy = 0;
+                let energy = 0;
                 if (msg.data.hasOwnProperty('currentSummDelivered')) {
                     const data = msg.data['currentSummDelivered'];
                     const value = (parseInt(data[0]) << 32) + parseInt(data[1]);
-                    result.energy += value * factor;
+                    energy += value * factor;
                 }
                 if (msg.data.hasOwnProperty('currentSummReceived')) {
                     const data = msg.data['currentSummReceived'];
                     const value = (parseInt(data[0]) << 32) + parseInt(data[1]);
-                    result.energy -= value * factor;
+                    energy -= value * factor;
                 }
+                result.energy = precisionRound(energy, 2);
             }
 
             return result;


### PR DESCRIPTION
```
zigbee2mqtt:debug 2020-01-14 00:47:52: Received Zigbee message from 'SmartPlug6', type 'attributeReport', cluster 'seMetering', data '{"currentSummDelivered":[0,6636]}' from endpoint 9 with groupID 0
zigbee2mqtt:info  2020-01-14 00:47:52: MQTT publish: topic 'zigbee2mqtt/SmartPlug6', payload '{"state":"OFF","linkquality":26,"power":0,"energy":0.6636000000000001}'
```

The above debug log shows an SP600 reporting the values `[0, 6636]` for power and a 10000 value for divisor.

However, it will calculate and report `0.6636000000000001` as the energy value, this due to some javascript math issue, so this PR will ensure that the value reported is rounded to 2 decimals.