### PR TITLE
Added support for Paul Neuhaus Q-Flag

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4695,6 +4695,13 @@ const devices = [
         fromZigbee: [fz.on_off],
         toZigbee: [tz.on_off],
     },
+    {
+        zigbeeModel: ['JZ-CT-Z01'],
+        model: '4034031P7',
+        vendor: 'Paul Neuhaus',
+        description: 'Q-FLAG LED Panel, Smart-Home CCT',
+        extend: generic.light_onoff_brightness_colortemp,
+    },
 
     // iCasa
     {

--- a/devices.js
+++ b/devices.js
@@ -4697,9 +4697,9 @@ const devices = [
     },
     {
         zigbeeModel: ['JZ-CT-Z01'],
-        model: '4034031P7',
+        model: '100.110.51',
         vendor: 'Paul Neuhaus',
-        description: 'Q-FLAG LED Panel, Smart-Home CCT',
+        description: 'Q-FLAG LED panel, Smart-Home CCT',
         extend: generic.light_onoff_brightness_colortemp,
     },
 


### PR DESCRIPTION
This adds support for a Paul Neuhaus Q-Flag LED Panel CCT. (https://www.paul-neuhaus.de/shop/de/led-panel-smart-home-alexa-tauglich-100-110-51.html)

The device itself announces itself as a Greeble JZ-CT-Z01. I am guessing that Paul Neuhaus is just reselling it. Let me know if you'd rather track this as a Greeble instead.