### PR TITLE
Update to Sinope TH1123ZB

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2231,6 +2231,18 @@ const converters = {
             return result;
         },
     },
+    sinope_thermostat_state: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options) => {
+            const result = {};
+            const piHeatingDemand = msg.data['pIHeatingDemand'];
+            if (typeof piHeatingDemand == 'number') {
+                result.operation = piHeatingDemand >= 10 ? 'heating' : 'idle';
+            }
+            return result;
+        },
+    },
     eurotronic_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],

--- a/devices.js
+++ b/devices.js
@@ -6146,34 +6146,54 @@ const devices = [
 
     // Sinope
     {
-        zigbeeModel: ['TH1123ZB'],
-        model: 'TH1123ZB',
-        vendor: 'Sinope',
-        description: 'Zigbee line volt thermostat',
-        supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
-        fromZigbee: [
-            fz.thermostat_att_report,
-        ],
-        toZigbee: [
-            tz.thermostat_local_temperature,
-            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout,
-            tz.thermostat_system_mode, tz.thermostat_running_state,
-            tz.sinope_thermostat_occupancy, tz.sinope_thermostat_backlight_autodim_param, tz.sinope_thermostat_time,
-            tz.sinope_thermostat_enable_outdoor_temperature, tz.sinope_thermostat_outdoor_temperature,
-        ],
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
+    zigbeeModel: ['TH1123ZB'],
+    model: 'TH1123ZB',
+    vendor: 'Sinope',
+    description: 'Zigbee line volt thermostat',
+    supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
+    fromZigbee: [
+        fz.thermostat_att_report,
+        fz.hvac_user_interface,
+        fz.generic_power,
+        fz.ignore_temperature_report,
+        fz.sinope_thermostat_state,
+    ],
+    toZigbee: [
+        tz.thermostat_local_temperature,
+        tz.thermostat_occupied_heating_setpoint,
+        tz.thermostat_unoccupied_heating_setpoint,
+        tz.thermostat_temperature_display_mode,
+        tz.thermostat_keypad_lockout,
+        tz.thermostat_system_mode,
+        tz.thermostat_running_state,
+        tz.sinope_thermostat_occupancy,
+        tz.sinope_thermostat_backlight_autodim_param,
+        tz.sinope_thermostat_time,
+        tz.sinope_thermostat_enable_outdoor_temperature,
+        tz.sinope_thermostat_outdoor_temperature,
+    ],
+    meta: {configureKey: 1},
+    configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const binds = [
-                'genBasic', 'genIdentify', 'genGroups', 'hvacThermostat', 'hvacUserInterfaceCfg',
+                'genBasic',
+                'genIdentify',
+                'genGroups',
+                'hvacThermostat',
+                'hvacUserInterfaceCfg',
                 'msTemperatureMeasurement',
+                'seMetering',
             ];
-            await bind(endpoint, coordinatorEndpoint, binds);
-            await configureReporting.thermostatTemperature(endpoint);
-            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await configureReporting.thermostatPIHeatingDemand(endpoint);
-        },
+
+        await bind(endpoint, coordinatorEndpoint, binds);
+        await configureReporting.thermostatTemperature(endpoint, 10, 60, 50);
+        await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, 1, 0, 50);
+        await configureReporting.thermostatSystemMode(endpoint, 1, 0);
+        await configureReporting.thermostatPIHeatingDemand(endpoint, 1, 900, 5);
+        await configureReporting.thermostatKeypadLockMode(endpoint, 1, 0);
+        await configureReporting.instantaneousDemand(endpoint);
+        await endpoint.read('seMetering', ['multiplier', 'divisor']);
+      },
     },
     {
         zigbeeModel: ['TH1124ZB'],

--- a/devices.js
+++ b/devices.js
@@ -5331,6 +5331,7 @@ const devices = [
                 'genGroups',
                 'hvacThermostat',
                 'hvacUserInterfaceCfg',
+                'msRelativeHumidity',
                 'msTemperatureMeasurement',
             ];
             await bind(endpoint, coordinatorEndpoint, binds);

--- a/devices.js
+++ b/devices.js
@@ -5322,7 +5322,7 @@ const devices = [
             tz.thermostat_running_state,
             tz.stelpro_thermostat_outdoor_temperature,
         ],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(25);
             const binds = [
@@ -6146,54 +6146,49 @@ const devices = [
 
     // Sinope
     {
-    zigbeeModel: ['TH1123ZB'],
-    model: 'TH1123ZB',
-    vendor: 'Sinope',
-    description: 'Zigbee line volt thermostat',
-    supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
-    fromZigbee: [
-        fz.thermostat_att_report,
-        fz.hvac_user_interface,
-        fz.generic_power,
-        fz.ignore_temperature_report,
-        fz.sinope_thermostat_state,
-    ],
-    toZigbee: [
-        tz.thermostat_local_temperature,
-        tz.thermostat_occupied_heating_setpoint,
-        tz.thermostat_unoccupied_heating_setpoint,
-        tz.thermostat_temperature_display_mode,
-        tz.thermostat_keypad_lockout,
-        tz.thermostat_system_mode,
-        tz.thermostat_running_state,
-        tz.sinope_thermostat_occupancy,
-        tz.sinope_thermostat_backlight_autodim_param,
-        tz.sinope_thermostat_time,
-        tz.sinope_thermostat_enable_outdoor_temperature,
-        tz.sinope_thermostat_outdoor_temperature,
-    ],
-    meta: {configureKey: 1},
-    configure: async (device, coordinatorEndpoint) => {
+        zigbeeModel: ['TH1123ZB'],
+        model: 'TH1123ZB',
+        vendor: 'Sinope',
+        description: 'Zigbee line volt thermostat',
+        supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
+        fromZigbee: [
+            fz.thermostat_att_report,
+            fz.hvac_user_interface,
+            fz.generic_power,
+            fz.ignore_temperature_report,
+            fz.sinope_thermostat_state,
+        ],
+        toZigbee: [
+            tz.thermostat_local_temperature,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_temperature_display_mode,
+            tz.thermostat_keypad_lockout,
+            tz.thermostat_system_mode,
+            tz.thermostat_running_state,
+            tz.sinope_thermostat_occupancy,
+            tz.sinope_thermostat_backlight_autodim_param,
+            tz.sinope_thermostat_time,
+            tz.sinope_thermostat_enable_outdoor_temperature,
+            tz.sinope_thermostat_outdoor_temperature,
+        ],
+        meta: {configureKey: 2},
+        configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const binds = [
-                'genBasic',
-                'genIdentify',
-                'genGroups',
-                'hvacThermostat',
-                'hvacUserInterfaceCfg',
-                'msTemperatureMeasurement',
-                'seMetering',
+                'genBasic', 'genIdentify', 'genGroups', 'hvacThermostat',
+                'hvacUserInterfaceCfg', 'msTemperatureMeasurement', 'seMetering',
             ];
 
-        await bind(endpoint, coordinatorEndpoint, binds);
-        await configureReporting.thermostatTemperature(endpoint, 10, 60, 50);
-        await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, 1, 0, 50);
-        await configureReporting.thermostatSystemMode(endpoint, 1, 0);
-        await configureReporting.thermostatPIHeatingDemand(endpoint, 1, 900, 5);
-        await configureReporting.thermostatKeypadLockMode(endpoint, 1, 0);
-        await configureReporting.instantaneousDemand(endpoint);
-        await endpoint.read('seMetering', ['multiplier', 'divisor']);
-      },
+            await bind(endpoint, coordinatorEndpoint, binds);
+            await configureReporting.thermostatTemperature(endpoint, 10, 60, 50);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, 1, 0, 50);
+            await configureReporting.thermostatSystemMode(endpoint, 1, 0);
+            await configureReporting.thermostatPIHeatingDemand(endpoint, 1, 900, 5);
+            await configureReporting.thermostatKeypadLockMode(endpoint, 1, 0);
+            await configureReporting.instantaneousDemand(endpoint);
+            await endpoint.read('seMetering', ['multiplier', 'divisor']);
+        },
     },
     {
         zigbeeModel: ['TH1124ZB'],


### PR DESCRIPTION

    Added bind for seMetering (generic power).
    Added config reporting for system mode (did not report system_mode in HA, now does).
    Added config reporting for keypad lockout.
    Added converter to ignore [temp att_report] to avoid missing converter message.
    Added converter for reporting current state of heating.
    It's not perfect. For the moment I get voltage but current stays at 0. Still better than it was, I needed system_mode which now reports in HA. Also added a converter to fromzigbee using the code of @carldebilly for reporting current status (heating vs idle).
