### PR TITLE
Add support for Hive thermostat SLR1b and remote WPT1

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2206,6 +2206,32 @@ const converters = {
             if (typeof msg.data['pIHeatingDemand'] == 'number') {
                 result.pi_heating_demand = precisionRound(msg.data['pIHeatingDemand'] / 255.0 * 100.0, 0);
             }
+            if (typeof msg.data['tempSetpointHold'] == 'number') {
+                result.temperature_setpoint_hold = msg.data['tempSetpointHold'];
+            }
+            if (typeof msg.data['tempSetpointHoldDuration'] == 'number') {
+                result.temperature_setpoint_hold_duration = msg.data['tempSetpointHoldDuration'];
+            }
+            return result;
+        },
+    },
+    thermostat_weekly_schedule_rsp: {
+        cluster: 'hvacThermostat',
+        type: ['commandGetWeeklyScheduleRsp'],
+        convert: (model, msg, publish, options, meta) => {
+            const result = {};
+            result.weekly_schedule = {};
+            if (typeof msg.data['dayofweek'] == 'number') {
+                result.weekly_schedule[msg.data['dayofweek']] = msg.data;
+                for (const elem of result.weekly_schedule[msg.data['dayofweek']]['transitions']) {
+                    if (typeof elem['heatSetpoint'] == 'number') {
+                        elem['heatSetpoint'] /= 100;
+                    }
+                    if (typeof elem['coolSetpoint'] == 'number') {
+                        elem['coolSetpoint'] /= 100;
+                    }
+                }
+            }
             return result;
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -225,6 +225,24 @@ const configureReporting = {
         }];
         await endpoint.configureReporting('hvacThermostat', payload);
     },
+    thermostatTemperatureSetpointHold: async (endpoint, min=0, max=repInterval.HOUR) => {
+        const payload = [{
+            attribute: 'tempSetpointHold',
+            minimumReportInterval: min,
+            maximumReportInterval: max,
+            reportableChange: 0,
+        }];
+        await endpoint.configureReporting('hvacThermostat', payload);
+    },
+    thermostatTemperatureSetpointHoldDuration: async (endpoint, min=0, max=repInterval.HOUR, change=10) => {
+        const payload = [{
+            attribute: 'tempSetpointHoldDuration',
+            minimumReportInterval: min,
+            maximumReportInterval: max,
+            reportableChange: change,
+        }];
+        await endpoint.configureReporting('hvacThermostat', payload);
+    },
     presentValue: async (endpoint) => {
         const payload = [{
             attribute: 'presentValue',
@@ -2050,8 +2068,7 @@ const devices = [
             tz.thermostat_occupancy, tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_unoccupied_heating_setpoint, tz.thermostat_setpoint_raise_lower,
             tz.thermostat_remote_sensing, tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
-            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_weekly_schedule_rsp,
-            tz.thermostat_relay_status_log, tz.thermostat_relay_status_log_rsp,
+            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_relay_status_log,
         ],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
@@ -2405,6 +2422,49 @@ const devices = [
             await configureReporting.thermostatPIHeatingDemand(endpoint);
         },
     },
+    {
+        zigbeeModel: ['SLR1b'],
+        model: 'SLR1b',
+        vendor: 'Hive',
+        description: 'Heating thermostat',
+        supports: 'thermostat, occupied heating, weekly schedule',
+        fromZigbee: [fz.thermostat_att_report, fz.thermostat_weekly_schedule_rsp],
+        toZigbee: [
+            tz.thermostat_local_temperature, tz.thermostat_system_mode, tz.thermostat_running_state,
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation,
+            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule,
+            tz.thermostat_temperature_setpoint_hold, tz.thermostat_temperature_setpoint_hold_duration,
+        ],
+        meta: {
+            configureKey: 1,
+            options: {disableDefaultResponse: true},
+        },
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(5);
+            const binds = [
+                'genBasic', 'genIdentify', 'genAlarms', 'genTime', 'hvacThermostat',
+            ];
+            await bind(endpoint, coordinatorEndpoint, binds);
+            await configureReporting.thermostatTemperature(endpoint, 0, repInterval.HOUR, 1);
+            await configureReporting.thermostatRunningState(endpoint);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await configureReporting.thermostatTemperatureSetpointHold(endpoint);
+            await configureReporting.thermostatTemperatureSetpointHoldDuration(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['WPT1'],
+        model: 'WPT1',
+        vendor: 'Hive',
+        description: 'Heating thermostat remote control',
+        supports: 'none, communicate via thermostat',
+        fromZigbee: [],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            // There is nothing to do here but mata and configure are required to have device "configured".
+        },
+    },
 
     // Innr
     {
@@ -2671,6 +2731,7 @@ const devices = [
         supports: 'on/off',
         fromZigbee: [fz.on_off],
         toZigbee: [tz.on_off],
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
@@ -6643,8 +6704,7 @@ const devices = [
             tz.thermostat_occupied_cooling_setpoint,
             tz.thermostat_unoccupied_heating_setpoint, tz.thermostat_setpoint_raise_lower,
             tz.thermostat_remote_sensing, tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
-            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_weekly_schedule_rsp,
-            tz.thermostat_relay_status_log, tz.thermostat_relay_status_log_rsp,
+            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_relay_status_log,
         ],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -2460,10 +2460,6 @@ const devices = [
         supports: 'none, communicate via thermostat',
         fromZigbee: [],
         toZigbee: [],
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            // There is nothing to do here but mata and configure are required to have device "configured".
-        },
     },
 
     // Innr


### PR DESCRIPTION
This pull request is not fully ready yet. getWeeklySchedule support is functional (i.e. I can get and set weekly schedule) but most probably it will require more work. I published it here to discuss implementation details. Another part of the required changes in https://github.com/Koenkk/zigbee-herdsman/pull/128

As far as I understand getWeeklySchedule  is very different from other requests because thermostat responses with multiple messages and I don't know how the data should be presented in Z2M. I choose dictionary of the day to payload. Also perhaps it make sense to decode thermoseqmode instead of using raw message format. Another problem that I see timeout in log:
```
zigbee2mqtt:error 2020-01-18 14:36:15: Publish 'get' 'weekly_schedule' to '0x001e5e0902478585' failed: 'Error: Timeout - 25726 - 5 - 4 - 513 - 11 after 15000ms'
zigbee2mqtt:debug 2020-01-18 14:36:15: Error: Timeout - 25726 - 5 - 4 - 513 - 11 after 15000ms                                                                                                        
  at Timeout.object.timer.setTimeout [as _onTimeout] (/home/pi/zigbee-herdsman/dist/utils/waitress.js:46:24)                                                                                        
  at ontimeout (timers.js:436:11)                                                                                                                                                                   
  at tryOnTimeout (timers.js:300:5)                                                                                                                                                                 
  at listOnTimeout (timers.js:263:5)                                                                                                                                                                
  at Timer.processTimers (timers.js:223:10)    
```
The timeout seems to cause no harm but it something that  needs to be fixed.