### PR TITLE
Support for SZ-DWS04N_SF  and SZ-PIR02_SF

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5961,6 +5961,37 @@ const devices = [
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
     },
+    {
+        zigbeeModel: ['SZ-DWS04N_SF'],
+        model: 'SZ-DWS04N_SF',
+        vendor: 'Sercomm',
+        description: 'Magnetic door & window contact sensor',
+        supports: 'contact',
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery_3V_2100],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await configureReporting.temperature(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['SZ-PIR02_SF'],
+        model: 'SZ-PIR02_SF',
+        vendor: 'Sercomm',
+        description: 'PIR motion sensor',
+        supports: 'occupancy',
+        fromZigbee: [fz.iaszone_occupancy_1, fz.battery_3V_2100],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
 
     // Leedarson
     {

--- a/devices.js
+++ b/devices.js
@@ -5963,7 +5963,7 @@ const devices = [
     },
     {
         zigbeeModel: ['SZ-PIR02_SF'],
-        model: 'SZ-PIR02_SF',
+        model: 'AL-PIR02',
         vendor: 'Sercomm',
         description: 'PIR motion sensor',
         supports: 'occupancy',

--- a/devices.js
+++ b/devices.js
@@ -5946,24 +5946,8 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['SZ-DWS04'],
+        zigbeeModel: ['SZ-DWS04', 'SZ-DWS04N_SF'],
         model: 'SZ-DWS04',
-        vendor: 'Sercomm',
-        description: 'Magnetic door & window contact sensor',
-        supports: 'contact',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery_3V_2100],
-        toZigbee: [],
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
-            await configureReporting.temperature(endpoint);
-            await configureReporting.batteryPercentageRemaining(endpoint);
-        },
-    },
-    {
-        zigbeeModel: ['SZ-DWS04N_SF'],
-        model: 'SZ-DWS04N_SF',
         vendor: 'Sercomm',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact',


### PR DESCRIPTION
Added support for new Sercomm devices: SZ-DWS04N_SF contact sensor and SZ-PIR02_SF motion sensor. These devices are typically branded as Securifi contact sensor and motion sensor.