### PR TITLE
Added support for Almond Click multi-function button ZB2-BU01

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3749,6 +3749,37 @@ const converters = {
             }
         },
     },
+    almond_click: {
+        cluster: 'ssIasAce',
+        type: ['commandArm'],
+        convert: (model, msg, publish, options, meta) => {
+            const action = msg.data['armmode'];
+            delete msg.data['armmode'];
+            const lookup = {
+                3: {click: 'single'}, // single click
+                0: {click: 'double'}, // double
+                2: {click: 'long'}, // hold
+            };
+
+            // Workaround to ignore duplicated (false) presses that
+            // are 100ms apart, since the button often generates
+            // multiple duplicated messages for a single click event.
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {since: 0};
+            }
+
+            const now = Date.now();
+            const since = store[deviceID].since;
+
+            if ((now-since)>100) {
+                store[deviceID].since = now;
+                return lookup[action] ? lookup[action] : null;
+            } else {
+                return;
+            }
+        },
+    },
 
     // Ignore converters (these message dont need parsing).
     ignore_onoff_report: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3756,9 +3756,9 @@ const converters = {
             const action = msg.data['armmode'];
             delete msg.data['armmode'];
             const lookup = {
-                3: {click: 'single'}, // single click
-                0: {click: 'double'}, // double
-                2: {click: 'long'}, // hold
+                3: {action: 'single'}, // single click
+                0: {action: 'double'}, // double
+                2: {action: 'long'}, // hold
             };
 
             // Workaround to ignore duplicated (false) presses that

--- a/devices.js
+++ b/devices.js
@@ -5582,7 +5582,7 @@ const devices = [
     },
     {
         zigbeeModel: ['ZB2-BU01'],
-        model: 'ZB2-BU01',
+        model: 'B01M7Y8BP9',
         vendor: 'Securifi',
         description: 'Almond Click multi-function button',
         supports: 'single, double and long click',

--- a/devices.js
+++ b/devices.js
@@ -5580,6 +5580,15 @@ const devices = [
             await configureReporting.acPowerDivisor(endpoint);
         },
     },
+    {
+        zigbeeModel: ['ZB2-BU01'],
+        model: 'ZB2-BU01',
+        vendor: 'Securifi',
+        description: 'Almond Click multi-function button',
+        supports: 'single, double and long click',
+        fromZigbee: [fz.almond_click],
+        toZigbee: [],
+    },
 
     // Visonic
     {


### PR DESCRIPTION
This code adds support for Almond Click multi-function button ZB2-BU01.

However, the button is not configured automatically because it does not advertise its ModelId "ZB2-BU01" (which stays undefined). It needs to be added manually to devices.db after the device has been discovered (after stopping zigbee2mqtt). Once zigbee2mqtt is restarted, the device is configured correctly.

As future work, this is the message that can help configure  automatically the device:
Received Zigbee message from 'XXX, type 'raw', cluster 'genBasic', data '{"type":"Buffer","data":[8,XXX,1,5,0,0,66,32,90,66,50,45,66,85,48,49,32,0,0,255,255,0,0,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,4,0,0,66,32,83,101,99,117,114,105,102,105,32,76,116,100,46,32,0,32,90,66,50,45,66,85,48,49,32,0,0,255,255,0,0,255,7,0,0,48]}

All data stays the same except for XXX.