### PR TITLE
Added support for Linkind Smart Zigbee LED

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7370,6 +7370,14 @@ const devices = [
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genBinaryInput']);
         },
     },
+    {
+        zigbeeModel: ['ZBT-CCTLight-D0106'],
+        model: 'ZBT-CCTLight-D0106',
+        vendor: 'lk',
+        description: 'Linkind Smart Zigbee LED Bulb',
+        supports: 'on/off, brightness',
+        extend: generic.light_onoff_brightness,
+    },
 ];
 
 module.exports = devices.map((device) =>

--- a/devices.js
+++ b/devices.js
@@ -7370,12 +7370,13 @@ const devices = [
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genBinaryInput']);
         },
     },
+    
+    // Linkind
     {
         zigbeeModel: ['ZBT-CCTLight-D0106'],
-        model: 'ZBT-CCTLight-D0106',
-        vendor: 'lk',
-        description: 'Linkind Smart Zigbee LED Bulb',
-        supports: 'on/off, brightness',
+        model: 'ZL1000100-CCT-US-V1A02',
+        vendor: 'Linkind',
+        description: 'Zigbee LED 9W A19 bulb, dimmable & tunable',
         extend: generic.light_onoff_brightness,
     },
 ];


### PR DESCRIPTION
Added support for Linkind Smart Zigbee LED
( https://www.linkind.com/product-page/smart-zigbee-led-9w-a19-bulb-dimmable-tunable-hub-required-alexa-control )