### PR TITLE
Fix wisertrv reporting and bind errors (Table Full)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8073,8 +8073,7 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const binds = [
-                'genBasic', 'genPowerCfg', 'genIdentify', 'genPollCtrl',
-                'hvacThermostat', 'hvacUserInterfaceCfg', 'haDiagnostic',
+                'genBasic', 'genPowerCfg', 'hvacThermostat', 'haDiagnostic',
             ];
             await bind(endpoint, coordinatorEndpoint, binds);
             await configureReporting.batteryVoltage(endpoint);

--- a/devices.js
+++ b/devices.js
@@ -26,6 +26,7 @@ const store = {};
 const repInterval = {
     MAX: 62000,
     HOUR: 3600,
+    MINUTES_15: 900,
     MINUTES_10: 600,
     MINUTES_5: 300,
     MINUTE: 60,
@@ -8077,9 +8078,9 @@ const devices = [
             ];
             await bind(endpoint, coordinatorEndpoint, binds);
             await configureReporting.batteryVoltage(endpoint);
-            await configureReporting.thermostatTemperature(endpoint);
-            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await configureReporting.thermostatPIHeatingDemand(endpoint);
+            await configureReporting.thermostatTemperature(endpoint, 0, repInterval.MINUTES_15, 25);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, 0, repInterval.MINUTES_15, 25);
+            await configureReporting.thermostatPIHeatingDemand(endpoint, 0, repInterval.MINUTES_15, 1);
             const userInterfaceConfig = [
                 {
                     attribute: 'keypadLockout',

--- a/devices.js
+++ b/devices.js
@@ -8089,7 +8089,7 @@ const devices = [
                 },
             ];
             await endpoint.configureReporting('hvacUserInterfaceCfg', userInterfaceConfig);
-            const draytonDeviceConfig = [
+            const wiserDeviceConfig = [
                 {
                     attribute: 'ALG',
                     minimumReportInterval: repInterval.MINUTE,
@@ -8109,7 +8109,7 @@ const devices = [
                     reportableChange: 0,
                 },
             ];
-            await endpoint.configureReporting('draytonDeviceInfo', draytonDeviceConfig);
+            await endpoint.configureReporting('wiserDeviceInfo', wiserDeviceConfig);
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -8080,36 +8080,23 @@ const devices = [
             await configureReporting.thermostatTemperature(endpoint, 0, repInterval.MINUTES_15, 25);
             await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, 0, repInterval.MINUTES_15, 25);
             await configureReporting.thermostatPIHeatingDemand(endpoint, 0, repInterval.MINUTES_15, 1);
-            const userInterfaceConfig = [
+            // bind of hvacUserInterfaceCfg fails with 'Table Full', does this have any effect?
+            await endpoint.configureReporting('hvacUserInterfaceCfg', [
                 {
                     attribute: 'keypadLockout',
                     minimumReportInterval: repInterval.MINUTE,
                     maximumReportInterval: repInterval.HOUR,
-                    reportableChange: 0,
+                    reportableChange: 1,
                 },
-            ];
-            await endpoint.configureReporting('hvacUserInterfaceCfg', userInterfaceConfig);
-            const wiserDeviceConfig = [
+            ]);
+            await endpoint.configureReporting('wiserDeviceInfo', [
                 {
-                    attribute: 'ALG',
+                    attribute: 'deviceInfo',
                     minimumReportInterval: repInterval.MINUTE,
                     maximumReportInterval: repInterval.HOUR,
-                    reportableChange: 0,
+                    reportableChange: 1,
                 },
-                {
-                    attribute: 'ADC',
-                    minimumReportInterval: repInterval.MINUTE,
-                    maximumReportInterval: repInterval.HOUR,
-                    reportableChange: 0,
-                },
-                {
-                    attribute: 'boost',
-                    minimumReportInterval: repInterval.MINUTE,
-                    maximumReportInterval: repInterval.HOUR,
-                    reportableChange: 0,
-                },
-            ];
-            await endpoint.configureReporting('wiserDeviceInfo', wiserDeviceConfig);
+            ]);
         },
     },
     {


### PR DESCRIPTION
- Fix the draytonDeviceInfo cluster does not exist error
- Decrease max reporting interval to improve temperature readings (similar to eurotronic trv's)

@Koenkk I was actually sitting on the 2nd commit for a while, but I never got around to swapping back to the wiser trv as the eurotronic one became much more stable after the updates from a few weeks ago.

I don't remember why I went with `MINUTES_15` here instead `MINUTES_10` I can change this to `MINUTES_10` too if we don't want to add `MINUTES_15`. Upside is this will then be the same as Eurotronic's reporting.