### PR TITLE
The SA-003 always sends attributeReports to the broadcast endpoint.

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2379,6 +2379,10 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const last = store[msg.device.ieeeAddr];
             const current = msg.meta.zclTransactionSequenceNumber;
+            
+            if (msg.type === 'attributeReport') {
+                msg.meta.frameControl.disableDefaultResponse = true;
+            }
 
             if (last !== current && msg.data.hasOwnProperty('onOff')) {
                 store[msg.device.ieeeAddr] = current;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2379,7 +2379,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const last = store[msg.device.ieeeAddr];
             const current = msg.meta.zclTransactionSequenceNumber;
-            
+     
             if (msg.type === 'attributeReport') {
                 msg.meta.frameControl.disableDefaultResponse = true;
             }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2373,6 +2373,19 @@ const converters = {
             };
         },
     },
+    SA003_on_off: {
+        cluster: 'genOnOff',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const last = store[msg.device.ieeeAddr];
+            const current = msg.meta.zclTransactionSequenceNumber;
+
+            if (last !== current && msg.data.hasOwnProperty('onOff')) {
+                store[msg.device.ieeeAddr] = last;
+                return {state: msg.data['onOff'] === 1 ? 'ON' : 'OFF'};
+            }
+        },
+    },
     tint404011_scene: {
         cluster: 'genBasic',
         type: 'write',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2379,7 +2379,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const last = store[msg.device.ieeeAddr];
             const current = msg.meta.zclTransactionSequenceNumber;
-     
+
             if (msg.type === 'attributeReport') {
                 msg.meta.frameControl.disableDefaultResponse = true;
             }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2381,7 +2381,7 @@ const converters = {
             const current = msg.meta.zclTransactionSequenceNumber;
 
             if (last !== current && msg.data.hasOwnProperty('onOff')) {
-                store[msg.device.ieeeAddr] = last;
+                store[msg.device.ieeeAddr] = current;
                 return {state: msg.data['onOff'] === 1 ? 'ON' : 'OFF'};
             }
         },

--- a/devices.js
+++ b/devices.js
@@ -7015,7 +7015,7 @@ const devices = [
         vendor: 'eWeLink',
         description: 'Zigbee smart plug',
         supports: 'on/off',
-        fromZigbee: [fz.on_off],
+        fromZigbee: [fz.SA003_on_off],
         toZigbee: [tz.on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
We shouldn't send a default response in this case, but Z-Stack doesn't tell us, so we just always set disableDefaultResponse for SA-003 attributeReports.