### PR TITLE
Ignore zclVersion read from MCT-340 contact sensors

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5788,7 +5788,7 @@ const devices = [
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact, temperature',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery_cr2032],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery_cr2032, fz.ignore_zclversion_read],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
@@ -5804,7 +5804,7 @@ const devices = [
         vendor: 'Visonic',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact, temperature',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery_cr2032],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery_cr2032, fz.ignore_zclversion_read],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
I've been seeing some Zigbee messages from my `MCT-340` contact sensors attempting to read `zclVersion`. Looking through the converters, it appears that z2m doesn't respond to this request - the only existing converter just ignores the read. Thus, this PR ignores the read from the MCT-340.

```
zigbee2mqtt:debug 2020-01-28 09:11:13: Received Zigbee message from 'Contact Sensor', type 'read', cluster 'genBasic', data '["zclVersion"]' from endpoint 1 with groupID 0
zigbee2mqtt:debug 2020-01-28 09:11:13: No converter available for 'MCT-340 E' with cluster 'genBasic' and type 'read' and data '["zclVersion"]'
```