### PR TITLE
Add ability to adjust energy reporting config per device model

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -254,31 +254,34 @@ const configureReporting = {
         }];
         await endpoint.configureReporting('genBinaryInput', payload);
     },
-    activePower: async (endpoint) => {
+    activePower: async (endpoint, overrides) => {
         const payload = [{
             attribute: 'activePower',
             minimumReportInterval: 5,
             maximumReportInterval: repInterval.MINUTES_5,
             reportableChange: 1,
         }];
+        Object.assign(payload[0], overrides);
         await endpoint.configureReporting('haElectricalMeasurement', payload);
     },
-    rmsCurrent: async (endpoint) => {
+    rmsCurrent: async (endpoint, overrides) => {
         const payload = [{
             attribute: 'rmsCurrent',
             minimumReportInterval: 5,
             maximumReportInterval: repInterval.MINUTES_5,
             reportableChange: 1,
         }];
+        Object.assign(payload[0], overrides);
         await endpoint.configureReporting('haElectricalMeasurement', payload);
     },
-    rmsVoltage: async (endpoint) => {
+    rmsVoltage: async (endpoint, overrides) => {
         const payload = [{
             attribute: 'rmsVoltage',
             minimumReportInterval: 5,
             maximumReportInterval: repInterval.MINUTES_5,
             reportableChange: 1,
         }];
+        Object.assign(payload[0], overrides);
         await endpoint.configureReporting('haElectricalMeasurement', payload);
     },
     powerFactor: async (endpoint) => {
@@ -4264,7 +4267,7 @@ const devices = [
         supports: 'on/off',
         fromZigbee: [fz.on_off, fz.electrical_measurement],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 4},
+        meta: {configureKey: 5},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
@@ -4273,9 +4276,9 @@ const devices = [
                 'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor',
             ]);
             await configureReporting.onOff(endpoint);
-            await configureReporting.rmsVoltage(endpoint);
-            await configureReporting.rmsCurrent(endpoint);
-            await configureReporting.activePower(endpoint);
+            await configureReporting.rmsVoltage(endpoint, {'reportableChange': 2}); // Voltage reports in V
+            await configureReporting.rmsCurrent(endpoint, {'reportableChange': 10}); // Current reports in mA
+            await configureReporting.activePower(endpoint); // Power reports in 0.1W
         },
     },
     {


### PR DESCRIPTION
(See #940 for some discussion)

This is my first attempt at a method of reducing energy reporting messages without reducing the usefulness of the energy reporting feature. With this PR, it is simple to override any parameter sent to `endpoint.configureReporting()` for `activePower`, `rmsCurrent`, and `rmsVoltage`.

For example, this PR configures the Iris 3210-L to report current in 0.01A intervals instead of 0.001A, and ignore voltage changes < 2V (the voltage `reportableChange` is somewhat arbitrary, but I added it as a basic debounce).

I did a (very basic) test using an Iris 3210-L that I use to power an LED desk lamp. This PR cut down the amount of Zigbee messages generated by the power plug over a 10-minute period by roughly 60%.

Please let me know how I can improve this so we can work to reduce the amount of Zigbee network noise generated by power-reporting devices.