### PR TITLE
Reduce energy reporting for Centralite Dimmer 4257050-ZHAC and Securifi Peanut Plug PP-WHT-US

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5851,20 +5851,18 @@ const devices = [
         supports: 'on/off, power measurement',
         fromZigbee: [fz.on_off, fz.peanut_electrical],
         toZigbee: [tz.on_off],
-        meta: {configureKey: 2},
+        meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
+            await endpoint.read('haElectricalMeasurement', [
+                'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier',
+                'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor',
+            ]);
             await configureReporting.onOff(endpoint);
-            await configureReporting.rmsVoltage(endpoint);
-            await configureReporting.rmsCurrent(endpoint);
-            await configureReporting.activePower(endpoint);
-            await configureReporting.acVoltageMultiplier(endpoint);
-            await configureReporting.acVoltageDivisor(endpoint);
-            await configureReporting.acCurrentMultiplier(endpoint);
-            await configureReporting.acCurrentDivisor(endpoint);
-            await configureReporting.acPowerMultiplier(endpoint);
-            await configureReporting.acPowerDivisor(endpoint);
+            await configureReporting.rmsVoltage(endpoint, {'reportableChange': 110}); // Voltage reports in 0.00458V
+            await configureReporting.rmsCurrent(endpoint, {'reportableChange': 55}); // Current reports in 0.00183A
+            await configureReporting.activePower(endpoint, {'reportableChange': 2}); // Power reports in 0.261W
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -4451,7 +4451,7 @@ const devices = [
         supports: 'on/off, brightness, power meter',
         fromZigbee: [fz.restorable_brightness, fz.on_off, fz.electrical_measurement],
         toZigbee: [tz.light_onoff_restorable_brightness],
-        meta: {configureKey: 3},
+        meta: {configureKey: 4},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement']);
@@ -4460,9 +4460,9 @@ const devices = [
                 'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor',
             ]);
             await configureReporting.onOff(endpoint);
-            await configureReporting.rmsVoltage(endpoint);
-            await configureReporting.rmsCurrent(endpoint);
-            await configureReporting.activePower(endpoint);
+            await configureReporting.rmsVoltage(endpoint, {'reportableChange': 2}); // Voltage reports in V
+            await configureReporting.rmsCurrent(endpoint, {'reportableChange': 10}); // Current reports in mA
+            await configureReporting.activePower(endpoint, {'reportableChange': 2}); // Power reports in 0.1W
         },
     },
 


### PR DESCRIPTION
This PR builds on #954 by increasing the Centralite dimmer's reportable change difference to 2V, 0.01A, and 0.2W (as a debounce). With these changes over a 10 minute span, I saw a reduction in traffic from a Centralite dimmer of approximately 66%.

It also increases the Peanut Plug's reportable change difference to 0.5V, 0.1A, and 0.5W. With these changes over a 10 minute period, I saw a reduction in traffic of approximately 90%.

Note that all of my tests lack all semblance of scientific rigor, and were performed with LED or regular incandescent lighting.

This should help @djchen in #940 .