### PR TITLE
Ignore basic report for 45852GE and 45853GE

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2953,7 +2953,7 @@ const devices = [
         vendor: 'GE',
         description: 'ZigBee plug-in smart dimmer',
         supports: 'on/off, brightness',
-        fromZigbee: [fz.brightness, fz.on_off],
+        fromZigbee: [fz.brightness, fz.on_off, fz.ignore_basic_report],
         toZigbee: [tz.light_onoff_brightness, tz.ignore_transition],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
@@ -2968,7 +2968,7 @@ const devices = [
         vendor: 'GE',
         description: 'Plug-in smart switch',
         supports: 'on/off',
-        fromZigbee: [fz.on_off, fz.generic_power],
+        fromZigbee: [fz.on_off, fz.generic_power, fz.ignore_basic_report],
         toZigbee: [tz.on_off, tz.ignore_transition],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Fixes "no converter available for ..."

```
debug 2020-02-01 21:53:38: No converter available for '45853GE' with cluster 'genBasic' and type 'readResponse' and data '{"zclVersion":1}'

debug 2020-02-01 21:54:34: No converter available for '45852GE' with cluster 'genBasic' and type 'readResponse' and data '{"zclVersion":1}'
```