### PR TITLE
Add another zigbeeModel for Blaupunkt SCM-S1

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4577,7 +4577,7 @@ const devices = [
 
     // Blaupunkt
     {
-        zigbeeModel: ['SCM-R_00.00.03.15TC', 'SCM_00.00.03.14TC'],
+        zigbeeModel: ['SCM-2_00.00.03.15', 'SCM-R_00.00.03.15TC', 'SCM_00.00.03.14TC'],
         model: 'SCM-S1',
         vendor: 'Blaupunkt',
         description: 'Roller shutter',

--- a/devices.js
+++ b/devices.js
@@ -4583,7 +4583,7 @@ const devices = [
         description: 'Roller shutter',
         supports: 'open/close',
         fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],
-        toZigbee: [tz.cover_position_via_brightness, tz.cover_open_close_via_brightness],
+        toZigbee: [tz.cover_position_via_brightness, tz.cover_open_close_via_brightness, tz.osram_cmds],
     },
 
     // Lupus

--- a/devices.js
+++ b/devices.js
@@ -4583,7 +4583,7 @@ const devices = [
         description: 'Roller shutter',
         supports: 'open/close',
         fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],
-        toZigbee: [tz.cover_position_via_brightness, tz.cover_open_close_via_brightness, tz.osram_cmds],
+        toZigbee: [tz.cover_position_via_brightness, tz.cover_open_close_via_brightness],
     },
 
     // Lupus


### PR DESCRIPTION
My brand new Blaupunkt SCM-S1 roller shutter were not support as they come with a different zigbeeModel ID (SCM-2_00.00.03.15). The patch below fixes this issue.