### PR TITLE
koenkk/zigbee2mqtt#2931 Add support for IKEA TRADFRI bulb E14 WS 470lm

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1021,6 +1021,14 @@ const devices = [
         ota: ota.tradfri,
     },
     {
+        zigbeeModel: ['TRADFRI bulb E14 WS 470lm'],
+        model: 'LED1903C5',
+        vendor: 'IKEA',
+        description: 'TRADFRI bulb E14 WS 470 lumen, dimmable, white spectrum, opal white',
+        extend: generic.light_onoff_brightness_colortemp,
+        ota: ota.tradfri,
+    },
+    {
         zigbeeModel: ['TRADFRI bulb GU10 WW 400lm'],
         model: 'LED1837R5',
         vendor: 'IKEA',


### PR DESCRIPTION
@SargonofAssyria  got a newer E14 bulb form IKEA, they mentioned this worked for them.
I don't have the bulb my self to test.