### PR TITLE
Gledopto GL-C-007S

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3540,6 +3540,14 @@ const devices = [
         supports: 'on/off, brightness, color, white',
     },
     {
+        zigbeeModel: ['GL-C-007S'],
+        model: 'GL-C-007S',
+        vendor: 'Gledopto',
+        description: 'Zigbee LED controller RGBW plus model',
+        extend: gledopto.light,
+        supports: 'on/off, brightness, color, white',
+    },
+    {
         zigbeeModel: ['GL-C-008'],
         model: 'GL-C-008',
         vendor: 'Gledopto',


### PR DESCRIPTION
Add support for Gledopto GL-C-007S 
Zigbee LED controller RGBW plus model