### PR TITLE
Devices: Add support for the Hue white ambiance BR30

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1601,7 +1601,7 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp_colorxy,
     },
     {
-        zigbeeModel: ['LTW011'],
+        zigbeeModel: ['LTW011', 'LTB002'],
         model: '464800',
         vendor: 'Philips',
         description: 'Hue white ambiance BR30 flood light',


### PR DESCRIPTION
The dual pack of Hue white ambiance BR30 at Bestbuy joined the network with Zigbee model LTB002. This commit adds the mapping for it