### PR TITLE
Adds support for Salus OTA updates

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5422,6 +5422,7 @@ const devices = [
             await configureReporting.currentSummDelivered(endpoint);
             await endpoint.read('seMetering', ['multiplier', 'divisor']);
         },
+        ota: ota.salus,
     },
 
     // AduroSmart

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1241,6 +1241,14 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "requires": {
+        "readable-stream": "^3.0.1"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1700,7 +1708,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -2246,6 +2253,11 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2527,8 +2539,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "7.0.4",
@@ -4562,7 +4573,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4813,6 +4823,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
     },
     "realpath-native": {
       "version": "1.1.0",
@@ -5579,6 +5599,21 @@
         "function-bind": "^1.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -5697,6 +5732,18 @@
             "strip-ansi": "^5.1.0"
           }
         }
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "requires": {
+        "bl": "^3.0.0",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       }
     },
     "terminal-link": {
@@ -5953,6 +6000,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "util.promisify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
@@ -6139,8 +6191,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/ota/index.js
+++ b/ota/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+    salus: require('./salus'),
     tradfri: require('./tradfri'),
 };
 

--- a/ota/salus.js
+++ b/ota/salus.js
@@ -1,0 +1,95 @@
+const axios = require('axios');
+const url = 'https://eu.salusconnect.io/demo/default/status/firmware?timestamp=0';
+const assert = require('assert');
+const common = require('./common');
+const tar = require('tar-stream');
+
+/**
+ * Helper functions
+ */
+
+async function getImageMeta(modelId) {
+    const images = (await axios.get(url)).data.versions;
+    const image = images.find((i) => i.model === modelId);
+    assert(image !== null, `No image available for modelId '${modelId}'`);
+    return {
+        fileVersion: parseInt(image.version, 16),
+        url: image.url.replace(/^http:\/\//, 'https://'),
+    };
+}
+
+async function untar(tarStream) {
+    return new Promise((resolve, reject) => {
+        const extract = tar.extract();
+
+        const result = [];
+
+        extract.on('error', reject);
+
+        extract.on('entry', (headers, stream, next) => {
+            const buffers = [];
+
+            stream.on('data', function(data) {
+                buffers.push(data);
+            });
+
+            stream.on('end', function() {
+                result.push({
+                    headers,
+                    data: Buffer.concat(buffers),
+                });
+
+                next();
+            });
+
+            stream.resume();
+        });
+
+        extract.on('finish', () => {
+            resolve(result);
+        });
+
+        tarStream.pipe(extract);
+    });
+}
+
+async function getNewImage(current, logger, device) {
+    const meta = await getImageMeta(device.modelID);
+    assert(meta.fileVersion > current.fileVersion, 'No new image available');
+
+    const download = await axios.get(meta.url, {responseType: 'stream'});
+
+    const files = await untar(download.data);
+
+    const imageFile = files.find((file) => file.headers.name.endsWith('.ota'));
+
+    const image = common.parseImage(imageFile.data);
+    assert(image.header.fileVersion === meta.fileVersion, 'File version mismatch');
+    assert(image.header.manufacturerCode === 4216, 'Manufacturer code mismatch');
+    assert(image.header.imageType === current.imageType, 'Image type mismatch');
+    return image;
+}
+
+async function isNewImageAvailable(current, logger, device) {
+    const meta = await getImageMeta(device.modelID);
+    const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
+    logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
+    return meta.fileVersion > current.fileVersion;
+}
+
+/**
+ * Interface implementation
+ */
+
+async function isUpdateAvailable(device, logger, requestPayload=null) {
+    return common.isUpdateAvailable(device, logger, isNewImageAvailable, requestPayload);
+}
+
+async function updateToLatest(device, logger, onProgress) {
+    return common.updateToLatest(device, logger, onProgress, getNewImage);
+}
+
+module.exports = {
+    isUpdateAvailable,
+    updateToLatest,
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "homepage": "https://github.com/Koenkk/zigbee-herdsman-converters",
   "dependencies": {
-    "axios": "*"
+    "axios": "*",
+    "tar-stream": "^2.1.0"
   },
   "devDependencies": {
     "eslint": "*",


### PR DESCRIPTION
This will add support for Salus OTA updates (only enabled for the SP600 smart plug)

I've added a dependency to [tar-stream](https://www.npmjs.com/package/tar-stream) as the update files are tar archives.

**Note 1:** while the update files are .tar.gz, I came to realized that they are not actually gzip'ed but just tar'ed. If we want to make it safe, I'd recommend also adding the [gunzip-maybe](https://github.com/mafintosh/gunzip-maybe) that will check if a files is actually gzip'ed before attempting to extract it.

**Note 2:** I've managed to test as far as to check for an update, however my SP600 is already using the latest available firmware, so I **have no way of confirming that this is actually working as expected**, so I'm hoping someone with an SP600 can confirm if this works or not...