### PR TITLE
Add support for another Philips Hue bluetooth bulb

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1557,7 +1557,7 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp_colorxy,
     },
     {
-        zigbeeModel: ['LCA001', 'LCA002'],
+        zigbeeModel: ['LCA001', 'LCA002', 'LCA003'],
         model: '9290022166',
         vendor: 'Philips',
         description: 'Hue white and color ambiance E26/E27',


### PR DESCRIPTION
New E26/E27 white and color ambiance bulbs presenting with model LCA003