### PR TITLE
Adds support for current 3A/Nue dimmer switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3365,7 +3365,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['FB56+ZSC05HG1.0', 'FNB56-ZBW01LX1.2'],
+        zigbeeModel: ['FB56+ZSC05HG1.0', 'FNB56-ZBW01LX1.2', 'LXN56-DS27LX1.3'],
         model: 'HGZB-04D / HGZB-4D-UK',
         vendor: 'Nue / 3A',
         description: 'Smart dimmer wall switch',


### PR DESCRIPTION
Adds support for the current 3A/Nue dimmer switch model HGZB-04D with zigbeeModel LXN56-DS27LX1.3