### PR TITLE
OTA update check: inform about uncommon version mismatch

### DIFF
--- a/ota/common.js
+++ b/ota/common.js
@@ -143,7 +143,7 @@ async function isUpdateAvailable(device, logger, isNewImageAvailable, requestPay
     }
 
     const available = await isNewImageAvailable(requestPayload, logger, device);
-    logger.debug(`Updata available for '${device.ieeeAddr}': ${available ? 'YES' : 'NO'}`);
+    logger.debug(`Update available for '${device.ieeeAddr}': ${available ? 'YES' : 'NO'}`);
     return available;
 }
 

--- a/ota/salus.js
+++ b/ota/salus.js
@@ -74,6 +74,11 @@ async function isNewImageAvailable(current, logger, device) {
     const meta = await getImageMeta(device.modelID);
     const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
     logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
+    if (meta.fileVersion < current.fileVersion) {
+        logger.debug(`Current image on '${device.ieeeAddr}' is NEWER than the latest one published.`);
+        logger.debug(`Device: '${currentS}'`);
+        logger.debug(`Latest Firmware: '${metaS}'`);
+    }
     return meta.fileVersion > current.fileVersion;
 }
 

--- a/ota/tradfri.js
+++ b/ota/tradfri.js
@@ -37,6 +37,11 @@ async function isNewImageAvailable(current, logger, device) {
     const meta = await getImageMeta(current.imageType);
     const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
     logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
+    if (meta.fileVersion < current.fileVersion) {
+        logger.debug(`Current image on '${device.ieeeAddr}' is NEWER than the latest one published.`);
+        logger.debug(`Device: '${currentS}'`);
+        logger.debug(`Latest Firmware: '${metaS}'`);
+    }
     return meta.fileVersion > current.fileVersion;
 }
 


### PR DESCRIPTION
Added debug message for cases where device firmware is newer than the latest version online. This should not happen but might be a helpful log message when version numbers were incorrectly interpreted or a manufacturer changed up the numbering scheme.

See https://github.com/Koenkk/zigbee-herdsman-converters/issues/1000#issuecomment-589443800