### PR TITLE
OTA update check: inform about uncommon version mismatch

### DIFF
--- a/ota/common.js
+++ b/ota/common.js
@@ -145,7 +145,7 @@ async function isUpdateAvailable(device, logger, isNewImageAvailable, requestPay
     const available = await isNewImageAvailable(requestPayload, logger, device);
     logger.debug(`Update available for '${device.ieeeAddr}': ${available < 0 ? 'YES' : 'NO'}`);
     if (available > 0) {
-        logger.debug(`Firmware on '${device.ieeeAddr}' is newer than latest firmware online. This is either a beta firmware or version mismatch.`);
+        logger.debug(`Firmware on '${device.ieeeAddr}' is newer than latest firmware online.`);
     }
     return (available < 0);
 }

--- a/ota/common.js
+++ b/ota/common.js
@@ -143,8 +143,11 @@ async function isUpdateAvailable(device, logger, isNewImageAvailable, requestPay
     }
 
     const available = await isNewImageAvailable(requestPayload, logger, device);
-    logger.debug(`Updata available for '${device.ieeeAddr}': ${available ? 'YES' : 'NO'}`);
-    return available;
+    logger.debug(`Update available for '${device.ieeeAddr}': ${available < 0 ? 'YES' : 'NO'}`);
+    if (available > 0) {
+        logger.debug(`Firmware on '${device.ieeeAddr}' is newer than latest firmware online. This is either a beta firmware or version mismatch.`);
+    }
+    return (available < 0);
 }
 
 async function updateToLatest(device, logger, onProgress, getNewImage) {

--- a/ota/common.js
+++ b/ota/common.js
@@ -145,7 +145,7 @@ async function isUpdateAvailable(device, logger, isNewImageAvailable, requestPay
     const available = await isNewImageAvailable(requestPayload, logger, device);
     logger.debug(`Update available for '${device.ieeeAddr}': ${available < 0 ? 'YES' : 'NO'}`);
     if (available > 0) {
-        logger.debug(`Firmware on '${device.ieeeAddr}' is newer than latest firmware online.`);
+        logger.warn(`Firmware on '${device.ieeeAddr}' is newer than latest firmware online.`);
     }
     return (available < 0);
 }

--- a/ota/salus.js
+++ b/ota/salus.js
@@ -74,7 +74,7 @@ async function isNewImageAvailable(current, logger, device) {
     const meta = await getImageMeta(device.modelID);
     const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
     logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
-    return meta.fileVersion > current.fileVersion;
+    return Math.sign(current.fileVersion - meta.fileVersion);
 }
 
 /**

--- a/ota/tradfri.js
+++ b/ota/tradfri.js
@@ -37,7 +37,7 @@ async function isNewImageAvailable(current, logger, device) {
     const meta = await getImageMeta(current.imageType);
     const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
     logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
-    return meta.fileVersion > current.fileVersion;
+    return Math.sign(current.fileVersion - meta.fileVersion);
 }
 
 /**


### PR DESCRIPTION
Added debug message for cases where device firmware is newer than the latest version online. This should not happen but might be a helpful log message when version numbers were incorrectly interpreted or a manufacturer changed up the numbering scheme.

See https://github.com/Koenkk/zigbee-herdsman-converters/issues/1000#issuecomment-589443800