### PR TITLE
Add support for OSRAM Lightify Dimming Switch 73743

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -493,7 +493,7 @@ const converters = {
             };
         },
     },
-    AC0251100NJ_long_middle: {
+    osram_lightify_switch_long_middle: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
         convert: (model, msg, publish, options, meta) => {
@@ -2698,28 +2698,28 @@ const converters = {
             return {pressure: calibrateAndPrecisionRoundOptions(pressure, options, 'pressure')};
         },
     },
-    AC0251100NJ_cmdOn: {
+    osram_lightify_switch_cmdOn: {
         cluster: 'genOnOff',
         type: 'commandOn',
         convert: (model, msg, publish, options, meta) => {
             return {action: 'up'};
         },
     },
-    AC0251100NJ_cmdOff: {
+    osram_lightify_switch_cmdOff: {
         cluster: 'genOnOff',
         type: 'commandOff',
         convert: (model, msg, publish, options, meta) => {
             return {action: 'down'};
         },
     },
-    AC0251100NJ_cmdMoveWithOnOff: {
+    osram_lightify_switch_cmdMoveWithOnOff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
         convert: (model, msg, publish, options, meta) => {
             return {action: 'up_hold'};
         },
     },
-    AC0251100NJ_cmdStop: {
+    osram_lightify_switch_AC0251100NJ_cmdStop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
         convert: (model, msg, publish, options, meta) => {
@@ -2731,14 +2731,14 @@ const converters = {
             return {action: map[msg.endpoint.ID]};
         },
     },
-    AC0251100NJ_cmdMove: {
+    osram_lightify_switch_cmdMove: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
         convert: (model, msg, publish, options, meta) => {
             return {action: 'down_hold'};
         },
     },
-    AC0251100NJ_cmdMoveHue: {
+    osram_lightify_switch_cmdMoveHue: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
         convert: (model, msg, publish, options, meta) => {
@@ -2747,24 +2747,31 @@ const converters = {
             }
         },
     },
-    AC0251100NJ_cmdMoveToSaturation: {
+    osram_lightify_switch_cmdMoveToSaturation: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToSaturation',
         convert: (model, msg, publish, options, meta) => {
             return {action: 'circle_hold'};
         },
     },
-    AC0251100NJ_cmdMoveToLevelWithOnOff: {
+    osram_lightify_switch_cmdMoveToLevelWithOnOff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveToLevelWithOnOff',
         convert: (model, msg, publish, options, meta) => {
             return {action: 'circle_click'};
         },
     },
-    AC0251100NJ_cmdMoveToColorTemp: {
+    osram_lightify_switch_cmdMoveToColorTemp: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToColorTemp',
         convert: (model, msg, publish, options, meta) => null,
+    },
+    osram_lightify_switch_73743_cmdStop: {
+        cluster: 'genLevelCtrl',
+        type: 'commandStop',
+        convert: (model, msg, publish, options, meta) => {
+            return {action: 'release'};
+        },
     },
     OJBCR701YZ_statuschange: {
         cluster: 'ssIasZone',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2716,6 +2716,11 @@ const converters = {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
         convert: (model, msg, publish, options, meta) => {
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {direction: null};
+            }
+            store[deviceID].direction = 'up';
             return {action: 'up_hold'};
         },
     },
@@ -2735,6 +2740,11 @@ const converters = {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
         convert: (model, msg, publish, options, meta) => {
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {direction: null};
+            }
+            store[deviceID].direction = 'down';
             return {action: 'down_hold'};
         },
     },
@@ -2770,7 +2780,15 @@ const converters = {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
         convert: (model, msg, publish, options, meta) => {
-            return {action: 'release'};
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = {direction: null};
+            }
+            let direction;
+            if (store[deviceID].direction) {
+                direction = `${store[deviceID].direction}_`;
+            }
+            return {action: `${direction}release`};
         },
     },
     OJBCR701YZ_statuschange: {

--- a/devices.js
+++ b/devices.js
@@ -2456,10 +2456,10 @@ const devices = [
         description: 'Smart+ switch mini',
         supports: 'circle, up, down and hold/release',
         fromZigbee: [
-            fz.AC0251100NJ_cmdOn, fz.AC0251100NJ_cmdMoveWithOnOff, fz.AC0251100NJ_cmdStop,
-            fz.AC0251100NJ_cmdMoveToColorTemp, fz.AC0251100NJ_cmdMoveHue, fz.AC0251100NJ_cmdMoveToSaturation,
-            fz.AC0251100NJ_cmdOff, fz.AC0251100NJ_cmdMove, fz.battery_3V,
-            fz.AC0251100NJ_cmdMoveToLevelWithOnOff,
+            fz.osram_lightify_switch_cmdOn, fz.osram_lightify_switch_cmdMoveWithOnOff, fz.osram_lightify_switch_AC0251100NJ_cmdStop,
+            fz.osram_lightify_switch_cmdMoveToColorTemp, fz.osram_lightify_switch_cmdMoveHue, fz.osram_lightify_switch_cmdMoveToSaturation,
+            fz.osram_lightify_switch_cmdOff, fz.osram_lightify_switch_cmdMove, fz.battery_3V,
+            fz.osram_lightify_switch_cmdMoveToLevelWithOnOff,
         ],
         toZigbee: [],
         meta: {configureKey: 1},
@@ -2901,6 +2901,27 @@ const devices = [
     },
 
     // Sylvania
+    {
+        zigbeeModel: ['LIGHTIFY Dimming Switch'],
+        model: '73743',
+        vendor: 'OSRAM',
+        description: 'Lightify OSRAM Dimming Switch',
+        supports: 'up, down and hold/release',
+        fromZigbee: [
+            fz.osram_lightify_switch_cmdOn,
+            fz.osram_lightify_switch_cmdMoveWithOnOff,
+            fz.osram_lightify_switch_cmdOff,
+            fz.osram_lightify_switch_cmdMove,
+            fz.osram_lightify_switch_73743_cmdStop,
+            fz.battery_3V],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genPowerCfg']);
+            await configureReporting.batteryVoltage(endpoint);
+        }
+    },
     {
         zigbeeModel: ['LIGHTIFY RT Tunable White'],
         model: '73742',

--- a/devices.js
+++ b/devices.js
@@ -2456,8 +2456,9 @@ const devices = [
         description: 'Smart+ switch mini',
         supports: 'circle, up, down and hold/release',
         fromZigbee: [
-            fz.osram_lightify_switch_cmdOn, fz.osram_lightify_switch_cmdMoveWithOnOff, fz.osram_lightify_switch_AC0251100NJ_cmdStop,
-            fz.osram_lightify_switch_cmdMoveToColorTemp, fz.osram_lightify_switch_cmdMoveHue, fz.osram_lightify_switch_cmdMoveToSaturation,
+            fz.osram_lightify_switch_cmdOn, fz.osram_lightify_switch_cmdMoveWithOnOff,
+            fz.osram_lightify_switch_AC0251100NJ_cmdStop, fz.osram_lightify_switch_cmdMoveToColorTemp,
+            fz.osram_lightify_switch_cmdMoveHue, fz.osram_lightify_switch_cmdMoveToSaturation,
             fz.osram_lightify_switch_cmdOff, fz.osram_lightify_switch_cmdMove, fz.battery_3V,
             fz.osram_lightify_switch_cmdMoveToLevelWithOnOff,
         ],
@@ -2904,23 +2905,20 @@ const devices = [
     {
         zigbeeModel: ['LIGHTIFY Dimming Switch'],
         model: '73743',
-        vendor: 'OSRAM',
-        description: 'Lightify OSRAM Dimming Switch',
+        vendor: 'Sylvania',
+        description: 'Lightify Smart Dimming Switch',
         supports: 'up, down and hold/release',
         fromZigbee: [
-            fz.osram_lightify_switch_cmdOn,
-            fz.osram_lightify_switch_cmdMoveWithOnOff,
-            fz.osram_lightify_switch_cmdOff,
-            fz.osram_lightify_switch_cmdMove,
-            fz.osram_lightify_switch_73743_cmdStop,
-            fz.battery_3V],
+            fz.osram_lightify_switch_cmdOn, fz.osram_lightify_switch_cmdMoveWithOnOff, fz.osram_lightify_switch_cmdOff,
+            fz.osram_lightify_switch_cmdMove, fz.osram_lightify_switch_73743_cmdStop, fz.battery_3V,
+        ],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genPowerCfg']);
             await configureReporting.batteryVoltage(endpoint);
-        }
+        },
     },
     {
         zigbeeModel: ['LIGHTIFY RT Tunable White'],


### PR DESCRIPTION
This PR adds support for the OSRAM Lightify Dimming Switch, model 73743 (and possibly 74091). The device also supports temperature reporting, but I'm not sure how to convert it (it's not a simple multiple of 10 like most other device temperature reports), so I've left it out.

@Koenkk, I wanted to get your input on something. I based my work on the `Lightify Switch Mini` code as you suggested in https://github.com/Koenkk/zigbee2mqtt/issues/2578, but there is one significant difference. The Mini uses separate endpoints, which gives a way to differentiate between a release of the up button and a release of the down button. The Dimming Switch only has one endpoint, and sends the exact same message whether you are releasing the up or the down button:
```
// Release Up button
Received Zigbee message from '0x...', type 'commandStop', cluster 'genLevelCtrl', data '{}' from endpoint 1 with groupID 0
// Release Down button
Received Zigbee message from '0x...', type 'commandStop', cluster 'genLevelCtrl', data '{}' from endpoint 1 with groupID 0
```
It's worth noting that both the up and down buttons can be held at the same time (but I don't know why anyone would).

Right now I have the stop function set to return `action: release` for either direction. Since I'm not sure how actions are used in HA/etc, I'm not sure if this is acceptable or not. Also, because there is only one endpoint and the data is identical, the `cmdStop` converter from the `Lightify Switch Mini` won't work (so I had to add one new converter).

Do you have any ideas on how to detect which direction is released?