### PR TITLE
Add support for bitron smoke detector 902010/24

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4469,12 +4469,21 @@ const devices = [
         zigbeeModel: ['902010/24A'],
         model: 'AV2010/24A',
         vendor: 'Bitron',
-        description: 'Optical smoke detector',
+        description: 'Optical smoke detector (hardware version v2)',
         supports: 'smoke, tamper and battery',
         fromZigbee: [fz.ias_smoke_alarm_1],
         toZigbee: [],
     },
-
+    {
+        zigbeeModel: ['902010/24'],
+        model: '902010/24',
+        vendor: 'Bitron',
+        description: 'Optical smoke detector (hardware version v1)',
+        supports: 'smoke, tamper and battery',
+        fromZigbee: [fz.ias_smoke_alarm_1],
+        toZigbee: [],
+    },
+    
     // Iris
     {
         zigbeeModel: ['3210-L'],

--- a/devices.js
+++ b/devices.js
@@ -4483,7 +4483,7 @@ const devices = [
         fromZigbee: [fz.ias_smoke_alarm_1],
         toZigbee: [],
     },
-    
+
     // Iris
     {
         zigbeeModel: ['3210-L'],


### PR DESCRIPTION
Hi,

there are two versions of the bitron smoke detector, a newer model (which is already supported, 902010/24A) and an older model (which is unsupported, 902010/24). Both send the same kind of data, therefore we can use the same converter.  I don't know if there is a difference betweent them, only the case seems obviously different.
The older one can be seen here for example: https://cdn.idealo.com/folder/Product/4587/2/4587285/s1_produktbild_gross/home-optischer-rauchmelder-902010-24.jpg 
The new one here:
https://www.zigbee2mqtt.io/devices/AV2010_24A.html
While searching for the internet, the new model is sometimes called v2 and the old one is sometimes called v1. I added this to the device description of both for clarification.