### PR TITLE
Add support for iCasa ICZB-KPD14S

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5261,7 +5261,10 @@ const devices = [
         vendor: 'iCasa',
         description: 'Zigbee 3.0 Keypad Pulse 4S',
         supports: 'on/off, brightness, scenes',
-        fromZigbee: [fz.scenes_recall_click, fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.battery_percentage_remaining, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff],
+        fromZigbee: [
+            fz.scenes_recall_click, fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.battery_percentage_remaining,
+            fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff
+        ],
         toZigbee: [],
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -5260,7 +5260,7 @@ const devices = [
         model: 'ICZB-KPD14S',
         vendor: 'iCasa',
         description: 'Zigbee 3.0 Keypad Pulse 4S',
-        supports: 'on/off, brightness, scenes',
+        supports: 'click, action, brightness, scenes',
         fromZigbee: [
             fz.scenes_recall_click, fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.battery_percentage_remaining,
             fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff,

--- a/devices.js
+++ b/devices.js
@@ -5256,6 +5256,15 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['ICZB-KPD14S'],
+        model: 'ICZB-KPD14S',
+        vendor: 'iCasa',
+        description: 'Zigbee 3.0 Keypad Pulse 4S',
+        supports: 'on/off, brightness, scenes',
+        fromZigbee: [fz.scenes_recall_click, fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.battery_percentage_remaining, fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff],
+        toZigbee: [],
+    },
+    {
         zigbeeModel: ['ICZB-KPD18S'],
         model: 'ICZB-KPD18S',
         vendor: 'iCasa',

--- a/devices.js
+++ b/devices.js
@@ -5263,7 +5263,7 @@ const devices = [
         supports: 'on/off, brightness, scenes',
         fromZigbee: [
             fz.scenes_recall_click, fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.battery_percentage_remaining,
-            fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff
+            fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff,
         ],
         toZigbee: [],
     },


### PR DESCRIPTION
Copied most of ICZB-KPD18S only added the hold/brightness support

I assume the hold/brightness support also works for the ICZB-KPD18S but I don't have one to verify (could add it to the PR if wanted).

Also, this device support binding, dunno where to document that.