### PR TITLE
ICZB-KPD18S - Update 8s model to match 4S supported modes

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5289,8 +5289,11 @@ const devices = [
         model: 'ICZB-KPD18S',
         vendor: 'iCasa',
         description: 'Zigbee 3.0 Keypad Pulse 8S',
-        supports: 'click',
-        fromZigbee: [fz.scenes_recall_click, fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.battery_percentage_remaining],
+        supports: 'click, action, brightness, scenes',
+        fromZigbee: [
+            fz.scenes_recall_click, fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.battery_percentage_remaining,
+            fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff,
+        ],
         toZigbee: [],
     },
     {


### PR DESCRIPTION
ICZB-KPD18S & ICZB-KPD14S are identical except for the number of scenes they support outside the generic on/off button. Therefore updated the 8S to match the 4S in terms of supported abilities. 

