### PR TITLE
Add Support for ubisys C4

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4046,6 +4046,45 @@ const converters = {
         },
     },
 
+    ubisys_c4_scenes: {
+        cluster: 'genScenes',
+        type: 'commandRecall',
+        convert: (model, msg, publish, options, meta) => {
+            return {click: `${msg.endpoint.ID}_scene_${msg.data.groupid}_${msg.data.sceneid}`};
+        },
+    },
+    ubisys_c4_onoff: {
+        cluster: 'genOnOff',
+        type: ['commandOn', 'commandOff', 'commandToggle'],
+        convert: (model, msg, publish, options, meta) => {
+            return {action: `${msg.endpoint.ID}_${msg.type.substr(7).toLowerCase()}`};
+        },
+    },
+    ubisys_c4_level: {
+        cluster: 'genLevelCtrl',
+        type: ['commandMoveWithOnOff', 'commandStopWithOnOff'],
+        convert: (model, msg, publish, options, meta) => {
+            switch (msg.type) {
+            case 'commandMoveWithOnOff':
+                return {action: `${msg.endpoint.ID}_level_move_${msg.data.movemode ? 'down' : 'up'}`};
+            case 'commandStopWithOnOff':
+                return {action: `${msg.endpoint.ID}_level_stop`};
+            }
+        },
+    },
+    ubisys_c4_cover: {
+        cluster: 'closuresWindowCovering',
+        type: ['commandUpOpen', 'commandDownClose', 'commandStop'],
+        convert: (model, msg, publish, options, meta) => {
+            const lookup = {
+                'commandUpOpen': 'open',
+                'commandDownClose': 'close',
+                'commandStop': 'stop',
+            };
+            return {action: `${msg.endpoint.ID}_cover_${lookup[msg.type]}`};
+        },
+    },
+
     // Ignore converters (these message dont need parsing).
     ignore_onoff_report: {
         cluster: 'genOnOff',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4045,12 +4045,11 @@ const converters = {
             return lookup[msg.type];
         },
     },
-
     ubisys_c4_scenes: {
         cluster: 'genScenes',
         type: 'commandRecall',
         convert: (model, msg, publish, options, meta) => {
-            return {click: `${msg.endpoint.ID}_scene_${msg.data.groupid}_${msg.data.sceneid}`};
+            return {action: `${msg.endpoint.ID}_scene_${msg.data.groupid}_${msg.data.sceneid}`};
         },
     },
     ubisys_c4_onoff: {

--- a/devices.js
+++ b/devices.js
@@ -7391,6 +7391,24 @@ const devices = [
         fromZigbee: [fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.ubisys_configure_j1],
     },
+    {
+        zigbeeModel: ['C4 (5504)'],
+        model: 'C4',
+        vendor: 'Ubisys',
+        description: 'Control unit C4',
+        supports: 'action',
+        fromZigbee: [fz.ubisys_c4_scenes, fz.ubisys_c4_onoff, fz.ubisys_c4_level, fz.ubisys_c4_cover],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            for (const ep of [1, 2, 3, 4]) {
+                await bind(device.getEndpoint(ep), coordinatorEndpoint, ['genScenes', 'genOnOff', 'genLevelCtrl']);
+            }
+            for (const ep of [5, 6]) {
+                await bind(device.getEndpoint(ep), coordinatorEndpoint, ['genScenes', 'closuresWindowCovering']);
+            }
+        },
+    },
 
     // Lutron
     {


### PR DESCRIPTION
The [ubisys C4 remote control unit](https://www.ubisys.de/en/products/additional-options/control-unit-c4/) seems to be primarily targeted to be bound to other ZigBee devices to control them. Therefore it does not emit plain "click" events or similar but can be configured to send commands like on, off, toggle, cover up, cover down etc. from up to 6 endpoints (4 with on/off, level and scenes for lights and another 2 to control window covering devices).

I looked through quite a few other implementations here and ended up returning theses commands as actions that are prefixed with the endpoint id. I hope this ok - please feel free to comment if you have further suggestions.

I will also file another PR to allow further configuration of the inputs (of all ubisys devices including the C4) to send other commands e.g. to bound lights or covers (see https://github.com/felixstorm/zigbee-herdsman-converters/commit/70ab168da3d935270c2150a1f303223c6c5954bf), but this PR is needed as a base for the next to depend upon.  
In their factory reset configuration the C4s just send a toggle command for each input that originates from endpoints 1 to 4 respectively - so this PR will already work even without being able to customize the inputs any further.