### PR TITLE
OTA support for ubisys devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7346,6 +7346,7 @@ const devices = [
             await configureReporting.instantaneousDemand(endpoint);
             await endpoint.read('seMetering', ['multiplier', 'divisor']);
         },
+        ota: ota.ubisys,
     },
     {
         zigbeeModel: ['S2 (5502)', 'S2-R (5602)'],
@@ -7365,6 +7366,7 @@ const devices = [
             await configureReporting.instantaneousDemand(endpoint);
             await endpoint.read('seMetering', ['multiplier', 'divisor']);
         },
+        ota: ota.ubisys,
     },
     {
         zigbeeModel: ['D1 (5503)', 'D1-R (5603)'],
@@ -7381,6 +7383,7 @@ const devices = [
             await configureReporting.instantaneousDemand(endpoint);
             await endpoint.read('seMetering', ['multiplier', 'divisor']);
         },
+        ota: ota.ubisys,
     },
     {
         zigbeeModel: ['J1 (5502)', 'J1-R (5602)'],
@@ -7390,6 +7393,7 @@ const devices = [
         supports: 'open, close, stop, position, tilt',
         fromZigbee: [fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.ubisys_configure_j1],
+        ota: ota.ubisys,
     },
 
     // Lutron

--- a/ota/common.js
+++ b/ota/common.js
@@ -38,11 +38,25 @@ function parseImage(buffer) {
         otaHeaderString: buffer.toString('utf8', 20, 52),
         totalImageSize: buffer.readUInt32LE(52),
     };
+    let headerPos = 56;
+    if (header.otaHeaderFieldControl & 1) {
+        header.securityCredentialVersion = buffer.readUInt8(headerPos);
+        headerPos += 1;
+    }
+    if (header.otaHeaderFieldControl & 2) {
+        header.upgradeFileDestination = buffer.subarray(headerPos, headerPos + 8);
+        headerPos += 8;
+    }
+    if (header.otaHeaderFieldControl & 4) {
+        header.minimumHardwareVersion = buffer.readUInt16LE(headerPos);
+        headerPos += 2;
+        header.maximumHardwareVersion = buffer.readUInt16LE(headerPos);
+        headerPos += 2;
+    }
 
     const raw = buffer.slice(0, header.totalImageSize);
 
     assert(Buffer.compare(header.otaUpgradeFileIdentifier, upgradeFileIdentifier) === 0, 'Not an OTA file');
-    assert(header.otaHeaderFieldControl === 0, 'Non zero field control not implemented yet');
 
     let position = header.otaHeaderLength;
     const elements = [];

--- a/ota/index.js
+++ b/ota/index.js
@@ -2,5 +2,6 @@ module.exports = {
     ledvance: require('./ledvance'),
     salus: require('./salus'),
     tradfri: require('./tradfri'),
+    ubisys: require('./ubisys'),
 };
 

--- a/ota/ubisys.js
+++ b/ota/ubisys.js
@@ -1,0 +1,70 @@
+const axios = require('axios');
+const firmwareHtmlPageUrl = 'https://www.ubisys.de/en/support/firmware/';
+const imageRegex = /[^"\s]*\/10F2-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{8})\S*ota\.zigbee/gi;
+const assert = require('assert');
+const url = require('url');
+const common = require('./common');
+
+/**
+ * Helper functions
+ */
+
+async function getImageMeta(imageType, hardwareVersion) {
+    const firmwarePageHtml = (await axios.get(firmwareHtmlPageUrl)).data;
+    let imageMatch = imageRegex.exec(firmwarePageHtml);
+    while (imageMatch != null) {
+        if (parseInt(imageMatch[1], 16) === imageType &&
+            parseInt(imageMatch[2], 16) <= hardwareVersion && hardwareVersion <= parseInt(imageMatch[3], 16)) {
+            break;
+        }
+        imageMatch = imageRegex.exec(firmwarePageHtml);
+    }
+    assert(imageMatch !== null,
+        `No image available for imageType '0x${imageType.toString(16)}' with hardware version ${hardwareVersion}`);
+    return {
+        hardwareVersionMin: parseInt(imageMatch[2], 16),
+        hardwareVersionMax: parseInt(imageMatch[3], 16),
+        fileVersion: parseInt(imageMatch[4], 16),
+        url: url.resolve(firmwareHtmlPageUrl, imageMatch[0]),
+    };
+}
+
+async function getNewImage(current, logger, device) {
+    const meta = await getImageMeta(current.imageType, device.hardwareVersion);
+    assert(meta.fileVersion > current.fileVersion, 'No new image available');
+
+    const download = await axios.get(meta.url, {responseType: 'arraybuffer'});
+    const start = download.data.indexOf(common.upgradeFileIdentifier);
+
+    const image = common.parseImage(download.data.slice(start));
+    assert(image.header.fileVersion === meta.fileVersion, 'File version mismatch');
+    assert(image.header.manufacturerCode === 0x10f2, 'Manufacturer code mismatch');
+    assert(image.header.imageType === current.imageType, 'Image type mismatch');
+    assert(image.header.minimumHardwareVersion <= device.hardwareVersion &&
+        device.hardwareVersion <= image.header.maximumHardwareVersion, 'Hardware version mismatch');
+    return image;
+}
+
+async function isNewImageAvailable(current, logger, device) {
+    const meta = await getImageMeta(current.imageType, device.hardwareVersion);
+    const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
+    logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
+    return meta.fileVersion > current.fileVersion;
+}
+
+/**
+ * Interface implementation
+ */
+
+async function isUpdateAvailable(device, logger, requestPayload=null) {
+    return common.isUpdateAvailable(device, logger, isNewImageAvailable, requestPayload);
+}
+
+async function updateToLatest(device, logger, onProgress) {
+    return common.updateToLatest(device, logger, onProgress, getNewImage);
+}
+
+module.exports = {
+    isUpdateAvailable,
+    updateToLatest,
+};


### PR DESCRIPTION
At the moment I only use HTML scraping to detect available firmware versions, but it does work ok so far. I wrote an email to ubisys asking for an official automatic distribution point and as soon as I receive any information I will either update this PR or file an additional one in case this has already been merged.  
But since carnival is pretty big in the area where their headquarter is located, they might need a few days to answer :wink: