### PR TITLE
OSRAM SMART+ Motion Sensor not supported by Ledvance OTA server

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2468,7 +2468,6 @@ const devices = [
         ],
         toZigbee: [],
         meta: {configureKey: 1},
-        ota: ota.ledvance,
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);


### PR DESCRIPTION
The OSRAM Smart+ Motion Sensor is not supported by the Ledvance OTA server, and
results in the following errors being logged:

	zigbee2mqtt    | zigbee2mqtt:error 2020-02-29 15:24:08: Failed to call 'OTAUpdate' 'onZigbeeEvent' (AssertionError [ERR_ASSERTION]: No image available for manufacturerCode '4174' imageType '48'
	zigbee2mqtt    |     at getImageMeta (/app/node_modules/zigbee-herdsman-converters/ota/ledvance.js:15:5)
	zigbee2mqtt    |     at runMicrotasks (<anonymous>)
	zigbee2mqtt    |     at async isNewImageAvailable (/app/node_modules/zigbee-herdsman-converters/ota/ledvance.js:48:18)
	zigbee2mqtt    |     at async Object.isUpdateAvailable (/app/node_modules/zigbee-herdsman-converters/ota/common.js:159:23)
	zigbee2mqtt    |     at async OTAUpdate.onZigbeeEvent (/app/lib/extension/otaUpdate.js:31:27)