### PR TITLE
ubisys: Support Configuration of Inputs

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1644,6 +1644,32 @@ const converters = {
             ], options.ubisys));
         },
     },
+    ubisys_device_setup: {
+        key: ['configure_device_setup'],
+        convertSet: async (entity, key, value, meta) => {
+            const devMgmtEp = meta.device.getEndpoint(232);
+            if (value.hasOwnProperty('inputConfigurations')) {
+                // example: [0, 0, 0, 0]
+                await devMgmtEp.write('manuSpecificUbisysDeviceSetup',
+                    {'inputConfigurations': {elementType: 'data8', elements: value.inputConfigurations}});
+            }
+            if (value.hasOwnProperty('inputActions')) {
+                // example (default for C4): [[0,13,1,6,0,2], [1,13,2,6,0,2], [2,13,3,6,0,2], [3,13,4,6,0,2]]
+                await devMgmtEp.write('manuSpecificUbisysDeviceSetup',
+                    {'inputActions': {elementType: 'octetStr', elements: value.inputActions}});
+            }
+            converters.ubisys_device_setup.convertGet(entity, key, meta);
+        },
+        convertGet: async (entity, key, meta) => {
+            const log = (json) => {
+                meta.logger.warn(
+                    `ubisys: Device setup read for '${meta.options.friendlyName}': ${JSON.stringify(json)}`);
+            };
+            const devMgmtEp = meta.device.getEndpoint(232);
+            log(await devMgmtEp.read('manuSpecificUbisysDeviceSetup', ['inputConfigurations']));
+            log(await devMgmtEp.read('manuSpecificUbisysDeviceSetup', ['inputActions']));
+        },
+    },
 
     tint_scene: {
         key: ['tint_scene'],

--- a/devices.js
+++ b/devices.js
@@ -7428,6 +7428,7 @@ const devices = [
                 await bind(device.getEndpoint(ep), coordinatorEndpoint, ['genScenes', 'closuresWindowCovering']);
             }
         },
+        ota: ota.ubisys,
     },
 
     // Lutron

--- a/devices.js
+++ b/devices.js
@@ -7354,7 +7354,7 @@ const devices = [
         description: 'Power switch S1',
         supports: 'on/off, power measurement',
         fromZigbee: [fz.on_off, fz.generic_power],
-        toZigbee: [tz.on_off],
+        toZigbee: [tz.on_off, tz.ubisys_device_setup],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(3);
@@ -7371,7 +7371,7 @@ const devices = [
         description: 'Power switch S2',
         supports: 'on/off, power measurement',
         fromZigbee: [fz.generic_state_multi_ep, fz.generic_power],
-        toZigbee: [tz.on_off],
+        toZigbee: [tz.on_off, tz.ubisys_device_setup],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
@@ -7391,7 +7391,7 @@ const devices = [
         description: 'Universal dimmer D1',
         supports: 'on/off, brightness, power measurement',
         fromZigbee: [fz.on_off, fz.brightness, fz.generic_power],
-        toZigbee: [tz.light_onoff_brightness],
+        toZigbee: [tz.light_onoff_brightness, tz.ubisys_device_setup],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(4);
@@ -7408,7 +7408,7 @@ const devices = [
         description: 'Shutter control J1',
         supports: 'open, close, stop, position, tilt',
         fromZigbee: [fz.cover_position_tilt],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.ubisys_configure_j1],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.ubisys_configure_j1, tz.ubisys_device_setup],
         ota: ota.ubisys,
     },
     {
@@ -7418,7 +7418,7 @@ const devices = [
         description: 'Control unit C4',
         supports: 'action',
         fromZigbee: [fz.ubisys_c4_scenes, fz.ubisys_c4_onoff, fz.ubisys_c4_level, fz.ubisys_c4_cover],
-        toZigbee: [],
+        toZigbee: [tz.ubisys_device_setup],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             for (const ep of [1, 2, 3, 4]) {


### PR DESCRIPTION
Support the configuration of inputs of ubisys devices. Especially helpful for the C4, but also for others (e.g. to use stationary switches instead of momentary ones or vice versa). Depends on https://github.com/Koenkk/zigbee-herdsman/commit/cf827b83838f2ed53c32acff7fac5ed1c81cece9  
Issue #973 should be completed with this PR.  

Also enables OTA updates for the C4.