### PR TITLE
Update SmartThings (Centralite OEM) UK outlet to support power measurement cluster

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3991,15 +3991,27 @@ const devices = [
         zigbeeModel: ['3200-Sgb'],
         model: 'F-APP-UK-V2',
         vendor: 'SmartThings',
-        description: 'Outlet UK',
-        supports: 'on/off',
-        fromZigbee: [fz.on_off],
+        description: 'Zigbee Outlet UK with power meter',
+        supports: 'on/off, power measurement',
+        fromZigbee: [fz.on_off, fz.electrical_measurement],
         toZigbee: [tz.on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
             await configureReporting.onOff(endpoint);
+            await configureReporting.rmsVoltage(endpoint, {'maximumReportInterval': 600, 'reportableChange': 3}); // Limit updates to 3V and max 600s (10m)
+            await configureReporting.rmsCurrent(endpoint, {'maximumReportInterval': 600, 'reportableChange': 10}); // Limit updates to 0.01A and max 600s (10m)
+            await configureReporting.activePower(endpoint, {'maximumReportInterval': 600, 'reportableChange': 40}); // Limit updates to 4.0W and max 600s (10m)
+            await endpoint.read('haElectricalMeasurement', [
+                'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier',
+            ]);
+            await endpoint.read('haElectricalMeasurement', [
+                'acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor',
+            ]);
+            await endpoint.read('haElectricalMeasurement', [
+                'activePower', 'rmsCurrent', 'rmsVoltage',
+            ]);
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -4000,9 +4000,12 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
             await configureReporting.onOff(endpoint);
-            await configureReporting.rmsVoltage(endpoint, {'maximumReportInterval': 600, 'reportableChange': 3}); // Limit updates to 3V and max 600s (10m)
-            await configureReporting.rmsCurrent(endpoint, {'maximumReportInterval': 600, 'reportableChange': 10}); // Limit updates to 0.01A and max 600s (10m)
-            await configureReporting.activePower(endpoint, {'maximumReportInterval': 600, 'reportableChange': 40}); // Limit updates to 4.0W and max 600s (10m)
+            // Limit updates to 3V and max 600s (10m)
+            await configureReporting.rmsVoltage(endpoint, {'maximumReportInterval': 600, 'reportableChange': 3});
+            // Limit updates to 0.01A and max 600s (10m)
+            await configureReporting.rmsCurrent(endpoint, {'maximumReportInterval': 600, 'reportableChange': 10});
+            // Limit updates to 4.0W and max 600s (10m)
+            await configureReporting.activePower(endpoint, {'maximumReportInterval': 600, 'reportableChange': 40});
             await endpoint.read('haElectricalMeasurement', [
                 'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier',
             ]);


### PR DESCRIPTION
The 3200-Sgb power outlet (marketed as Samsung SmartThings power outlet) supports power meter readings, this PR adds support for that reporting cluster. I've tested it with my outlets and they are reporting just like they did when they were paired with the ST hub.

I have overridden the power reporting settings with slightly more sane values using the overrides introduced in #954 and discussed in #940, as the defaults resulted in a lot of reports being sent on the Zigbee network.

Do I need to submit a separate PR in koenkk/zigbee2mqtt for the additional Home Assistant MQTT autodiscovery config, or is that file autogenerated? I couldn't figure this out from [the documentation on supporting new devices](https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html).