### PR TITLE
Innr RB 250C does not support enhancedHue

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -499,7 +499,7 @@ const converters = {
             } else if (value.hasOwnProperty('hue') && value.hasOwnProperty('saturation') &&
                        meta.options.enhancedHue === false) {
                 newState.color = {hue: value.hue, saturation: value.saturation};
-                value.hue = value.hue;
+                value.hue = Math.round(value.hue / 360 * 254);
                 value.saturation = value.saturation * (2.54);
                 cmd = 'moveToHueAndSaturation';
             } else if (value.hasOwnProperty('hue') && value.hasOwnProperty('saturation')) {
@@ -509,7 +509,7 @@ const converters = {
                 cmd = 'enhancedMoveToHueAndSaturation';
             } else if (value.hasOwnProperty('hue') && meta.options.enhancedHue === false) {
                 newState.color = {hue: value.hue};
-                value.hue = value.hue;
+                value.hue = Math.round(value.hue / 360 * 254);
                 cmd = 'moveToHue';
             } else if (value.hasOwnProperty('hue')) {
                 newState.color = {hue: value.hue};

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -578,7 +578,7 @@ const converters = {
             return {state: newState, readAfterWriteTime: zclData.transtime * 100};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('lightingColorCtrl', ['currentX', 'currentY']);
+            await entity.read('lightingColorCtrl', ['currentX', 'currentY', 'currentHue', 'currentSaturation']);
         },
     },
     light_color_colortemp: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -496,11 +496,21 @@ const converters = {
                 newState.color = {s: value.s};
                 value.saturation = value.s * (2.54);
                 cmd = 'moveToSaturation';
+            } else if (value.hasOwnProperty('hue') && value.hasOwnProperty('saturation') &&
+                       meta.options.enhancedHue === false) {
+                newState.color = {hue: value.hue, saturation: value.saturation};
+                value.hue = value.hue;
+                value.saturation = value.saturation * (2.54);
+                cmd = 'moveToHueAndSaturation';
             } else if (value.hasOwnProperty('hue') && value.hasOwnProperty('saturation')) {
                 newState.color = {hue: value.hue, saturation: value.saturation};
                 value.hue = value.hue % 360 * (65535 / 360);
                 value.saturation = value.saturation * (2.54);
                 cmd = 'enhancedMoveToHueAndSaturation';
+            } else if (value.hasOwnProperty('hue') && meta.options.enhancedHue === false) {
+                newState.color = {hue: value.hue};
+                value.hue = value.hue;
+                cmd = 'moveToHue';
             } else if (value.hasOwnProperty('hue')) {
                 newState.color = {hue: value.hue};
                 value.hue = value.hue % 360 * (65535 / 360);
@@ -535,7 +545,15 @@ const converters = {
                 zclData.enhancehue = value.hue;
                 zclData.direction = value.direction || 0;
                 break;
-
+            case 'moveToHueAndSaturation':
+                zclData.hue = value.hue;
+                zclData.saturation = value.saturation;
+                zclData.direction = value.direction || 0;
+                break;
+            case 'moveToHue':
+                zclData.hue = value.hue;
+                zclData.direction = value.direction || 0;
+                break;
             case 'moveToSaturation':
                 zclData.saturation = value.saturation;
                 break;

--- a/devices.js
+++ b/devices.js
@@ -2679,6 +2679,7 @@ const devices = [
         vendor: 'Innr',
         description: 'E14 bulb RGBW',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
+        meta: {options: {enhancedHue: false}},
     },
     {
         zigbeeModel: ['RB 265'],


### PR DESCRIPTION
I noticed a while ago that the Innr RB 250C did not support the `enhancedHue` and friends command.

It does however support the generic `moveToHue`, `moveToSaturation`, and `moveToHueAndSaturation` commands. I never figured out how to till the converter how to deal with this until I saw your `options.applyRedFix`.

This PR introduces `options.enhancedHue`, I set this to `false` for the Innr RB 250C (probably other Innr bulbs would need it too, but I don't own those so I couldn't test).

I thought this would be less disruptive than setting `options.enhancedHue` to `true` for all existing bulbs. I then added an extra branch to the if and case statements in light_color toZigbee converter to make it do the right thing.