### PR TITLE
Support 2 new Namron devices

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4084,14 +4084,14 @@ const converters = {
         cluster: 'genOnOff',
         type: 'commandOn',
         convert: (model, msg, publish, options, meta) => {
-            return { click: `on`, key: `${msg.endpoint.ID}` };
+            return {click: `on`, key: `${msg.endpoint.ID}`};
         },
     },
     multiOnOff_cmdOff: {
         cluster: 'genOnOff',
         type: 'commandOff',
         convert: (model, msg, publish, options, meta) => {
-            return { click: `off`, key: `${msg.endpoint.ID}` };
+            return {click: `off`, key: `${msg.endpoint.ID}`};
         },
     },
     multi_move_with_onoff: {
@@ -4100,7 +4100,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             ictcg1(model, msg, publish, options, 'move');
             const direction = msg.data.movemode === 1 ? 'left' : 'right';
-            return { action: `rotate_${direction}`, rate: msg.data.rate, key: `${msg.endpoint.ID}` };
+            return {action: `rotate_${direction}`, rate: msg.data.rate, key: `${msg.endpoint.ID}`};
         },
     },
     multi_stop_with_onoff: {
@@ -4108,7 +4108,7 @@ const converters = {
         type: 'commandStopWithOnOff',
         convert: (model, msg, publish, options, meta) => {
             const value = ictcg1(model, msg, publish, options, 'stop');
-            return { action: `rotate_stop`, brightness: value, key: `${msg.endpoint.ID}`};
+            return {action: `rotate_stop`, brightness: value, key: `${msg.endpoint.ID}`};
         },
     },
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4083,6 +4083,38 @@ const converters = {
             return {action: `${msg.endpoint.ID}_cover_${lookup[msg.type]}`};
         },
     },
+    // Switches with multiple set of switches identified by endpoints
+    multiOnOff_cmdOn: {
+        cluster: 'genOnOff',
+        type: 'commandOn',
+        convert: (model, msg, publish, options, meta) => {
+            return { click: `on`, key: `${msg.endpoint.ID}` };
+        },
+    },
+    multiOnOff_cmdOff: {
+        cluster: 'genOnOff',
+        type: 'commandOff',
+        convert: (model, msg, publish, options, meta) => {
+            return { click: `off`, key: `${msg.endpoint.ID}` };
+        },
+    },
+    multi_move_with_onoff: {
+        cluster: 'genLevelCtrl',
+        type: 'commandMoveWithOnOff',
+        convert: (model, msg, publish, options, meta) => {
+            ictcg1(model, msg, publish, options, 'move');
+            const direction = msg.data.movemode === 1 ? 'left' : 'right';
+            return { action: `rotate_${direction}`, rate: msg.data.rate, key: `${msg.endpoint.ID}` };
+        },
+    },
+    multi_stop_with_onoff: {
+        cluster: 'genLevelCtrl',
+        type: 'commandStopWithOnOff',
+        convert: (model, msg, publish, options, meta) => {
+            const value = ictcg1(model, msg, publish, options, 'stop');
+            return { action: `rotate_stop`, brightness: value, key: `${msg.endpoint.ID}`};
+        },
+    },
 
     // Ignore converters (these message dont need parsing).
     ignore_onoff_report: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1956,6 +1956,28 @@ const converters = {
             return {action: `rotate_${direction}`, rate: msg.data.rate};
         },
     },
+    cmd_step_with_onoff: {
+        cluster: 'genLevelCtrl',
+        type: 'commandStepWithOnOff',
+        convert: (model, msg, publish, options, meta) => {
+            // Get/adjust stored brightness
+            const deviceID = msg.device.ieeeAddr;
+            if (!store[deviceID]) {
+                store[deviceID] = { since: false, direction: false, value: 255, publish: publish };
+            }
+            const s = store[deviceID];
+            const delta = Math.round(msg.data.stepsize * (msg.data.stepmode === 1 ? -1 : 1));
+            const newValue = Math.min(Math.max(s.value + delta, 0), 255);
+            s.value = newValue;
+            return {
+                action: msg.data.stepmode === 1 ? 'down' : 'up', 
+                brightness: s.value,
+                step_mode: msg.data.stepmode,
+                step_size: msg.data.stepsize,
+                transition_time: msg.data.transtime,
+            };
+        },
+    },
     cmd_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -117,10 +117,8 @@ const ictcg1 = (model, msg, publish, options, action) => {
         if (s.direction) {
             const duration = Date.now() - s.since;
             const delta = Math.round(rate * (duration / 10) * (s.direction === 'left' ? -1 : 1));
-            const newValue = s.value + delta;
-            if (newValue >= 0 && newValue <= 255) {
-                s.value = newValue;
-            }
+            const newValue = Math.min(Math.max(s.value + delta, 0), 255);
+            s.value = newValue;
         }
         payload.action = 'rotate_stop';
         payload.brightness = s.value;
@@ -134,10 +132,8 @@ const ictcg1 = (model, msg, publish, options, action) => {
         s.timerId = setInterval(() => {
             const duration = Date.now() - s.since;
             const delta = Math.round(rate * (duration / 10) * (s.direction === 'left' ? -1 : 1));
-            const newValue = s.value + delta;
-            if (newValue >= 0 && newValue <= 255) {
-                s.value = newValue;
-            }
+            const newValue = Math.min(Math.max(s.value + delta, 0), 255);
+            s.value = newValue;
             payload.brightness = s.value;
             s.since = Date.now();
             s.publish(payload);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -531,6 +531,16 @@ const converters = {
 
             default:
                 cmd = 'moveToColor';
+
+                // Some bulbs e.g. RB 185 C don't turn to red (they don't respond at all) when x: 0.701 and y: 0.299
+                // is send. These values are e.g. send by Home Assistant when clicking red in the color wheel.
+                // If we slighlty modify these values the bulb will respond.
+                // https://github.com/home-assistant/home-assistant/issues/31094
+                if (meta.options.applyRedFix && value.x == 0.701 && value.y === 0.299) {
+                    value.x = 0.7006;
+                    value.y = 0.2993;
+                }
+
                 newState.color = {x: value.x, y: value.y};
                 zclData.colorx = Math.round(value.x * 65535);
                 zclData.colory = Math.round(value.y * 65535);

--- a/devices.js
+++ b/devices.js
@@ -3936,6 +3936,18 @@ const devices = [
         ],
         toZigbee: [],
     },
+    {
+        zigbeeModel: ['4512702'],
+        model: '4512702',
+        vendor: 'Namron',
+        description: 'ZigBee 1 channel switch K4',
+        supports: 'click, brightness',
+        fromZigbee: [
+            fz.genOnOff_cmdOn, fz.genOnOff_cmdOff, fz.generic_battery,
+            fz.cmd_move_with_onoff, fz.cmd_stop_with_onoff, fz.cmd_step_with_onoff,
+        ],
+        toZigbee: [],
+    },
 
     // SmartThings
     {

--- a/devices.js
+++ b/devices.js
@@ -2665,6 +2665,7 @@ const devices = [
         vendor: 'Innr',
         description: 'E27 bulb RGBW',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
+        meta: {options: {applyRedFix: true}},
     },
     {
         zigbeeModel: ['BY 185 C'],

--- a/devices.js
+++ b/devices.js
@@ -3924,6 +3924,18 @@ const devices = [
             await configureReporting.onOff(endpoint);
         },
     },
+    {
+        zigbeeModel: ['4512703'],
+        model: '4512703',
+        vendor: 'Namron',
+        description: 'ZigBee 4 channel switch K8',
+        supports: 'click, brightness',
+        fromZigbee: [
+            fz.multiOnOff_cmdOn, fz.multiOnOff_cmdOff, fz.generic_battery,
+            fz.multi_move_with_onoff, fz.multi_stop_with_onoff,
+        ],
+        toZigbee: [],
+    },
 
     // SmartThings
     {


### PR DESCRIPTION
- Support Namron ZigBee 4 channel switch K8, model 4512703. Supports on/off and dimming on 4 endpoints
- Allow dimmer buttons to dim all the way down to 0 and up to 255
- Support Namron ZigBee 1 channel switch K4, model 4512702. Has separate buttons for on/off and dim up/down.