### PR TITLE
Add support for LCT011 Hue BR30 downlight (previous gen)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1585,7 +1585,7 @@ const devices = [
         extend: hue.light_onoff_brightness_colortemp_colorxy,
     },
     {
-        zigbeeModel: ['LCT002'],
+        zigbeeModel: ['LCT002', 'LCT011'],
         model: '9290002579A',
         vendor: 'Philips',
         description: 'Hue white and color ambiance BR30',


### PR DESCRIPTION
Hi, I have some hue bulbs that identify them as `LCT011` so I added them to the correct item.