### PR TITLE
Support heiman Smart emergency button

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5193,7 +5193,7 @@ const devices = [
         model: 'HS1EB',
         vendor: 'HEIMAN',
         description: 'Smart emergency button',
-        supports: 'single',
+        supports: 'click',
         fromZigbee: [fz.st_button_state],
         toZigbee: [],
     },

--- a/devices.js
+++ b/devices.js
@@ -5188,6 +5188,15 @@ const devices = [
             await configureReporting.batteryVoltage(endpoint);
         },
     },
+    {
+        zigbeeModel: ['SOS-EM'],
+        model: 'HS1EB',
+        vendor: 'HEIMAN',
+        description: 'Smart emergency button',
+        supports: 'single',
+        fromZigbee: [fz.st_button_state],
+        toZigbee: [],
+    },
 
     // GS
     {


### PR DESCRIPTION
http://www.heiman.com.cn/product/100.html
```
zigbee2mqtt:info  2020-03-11 11:31:41: Device '0x000d6f0015351723' joined
zigbee2mqtt:info  2020-03-11 11:31:41: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"device_connected","message":{"friendly_name":"0x000d6f0015351723"}}'
zigbee2mqtt:info  2020-03-11 11:31:41: Starting interview of '0x000d6f0015351723'
zigbee2mqtt:info  2020-03-11 11:31:41: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"pairing","message":"interview_started","meta":{"friendly_name":"0x000d6f0015351723"}}'
zigbee2mqtt:debug 2020-03-11 11:31:55: Device '0x000d6f0015351723' announced itself
zigbee2mqtt:debug 2020-03-11 11:32:05: Received Zigbee message from '0x000d6f0015351723', type 'readResponse', cluster 'genBasic', data '{"modelId":"SOS-EM","manufacturerName":"HEIMAN"}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-03-11 11:32:05: Device '0x000d6f0015351723' is supported, identified as: HEIMAN Smart emergency button (HS1EB)
zigbee2mqtt:info  2020-03-11 11:32:05: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"pairing","message":"interview_successful","meta":{"friendly_name":"0x000d6f0015351723","model":"HS1EB","vendor":"HEIMAN","description":"Smart emergency button","supported":true}}'

```