### PR TITLE
add Centralite 3323-G Micro-Door sensor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2017,6 +2017,13 @@ const converters = {
             return {contact: msg.data.zonestatus === 36};
         },
     },
+    centralite_3323G_contact: {
+        cluster: 'ssIasZone',
+        type: 'commandStatusChangeNotification',
+        convert: (model, msg, publish, options, meta) => {
+            return {contact: msg.data.zonestatus === 32};
+        },
+    },
     nue_power_state: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2017,13 +2017,6 @@ const converters = {
             return {contact: msg.data.zonestatus === 36};
         },
     },
-    centralite_3323G_contact: {
-        cluster: 'ssIasZone',
-        type: 'commandStatusChangeNotification',
-        convert: (model, msg, publish, options, meta) => {
-            return {contact: msg.data.zonestatus === 32};
-        },
-    },
     nue_power_state: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],

--- a/devices.js
+++ b/devices.js
@@ -4698,12 +4698,12 @@ const devices = [
         vendor: 'Centralite',
         description: 'Micro-Door sensor',
         supports: 'contact and temperature',
-        fromZigbee: [fz.centralite_3323G_contact, fz.temperature],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await configureReporting.temperature(endpoint);
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -4691,23 +4691,6 @@ const devices = [
         toZigbee: [],
     },
 
-    // Centralite
-    {
-        zigbeeModel: ['3323-G'],
-        model: '3323-G',
-        vendor: 'Centralite',
-        description: 'Micro-Door sensor',
-        supports: 'contact and temperature',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature],
-        toZigbee: [],
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await configureReporting.temperature(endpoint);
-        },
-    },
-
     // ksentry
     {
         zigbeeModel: ['Lamp_01'],
@@ -4779,7 +4762,7 @@ const devices = [
         extend: generic.light_onoff_brightness_colortemp,
     },
 
-    // Centralite Swiss Plug
+    // Centralite
     {
         zigbeeModel: ['4256251-RZHAC', '4257050-RZHAC'],
         model: '4256251-RZHAC',
@@ -4815,6 +4798,21 @@ const devices = [
             await configureReporting.rmsVoltage(endpoint, {'reportableChange': 2}); // Voltage reports in V
             await configureReporting.rmsCurrent(endpoint, {'reportableChange': 10}); // Current reports in mA
             await configureReporting.activePower(endpoint, {'reportableChange': 2}); // Power reports in 0.1W
+        },
+    },
+    {
+        zigbeeModel: ['3323-G'],
+        model: '3323-G',
+        vendor: 'Centralite',
+        description: 'Micro-door sensor',
+        supports: 'contact, temperature',
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
+            await configureReporting.temperature(endpoint);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -4691,6 +4691,23 @@ const devices = [
         toZigbee: [],
     },
 
+    // Centralite
+    {
+        zigbeeModel: ['3323-G'],
+        model: '3323-G',
+        vendor: 'Centralite',
+        description: 'Micro-Door sensor',
+        supports: 'contact and temperature',
+        fromZigbee: [fz.centralite_3323G_contact, fz.temperature],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await configureReporting.temperature(endpoint);
+        },
+    },
+
     // ksentry
     {
         zigbeeModel: ['Lamp_01'],


### PR DESCRIPTION
Similar to the now defunct Iris Contact/Temperature sensor (3320-L), no battery but contact/temperature work fine. 