### PR TITLE
Prevent Xiaomi reset on long press

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -495,6 +495,27 @@ const legrand = {
     },
 };
 
+const xiaomi = {
+    prevent_reset: async (type, data, device) => {
+        if (
+            // options.allow_reset ||
+            type !== 'message' ||
+            data.type !== 'attributeReport' ||
+            data.cluster !== 'genBasic' ||
+            !data.data[0xfff0] ||
+            // eg: [0xaa, 0x10, 0x05, 0x41, 0x87, 0x01, 0x01, 0x10, 0x00]
+            !data.data[0xFFF0].slice(0, 5).equals(Buffer.from([0xaa, 0x10, 0x05, 0x41, 0x87]))
+        ) {
+            return;
+        }
+        const options = {manufacturerCode: 0x115f};
+        const payload = {[0xfff0]: {
+            value: [0xaa, 0x10, 0x05, 0x41, 0x47, 0x01, 0x01, 0x10, 0x01],
+            type: 0x41,
+        }};
+        await device.getEndpoint(1).write('genBasic', payload, options);
+    },
+};
 const devices = [
     // Xiaomi
     {
@@ -553,6 +574,7 @@ const devices = [
             fz.xiaomi_action_click_multistate,
         ],
         toZigbee: [],
+        onEvent: xiaomi.prevent_reset,
     },
     {
         zigbeeModel: ['lumi.sensor_86sw2', 'lumi.sensor_86sw2.es1', 'lumi.remote.b286acn01'],
@@ -568,6 +590,7 @@ const devices = [
         endpoint: (device) => {
             return {'left': 1, 'right': 2, 'both': 3};
         },
+        onEvent: xiaomi.prevent_reset,
     },
     {
         zigbeeModel: ['lumi.ctrl_neutral1'],
@@ -600,6 +623,7 @@ const devices = [
         endpoint: (device) => {
             return {'system': 1};
         },
+        onEvent: xiaomi.prevent_reset,
     },
     {
         zigbeeModel: ['lumi.ctrl_neutral2'],
@@ -632,6 +656,7 @@ const devices = [
         endpoint: (device) => {
             return {'left': 1, 'right': 2, 'system': 1};
         },
+        onEvent: xiaomi.prevent_reset,
     },
     {
         zigbeeModel: ['lumi.sens', 'lumi.sensor_ht'],


### PR DESCRIPTION
Respond to long press like stock hub does.

Currently added behavior only to devices I own, but most likely applies
to "without neutral" variants as well, since those lie in-between battery
and "with neutral" devices.

Remaining questions:
1. This does **not** prevent kicking from the network, but some crazy people might still want it configurable. For this `options` (device specific configuration) needs to be passed to `onEvent` or I need a way to obtain it using the passed in `device`. Or, does this need to be dynamically configurable via mqtt?
2. Maybe I should blindly add this to more devices, otherwise we need testers with device / sniffers with device and hub / someone to send me a device. Shouldn't be any harm.
3. It's not clear what the contents of the message actually are, and when they might change.

`[0xaa, 0x10, 0x05, 0x41, 0x87, 0x01, 0x01, 0x10, 0x00]`
On wired devices in the report, the last octet is always 0, and the  "counter" octet (after `0x84`) is always 1.
On wireless buttons, the last octet was 1 (like in the `write` response from hub) and the counter was incremented on the device side, sometimes by 2.
The `write` response always has `0x47` instead of `0x87`, so that bit is moved, always 1 in the last octet, and is generally identical for all devices tested, just merrily incrementing the counter (IIRC globally, for any device it sends this to). Not incrementing the counter didn't interfere with the functionality of this PR, even if the response value was less than that in the report, so its purpose remains unknown.

It might be worthwhile to mess around more with what we send and see what works, but currently the goal is achieved.
I tested this with CC2531 to not disturb my production networks.