### PR TITLE
Add alternate zigbeeModel for Linkind ZL1000100-CCT-US-V1A02

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8465,7 +8465,7 @@ const devices = [
 
     // Linkind
     {
-        zigbeeModel: ['ZBT-CCTLight-D0106'],
+        zigbeeModel: ['ZBT-CCTLight-D0106', 'ZBT-CCTLight-GLS0108'],
         model: 'ZL1000100-CCT-US-V1A02',
         vendor: 'Linkind',
         description: 'Zigbee LED 9W A19 bulb, dimmable & tunable',


### PR DESCRIPTION
Newly bought Linkind ZL1000100-CCT-US-V1A02 reports a different model than previously seen. Tested on my local hassio, confirmed to work.