### PR TITLE
More intuitive behavior for GL-C-007 2ID

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1306,10 +1306,9 @@ const converters = {
                 // GL-C-007 RGBW
                 if (utils.hasEndpoints(meta.device, [11, 13, 15])) {
                     if (key === 'white_value') {
-                        // Switch from RGB to white
+                        // Activating white LEDs
                         if (!meta.options.separate_control) {
                             await meta.device.getEndpoint(15).command('genOnOff', 'on', {});
-                            await meta.device.getEndpoint(11).command('genOnOff', 'off', {});
                             state.color = xyWhite;
                         }
 
@@ -1320,10 +1319,9 @@ const converters = {
                             state: {white_value: value, ...result.state, ...state},
                             readAfterWriteTime: 0,
                         };
-                    } else {
+                    } else if (key === 'color') {
                         if (meta.state.white_value !== -1 && !meta.options.separate_control) {
-                            // Switch from white to RGB
-                            await meta.device.getEndpoint(11).command('genOnOff', 'on', {});
+                            // Disabling white LEDs
                             await meta.device.getEndpoint(15).command('genOnOff', 'off', {});
                             state.white_value = -1;
                         }


### PR DESCRIPTION
After playing with the GL-C-007 2ID for a while I was quite confused with the behavior. I was not able to use the color temperature while in white mode. This change allows the color temperature while in white mode, and when sending a color, it disables white mode again.