### PR TITLE
Fix power reporting of Centralite 4257050-RZHAC

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5083,7 +5083,7 @@ const devices = [
 
     // Centralite
     {
-        zigbeeModel: ['4256251-RZHAC', '4257050-RZHAC'],
+        zigbeeModel: ['4256251-RZHAC'],
         model: '4256251-RZHAC',
         vendor: 'Centralite',
         description: 'White Swiss power outlet switch with power meter',
@@ -5112,6 +5112,25 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement']);
+            await configureReporting.onOff(endpoint);
+            await readEletricalMeasurementPowerConverterAttributes(endpoint);
+            await configureReporting.rmsVoltage(endpoint, {'reportableChange': 2}); // Voltage reports in V
+            await configureReporting.rmsCurrent(endpoint, {'reportableChange': 10}); // Current reports in mA
+            await configureReporting.activePower(endpoint, {'reportableChange': 2}); // Power reports in 0.1W
+        },
+    },
+    {
+        zigbeeModel: ['4257050-RZHAC'],
+        model: '4257050-RZHAC',
+        vendor: 'Centralite',
+        description: '3-Series smart outlet',
+        supports: 'on/off, power measurement',
+        fromZigbee: [fz.on_off, fz.electrical_measurement_power],
+        toZigbee: [tz.on_off],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
             await configureReporting.onOff(endpoint);
             await readEletricalMeasurementPowerConverterAttributes(endpoint);
             await configureReporting.rmsVoltage(endpoint, {'reportableChange': 2}); // Voltage reports in V


### PR DESCRIPTION
The Centralite 4257050-RZHAC power reporting was incorrect.  Create new device description to fix this issue.

Closes https://github.com/Koenkk/zigbee-herdsman-converters/issues/1103
Supports pull request https://github.com/Koenkk/zigbee2mqtt/pull/3236