### PR TITLE
Support PEQ (Centralite) 3305 motion sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4501,7 +4501,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['3305-S'],
+        zigbeeModel: ['3305-S', '3305'],
         model: '3305-S',
         vendor: 'SmartThings',
         description: 'Motion sensor (2014 model)',


### PR DESCRIPTION
This is for the PEQ branded motion sensor, but it works just the same as the SmartThings one.  They're both made by Centralite.
