### PR TITLE
Fix definition of Nyce NCZ-3011-HA

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6808,14 +6808,15 @@ const devices = [
         model: 'NCZ-3011-HA',
         vendor: 'Nyce',
         description: 'Door/window sensor',
-        supports: 'motion, humidity and temperature',
-        fromZigbee: [
-            fz.ignore_basic_report,
-            fz.ignore_genIdentify, fz.ignore_poll_ctrl,
-            fz.battery_not_divided, fz.ignore_iaszone_report,
-            fz.ias_occupancy_alarm_2, fz.ias_contact_alarm_1,
-        ],
+        supports: 'contact',
+        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
     },
     {
         zigbeeModel: ['3043'],


### PR DESCRIPTION
The definition did not match my device, it seems to be wrong.  My device does match the manufacturer web page here:
https://www.nycesensors.com/product/door-window-sensor
Supports pull request https://github.com/Koenkk/zigbee2mqtt/pull/3267