### PR TITLE
Add threshold based precision support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -40,9 +40,7 @@ const precisionRound = (number, precision) => {
         const factor = Math.pow(10, precision);
         return Math.round(number * factor) / factor;
     } else if (typeof precision === 'object') {
-        const thresholds = Object.keys(precision).map(Number).sort((a, b) => {
-            return b - a;
-        });
+        const thresholds = Object.keys(precision).map(Number).sort((a, b) => b - a);
         for (const t of thresholds) {
             if (! isNaN(t) && number >= t) {
                 return precisionRound(number, precision[t]);

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -36,11 +36,13 @@ const calibrateAndPrecisionRoundOptions = (number, options, type) => {
 };
 
 const precisionRound = (number, precision) => {
-    if (typeof precision === "number") {
+    if (typeof precision === 'number') {
         const factor = Math.pow(10, precision);
         return Math.round(number * factor) / factor;
-    } else if (typeof precision === "object") {
-        const thresholds = Object.keys(precision).map(Number).sort((a,b) => { return b-a; });
+    } else if (typeof precision === 'object') {
+        const thresholds = Object.keys(precision).map(Number).sort((a, b) => {
+            return b - a;
+        });
         for (const t of thresholds) {
             if (! isNaN(t) && number >= t) {
                 return precisionRound(number, precision[t]);

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -36,9 +36,20 @@ const calibrateAndPrecisionRoundOptions = (number, options, type) => {
 };
 
 const precisionRound = (number, precision) => {
-    const factor = Math.pow(10, precision);
-    return Math.round(number * factor) / factor;
+    if (typeof precision === "number") {
+        const factor = Math.pow(10, precision);
+        return Math.round(number * factor) / factor;
+    } else if (typeof precision === "object") {
+        const thresholds = Object.keys(precision).map(Number).sort((a,b) => { return b-a; });
+        for (const t of thresholds) {
+            if (! isNaN(t) && number >= t) {
+                return precisionRound(number, precision[t]);
+            }
+        }
+    }
+    return number;
 };
+
 
 const toPercentage = (value, min, max) => {
     if (value > max) {
@@ -265,7 +276,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             // DEPRECATED: only return lux here (change illuminance_lux -> illuminance)
             const illuminance = msg.data['measuredValue'];
-            const illuminanceLux = Math.round(Math.pow(10, illuminance / 10000) - 1);
+            const illuminanceLux = Math.pow(10, illuminance / 10000) - 1;
             return {
                 illuminance: calibrateAndPrecisionRoundOptions(illuminance, options, 'illuminance'),
                 illuminance_lux: calibrateAndPrecisionRoundOptions(illuminanceLux, options, 'illuminance_lux'),


### PR DESCRIPTION
Added ability to specify threshold based precision values via an object, eg. `{ 50: 0, 10: 1, 5: 2, 0: 4 }` to use precision `0` when value >= `50`, precision `1` when value >= `10`, etc. This is useful for lux values where greater precision is sometimes necessary when the value is small. Threshold-based precision may be used both in `device_options` and as device specific options.

Removed integer rounding for lux value calculations so that the precision code can be used. The default precision of `0` makes this change backwards compatible should no precision be specified.