### PR TITLE
Update ZYCT202 to use command_off_with_effect

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4829,7 +4829,7 @@ const devices = [
         description: 'Remote control',
         supports: 'on, off, stop, up-press, down-press',
         fromZigbee: [
-            fz.command_on, fz.command_off, fz.ZYCT202_stop, fz.ZYCT202_up_down,
+            fz.command_on, fz.command_off_with_effect, fz.ZYCT202_stop, fz.ZYCT202_up_down,
         ],
         toZigbee: [],
         meta: {configureKey: 2},

--- a/devices.js
+++ b/devices.js
@@ -2007,7 +2007,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue smart button',
         supports: 'action',
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_off_with_effect, fz.SmartButton_skip, fz.battery],
+        fromZigbee: [fz.command_on, fz.command_off_with_effect, fz.SmartButton_skip, fz.battery],
         toZigbee: [],
         meta: {configureKey: 4},
         configure: async (device, coordinatorEndpoint) => {
@@ -4829,7 +4829,7 @@ const devices = [
         description: 'Remote control',
         supports: 'on, off, stop, up-press, down-press',
         fromZigbee: [
-            fz.command_on, fz.command_off_with_effect, fz.ZYCT202_stop, fz.ZYCT202_up_down,
+            fz.command_on, fz.command_off, fz.command_off_with_effect, fz.ZYCT202_stop, fz.ZYCT202_up_down,
         ],
         toZigbee: [],
         meta: {configureKey: 2},

--- a/devices.js
+++ b/devices.js
@@ -2007,7 +2007,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue smart button',
         supports: 'action',
-        fromZigbee: [fz.command_on, fz.command_off_with_effect, fz.SmartButton_skip, fz.battery],
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_off_with_effect, fz.SmartButton_skip, fz.battery],
         toZigbee: [],
         meta: {configureKey: 4},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
This device seems to require "commandOffWithEffect" instead of "commandOff"

Fixes #1141