### PR TITLE
Update to ptvo.switch

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3631,7 +3631,7 @@ const converters = {
         cluster: 'genMultistateValue',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
-            return {'ep1': msg.data['stateText']};
+            return {'action': msg.data['stateText']};
         },
     },
     ptvo_switch_analog_input: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1639,7 +1639,7 @@ const converters = {
         },
     },
     ptvo_switch_uart: {
-        key: ['ep1'],
+        key: ['action'],
         convertSet: async (entity, key, value, meta) => {
             if (!value) {
                 return;

--- a/devices.js
+++ b/devices.js
@@ -2281,7 +2281,7 @@ const devices = [
         toZigbee: [tz.on_off, tz.ptvo_switch_trigger, tz.ptvo_switch_uart, tz.ptvo_switch_analog_input],
         endpoint: (device) => {
             return {
-                'bottom_left': 1, 'bottom_right': 2, 'top_left': 3, 'top_right': 4, 'center': 5, 'ep1': 1,
+                'bottom_left': 1, 'bottom_right': 2, 'top_left': 3, 'top_right': 4, 'center': 5, 'action': 1,
                 'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5, 'l6': 6, 'l7': 7, 'l8': 8,
             };
         },


### PR DESCRIPTION
Changed ep1->action, because we don't need to cache data from UART 
zigbee2mqtt [#3320](https://github.com/Koenkk/zigbee2mqtt/issues/3320).