### PR TITLE
Support legrand wakeup sleep

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4219,13 +4219,29 @@ const converters = {
             };
         },
     },
-    legrand_master_switch_scenes: {
+    legrand_scenes: {
         cluster: 'genScenes',
         type: 'commandRecall',
         convert: (model, msg, publish, options, meta) => {
             let action = 'default';
-            if (msg.data.groupid === 0xfff7) action = 'enter';
-            if (msg.data.groupid === 0xfff6) action = 'leave';
+            switch (msg.data.groupid) {
+                case 0xfff7:
+                   action = 'enter';
+                   break;
+
+                case 0xfff6:
+                   action = 'leave';
+                   break;
+
+                case 0xfff4:
+                   action = 'sleep';
+                   break;
+
+                case 0xfff5:
+                   action = 'wakeup';
+                   break;
+
+            };
             return {
                 action: action,
             };

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4225,23 +4225,23 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             let action = 'default';
             switch (msg.data.groupid) {
-                case 0xfff7:
-                   action = 'enter';
-                   break;
+            case 0xfff7:
+                action = 'enter';
+                break;
 
-                case 0xfff6:
-                   action = 'leave';
-                   break;
+            case 0xfff6:
+                action = 'leave';
+                break;
 
-                case 0xfff4:
-                   action = 'sleep';
-                   break;
+            case 0xfff4:
+                action = 'sleep';
+                break;
 
-                case 0xfff5:
-                   action = 'wakeup';
-                   break;
+            case 0xfff5:
+                action = 'wakeup';
+                break;
+            }
 
-            };
             return {
                 action: action,
             };

--- a/devices.js
+++ b/devices.js
@@ -9055,7 +9055,7 @@ const devices = [
         description: 'Home & away switch / master switch',
         supports: 'action',
         fromZigbee: [
-            fz.legrand_master_switch_scenes, fz.legrand_master_switch_center,
+            fz.legrand_scenes, fz.legrand_master_switch_center,
             fz.ignore_poll_ctrl, fz.battery_3V,
         ],
         toZigbee: [],
@@ -9082,7 +9082,20 @@ const devices = [
             }
         },
     },
+    {   zigbeeModel: ['Remote switch Wake up / Sleep'],
+        model: '752189',
+        vendor: 'Legrand',
+        description: 'Night/Day Wireless switch',
+        supports: 'action',
+        fromZigbee: [fz.legrand_scenes, fz.battery_3V,  fz.ignore_poll_ctrl, fz.legrand_master_switch_cente],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genPowerCfg']);
+        }
 
+    },
     // BTicino (Legrand brand)
     {
         zigbeeModel: [' Light switch with neutral\u0000\u0000\u0000\u0000\u0000'],
@@ -9101,6 +9114,7 @@ const devices = [
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genBinaryInput']);
         },
     },
+    
 
     // Linkind
     {

--- a/devices.js
+++ b/devices.js
@@ -9088,7 +9088,7 @@ const devices = [
         vendor: 'Legrand',
         description: 'Night/Day Wireless switch',
         supports: 'action',
-        fromZigbee: [fz.legrand_scenes, fz.battery_3V, fz.ignore_poll_ctrl, fz.legrand_master_switch_cente],
+        fromZigbee: [fz.legrand_scenes, fz.battery_3V, fz.ignore_poll_ctrl, fz.legrand_master_switch_center],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -9086,7 +9086,7 @@ const devices = [
         zigbeeModel: ['Remote switch Wake up / Sleep'],
         model: '752189',
         vendor: 'Legrand',
-        description: 'Night/Day Wireless switch',
+        description: 'Night/day wireless switch',
         supports: 'action',
         fromZigbee: [fz.legrand_scenes, fz.battery_3V, fz.ignore_poll_ctrl, fz.legrand_master_switch_center],
         toZigbee: [],
@@ -9095,8 +9095,8 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genPowerCfg']);
         },
-
     },
+
     // BTicino (Legrand brand)
     {
         zigbeeModel: [' Light switch with neutral\u0000\u0000\u0000\u0000\u0000'],

--- a/devices.js
+++ b/devices.js
@@ -9082,18 +9082,19 @@ const devices = [
             }
         },
     },
-    {   zigbeeModel: ['Remote switch Wake up / Sleep'],
+    {
+        zigbeeModel: ['Remote switch Wake up / Sleep'],
         model: '752189',
         vendor: 'Legrand',
         description: 'Night/Day Wireless switch',
         supports: 'action',
-        fromZigbee: [fz.legrand_scenes, fz.battery_3V,  fz.ignore_poll_ctrl, fz.legrand_master_switch_cente],
+        fromZigbee: [fz.legrand_scenes, fz.battery_3V, fz.ignore_poll_ctrl, fz.legrand_master_switch_cente],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genPowerCfg']);
-        }
+        },
 
     },
     // BTicino (Legrand brand)
@@ -9114,7 +9115,6 @@ const devices = [
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genBinaryInput']);
         },
     },
-    
 
     // Linkind
     {


### PR DESCRIPTION
This pull request is to support Legrand Wake up/Sleep.
It is mostly a variant of already existing legrand "Master remote Home" switch.
Apparently legrand has two series, celiano and Valero life. The existing legrand switches are from celiano series, mine is from Valena Life. The model numbers are different.