### PR TITLE
Add support for TCI VOLARE ZB3

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8459,6 +8459,15 @@ const devices = [
         fromZigbee: [fz.ias_occupancy_alarm_1],
         toZigbee: [],
     },
+    
+    // TCI
+    {
+        zigbeeModel: ['VOLARE ZB3\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
+        model: 'VOLARE ZB3',
+        vendor: 'TCI',
+        description: 'Volare ZB3 Spot',
+        extend: generic.light_onoff_brightness,
+    },
 
     // TERNCY
     {

--- a/devices.js
+++ b/devices.js
@@ -8465,7 +8465,7 @@ const devices = [
         zigbeeModel: ['VOLARE ZB3\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
         model: '676-00301024955Z',
         vendor: 'TCI',
-        description: 'Zigbee Dash L DC Volare',
+        description: 'Dash L DC Volare',
         extend: generic.light_onoff_brightness,
     },
 

--- a/devices.js
+++ b/devices.js
@@ -8463,9 +8463,9 @@ const devices = [
     // TCI
     {
         zigbeeModel: ['VOLARE ZB3\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
-        model: 'VOLARE ZB3',
+        model: '676-00301024955Z',
         vendor: 'TCI',
-        description: 'DASH L DC VOLARE ZB3',
+        description: 'Zigbee Dash L DC Volare',
         extend: generic.light_onoff_brightness,
     },
 

--- a/devices.js
+++ b/devices.js
@@ -8459,7 +8459,7 @@ const devices = [
         fromZigbee: [fz.ias_occupancy_alarm_1],
         toZigbee: [],
     },
-    
+
     // TCI
     {
         zigbeeModel: ['VOLARE ZB3\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],

--- a/devices.js
+++ b/devices.js
@@ -8465,7 +8465,7 @@ const devices = [
         zigbeeModel: ['VOLARE ZB3\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
         model: 'VOLARE ZB3',
         vendor: 'TCI',
-        description: 'Volare ZB3 Spot',
+        description: 'DASH L DC VOLARE ZB3',
         extend: generic.light_onoff_brightness,
     },
 


### PR DESCRIPTION
Vendor page: https://www.moltoluce.com/shop/de_en/dash-l-dc-volare.html

Debug info (device address replaced by '0x0000000000000'):

```
info  2020-04-13 08:36:54: Device '0x0000000000000000' joined
info  2020-04-13 08:36:54: Starting interview of '0x0000000000000000'
info  2020-04-13 08:36:54: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"device_connected","message":{"friendly_name":"0x0000000000000000"}}'
info  2020-04-13 08:36:54: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"pairing","message":"interview_started","meta":{"friendly_name":"0x0000000000000000"}}'
debug 2020-04-13 08:36:55: Device '0x0000000000000000' announced itself
info  2020-04-13 08:36:55: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"device_announced","message":"announce","meta":{"friendly_name":"0x0000000000000000"}}'
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"modelId":"VOLARE ZB3\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"manufacturerName":"TCI"}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"powerSource":1}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"zclVersion":2}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"appVersion":1}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"stackVersion":1}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"hwVersion":1}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"dateCode":"20171130"}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
debug 2020-04-13 08:36:56: Received Zigbee message from '0x0000000000000000', type 'readResponse', cluster 'genBasic', data '{"swBuildId":"v.1.2\u0000\u0000\u0000\u0000"}' from endpoint 1 with groupID 0
warn  2020-04-13 08:36:56: Received message from unsupported device with Zigbee model 'VOLARE ZB3'
warn  2020-04-13 08:36:56: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.
info  2020-04-13 08:36:56: Successfully interviewed '0x0000000000000000', device has successfully been paired
warn  2020-04-13 08:36:56: Device '0x0000000000000000' with Zigbee model 'VOLARE ZB3' is NOT supported, please follow https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html
info  2020-04-13 08:36:56: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"pairing","message":"interview_successful","meta":{"friendly_name":"0x0000000000000000","supported":false}}'
```