### PR TITLE
Added missing raw button events for Philips Hue Smart Button ROM001

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3966,6 +3966,29 @@ const converters = {
             };
         },
     },
+    SmartButton_event: {
+        cluster: 'manuSpecificPhilips',
+        type: 'commandHueNotification',
+        convert: (model, msg, publish, options, meta) => {
+            // Philips HUE Smart Button "ROM001": these events are always from "button 1"
+            let type = null;
+            switch (msg.data['type']) {
+            case 0:
+                type = 'press';
+                break;
+            case 1:
+                type = 'hold';
+                break;
+            case 2:
+            case 3:
+                type = 'release';
+                break;
+            }
+            return {
+                action: `${type}`,
+            };
+        },
+    },
     CCTSwitch_D0001_on_off: {
         cluster: 'genOnOff',
         type: ['commandOn', 'commandOff'],

--- a/devices.js
+++ b/devices.js
@@ -2020,7 +2020,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue smart button',
         supports: 'action',
-        fromZigbee: [fz.command_on, fz.command_off_with_effect, fz.SmartButton_skip, fz.battery],
+        fromZigbee: [fz.command_on, fz.command_off_with_effect, fz.SmartButton_skip, fz.SmartButton_event, fz.battery],
         toZigbee: [],
         meta: {configureKey: 4},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Regarding the Philips Hue Smart Button "ROM001", currently only a set of high-level events is implemented and parsed. An example is the "skip_backward" event created by the button itself during a "long button press & hold", with the direction resulting from a button-internal hidden variable.

However, we had no support for the raw button events "press", "hold", and "release" yet. At first, those missing events lead to warning messages while using zigbee2mqtt ("missing converter"). Furthermore, without a specific support for these raw events it is not possible to react to a fast series of button press events. If the button is pressed in a very fast series, no events are generated but only a final high-level action event "on" or "off" is emitted. Thus, it is not possible to rotate through a set of light scenes using very fast button presses, such as the Hue Bridge provides.

This pull request provides support for these events, and I'm looking forward seeing this included by the IoBroker.zigbee repository. Then I'm going to push my adaptions there as well to also support these introduced events in the IoBroker object tree. That code is already up and running here on my server.