### PR TITLE
added 2. model no. of the bigger sized Impress wall lamp

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1955,6 +1955,14 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['1743030P7'],
+        model: '1742930P7',
+        vendor: 'Philips',
+        description: 'Hue outdoor Impress wall lamp',
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['1743230P7'],
         model: '1743230P7',
         vendor: 'Philips',


### PR DESCRIPTION
Philips Impress wall lamp exists in normal size and a little bigger one. I added the larger lamp with the modelno.  1743030P7.