### PR TITLE
Added support for 1743530V7

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2170,7 +2170,7 @@ const devices = [
         extend: hue.light_onoff_brightness,
     },
     {
-        zigbeeModel: ['1743530P7'],
+        zigbeeModel: ['1743530P7', '1743530V7'],
         model: '17435/30/P7',
         vendor: 'Philips',
         description: 'Hue Discover white and color ambiance flood light',


### PR DESCRIPTION
Similar to the Hue floodlight white: ['1743630P7', '1743630V7']

there also is a V7 model for the Hue floodlight with color: 1743530V7