### PR TITLE
add Viessmann thermostat

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9586,6 +9586,28 @@ const devices = [
         description: 'RGBW LED bulb with dimmer',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
+    //Viessmann
+    {
+        zigbeeModel: ['7637434'],
+        model: 'ZK03840',
+        vendor: 'Viessmann',
+        description: 'Vicare Radiator Thermostat Valve',
+        supports: 'Temperature, Battery',
+        fromZigbee: [fz.thermostat_att_report, fz.battery],
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_tmperature_calibration],
+        meta:{configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, [
+                'genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'genPollCtrl', 'hvacThermostat',
+                'hvacUserInterfaceCfg',
+            ]);
+            await configureReporting.thermostatTemperature(endpoint);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await configureReporting.thermostatPIHeatingDemand(endpoint);
+           },
+
+    },
 ];
 
 module.exports = devices.map((device) =>

--- a/devices.js
+++ b/devices.js
@@ -9594,7 +9594,7 @@ const devices = [
         description: 'Vicare Radiator Thermostat Valve',
         supports: 'Temperature, Battery',
         fromZigbee: [fz.thermostat_att_report, fz.battery],
-        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_tmperature_calibration],
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],
         meta:{configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/devices.js
+++ b/devices.js
@@ -9586,7 +9586,7 @@ const devices = [
         description: 'RGBW LED bulb with dimmer',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
-    //Viessmann
+    // Viessmann
     {
         zigbeeModel: ['7637434'],
         model: 'ZK03840',
@@ -9595,7 +9595,7 @@ const devices = [
         supports: 'Temperature, Battery',
         fromZigbee: [fz.thermostat_att_report, fz.battery],
         toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],
-        meta:{configureKey: 1},
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, [
@@ -9605,8 +9605,7 @@ const devices = [
             await configureReporting.thermostatTemperature(endpoint);
             await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await configureReporting.thermostatPIHeatingDemand(endpoint);
-           },
-
+        },
     },
 ];
 

--- a/devices.js
+++ b/devices.js
@@ -9586,13 +9586,14 @@ const devices = [
         description: 'RGBW LED bulb with dimmer',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
+
     // Viessmann
     {
         zigbeeModel: ['7637434'],
         model: 'ZK03840',
         vendor: 'Viessmann',
-        description: 'Vicare Radiator Thermostat Valve',
-        supports: 'Temperature, Battery',
+        description: 'Vicare radiator thermostat valve',
+        supports: 'thermostat',
         fromZigbee: [fz.thermostat_att_report, fz.battery],
         toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],
         meta: {configureKey: 1},

--- a/devices.js
+++ b/devices.js
@@ -9592,7 +9592,7 @@ const devices = [
         zigbeeModel: ['7637434'],
         model: 'ZK03840',
         vendor: 'Viessmann',
-        description: 'Vicare radiator thermostat valve',
+        description: 'ViCare radiator thermostat valve',
         supports: 'thermostat',
         fromZigbee: [fz.thermostat_att_report, fz.battery],
         toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration],


### PR DESCRIPTION
add Viessmann Vicare Radiator Thermostat Valve.

it supports local_temperature, occupied_heating_setpoint, battery, pi_heating_demand, linkquality.

i will analyze it further to look if it supports more data.

its my first pull request. i hope i make it right ;-)