### PR TITLE
HSV gamma correction, new light utilities

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -510,122 +510,140 @@ const converters = {
                 const xy = utils.hexToXY(typeof value === 'string' && value.startsWith('#') ? value : value.hex);
                 value = {x: xy.x, y: xy.y};
             } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('l')) {
-                const hsb = utils.hslToHsb(value.h, value.s, value.l);
-                value.saturation = hsb.s * (2.54);
-                value.brightness = hsb.b * (2.54);
                 newState.color = {h: value.h, s: value.s, l: value.l};
+                const hsv = utils.gammaCorrectHSV(...Object.values(
+			    utils.hslToHSV(value.h, value.s, value.l)));
+                value.saturation = hsv.s * (2.54);
+                value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
+
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(hsb.h / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHueAndSaturationAndBrightness';
                 } else {
-                    value.hue = hsb.h % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
                 }
             } else if (value.hasOwnProperty('hsl')) {
-                const hsl = value.hsl.split(',').map((i) => parseInt(i));
-                const hsb = utils.hslToHsb(hsl.h, hsl.s, hsl.l);
-                value.saturation = hsb.s * (2.54);
-                value.brightness = hsb.b * (2.54);
                 newState.color = {hsl: value.hsl};
+                const hsl = value.hsl.split(',').map((i) => parseInt(i));
+                const hsv = utils.gammaCorrectHSV(...Object.values(
+			    utils.hslToHSV(hsl[0], hsl[1], hsl[2])));
+                value.saturation = hsv.s * (2.54);
+                value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(hsb.h / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHueAndSaturationAndBrightness';
                 } else {
-                    value.hue = hsb.h % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
                 }
             } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('b')) {
                 newState.color = {h: value.h, s: value.s, b: value.b};
-                value.hue = value.h % 360 * (65535 / 360);
-                value.saturation = value.s * (2.54);
-                value.brightness = value.b * (2.54);
-                newState.brightness = value.brightness;
-                cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
-            } else if (value.hasOwnProperty('hsb')) {
-                const hsb = value.hsb.split(',').map((i) => parseInt(i));
-                value.saturation = hsb[1] * (2.54);
-                value.brightness = hsb[2] * (2.54);
-                newState.color = {hsb: value.hsb};
+                const hsv = utils.gammaCorrectHSV(value.h, value.s, value.b);
+                value.saturation = hsv.s * (2.54);
+                value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(hsb[0] / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHueAndSaturationAndBrightness';
                 } else {
-                    value.hue = hsb[0] % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
+                    cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
+                }
+            } else if (value.hasOwnProperty('hsb')) {
+                let hsv = value.hsb.split(',').map((i) => parseInt(i));
+                newState.color = {h: hsv[0], s: hsv[1], b: hsv[2]};
+                hsv = utils.gammaCorrectHSV(hsv[0], hsv[1], hsv[2]);
+                value.saturation = hsv.s * (2.54);
+                value.brightness = hsv.v * (2.54);
+                newState.brightness = value.brightness;
+                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                    value.hue = Math.round(hsv.h / 360 * 254);
+                    cmd = 'moveToHueAndSaturationAndBrightness';
+                } else {
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
                 }
             } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('v')) {
-                value.saturation = value.s * (2.54);
-                value.brightness = value.v * (2.54);
-                newState.color = {h: value.h, s: value.s, v: value.v};
+                newState.color = {h: value.h, s: value.s, b: value.v};
+                const hsv = utils.gammaCorrectHSV(value.h, value.s, value.v);
+                value.saturation = hsv.s * (2.54);
+                value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(value.h / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHueAndSaturationAndBrightness';
                 } else {
-                    value.hue = value.h % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
                 }
             } else if (value.hasOwnProperty('hsv')) {
-                const hsv = value.hsv.split(',').map((i) => parseInt(i));
-                value.saturation = hsv[1] * (2.54);
-                value.brightness = hsv[2] * (2.54);
-                newState.color = {hsv: value.hsv};
+                let hsv = value.hsv.split(',').map((i) => parseInt(i));
+                newState.color = {h: hsv[0], s: hsv[1], v: hsv[2]};
+                hsv = utils.gammaCorrectHSV(hsv[0], hsv[1], hsv[2]);
+                value.saturation = hsv.s * (2.54);
+                value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(hsv[0] / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHueAndSaturationAndBrightness';
                 } else {
-                    value.hue = hsv[0] % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
                 }
             } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s')) {
                 newState.color = {h: value.h, s: value.s};
-                value.saturation = value.s * (2.54);
+                const hsv = utils.gammaCorrectHSV(value.h, value.s, 100);
+                value.saturation = hsv.s * (2.54);
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(value.h / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHueAndSaturation';
                 } else {
-                    value.hue = value.h % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHueAndSaturation';
                 }
             } else if (value.hasOwnProperty('h')) {
                 newState.color = {h: value.h};
+                const hsv = utils.gammaCorrectHSV(value.h, 100, 100);
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(value.h / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHue';
                 } else {
-                    value.hue = value.h % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHue';
                 }
             } else if (value.hasOwnProperty('s')) {
                 newState.color = {s: value.s};
-                value.saturation = value.s * (2.54);
+                const hsv = utils.gammaCorrectHSV(360, value.s, 100);
+                value.saturation = hsv.s * (2.54);
                 cmd = 'moveToSaturation';
             } else if (value.hasOwnProperty('hue') && value.hasOwnProperty('saturation')) {
                 newState.color = {hue: value.hue, saturation: value.saturation};
-                value.saturation = value.saturation * (2.54);
+                const hsv = utils.gammaCorrectHSV(value.hue, value.saturation, 100);
+                value.saturation = hsv.s * (2.54);
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(value.hue / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHueAndSaturation';
                 } else {
-                    value.hue = value.hue % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHueAndSaturation';
                 }
             } else if (value.hasOwnProperty('hue')) {
                 newState.color = {hue: value.hue};
+                const hsv = utils.gammaCorrectHSV(value.hue, 100, 100);
                 if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
-                    value.hue = Math.round(value.hue / 360 * 254);
+                    value.hue = Math.round(hsv.h / 360 * 254);
                     cmd = 'moveToHue';
                 } else {
-                    value.hue = value.hue % 360 * (65535 / 360);
+                    value.hue = hsv.h % 360 * (65535 / 360);
                     cmd = 'enhancedMoveToHue';
                 }
             } else if (value.hasOwnProperty('saturation')) {
                 newState.color = {saturation: value.saturation};
-                value.saturation = value.saturation * (2.54);
+                const hsv = utils.gammaCorrectHSV(360, value.saturation, 100);
+                value.saturation = hsv.s * (2.54);
                 cmd = 'moveToSaturation';
             }
 

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -540,7 +540,7 @@ const converters = {
                     cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
                 }
             } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('b')) {
-                newState.color = {h: value.h, s: value.s, b: value.b};
+                newState.color = {h: value.h, s: value.s, v: value.b};
                 const hsv = utils.gammaCorrectHSV(value.h, value.s, value.b);
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
@@ -554,7 +554,7 @@ const converters = {
                 }
             } else if (value.hasOwnProperty('hsb')) {
                 let hsv = value.hsb.split(',').map((i) => parseInt(i));
-                newState.color = {h: hsv[0], s: hsv[1], b: hsv[2]};
+                newState.color = {h: hsv[0], s: hsv[1], v: hsv[2]};
                 hsv = utils.gammaCorrectHSV(hsv[0], hsv[1], hsv[2]);
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
@@ -567,7 +567,7 @@ const converters = {
                     cmd = 'enhancedMoveToHueAndSaturationAndBrightness';
                 }
             } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('v')) {
-                newState.color = {h: value.h, s: value.s, b: value.v};
+                newState.color = {h: value.h, s: value.s, v: value.v};
                 const hsv = utils.gammaCorrectHSV(value.h, value.s, value.v);
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -512,7 +512,7 @@ const converters = {
             } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('l')) {
                 newState.color = {h: value.h, s: value.s, l: value.l};
                 const hsv = utils.gammaCorrectHSV(...Object.values(
-			    utils.hslToHSV(value.h, value.s, value.l)));
+                    utils.hslToHSV(value.h, value.s, value.l)));
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
@@ -528,7 +528,7 @@ const converters = {
                 newState.color = {hsl: value.hsl};
                 const hsl = value.hsl.split(',').map((i) => parseInt(i));
                 const hsv = utils.gammaCorrectHSV(...Object.values(
-			    utils.hslToHSV(hsl[0], hsl[1], hsl[2])));
+                    utils.hslToHSV(hsl[0], hsl[1], hsl[2])));
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -11,10 +11,9 @@ const kelvinToXyLookup = require('./lookup/kelvinToXy');
  * @return {Array} Array that contains the CIE color values for x and y
  */
 function rgbToXY(red, green, blue) {
-
     // Apply a gamma correction to the RGB values, which makes the color
     // more vivid and more the like the color displayed on the screen of your device
-    const rgb = gammaCorrectRGB(red, green, blue)
+    const rgb = gammaCorrectRGB(red, green, blue);
 
     // RGB values to XYZ using the Wide RGB D65 conversion formula
     const X = rgb.r * 0.664511 + rgb.g * 0.154324 + rgb.b * 0.162028;
@@ -47,36 +46,36 @@ function gammaCorrectRGB(r, g, b) {
     b = (b > 0.04045) ? Math.pow((b + 0.055) / (1.0 + 0.055), 2.4) : (b / 12.92);
 
     return {r: Math.round(r*255),
-	    g: Math.round(g*255),
-	    b: Math.round(b*255)};
+        g: Math.round(g*255),
+        b: Math.round(b*255)};
 }
 
 function hsvToRGB(h, s, v) {
     h = h % 360 / 360;
     s = s / 100;
     v = v / 100;
-    
-    let r, g, b, i, f, p, q, t;
+
+    let r; let g; let b;
     if (arguments.length === 1) {
         s = h.s, v = h.v, h = h.h;
     }
-    i = Math.floor(h * 6);
-    f = h * 6 - i;
-    p = v * (1 - s);
-    q = v * (1 - f * s);
-    t = v * (1 - (1 - f) * s);
+    const i = Math.floor(h * 6);
+    const f = h * 6 - i;
+    const p = v * (1 - s);
+    const q = v * (1 - f * s);
+    const t = v * (1 - (1 - f) * s);
     switch (i % 6) {
-        case 0: r = v, g = t, b = p; break;
-        case 1: r = q, g = v, b = p; break;
-        case 2: r = p, g = v, b = t; break;
-        case 3: r = p, g = q, b = v; break;
-        case 4: r = t, g = p, b = v; break;
-        case 5: r = v, g = p, b = q; break;
+    case 0: r = v, g = t, b = p; break;
+    case 1: r = q, g = v, b = p; break;
+    case 2: r = p, g = v, b = t; break;
+    case 3: r = p, g = q, b = v; break;
+    case 4: r = t, g = p, b = v; break;
+    case 5: r = v, g = p, b = q; break;
     }
     return {
         r: Math.round(r * 255),
         g: Math.round(g * 255),
-        b: Math.round(b * 255)
+        b: Math.round(b * 255),
     };
 }
 
@@ -84,30 +83,30 @@ function rgbToHSV(r, g, b) {
     if (arguments.length === 1) {
         g = r.g, b = r.b, r = r.r;
     }
-    var max = Math.max(r, g, b), min = Math.min(r, g, b),
-        d = max - min,
-        h,
-        s = (max === 0 ? 0 : d / max),
-        v = max / 255;
+    const max = Math.max(r, g, b); const min = Math.min(r, g, b);
+    const d = max - min;
+    let h;
+    const s = (max === 0 ? 0 : d / max);
+    const v = max / 255;
 
     switch (max) {
-        case min: h = 0; break;
-        case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
-        case g: h = (b - r) + d * 2; h /= 6 * d; break;
-        case b: h = (r - g) + d * 4; h /= 6 * d; break;
+    case min: h = 0; break;
+    case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
+    case g: h = (b - r) + d * 2; h /= 6 * d; break;
+    case b: h = (r - g) + d * 4; h /= 6 * d; break;
     }
 
     return {
         h: (h * 360).toFixed(3),
         s: (s * 100).toFixed(3),
-        v: (v * 100).toFixed(3)
+        v: (v * 100).toFixed(3),
     };
 }
 
 function gammaCorrectHSV(h, s, v) {
     return rgbToHSV(
-	    ...Object.values(gammaCorrectRGB(
-	    ...Object.values(hsvToRGB(h, s, v)))));
+        ...Object.values(gammaCorrectRGB(
+            ...Object.values(hsvToRGB(h, s, v)))));
 }
 
 
@@ -141,7 +140,7 @@ function hslToHSV(h, s, l) {
     l = l / 100;
     const retH = h;
     const retV = s * Math.min(l, 1-l) + l;
-    const retS = retB ? 2-2*l/retB : 0;
+    const retS = retV ? 2-2*l/retV : 0;
     return {h: retH, s: retS, v: retV};
 }
 

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -11,20 +11,15 @@ const kelvinToXyLookup = require('./lookup/kelvinToXy');
  * @return {Array} Array that contains the CIE color values for x and y
  */
 function rgbToXY(red, green, blue) {
-    // The RGB values should be between 0 and 1. So convert them.
-    // The RGB color (255, 0, 100) becomes (1.0, 0.0, 0.39)
-    red /= 255; green /= 255; blue /= 255;
 
     // Apply a gamma correction to the RGB values, which makes the color
     // more vivid and more the like the color displayed on the screen of your device
-    red = (red > 0.04045) ? Math.pow((red + 0.055) / (1.0 + 0.055), 2.4) : (red / 12.92);
-    green = (green > 0.04045) ? Math.pow((green + 0.055) / (1.0 + 0.055), 2.4) : (green / 12.92);
-    blue = (blue > 0.04045) ? Math.pow((blue + 0.055) / (1.0 + 0.055), 2.4) : (blue / 12.92);
+    const rgb = gammaCorrectRGB(red, green, blue)
 
     // RGB values to XYZ using the Wide RGB D65 conversion formula
-    const X = red * 0.664511 + green * 0.154324 + blue * 0.162028;
-    const Y = red * 0.283881 + green * 0.668433 + blue * 0.047685;
-    const Z = red * 0.000088 + green * 0.072310 + blue * 0.986039;
+    const X = rgb.r * 0.664511 + rgb.g * 0.154324 + rgb.b * 0.162028;
+    const Y = rgb.r * 0.283881 + rgb.g * 0.668433 + blue * 0.047685;
+    const Z = rgb.r * 0.000088 + rgb.g * 0.072310 + blue * 0.986039;
 
     // Calculate the xy values from the XYZ values
     let x = (X / (X + Y + Z)).toFixed(4);
@@ -40,6 +35,79 @@ function rgbToXY(red, green, blue) {
 
     return {x: Number.parseFloat(x), y: Number.parseFloat(y)};
 }
+
+
+function gammaCorrectRGB(r, g, b) {
+    // The RGB values should be between 0 and 1. So convert them.
+    // The RGB color (255, 0, 100) becomes (1.0, 0.0, 0.39)
+    r /= 255; g /= 255; b /= 255;
+
+    r = (r > 0.04045) ? Math.pow((r + 0.055) / (1.0 + 0.055), 2.4) : (r / 12.92);
+    g = (g > 0.04045) ? Math.pow((g + 0.055) / (1.0 + 0.055), 2.4) : (g / 12.92);
+    b = (b > 0.04045) ? Math.pow((b + 0.055) / (1.0 + 0.055), 2.4) : (b / 12.92);
+
+    return {r: Math.round(r*255),
+	    g: Math.round(g*255),
+	    b: Math.round(b*255)};
+}
+
+function hsvToRGB(h, s, v) {
+    h = h % 360;
+    s = s / 100;
+    v = v / 100;
+    
+    let r, g, b, i, f, p, q, t;
+    if (arguments.length === 1) {
+        s = h.s, v = h.v, h = h.h;
+    }
+    i = Math.floor(h * 6);
+    f = h * 6 - i;
+    p = v * (1 - s);
+    q = v * (1 - f * s);
+    t = v * (1 - (1 - f) * s);
+    switch (i % 6) {
+        case 0: r = v, g = t, b = p; break;
+        case 1: r = q, g = v, b = p; break;
+        case 2: r = p, g = v, b = t; break;
+        case 3: r = p, g = q, b = v; break;
+        case 4: r = t, g = p, b = v; break;
+        case 5: r = v, g = p, b = q; break;
+    }
+    return {
+        r: Math.round(r * 255),
+        g: Math.round(g * 255),
+        b: Math.round(b * 255)
+    };
+}
+
+function rgbToHSV(r, g, b) {
+    if (arguments.length === 1) {
+        g = r.g, b = r.b, r = r.r;
+    }
+    var max = Math.max(r, g, b), min = Math.min(r, g, b),
+        d = max - min,
+        h,
+        s = (max === 0 ? 0 : d / max),
+        v = max / 255;
+
+    switch (max) {
+        case min: h = 0; break;
+        case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
+        case g: h = (b - r) + d * 2; h /= 6 * d; break;
+        case b: h = (r - g) + d * 4; h /= 6 * d; break;
+    }
+
+    return {
+        h: h * 360,
+        s: s * 100,
+        v: v * 100
+    };
+}
+
+function gammaCorrectHSV(h, s, v) {
+    return rgbToHSV(gammaCorrectRGB(hsvToRGB(h, s, v)));
+}
+
 
 function hexToXY(hex) {
     const rgb = hexToRgb(hex);
@@ -134,3 +202,5 @@ module.exports = {
     convertMultiByteNumberPayloadToSingleDecimalNumber,
     convertDecimalValueTo2ByteHexArray,
 };
+
+console.log(gammaCorrectRGB(255,125,0))

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -52,7 +52,7 @@ function gammaCorrectRGB(r, g, b) {
 }
 
 function hsvToRGB(h, s, v) {
-    h = h % 360;
+    h = h % 360 / 360;
     s = s / 100;
     v = v / 100;
     
@@ -98,14 +98,16 @@ function rgbToHSV(r, g, b) {
     }
 
     return {
-        h: h * 360,
-        s: s * 100,
-        v: v * 100
+        h: (h * 360).toFixed(3),
+        s: (s * 100).toFixed(3),
+        v: (v * 100).toFixed(3)
     };
 }
 
 function gammaCorrectHSV(h, s, v) {
-    return rgbToHSV(gammaCorrectRGB(hsvToRGB(h, s, v)));
+    return rgbToHSV(
+	    ...Object.values(gammaCorrectRGB(
+	    ...Object.values(hsvToRGB(h, s, v)))));
 }
 
 
@@ -133,14 +135,14 @@ function xyToMireds(x, y) {
     return Math.round(kelvinToMireds(Math.abs(kelvin)));
 }
 
-function hslToHsb(h, s, l) {
+function hslToHSV(h, s, l) {
     h = h % 360;
     s = s / 100;
     l = l / 100;
     const retH = h;
-    const retB = s * Math.min(l, 1-l) + l;
+    const retV = s * Math.min(l, 1-l) + l;
     const retS = retB ? 2-2*l/retB : 0;
-    return {h: retH, s: retS, b: retB};
+    return {h: retH, s: retS, v: retV};
 }
 
 function hexToRgb(hex) {
@@ -193,14 +195,14 @@ module.exports = {
     rgbToXY,
     hexToXY,
     hexToRgb,
-    hslToHsb,
+    hslToHSV,
     getKeyByValue,
     hasEndpoints,
     miredsToXY,
     xyToMireds,
+    gammaCorrectHSV,
+    gammaCorrectRGB,
     getRandomInt,
     convertMultiByteNumberPayloadToSingleDecimalNumber,
     convertDecimalValueTo2ByteHexArray,
 };
-
-console.log(gammaCorrectRGB(255,125,0))


### PR DESCRIPTION
This patch was specifically made for my OSRAM lights that had problems with xy color, but where hsv produced the correct colors. The only thing missing from the xy color implementation was gamma correction (see https://tasmota.github.io/docs/Lights/#gamma-correction), which this patch implements. This patch also cleans up some stuff in the hue/saturation code.

Tested on OSRAM AC03647/AC03645 and the Philips HUE Bluetooth+Zigbee.