### PR TITLE
Add support for Sengled Extra Bright A19 bulbs

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3572,6 +3572,14 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['E11-N13', 'E11-N13A', 'E11-N14', 'E11-N14A'],
+        model: 'E11-N13/N13A/N14/N14A',
+        vendor: 'Sengled',
+        description: 'Element Extra Bright (A19)',
+        extend: generic.light_onoff_brightness,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['Z01-CIA19NAE26'],
         model: 'Z01-CIA19NAE26',
         vendor: 'Sengled',

--- a/devices.js
+++ b/devices.js
@@ -3573,9 +3573,9 @@ const devices = [
     },
     {
         zigbeeModel: ['E11-N13', 'E11-N13A', 'E11-N14', 'E11-N14A'],
-        model: 'E11-N13/N13A/N14/N14A',
+        model: 'E11-N13/E11-N13A/E11-N14/E11-N14A',
         vendor: 'Sengled',
-        description: 'Element Extra Bright (A19)',
+        description: 'Element extra bright (A19)',
         extend: generic.light_onoff_brightness,
         ota: ota.zigbeeOTA,
     },


### PR DESCRIPTION
Tested and working with the E11-N13A bulb, but based on the other Sengled configs and the spec sheet for the bulbs, I added support for those bulbs (same bulb, different color temps for each model).