### PR TITLE
TH1400ZB doesn't report pIHeatingDemand between 0 and 255 but 0 and 100

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2609,6 +2609,18 @@ const converters = {
             return result;
         },
     },
+    sinope_thermostat_att_report: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result = converters.thermostat_att_report.convert(model, msg, publish, options, meta);
+            // Sinope seems to report pIHeatingDemand between 0 and 100 already
+            if (typeof msg.data['pIHeatingDemand'] == 'number') {
+                result.pi_heating_demand = precisionRound(msg.data['pIHeatingDemand'], 0);
+            }
+            return result;
+        }
+    },
     sinope_thermostat_state: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2619,7 +2619,7 @@ const converters = {
                 result.pi_heating_demand = precisionRound(msg.data['pIHeatingDemand'], 0);
             }
             return result;
-        }
+        },
     },
     sinope_thermostat_state: {
         cluster: 'hvacThermostat',

--- a/devices.js
+++ b/devices.js
@@ -8089,14 +8089,14 @@ const devices = [
         description: 'Zigbee low volt thermostat',
         supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
         fromZigbee: [
-            fz.thermostat_att_report,
+            fz.sinope_thermostat_att_report,
         ],
         toZigbee: [
             tz.thermostat_local_temperature,
-            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode, tz.thermostat_running_state,
-            tz.sinope_thermostat_occupancy, tz.sinope_thermostat_backlight_autodim_param, tz.sinope_thermostat_time,
+            tz.sinope_thermostat_backlight_autodim_param, tz.sinope_thermostat_time,
             tz.sinope_thermostat_enable_outdoor_temperature, tz.sinope_thermostat_outdoor_temperature,
         ],
         meta: {configureKey: 1},


### PR DESCRIPTION
I have a TH1400ZB and at peak demand, pIHeatingDemand is only at 39, which leads me to believe it already report it as a percentage, not as a value between 0 and 255. This PR addresses it.

I'm suspecting other Sinope products probably behave the same way, but I cannot know for sure as I only have a TH1400ZB to test with.

Also, the TH1400ZB doesn't see to support occupancy, which I therefore removed from the device.