### PR TITLE
Brightness for tuya_dimmer reported as string

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4337,7 +4337,7 @@ const converters = {
             } else {
                 const level = val[2]*256 + val[3];
                 const normalised = (level - 10) / (1000 - 10);
-                return {brightness: (normalised * 254).toFixed(2), level: level};
+                return {brightness: Math.round(normalised * 254), level: level};
             }
         },
     },


### PR DESCRIPTION
It seems that `toFixed()` function returns a string. I have experienced the problem where brightness for gq8b1uv dimmer is reported as string to MQTT. See the log entry:
`zigbee2mqtt:info  2020-04-25 10:28:53: MQTT publish: topic 'zigbee2mqtt/0xec1bbdfffec3e6d1', payload '{"state":"ON","linkquality":68,"brightness":"254.00","level":1000}'`

I've noticed that because ControllerX failed to change brighness because it obviously didn't understand the string value. See the discussion here: https://github.com/xaviml/controllerx/issues/69
