### PR TITLE
Enable Osram commands and OTA for certain Sylvania devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3286,7 +3286,8 @@ const devices = [
         model: '73741',
         vendor: 'Sylvania',
         description: 'LIGHTIFY LED adjustable color RT 5/6',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        extend: osram.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.ledvance,
     },
     {
         zigbeeModel: ['LIGHTIFY BR Tunable White'],
@@ -3309,9 +3310,8 @@ const devices = [
         model: '73693',
         vendor: 'Sylvania',
         description: 'LIGHTIFY LED RGBW A19',
-        supports: generic.light_onoff_brightness_colortemp_colorxy.supports,
-        toZigbee: generic.light_onoff_brightness_colortemp_colorxy.toZigbee.concat([tz.osram_cmds]),
-        fromZigbee: generic.light_onoff_brightness_colortemp_colorxy.fromZigbee,
+        extend: osram.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.ledvance,
     },
     {
         zigbeeModel: ['LIGHTIFY A19 ON/OFF/DIM', 'LIGHTIFY A19 ON/OFF/DIM 10 Year'],


### PR DESCRIPTION
The "RT RGBW" and "LIGHTIFY A19 RGBW" Sylvania devices are updatable using the same methods as the LEDVANCE devices. 

Likely other devices made by Sylvania are updatable as well, but I only have these two devices to confirm.