### PR TITLE
Support Hive SLT2

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2923,7 +2923,7 @@ const devices = [
         model: 'SLT2',
         vendor: 'Hive',
         description: 'Heating thermostat remote control',
-        supports: 'none, communicate via thermostat',
+        supports: 'nothing, communicate via thermostat',
         fromZigbee: [],
         toZigbee: [],
     },

--- a/devices.js
+++ b/devices.js
@@ -2918,6 +2918,15 @@ const devices = [
         fromZigbee: [],
         toZigbee: [],
     },
+    {
+        zigbeeModel: ['SLT2'],
+        model: 'SLT2',
+        vendor: 'Hive',
+        description: 'Heating thermostat remote control',
+        supports: 'none, communicate via thermostat',
+        fromZigbee: [],
+        toZigbee: [],
+    },
 
     // Innr
     {


### PR DESCRIPTION
This is really "support" in the narrowest sense: This only serves to shutup zigbee2mqtt complaining about an unsupported device: all controlling and communication happens through the thermostat box.