### PR TITLE
Add support for device: ZBT-DIMLight-A4700003 (ZL1000700-22-EU-V1A02)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9289,6 +9289,13 @@ const devices = [
         extend: generic.light_onoff_brightness,
     },
     {
+        zigbeeModel: ['ZBT-DIMLight-A4700003'],
+        model: 'ZL1000700-22-EU-V1A02',
+        vendor: 'Linkind',
+        description: 'Zigbee A60 Led Filament, Dimmable warm light (2200K), E27. 4.2W, 420lm',
+        extend: generic.light_onoff_brightness,
+    },
+    {
         zigbeeModel: ['ZB-MotionSensor-D0003'],
         model: 'ZS1100400-IN-V1A02',
         vendor: 'Linkind',

--- a/devices.js
+++ b/devices.js
@@ -9292,7 +9292,7 @@ const devices = [
         zigbeeModel: ['ZBT-DIMLight-A4700003'],
         model: 'ZL1000700-22-EU-V1A02',
         vendor: 'Linkind',
-        description: 'Zigbee A60 Led Filament, Dimmable warm light (2200K), E27. 4.2W, 420lm',
+        description: 'Zigbee A60 led filament, dimmable warm light (2200K), E27. 4.2W, 420lm',
         extend: generic.light_onoff_brightness,
     },
     {


### PR DESCRIPTION
Support for Linkind bulb ZL1000700-22-EU-V1A02. I could not find anywhere in the internet that model number, but seems  the actual brand. https://www.amazon.co.uk/gp/product/B07XJ3X2LK/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&th=1

I'll do another PR for the documentation and home assistant in zigbee2mqtt later.