### PR TITLE
fix the configuration for the Smart+ motion sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2753,7 +2753,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
             await configureReporting.temperature(endpoint);
-            await configureReporting.batteryPercentageRemaining(endpoint);
+            await configureReporting.batteryVoltage(endpoint);
         },
     },
     {


### PR DESCRIPTION
switch from `batteryPercentageRemaining` to `batteryVoltage`
see: https://github.com/Koenkk/zigbee2mqtt/issues/3416