### PR TITLE
add yphix dimmer support

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7344,14 +7344,14 @@ const devices = [
         vendor: 'Sunricher',
         description: 'ZigBee knob smart dimmer',
         extend: generic.light_onoff_brightness,
-		meta: {configureKey: 1},
-		whiteLabel: [
-			{vendor: 'YPHIX', model: '50208695'},
-		],
-		configure: async (device, coordinatorEndpoint) => {
-			const endpoint = device.getEndpoint(1);
-			await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-		},
+        meta: {configureKey: 1},
+        whiteLabel: [
+            {vendor: 'YPHIX', model: '50208695'},
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+        },
     },
 
     // Shenzhen Homa

--- a/devices.js
+++ b/devices.js
@@ -7344,6 +7344,14 @@ const devices = [
         vendor: 'Sunricher',
         description: 'ZigBee knob smart dimmer',
         extend: generic.light_onoff_brightness,
+		meta: {configureKey: 1},
+		whiteLabel: [
+			{vendor: 'YPHIX', model: '50208695'},
+		],
+		configure: async (device, coordinatorEndpoint) => {
+			const endpoint = device.getEndpoint(1);
+			await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+		},
     },
 
     // Shenzhen Homa


### PR DESCRIPTION
Added Yphix dimmer support based on [suggestion ](https://github.com/Koenkk/zigbee2mqtt/issues/3449)bij Koenkk.

Tested locally with the dimmer and am now receiving the dimmer brightness values. I can also set the dimmer brightness. npm test ran fine