### PR TITLE
Added Gledopto GL-FL-004TZS

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4422,6 +4422,14 @@ const devices = [
         supports: 'on/off, brightness, color temperature, color',
     },
     {
+        zigbeeModel: ['GL-FL-004TZS'],
+        model: 'GL-FL-004TZS',
+        vendor: 'Gledopto',
+        description: 'Zigbee 10W floodlight RGB CCT',
+        extend: gledopto.light,
+        supports: 'on/off, brightness, color temperature, color',
+    },
+    {
         zigbeeModel: ['GL-FL-005TZ'],
         model: 'GL-FL-005TZ',
         vendor: 'Gledopto',


### PR DESCRIPTION
Added `GL-FL-004TZS` to `devices.json` (see Koenkk/zigbee2mqtt#3480).

I wasn't sure if is should duplicate the GL-FL-004TZ device that already existed (which is what I did now) or add the additional model to the `zigbeeModel` array.
If you'd rather have the latter, let me know then I'll change it.