### PR TITLE
Ninja Smart Plug - uppercase in P

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5480,7 +5480,7 @@ const devices = [
 
     // Ninja Blocks
     {
-        zigbeeModel: ['Ninja Smart plug'],
+        zigbeeModel: ['Ninja Smart Plug'],
         model: 'Z809AF',
         vendor: 'Ninja Blocks',
         description: 'Zigbee smart plug with power meter',


### PR DESCRIPTION
On my original (from Kickstarter) ninja plug, this only works if the P is upper case. 
