### PR TITLE
Support LTP008 - Philips Hue Being Pendant

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1897,6 +1897,14 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LTP008'],
+        model: '4098430P7',
+        vendor: 'Philips',
+        description: 'Hue Being Pendant',
+        extend: hue.light_onoff_brightness_colortemp,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTC003'],
         model: '3261331P7',
         vendor: 'Philips',


### PR DESCRIPTION
Support added for Philips Hue Being Pendant, slightly different from Hue Being.
https://www2.meethue.com/en-gb/p/hue-white-ambience-being-pendant-light/4098430P7