### PR TITLE
Fix SE-metering configuration

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -166,7 +166,7 @@ const configureReporting = {
             attribute: 'currentSummDelivered',
             minimumReportInterval: 0,
             maximumReportInterval: repInterval.HOUR,
-            reportableChange: [0, 1],
+            reportableChange: [1, 1],
         }];
         Object.assign(payload[0], overrides);
         await endpoint.configureReporting('seMetering', payload);
@@ -176,7 +176,7 @@ const configureReporting = {
             attribute: 'currentSummReceived',
             minimumReportInterval: 0,
             maximumReportInterval: repInterval.HOUR,
-            reportableChange: 1,
+            reportableChange: [1, 1],
         }];
         await endpoint.configureReporting('seMetering', payload);
     },


### PR DESCRIPTION
The N2G-SP device will send multiple updates per second if the
reportable change is set to 0. currentSummReceived is read as a pair of
numbers, so the reportable change should be that as well.

Tested by re-paring a N2G-SP device to zigbee2mqtt.

Fixes Koenkk/zigbee2mqtt#3556