### PR TITLE
This works better with my N2G-SP

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7692,7 +7692,7 @@ const devices = [
 
     // NET2GRID
     {
-        zigbeeModel: ['SP31           ','SP31'],
+        zigbeeModel: ['SP31           ', 'SP31'],
         model: 'N2G-SP',
         vendor: 'NET2GRID',
         description: 'White Net2Grid power outlet switch with power meter',

--- a/devices.js
+++ b/devices.js
@@ -7692,7 +7692,7 @@ const devices = [
 
     // NET2GRID
     {
-        zigbeeModel: ['SP31           '],
+        zigbeeModel: ['SP31           ','SP31'],
         model: 'N2G-SP',
         vendor: 'NET2GRID',
         description: 'White Net2Grid power outlet switch with power meter',


### PR DESCRIPTION
Hello Zigbee community.

So this is my fist public pull ever, so please be kind :)

So my device has an other identifier then the one in the converter.
After my change i had to rebind it. But then it worked great.

**Zigbee2mqtt:**

`zigbee2mqtt:info  2020-05-22 19:52:16: 0x84df0c0010000114 (0x84df0c0010000114): N2G-SP - NET2GRID White Net2Grid power outlet switch with power meter (Router)
zigbee2mqtt:warn  2020-05-22 19:52:16: `permit_join` set to  `true` in configuration.yaml.
zigbee2mqtt:warn  2020-05-22 19:52:16: Allowing new devices to join.
zigbee2mqtt:warn  2020-05-22 19:52:16: Set `permit_join` to `false` once you joined all devices.
zigbee2mqtt:info  2020-05-22 19:52:16: Zigbee: allowing new devices to join.
zigbee2mqtt:debug 2020-05-22 19:52:16: Setup reporting for '0x84df0c0010000114' - 1 - genOnOff
zigbee2mqtt:info  2020-05-22 19:52:16: Successfully setup reporting for '0x84df0c0010000114' - 1 - genOnOff
zigbee2mqtt:info  2020-05-22 19:52:16: Connected to MQTT server
zigbee2mqtt:info  2020-05-22 19:52:16: MQTT publish: topic 'zigbee2mqtt_test/bridge/state', payload 'online'
zigbee2mqtt:info  2020-05-22 19:52:16: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":111,"power":77,"energy":0.01}'
zigbee2mqtt:info  2020-05-22 19:52:16: MQTT publish: topic 'zigbee2mqtt_test/bridge/config', payload '{"version":"1.13.1-dev","commit":"83215c3","coordinator":{"type":"zStack3x0","meta":{"transportrev":2,"product":1,"majorrel":2,"minorrel":7,"maintrel":1,"revision":20200417}},"log_level":"debug","permit_join":true}'
zigbee2mqtt:debug 2020-05-22 19:52:33: Received Zigbee message from '0x84df0c0010000114', type 'commandQueryNextImageRequest', cluster 'genOta', data '{"fieldControl":0,"manufacturerCode":20039,"imageType":1,"fileVersion":538118437}' from endpoint 1 with groupID 0
zigbee2mqtt:debug 2020-05-22 19:53:07: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:53:07: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":120,"power":77,"energy":0.01}'
zigbee2mqtt:debug 2020-05-22 19:53:07: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":77,"currentSummDelivered":[0,19],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:53:07: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":117,"power":77,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:53:48: Received Zigbee message from '0x00158d0003602803', type 'commandQueryNextImageRequest', cluster 'genOta', data '{"fieldControl":0,"manufacturerCode":4151,"imageType":1024,"fileVersion":1}' from endpoint 1 with groupID 0
zigbee2mqtt:debug 2020-05-22 19:55:51: Received Zigbee message from '0x00158d0003602803', type 'commandQueryNextImageRequest', cluster 'genOta', data '{"fieldControl":0,"manufacturerCode":4151,"imageType":1024,"fileVersion":1}' from endpoint 1 with groupID 0
zigbee2mqtt:debug 2020-05-22 19:56:46: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:46: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":120,"power":77,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:56:46: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":78,"currentSummDelivered":[0,24],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:46: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":126,"power":78,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:56:47: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:47: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":114,"power":78,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:56:47: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":77,"currentSummDelivered":[0,24],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:47: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":120,"power":77,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:56:56: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:56: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":114,"power":77,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:56:56: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":78,"currentSummDelivered":[0,24],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:56: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":114,"power":78,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:56:57: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:57: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":120,"power":78,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:56:58: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":77,"currentSummDelivered":[0,24],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:56:58: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":111,"power":77,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:57:14: Saving state to file /opt/zigbee2mqtt/data/state.json
zigbee2mqtt:debug 2020-05-22 19:57:27: Received Zigbee message from '0x84df0c0010000114', type 'commandQueryNextImageRequest', cluster 'genOta', data '{"fieldControl":0,"manufacturerCode":20039,"imageType":1,"fileVersion":538118437}' from endpoint 1 with groupID 0
zigbee2mqtt:debug 2020-05-22 19:57:53: Received Zigbee message from '0x00158d0003602803', type 'commandQueryNextImageRequest', cluster 'genOta', data '{"fieldControl":0,"manufacturerCode":4151,"imageType":1024,"fileVersion":1}' from endpoint 1 with groupID 0
zigbee2mqtt:debug 2020-05-22 19:58:08: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:08: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":117,"power":77,"energy":0.02}'
zigbee2mqtt:debug 2020-05-22 19:58:08: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":78,"currentSummDelivered":[0,26],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:08: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":93,"power":78,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:58:09: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:09: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":102,"power":78,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:58:09: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":77,"currentSummDelivered":[0,26],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:09: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":105,"power":77,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:58:13: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:13: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":117,"power":77,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:58:13: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":78,"currentSummDelivered":[0,26],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:13: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":111,"power":78,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:58:14: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:14: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":105,"power":78,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:58:14: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":77,"currentSummDelivered":[0,26],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
zigbee2mqtt:info  2020-05-22 19:58:14: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":114,"power":77,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:59:32: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'genOnOff', data '{"onOff":1}' from endpoint 1 with groupID 0
zigbee2mqtt:info  2020-05-22 19:59:32: MQTT publish: topic 'zigbee2mqtt_test/0x84df0c0010000114', payload '{"state":"ON","linkquality":117,"power":77,"energy":0.03}'
zigbee2mqtt:debug 2020-05-22 19:59:32: Received Zigbee message from '0x84df0c0010000114', type 'attributeReport', cluster 'seMetering', data '{"instantaneousDemand":78,"currentSummDelivered":[0,27],"currentSummReceived":[0,0]}' from endpoint 10 with groupID 0
`
**Wireshark:** 

ZigBee Cluster Library Frame, Command: Read Attributes Response, Seq: 22
    Frame Control Field: Profile-wide (0x08)
    Sequence Number: 22
    Command: Read Attributes Response (0x01)
    Status Record, String: SP31
        Attribute: Model Identifier (0x0005)
        Status: Success (0x00)
        Data Type: Character String (0x42)
        String: SP31


0000   40 01 00 00 04 01 01 c8 08 16 01 05 00 00 42 04   @.............B.
0010   53 50 33 31                                       SP31

Kind regards
