### PR TITLE
Adding support for Schlage BE-468 locks. See pull request into Samsun…

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9938,6 +9938,24 @@ const devices = [
         },
     },
 
+    // SCHLAGE
+    {
+        zigbeeModel: ['BE468'],
+        model: 'BE468',
+        vendor: 'Schlage',
+        description: 'Schlage Connect Smart Deadbolt',
+        supports: 'lock/unlock, battery',
+        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery],
+        toZigbee: [tz.generic_lock],
+        meta: {configureKey: 3},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(2);
+            await bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await configureReporting.lockState(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+
     // HORNBACH
     {
         zigbeeModel: ['VIYU-A60-806-RGBW-10011725'],

--- a/devices.js
+++ b/devices.js
@@ -9938,12 +9938,12 @@ const devices = [
         },
     },
 
-    // SCHLAGE
+    // Schlage
     {
         zigbeeModel: ['BE468'],
         model: 'BE468',
         vendor: 'Schlage',
-        description: 'Schlage Connect Smart Deadbolt',
+        description: 'Connect smart deadbolt',
         supports: 'lock/unlock, battery',
         fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery],
         toZigbee: [tz.generic_lock],


### PR DESCRIPTION
Adding support for Schlage BE-468 locks. See pull request into Samsung SmartThings repo - https://github.com/sashamobilesm/Josh85/commit/b6fcc357be7ac20eb9eb82bff5d6f2ed4f00f029 , should have parity with existing KwikSet locks. Seems like only the Yale locks had different commands