### PR TITLE
Update Zen thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2736,7 +2736,9 @@ const converters = {
             }
             const piHeatingDemand = msg.data['pIHeatingDemand'];
             if (typeof piHeatingDemand == 'number') {
+                // DEPRECATED: only return running_state here (change operation -> running_state)
                 result.operation = piHeatingDemand >= 10 ? 'heating' : 'idle';
+                result.running_state = piHeatingDemand >= 10 ? 'heat' : 'idle';
             }
             return result;
         },

--- a/devices.js
+++ b/devices.js
@@ -8586,7 +8586,12 @@ const devices = [
                 'genBasic', 'genIdentify', 'genPowerCfg', 'genTime', 'hvacThermostat', 'hvacUserInterfaceCfg',
             ];
             await bind(endpoint, coordinatorEndpoint, binds);
+
+            await configureReporting.thermostatSystemMode(endpoint);
+            await configureReporting.batteryVoltage(endpoint);
             await configureReporting.thermostatTemperature(endpoint);
+            await configureReporting.thermostatRunningState(endpoint);
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
         },
     },
 


### PR DESCRIPTION
This change enables reporting of extra parameters for the Zen thermostat.

I'm also changing the "operation" parameter on some other thermostats to
align with running state (as per the thermostatHeatCool templates that are
applied to a few other thermostats in the home assistant auto config logic)

This change will be matched by a commit to the HA autoconfig code such that
the thermostats which used the "operation" field should effectively see a
no-op.