### PR TITLE
Update devices.js

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9935,7 +9935,7 @@ const devices = [
         supports: 'on/off, brightness',
         fromZigbee: [fz.brightness, fz.identify, fz.on_off],
         toZigbee: [
-            tz.light_onoff_brightness, tz.legrand_settingAlwaysEnableLed, 
+            tz.light_onoff_brightness, tz.legrand_settingAlwaysEnableLed,
             tz.legrand_settingEnableLedIfOn, tz.legrand_settingEnableDimmer, tz.legrand_identify,
         ],
         meta: {configureKey: 2},
@@ -9943,7 +9943,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genLevelCtrl', 'genBinaryInput']);
             await configureReporting.onOff(endpoint);
-            await configureReporting.brightness(endpoint);            
+            await configureReporting.brightness(endpoint);
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -9932,16 +9932,18 @@ const devices = [
         vendor: 'Legrand',
         // led blink RED when battery is low
         description: 'Wired switch without neutral',
-        supports: 'on/off',
-        fromZigbee: [fz.identify, fz.on_off],
+        supports: 'on/off, brightness',
+        fromZigbee: [fz.brightness, fz.identify, fz.on_off],
         toZigbee: [
-            tz.on_off, tz.legrand_settingAlwaysEnableLed, tz.legrand_settingEnableLedIfOn,
-            tz.legrand_settingEnableDimmer, tz.legrand_identify,
+            tz.light_onoff_brightness, tz.legrand_settingAlwaysEnableLed, 
+            tz.legrand_settingEnableLedIfOn, tz.legrand_settingEnableDimmer, tz.legrand_identify,
         ],
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genLevelCtrl', 'genBinaryInput']);
+            await configureReporting.onOff(endpoint);
+            await configureReporting.brightness(endpoint);            
         },
     },
     {


### PR DESCRIPTION
Together with pull request #1281 (https://github.com/Koenkk/zigbee-herdsman-converters/pull/1281). 

Adds brightness support.

However, I find 2 issues:
1.- Brightness works in Home Assistant, but only setting and getting the value manually (e.g. {
"state": "ON", "brightness": 254 }). No visual bar to set it in Home Assistant like with bulbs.
2.- I can't find a way to only setup brightness when dimmer is enabled on the device. Device can use dimmer or not. Brightness only makes sense when dimmer is on.