### PR TITLE
Restrict Mijia light sensor updates to 60 seconds

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1134,7 +1134,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msIlluminanceMeasurement']);
             await configureReporting.batteryVoltage(endpoint);
-            await configureReporting.illuminance(endpoint, 60);
+            await configureReporting.illuminance(endpoint, 15, repInterval.HOUR, 500);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -142,14 +142,13 @@ const configureReporting = {
         }];
         await endpoint.configureReporting('msPressureMeasurement', payload);
     },
-    illuminance: async (endpoint, overrides) => {
+    illuminance: async (endpoint, min=0, max=repInterval.HOUR, change=0) => {
         const payload = [{
             attribute: 'measuredValue',
-            minimumReportInterval: 0,
-            maximumReportInterval: repInterval.HOUR,
-            reportableChange: 0,
+            minimumReportInterval: min,
+            maximumReportInterval: max,
+            reportableChange: change,
         }];
-        Object.assign(payload[0], overrides);
         await endpoint.configureReporting('msIlluminanceMeasurement', payload);
     },
     instantaneousDemand: async (endpoint, overrides) => {
@@ -1135,7 +1134,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msIlluminanceMeasurement']);
             await configureReporting.batteryVoltage(endpoint);
-            await configureReporting.illuminance(endpoint, {'minimumReportInterval': 60});
+            await configureReporting.illuminance(endpoint, 60);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -1135,7 +1135,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msIlluminanceMeasurement']);
             await configureReporting.batteryVoltage(endpoint);
-            await configureReporting.illuminance(endpoint, { 'minimumReportInterval': 60 });
+            await configureReporting.illuminance(endpoint, {'minimumReportInterval': 60});
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -142,13 +142,14 @@ const configureReporting = {
         }];
         await endpoint.configureReporting('msPressureMeasurement', payload);
     },
-    illuminance: async (endpoint) => {
+    illuminance: async (endpoint, overrides) => {
         const payload = [{
             attribute: 'measuredValue',
             minimumReportInterval: 0,
             maximumReportInterval: repInterval.HOUR,
             reportableChange: 0,
         }];
+        Object.assign(payload[0], overrides);
         await endpoint.configureReporting('msIlluminanceMeasurement', payload);
     },
     instantaneousDemand: async (endpoint, overrides) => {
@@ -1134,6 +1135,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msIlluminanceMeasurement']);
             await configureReporting.batteryVoltage(endpoint);
+            await configureReporting.illuminance(endpoint, { 'minimumReportInterval': 60 });
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -1129,7 +1129,7 @@ const devices = [
         supports: 'illuminance',
         fromZigbee: [fz.battery_3V, fz.illuminance],
         toZigbee: [],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msIlluminanceMeasurement']);


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#3571

The changes made in Koenkk/zigbee2mqtt#3571 did not have any effect since the illuminance configureReporting function didn't accept overrides.

I opted for a minimum interval of 60 seconds instead of a reportableChange value, since it would be hard to find a sane value for the latter. A difference of e.g. 10 lux may work for rooms (illuminated living room is about 50 lux), but it doesn't make any sense at all if you measure outdoor illuminance, where values are in the hundreds of thousands (e.g. direct sunlight -> ~120.000 lux).

/cc @sjorge 