### PR TITLE
Request to add Centralite 3400 Device

### DIFF
--- a/converters/common.js
+++ b/converters/common.js
@@ -91,6 +91,7 @@ const armMode = {
     1: 'arm_day_zones',
     2: 'arm_night_zones',
     3: 'arm_all_zones',
+    4: 'invalid_code',
 };
 
 module.exports = {

--- a/converters/common.js
+++ b/converters/common.js
@@ -86,6 +86,13 @@ const lockSourceName = {
     3: 'rfid',
 };
 
+const armMode = {
+    0: 'disarm',
+    1: 'arm_day_zones',
+    2: 'arm_night_zones',
+    3: 'arm_all_zones',
+};
+
 module.exports = {
     thermostatControlSequenceOfOperations,
     thermostatSystemModes,
@@ -97,4 +104,5 @@ module.exports = {
     TuyaThermostatWeekFormat,
     TuyaThermostatForceMode,
     lockSourceName,
+    armMode,
 };

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -847,7 +847,7 @@ const converters = {
         type: 'commandArm',
         convert: (model, msg, publish, options, meta) => {
             const payload = {
-                action: getProperty(common.armMode[msg.data['armmode']], msg, model),
+                action: postfixWithEndpointName(common.armMode[msg.data['armmode']], msg, model),
                 action_code: msg.data.code,
                 action_zone: msg.data.zoneid,
             };

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -846,14 +846,15 @@ const converters = {
         cluster: 'ssIasAce',
         type: 'commandArm',
         convert: (model, msg, publish, options, meta) => {
-            const lookup = {
-                0: 'disarm',
-                1: 'arm_day_zones',
-                2: 'arm_night_zones',
-                3: 'arm_all_zones',
+            const payload = {
+                action: getProperty(common.armMode[msg.data['armmode']], msg, model),
+                action_code: msg.data.code,
+                action_zone: msg.data.zoneid,
             };
-            const payload = {action: postfixWithEndpointName(lookup[msg.data['armmode']], msg, model)};
-            addActionGroup(payload, msg, model);
+            if (model.meta && model.meta.commandArmIncludeTransaction) {
+                payload.action_transaction = msg.meta.zclTransactionSequenceNumber;
+            }
+            if (msg.groupID) payload.action_group = msg.groupID;
             return payload;
         },
     },

--- a/converters/store.js
+++ b/converters/store.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const store = new Map();
+
+function hasValue(deviceKey, key) {
+    return store.has(deviceKey) && store.get(deviceKey).hasOwnProperty(key);
+}
+
+function getValue(deviceKey, key) {
+    if (store.has(deviceKey)) {
+        return store.get(deviceKey)[key];
+    }
+
+    return undefined;
+}
+
+function putValue(deviceKey, key, value) {
+    if (!store.has(deviceKey)) {
+        store.set(deviceKey, {});
+    }
+
+    store.get(deviceKey)[key] = value;
+}
+
+module.exports = {
+    hasValue,
+    getValue,
+    putValue,
+};

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1068,7 +1068,7 @@ const converters = {
                 entity.commandResponse('ssIasAce', 'armRsp', {armnotification: mode}, {}, value.transaction);
             }
 
-            const panelStatus = mode !== 0 ? 0x80: 0x00;
+            const panelStatus = mode !== 0 && mode !== 4 ? 0x80: 0x00;
             globalStore.putValue(entity.deviceIeeeAddress, 'panelStatus', panelStatus);
             const payload = {panelstatus: panelStatus, secondsremain: 0, audiblenotif: 0, alarmstatus: 0};
             entity.commandResponse('ssIasAce', 'panelStatusChanged', payload);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2355,6 +2355,29 @@ const converters = {
             sendTuyaCommand(entity, 263, 0, [1, value==='LOCK' ? 1 : 0]);
         },
     },
+    
+    // Centralite 3400-D Keypad Alarm
+    3400_arm_mode: {
+        key: ['arm_mode’],
+        convertSet: async (entity, key, value, meta) => {
+        	const lookup = {
+            	'disarm': 0x0000,
+            	'arm_stay': 0x0100,
+            	'arm_arm_night': 0x0200,
+            	'armed_away': 0x0300
+        	};
+            const entry_exit_lookup = {
+                'entry_delay': 0x05,
+                'exit_delay': 0x10
+            };
+            if (((value == 'entry_delay') || (value == 'exit_delay')) && message.hasOwnProperty('delay')) {
+                await entity.write('ssIasZone', (entry_exit_lookup[value.toLowercase()]<<16)+message['delay'].toString(16));
+                return {state: {arm_mode: value}};
+            }
+            await entity.write('ssIasZone', lookup[value.toLowercase()]);
+            return {state: {arm_mode: value}};
+        },
+    },    
     tuya_thermostat_window_detection: {
         key: ['window_detection'],
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2371,7 +2371,7 @@ const converters = {
                 'exit_delay': 0x10
             };
             if (((value == 'entry_delay') || (value == 'exit_delay')) && message.hasOwnProperty('delay')) {
-                await entity.write('ssIasZone', (entry_exit_lookup[value.toLowercase()]<<16)+message['delay'].toString(16));
+                await entity.write('ssIasZone', (entry_exit_lookup[value.toLowercase()]<<16)+options.delay.toString(16));
                 return {state: {arm_mode: value}};
             }
             await entity.write('ssIasZone', lookup[value.toLowercase()]);

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -180,7 +180,7 @@ function interpolateHue(hue, correctionMap) {
 
 function getKeyByValue(object, value, fallback) {
     const key = Object.keys(object).find((k) => object[k] === value);
-    return key != null ? Number(key) : (fallback || 0);
+    return key != null ? Number(key) : fallback;
 }
 
 function hasEndpoints(device, endpoints) {

--- a/devices.js
+++ b/devices.js
@@ -6620,7 +6620,7 @@ const devices = [
         supports: 'action, arm',
         meta: {configureKey: 1, commandArmIncludeTransaction: true},
         fromZigbee: [fz.command_arm, fz.temperature, fz.battery],
-        toZigbee: [tz.centralite_arm_mode],
+        toZigbee: [tz.arm_mode],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const clusters = ['msTemperatureMeasurement', 'genPowerCfg', 'ssIasZone', 'ssIasAce'];

--- a/devices.js
+++ b/devices.js
@@ -6618,7 +6618,7 @@ const devices = [
         description: 'CentraLite 3400-D Keypad',
         supports: 'keypad',
         meta: {configureKey: 1, disableDefaultResponse: true},
-        fromZigbee: [ fz.command_arm, fz.temperature ],
+        fromZigbee: [ fz.3400_command_arm, fz.temperature ],
         toZigbee: [ tz.arm_mode ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/devices.js
+++ b/devices.js
@@ -6612,6 +6612,22 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['3400-D'],
+        model: '3400-D',
+        vendor: 'CentraLite',
+        description: 'CentraLite 3400-D Keypad',
+        supports: 'keypad',
+        meta: {configureKey: 1, disableDefaultResponse: true},
+        fromZigbee: [ fz.command_arm, fz.temperature ],
+        toZigbee: [ tz.arm_mode ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg', 'ssIasZone', 'ssIasAce']);
+            await configureReporting.temperature(endpoint);
+            await configureReporting.batteryVoltage(endpoint);
+        },
+    }
+    {
         zigbeeModel: ['3420'],
         model: '3420-G',
         vendor: 'Centralite',

--- a/devices.js
+++ b/devices.js
@@ -6614,9 +6614,9 @@ const devices = [
     {
         zigbeeModel: ['3400-D'],
         model: '3400-D',
-        vendor: 'CentraLite',
-        description: 'CentraLite 3400-D Keypad',
-        supports: 'keypad',
+        vendor: 'Centralite',
+        description: '3400-D keypad',
+        supports: 'action, arm',
         meta: {configureKey: 1, disableDefaultResponse: true},
         fromZigbee: [ fz.3400_command_arm, fz.temperature ],
         toZigbee: [ tz.arm_mode ],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -249,7 +249,7 @@ describe('index.js', () => {
             }
 
             if (device.meta) {
-                containsOnly(['disableActionGroup', 'configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation', 'battery', 'coverInverted', 'turnsOffAtBrightness1', 'pinCodeCount'], Object.keys(device.meta));
+                containsOnly(['disableActionGroup', 'configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation', 'battery', 'coverInverted', 'turnsOffAtBrightness1', 'pinCodeCount', 'commandArmIncludeTransaction'], Object.keys(device.meta));
             }
 
             if (device.zigbeeModel) {


### PR DESCRIPTION
I have created a fork with the neccessary changes I believe to support the Centralite 3400 keypad and its variants, I was unsure of:

- if I should create new functions for the arm modes, as there are arm modes of the 3400 not supported by previous definitions
// Statuses:
// 00 - Disarmed
// 01 - Armed partial
// 02 - Armed partial
// 03 - Armed Away
// 04 - ?
// 05 - Fast beep (1 per second)
// 05 - Entry delay (Uses seconds) Appears to keep the status lights as it was
// 06 - Amber status blink (Ignores seconds)
// 07 - ?
// 08 - Red status blink
// 09 - ?
// 10 - Exit delay Slow beep (2 per second, accelerating to 1 beep per second for the last 10 seconds) - With red flashing status - Uses seconds
// 11 - ?
// 12 - ?
// 13 - ?
- where should i place functions, i put them where grouped by manufactuer (in fromZigbee) and grouped by item type (in toZigbee)

- i am not very confident in my tozigbee definitions, basically I want to be able to recieve arm modes or an entry exit delay in the original code it appears to be four bytes for arm code type and four more bytes for the delay seconds, does the bitshift look how I should be doing this to you?

- I based this work of other peoples previous work to get this working in SmartThings [https://raw.githubusercontent.com/miriad/Centralite-Keypad/master/devicetypes/mitchpond/centralite-keypad.src/centralite-keypad.groovy]
(its my first nodejs project so sorry if its rough)
