### PR TITLE
Add basic support for RS-23ZBS temperature sensor.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6359,6 +6359,22 @@ const devices = [
                 {'minimumReportInterval': 10, 'reportableChange': 2});
         },
     },
+    {
+        zigbeeModel: ['RS_00.00.02.06TC'],
+        model: 'RS-23ZBS',
+        vendor: 'Climax',
+        description: 'Temperature & humidity sensor',
+        supports: 'Temperature measurements',
+        fromZigbee: [fz.temperature],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
+            await configureReporting.temperature(endpoint);
+        },
+    },
+
 
     // HEIMAN
     {

--- a/devices.js
+++ b/devices.js
@@ -6364,7 +6364,7 @@ const devices = [
         model: 'RS-23ZBS',
         vendor: 'Climax',
         description: 'Temperature & humidity sensor',
-        supports: 'Temperature & relative humidity measurements',
+        supports: 'temperature, humidity',
         fromZigbee: [fz.temperature, fz.humidity],
         toZigbee: [],
         meta: {configureKey: 1},
@@ -6375,7 +6375,6 @@ const devices = [
             await configureReporting.humidity(endpoint);
         },
     },
-
 
     // HEIMAN
     {

--- a/devices.js
+++ b/devices.js
@@ -6364,14 +6364,15 @@ const devices = [
         model: 'RS-23ZBS',
         vendor: 'Climax',
         description: 'Temperature & humidity sensor',
-        supports: 'Temperature measurements',
-        fromZigbee: [fz.temperature],
+        supports: 'Temperature & relative humidity measurements',
+        fromZigbee: [fz.temperature, fz.humidity],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity']);
             await configureReporting.temperature(endpoint);
+            await configureReporting.humidity(endpoint);
         },
     },
 


### PR DESCRIPTION
I bought a temperature sensor that ended up being the RS-23ZBS temperature sensor. In theory, this device reports humidity and temperature sensors, but I can only see temperature being reported with link quality.

I think I need to sniff the zigbee network or something to figure it out if it's really reporting the humidity data in a different format.

Known resellers: Nookbox, Vesta Family, OZOM, TrueGuard.

docs PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/317
zigbee2mqtt PR: https://github.com/Koenkk/zigbee2mqtt/pull/3720