### PR TITLE
Add conversion to battery % for 1TST-EU

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2906,9 +2906,9 @@ const devices = [
         model: '1TST-EU',
         vendor: 'eCozy',
         description: 'Smart heating thermostat',
-        supports: 'temperature, occupancy, un-/occupied heating, schedule',
+        supports: 'temperature, battery, occupancy, un-/occupied heating, schedule',
         fromZigbee: [
-            fz.legacy_battery_voltage,
+            fz.wiser_itrv_battery,
             fz.thermostat_att_report,
         ],
         toZigbee: [


### PR DESCRIPTION
Add conversion for battery of 1TST-EU based function used by WV704R0A0902. Fixes part of problems mentioned in https://github.com/Koenkk/zigbee2mqtt/issues/3727.