### PR TITLE
Add new model to Climax Power plug with routing capabilities.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6358,7 +6358,7 @@ const devices = [
         toZigbee: [tz.cover_position_via_brightness, tz.cover_open_close_via_brightness],
     },
     {
-        zigbeeModel: ['PSM_00.00.00.35TC'],
+        zigbeeModel: ['PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC'],
         model: 'PSM-29ZBSR',
         vendor: 'Climax',
         description: 'Power plug',


### PR DESCRIPTION
Just a small addition. My power plug with zigbee router has a different model than the one registered in the devices file.