### PR TITLE
For lumi.plug.mmeu01 read an extended information from the aqaraOpple cluster

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1666,51 +1666,52 @@ const converters = {
                 const payload = {};
                 // Xiaomi struct parsing
                 const length = data.length;
-                if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: length ${length}`);
+                // if (meta.logger) meta.logger.debug(`plug.mmeu01: Xiaomi struct: length ${length}`);
                 for (let i=0; i < length; i++) {
                     const index = data[i];
                     let value = null;
-                    if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: in position ${i} the index is ${data[i]} and type of value is ${data[i+1]} with type of data is ${typeof(data[i+1])}`);
+                    // if (meta.logger) meta.logger.debug(`plug.mmeu01: pos=${i}, ind=${data[i]}, vtype=${data[i+1]}`);
                     switch (data[i+1]) {
-                        case 16:
-                            //ZclBoolean
-                            value = data.readUInt8(i+2);
-                            i += 2;
-                            break;
-                        case 32:
-                            //Zcl8BitUint
-                            value = data.readUInt8(i+2);
-                            i += 2;
-                            break;
-                        case 33:
-                            //Zcl16BitUint
-                            value = data.readUInt16LE(i+2);
-                            i += 3;
-                            break;
-                        case 39:
-                            //Zcl64BitUint
-                            i += 9;
-                            break;
-                        case 40:
-                            //Zcl8BitInt
-                            value = data.readInt8(i+2);
-                            i += 2;
-                            break;
-                        case 57:
-                            //ZclSingleFloat
-                            value = data.readFloatLE(i+2);
-                            i += 5;
-                            break;
-                        default:
-                            if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: unknown current type ${data[i+1]}, in position ${i+1}`);
+                    case 16:
+                        // 0x10 ZclBoolean
+                        value = data.readUInt8(i+2);
+                        i += 2;
+                        break;
+                    case 32:
+                        // 0x20 Zcl8BitUint
+                        value = data.readUInt8(i+2);
+                        i += 2;
+                        break;
+                    case 33:
+                        // 0x21 Zcl16BitUint
+                        value = data.readUInt16LE(i+2);
+                        i += 3;
+                        break;
+                    case 39:
+                        // 0x27 Zcl64BitUint
+                        i += 9;
+                        break;
+                    case 40:
+                        // 0x28 Zcl8BitInt
+                        value = data.readInt8(i+2);
+                        i += 2;
+                        break;
+                    case 57:
+                        // 0x39 ZclSingleFloat
+                        value = data.readFloatLE(i+2);
+                        i += 5;
+                        break;
+                    default:
+                        // if (meta.logger) meta.logger.debug(`plug.mmeu01: unknown vtype=${data[i+1]}, pos=${i+1}`);
                     }
                     payload[index] = value;
-                    if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: recorded index ${index} with value ${value}`);
+                    // if (meta.logger) meta.logger.debug(`plug.mmeu01: recorded index ${index} with value ${value}`);
                 }
                 return {
                     state: payload['100'] === 1 ? 'ON' : 'OFF',
                     power: precisionRound(payload['152'], 2),
                     voltage: precisionRound(payload['150'] * 0.1, 1),
+                    current: precisionRound((payload['151'] * 0.001), 4),
                     consumption: precisionRound(payload['149'], 2),
                     temperature: calibrateAndPrecisionRoundOptions(payload['3'], options, 'temperature'),
                 };

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1657,6 +1657,66 @@ const converters = {
             return {power: precisionRound(msg.data['presentValue'], 2)};
         },
     },
+    xiaomi_plug_eu_state: {
+        cluster: 'aqaraOpple',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.data['247']) {
+                const data = msg.data['247'];
+                const payload = {};
+                // Xiaomi struct parsing
+                const length = data.length;
+                if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: length ${length}`);
+                for (let i=0; i < length; i++) {
+                    const index = data[i];
+                    let value = null;
+                    if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: in position ${i} the index is ${data[i]} and type of value is ${data[i+1]} with type of data is ${typeof(data[i+1])}`);
+                    switch (data[i+1]) {
+                        case 16:
+                            //ZclBoolean
+                            value = data.readUInt8(i+2);
+                            i += 2;
+                            break;
+                        case 32:
+                            //Zcl8BitUint
+                            value = data.readUInt8(i+2);
+                            i += 2;
+                            break;
+                        case 33:
+                            //Zcl16BitUint
+                            value = data.readUInt16LE(i+2);
+                            i += 3;
+                            break;
+                        case 39:
+                            //Zcl64BitUint
+                            i += 9;
+                            break;
+                        case 40:
+                            //Zcl8BitInt
+                            value = data.readInt8(i+2);
+                            i += 2;
+                            break;
+                        case 57:
+                            //ZclSingleFloat
+                            value = data.readFloatLE(i+2);
+                            i += 5;
+                            break;
+                        default:
+                            if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: unknown current type ${data[i+1]}, in position ${i+1}`);
+                    }
+                    payload[index] = value;
+                    if (meta.logger) meta.logger.debug(`lumi.plug.mmeu01: Xiaomi struct: recorded index ${index} with value ${value}`);
+                }
+                return {
+                    state: payload['100'] === 1 ? 'ON' : 'OFF',
+                    power: precisionRound(payload['152'], 2),
+                    voltage: precisionRound(payload['150'] * 0.1, 1),
+                    consumption: precisionRound(payload['149'], 2),
+                    temperature: calibrateAndPrecisionRoundOptions(payload['3'], options, 'temperature'),
+                };
+            }
+        },
+    },
     xiaomi_plug_state: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],

--- a/devices.js
+++ b/devices.js
@@ -938,9 +938,9 @@ const devices = [
         supports: 'on/off, power measurement',
         vendor: 'Xiaomi',
         fromZigbee: [
-            fz.on_off, fz.xiaomi_power, fz.xiaomi_plug_eu_state, 
+            fz.on_off, fz.xiaomi_power, fz.xiaomi_plug_eu_state,
             fz.ignore_occupancy_report,
-            fz.ignore_illuminance_report,
+            fz.ignore_illuminance_report, fz.ignore_time_read,
         ],
         toZigbee: [tz.on_off, tz.ZNCZ04LM_power_outage_memory],
     },

--- a/devices.js
+++ b/devices.js
@@ -938,7 +938,9 @@ const devices = [
         supports: 'on/off, power measurement',
         vendor: 'Xiaomi',
         fromZigbee: [
-            fz.on_off, fz.xiaomi_power, fz.xiaomi_plug_state,
+            fz.on_off, fz.xiaomi_power, fz.xiaomi_plug_eu_state, 
+            fz.ignore_occupancy_report,
+            fz.ignore_illuminance_report,
         ],
         toZigbee: [tz.on_off, tz.ZNCZ04LM_power_outage_memory],
     },


### PR DESCRIPTION
… and Xiaomi struct under attribute 247. 
Small workaround instead of deep changes in zigbee-herdsman.

The new EU ZNCZ04LM plugs reported consumption, temperature, voltage in a different way, in comparison with ZNCZ02LM.

They are reported the array of data under aqaraOpple cluster, in the attribute 247.
It is a sligtly different from the "usual" lumi.plug, which are repoted the same under genBasic cluster with attribute 65281.

As can I see - the convertin the 65281 already made in the zigbee-herdsman inside the zcl/buffaloZcl, if I'm right ...

I hva no anought expirience for the chnaging the zigbee-herdsman, that's why I'm applied the similar logic inside the converter.

Currently I can see all missed data, like on ZNCZ02LM, which I don't have ;-)