### PR TITLE
Add support for ecosmart BR30 CCT bulb. A9BR3065WESDZ02

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6840,6 +6840,13 @@ const devices = [
         extend: generic.light_onoff_brightness_colortemp,
     },
     {
+        zigbeeModel: ['Ecosmart-ZBT-BR30-CCT-Bulb'],
+        model: 'A9BR3065WESDZ02',
+        vendor: 'EcoSmart',
+        description: 'Tuneable white (BR30)',
+        extend: generic.light_onoff_brightness_colortemp,
+    },
+    {
         zigbeeModel: ['zhaRGBW'],
         model: 'D1821',
         vendor: 'EcoSmart',


### PR DESCRIPTION
This device is very similar to the ecosmart A19 CCT bulb