### PR TITLE
ADC and ALG to occupied_heating_setpoint, local_temperature, pi_heating_demand

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4644,10 +4644,17 @@ const converters = {
             const data = msg.data['deviceInfo'].split(',');
             if (data[0] === 'ALG') {
                 // TODO What is ALG
-                result['ALG'] = data.slice(1).join(',');
+                const alg = data.slice(1);
+                result['ALG'] = alg.join(',');
+                result['occupied_heating_setpoint'] = alg[2]/10;
+                result['local_temperature'] = alg[3]/10;
+                result['pi_heating_demand'] = alg[9];
             } else if (data[0] === 'ADC') {
                 // TODO What is ADC
-                result['ADC'] = data.slice(1).join(',');
+                const adc = data.slice(1);
+                result['ADC'] = adc.join(',');
+                result['occupied_heating_setpoint'] = adc[5]/100;
+                result['local_temperature'] = adc[3]/10;
             } else if (data[0] === 'UI') {
                 if (data[1] === 'BoostUp') {
                     result['boost'] = 'Up';

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4648,7 +4648,7 @@ const converters = {
                 result['ALG'] = alg.join(',');
                 result['occupied_heating_setpoint'] = alg[2]/10;
                 result['local_temperature'] = alg[3]/10;
-                result['pi_heating_demand'] = alg[9];
+                result['pi_heating_demand'] = parseInt(alg[9]);
             } else if (data[0] === 'ADC') {
                 // TODO What is ADC
                 const adc = data.slice(1);


### PR DESCRIPTION
When I was testing this trv, I've realized that sometimes it didn't report change of occupied_heating_setpoint, local_temperature and pi_heating_demand, but ALG and ADC values were updated, and those two have all information needed.

With ability of this trv to reset occupied_heating_setpoint to 20 degrees after 2 hours, this change is needed. It's better to know earlier that trv received our message to update occupied_heating_setpoint back to our setpoint (different than 20), so we don't have to send this message again.

Sometimes it happened before that trv didn't respond to command, but it was timeout error or something else, but it received our command, it just didn't respond with correct message.

This small change makes wiser trv more responsive.

@sjorge - would you mind to take a look?