### PR TITLE
Skip currentHue and currentSaturation for Tådfri LED1624G9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .vs/slnx.sqlite
 .vs/ProjectSettings.json
+.idea

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -781,13 +781,13 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             // Some bulb like Ikea Tådfri LED1624G9 do not support 'currentHue' and 'currentSaturation' attributes.
-            // Skip them if the `skipHueAndSaturation` flag is set
+            // Skip them if the `supportsHue` flag is set to false
             // https://github.com/Koenkk/zigbee-herdsman-converters/issues/1340
-            if (meta.mapped && meta.mapped.meta && meta.mapped.meta.skipHueAndSaturation) {
-                await entity.read('lightingColorCtrl', ['currentX', 'currentY']);
-            } else {
-                await entity.read('lightingColorCtrl', ['currentX', 'currentY', 'currentHue', 'currentSaturation']);
+            const attributes = ['currentX', 'currentY'];
+            if (meta.mapped && meta.mapped.meta && meta.mapped.meta.supportsHue !== false) {
+                attributes.push('currentHue', 'currentSaturation');
             }
+            await entity.read('lightingColorCtrl', attributes);
         },
     },
     light_color_colortemp: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -781,10 +781,10 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             // Some bulb like Ikea Tådfri LED1624G9 do not support 'currentHue' and 'currentSaturation' attributes.
-            // Skip them if the `supportsHue` flag is set to false
+            // Skip them if the `supportsHueAndSaturation` flag is set to false
             // https://github.com/Koenkk/zigbee-herdsman-converters/issues/1340
             const attributes = ['currentX', 'currentY'];
-            if (meta.mapped && meta.mapped.meta && meta.mapped.meta.supportsHue !== false) {
+            if (meta.mapped && meta.mapped.meta && meta.mapped.meta.supportsHueAndSaturation !== false) {
                 attributes.push('currentHue', 'currentSaturation');
             }
             await entity.read('lightingColorCtrl', attributes);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -780,7 +780,14 @@ const converters = {
             return {state: newState, readAfterWriteTime: zclData.transtime * 100};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('lightingColorCtrl', ['currentX', 'currentY', 'currentHue', 'currentSaturation']);
+            // Some bulb like Ikea Tådfri LED1624G9 do not support 'currentHue' and 'currentSaturation' attributes.
+            // Skip them if the `skipHueAndSaturation` flag is set
+            // https://github.com/Koenkk/zigbee-herdsman-converters/issues/1340
+            if (meta.mapped && meta.mapped.meta && meta.mapped.meta.skipHueAndSaturation) {
+                await entity.read('lightingColorCtrl', ['currentX', 'currentY']);
+            } else {
+                await entity.read('lightingColorCtrl', ['currentX', 'currentY', 'currentHue', 'currentSaturation']);
+            }
         },
     },
     light_color_colortemp: {

--- a/devices.js
+++ b/devices.js
@@ -15,7 +15,7 @@
  *                         don't provide one.
  * applyRedFix: see toZigbee.light_color
  * enhancedHue: see toZigbee.light_color
- * skipHueAndSaturation: see toZigbee.light_color
+ * supportsHue: see toZigbee.light_color
  * timeout: timeout for commands to this device used in toZigbee.
  */
 
@@ -1523,7 +1523,7 @@ const devices = [
         description: 'TRADFRI LED bulb E14/E26/E27 600 lumen, dimmable, color, opal white',
         extend: generic.light_onoff_brightness_colorxy,
         ota: ota.tradfri,
-        meta: {skipHueAndSaturation: true},
+        meta: {supportsHue: false},
     },
     {
         zigbeeModel: [

--- a/devices.js
+++ b/devices.js
@@ -1896,7 +1896,7 @@ const devices = [
         model: '046677548285',
         vendor: 'Philips',
         description: 'Hue white E12 with Bluetooth',
-        extend: hue.light_onoff_brightnes,
+        extend: hue.light_onoff_brightness,
         ota: ota.zigbeeOTA,
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -15,6 +15,7 @@
  *                         don't provide one.
  * applyRedFix: see toZigbee.light_color
  * enhancedHue: see toZigbee.light_color
+ * skipHueAndSaturation: see toZigbee.light_color
  * timeout: timeout for commands to this device used in toZigbee.
  */
 
@@ -1522,6 +1523,7 @@ const devices = [
         description: 'TRADFRI LED bulb E14/E26/E27 600 lumen, dimmable, color, opal white',
         extend: generic.light_onoff_brightness_colorxy,
         ota: ota.tradfri,
+        meta: {skipHueAndSaturation: true},
     },
     {
         zigbeeModel: [

--- a/devices.js
+++ b/devices.js
@@ -15,7 +15,7 @@
  *                         don't provide one.
  * applyRedFix: see toZigbee.light_color
  * enhancedHue: see toZigbee.light_color
- * supportsHue: see toZigbee.light_color
+ * supportsHueAndSaturation: see toZigbee.light_color
  * timeout: timeout for commands to this device used in toZigbee.
  */
 
@@ -1523,7 +1523,7 @@ const devices = [
         description: 'TRADFRI LED bulb E14/E26/E27 600 lumen, dimmable, color, opal white',
         extend: generic.light_onoff_brightness_colorxy,
         ota: ota.tradfri,
-        meta: {supportsHue: false},
+        meta: {supportsHueAndSaturation: false},
     },
     {
         zigbeeModel: [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,7 +147,7 @@ describe('index.js', () => {
             }
 
             if (device.meta) {
-                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHue'], Object.keys(device.meta));
+                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation'], Object.keys(device.meta));
             }
 
             if (device.zigbeeModel) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,7 +147,7 @@ describe('index.js', () => {
             }
 
             if (device.meta) {
-                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout'], Object.keys(device.meta));
+                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'skipHueAndSaturation'], Object.keys(device.meta));
             }
 
             if (device.zigbeeModel) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,7 +147,7 @@ describe('index.js', () => {
             }
 
             if (device.meta) {
-                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'skipHueAndSaturation'], Object.keys(device.meta));
+                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHue'], Object.keys(device.meta));
             }
 
             if (device.zigbeeModel) {


### PR DESCRIPTION
Fix `light_color.converterGet` for IKEA LED1624G9 that does not support `currentHue` and `currentSaturation` attributes.
To avoid any disruptive change, I added a new flag in `meta` to activate the fix only when needed 

Fix issue #1340 