### PR TITLE
Add DIYRuZ_RT CC2530 with zigbee 3.0

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2953,7 +2953,7 @@ const devices = [
         zigbeeModel: ['DIYRuZ_RT'],
         model: 'DIYRuZ_RT',
         vendor: 'DIYRuZ',
-        description: '',
+        description: '[DiY CC2530 Zigbee 3.0 firmware](https://habr.com/ru/company/iobroker/blog/495926/)',
         supports: 'on/off, temperature',
         fromZigbee: [fz.on_off, fz.temperature],
         toZigbee: [tz.on_off],

--- a/devices.js
+++ b/devices.js
@@ -2949,6 +2949,15 @@ const devices = [
             };
         },
     },
+    {
+        zigbeeModel: ['DIYRuZ_RT'],
+        model: 'DIYRuZ_RT',
+        vendor: 'DIYRuZ',
+        description: '',
+        supports: 'on/off, temperature',
+        fromZigbee: [fz.on_off, fz.temperature],
+        toZigbee: [tz.on_off],
+    },
 
     // eCozy
     {


### PR DESCRIPTION
DIYRuZ_RT is a CC2530 device flashed with the DIYRuZ_RT firmware. Capable with Zigbee 3.0 with on/off relay and temperature sensor.
One of the devices that can be flashed is the Sonoff BASICZBR3 to support Zigbee 3.0.

More information: https://habr.com/ru/company/iobroker/blog/495926/ 
Firmware hex: https://github.com/diyruz/diyruz_rt