### PR TITLE
Allow Kwikset lock programming

### DIFF
--- a/converters/common.js
+++ b/converters/common.js
@@ -79,6 +79,13 @@ const TuyaThermostatForceMode = {
     2: 'close',
 };
 
+const lockSourceName = {
+    0: 'keypad',
+    1: 'rf',
+    2: 'manual',
+    3: 'rfid',
+};
+
 module.exports = {
     thermostatControlSequenceOfOperations,
     thermostatSystemModes,
@@ -89,4 +96,5 @@ module.exports = {
     TuyaThermostatSystemModes,
     TuyaThermostatWeekFormat,
     TuyaThermostatForceMode,
+    lockSourceName,
 };

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -193,6 +193,10 @@ function hasEndpoints(device, endpoints) {
     return true;
 }
 
+function isInRange(min, max, value) {
+    return value >= min && value <= max;
+}
+
 const getRandomInt = (min, max) =>
     Math.floor(Math.random() * (max - min)) + min;
 
@@ -229,6 +233,16 @@ const replaceInArray = (arr, oldElements, newElements) => {
     return clone;
 };
 
+async function getDoorLockPinCode(entity, user, options = null) {
+    await entity.command(
+        'closuresDoorLock',
+        'getPinCode',
+        {
+            'userid': user,
+        },
+        options | {});
+}
+
 module.exports = {
     rgbToXY,
     hexToXY,
@@ -242,7 +256,9 @@ module.exports = {
     gammaCorrectHSV,
     gammaCorrectRGB,
     getRandomInt,
+    isInRange,
     convertMultiByteNumberPayloadToSingleDecimalNumber,
     convertDecimalValueTo2ByteHexArray,
     replaceInArray,
+    getDoorLockPinCode,
 };

--- a/devices.js
+++ b/devices.js
@@ -19,6 +19,7 @@
  * timeout: timeout for commands to this device used in toZigbee.
  */
 
+const common = require('./converters/common');
 const fz = require('./converters/fromZigbee');
 const tz = require('./converters/toZigbee');
 const utils = require('./converters/utils');
@@ -366,6 +367,21 @@ const livolo = {
             await endpoint.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
         } catch (error) {
             // device is lost, need to permit join
+        }
+    },
+};
+
+const pincodeLock = {
+    readPinCodeAfterProgramming: async (type, data, device) => {
+        // When we receive a code updated message, lets read the new value
+        if (data.type === 'commandProgrammingEventNotification' &&
+            data.cluster === 'closuresDoorLock' &&
+            data.data &&
+            data.data.userid !== undefined &&
+            // Don't read RF events, we can do this with retrieve_state
+            (data.data.programeventsrc === undefined || common.lockSourceName[data.data.programeventsrc] != 'rf')
+        ) {
+            await utils.getDoorLockPinCode( device.endpoints[0], data.data.userid );
         }
     },
 };
@@ -8043,16 +8059,18 @@ const devices = [
         model: '9GED18000-009',
         vendor: 'Weiser',
         description: 'SmartCode 10',
-        supports: 'lock/unlock, battery',
-        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery],
-        toZigbee: [tz.generic_lock],
-        meta: {configureKey: 3},
+        supports: 'lock/unlock, battery, pin code programming',
+        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery, fz.lock_programming_event, fz.lock_pin_code_rep],
+        toZigbee: [tz.generic_lock, tz.pincode_lock],
+        meta: {configureKey: 4, pinCodeCount: 30},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
+        // Note - Keypad triggered deletions do not cause a zigbee event, though Adds work fine.
+        onEvent: pincodeLock.readPinCodeAfterProgramming,
     },
     {
         zigbeeModel: ['SMARTCODE_DEADBOLT_10T'],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -249,7 +249,7 @@ describe('index.js', () => {
             }
 
             if (device.meta) {
-                containsOnly(['disableActionGroup', 'configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation', 'battery', 'coverInverted', 'turnsOffAtBrightness1'], Object.keys(device.meta));
+                containsOnly(['disableActionGroup', 'configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation', 'battery', 'coverInverted', 'turnsOffAtBrightness1', 'pinCodeCount'], Object.keys(device.meta));
             }
 
             if (device.zigbeeModel) {


### PR DESCRIPTION
Hi Koenkk,

I am attempting to bring parity from SmartThings to z2m for my zigbee locks (specifically, Kwikset locks with a pinpad). This adds an initial implementation for getting/setting pin codes, as well as exposing the lock/unlock event source. 

Ideally, I'm trying to build support for managing pin codes + seeing who/how locks were locked/unlocked. From z2m, this means exposing all the enddpoints, and then hopefully I'll get to adding it into HASS somehow.

I will admit, I wrote and tested this ~2 months ago, but am not physically in access of the lock currently - I will be in a few weeks time - so I will likely need to delay the merging of these handles until that time, unless someone else is physically able to do it.

That said, I'd love any early feedback or impressions. Please see https://github.com/Koenkk/zigbee-herdsman/pull/194 as well