### PR TITLE
Cleanup OTA Update Code

### DIFF
--- a/ota/ledvance.js
+++ b/ota/ledvance.js
@@ -8,7 +8,9 @@ const axios = common.getAxios();
  * Helper functions
  */
 
-async function getImageMeta(manufacturerCode, imageType) {
+async function getImageMeta(current, logger, device) {
+    const manufacturerCode = current.manufacturerCode;
+    const imageType = current.imageType;
     const {data} = await axios.get(updateCheckUrl +
         `?company=${manufacturerCode}&product=${imageType}&version=0.0.0`);
 
@@ -30,37 +32,16 @@ async function getImageMeta(manufacturerCode, imageType) {
     };
 }
 
-async function getNewImage(current, logger, device) {
-    const meta = await getImageMeta(current.manufacturerCode, current.imageType);
-    assert(meta.fileVersion > current.fileVersion, 'No new image available');
-
-    const download = await axios.get(meta.url, {responseType: 'arraybuffer'});
-
-    const image = common.parseImage(download.data);
-    assert(image.header.fileVersion === meta.fileVersion, 'File version mismatch');
-    assert(image.header.totalImageSize === meta.fileSize, 'Image size mismatch');
-    assert(image.header.manufacturerCode === current.manufacturerCode, 'Manufacturer code mismatch');
-    assert(image.header.imageType === current.imageType, 'Image type mismatch');
-    return image;
-}
-
-async function isNewImageAvailable(current, logger, device) {
-    const meta = await getImageMeta(current.manufacturerCode, current.imageType);
-    const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
-    logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
-    return Math.sign(current.fileVersion - meta.fileVersion);
-}
-
 /**
  * Interface implementation
  */
 
 async function isUpdateAvailable(device, logger, requestPayload=null) {
-    return common.isUpdateAvailable(device, logger, isNewImageAvailable, requestPayload);
+    return common.isUpdateAvailable(device, logger, common.isNewImageAvailable, requestPayload, getImageMeta);
 }
 
 async function updateToLatest(device, logger, onProgress) {
-    return common.updateToLatest(device, logger, onProgress, getNewImage);
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta);
 }
 
 module.exports = {

--- a/ota/salus.js
+++ b/ota/salus.js
@@ -8,7 +8,8 @@ const axios = common.getAxios();
  * Helper functions
  */
 
-async function getImageMeta(modelId) {
+async function getImageMeta(current, logger, device) {
+    const modelId = device.modelId;
     const images = (await axios.get(url)).data.versions;
     const image = images.find((i) => i.model === modelId);
     assert(image !== null, `No image available for modelId '${modelId}'`);
@@ -53,28 +54,14 @@ async function untar(tarStream) {
     });
 }
 
-async function getNewImage(current, logger, device) {
-    const meta = await getImageMeta(device.modelID);
-    assert(meta.fileVersion > current.fileVersion, 'No new image available');
-
+async function downloadImage(meta, logger) {
     const download = await axios.get(meta.url, {responseType: 'stream'});
 
     const files = await untar(download.data);
 
     const imageFile = files.find((file) => file.headers.name.endsWith('.ota'));
 
-    const image = common.parseImage(imageFile.data);
-    assert(image.header.fileVersion === meta.fileVersion, 'File version mismatch');
-    assert(image.header.manufacturerCode === 4216, 'Manufacturer code mismatch');
-    assert(image.header.imageType === current.imageType, 'Image type mismatch');
-    return image;
-}
-
-async function isNewImageAvailable(current, logger, device) {
-    const meta = await getImageMeta(device.modelID);
-    const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
-    logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
-    return Math.sign(current.fileVersion - meta.fileVersion);
+    return imageFile.data;
 }
 
 /**
@@ -82,11 +69,11 @@ async function isNewImageAvailable(current, logger, device) {
  */
 
 async function isUpdateAvailable(device, logger, requestPayload=null) {
-    return common.isUpdateAvailable(device, logger, isNewImageAvailable, requestPayload);
+    return common.isUpdateAvailable(device, logger, common.isNewImageAvailable, requestPayload, getImageMeta);
 }
 
 async function updateToLatest(device, logger, onProgress) {
-    return common.updateToLatest(device, logger, onProgress, getNewImage);
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta, downloadImage);
 }
 
 module.exports = {

--- a/ota/tradfri.js
+++ b/ota/tradfri.js
@@ -7,7 +7,8 @@ const axios = common.getAxios();
  * Helper functions
  */
 
-async function getImageMeta(imageType) {
+async function getImageMeta(current, logger, device) {
+    const imageType = current.imageType;
     const images = (await axios.get(url)).data;
     const image = images.find((i) => i.fw_image_type === imageType);
     assert(image !== undefined, `No image available for imageType '${imageType}'`);
@@ -18,38 +19,16 @@ async function getImageMeta(imageType) {
     };
 }
 
-async function getNewImage(current, logger, device) {
-    const meta = await getImageMeta(current.imageType);
-    assert(meta.fileVersion > current.fileVersion, 'No new image available');
-
-    const download = await axios.get(meta.url, {responseType: 'arraybuffer'});
-    const start = download.data.indexOf(common.upgradeFileIdentifier);
-
-    const image = common.parseImage(download.data.slice(start));
-    assert(image.header.fileVersion === meta.fileVersion, 'File version mismatch');
-    assert(image.header.totalImageSize === meta.fileSize, 'Image size mismatch');
-    assert(image.header.manufacturerCode === 4476, 'Manufacturer code mismatch');
-    assert(image.header.imageType === current.imageType, 'Image type mismatch');
-    return image;
-}
-
-async function isNewImageAvailable(current, logger, device) {
-    const meta = await getImageMeta(current.imageType);
-    const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
-    logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
-    return Math.sign(current.fileVersion - meta.fileVersion);
-}
-
 /**
  * Interface implementation
  */
 
 async function isUpdateAvailable(device, logger, requestPayload=null) {
-    return common.isUpdateAvailable(device, logger, isNewImageAvailable, requestPayload);
+    return common.isUpdateAvailable(device, logger, common.isNewImageAvailable, requestPayload, getImageMeta);
 }
 
 async function updateToLatest(device, logger, onProgress) {
-    return common.updateToLatest(device, logger, onProgress, getNewImage);
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta);
 }
 
 module.exports = {


### PR DESCRIPTION
The OTA functions `getNewImage` and `isNewImageAvailable` seem to be replicated in a very similar way inside the implementations for the different manufacturers. As this already led to a problem with ubisys OTA after a minor interface change, I tried to provide general default implementations inside `common.js` and use them from the manufacturer specific files.

Up to now I only updated `ubisys.js` and `zigbeeOTA.js` to use the default implementations as these are the only ones I could test myself. The rest should continue to work as before (but not benefit from the cleanup), but in case you or somebody else would be able and willing to test OTA updates for Ledvance, Ikea TRÅDFRI and Salus, I'd be happy to add the changes for them to this PR as well.

Please feel free to comment or suggest different approaches!

Thanks,
Felix