### PR TITLE
Fix Iris 3320L Conversion to only examine Alarm1 bit

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2566,7 +2566,7 @@ const converters = {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
         convert: (model, msg, publish, options, meta) => {
-            return {contact: (msg.data.zonestatus & 1) === 0};
+            return {contact: msg.data.zonestatus === 36};
         },
     },
     RZHAC_4256251_power: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2566,7 +2566,7 @@ const converters = {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
         convert: (model, msg, publish, options, meta) => {
-            return {contact: msg.data.zonestatus === 36};
+            return {contact: (msg.data.zonestatus & 1) === 0};
         },
     },
     RZHAC_4256251_power: {

--- a/devices.js
+++ b/devices.js
@@ -6119,7 +6119,7 @@ const devices = [
         vendor: 'Iris',
         description: 'Contact and temperature sensor',
         supports: 'contact and temperature',
-        fromZigbee: [fz.iris_3320L_contact, fz.temperature, fz.battery_3V_2100],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery_3V_2100],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Iris 3320L from zigbee conversion uses all bits of the zonestatus to determine if the sensor is open or closed; However only bit 0 actually indicates the open close status. (See https://docs.smartthings.com/en/latest/ref-docs/zigbee-ref.html#accessing-a-property-attribute)


Fixes #1362