### PR TITLE
Bugfix/hue motion converters

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -533,6 +533,17 @@ const converters = {
             }
         },
     },
+    hue_motion_sensitivity: {
+        cluster: 'msOccupancySensing',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const lookup = ['low', 'medium', 'high'];
+
+            if (msg.data.hasOwnProperty('48')) {
+                return {motion_sensitivity: lookup[msg.data['48']]};
+            }
+        },
+    },
     brightness: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -533,17 +533,6 @@ const converters = {
             }
         },
     },
-    hue_motion_sensitivity: {
-        cluster: 'msOccupancySensing',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            const lookup = ['low', 'medium', 'high'];
-
-            if (msg.data.hasOwnProperty('48')) {
-                return {motion_sensitivity: lookup[msg.data['48']]};
-            }
-        },
-    },
     brightness: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -2717,6 +2706,17 @@ const converters = {
         type: 'commandRecall',
         convert: (model, msg, publish, options, meta) => {
             return {click: `scene_${msg.data.groupid}_${msg.data.sceneid}`};
+        },
+    },
+    hue_motion_sensitivity: {
+        cluster: 'msOccupancySensing',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const lookup = ['low', 'medium', 'high'];
+
+            if (msg.data.hasOwnProperty('48')) {
+                return {motion_sensitivity: lookup[msg.data['48']]};
+            }
         },
     },
     thermostat_att_report: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1632,6 +1632,7 @@ const converters = {
                 },
             };
             await entity.write('msOccupancySensing', payload, options.hue);
+            return {state: {motion_sensitivity: value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('msOccupancySensing', [48], options.hue);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -292,6 +292,7 @@ const converters = {
         // set delay after motion detector changes from occupied to unoccupied
         key: ['occupancy_timeout'],
         convertSet: async (entity, key, value, meta) => {
+            value *= 1;
             await entity.write('msOccupancySensing', {pirOToUDelay: value});
             return {state: {occupancy_timeout: value}};
         },

--- a/devices.js
+++ b/devices.js
@@ -2503,7 +2503,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue motion outdoor sensor',
         supports: 'occupancy, temperature, illuminance',
-        fromZigbee: [fz.battery, fz.occupancy, fz.temperature, fz.illuminance, fz.occupancy_timeout],
+        fromZigbee: [fz.battery, fz.occupancy, fz.temperature, fz.illuminance, fz.occupancy_timeout, fz.hue_motion_sensitivity],
         toZigbee: [tz.occupancy_timeout, tz.hue_motion_sensitivity],
         endpoint: (device) => {
             return {

--- a/devices.js
+++ b/devices.js
@@ -2475,7 +2475,7 @@ const devices = [
         supports: 'occupancy, temperature, illuminance',
         fromZigbee: [
             fz.battery, fz.occupancy, fz.temperature, fz.occupancy_timeout, fz.illuminance,
-            fz.ignore_basic_report,
+            fz.ignore_basic_report, fz.hue_motion_sensitivity,
         ],
         toZigbee: [tz.occupancy_timeout, tz.hue_motion_sensitivity],
         endpoint: (device) => {

--- a/devices.js
+++ b/devices.js
@@ -2503,7 +2503,10 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue motion outdoor sensor',
         supports: 'occupancy, temperature, illuminance',
-        fromZigbee: [fz.battery, fz.occupancy, fz.temperature, fz.illuminance, fz.occupancy_timeout, fz.hue_motion_sensitivity],
+        fromZigbee: [
+            fz.battery, fz.occupancy, fz.temperature, fz.illuminance, fz.occupancy_timeout,
+            fz.hue_motion_sensitivity,
+        ],
         toZigbee: [tz.occupancy_timeout, tz.hue_motion_sensitivity],
         endpoint: (device) => {
             return {


### PR DESCRIPTION
I followed your pattern for occupancy_timeout and returned the values also for motion_sensitivity.  These have been tested in my environment and are working as expected.

Also, small fix so that on initial set of occupancy_timeout the value is converted to numeric.  I'm assuming it should be numeric as on subsequent calls to "get" I'm getting a numeric value back.