### PR TITLE
Adds Samotech SM311 as Sunricher ZG2835RAC white-label

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8204,6 +8204,7 @@ const devices = [
         meta: {configureKey: 1},
         whiteLabel: [
             {vendor: 'YPHIX', model: '50208695'},
+            {vendor: 'Samotech', model: 'SM311'},
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Got a Samotech SM311 today and just finished installing it, I knew it was a Sunricher white-label, only didn't know it was all ready to work out of the box as it is the ZG2835RAC!

https://www.samotech.co.uk/products/sm311-rotary-zigbee-dimmer/