### PR TITLE
Fixes #1376: Adds full power measurement to the Sunricher ZG2835RAC

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8200,11 +8200,11 @@ const devices = [
         model: 'ZG2835RAC',
         vendor: 'Sunricher',
         description: 'ZigBee knob smart dimmer',
-        extend: generic.light_onoff_brightness,
-        supports: 'on/off, brightness, power measurement',
-        fromZigbee: [
-            fz.on_off, fz.brightness, fz.electrical_measurement_power, fz.metering_power, fz.ignore_basic_report,
-        ],
+        supports: generic.light_onoff_brightness.supports + ', power measurements',
+        fromZigbee: generic.light_onoff_brightness.fromZigbee.concat(
+            [fz.electrical_measurement_power, fz.metering_power]
+        ),
+        toZigbee: generic.light_onoff_brightness.toZigbee,
         meta: {configureKey: 2},
         whiteLabel: [
             {vendor: 'YPHIX', model: '50208695'},

--- a/devices.js
+++ b/devices.js
@@ -8201,14 +8201,30 @@ const devices = [
         vendor: 'Sunricher',
         description: 'ZigBee knob smart dimmer',
         extend: generic.light_onoff_brightness,
-        meta: {configureKey: 1},
+        supports: 'on/off, brightness, power measurement',
+        fromZigbee: [
+            fz.on_off, fz.brightness, fz.electrical_measurement_power, fz.metering_power, fz.ignore_basic_report,
+        ],
+        meta: {configureKey: 2},
         whiteLabel: [
             {vendor: 'YPHIX', model: '50208695'},
             {vendor: 'Samotech', model: 'SM311'},
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            const binds = [
+                'genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering',
+            ];
+            await bind(endpoint, coordinatorEndpoint, binds);
+
+            await configureReporting.onOff(endpoint);
+            await configureReporting.brightness(endpoint);
+            await readEletricalMeasurementPowerConverterAttributes(endpoint);
+            await configureReporting.activePower(endpoint);
+            await configureReporting.rmsCurrent(endpoint, {min: 5, change: 5});
+            await configureReporting.rmsVoltage(endpoint, {min: 5});
+            await readMeteringPowerConverterAttributes(endpoint);
+            await configureReporting.currentSummDelivered(endpoint);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -8202,7 +8202,7 @@ const devices = [
         description: 'ZigBee knob smart dimmer',
         supports: generic.light_onoff_brightness.supports + ', power measurements',
         fromZigbee: generic.light_onoff_brightness.fromZigbee.concat(
-            [fz.electrical_measurement_power, fz.metering_power]
+            [fz.electrical_measurement_power, fz.metering_power],
         ),
         toZigbee: generic.light_onoff_brightness.toZigbee,
         meta: {configureKey: 2},


### PR DESCRIPTION
Also supports some white-labels like YPHIX 50208695 and Samotech SM311

I kept the existing `extends` attribute but overrided the `fromZigbee` one to match the requirements for this to work. Is this ok ir is it better to have the whole thing locally and remove the `extends` completely?