### PR TITLE
Adds Samotech SM301Z as Tuya RH3040 white-label

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1163,6 +1163,9 @@ const devices = [
         ],
         toZigbee: [],
         meta: {configureKey: 1},
+        whiteLabel: [
+            {vendor: 'Samotech', model: 'SM301Z'},
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genPowerCfg']);


### PR DESCRIPTION
Got a [Samotech SM301Z](https://www.samotech.co.uk/products/zigbee-smart-wireless-motion-sensor-compatible-with-echo-plus-and-echo-show-2nd-generation/) last week, and though they do look quite different from a Tuya RH3040, it has been identified as such (and is working fine)