### PR TITLE
Add support for HOMA1064 (HLC833-Z-SC)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8354,6 +8354,13 @@ const devices = [
             return {l1: 1, l2: 2, l3: 3};
         },
     },
+    {
+        zigbeeModel: ['HOMA1064'],
+        model: 'HLC833-Z-SC',
+        vendor: 'Shenzhen Homa',
+        description: 'Wireless Dimmable Controller',
+        extend: generic.light_onoff_brightness,
+    },
 
     // Honyar
     {

--- a/devices.js
+++ b/devices.js
@@ -8358,7 +8358,7 @@ const devices = [
         zigbeeModel: ['HOMA1064'],
         model: 'HLC833-Z-SC',
         vendor: 'Shenzhen Homa',
-        description: 'Wireless Dimmable Controller',
+        description: 'Wireless dimmable controller',
         extend: generic.light_onoff_brightness,
     },
 


### PR DESCRIPTION
Added support for HOMA1064 (HLC833-Z-SC) a Wireless Dimmable Controller by Shenzhen Homa.

Product on [AliBaba](https://amelech.en.alibaba.com/product/62089946938-810739852/100meter_IP65_1_10V_energy_saving_smart_wireless_lighting_remote_control_outdoor_led_garden_lights.html?spm=a2700.icbuShop.41413.16.71dc6a10cwzRUk)

---

Z2M recognizes it fine but also indicates that its missing a converter:

```bash
zigbee2mqtt:debug 2020-07-14 11:52:01: Received Zigbee message from '0x00124b001eb0a6bb', type 'raw', cluster '65518', data '{"type":"Buffer","data":[25,2,129]}' from endpoint 128 with groupID 0
zigbee2mqtt:debug 2020-07-14 11:52:01: No converter available for 'HLC833-Z-SC' with cluster '65518' and type 'raw' and data '{"type":"Buffer","data":[25,2,129]}'
```

I'm not sure what it expects here.

Output from the device in `database.db`:

```json
{
   "id":2,
   "type":"Router",
   "ieeeAddr":"0x00124b001eb0a6bb",
   "nwkAddr":47830,
   "manufId":0,
   "manufName":"ShenZhen_Homa",
   "powerSource":"Mains (single phase)",
   "modelId":"HOMA1064",
   "epList":[
      128
   ],
   "endpoints":{
      "128":{
         "profId":260,
         "epId":128,
         "devId":257,
         "inClusterList":[
            0,
            3,
            4,
            5,
            6,
            8
         ],
         "outClusterList":[
            25
         ],
         "clusters":{
            "genBasic":{
               "attributes":{
                  "modelId":"HOMA1064",
                  "manufacturerName":"ShenZhen_Homa",
                  "powerSource":1,
                  "zclVersion":1,
                  "appVersion":1,
                  "stackVersion":2,
                  "hwVersion":1,
                  "dateCode":"20171014",
                  "swBuildId":"1.0.2"
               }
            }
         },
         "binds":[

         ]
      }
   },
   "appVersion":1,
   "stackVersion":2,
   "hwVersion":1,
   "dateCode":"20171014",
   "swBuildId":"1.0.2",
   "zclVersion":1,
   "interviewCompleted":true,
   "meta":{

   },
   "lastSeen":1594720406862
}
```