### PR TITLE
Add HEIMAN HS1HT-E variant

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6724,7 +6724,7 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['HT-EM', 'TH-T_V14'],
+        zigbeeModel: ['HT-EM', 'TH-EM', 'TH-T_V14'],
         model: 'HS1HT',
         vendor: 'HEIMAN',
         description: 'Smart temperature & humidity Sensor',


### PR DESCRIPTION
I ordered a HS1HT from aliexpress a while ago, box came labeled HS1HT-E, seems functionally the same but it had model `TH-EM` instead of `HT-EM`.

```json
{
  "id": 28,
  "type": "EndDevice",
  "ieeeAddr": "0x000d6f0011f9f87b",
  "nwkAddr": 773,
  "manufId": 4619,
  "manufName": "HEIMAN",
  "powerSource": "Battery",
  "modelId": "TH-EM",
  "epList": [
    1,
    2
  ],
  "endpoints": {
    "1": {
      "profId": 260,
      "epId": 1,
      "devId": 770,
      "inClusterList": [
        0,
        1,
        3,
        9,
        1026
      ],
      "outClusterList": [
        3
      ],
      "clusters": {
        "genBasic": {
          "attributes": {
            "modelId": "TH-EM",
            "manufacturerName": "HEIMAN",
            "powerSource": 3,
            "zclVersion": 2,
            "appVersion": 16,
            "hwVersion": 16,
            "dateCode": "2017.9.14"
          }
        }
      },
      "binds": [
        {
          "cluster": 1026,
          "type": "endpoint",
          "deviceIeeeAddress": "0x00124b001938a7e5",
          "endpointID": 1
        }
      ]
    },
    "2": {
      "profId": 260,
      "epId": 2,
      "devId": 770,
      "inClusterList": [
        0,
        1,
        3,
        1029
      ],
      "outClusterList": [
        3
      ],
      "clusters": {
        "genBasic": {
          "attributes": {
            
          }
        }
      },
      "binds": [
        {
          "cluster": 1029,
          "type": "endpoint",
          "deviceIeeeAddress": "0x00124b001938a7e5",
          "endpointID": 1
        },
        {
          "cluster": 1,
          "type": "endpoint",
          "deviceIeeeAddress": "0x00124b001938a7e5",
          "endpointID": 1
        }
      ]
    }
  },
  "appVersion": 16,
  "hwVersion": 16,
  "dateCode": "2017.9.14",
  "zclVersion": 2,
  "interviewCompleted": true,
  "meta": {
    "configured": 2
  },
  "lastSeen": 1594836682079
}
```