### PR TITLE
Zemismart ZM-CSW032-D Curtain/roller blind switch set position

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6745,7 +6745,7 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['HT-EM', 'TH-T_V14'],
+        zigbeeModel: ['HT-EM', 'TH-EM', 'TH-T_V14'],
         model: 'HS1HT',
         vendor: 'HEIMAN',
         description: 'Smart temperature & humidity Sensor',


### PR DESCRIPTION
This update is intended for an interactive movement by definition of the position. If you add 2 properties (time_close and time_open) in your configuration.yaml, you can get the real position
This modification depends on a modification in "zigbee-herdsman" (cluster.js > closuresWindowCovering)