### PR TITLE
Add support for acceleration sensor in Samsung Smartthings Multipurpo…

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5050,7 +5050,6 @@ const converters = {
             return {humidity: calibrateAndPrecisionRoundOptions(humidity, options, 'humidity')};
         },
     },
-
     smartthings_acceleration: {
         cluster: 'manuSpecificSamsungAccelerometer',
         type: ['attributeReport', 'readResponse'],
@@ -5058,7 +5057,6 @@ const converters = {
             return {moving: msg.data['acceleration'] === 1 ? true : false};
         },
     },
-
     MultiSensor_ias_contact_alarm: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5055,7 +5055,7 @@ const converters = {
         cluster: 'manuSpecificSamsungAccelerometer',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
-            return {acceleration: msg.data['acceleration'] === 1 ? true : false};
+            return {acceleration: msg.data['moving'] === 1 ? true : false};
         },
     },
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5055,7 +5055,7 @@ const converters = {
         cluster: 'manuSpecificSamsungAccelerometer',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
-            return {acceleration: msg.data['moving'] === 1 ? true : false};
+            return {moving: msg.data['acceleration'] === 1 ? true : false};
         },
     },
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5050,6 +5050,15 @@ const converters = {
             return {humidity: calibrateAndPrecisionRoundOptions(humidity, options, 'humidity')};
         },
     },
+
+    smartthings_acceleration: {
+        cluster: 'manuSpecificSamsungAccelerometer',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            return {acceleration: msg.data['acceleration'] === 1 ? true : false};
+        },
+    },
+
     MultiSensor_ias_contact_alarm: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/devices.js
+++ b/devices.js
@@ -72,6 +72,11 @@ const configureReportingPayload = (attribute, min, max, change, overrides) => {
 };
 
 const configureReporting = {
+    accelerationState: async (endpoint, overrides) => {
+        const payload = configureReportingPayload('acceleration', 10, repInterval.MINUTE, 1, overrides);
+        const options = {manufacturerCode: 0x110A};
+        await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payload, options);
+    },
     currentPositionLiftPercentage: async (endpoint, overrides) => {
         const payload = configureReportingPayload('currentPositionLiftPercentage', 1, repInterval.MAX, 1, overrides);
         await endpoint.configureReporting('closuresWindowCovering', payload);
@@ -5654,9 +5659,13 @@ const devices = [
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            const options = {manufacturerCode: 0x110A};
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg', 'manuSpecificSamsungAccelerometer']);
+            await endpoint.write('manuSpecificSamsungAccelerometer', {0x0000: {value: 0x01, type: 0x20}}, options);
+            await endpoint.write('manuSpecificSamsungAccelerometer', {0x0002: {value: 0x0276, type: 0x21}}, options);
             await configureReporting.temperature(endpoint);
             await configureReporting.batteryVoltage(endpoint);
+            await configureReporting.accelerationState(endpoint);
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -72,11 +72,6 @@ const configureReportingPayload = (attribute, min, max, change, overrides) => {
 };
 
 const configureReporting = {
-    accelerationState: async (endpoint, overrides) => {
-        const payload = configureReportingPayload('acceleration', 10, repInterval.MINUTE, 1, overrides);
-        const options = {manufacturerCode: 0x110A};
-        await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payload, options);
-    },
     currentPositionLiftPercentage: async (endpoint, overrides) => {
         const payload = configureReportingPayload('currentPositionLiftPercentage', 1, repInterval.MAX, 1, overrides);
         await endpoint.configureReporting('closuresWindowCovering', payload);
@@ -5656,7 +5651,7 @@ const devices = [
         supports: 'contact',
         fromZigbee: [fz.temperature, fz.battery_3V, fz.ias_contact_alarm_1],
         toZigbee: [],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const options = {manufacturerCode: 0x110A};
@@ -5665,7 +5660,8 @@ const devices = [
             await endpoint.write('manuSpecificSamsungAccelerometer', {0x0002: {value: 0x0276, type: 0x21}}, options);
             await configureReporting.temperature(endpoint);
             await configureReporting.batteryVoltage(endpoint);
-            await configureReporting.accelerationState(endpoint);
+            const payload = configureReportingPayload('acceleration', 10, repInterval.MINUTE, 1);
+            await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payload, options);
         },
     },
     {


### PR DESCRIPTION
…se sensor (2016 model)

Add the attribute that indicates the device has been moved.

I'm not sure sure how to add this purely in Zigbee-herdsman-converters, so needed to add the following to the Zigbee-herdsman package as well.


file: src/zcl/definition/manufacturerCode.ts:
export default {
    Centralite: 0x104E,
    Philips: 0x100B,
    Sinope: 0x119C,
    Stelpro: 0x1185,
    Ubisys: 0x10f2,
    LegrandNetatmo: 0x1021,
    SmartThings: 0x110a,
};

and
file: src/zcl/definition/cluster.ts:
    manuSpecificSamsungAccelerometer: {
        ID: 0xFC02,
        manufacturerCode: ManufacturerCode.SmartThings,
        attributes: {
             motion_threshold_multiplier: {ID: 0, type: DataType.uint8},
             motion_threshold: {ID: 2, type: DataType.uint16},
             acceleration: {ID: 16, type: DataType.bitmap8},
             x_axis: {ID:18, type: DataType.int16},
             y_axis: {ID:19, type: DataType.int16},
             z_axis: {ID:20, type: DataType.int16},
        },
        commands: {},
        commandsResponse: {},
    },

