### PR TITLE
Increases some min reporting timings for ZG2835RAC

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8405,7 +8405,7 @@ const devices = [
         description: 'ZigBee knob smart dimmer',
         supports: generic.light_onoff_brightness.supports + ', power measurements',
         fromZigbee: generic.light_onoff_brightness.fromZigbee.concat(
-            [fz.electrical_measurement_power, fz.metering_power],
+            [fz.electrical_measurement_power, fz.metering_power, fz.ignore_genOta],
         ),
         toZigbee: generic.light_onoff_brightness.toZigbee,
         meta: {configureKey: 2},
@@ -8424,8 +8424,8 @@ const devices = [
             await configureReporting.brightness(endpoint);
             await readEletricalMeasurementPowerConverterAttributes(endpoint);
             await configureReporting.activePower(endpoint);
-            await configureReporting.rmsCurrent(endpoint, {min: 5, change: 5});
-            await configureReporting.rmsVoltage(endpoint, {min: 5});
+            await configureReporting.rmsCurrent(endpoint, {min: 10, change: 10});
+            await configureReporting.rmsVoltage(endpoint, {min: 10});
             await readMeteringPowerConverterAttributes(endpoint);
             await configureReporting.currentSummDelivered(endpoint);
         },


### PR DESCRIPTION
I've noticed some issues on my zigbee network lately (lots of errors mentioning BUFFER_FULL and MAC channel access failure) and they seem related to when I previously added the power monitoring to the ZG2835RAC (https://github.com/Koenkk/zigbee-herdsman-converters/pull/1377)

This PR increases the timings for rmsVoltage and rmsCurrent monitoring, in the hopes this fixes it, but I am keeping open the option to just disable the whole thing and revert back to when we didn't have any power monitoring.

The only other thing is that I have changed the host machine (from a NanoPi Neo 2 to a NanoPi M4V2) and by doing so, had so many issues with the whole thing that I eventually reflashed my Texas Instruments LAUNCHXL-CC26X2R1 with the latest firmware available...

The network is now "rebuilding" so I hope this will stabilize in the next couple of days, but these values still seem safer/saner for now!

On a side note, @Koenkk I don't see any specific documentation on how the whole report configuration works, perhaps it would be good to add some documentation around it? I've been making quite a few assumptions around this stuff and would be great to have some clarity.