### PR TITLE
Fix WXKG01LM if no click up event is received

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1272,6 +1272,9 @@ const converters = {
                     publish({click: 'long'});
                     store[deviceID].timer = null;
                     store[deviceID].long = Date.now();
+                    store[deviceID].long_timer = ](() => {
+                        store[deviceID].long = false;
+                    }, 4000); // After 4000 milliseconds of not reciving long_release we assume it will not happen.
                 }, options.long_timeout || 1000); // After 1000 milliseconds of not releasing we assume long click.
             } else if (state === 1) {
                 if (store[deviceID].long) {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1272,7 +1272,7 @@ const converters = {
                     publish({click: 'long'});
                     store[deviceID].timer = null;
                     store[deviceID].long = Date.now();
-                    store[deviceID].long_timer = ](() => {
+                    store[deviceID].long_timer = setTimeout(() => {
                         store[deviceID].long = false;
                     }, 4000); // After 4000 milliseconds of not reciving long_release we assume it will not happen.
                 }, options.long_timeout || 1000); // After 1000 milliseconds of not releasing we assume long click.


### PR DESCRIPTION
Added timeout equals to 5 seconds timeout after `click down`. If no `click up` event is received (e.g. it was sent before `click up` event) it will reset the `long` variable so the next click is not treated as `click up` of previous one.