### PR TITLE
Corrected battery information from Develco Smoke detector

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -388,18 +388,25 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const payload = {};
             if (msg.data.hasOwnProperty('batteryPercentageRemaining')) {
-                payload['battery'] = precisionRound(msg.data['batteryPercentageRemaining'] / 2, 2);
+                payload.battery = precisionRound(msg.data['batteryPercentageRemaining'] / 2, 2);
             }
 
             if (msg.data.hasOwnProperty('batteryVoltage')) {
-                payload['voltage'] = msg.data['batteryVoltage'] * 100;
+                // Deprecated: voltage is = mV now but should be V
+                payload.voltage = msg.data['batteryVoltage'] * 100;
+
+                if (model.meta.hasOwnProperty('batteryVoltageToPercentage')) {
+                    if (model.meta.batteryVoltageToPercentage === 'CR2032') {
+                        payload.battery = toPercentageCR2032(payload.voltage);
+                    }
+                }
             }
 
             if (msg.data.hasOwnProperty('batteryAlarmState')) {
                 const battery1Low = (msg.data.batteryAlarmState & 1<<0) > 0;
                 const battery2Low = (msg.data.batteryAlarmState & 1<<9) > 0;
                 const battery3Low = (msg.data.batteryAlarmState & 1<<19) > 0;
-                payload['battery_low'] = battery1Low || battery2Low || battery3Low;
+                payload.battery_low = battery1Low || battery2Low || battery3Low;
             }
 
             return payload;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -395,7 +395,7 @@ const converters = {
                 // Deprecated: voltage is = mV now but should be V
                 payload.voltage = msg.data['batteryVoltage'] * 100;
 
-                if (model.meta.hasOwnProperty('battery') && model.meta.hasOwnProperty('voltageToPercentage')) {
+                if (model.meta.hasOwnProperty('battery') && model.meta.battery.hasOwnProperty('voltageToPercentage')) {
                     if (model.meta.battery.voltageToPercentage === 'CR2032') {
                         payload.battery = toPercentageCR2032(payload.voltage);
                     }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -395,8 +395,8 @@ const converters = {
                 // Deprecated: voltage is = mV now but should be V
                 payload.voltage = msg.data['batteryVoltage'] * 100;
 
-                if (model.meta.hasOwnProperty('batteryVoltageToPercentage')) {
-                    if (model.meta.batteryVoltageToPercentage === 'CR2032') {
+                if (model.meta.hasOwnProperty('battery') && model.meta.hasOwnProperty('voltageToPercentage')) {
+                    if (model.meta.battery.voltageToPercentage === 'CR2032') {
                         payload.battery = toPercentageCR2032(payload.voltage);
                     }
                 }

--- a/devices.js
+++ b/devices.js
@@ -10985,7 +10985,7 @@ const devices = [
         supports: 'smoke, warning, temperature',
         fromZigbee: [fz.temperature, fz.battery, fz.ias_smoke_alarm_1, fz.ignore_basic_report, fz.ignore_genOta],
         toZigbee: [tz.warning],
-        meta: {configureKey: 1, batteryVoltageToPercentage: 'CR2032'},
+        meta: {configureKey: 1, battery: {voltageToPercentage: 'CR2032'}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'genBasic']);

--- a/devices.js
+++ b/devices.js
@@ -10983,7 +10983,7 @@ const devices = [
         vendor: 'Develco',
         description: 'Smoke detector with siren',
         supports: 'smoke, warning, temperature',
-        fromZigbee: [fz.temperature, fz.battery, fz.ias_smoke_alarm_1, fz.ignore_basic_report, fz.ignore_genOta],
+        fromZigbee: [fz.temperature, fz.battery_cr2032, fz.ias_smoke_alarm_1, fz.ignore_basic_report, fz.ignore_genOta],
         toZigbee: [tz.warning],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -10983,9 +10983,9 @@ const devices = [
         vendor: 'Develco',
         description: 'Smoke detector with siren',
         supports: 'smoke, warning, temperature',
-        fromZigbee: [fz.temperature, fz.battery_cr2032, fz.ias_smoke_alarm_1, fz.ignore_basic_report, fz.ignore_genOta],
+        fromZigbee: [fz.temperature, fz.battery, fz.ias_smoke_alarm_1, fz.ignore_basic_report, fz.ignore_genOta],
         toZigbee: [tz.warning],
-        meta: {configureKey: 1},
+        meta: {configureKey: 1, batteryVoltageToPercentage: 'CR2032'},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'genBasic']);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -211,7 +211,7 @@ describe('index.js', () => {
             }
 
             if (device.meta) {
-                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'battery', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation'], Object.keys(device.meta));
+                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation', 'battery'], Object.keys(device.meta));
             }
 
             if (device.zigbeeModel) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -211,7 +211,7 @@ describe('index.js', () => {
             }
 
             if (device.meta) {
-                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation'], Object.keys(device.meta));
+                containsOnly(['configureKey', 'multiEndpoint', 'applyRedFix', 'battery', 'disableDefaultResponse', 'enhancedHue', 'timeout', 'supportsHueAndSaturation'], Object.keys(device.meta));
             }
 
             if (device.zigbeeModel) {


### PR DESCRIPTION
To get a correct battery reading 'fz.battery_cr2032' should be used iso 'fz.battery'.