### PR TITLE
Add "discovery" mode for Xiaomi ZNCLDJ12LM

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1205,7 +1205,7 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             let running = false;
-            
+
             if (model.model === 'ZNCLDJ12LM' && msg.type === 'attributeReport' && [0, 2].includes(msg.data['presentValue'])) {
                 // Incorrect reports from the device, ignore (re-read by onEvent of ZNCLDJ12LM)
                 // https://github.com/Koenkk/zigbee-herdsman-converters/pull/1427#issuecomment-663862724

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1205,6 +1205,12 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             let running = false;
+            
+            if (model.model === 'ZNCLDJ12LM' && msg.type === 'attributeReport' && [0, 2].includes(msg.data['presentValue'])) {
+                // Incorrect reports from the device, ignore (re-read by onEvent of ZNCLDJ12LM)
+                // https://github.com/Koenkk/zigbee-herdsman-converters/pull/1427#issuecomment-663862724
+                return;
+            }
 
             if (msg.data['61440']) {
                 running = msg.data['61440'] !== 0;

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1176,7 +1176,7 @@ const converters = {
             const opts = {
                 reverse_direction: false,
                 hand_open: true,
-                reset_limits: false, // TODO how is this called in the Xiaomi app?
+                reset_limits: false,
                 ...value,
             };
 
@@ -1205,7 +1205,9 @@ const converters = {
             } else {
                 throw new Error(`xiaomi_curtain_options set called for not supported model: ${meta.mapped.model}`);
             }
-
+            
+            // Reset limits is an action, not a state.
+            delete opts.reset_limits;
             return {state: {options: opts}};
         },
         convertGet: async (entity, key, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1245,6 +1245,13 @@ const converters = {
             await entity.read('genAnalogOutput', [0x0055]);
         },
     },
+	ZNCLDJ12LM_control: {
+		key: ['discovery'],
+		convertSet: async (entity, key, value, meta) => {
+			meta.logger.info(`${meta.options.friendlyName}: activating end stops discovery mode`);
+			await entity.write('genBasic', {0xff27: {value: 0x00, type: 0x10}}, options.xiaomi);
+		},
+	},
     ledvance_commands: {
         /* deprectated osram_*/
         key: ['set_transition', 'remember_state', 'osram_set_transition', 'osram_remember_state'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1205,7 +1205,7 @@ const converters = {
             } else {
                 throw new Error(`xiaomi_curtain_options set called for not supported model: ${meta.mapped.model}`);
             }
-            
+
             // Reset limits is an action, not a state.
             delete opts.reset_limits;
             return {state: {options: opts}};

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1186,7 +1186,7 @@ const converters = {
 
             if (meta.mapped.model === 'ZNCLDJ12LM') {
                 await entity.write('genBasic', {0xff28: {value: opts.reverse_direction, type: 0x10}}, options.xiaomi);
-                await entity.write('genBasic', {0xff29: {value: !opts.auto_close, type: 0x10}}, options.xiaomi);
+                await entity.write('genBasic', {0xff29: {value: !opts.hand_open, type: 0x10}}, options.xiaomi);
 
                 if (opts.reset_limits) {
                     await entity.write('genBasic', {0xff27: {value: 0x00, type: 0x10}}, options.xiaomi);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1216,10 +1216,10 @@ const converters = {
             }
         },
     },
-    xiaomi_curtain: {
+    xiaomi_curtain_position_state: {
         key: ['state', 'position'],
         convertSet: async (entity, key, value, meta) => {
-            if (key === 'state' && value.toLowerCase() === 'stop') {
+            if (key === 'state' && typeof value === 'string' && value.toLowerCase() === 'stop') {
                 await entity.command('closuresWindowCovering', 'stop', {}, getOptions(meta.mapped, entity));
             } else {
                 const lookup = {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1245,13 +1245,13 @@ const converters = {
             await entity.read('genAnalogOutput', [0x0055]);
         },
     },
-	ZNCLDJ12LM_control: {
-		key: ['discovery'],
-		convertSet: async (entity, key, value, meta) => {
-			meta.logger.info(`${meta.options.friendlyName}: activating end stops discovery mode`);
-			await entity.write('genBasic', {0xff27: {value: 0x00, type: 0x10}}, options.xiaomi);
-		},
-	},
+    ZNCLDJ12LM_control: {
+        key: ['discovery'],
+        convertSet: async (entity, key, value, meta) => {
+            meta.logger.info(`${meta.options.friendlyName}: activating end stops discovery mode`);
+            await entity.write('genBasic', {0xff27: {value: 0x00, type: 0x10}}, options.xiaomi);
+        },
+    },
     ledvance_commands: {
         /* deprectated osram_*/
         key: ['set_transition', 'remember_state', 'osram_set_transition', 'osram_remember_state'],

--- a/devices.js
+++ b/devices.js
@@ -943,7 +943,7 @@ const devices = [
             fz.ZNCLDJ11LM_ZNCLDJ12LM_curtain_analog_output, fz.cover_position_tilt, fz.ignore_basic_report,
             fz.battery,
         ],
-        toZigbee: [tz.ZNCLDJ11LM_ZNCLDJ12LM_control, tz.ZNCLDJ12LM_options],
+        toZigbee: [tz.ZNCLDJ11LM_ZNCLDJ12LM_control, tz.ZNCLDJ12LM_control, tz.ZNCLDJ12LM_options],
         onEvent: async (type, data, device) => {
             // The position (genAnalogOutput.presentValue) reported via an attribute contains an invaid value
             // however when reading it will provide the correct value.

--- a/devices.js
+++ b/devices.js
@@ -950,7 +950,7 @@ const devices = [
         supports: 'open, close, stop, position',
         vendor: 'Xiaomi',
         fromZigbee: [fz.xiaomi_curtain_position, fz.cover_position_tilt, fz.xiaomi_curtain_options],
-        toZigbee: [tz.xiaomi_curtain, tz.xiaomi_curtain_options],
+        toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_options],
     },
     {
         zigbeeModel: ['lumi.curtain.hagl04'],
@@ -959,7 +959,7 @@ const devices = [
         description: 'Aqara B1 curtain motor ',
         supports: 'open, close, stop, position',
         fromZigbee: [fz.xiaomi_curtain_position, fz.battery, fz.cover_position_tilt, fz.ignore_basic_report, fz.xiaomi_curtain_options],
-        toZigbee: [tz.xiaomi_curtain, tz.xiaomi_curtain_options],
+        toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_options],
         onEvent: async (type, data, device) => {
             // The position (genAnalogOutput.presentValue) reported via an attribute contains an invaid value
             // however when reading it will provide the correct value.

--- a/devices.js
+++ b/devices.js
@@ -950,7 +950,7 @@ const devices = [
         supports: 'open, close, stop, position',
         vendor: 'Xiaomi',
         fromZigbee: [fz.xiaomi_curtain_position, fz.cover_position_tilt, fz.xiaomi_curtain_options],
-        toZigbee: [tz.xiaomi_curtain, tz.ZNCLDJ11LM_options],
+        toZigbee: [tz.xiaomi_curtain, tz.xiaomi_curtain_options],
     },
     {
         zigbeeModel: ['lumi.curtain.hagl04'],
@@ -959,7 +959,7 @@ const devices = [
         description: 'Aqara B1 curtain motor ',
         supports: 'open, close, stop, position',
         fromZigbee: [fz.xiaomi_curtain_position, fz.battery, fz.cover_position_tilt, fz.ignore_basic_report, fz.xiaomi_curtain_options],
-        toZigbee: [tz.xiaomi_curtain, tz.ZNCLDJ12LM_control, tz.ZNCLDJ12LM_options],
+        toZigbee: [tz.xiaomi_curtain, tz.xiaomi_curtain_options],
         onEvent: async (type, data, device) => {
             // The position (genAnalogOutput.presentValue) reported via an attribute contains an invaid value
             // however when reading it will provide the correct value.


### PR DESCRIPTION
Add "discovery" mode for Xiaomi ZNCLDJ12LM to calibrate end points. This PR fixes my issue home-assistant/core#37943.

Use case for my solution to calibrate curtains after mains loss (automations.yaml):
```
- alias: Calibrate curtains
  trigger:
  - platform: homeassistant
    event: start
  action:
  - service: mqtt.publish
    data:
      topic: zigbee2mqtt/br_cover/set
      payload: "{'discovery': true}"
  - service: cover.close_cover
    entity_id:
    - cover.br_cover
  - delay:
      seconds: 13
  - service: cover.open_cover
    entity_id:
    - cover.br_cover
```