### PR TITLE
Added 1746330P7/Philips Hue Appear

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2624,6 +2624,14 @@ const devices = [
         extend: hue.light_onoff_brightness_colorxy,
     },
     {
+        zigbeeModel: ['1746330P7'],
+        model: '1746330P7',
+        vendor: 'Philips',
+        description: 'Hue Appear outdoor wall light',
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LCS001'],
         model: '1741830P7',
         vendor: 'Philips',


### PR DESCRIPTION
Hi,

I think this is all it takes to add support for a new device; the docs get generated automagically?

```
2020-07-14.09-41-27/log.txt:info  2020-07-23 17:57:55: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"type":"pairing","message":"interview_started","meta":{"friendly_name":"0x00178801067da590"}}'
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:56: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"modelId":"1746330P7"}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:56: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"manufacturerName":"Philips"}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:56: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"powerSource":1}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:57: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"zclVersion":2}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:57: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"appVersion":2}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:57: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"stackVersion":1}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:57: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"hwVersion":0}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:57: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"dateCode":"20190529"}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:debug 2020-07-23 17:57:57: Received Zigbee message from '0x00178801067da590', type 'readResponse', cluster 'genBasic', data '{"swBuildId":"1.56.7_r29434"}' from endpoint 11 with groupID null
2020-07-14.09-41-27/log.txt:warn  2020-07-23 17:57:58: Device '0x00178801067da590' with Zigbee model '1746330P7' is NOT supported, please follow https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html
```