### PR TITLE
Fix Wally U02I007C.01 configuration

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10920,7 +10920,6 @@ const devices = [
             const binds = ['genPowerCfg', 'genOnOff', 'msTemperatureMeasurement', 'msRelativeHumidity'];
             await bind(endpoint, coordinatorEndpoint, binds);
             await configureReporting.batteryPercentageRemaining(endpoint);
-            await configureReporting.onOff(endpoint);
             await configureReporting.temperature(endpoint);
             await configureReporting.humidity(endpoint);
         },


### PR DESCRIPTION
Attribute report config fails for onOff with UNSUPPORTED_ATTRIBUTE.
Device does not need this to be configured to operate properly.