### PR TITLE
Add BTicino switches

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10743,7 +10743,7 @@ const devices = [
     // BTicino (Legrand brand)
     {
         zigbeeModel: [' Light switch with neutral\u0000\u0000\u0000\u0000\u0000'],
-        model: 'K4003C',
+        model: 'K4003C/L4003C/N4003C/NT4003C',
         vendor: 'BTicino',
         description: 'Light switch with neutral',
         supports: 'on/off, led color',


### PR DESCRIPTION
I added three variant of the existing BTicino/Legrand switch.

These belongs to the more common Livinglight serie:

- https://catalogo.bticino.it/BTI-L4003C-IT
- https://catalogo.bticino.it/BTI-N4003C-IT
- https://catalogo.bticino.it/BTI-NT4003C-IT

while the existing one belongs to Living Now serie: https://catalogo.bticino.it/BTI-K4003C-IT.

I updated the image in Koenkk/zigbee2mqtt.io/pull/353.