### PR TITLE
Add support for BTicino F20T60A

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10713,7 +10713,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: [' DIN power consumption module\u0000\u0000'],
+        zigbeeModel: [' DIN power consumption module\u0000\u0000', ' DIN power consumption module'],
         model: '412015',
         vendor: 'Legrand',
         description: 'DIN power consumption module',


### PR DESCRIPTION
This PR adds support for BTicino F20T60A DIN power consumption module, which is actually a Legrand 412015 module.

The issue was that the BTicino module identifies itself as ` DIN power consumption module` without the trailing NULL characters, and because of that it was not recognized as a supported device.