### PR TITLE
Device T21W1Z showing ConfigureReporting errors

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10087,7 +10087,6 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
-            await configureReporting.onOff(endpoint);
         },
     },
     {


### PR DESCRIPTION
Because of that line `zigbee2mqtt `is showing error messages, like `Failed to configure 'device1', attempt 2 (Error: ConfigureReporting .. genOnOff([{"attribute":"onOff","minimumReportInterval":0 ...`.