### PR TITLE
NLG Q-REMOTE improvements

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3417,13 +3417,6 @@ const converters = {
             }
         },
     },
-    nlg_remote_command_set_scene: {
-        cluster: 'genScenes',
-        type: 'commandRecall',
-        convert: (model, msg, publish, options, meta) => {
-            return { action: 'set_scene', action_scene_id: msg.data.sceneid };
-        },
-    },
     tint404011_scene: {
         cluster: 'genBasic',
         type: 'write',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3417,6 +3417,13 @@ const converters = {
             }
         },
     },
+    nlg_remote_command_set_scene: {
+        cluster: 'genScenes',
+        type: 'commandRecall',
+        convert: (model, msg, publish, options, meta) => {
+            return { action: 'set_scene', action_scene_id: msg.data.sceneid };
+        },
+    },
     tint404011_scene: {
         cluster: 'genBasic',
         type: 'write',

--- a/devices.js
+++ b/devices.js
@@ -6128,7 +6128,7 @@ const devices = [
             fz.command_on, fz.command_off, fz.command_toggle, fz.command_step,
             fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_stop,
             fz.command_move, fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation,
-            fz.tint404011_scene, fz.nlg_remote_command_set_scene,
+            fz.tint404011_scene, fz.command_recall,
         ],
         toZigbee: [],
     },

--- a/devices.js
+++ b/devices.js
@@ -6128,7 +6128,7 @@ const devices = [
             fz.command_on, fz.command_off, fz.command_toggle, fz.command_step,
             fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_stop,
             fz.command_move, fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation,
-            fz.tint404011_scene,
+            fz.tint404011_scene, fz.nlg_remote_command_set_scene,
         ],
         toZigbee: [],
     },

--- a/devices.js
+++ b/devices.js
@@ -6119,7 +6119,7 @@ const devices = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['NLG-remote'],
+        zigbeeModel: ['NLG-remote', 'Neuhaus remote'],
         model: '100.462.31',
         vendor: 'Paul Neuhaus',
         description: 'Q-REMOTE',


### PR DESCRIPTION
I wasn't sure about the naming convention of `nlg_remote_command_set_scene` so I'm open for suggestions. 

The command is fired whenever the `.` or `. .` button is pressed where `scene_id` is the "id" of the button. 
`.` => scene_id = 1
`. .` => scene_id = 2