### PR TITLE
Add support for TuYa SNTZ009 water leak sensor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3404,6 +3404,21 @@ const converters = {
             return {action: `${button}${clickMapping[msg.data[3]]}`};
         },
     },
+    tuya_water_leak: {
+        cluster: 'manuSpecificTuyaDimmer',
+        type: 'commandSetDataResponse',
+        convert: (model, msg, publish, options, meta) => {
+            const key = msg.data.dp;
+            const val = msg.data.data;
+            if (key === 357) {
+                return {
+                    water_leak: val[0] === 1,
+                };
+            }
+
+            return null;
+        },
+    },
     tint404011_brightness_updown_click: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',

--- a/devices.js
+++ b/devices.js
@@ -1436,7 +1436,7 @@ const devices = [
         vendor: 'TuYa',
         description: 'Water leak sensor',
         supports: 'water leak',
-        fromZigbee: [fz.tuya_water_leak],
+        fromZigbee: [fz.tuya_water_leak, fz.ignore_basic_report],
         toZigbee: [],
     },
     // Norklmes

--- a/devices.js
+++ b/devices.js
@@ -1430,7 +1430,15 @@ const devices = [
         fromZigbee: [fz.scenes_recall_scene_65029],
         toZigbee: [],
     },
-
+    {
+        zigbeeModel: ['q9mpfhw'],
+        model: 'SNTZ009',
+        vendor: 'TuYa',
+        description: 'Water leak sensor',
+        supports: 'water leak',
+        fromZigbee: [fz.tuya_water_leak],
+        toZigbee: [],
+    },
     // Norklmes
     {
         zigbeeModel: ['qnazj70'],

--- a/devices.js
+++ b/devices.js
@@ -1439,6 +1439,7 @@ const devices = [
         fromZigbee: [fz.tuya_water_leak, fz.ignore_basic_report],
         toZigbee: [],
     },
+
     // Norklmes
     {
         zigbeeModel: ['qnazj70'],


### PR DESCRIPTION
Added support for TuYa SNTZ009 water leak sensor.
Device details and pictures can be accessed here: https://www.houseiq.pl/pl/p/Czujnik-zalania-ZIGBEE-TUYA-SMART/848