### PR TITLE
multiple Paulmann models with same zigbeeid

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6207,9 +6207,9 @@ const devices = [
     },
     {
         zigbeeModel: ['371000002'],
-        model: '798.09',
+        model: '371000002',
         vendor: 'Paulmann',
-        description: 'LED panel Amaris 595x595mm 35W matt white',
+        description: 'Amaris LED panels',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
     {


### PR DESCRIPTION
per https://github.com/ioBroker/ioBroker.zigbee/issues/586#issuecomment-650319541

i would make and educated guess that all 3 models (https://en.paulmann.com/search?sSearch=amaris) share the same zigbee id