### PR TITLE
Fix cover_position_tilt's returned position.

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -193,11 +193,11 @@ const converters = {
         key: ['position'],
         convertSet: async (entity, key, value, meta) => {
             const invert = meta.mapped.meta && meta.mapped.meta.coverInverted ? !meta.options.invert_cover : meta.options.invert_cover;
-            value = invert ? 100 - value : value;
+            const zpos = invert ? 100 - value : value;
             await entity.command(
                 'genLevelCtrl',
                 'moveToLevelWithOnOff',
-                {level: Math.round(Number(value) * 2.55).toString(), transtime: 0},
+                {level: Math.round(Number(zpos) * 2.55).toString(), transtime: 0},
                 getOptions(meta.mapped, entity),
             );
 
@@ -268,7 +268,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const isPosition = (key === 'position');
             const invert = !(meta.mapped.meta && meta.mapped.meta.coverInverted ? !meta.options.invert_cover : meta.options.invert_cover);
-            value = invert ? 100 - value : value;
+            const zpos = invert ? 100 - value : value;
 
             // Zigbee officially expects 'open' to be 0 and 'closed' to be 100 whereas
             // HomeAssistant etc. work the other way round.
@@ -276,7 +276,7 @@ const converters = {
             await entity.command(
                 'closuresWindowCovering',
                 isPosition ? 'goToLiftPercentage' : 'goToTiltPercentage',
-                isPosition ? {percentageliftvalue: value} : {percentagetiltvalue: value},
+                isPosition ? {percentageliftvalue: zpos} : {percentagetiltvalue: zpos},
                 getOptions(meta.mapped, entity),
             );
 


### PR DESCRIPTION
When running with invert_cover unset or false, the zigbee position sent to device as 100-position. Working as intended. However it also reports back the same inverted value as the new state. This is wrong. When HA sets the position to 35, it gets back 65.
Even worse, if it want to open the cover by sending it 100 (=HA-open), it gets back a 0 (=HA-closed) which then disabled the down arrow, making it annoying to figure out what just happened.

Of course, when invert_cover=true, no translation happens and setting it to 35, returns 35.