### PR TITLE
Add Blaupunkt PSM-S1

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6919,7 +6919,7 @@ const devices = [
         toZigbee: [tz.cover_position_via_brightness, tz.cover_open_close_via_brightness],
     },
     {
-        zigbeeModel: ['PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC', 'PSMP5_00.00.05.10TC'],
+        zigbeeModel: ['PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC', 'PSMP5_00.00.05.01TC', 'PSMP5_00.00.05.10TC'],
         model: 'PSM-29ZBSR',
         vendor: 'Climax',
         description: 'Power plug',


### PR DESCRIPTION
Add support for blaupunkt Power swith meter PSM-S1. The same as Climax PSM-29ZBSR