### PR TITLE
Fix typo: batery -> battery

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -450,7 +450,7 @@ const converters = {
                 // Deprecated: voltage is = mV now but should be V
                 payload.voltage = msg.data['batteryVoltage'] * 100;
 
-                if (model.meta && model.meta.batery && model.meta.battery.voltageToPercentage) {
+                if (model.meta && model.meta.battery && model.meta.battery.voltageToPercentage) {
                     if (model.meta.battery.voltageToPercentage === 'CR2032') {
                         payload.battery = toPercentageCR2032(payload.voltage);
                     }


### PR DESCRIPTION
Fix for https://github.com/Koenkk/zigbee-herdsman-converters/issues/1477