### PR TITLE
Add support for earlier version of Nordtronic Box Dimmer 2.0

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4981,7 +4981,7 @@ const devices = [
 
     // Nordtronic
     {
-        zigbeeModel: ['BoxDIM2 98425031','98425031'],
+        zigbeeModel: ['BoxDIM2 98425031', '98425031'],
         model: '98425031',
         vendor: 'Nordtronic',
         description: 'Box Dimmer 2.0',

--- a/devices.js
+++ b/devices.js
@@ -4981,20 +4981,7 @@ const devices = [
 
     // Nordtronic
     {
-        zigbeeModel: ['98425031'],
-        model: '98425031',
-        vendor: 'Nordtronic',
-        description: 'Box Dimmer 2.0',
-        extend: generic.light_onoff_brightness,
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await configureReporting.onOff(endpoint);
-        },
-    },
-    {
-        zigbeeModel: ['BoxDIM2 98425031'],
+        zigbeeModel: ['BoxDIM2 98425031','98425031'],
         model: '98425031',
         vendor: 'Nordtronic',
         description: 'Box Dimmer 2.0',

--- a/devices.js
+++ b/devices.js
@@ -4981,6 +4981,19 @@ const devices = [
 
     // Nordtronic
     {
+        zigbeeModel: ['98425031'],
+        model: '98425031',
+        vendor: 'Nordtronic',
+        description: 'Box Dimmer 2.0',
+        extend: generic.light_onoff_brightness,
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await configureReporting.onOff(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['BoxDIM2 98425031'],
         model: '98425031',
         vendor: 'Nordtronic',


### PR DESCRIPTION
I have a Nordtronic Box Dimmer 2.0 that registers with the following zigbee model.
It works just like the other Box Dimmer 2.0, that I also have and that works well with Z2M.

Therefore I thin it makes sense just to register the device and use the same converters as the existing Box Dimmer 2.0..

zigbee2mqtt:warn  2020-08-22 22:29:34: Received message from unsupported device with Zigbee model '98425031'
zigbee2mqtt:warn  2020-08-22 22:29:34: Please see: https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html.

Please note: This is my very first PR, so feedback is welcome.

Thanks.