### PR TITLE
Add converter for Samsung Accelerometer

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6253,7 +6253,7 @@ const devices = [
         vendor: 'SmartThings',
         description: 'Multipurpose sensor (2016 model)',
         supports: 'contact',
-        fromZigbee: [fz.temperature, fz.battery_3V, fz.ias_contact_alarm_1],
+        fromZigbee: [fz.temperature, fz.battery_3V, fz.ias_contact_alarm_1, fz.smartthings_acceleration],
         toZigbee: [],
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Fixes this issue: https://github.com/Koenkk/zigbee-herdsman-converters/pull/1415#issuecomment-675195331