### PR TITLE
Device Support: TS110F Lonsonho 1-gang

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1644,7 +1644,7 @@ const devices = [
         model: 'QS-Zigbee-D02-TRIAC-LN',
         vendor: 'Lonsonho',
         description: '1 gang smart dimmer switch module with neutral',
-        extend: generic.light_onoff_brightness_colortemp,
+        extend: generic.light_onoff_brightness,
     },
     {
         fingerprint: [{modelID: 'TS110F', manufacturerName: '_TYZB01_v8gtiaed'}],
@@ -8041,7 +8041,7 @@ const devices = [
         vendor: 'Müller Licht',
         description: 'Tint LED Panel, color, opal white',
         supports: generic.light_onoff_brightness_colortemp_colorxy.supports,
-        fromZigbee: generic.light_onoff_brightness_colortemp_colorxy.fromZigbee,
+        TS110FfromZigbee: generic.light_onoff_brightness_colortemp_colorxy.fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy.toZigbee.concat([tz.tint_scene]),
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -8041,7 +8041,7 @@ const devices = [
         vendor: 'Müller Licht',
         description: 'Tint LED Panel, color, opal white',
         supports: generic.light_onoff_brightness_colortemp_colorxy.supports,
-        TS110FfromZigbee: generic.light_onoff_brightness_colortemp_colorxy.fromZigbee,
+        fromZigbee: generic.light_onoff_brightness_colortemp_colorxy.fromZigbee,
         toZigbee: generic.light_onoff_brightness_colortemp_colorxy.toZigbee.concat([tz.tint_scene]),
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -1646,6 +1646,25 @@ const devices = [
         description: '1 gang smart dimmer switch module with neutral',
         extend: generic.light_onoff_brightness_colortemp,
     },
+    {
+        fingerprint: [{modelID: 'TS110F', manufacturerName: '_TYZB01_v8gtiaed'}],
+        model: 'QS-Zigbee-D02-TRIAC-2C-LN',
+        vendor: 'Lonsonho',
+        description: '2 gang smart dimmer switch module with neutral',
+        extend: generic.light_onoff_brightness,
+        meta: {multiEndpoint: true, configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await configureReporting.onOff(endpoint);
+            const endpoint2 = device.getEndpoint(2);
+            await bind(endpoint2, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await configureReporting.onOff(endpoint2);
+        },
+        endpoint: (device) => {
+            return {l1: 1, l2: 2};
+        },
+    },
 
     // IKEA
     {
@@ -10497,25 +10516,6 @@ const devices = [
             const endpoint = device.getEndpoint(11);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await configureReporting.onOff(endpoint);
-        },
-    },
-    {
-        zigbeeModel: ['TS110F'],
-        model: 'QS-Zigbee-D02-TRIAC-2C-LN',
-        vendor: 'Lonsonho',
-        description: '2 gang smart dimmer switch module with neutral',
-        extend: generic.light_onoff_brightness,
-        meta: {multiEndpoint: true, configureKey: 1},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await configureReporting.onOff(endpoint);
-            const endpoint2 = device.getEndpoint(2);
-            await bind(endpoint2, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await configureReporting.onOff(endpoint2);
-        },
-        endpoint: (device) => {
-            return {l1: 1, l2: 2};
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -1639,6 +1639,13 @@ const devices = [
             return {'l1': 1, 'l2': 1, 'l3': 1};
         },
     },
+    {
+        fingerprint: [{modelID: 'TS110F', manufacturerName: '_TYZB01_qezuin6k'}],
+        model: 'QS-Zigbee-D02-TRIAC-LN',
+        vendor: 'Lonsonho',
+        description: '1 gang smart dimmer switch module with neutral',
+        extend: generic.light_onoff_brightness_colortemp,
+    },
 
     // IKEA
     {


### PR DESCRIPTION
Support for 2-gang dimmer was already there, and now both 1-gang and 2-gang dimmer modules will be supported (they share the same model ID, so the distinction is going to be made based on manufacturerName).