### PR TITLE
Update support for ROB_200-010-0

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6001,7 +6001,7 @@ const devices = [
         ],
     },
     {
-        zigbeeModel: ['Motor Controller'],
+        zigbeeModel: ['Motor Controller', 'ROB_200-010-0'],
         model: 'ROB_200-010-0',
         vendor: 'ROBB',
         description: 'Zigbee curtain motor controller',


### PR DESCRIPTION
The vendor updated the module to identify it as 'ROB_200-010-0'. The version that identifies as 'Motor Controller' is still being sent out. Devices seem identical.
Added the extra zigbeeModel to devices.js. Tested locally and works perfectly.