### PR TITLE
Add ignore temperature report to device Sinope TH1124ZB

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9999,6 +9999,7 @@ const devices = [
         supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
         fromZigbee: [
             fz.thermostat_att_report,
+            fz.ignore_temperature_report,
         ],
         toZigbee: [
             tz.thermostat_local_temperature,


### PR DESCRIPTION
Sinope Thermostat TH1124ZB send msTemperatureMeasurement reports. No converter is associated with this message and the temperature is already provided in the hvacThermostat report as local_temperature.