### PR TITLE
Support for YSR-MINI-01 with different ZigBee ID

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5893,7 +5893,7 @@ const devices = [
 
     // YSRSAI
     {
-        zigbeeModel: ['ZB-CL01'],
+        zigbeeModel: ['ZB-CL01', 'FB56-ZCW20FB1.2'],
         model: 'YSR-MINI-01',
         vendor: 'YSRSAI',
         description: 'Zigbee LED controller (RGB+CCT)',


### PR DESCRIPTION
My LED Controller shows YSR-MINI-01 on the case but uses a different ZigBee ID.