### PR TITLE
Add support for the UK Philips Hue smart plug

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3022,6 +3022,22 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LOM003'],
+        model: '8718699689308',
+        vendor: 'Philips',
+        description: 'Hue smart plug - UK',
+        supports: 'on/off',
+        fromZigbee: [fz.on_off],
+        toZigbee: [tz.on_off].concat(tzHuePowerOnBehavior),
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(11);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await configureReporting.onOff(endpoint);
+        },
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LOM005'],
         model: '9290022408',
         vendor: 'Philips',


### PR DESCRIPTION
See [this Zigbee2MQTT issue](https://github.com/Koenkk/zigbee2mqtt/issues/4244) for details. With that change and Zigbee2MQTT restarted, I am no longer seeing `Received message from unsupported device with Zigbee model 'LOM003'` messages and pulling a device map through a `zigbee2mqtt/bridge/config/devices/get` command shows the proper configuration:

    {
      "dateCode": "20200124",
      "description": "Hue smart plug - UK",
      "friendly_name": "living_room_tv_light",
      "hardwareVersion": 1,
      "ieeeAddr": "0x0017880108051bb0",
      "lastSeen": 1599214711140,
      "manufacturerID": 4107,
      "manufacturerName": "Philips",
      "model": "8718699689308",
      "modelID": "LOM003",
      "networkAddress": 54272,
      "powerSource": "Mains (single phase)",
      "softwareBuildID": "1.65.9_hB3217DF4",
      "type": "Router",
      "vendor": "Philips"
    },

I could add a documentation file, but that would basically be an exact copy of the EU and AU models that are already there, so would rather consolidate these documentations rather than add a new one, but open to suggestions there.

This is my first contribution, so please feel free to tell me if I missed a few places that I should update as well to get this properly integrated.