### PR TITLE
Add Sengled E1F-N5E

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5009,6 +5009,14 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['E1F-N5E'],
+        model: 'E1F-N5E',
+        vendor: 'Sengled',
+        description: 'Element color plus E12',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['E12-N14'],
         model: 'E12-N14',
         vendor: 'Sengled',


### PR DESCRIPTION
Add Sengled E1F-N5E to `devices.js`. The Sengled E1F-N5E is similar to the Sengled E11-N1EA but is smaller and has an E12 screw base.