### PR TITLE
Replaced parsing of temperature for QBKG03LM

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2540,20 +2540,26 @@ const converters = {
             }
         },
     },
-    xiaomi_power_from_basic: {
-        cluster: 'genBasic',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            if (msg.data['65281']) {
-                const data = msg.data['65281'];
-                return {
-                    power: precisionRound(data['152'], 2),
-                    consumption: precisionRound(data['149'], 2),
-                    temperature: calibrateAndPrecisionRoundOptions(data['3'], options, 'temperature'),
-                };
-            }
-        },
-    },
+    xiaomi_power_from_basic: {                                                     
+        cluster: 'genBasic',                                                       
+        type: ['attributeReport', 'readResponse'],                                 
+        convert: (model, msg, publish, options, meta) => {                         
+            if (msg.data['65281']) {                                               
+                const data = msg.data['65281'];                                    
+                const result = {};                                                 
+                if (data['152']) {                                                 
+                    result.power = precisionRound(data['152'], 2);                 
+                }                                                                  
+                if (data['149']) {                                                 
+                    result.consumption = precisionRound(data['149'], 2);           
+                }                                                                  
+                if (data['3']) {                                                   
+                    result.temperature = calibrateAndPrecisionRoundOptions(data['3'
+                }                                                                  
+                return result;                                                     
+            }                                                                      
+        },                                                                         
+    },   
     QBKG04LM_buttons: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2540,26 +2540,26 @@ const converters = {
             }
         },
     },
-    xiaomi_power_from_basic: {                                                     
-        cluster: 'genBasic',                                                       
-        type: ['attributeReport', 'readResponse'],                                 
-        convert: (model, msg, publish, options, meta) => {                         
-            if (msg.data['65281']) {                                               
-                const data = msg.data['65281'];                                    
-                const result = {};                                                 
-                if (data['152']) {                                                 
-                    result.power = precisionRound(data['152'], 2);                 
-                }                                                                  
-                if (data['149']) {                                                 
-                    result.consumption = precisionRound(data['149'], 2);           
-                }                                                                  
-                if (data['3']) {                                                   
+    xiaomi_power_from_basic: {
+        cluster: 'genBasic',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.data['65281']) {
+                const data = msg.data['65281'];
+                const result = {};
+                if (data['152']) {
+                    result.power = precisionRound(data['152'], 2);
+                }
+                if (data['149']) {
+                    result.consumption = precisionRound(data['149'], 2);
+                }
+                if (data['3']) {
                     result.temperature = calibrateAndPrecisionRoundOptions(data['3'], options, 'temperature');
-                }                                                                  
-                return result;                                                     
-            }                                                                      
-        },                                                                         
-    },   
+                }
+                return result;
+            }
+        },
+    },
     QBKG04LM_buttons: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2554,7 +2554,7 @@ const converters = {
                     result.consumption = precisionRound(data['149'], 2);           
                 }                                                                  
                 if (data['3']) {                                                   
-                    result.temperature = calibrateAndPrecisionRoundOptions(data['3'
+                    result.temperature = calibrateAndPrecisionRoundOptions(data['3'], options, 'temperature');
                 }                                                                  
                 return result;                                                     
             }                                                                      

--- a/devices.js
+++ b/devices.js
@@ -617,7 +617,7 @@ const devices = [
             fz.xiaomi_on_off_action,
             /* check these */
             fz.on_off_xiaomi_ignore_endpoint_4_5_6, fz.legacy_QBKG03LM_QBKG12LM_click, fz.QBKG03LM_buttons,
-            fz.xiaomi_operation_mode_basic, fz.xiaomi_power_from_basic
+            fz.xiaomi_operation_mode_basic, fz.xiaomi_power_from_basic,
         ],
         toZigbee: [tz.on_off, tz.xiaomi_switch_operation_mode],
         meta: {multiEndpoint: true, configureKey: 1},

--- a/devices.js
+++ b/devices.js
@@ -617,7 +617,7 @@ const devices = [
             fz.xiaomi_on_off_action,
             /* check these */
             fz.on_off_xiaomi_ignore_endpoint_4_5_6, fz.legacy_QBKG03LM_QBKG12LM_click, fz.QBKG03LM_buttons,
-            fz.xiaomi_operation_mode_basic, fz.generic_device_temperature,
+            fz.xiaomi_operation_mode_basic, fz.xiaomi_power_from_basic
         ],
         toZigbee: [tz.on_off, tz.xiaomi_switch_operation_mode],
         meta: {multiEndpoint: true, configureKey: 1},


### PR DESCRIPTION
Temperature data from QBKG03LM now uses generic_device_temperature converter, but it is incompatible. Temperature comes in format similar to QBKG12LM where it is parsed in xiaomi_power_from_basic converter.
So I had to replace generic_device_temperature with xiaomi_power_from_basic in devices.js to get temperature work.
 Also added conditions to xiaomi_power_from_basic_info to parse only existed data