### PR TITLE
Add manufacturer specific attributes converters to Sinope TH1300ZB

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3462,7 +3462,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const lookup = {0: 'off', 1: 'on'};
             if (msg.data.hasOwnProperty('GFCiStatus')) {
-                return {GFCi_status: lookup[msg.data['GFCiStatus']]};
+                return {gfci_status: lookup[msg.data['GFCiStatus']]};
             }
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3455,6 +3455,29 @@ const converters = {
             return result;
         },
     },
+    sinope_GFCi_status: {
+        // TH1300ZB specific
+        cluster: 'manuSpecificSinope',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const lookup = {0: 'off', 1: 'on'};
+            if (msg.data.hasOwnProperty('GFCiStatus')) {
+                return {GFCi_status: lookup[msg.data['GFCiStatus']]};
+            }
+        },
+    },
+    sinope_floor_limit_status: {
+        // TH1300ZB specific
+        cluster: 'manuSpecificSinope',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const lookup = {0: 'off', 1: 'on'};
+            if (msg.data.hasOwnProperty('floorLimitStatus')) {
+                return {floor_limit_status: lookup[msg.data['floorLimitStatus']]};
+            }
+        },
+    },
+
     eurotronic_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1899,6 +1899,78 @@ const converters = {
             }
         },
     },
+    sinope_floor_control_mode: {
+        // TH1300ZB specific
+        key: ['floor_control_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            if (typeof value !== 'string') {
+                return;
+            }
+            const lookup = {'ambiant': 1, 'floor': 2};
+            value = value.toLowerCase();
+            if (lookup.hasOwnProperty(value)) {
+                await entity.write('manuSpecificSinope', {floorControlMode: lookup[value]});
+            }
+        },
+    },
+    sinope_ambiant_max_heat_setpoint: {
+        // TH1300ZB specific
+        key: ['ambiant_max_heat_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            if (value >= 5 && value <= 36) {
+                await entity.write('manuSpecificSinope', {ambiantMaxHeatSetpointLimit: value * 100});
+            }
+        },
+    },
+    sinope_floor_min_heat_setpoint: {
+        // TH1300ZB specific
+        key: ['floor_min_heat_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            if (value >= 5 && value <= 36) {
+                await entity.write('manuSpecificSinope', {floorMinHeatSetpointLimit: value * 100});
+            }
+        },
+    },
+    sinope_floor_max_heat_setpoint: {
+        // TH1300ZB specific
+        key: ['floor_max_heat_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            if (value >= 5 && value <= 36) {
+                await entity.write('manuSpecificSinope', {floorMaxHeatSetpointLimit: value * 100});
+            }
+        },
+    },
+    sinope_temperature_sensor: {
+        // TH1300ZB specific
+        key: ['floor_temperature_sensor'],
+        convertSet: async (entity, key, value, meta) => {
+            if (typeof value !== 'string') {
+                return;
+            }
+            const lookup = {'10k': 0, '12k': 1};
+            value = value.toLowerCase();
+            if (lookup.hasOwnProperty(value)) {
+                await entity.write('manuSpecificSinope', {temperatureSensor: lookup[value]});
+            }
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificSinope', ['temperatureSensor']);
+        },
+    },
+    sinope_time_format: {
+        // TH1300ZB specific
+        key: ['time_format'],
+        convertSet: async (entity, key, value, meta) => {
+            if (typeof value !== 'string') {
+                return;
+            }
+            const lookup = {'24h': 0, '12h': 1};
+            value = value.toLowerCase();
+            if (lookup.hasOwnProperty(value)) {
+                await entity.write('manuSpecificSinope', {timeFormatToDisplay: lookup[value]});
+            }
+        },
+    },
     stelpro_thermostat_outdoor_temperature: {
         key: ['thermostat_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {


### PR DESCRIPTION
Adds the following configuration attributes:
- floor_control_mode: select the sensor to use for temperature regulation (values: ambiant , floor)
- ambiant_max_heat_setpoint: set the maximum ambiant temperature.
- floor_min_heat_setpoint: set the minimum floor temperature.
- floor_max_heat_setpoint: set the maximum floor temperature.
- temperature_sensor: set the value of the floor thermistor temperature sensor connected to the thermostat (values: 10k, 12k)
- time_format: set the display time format (values: 12h, 24h)

Adds the following reporting:
- GFCi_status:  'on' when a ground fault is detected (values: on, off)
- floor_limit_status: 'on' when the floor temperature exceeds the  floor_max_heat_setpoint (values: on, off)

Also use different maximum interval reporting values to reduce network congestion when multiple thermostats are connected.
