### PR TITLE
Added Innr FL 140 C (LED Strip) to devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4239,6 +4239,14 @@ const devices = [
 
     // Innr
     {
+        zigbeeModel: ['FL 140 C'],
+        model: 'FL 140 C',
+        vendor: 'Innr',
+        description: 'Color Flex LED strip 4m 1200lm',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        meta: {applyRedFix: true, turnsOffAtBrightness1: true},
+    },
+    {
         zigbeeModel: ['FL 130 C'],
         model: 'FL 130 C',
         vendor: 'Innr',


### PR DESCRIPTION
I've added support for the Innr FL 140 C LED strip. Works great so far. From my understanding this is basically the same light strip as the FL 130 C with 1200lm instead of 1000lm. 