### PR TITLE
adds support of Philips Hue LTD011

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2246,7 +2246,7 @@ const devices = [
     },
     {
         zigbeeModel: ['LTD011'],
-        model: '5110131H5',
+        model: 'LTD011',
         vendor: 'Philips',
         description: 'Garnea Downlight',
         supports: 'on/off, brightness, color temperature, power-on behavior',

--- a/devices.js
+++ b/devices.js
@@ -2246,10 +2246,10 @@ const devices = [
     },
     {
         zigbeeModel: ['LTD011'],
-        model: 'LTD011',
+        model: '5110131H5',
         vendor: 'Philips',
-        description: 'Garnea Downlight',
-        supports: 'on/off, brightness, color temperature, power-on behavior',
+        description: 'Garnea downlight',
+        meta: {turnsOffAtBrightness1: true},
         extend: hue.light_onoff_brightness_colortemp,
         ota: ota.zigbeeOTA,
     },

--- a/devices.js
+++ b/devices.js
@@ -2245,6 +2245,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LTD011'],
+        model: '5110131H5',
+        vendor: 'Philips',
+        description: 'Garnea Downlight',
+        supports: 'on/off, brightness, color temperature, power-on behavior',
+        extend: hue.light_onoff_brightness_colortemp,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LWA010'],
         model: '929002335001',
         vendor: 'Philips',


### PR DESCRIPTION
Adds support for [Philips Hue LTD011 ](https://www.philips-hue.com/en-au/p/hue-white-ambiance-garnea-downlight/5110131H5). Essentially just a copy of https://www.zigbee2mqtt.io/devices/5900131C5.html as their functionality is the same.