### PR TITLE
Update zigbeeModel for SONOFF SNZB-03

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11522,7 +11522,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['MS01'],
+        zigbeeModel: ['MS01', 'MSO1'],
         model: 'SNZB-03',
         vendor: 'SONOFF',
         whiteLabel: [


### PR DESCRIPTION
I am unsure if the original zigbee model was a typo however the latest model shipped to me is 'MSO1' and not MS01'