### PR TITLE
Fix for Sinope SW2500ZB light switch does not report state change

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10557,6 +10557,12 @@ const devices = [
         supports: 'on/off',
         fromZigbee: [fz.on_off],
         toZigbee: [tz.on_off],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await configureReporting.onOff(endpoint);
+        },
     },
     {
         zigbeeModel: ['DM2500ZB'],


### PR DESCRIPTION
Configure section was missing. Added the section and tested with my SW2500ZB. This fixed the issue.