### PR TITLE
Update to Sinope TH1123ZB, TH1124ZB and TH1300ZB

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10152,7 +10152,7 @@ const devices = [
             tz.sinope_thermostat_enable_outdoor_temperature,
             tz.sinope_thermostat_outdoor_temperature,
         ],
-        meta: {configureKey: 2},
+        meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const binds = [
@@ -10161,19 +10161,26 @@ const devices = [
             ];
 
             await bind(endpoint, coordinatorEndpoint, binds);
-            await configureReporting.thermostatTemperature(endpoint, {min: 10, max: 60, change: 50});
-            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 0, change: 50});
+            await configureReporting.thermostatTemperature(endpoint, {min: 10, max: 300, change: 20});
+            await configureReporting.thermostatPIHeatingDemand(endpoint, {min: 10, max: 301, change: 5});
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
             await configureReporting.thermostatSystemMode(endpoint, {min: 1, max: 0});
-            await configureReporting.thermostatPIHeatingDemand(endpoint, {min: 1, max: 900, change: 5});
 
             await readMeteringPowerConverterAttributes(endpoint);
 
             try {
                 await configureReporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
-                await configureReporting.instantaneousDemand(endpoint);
+                await configureReporting.instantaneousDemand(endpoint, {min: 10, max: 303, change: 1});
             } catch (error) {
                 // Not all support this: https://github.com/Koenkk/zigbee2mqtt/issues/3760
             }
+
+            // Disable default reporting
+            await configureReporting.temperature(endpoint, {min: 1, max: 0xFFFF});
+            await endpoint.configureReporting('msTemperatureMeasurement', [{
+                attribute: 'tolerance', minimumReportInterval: 1, maximumReportInterval: 0xFFFF,
+                reportableChange: 1,
+           }]);
         },
     },
     {
@@ -10184,27 +10191,53 @@ const devices = [
         supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
         fromZigbee: [
             fz.thermostat_att_report,
+            fz.hvac_user_interface,
+            fz.metering_power,
             fz.ignore_temperature_report,
+            fz.sinope_thermostat_state,
         ],
         toZigbee: [
             tz.thermostat_local_temperature,
-            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout,
-            tz.thermostat_system_mode, tz.thermostat_running_state,
-            tz.sinope_thermostat_occupancy, tz.sinope_thermostat_backlight_autodim_param, tz.sinope_thermostat_time,
-            tz.sinope_thermostat_enable_outdoor_temperature, tz.sinope_thermostat_outdoor_temperature,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_temperature_display_mode,
+            tz.thermostat_keypad_lockout,
+            tz.thermostat_system_mode,
+            tz.thermostat_running_state,
+            tz.sinope_thermostat_occupancy,
+            tz.sinope_thermostat_backlight_autodim_param,
+            tz.sinope_thermostat_time,
+            tz.sinope_thermostat_enable_outdoor_temperature,
+            tz.sinope_thermostat_outdoor_temperature,
         ],
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const binds = [
                 'genBasic', 'genIdentify', 'genGroups', 'hvacThermostat', 'hvacUserInterfaceCfg',
-                'msTemperatureMeasurement',
+                'msTemperatureMeasurement', 'seMetering',
             ];
             await bind(endpoint, coordinatorEndpoint, binds);
-            await configureReporting.thermostatTemperature(endpoint);
-            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await configureReporting.thermostatPIHeatingDemand(endpoint);
+            await configureReporting.thermostatTemperature(endpoint, {min: 10, max: 300, change: 20});
+            await configureReporting.thermostatPIHeatingDemand(endpoint, {min: 10, max: 301, change: 5});
+            await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
+
+            await readMeteringPowerConverterAttributes(endpoint);
+            await configureReporting.currentSummDelivered(endpoint, {min: 10, max: 303, change: [1,1]});
+
+            try {
+                await configureReporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+                await configureReporting.instantaneousDemand(endpoint, {min: 10, max: 303, change: 1});
+            } catch (error) {
+                // Not all support this: https://github.com/Koenkk/zigbee2mqtt/issues/3760
+            }
+
+            // Disable default reporting
+            await configureReporting.temperature(endpoint, {min: 1, max: 0xFFFF});
+            await endpoint.configureReporting('msTemperatureMeasurement', [{
+                attribute: 'tolerance', minimumReportInterval: 1, maximumReportInterval: 0xFFFF,
+                reportableChange: 1,
+           }]);
         },
     },
     {
@@ -10241,7 +10274,7 @@ const devices = [
             tz.sinope_temperature_sensor,
             tz.sinope_time_format,
         ],
-        meta: {configureKey: 2},
+        meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const binds = [
@@ -10250,8 +10283,14 @@ const devices = [
             ];
             await bind(endpoint, coordinatorEndpoint, binds);
             await configureReporting.thermostatTemperature(endpoint, {min: 10, max: 300, change: 20});
-            await configureReporting.thermostatPIHeatingDemand(endpoint, {min: 1, max: 301, change: 5});
+            await configureReporting.thermostatPIHeatingDemand(endpoint, {min: 10, max: 301, change: 5});
             await configureReporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
+
+            try {
+                await configureReporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+            } catch (error) {
+                // Not all support this: https://github.com/Koenkk/zigbee2mqtt/issues/3760
+            }
 
             await endpoint.configureReporting('manuSpecificSinope', [{
                 attribute: 'GFCiStatus',


### PR DESCRIPTION
Uniformized reporting behavior for Sinope baseboards and floor thermostats.

TH1123ZB, TH1124ZB and TH1300ZB:
- change PI Heating Demand reporting min interval to 10 sec.

TH1123ZB and TH1124ZB:
- change Thermostat Temperature reporting sensitivity to 0.2C
- add Occupied Heating Setpoint reporting.
- change Instantaneous Demand reporting min and max interval.
- change max reporting intervals to different values from 300 to 303 sec. to minimize Zigbee network congestion.
- disable Temperature Measurement default reporting (same as Thermostat temperature and not used)
- remove Temperature Measurement Tolerance reporting (remaining Zombie's)

TH1124ZB only:
- add user interface, metering power, energy and state reporting