### PR TITLE
Fix the position of TS0601_curtain

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2683,10 +2683,10 @@ const converters = {
 
                 switch (value) {
                 case 'close':
-                    await sendTuyaCommand(entity, 1025, 0, [1, 2]); // 0x04 0x01: Open
+                    await sendTuyaCommand(entity, 1025, 0, [1, 2]); // 0x04 0x01: Close
                     break;
                 case 'open':
-                    await sendTuyaCommand(entity, 1025, 0, [1, 0]); // 0x04 0x01: Close
+                    await sendTuyaCommand(entity, 1025, 0, [1, 0]); // 0x04 0x01: Open
                     break;
                 case 'stop':
                     await sendTuyaCommand(entity, 1025, 0, [1, 1]); // 0x04 0x01: Stop

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2673,7 +2673,7 @@ const converters = {
                 if (value >= 0 && value <= 100) {
                     const invert = !(meta.mapped.meta && meta.mapped.meta.coverInverted ?
                         !meta.options.invert_cover : meta.options.invert_cover);
-                    value = invert ? 100 - value : value;
+                    value = invert ? value : 100 - value;
                     await sendTuyaCommand(entity, 514, 0, [4, 0, 0, 0, value]); // 0x02 0x02: Set position from 0 - 100%
                 } else {
                     meta.logger.debug('owvfni3: Curtain motor position is out of range');
@@ -2682,10 +2682,10 @@ const converters = {
                 value = value.toLowerCase();
 
                 switch (value) {
-                case 'open':
+                case 'close':
                     await sendTuyaCommand(entity, 1025, 0, [1, 2]); // 0x04 0x01: Open
                     break;
-                case 'close':
+                case 'open':
                     await sendTuyaCommand(entity, 1025, 0, [1, 0]); // 0x04 0x01: Close
                     break;
                 case 'stop':


### PR DESCRIPTION
At current, after pairing the [TS0601_curtain](https://www.zigbee2mqtt.io/devices/TS0601_curtain.html) to Zigbee coordinator, the position is not correct. Beside that, the direction from Home Assistant is also not synchronized  with the direction of RF remote.
I've tried some advanced configuration as below but still not success:
1. If we set the reverse_direction to true, the position is still not correct  
2. Even If we set the invert_cover: true in the configuration.yaml file, the position is still not correct.
3. Tried some combination between reverse_direction & invert_cover and still not work.

Solution:
- Fix the logic to calculate the position
- Still need to set the invert_cover option to true. 
