### PR TITLE
Added support for Sunricher ZG2835

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9784,9 +9784,9 @@ const devices = [
         model: 'ZG2835',
         vendor: 'Sunricher',
         description: 'ZigBee knob smart dimmer',
-        supports: generic.light_onoff_brightness.supports,
+        supports: 'action',
         fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level],
-        toZigbee: []
+        toZigbee: [],
     },
 
     // Samotech

--- a/devices.js
+++ b/devices.js
@@ -9779,6 +9779,15 @@ const devices = [
             await configureReporting.currentSummDelivered(endpoint);
         },
     },
+    {
+        zigbeeModel: ['ZG2835'],
+        model: 'ZG2835',
+        vendor: 'Sunricher',
+        description: 'ZigBee knob smart dimmer',
+        supports: generic.light_onoff_brightness.supports,
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level],
+        toZigbee: []
+    },
 
     // Samotech
     {


### PR DESCRIPTION
Added support for Sunricher ZG2835.
It is just the dimmer knob to use as an input device. I bought it as ROBB ROB_200-018-0.