### PR TITLE
Add option to publish periodic brightness updates during rotation

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1114,6 +1114,12 @@ const converters = {
                 action_transition_time: msg.data.transtime / 100,
             };
             addActionGroup(payload, msg, model);
+
+            if (options.simulated_brightness) {
+                globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', msg.data.level);
+                payload.brightness = msg.data.level;
+            }
+
             return payload;
         },
     },
@@ -1161,6 +1167,16 @@ const converters = {
                 action_transition_time: msg.data.transtime / 100,
             };
             addActionGroup(payload, msg, model);
+
+            if (options.simulated_brightness) {
+                let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', 255);
+                const delta = direction === 'up' ? msg.data.stepsize : -1 * msg.data.stepsize;
+                brightness += delta;
+                brightness = numberWithinRange(brightness, 0, 255);
+                globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
+                payload.brightness = brightness;
+            }
+
             return payload;
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1129,15 +1129,24 @@ const converters = {
             const payload = {action, action_rate: msg.data.rate};
             addActionGroup(payload, msg, model);
 
-            if (options.hasOwnProperty('repeat_brightness_move_event') &&
-            options.repeat_brightness_move_event) {
+            if (options.hasOwnProperty('periodic_brightness_updates') &&
+            options.periodic_brightness_updates) {
+                let brightness = direction === 'up' ? 0 : 255;
+                const brightnessDelta = direction === 'up' ? 0.5 : -0.5;
+
+                publish({brightness: brightness, direction: direction});
+                brightness += brightnessDelta;
+
                 // We need a list, because multiple events are comming in
                 // and we like to cancel all in stop call
                 store[deviceID].timers.push(setInterval(() => {
-                    publish(payload);
+                    if (brightness > 0 && brightness < 255) {
+                        brightness += brightnessDelta;
+                    }
+                    publish({brightness: brightness, direction: direction});
                 },
-                options.hasOwnProperty('repeat_brightness_move_event_ms') ?
-                    options.repeat_brightness_move_event_ms : 500),
+                options.hasOwnProperty('periodic_brightness_updates_interval') ?
+                    options.periodic_brightness_updates_interval : 200),
                 );
             }
 
@@ -1165,8 +1174,8 @@ const converters = {
             const deviceID = msg.device.ieeeAddr;
             if (!store[deviceID]) store[deviceID] = {};
 
-            if (options.hasOwnProperty('repeat_brightness_move_event') &&
-                options.repeat_brightness_move_event) {
+            if (options.hasOwnProperty('periodic_brightness_updates') &&
+                options.periodic_brightness_updates) {
                 store[deviceID].timers.forEach((timer) => clearInterval(timer));
                 store[deviceID].timers = [];
             }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1132,7 +1132,9 @@ const converters = {
             if (options.hasOwnProperty('periodic_brightness_updates') &&
             options.periodic_brightness_updates) {
                 let brightness = direction === 'up' ? 0 : 255;
-                const brightnessDelta = direction === 'up' ? 0.5 : -0.5;
+                const brightnessDeltaBase = options.hasOwnProperty('periodic_brightness_updates_delta') ?
+                    options.periodic_brightness_updates_delta : 0.5;
+                const brightnessDelta = direction === 'up' ? brightnessDeltaBase : -1 * brightnessDeltaBase;
 
                 publish({brightness: brightness, direction: direction});
                 brightness += brightnessDelta;

--- a/converters/store.js
+++ b/converters/store.js
@@ -19,7 +19,7 @@ function hasValue(entity, key) {
 
 function getValue(entity, key, default_=undefined) {
     const entityKey = getEntityKey(entity);
-    if (store.has(entityKey)) {
+    if (store.has(entityKey) && store.get(entityKey).hasOwnProperty(key)) {
         return store.get(entityKey)[key];
     }
 

--- a/devices.js
+++ b/devices.js
@@ -2209,7 +2209,7 @@ const devices = [
         model: 'ICTC-G-1',
         vendor: 'IKEA',
         description: 'TRADFRI wireless dimmer',
-        supports: 'brightness [0-255] (quick rotate for instant 0/255), action',
+        supports: 'action',
         fromZigbee: [
             fz.legacy_cmd_move, fz.legacy_cmd_move_with_onoff, fz.legacy_cmd_stop, fz.legacy_cmd_stop_with_onoff,
             fz.legacy_cmd_move_to_level_with_onoff, fz.battery_not_divided,


### PR DESCRIPTION
I like to add an option to send move events until stop event comes in.

This will address the following feature request: 

Resolves https://github.com/Koenkk/zigbee2mqtt/issues/4372