### PR TITLE
Expose color_hs for Innr RB 2xx C

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4570,6 +4570,7 @@ const devices = [
         vendor: 'Innr',
         description: 'E14 bulb RGBW',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
+        exposes: [exposes.light().withBrightness().withColorTemp().withColorXY().withColorHS()],
         meta: {enhancedHue: false, applyRedFix: true, turnsOffAtBrightness1: true},
     },
     {
@@ -4602,7 +4603,8 @@ const devices = [
         vendor: 'Innr',
         description: 'E27 bulb RGBW',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
-        meta: {applyRedFix: true, turnsOffAtBrightness1: true},
+        exposes: [exposes.light().withBrightness().withColorTemp().withColorXY().withColorHS()],
+        meta: {enhancedHue: false, applyRedFix: true, turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['BY 285 C'],


### PR DESCRIPTION
As mentioned in koenkk/zigbee2mqtt#4466

- expose Hue/Saturation for Innr RB 2xx C bulbs
- enable Hue/Saturation for Innr RB 285 C bulbs

I suspect all inner color bulbs might support Hue/Saturation with the enhancedHue = false meta. But I only own the E27 and E14 ones to test with.