### PR TITLE
Add parameter 'preset' to the Siterwell/Essential smart thermostate

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13368,6 +13368,7 @@ const devices = [
             tz.tuya_thermostat_comfort_temp,
             tz.tuya_thermostat_eco_temp,
             tz.tuya_thermostat_force,
+            tz.tuya_thermostat_preset,
         ],
         whiteLabel: [
             {vendor: 'Essentials', description: 'Smart home heizkörperthermostat premium', model: '120112'},


### PR DESCRIPTION
My new Essential/Siterwell GS361A-H04 device has a channel "preset" which can be either "manual" or "schedule".
Adding this new parameter.  

I however don't see all the parameters mentioned in https://www.zigbee2mqtt.io/devices/GS361A-H04.html, like ```min_temp``` and ```max_temp```. The device might be another subtype, but i don't know how to read it out.
```
Only the following values are being transmitted:
zigbee2mqtt/<device_id>/battery 100
zigbee2mqtt/<device_id>/child_lock LOCKED
zigbee2mqtt/<device_id>/current_heating_setpoint 20.0
zigbee2mqtt/<device_id>/linkquality 5
zigbee2mqtt/<device_id>/local_temperature 22.8
zigbee2mqtt/<device_id>/preset manual
zigbee2mqtt/<device_id>/system_mode manual
zigbee2mqtt/<device_id>/valve_detection ON
zigbee2mqtt/<device_id>/window_detection ON
```