### PR TITLE
Add Saswell TRV Models: SEA801/SEA802

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -457,6 +457,7 @@ const tuyaThermostat = (model, msg, publish, options, meta) => {
             dp} with data ${JSON.stringify(data)}`);
     }
 };
+
 const saswellThermostat = (model, msg, publish, options, meta) => {
     const dp = msg.data.dp;
     const data = msg.data.data;
@@ -486,6 +487,7 @@ const saswellThermostat = (model, msg, publish, options, meta) => {
             dp} with data ${JSON.stringify(data)}`);
     }
 };
+
 const converters = {
     /**
      * Generic/recommended converters, re-use if possible.

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -457,7 +457,35 @@ const tuyaThermostat = (model, msg, publish, options, meta) => {
             dp} with data ${JSON.stringify(data)}`);
     }
 };
-
+const saswellThermostat = (model, msg, publish, options, meta) => {
+    const dp = msg.data.dp;
+    const data = msg.data.data;
+    const dataAsDecNumber = utils.convertMultiByteNumberPayloadToSingleDecimalNumber(data);
+    let temperature;
+    if (dp >= 110 && dp <=122) return; // set of 3 DP history data - hourly/daily/weekly/monthly sets
+    if (dp >= 123 && dp <=129) return;
+    /* The above DPs return program data for each day in format: [4, 1, 14, 0, 155, .....] */
+    /*  e.g time is (1*256+14) minutes,  set temp = (0*256+155)/10 */
+    switch (dp) {
+    case 357: // Thermostat [off = off, on = heat] to comply with HA standards
+        return {system_mode: dataAsDecNumber ? 'heat' : 'off'};
+    case 362: // away mode
+        return {preset_mode: dataAsDecNumber ? 'away' : 'auto'};
+    case 364: // Changed program mode
+        return {preset_mode: dataAsDecNumber ? 'auto' : 'manual'};
+    case 614: // MCU reporting room temperature
+        temperature = (dataAsDecNumber / 10).toFixed(1);
+        return {local_temperature: temperature};
+    case 615: // set temperature
+        temperature = (dataAsDecNumber / 10).toFixed(1);
+        return {current_heating_setpoint: temperature};
+    case 1385: // battery alert
+        return {battery_low: dataAsDecNumber ? 'true' : 'false'};
+    default:
+        meta.logger.warn(`zigbee-herdsman-converters:SaswellThermostat: NOT RECOGNIZED DP #${
+            dp} with data ${JSON.stringify(data)}`);
+    }
+};
 const converters = {
     /**
      * Generic/recommended converters, re-use if possible.
@@ -5525,6 +5553,11 @@ const converters = {
         cluster: 'manuSpecificTuyaDimmer',
         type: 'commandGetData',
         convert: moesThermostat,
+    },
+    saswell_thermostat: {
+        cluster: 'manuSpecificTuyaDimmer',
+        type: ['commandGetData', 'commandSetDataResponse'],
+        convert: saswellThermostat,
     },
     etop_thermostat: {
         cluster: 'manuSpecificTuyaDimmer',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3098,6 +3098,30 @@ const converters = {
             await entity.read('genOnOff', ['onOff']);
         },
     },
+    saswell_thermostat_current_heating_setpoint: {
+        key: ['current_heating_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            const temp = Math.round(value * 10);
+            const payloadValue = utils.convertDecimalValueTo2ByteHexArray(temp);
+            await sendTuyaCommand(entity, 615, 0, [4, 0, 0, ...payloadValue]);
+        },
+    },
+    saswell_thermostat_mode: {
+        key: ['preset'],
+        convertSet: async (entity, key, value, meta) => {
+            if ( value == 'auto' ) {
+                sendTuyaCommand(entity, 364, 0, [1, 1]);
+            } else {
+                sendTuyaCommand(entity, 364, 0, [1, 0]);
+            }
+        },
+    },
+    saswell_thermostat_standby: {
+        key: ['system_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            sendTuyaCommand(entity, 357, 0, [1, value === 'heat' ? 1 : 0]);
+        },
+    },
 
     // Not a converter, can be used by tests to clear the store.
     __clearStore__: () => {

--- a/devices.js
+++ b/devices.js
@@ -12627,6 +12627,24 @@ const devices = [
             tz.moes_thermostat_standby, tz.moes_thermostat_sensor, tz.moes_thermostat_calibration, tz.moes_thermostat_min_temperature,
         ],
     },
+    {
+        fingerprint: [{modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'}],
+        model: 'GbxAXL2',
+        vendor: 'Saswell',
+        description: 'Saswell Thermostatic Radiator Valve',
+        supports: 'thermostat, temperature',
+        fromZigbee: [fz.saswell_thermostat],
+        toZigbee: [
+            tz.saswell_thermostat_current_heating_setpoint,
+            tz.saswell_thermostat_mode,
+            tz.saswell_thermostat_standby,
+        ],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genBasic']);
+        },
+    },
 
     // Schneider Electric
     {

--- a/devices.js
+++ b/devices.js
@@ -12629,9 +12629,9 @@ const devices = [
     },
     {
         fingerprint: [{modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'}],
-        model: 'GbxAXL2',
+        model: 'SEA801-Zigbee',
         vendor: 'Saswell',
-        description: 'Saswell Thermostatic Radiator Valve',
+        description: 'Thermostatic radiator valve',
         supports: 'thermostat, temperature',
         fromZigbee: [fz.saswell_thermostat],
         toZigbee: [

--- a/devices.js
+++ b/devices.js
@@ -12628,7 +12628,10 @@ const devices = [
         ],
     },
     {
-        fingerprint: [{modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'}],
+        fingerprint: [
+            {modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'},
+            {modelID: '88teujp\u0000', manufacturerName: '_TYST11_c88teujp'},
+        ],
         model: 'SEA801-Zigbee',
         vendor: 'Saswell',
         description: 'Thermostatic radiator valve',


### PR DESCRIPTION
Add converters and device data for Saswell TRVs (TuYa based) 

tested prior to PR per issue [https://github.com/Koenkk/zigbee2mqtt/issues/2781](url)