### PR TITLE
 Fix Sinope TH1123ZB piHeatingDemand

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11143,7 +11143,7 @@ const devices = [
         description: 'Zigbee line volt thermostat',
         supports: 'local temp, units, keypad lockout, mode, state, backlight, outdoor temp, time',
         fromZigbee: [
-            fz.thermostat_att_report,
+            fz.sinope_thermostat_att_report,
             fz.hvac_user_interface,
             fz.metering_power,
             fz.ignore_temperature_report,


### PR DESCRIPTION
My TH1123ZB thermostat was only reporting a maximum `pi_heating_demand` of 39. I found PR #1185 which fixes this problem for a different Sinope thermostat, so I confirmed that the TH1123ZB model reports properly with the same fix.