### PR TITLE
Add support for Consciot tunable white lamp

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13055,7 +13055,7 @@ const devices = [
 
     // Linkind
     {
-        zigbeeModel: ['ZBT-CCTLight-D0106', 'ZBT-CCTLight-GLS0108'],
+        zigbeeModel: ['ZBT-CCTLight-D0106', 'ZBT-CCTLight-GLS0108', 'ZBT-CCTLight-GLS0109'],
         model: 'ZL1000100-CCT-US-V1A02',
         vendor: 'Linkind',
         description: 'Zigbee LED 9W A19 bulb, dimmable & tunable',


### PR DESCRIPTION
Add support for this light (rebranded Linkind): https://www.amazon.com/gp/product/B07V1GJZYD