### PR TITLE
ubisys D1: Allow ballast configuration

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1167,7 +1167,9 @@ const converters = {
     },
     ballast_config: {
         key: ['ballast_config'],
+        // zcl attribute names are camel case, but we want to use snake case in the outside communication
         convertSet: async (entity, key, value, meta) => {
+            value = utils.toCamelCase(value);
             for (const [attrName, attrValue] of Object.entries(value)) {
                 const attributes = {};
                 attributes[attrName] = attrValue;
@@ -1178,30 +1180,30 @@ const converters = {
         convertGet: async (entity, key, meta) => {
             let result = {};
             for (const attrName of [
-                'physicalMinLevel',
-                'physicalMaxLevel',
-                'ballastStatus',
-                'minLevel',
-                'maxLevel',
-                'powerOnLevel',
-                'powerOnFadeTime',
-                'intrinsicBallastFactor',
-                'ballastFactorAdjustment',
-                'lampQuantity',
-                'lampType',
-                'lampManufacturer',
-                'lampRatedHours',
-                'lampBurnHours',
-                'lampAlarmMode',
-                'lampBurnHoursTripPoint',
+                'physical_min_level',
+                'physical_max_level',
+                'ballast_status',
+                'min_level',
+                'max_level',
+                'power_on_level',
+                'power_on_fade_time',
+                'intrinsic_ballast_factor',
+                'ballast_factor_adjustment',
+                'lamp_quantity',
+                'lamp_type',
+                'lamp_manufacturer',
+                'lamp_rated_hours',
+                'lamp_burn_hours',
+                'lamp_alarm_mode',
+                'lamp_burn_hours_trip_point',
             ]) {
                 try {
-                    result = {...result, ...(await entity.read('lightingBallastCfg', [attrName]))};
+                    result = {...result, ...(await entity.read('lightingBallastCfg', [utils.toCamelCase(attrName)]))};
                 } catch (ex) {
                     // continue regardless of error
                 }
             }
-            meta.logger.warn(`ballast_config attribute results received: ${JSON.stringify(result)}`);
+            meta.logger.warn(`ballast_config attribute results received: ${JSON.stringify(utils.toSnakeCase(result))}`);
         },
     },
 

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1165,6 +1165,45 @@ const converters = {
             entity.commandResponse('ssIasAce', 'panelStatusChanged', payload);
         },
     },
+    ballast_config: {
+        key: ['ballast_config'],
+        convertSet: async (entity, key, value, meta) => {
+            for (const [attrName, attrValue] of Object.entries(value)) {
+                const attributes = {};
+                attributes[attrName] = attrValue;
+                await entity.write('lightingBallastCfg', attributes);
+            }
+            converters.ballast_config.convertGet(entity, key, meta);
+        },
+        convertGet: async (entity, key, meta) => {
+            let result = {};
+            for (const attrName of [
+                'physicalMinLevel',
+                'physicalMaxLevel',
+                'ballastStatus',
+                'minLevel',
+                'maxLevel',
+                'powerOnLevel',
+                'powerOnFadeTime',
+                'intrinsicBallastFactor',
+                'ballastFactorAdjustment',
+                'lampQuantity',
+                'lampType',
+                'lampManufacturer',
+                'lampRatedHours',
+                'lampBurnHours',
+                'lampAlarmMode',
+                'lampBurnHoursTripPoint',
+            ]) {
+                try {
+                    result = {...result, ...(await entity.read('lightingBallastCfg', [attrName]))};
+                } catch (ex) {
+                    // continue regardless of error
+                }
+            }
+            meta.logger.warn(`ballast_config attribute results received: ${JSON.stringify(result)}`);
+        },
+    },
 
     /**
      * Device specific

--- a/converters/utils.js
+++ b/converters/utils.js
@@ -293,6 +293,36 @@ const sleepMs = async (ms) => {
     return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
+function toSnakeCase(value) {
+    if (typeof value === 'object') {
+        for (const key of Object.keys(value)) {
+            const keySnakeCase = toSnakeCase(key);
+            if (key !== keySnakeCase) {
+                value[keySnakeCase] = value[key];
+                delete value[key];
+            }
+        }
+        return value;
+    } else {
+        return value.replace(/\.?([A-Z])/g, (x, y) => '_' + y.toLowerCase()).replace(/^_/, '').replace('_i_d', '_id');
+    }
+}
+
+function toCamelCase(value) {
+    if (typeof value === 'object') {
+        for (const key of Object.keys(value)) {
+            const keyCamelCase = toCamelCase(key);
+            if (key !== keyCamelCase) {
+                value[keyCamelCase] = value[key];
+                delete value[key];
+            }
+        }
+        return value;
+    } else {
+        return value.replace(/_([a-z])/g, (x, y) => y.toUpperCase());
+    }
+}
+
 module.exports = {
     rgbToXY,
     hexToXY,
@@ -315,4 +345,6 @@ module.exports = {
     getMetaValue,
     filterObject,
     sleepMs,
+    toSnakeCase,
+    toCamelCase,
 };

--- a/devices.js
+++ b/devices.js
@@ -11922,7 +11922,7 @@ const devices = [
         description: 'Universal dimmer D1',
         supports: 'on/off, brightness, power measurement',
         fromZigbee: [fz.on_off, fz.brightness, fz.metering_power],
-        toZigbee: [tz.light_onoff_brightness, tz.ubisys_device_setup],
+        toZigbee: [tz.light_onoff_brightness, tz.ballast_config, tz.ubisys_device_setup],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(4);


### PR DESCRIPTION
Primarily allows to control dimmer min and max levels (and could also be used for other devices if they implement the ZCL ballast configuration cluster).

Documentation will follow as well.

Thanks,  
Felix