### PR TITLE
fix support for adurosmart light bulbs

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9279,7 +9279,7 @@ const devices = [
 
     // AduroSmart
     {
-        zigbeeModel: ['ZLL-ExtendedColo'],
+        zigbeeModel: ['ZLL-ExtendedColo', 'ZLL-ExtendedColor'],
         model: '81809/81813',
         vendor: 'AduroSmart',
         description: 'ERIA colors and white shades smart light bulb A19/BR30',


### PR DESCRIPTION
in the latest version of the adurosmart firmware for bulbs 81809, firmware version `1000-0007`, firmware date `20181008` they changed the zigbee model to be `ZLL-ExtendedColor` opposed to `ZLL-ExtendedColo`