### PR TITLE
feat: Add support for Nue/3A Door sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5998,10 +5998,11 @@ const devices = [
         zigbeeModel: ['FNB56-DOS07FB3.1'],
         model: 'HGZB-13A',
         vendor: 'Nue / 3A',
-        description: 'Door/Window sensor',
+        description: 'Door/window sensor',
         supports: 'contact',
         fromZigbee: [fz.ias_contact_alarm_1],
         toZigbee: [],
+        exposes: [exposes.boolean('contact'), exposes.boolean('battery_low'), exposes.boolean('tamper')],
     },
 
     // Smart Home Pty

--- a/devices.js
+++ b/devices.js
@@ -5994,6 +5994,15 @@ const devices = [
             exposes.numeric('battery').withUnit('%'),
         ],
     },
+    {
+        zigbeeModel: ['FNB56-DOS07FB3.1'],
+        model: 'HGZB-13A',
+        vendor: 'Nue / 3A',
+        description: 'Door/Window sensor',
+        supports: 'contact',
+        fromZigbee: [fz.ias_contact_alarm_1],
+        toZigbee: [],
+    },
 
     // Smart Home Pty
     {


### PR DESCRIPTION
The Nue / 3A door and window sensor is relatively simple and just exposes a binary contact sensor.