### PR TITLE
Adding Power Measurement to SSM-U01

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1280,16 +1280,18 @@ const devices = [
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (with neutral)',
         supports: 'on/off, power measurement',
-        fromZigbee: [fz.on_off, fz.metering_power],
-        exposes: [exposes.switch(), exposes.numeric('energy').withUnit('kWh')],
+        fromZigbee: [fz.on_off, fz.metering_power, fz.electrical_measurement_power],
+        exposes: [exposes.switch(), exposes.numeric('energy').withUnit('kWh'), exposes.numeric('power').withUnit('W')],
         toZigbee: [tz.on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering' ]);
             await configureReporting.onOff(endpoint);
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await readMeteringPowerConverterAttributes(endpoint);
             await configureReporting.currentSummDelivered(endpoint);
+            await configureReporting.activePower(endpoint);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -1286,7 +1286,7 @@ const devices = [
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering' ]);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await configureReporting.onOff(endpoint);
             await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await readMeteringPowerConverterAttributes(endpoint);

--- a/devices.js
+++ b/devices.js
@@ -1288,6 +1288,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await configureReporting.onOff(endpoint);
+            // Gives UNSUPPORTED_ATTRIBUTE on readEletricalMeasurementPowerConverterAttributes.
             await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await readMeteringPowerConverterAttributes(endpoint);
             await configureReporting.currentSummDelivered(endpoint);

--- a/devices.js
+++ b/devices.js
@@ -1292,7 +1292,7 @@ const devices = [
             await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await readMeteringPowerConverterAttributes(endpoint);
             await configureReporting.currentSummDelivered(endpoint);
-            await configureReporting.activePower(endpoint);
+            await configureReporting.activePower(endpoint, {min: 5, max: 600, change: 10});
         },
     },
 


### PR DESCRIPTION
Also discovered power reporting. Adding support for it. Sorry I did not see this last time. This is my first added device :-)

I do have a question, it basically sends updates every few seconds. I'm trying to throttle to maybe a certain value delta using 
            `await configureReporting.activePower(endpoint, {max: 600, change: 4});
`
But I don't understand how the "max/min/change" value correlates to the W and time...

Ultimately, it would maybe be beneficial to allow this to be customized by the user depending on the load. But I'm concerned the Zigbee network will be flooded with these messages...



```
Zigbee2MQTT:info  2020-10-15 22:40:56: MQTT publish: topic 'zigbee2mqtt/0x04cf8cdf3c8e18fe', payload '{"energy":0.02,"linkquality":0,"power":27.9,"state":"ON"}',
Zigbee2MQTT:info  2020-10-15 22:40:51: MQTT publish: topic 'zigbee2mqtt/0x04cf8cdf3c8e18fe', payload '{"energy":0.02,"linkquality":0,"power":28,"state":"ON"}',
Zigbee2MQTT:info  2020-10-15 22:41:09: MQTT publish: topic 'zigbee2mqtt/0x04cf8cdf3c8e18fe', payload '{"energy":0.02,"linkquality":0,"power":27.9,"state":"ON"}',
Zigbee2MQTT:info  2020-10-15 22:40:38: MQTT publish: topic 'zigbee2mqtt/0x04cf8cdf3c8e18fe', payload '{"energy":0.02,"linkquality":0,"power":27.9,"state":"ON"}'
```

<img width="327" alt="Skärmavbild 2020-10-15 kl  22 55 22" src="https://user-images.githubusercontent.com/34924009/96185103-b211de00-0f39-11eb-81d0-9a7552bf2c0e.png">
