### PR TITLE
Added new zigbeeModel for Lupus 2 channel relay

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8097,7 +8097,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['PRS3CH2_00.00.05.10TC'],
+        zigbeeModel: ['PRS3CH2_00.00.05.10TC', 'PRS3CH2_00.00.05.11TC'],
         model: '12127',
         vendor: 'Lupus',
         description: '2 chanel relay',


### PR DESCRIPTION
I have purchased a Lupus 2 channel relay because it is in the supported devices list. After pairing I found out, that the zigbeeModel was increased.
`Device '0x00124b001ebeaf35' with Zigbee model 'PRS3CH2_00.00.05.11TC' is NOT supported`. So I added the new zigbeeModel number to the array.