### PR TITLE
Adding support for Hue White Ambiance Being Alu (3261048P6)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3138,6 +3138,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['3261048P6'],
+        model: '3261048P6',
+        vendor: 'Philips',
+        description: 'Hue Being Alu',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp,
+        ota: ota.zigbeeOTA,
+    },    
+    {
         zigbeeModel: ['3261030P6'],
         model: '3261030P6',
         vendor: 'Philips',


### PR DESCRIPTION
Added support for Philips Hue White Ambiance Being Alu (3261048P6 - https://www.philips-hue.com/nl-nl/p/hue-white-ambiance-being-plafondlamp/3261048P6).

Similar to already existing 3261030P7 (https://www.zigbee2mqtt.io/devices/3261030P7.html) but identifies with a different model number so Zigbee2MQTT didn't register it automatically. 