### PR TITLE
Add support for iCasa ICZB-R12D

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9081,6 +9081,19 @@ const devices = [
             await configureReporting.onOff(endpoint);
         },
     },
+    {
+        zigbeeModel: ['ICZB-R12D'],
+        model: 'ICZB-R12D',
+        vendor: 'iCasa',
+        description: 'Zigbee AC dimmer',
+        extend: generic.light_onoff_brightness,
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await configureReporting.onOff(endpoint);
+        },
+    },
 
     // Busch-Jaeger
     {


### PR DESCRIPTION
Config is copied from the ICZB-R11D because these models are (except wiring) the same.
Tested and working :nerd_face: 

Manufacturer device info: https://en.icasa.io/copy-of-dimmers-en-switches