### PR TITLE
Add support for iCasa ICZB-RM11S

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9062,6 +9062,17 @@ const devices = [
         toZigbee: [],
     },
     {
+        zigbeeModel: ['ICZB-RM11S'],
+        model: 'ICZB-RM11S',
+        vendor: 'iCasa',
+        description: 'Zigbee 3.0 Remote Control',
+        supports: 'click, action, brightness, scenes',
+        fromZigbee: [
+            fz.command_recall, fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.battery,
+        ],
+        toZigbee: [],
+    },
+    {
         zigbeeModel: ['ICZB-FC'],
         model: 'ICZB-B1FC60/B3FC64/B2FC95/B2FC125',
         vendor: 'iCasa',

--- a/devices.js
+++ b/devices.js
@@ -9065,11 +9065,9 @@ const devices = [
         zigbeeModel: ['ICZB-RM11S'],
         model: 'ICZB-RM11S',
         vendor: 'iCasa',
-        description: 'Zigbee 3.0 Remote Control',
-        supports: 'click, action, brightness, scenes',
-        fromZigbee: [
-            fz.command_recall, fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.battery,
-        ],
+        description: 'Zigbee 3.0 remote control',
+        supports: 'action',
+        fromZigbee: [fz.command_recall, fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.battery],
         toZigbee: [],
     },
     {


### PR DESCRIPTION
This PR adds support for iCasa ICZB-RM11S as proposed in Koenkk/zigbee2mqtt#4127.

I tried to distinguishing the pressed group button (as stated in the issue). In the output below you can see that both group 1 and group 2 have payload "on". I want the payload to contain the button (group) that was pressed. This makes it lot easier for end-users to use in automations (because they can use just the MQTT action endpoint).

I tried to accomplish this using multiEndpoints but that is not working because the all on and all off buttons use the same endpoint as the first group. Just like the scenes buttons. 

Is it possible in some way to accomplish this? Otherwise it will be good to get the given configuration merged.

An other solution I was thinking of is including the groupID in the action payload, like "on_15361" and "on_15362". Is there a way to do this?

Output of pressing on for group 1 and 2:
```
debug 2020-10-19 22:39:37: Received Zigbee message from '0xccccccfffe26a38e', type 'commandOn', cluster 'genOnOff', data '{}' from endpoint 1 with groupID 15361
info  2020-10-19 22:39:37: MQTT publish: topic 'zigbee2mqtt/0xccccccfffe26a38e', payload '{"action":"on","action_group":15361,"linkquality":13}'
info  2020-10-19 22:39:37: MQTT publish: topic 'zigbee2mqtt/0xccccccfffe26a38e/action', payload 'on'
debug 2020-10-19 22:39:38: Received Zigbee message from '0xccccccfffe26a38e', type 'commandOn', cluster 'genOnOff', data '{}' from endpoint 2 with groupID 15362
info  2020-10-19 22:39:38: MQTT publish: topic 'zigbee2mqtt/0xccccccfffe26a38e', payload '{"action":"on","action_group":15362,"linkquality":23}'
info  2020-10-19 22:39:38: MQTT publish: topic 'zigbee2mqtt/0xccccccfffe26a38e/action', payload 'on'
```