### PR TITLE
Update BE468 to have both BE468/GBAK working

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13203,7 +13203,7 @@ const devices = [
         toZigbee: [tz.generic_lock],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(2);
+            const endpoint = device.endpoints[0];
             await bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);


### PR DESCRIPTION
Hi,

As mentioned in the following issue: https://github.com/Koenkk/zigbee2mqtt/issues/4464
The model BE468GBAK is not the exact same as the BE468 model.
BE468GBAK uses endpoint index 1, BE468 uses endpoint index 2

Replacing `device.getEndpoint(specificNumber)` by `device.endpoints[0]` make sure both models work.