### PR TITLE
Adding support to devices.js for Xfinity XHS2-UE

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10915,10 +10915,11 @@ const devices = [
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },
+    // Comcast Xfinity branded XHS2-UE Door / Window / Temp sensor by Universal Electronics, Inc
     {
         zigbeeModel: ['URC4460BC0-X-R'],
         model: 'XHS2-UE',
-        vendor: 'Visonic',
+        vendor: 'Universal Electronics, Inc.',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact, temperature',
         fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],

--- a/devices.js
+++ b/devices.js
@@ -10915,24 +10915,6 @@ const devices = [
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },
-    // Comcast Xfinity branded XHS2-UE Door / Window / Temp sensor by Universal Electronics, Inc
-    {
-        zigbeeModel: ['URC4460BC0-X-R'],
-        model: 'XHS2-UE',
-        vendor: 'Universal Electronics, Inc.',
-        description: 'Magnetic door & window contact sensor',
-        supports: 'contact, temperature',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],
-        toZigbee: [],
-        meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
-            await configureReporting.temperature(endpoint);
-            await configureReporting.batteryPercentageRemaining(endpoint);
-        },
-        exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
-    },
     {
         zigbeeModel: ['SZ-DWS04', 'SZ-DWS04N_SF'],
         model: 'SZ-DWS04',
@@ -10965,6 +10947,25 @@ const devices = [
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
         exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],
+    },
+
+    // Comcast Xfinity branded XHS2 devices manufactured by Universal Electronics, Inc
+    {
+        zigbeeModel: ['URC4460BC0-X-R'],
+        model: 'XHS2-UE',
+        vendor: 'Universal Electronics, Inc.',
+        description: 'Magnetic door & window contact sensor',
+        supports: 'contact, temperature',
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],
+        toZigbee: [],
+        meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await configureReporting.temperature(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+        exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },
 
     // Leedarson

--- a/devices.js
+++ b/devices.js
@@ -10916,6 +10916,23 @@ const devices = [
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },
     {
+        zigbeeModel: ['URC4460BC0-X-R'],
+        model: 'XHS2-UE',
+        vendor: 'Visonic',
+        description: 'Magnetic door & window contact sensor',
+        supports: 'contact, temperature',
+        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],
+        toZigbee: [],
+        meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
+            await configureReporting.temperature(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+        exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
+    },
+    {
         zigbeeModel: ['SZ-DWS04', 'SZ-DWS04N_SF'],
         model: 'SZ-DWS04',
         vendor: 'Sercomm',

--- a/devices.js
+++ b/devices.js
@@ -10949,7 +10949,7 @@ const devices = [
         exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],
     },
 
-    // Comcast Xfinity branded XHS2 devices manufactured by Universal Electronics
+    // Universal Electronics Inc
     {
         zigbeeModel: ['URC4460BC0-X-R'],
         model: 'XHS2-UE',

--- a/devices.js
+++ b/devices.js
@@ -10949,11 +10949,11 @@ const devices = [
         exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],
     },
 
-    // Comcast Xfinity branded XHS2 devices manufactured by Universal Electronics, Inc
+    // Comcast Xfinity branded XHS2 devices manufactured by Universal Electronics
     {
         zigbeeModel: ['URC4460BC0-X-R'],
         model: 'XHS2-UE',
-        vendor: 'Universal Electronics, Inc.',
+        vendor: 'Universal Electronics Inc',
         description: 'Magnetic door & window contact sensor',
         supports: 'contact, temperature',
         fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],


### PR DESCRIPTION
Almost identical to the XHS2-SE from Sercom.  Both are sold as Xfinity devices - this pull request is for a version made by Visonic.