### PR TITLE
Add ZB-CL03 to YSR-MINI-01

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6715,7 +6715,7 @@ const devices = [
 
     // YSRSAI
     {
-        zigbeeModel: ['ZB-CL01', 'FB56-ZCW20FB1.2'],
+        zigbeeModel: ['ZB-CL01', 'ZB-CL03', 'FB56-ZCW20FB1.2'],
         model: 'YSR-MINI-01',
         vendor: 'YSRSAI',
         description: 'Zigbee LED controller (RGB+CCT)',


### PR DESCRIPTION
Received a new "Smart Light Strip Controller".
The model listed on it is YSR-MINI-01, which was already a known device, but apparently this one uses a different `modelId`.

Note that on the particular controller I have there is a label that indicates what kind of LED strips are supported, mine is only labelled (and wired) for RGB.
I checked internally and it looks like all the other electronics (for CCT) are there as well, but there just aren't any wires.

To be honest, I'm not 100% sure if this `modelId` is maybe strictly for the RGB only model, or if the behavior is identical to the other YSR-MINI-01 that are already known to zigbee-herdsman.
