### PR TITLE
fix: support colortemp for Philips Hue Discover

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3698,7 +3698,7 @@ const devices = [
         description: 'Hue Discover white and color ambiance flood light',
         ota: ota.zigbeeOTA,
         meta: {turnsOffAtBrightness1: true},
-        extend: hue.light_onoff_brightness_colorxy,
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
     },
     {
         zigbeeModel: ['1746330P7'],


### PR DESCRIPTION
support missing colortemp for Philips Hue Discover