### PR TITLE
Add Q-LED E27 socket light

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9073,6 +9073,13 @@ const devices = [
         },
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
+    {
+        zigbeeModel: ['JZD60-J4R150'],
+        model: '100.001.96',
+        vendor: 'Paul Neuhaus',
+        description: 'Q-LED Lamp RGBW E27 socket',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
 
     // iCasa
     {


### PR DESCRIPTION
adding support for Paul Neumann light, p/n 100.001.96. Apparently these are not for sale anymore but I still have a couple of them about, so I thought I might as well...