### PR TITLE
Fix MCT-340 E configure failing

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10486,7 +10486,7 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
             await configureReporting.temperature(endpoint);
-            await configureReporting.batteryPercentageRemaining(endpoint);
+            await configureReporting.batteryVoltage(endpoint);
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },


### PR DESCRIPTION
It looks like I messed up battery reporting in the `MCT-340` devices back in 9f7dcb202097bf1858ae46d5c34fc66de784e76d - when trying to configure for `batteryPercentageRemaining`, an `UNSUPPORTED_ATTRIBUTE ` error is thrown. Turns out it should be using `batteryVoltage`. This was already fixed for the `MCT-340 SMA` in 8cac16b031c636316a16d48ea49950ba2e97d811.

This PR is identical to the fix for #1321 (`MCT-340 E` and `MCT-340 SMA` are virtually identical as far as I can tell).