### PR TITLE
add support for LXT56-LS27LX1.4 - Nue/3A 3A12S-15 RGBW Controller, fixes #677

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6199,6 +6199,13 @@ const devices = [
         toZigbee: [],
         exposes: [e.contact(), e.battery_low(), e.tamper()],
     },
+    {
+        zigbeeModel: ['LXT56-LS27LX1.4'],
+        model: '3A12S-15',
+        vendor: 'Nue / 3A',
+        description: 'Smart ZigBee 3.0 Strip Light Controller',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+    },
 
     // Smart Home Pty
     {

--- a/devices.js
+++ b/devices.js
@@ -6203,7 +6203,7 @@ const devices = [
         zigbeeModel: ['LXT56-LS27LX1.4'],
         model: '3A12S-15',
         vendor: 'Nue / 3A',
-        description: 'Smart ZigBee 3.0 Strip Light Controller',
+        description: 'Smart Zigbee 3.0 strip light controller',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
 


### PR DESCRIPTION
Support for RGBW controller 3A 3A12S-15 which announces itself as "LXT56-LS27LX1.4".
As mentioned in the ticket #677, it can be set by sending e.g.
```
{
    "state": "ON",
    "brightness": 254,
    "color": {
        "hue": 20,
        "saturation": 100
    }
}
```
to the <device-name>/set topic. More should be possible as well.
I did not find out how or if the white channel can be controlled separately yet - maybe different converters are needed? I followed the configuration of a RGBW downlight of the same vendor (LXT56-LS27LX1.7).