### PR TITLE
fix: correct typo in modelID attr in Salus device update check

### DIFF
--- a/ota/salus.js
+++ b/ota/salus.js
@@ -9,10 +9,10 @@ const axios = common.getAxios();
  */
 
 async function getImageMeta(current, logger, device) {
-    const modelId = device.modelId;
+    const modelID = device.modelID;
     const images = (await axios.get(url)).data.versions;
-    const image = images.find((i) => i.model === modelId);
-    assert(image, `No image available for modelId '${modelId}'`);
+    const image = images.find((i) => i.model === modelID);
+    assert(image, `No image available for modelID '${modelID}'`);
     return {
         fileVersion: parseInt(image.version, 16),
         url: image.url.replace(/^http:\/\//, 'https://'),


### PR DESCRIPTION
This fixes the following error that was appearing in logs:

    ERROR: Failed to call 'OTAUpdate' 'onZigbeeEvent' (
        AssertionError [ERR_ASSERTION]: No image available for modelId 'undefined'
            at getImageMeta (/app/node_modules/zigbee-herdsman-converters/ota/salus.js:15:5)
            at runMicrotasks (<anonymous>)
            at processTicksAndRejections (internal/process/task_queues.js:97:5)
            at async isNewImageAvailable (/app/node_modules/zigbee-herdsman-converters/ota/common.js:177:18)
            at async Object.isUpdateAvailable (/app/node_modules/zigbee-herdsman-converters/ota/common.js:168:23)
            at async OTAUpdate.onZigbeeEvent (/app/lib/extension/otaUpdate.js:58:31)
            at async Controller.callExtensionMethod (/app/lib/controller.js:371:21)
    )