### PR TITLE
Add support to Tuya GTZ02 radiator valve support, using Siterwell device entry

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14158,7 +14158,8 @@ const devices = [
 
     // Siterwell
     {
-        zigbeeModel: ['ivfvd7h', 'eaxp72v\u0000', 'TS0601'],
+        zigbeeModel: ['ivfvd7h', 'eaxp72v\u0000'],
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_zivfvd7h'}],
         model: 'GS361A-H04',
         vendor: 'Siterwell',
         description: 'Radiator valve with thermostat',
@@ -14187,7 +14188,7 @@ const devices = [
         ],
         whiteLabel: [
             {vendor: 'Essentials', description: 'Smart home heizkörperthermostat premium', model: '120112'},
-            {vendor: "Tuya", description: "Głowica termostatyczna", model:"GTZ02"},
+            {vendor: 'Tuya', description: 'Głowica termostatyczna', model: 'GTZ02'},
         ],
     },
 

--- a/devices.js
+++ b/devices.js
@@ -14158,7 +14158,7 @@ const devices = [
 
     // Siterwell
     {
-        zigbeeModel: ['ivfvd7h', 'eaxp72v\u0000'],
+        zigbeeModel: ['ivfvd7h', 'eaxp72v\u0000', 'TS0601'],
         model: 'GS361A-H04',
         vendor: 'Siterwell',
         description: 'Radiator valve with thermostat',
@@ -14187,6 +14187,7 @@ const devices = [
         ],
         whiteLabel: [
             {vendor: 'Essentials', description: 'Smart home heizkörperthermostat premium', model: '120112'},
+            {vendor: "Tuya", description: "Głowica termostatyczna", model:"GTZ02"},
         ],
     },
 


### PR DESCRIPTION
This PR adds support to radiator valve device that looks very much same as [Siterwell GS361A-H04](https://www.zigbee2mqtt.io/devices/GS361A-H04.html)

Zibbe2mqtt log message:
```
Received message from unsupported device with Zigbee model 'TS0601'
```
"TS601" looks like very popular model name in the `devices.js`, but apparently there are "no conflicts" in resolving the unsupported device with the current changes. I'm worries thought that they may appear in the future. I noticed that other devices that have "TS0601" as their `modelId`, have `manufacturerName` name provider under `fingerprint` field. 

Question from me: How can I get `manufacturerName` of the device, to avoid possible future conflicts of device resolving ?

------
How `TS0601` modelId popular is:
```
cat devices.js | grep TS0601
            {modelID: 'TS0601', manufacturerName: '_TZE200_whpb9yts'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_ebwgzdqq'},
        model: 'TS0601_dimmer',
        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_sbordckq'}],
        model: 'TS0601_curtain_switch',
            {modelID: 'TS0601', manufacturerName: '_TZE200_wunufsil'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_vhy3iakz'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_oisqyl4o'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_aqnazj70'}, // 4 gang
        model: 'TS0601_switch',
            {modelID: 'TS0601', manufacturerName: '_TZE200_nkjintbl'},
        model: 'TS0601_switch_2_gang',
            {modelID: 'TS0601', manufacturerName: '_TZE200_kyfqmmyl'},
        model: 'TS0601_switch_3_gang',
            {modelID: 'TS0601', manufacturerName: '_TZE200_5zbp6j0u'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_nkoabg8w'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_xuzcvlku'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_4vobcgd3'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_nogaemzt'},
        model: 'TS0601_curtain',
            {modelID: 'TS0601', manufacturerName: '_TZE200_wmcdj3aq'},
        model: 'TS0601_roller_blind',
        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l'}],
        model: 'TS0601_thermostat',
        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_znzs7yaw'}],
            {modelID: 'TS0601', manufacturerName: '_TZE200_8vxj8khv'},
            {modelID: 'TS0601', manufacturerName: '_TZE200_7tdtqgwv'},
        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_dhdstcqc'}],
        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_fqytfymk'}],
        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_aoclfnxz'}],
        zigbeeModel: ['ivfvd7h', 'eaxp72v\u0000', 'TS0601'],
```

Vendor links: 
https://allegro.pl/oferta/glowica-termostatyczna-st-zigbee-3-0-tuya-smart-9168843228
https://www.houseiq.pl/pl/p/Glowica-termostatyczna-ST-ZigBee-3.0-TUYA-Smart/955
