### PR TITLE
read timeout and sensitivity during configure for hue motion

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3695,7 +3695,7 @@ const devices = [
                 'ep2': 2, // e.g. for write to msOccupancySensing
             };
         },
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             const binds = ['genPowerCfg', 'msIlluminanceMeasurement', 'msTemperatureMeasurement', 'msOccupancySensing'];
@@ -3704,6 +3704,9 @@ const devices = [
             await configureReporting.occupancy(endpoint);
             await configureReporting.temperature(endpoint);
             await configureReporting.illuminance(endpoint);
+            // read occupancy_timeout and motion_sensitivity
+            await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
+            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: 4107});
         },
         ota: ota.zigbeeOTA,
     },
@@ -3730,7 +3733,7 @@ const devices = [
                 'ep2': 2, // e.g. for write to msOccupancySensing
             };
         },
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             const binds = ['genPowerCfg', 'msIlluminanceMeasurement', 'msTemperatureMeasurement', 'msOccupancySensing'];
@@ -3739,6 +3742,9 @@ const devices = [
             await configureReporting.occupancy(endpoint);
             await configureReporting.temperature(endpoint);
             await configureReporting.illuminance(endpoint);
+            // read occupancy_timeout and motion_sensitivity
+            await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
+            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: 4107});
         },
         ota: ota.zigbeeOTA,
     },


### PR DESCRIPTION
Since we are now exposing them, we read the once during configuration so the value is available in the cache (if enabled)

Tested with a 9290012607 as I do not own the outdoor one, but they look to be nearly identical.

```
Zigbee2MQTT:info  2020-10-31 14:01:32: Configuring 'entrance/motion'
Zigbee2MQTT:info  2020-10-31 14:01:38: MQTT publish: topic 'zigbee2mqtt/entrance/motion', payload '{"battery":100,"illuminance":0,"illuminance_lux":0,"linkquality":70,"occupancy":false,"occupancy_t
imeout":30,"temperature":19.48,"update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-10-31 14:01:38: MQTT publish: topic 'zigbee2mqtt/entrance/motion', payload '{"battery":100,"illuminance":0,"illuminance_lux":0,"linkquality":70,"motion_sensitivity":"high","o
ccupancy":false,"occupancy_timeout":30,"temperature":19.48,"update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-10-31 14:01:38: Successfully configured 'entrance/motion'
```
