### PR TITLE
Expose position for compatible thermostats

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1806,7 +1806,7 @@ const devices = [
             tz.tuya_thermostat_window_detect, tz.tuya_thermostat_schedule, tz.tuya_thermostat_week, tz.tuya_thermostat_away_preset,
         ],
         exposes: [
-            e.child_lock(), e.window_detection(), e.battery(), e.valve_detection(),
+            e.child_lock(), e.window_detection(), e.battery(), e.valve_detection(), e.position(),
             exposes.climate().withSetpoint('current_heating_setpoint', 5, 35, 0.5).withLocalTemperature()
                 .withSystemMode(['auto']).withRunningState(['idle', 'heat']).withAwayMode()
                 .withPreset(['schedule', 'manual', 'boost', 'complex', 'comfort', 'eco']),
@@ -14606,7 +14606,7 @@ const devices = [
             {vendor: 'Tuya', description: 'Głowica termostatyczna', model: 'GTZ02'},
         ],
         exposes: [
-            e.child_lock(), e.window_detection(), e.battery(), e.valve_detection(),
+            e.child_lock(), e.window_detection(), e.battery(), e.valve_detection(), e.position(),
             exposes.climate().withSetpoint('current_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
                 .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']),
         ],

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -330,6 +330,7 @@ module.exports = {
         occupancy: () => new Binary('occupancy', access.STATE, true, false),
         pm10: () => new Numeric('pm10', access.STATE).withUnit('µg/m³'),
         pm25: () => new Numeric('pm25', access.STATE).withUnit('µg/m³'),
+        position: () => new Numeric('position', access.STATE).withUnit('%'),
         power: () => new Numeric('power', access.STATE_GET).withUnit('W'),
         presence: () => new Binary('presence', access.STATE, true, false),
         pressure: () => new Numeric('pressure', access.STATE).withUnit('hPa'),


### PR DESCRIPTION
This adds `position` as an HA exposed parameter.

Requires: https://github.com/Koenkk/zigbee2mqtt/pull/4936