### PR TITLE
Added Philips Hue Bloom with BT (929002375901)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2930,7 +2930,7 @@ const devices = [
         zigbeeModel: ['929002375901'],
         model: '929002375901',
         vendor: 'Philips',
-        description: 'Hue Bloom',
+        description: 'Hue Bloom with Bluetooth',
         meta: {turnsOffAtBrightness1: true},
         extend: hue.light_onoff_brightness_colortemp_colorxy,
         ota: ota.zigbeeOTA,

--- a/devices.js
+++ b/devices.js
@@ -2927,6 +2927,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['929002375901'],
+        model: '929002375901',
+        vendor: 'Philips',
+        description: 'Hue Bloom',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LCP001', 'LCP002', '4090331P9_01', '4090331P9_02'],
         model: '4090331P9',
         vendor: 'Philips',


### PR DESCRIPTION
The excisting 2 versions of Bloom in devices.js do not include colortemp, not sure if they support it. The new version does, so I added it separately.

https://www.philips-hue.com/de-de/p/hue-white---color-ambiance-bloom-tischleuchte/8718699770983

