### PR TITLE
Fix Iris 3210-L and Centralite 4257050-ZHAC configure

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3578,13 +3578,6 @@ const converters = {
             return {};
         },
     },
-    iris_3320L_contact: {
-        cluster: 'ssIasZone',
-        type: 'commandStatusChangeNotification',
-        convert: (model, msg, publish, options, meta) => {
-            return {contact: msg.data.zonestatus === 36};
-        },
-    },
     RZHAC_4256251_power: {
         cluster: 'haElectricalMeasurement',
         type: ['attributeReport', 'readResponse'],

--- a/devices.js
+++ b/devices.js
@@ -8403,7 +8403,9 @@ const devices = [
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement']);
             await configureReporting.onOff(endpoint);
-            await readEletricalMeasurementPowerConverterAttributes(endpoint);
+            // 4257050-ZHAC doesn't support reading 'acVoltageMultiplier' or 'acVoltageDivisor'
+            await endpoint.read('haElectricalMeasurement', ['acCurrentMultiplier', 'acCurrentDivisor']);
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await configureReporting.rmsVoltage(endpoint, {change: 2}); // Voltage reports in V
             await configureReporting.rmsCurrent(endpoint, {change: 10}); // Current reports in mA
             await configureReporting.activePower(endpoint, {change: 2}); // Power reports in 0.1W

--- a/devices.js
+++ b/devices.js
@@ -8205,7 +8205,9 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
-            await readEletricalMeasurementPowerConverterAttributes(endpoint);
+            // 3210-L doesn't support reading 'acVoltageMultiplier' or 'acVoltageDivisor'
+            await endpoint.read('haElectricalMeasurement', ['acCurrentMultiplier', 'acCurrentDivisor']);
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await configureReporting.onOff(endpoint);
             await configureReporting.rmsVoltage(endpoint, {change: 2}); // Voltage reports in V
             await configureReporting.rmsCurrent(endpoint, {change: 10}); // Current reports in mA


### PR DESCRIPTION
Hi Koen,
I noticed that configuration was failing on my Iris 3210-L smart plugs. The error was `UNSUPPORTED_ATTRIBUTE`, and it turns out that they (at least the two I have) don't support the `acVoltageMultiplier` or `acVoltageDivisor` attributes of the `haElectricalMeasurement` cluster. The voltage is reported in volts (so it needs no multiplier or divisor).

Apparently I broke this in #705 😞 , and Centralite 4257050-ZHAC dimming plugs are also affected. I'm pretty surprised this got past me (and stood for a year), but as I have never been able to update the firmware on these things, I'm not sure how anything could have changed behavior-wise... and it is definitely throwing errors now.

With these changes, my 3210-L plugs and 4257050-ZHAC dimming plugs now configure fine. I'm not sure if this needs a `configureKey` bump or not.

I also noticed some unused code (due to #1363) and removed it.