### PR TITLE
add modelid  to Osram Smart+ switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4850,7 +4850,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['Switch 4x EU-LIGHTIFY'],
+        zigbeeModel: ['Switch 4x EU-LIGHTIFY', 'Switch 4x-LIGHTIFY'],
         model: '4058075816459',
         vendor: 'OSRAM',
         description: 'Smart+ switch',


### PR DESCRIPTION
add another modelid to Osram Smart+ switch referring to https://github.com/blakadder/zigbee/pull/113#issuecomment-725028865