### PR TITLE
Add new model name to known device

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2883,6 +2883,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LTC002'],
+        model: '4034031P6',
+        vendor: 'Philips',
+        description: 'Hue Fair with Bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTD011'],
         model: '5110131H5',
         vendor: 'Philips',


### PR DESCRIPTION
My Philips Hue Fair ceiling light with bluetooth is showing the name "4034031P6" and not like here "4034031P7". Added new device with equal parameters.