### PR TITLE
Add support for GL-H-001 Gledopto RF bridge

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6902,6 +6902,18 @@ const devices = [
         },
     },
     {
+        fingerprint: [
+            {type: 'Router', manufacturerName: 'GLEDOPTO', modelID: 'GL-H-001', endpoints: [
+                {ID: 11, profileID: 49246, deviceID: 528, inputClusters: [0, 3, 4, 5, 6, 8, 768], outputClusters: []},
+                {ID: 13, profileID: 49246, deviceID: 528, inputClusters: [4096], outputClusters: [4096]},
+            ]},
+        ],
+        model: 'GL-H-001',
+        vendor: 'Gledopto',
+        description: 'Zigbee RF Hub',
+        extend: gledopto.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
         zigbeeModel: ['GL-S-004ZS'],
         model: 'GL-S-004ZS',
         vendor: 'Gledopto',


### PR DESCRIPTION
Add configuration that allows GLEDOPTO RF bridge GL-H-001 to be recognized and adopted.
Currently known issues:
The RGB color selection seems to happen in a shifted matter when using the homeassistant color wheel.
(pink translates to a yellowish color while light green is translated to a shade of blue).
The scene selection (breathe, blink etc.) isn't working.

Image of the device: https://images-na.ssl-images-amazon.com/images/I/41j2JWzGjPL._AC_SL1000_.jpg
