### PR TITLE
Add Heiman HS1RC-EM support

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9041,22 +9041,22 @@ const devices = [
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
     },
-    {                                   
+    {
         fingerprint: [{modelID: 'RC-EM', manufacturerName: 'HEIMAN'}],
-        model: 'HS1RC-EM',                                       
-        vendor: 'HEIMAN',                                                        
+        model: 'HS1RC-EM',
+        vendor: 'HEIMAN',
         description: 'Smart remote controller',
-        supports: 'action',    
+        supports: 'action',
         fromZigbee: [fz.battery, fz.heiman_smart_controller_armmode, fz.command_emergency],
-        toZigbee: [],                         
+        toZigbee: [],
         exposes: [e.battery(), e.action(['emergency', 'disarm', 'arm_partial_zones', 'arm_all_zones'])],
-        meta: {configureKey: 1},                       
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);                               
+            const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await configureReporting.batteryPercentageRemaining(endpoint, {min: repInterval.MINUTES_5, max: repInterval.HOUR});
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
-        },                                                                
+        },
     },
     {
         zigbeeModel: ['COSensor-EM', 'COSensor-N'],

--- a/devices.js
+++ b/devices.js
@@ -9041,6 +9041,23 @@ const devices = [
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
     },
+    {                                   
+        fingerprint: [{modelID: 'RC-EM', manufacturerName: 'HEIMAN'}],
+        model: 'HS1RC-EM',                                       
+        vendor: 'HEIMAN',                                                        
+        description: 'Smart remote controller',
+        supports: 'action',    
+        fromZigbee: [fz.battery, fz.heiman_smart_controller_armmode, fz.command_emergency],
+        toZigbee: [],                         
+        exposes: [e.battery(), e.action(['emergency', 'disarm', 'arm_partial_zones', 'arm_all_zones'])],
+        meta: {configureKey: 1},                       
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);                               
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint, {min: repInterval.MINUTES_5, max: repInterval.HOUR});
+            await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
+        },                                                                
+    },
     {
         zigbeeModel: ['COSensor-EM', 'COSensor-N'],
         model: 'HS1CA-E',


### PR DESCRIPTION
Hi all,

I bought two Heiman RC-EM last year and they were not working at that time. I retry last week just by copying the code from RC-N and it is now working properly.

Here are the firmware I use :
- Cordinator : CC2531_SOURCE_ROUTING_20190619.zip
- Router : CC2530_CC2591_router_2020_09_29.zip

@Koenkk : Would you like me to add a new device in zigbee2mqtt.io or just complete the RC-N device? They look exactly the same.

Thanks for your help.

Caizzii.