### PR TITLE
battery_low added to exposes for Tuya TRV (moes)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1827,7 +1827,7 @@ const devices = [
             tz.tuya_thermostat_window_detect, tz.tuya_thermostat_schedule, tz.tuya_thermostat_week, tz.tuya_thermostat_away_preset,
         ],
         exposes: [
-            e.child_lock(), e.window_detection(), e.battery(), e.valve_detection(), e.position(),
+            e.child_lock(), e.window_detection(), e.battery(), e.battery_low(), e.valve_detection(), e.position(),
             exposes.climate().withSetpoint('current_heating_setpoint', 5, 35, 0.5).withLocalTemperature()
                 .withSystemMode(['auto']).withRunningState(['idle', 'heat']).withAwayMode()
                 .withPreset(['schedule', 'manual', 'boost', 'complex', 'comfort', 'eco']),


### PR DESCRIPTION
As long TRV doesn't report battery in percentage, but reports battery low status, this should be added to exposed.