### PR TITLE
Ubisys S1/S2 default bindings should be stored

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -12532,6 +12532,23 @@ const devices = [
             await readMeteringPowerConverterAttributes(endpoint);
             await configureReporting.instantaneousDemand(endpoint);
         },
+        onEvent: async (type, data, device) => {
+            /*
+             * As per technical doc page 18 section 7.3.4
+             * https://www.ubisys.de/wp-content/uploads/ubisys-s1-technical-reference.pdf
+             *
+             * This cluster uses the binding table for managing command targets.
+             * When factory fresh, this cluster is bound to endpoint #1 to
+             * enable local control.
+             *
+             * We use addBinding to 'record' this default binding.
+             */
+            if (type === 'deviceInterview') {
+                const ep1 = device.getEndpoint(1);
+                const ep2 = device.getEndpoint(2);
+                ep2.addBinding('genOnOff', ep1);
+            }
+        },
         ota: ota.ubisys,
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -12569,6 +12569,31 @@ const devices = [
             await readMeteringPowerConverterAttributes(endpoint);
             await configureReporting.instantaneousDemand(endpoint);
         },
+        onEvent: async (type, data, device) => {
+            /*
+             * As per technical doc page 20 section 7.4.4 and
+             *                      page 22 section 7.5.4
+             * https://www.ubisys.de/wp-content/uploads/ubisys-s2-technical-reference.pdf
+             *
+             * This cluster uses the binding table for managing command targets.
+             * When factory fresh, this cluster is bound to endpoint #1 to
+             * enable local control.
+             *
+             * This cluster uses the binding table for managing command targets.
+             * When factory fresh, this cluster is bound to endpoint #2 to
+             * enable local control
+             *
+             * We use addBinding to 'record' this default binding.
+             */
+            if (type === 'deviceInterview') {
+                const ep1 = device.getEndpoint(1);
+                const ep2 = device.getEndpoint(2);
+                const ep3 = device.getEndpoint(3);
+                const ep4 = device.getEndpoint(4);
+                ep3.addBinding('genOnOff', ep1);
+                ep4.addBinding('genOnOff', ep2);
+            }
+        },
         ota: ota.ubisys,
     },
     {


### PR DESCRIPTION
This PR fixes https://github.com/Koenkk/zigbee2mqtt/issues/4682 and stores the binding state of a fresh/factory reset S1 or S2 switch.

This allows for easy unbind/binding via the frontend. This PR required `addBindings` from zigbee-herdsman so it depends on this PR https://github.com/Koenkk/zigbee-herdsman/pull/256.

This was tested by removing the device from the network, allowing it to join and observing no binding.
Then do the same after this change, the default bindings show up and I was able to remove them via the frontend.