### PR TITLE
Added support for GLEDOPTO ceiling lights PRO GL-D-003P/004P/005P

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7028,7 +7028,7 @@ const devices = [
         vendor: 'Gledopto',
         description: 'LED RGB + CCT downlight PRO',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
-    },	
+    },
     {
         zigbeeModel: ['GL-D-004ZS'],
         model: 'GL-D-004ZS',
@@ -7049,7 +7049,7 @@ const devices = [
         vendor: 'Gledopto',
         description: 'LED RGB + CCT downlight PRO',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
-    },	
+    },
     {
         zigbeeModel: ['GL-D-005ZS'],
         model: 'GL-D-005ZS',

--- a/devices.js
+++ b/devices.js
@@ -7008,6 +7008,13 @@ const devices = [
         description: 'LED RGB + CCT downlight',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
     },
+	{
+        zigbeeModel: ['GL-D-003P'],
+        model: 'GL-D-003P',
+        vendor: 'Gledopto',
+        description: 'LED RGB + CCT downlight PRO',
+        extend: gledopto.light_onoff_brightness_colortemp_colorxy,
+    },
     {
         zigbeeModel: ['GL-D-004Z'],
         model: 'GL-D-004Z',
@@ -7015,6 +7022,13 @@ const devices = [
         description: 'LED RGB + CCT downlight',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
     },
+	{
+        zigbeeModel: ['GL-D-004P'],
+        model: 'GL-D-004P',
+        vendor: 'Gledopto',
+        description: 'LED RGB + CCT downlight PRO',
+        extend: gledopto.light_onoff_brightness_colortemp_colorxy,
+    },	
     {
         zigbeeModel: ['GL-D-004ZS'],
         model: 'GL-D-004ZS',
@@ -7029,6 +7043,13 @@ const devices = [
         description: 'LED RGB + CCT downlight',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
     },
+	{
+        zigbeeModel: ['GL-D-005P'],
+        model: 'GL-D-005P',
+        vendor: 'Gledopto',
+        description: 'LED RGB + CCT downlight PRO',
+        extend: gledopto.light_onoff_brightness_colortemp_colorxy,
+    },	
     {
         zigbeeModel: ['GL-D-005ZS'],
         model: 'GL-D-005ZS',

--- a/devices.js
+++ b/devices.js
@@ -7008,7 +7008,7 @@ const devices = [
         description: 'LED RGB + CCT downlight',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
     },
-	{
+    {
         zigbeeModel: ['GL-D-003P'],
         model: 'GL-D-003P',
         vendor: 'Gledopto',
@@ -7022,7 +7022,7 @@ const devices = [
         description: 'LED RGB + CCT downlight',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
     },
-	{
+    {
         zigbeeModel: ['GL-D-004P'],
         model: 'GL-D-004P',
         vendor: 'Gledopto',
@@ -7043,7 +7043,7 @@ const devices = [
         description: 'LED RGB + CCT downlight',
         extend: gledopto.light_onoff_brightness_colortemp_colorxy,
     },
-	{
+    {
         zigbeeModel: ['GL-D-005P'],
         model: 'GL-D-005P',
         vendor: 'Gledopto',


### PR DESCRIPTION
Added support for GLEDOPTO ceiling lights PRO GL-D-003P/004P/005P which are basically ZigBee 3.0 versions of GL-D-003Z/004Z/005Z.

Tested on my GL-D-003P