### PR TITLE
HSB fix for HG06467

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5808,6 +5808,7 @@ const converters = {
                 const s = parseInt(value.substring(4, 8), 16);
                 const b = parseInt(value.substring(8, 12), 16);
                 result.color = {b: (b / 1000) * 255, h, s: s / 10};
+                result.brightness = result.color.b;
             } else if (dp === common.TuyaDataPoints.silvercrestSetEffect) {
                 result.effect = {
                     effect: utils.getKeyStringByValue(common.silvercrestEffects, value.substring(0, 2), ''),

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3899,17 +3899,19 @@ const converters = {
                         b: '03e8', // 1000
                     };
 
+                    // The device expects 0-359
                     if (h) {
-                        hsb.h = make4sizedString(h.toString(16));
+                        hsb.h = make4sizedString((h - 1).toString(16));
                     } else if (state.color && state.color.h) {
                         hsb.h = make4sizedString(state.color.h.toString(16));
                     }
 
                     // Device expects 0-1000, saturation normally is 0-100 so we expect that from the user
+                    // The device expects a round number, otherwise everything breaks
                     if (s) {
-                        hsb.s = make4sizedString((s * 10).toString(16));
+                        hsb.s = make4sizedString(Math.round(s * 10).toString(16));
                     } else if (state.color && state.color.s) {
-                        hsb.s = make4sizedString((state.color.s * 10).toString(16));
+                        hsb.s = make4sizedString(Math.round(state.color.s * 10).toString(16));
                     }
 
                     // Scale 0-255 to 0-1000 what the device expects.

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3920,8 +3920,6 @@ const converters = {
                     // Scale 0-255 to 0-1000 what the device expects.
                     if (b) {
                         hsb.b = make4sizedString(Math.round(scale(b, 0, 255, 0, 1000)).toString(16));
-                    } else if (state.color && state.color.b) {
-                        hsb.b = make4sizedString(Math.round(scale(state.color.b, 0, 255, 0, 1000)).toString(16));
                     } else if (state.brightness) {
                         hsb.b = make4sizedString(Math.round(scale(state.brightness, 0, 255, 0, 1000)).toString(16));
                     }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3899,9 +3899,12 @@ const converters = {
                         b: '03e8', // 1000
                     };
 
-                    // The device expects 0-359
                     if (h) {
-                        hsb.h = make4sizedString((h - 1).toString(16));
+                        // The device expects 0-359
+                        if (h >= 360) {
+                            h = 359;
+                        }
+                        hsb.h = make4sizedString(h.toString(16));
                     } else if (state.color && state.color.h) {
                         hsb.h = make4sizedString(state.color.h.toString(16));
                     }


### PR DESCRIPTION
Found out that HA sends decimal values for saturation, but the device doesn't like that.
Added rounding for that number.

Also: the hue expects 1-359 instead of 1-360.

And only use state.brightness, because that is what HA does.