### PR TITLE
Add support for TERNCY LS01 Smart Light Socket

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -12907,6 +12907,20 @@ const devices = [
         meta: {battery: {dontDividePercentage: true}},
         exposes: [e.battery(), e.action(['single', 'double', 'triple', 'quadruple']), exposes.text('direction', exposes.access.STATE)],
     },
+    {
+        zigbeeModel: ['TERNCY-LS01'],
+        model: 'TERNCY-LS01',
+        vendor: 'TERNCY',
+        description: 'Smart Light Socket',
+        exposes: [e.switch(), e.action(['single'])],
+        fromZigbee: [fz.on_off, fz.terncy_raw, fz.ignore_basic_report],
+        toZigbee: [tz.on_off],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+        },
+    },
 
     // ORVIBO
     {

--- a/devices.js
+++ b/devices.js
@@ -12911,7 +12911,7 @@ const devices = [
         zigbeeModel: ['TERNCY-LS01'],
         model: 'TERNCY-LS01',
         vendor: 'TERNCY',
-        description: 'Smart Light Socket',
+        description: 'Smart light socket',
         exposes: [e.switch(), e.action(['single'])],
         fromZigbee: [fz.on_off, fz.terncy_raw, fz.ignore_basic_report],
         toZigbee: [tz.on_off],


### PR DESCRIPTION
Add support for TERNCY LS01 Smart Light Socket

**Link to product on aliexpress:**
https://www.aliexpress.com/item/32987805132.html?spm=a2g0o.detail.1000023.1.d3346cc1FpYDHZ

**Device entry in database.db:**
```
{"id":9,"type":"Router","ieeeAddr":"0x000d6f0016332df5","nwkAddr":22016,"manufId":4648,"powerSource":"Unknown","modelId":"TERNCY-LS01","epList":[1],"endpoints":{"1":{"profId":260,"epId":1,"devId":256,"inClusterList":[0,3,6],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"powerSource":0,"zclVersion":2,"hwVersion":0,"modelId":"TERNCY-LS01"}},"genOnOff":{"attributes":{"onOff":0}},"genOta":{"attributes":{"currentFileVersion":80}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0021b4a268","endpointID":1}],"meta":{}}},"hwVersion":0,"zclVersion":2,"interviewCompleted":true,"meta":{"configured":1},"lastSeen":1606490015933}
```

There is a small button on the bulb that when pressed will toggle the light and send 2 ZigBee messages 'genOnOff' and 'manuSpecificClusterAduroSmart'.

For the manufacturer-specific message, once passed into `fz.terncy_raw`, it will be decoded into `{ action: 'single' }`. 
Not really sure what the use case for that button might be, but this commit enables processing for that too.

Thanks!