### PR TITLE
added new modelId for Feibit STH01ZB

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6610,7 +6610,7 @@ const devices = [
         exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
-        zigbeeModel: ['FNB56-THM14FB2.4'],
+        zigbeeModel: ['FNB56-THM14FB2.4', 'FNB54-THM17ML1.1'],
         model: 'STH01ZB',
         vendor: 'Feibit',
         description: 'Smart temperature & humidity Sensor',


### PR DESCRIPTION
I've ordered this device as "EWelink Smart Temperature And Humidity Sensor". It identifies with manufacturerName "fei" and looks like the Feibit device. Long story short, adding the modelId for the Feibit makes this thing work just fine.