### PR TITLE
Add support for Philips hue 4" recessed lights 5996311U5

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3344,6 +3344,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LTD009'],
+        model: '5996311U5',
+        vendor: 'Philips',
+        description: 'Hue white ambiance 4" retrofit recessed downlight',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTD010'],
         model: '5996411U5',
         vendor: 'Philips',


### PR DESCRIPTION
[LTD009 model ](https://www.philips-hue.com/en-us/p/hue-white-ambiance-downlight-4-inch/5996311U5) pretty much identical to their 5/6" counterpart LTD010. Tested with a CC2531. Will do a separate PR for docs and home assistant support.