### PR TITLE
Improve scene error messages

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3649,7 +3649,7 @@ const converters = {
                     if (member.meta.hasOwnProperty('scenes') && member.meta.scenes.hasOwnProperty(metaKey)) {
                         membersState[member.getDevice().ieeeAddr] = member.meta.scenes[metaKey].state;
                     } else {
-                        meta.logger.warn(`unknown scene was recalled for ${member.getDevice().ieeeAddr}, can't restore state.`);
+                        meta.logger.warn(`Unknown scene was recalled for ${member.getDevice().ieeeAddr}, can't restore state.`);
                         membersState[member.getDevice().ieeeAddr] = {};
                     }
                 }
@@ -3659,7 +3659,7 @@ const converters = {
                 if (entity.meta.scenes.hasOwnProperty(metaKey)) {
                     return {state: entity.meta.scenes[metaKey].state};
                 } else {
-                    meta.logger.warn(`unknown scene was recalled for ${entity.deviceIeeeAddress}, can't restore state.`);
+                    meta.logger.warn(`Unknown scene was recalled for ${entity.deviceIeeeAddress}, can't restore state.`);
                     return {state: {}};
                 }
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3668,8 +3668,12 @@ const converters = {
     scene_add: {
         key: ['scene_add'],
         convertSet: async (entity, key, value, meta) => {
-            if (typeof value !== 'object' || !value.hasOwnProperty('ID')) {
-                throw new Error('Invalid payload');
+            if (typeof value !== 'object') {
+                throw new Error('Payload should be object.');
+            }
+
+            if (!value.hasOwnProperty('ID')) {
+                throw new Error('Payload missing ID.');
             }
 
             if (value.hasOwnProperty('color_temp') && value.hasOwnProperty('color')) {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3646,12 +3646,22 @@ const converters = {
             if (isGroup) {
                 const membersState = {};
                 for (const member of entity.members) {
-                    membersState[member.getDevice().ieeeAddr] = member.meta.scenes[metaKey].state;
+                    if (member.meta.hasOwnProperty('scenes') && member.meta.scenes.hasOwnProperty(metaKey)) {
+                        membersState[member.getDevice().ieeeAddr] = member.meta.scenes[metaKey].state;
+                    } else {
+                        meta.logger.warn(`unknown scene was recalled for ${member.getDevice().ieeeAddr}, can't restore state.`);
+                        membersState[member.getDevice().ieeeAddr] = {};
+                    }
                 }
 
                 return {membersState};
             } else {
-                return {state: entity.meta.scenes[metaKey].state};
+                if (entity.meta.scenes.hasOwnProperty(metaKey)) {
+                    return {state: entity.meta.scenes[metaKey].state};
+                } else {
+                    meta.logger.warn(`unknown scene was recalled for ${entity.deviceIeeeAddress}, can't restore state.`);
+                    return {state: {}};
+                }
             }
         },
     },


### PR DESCRIPTION
See koenkk/zigbee2mqtt#5102, 

- warn when we can't restore state for a scene_recall (but don't error, as we still send the zigbee command and the device could have still have scenes we don't know about)
- split generic into missing ID and wrong payload type for scene_add