### PR TITLE
Add Fingerprint for Silvercrest Type J Switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -15205,6 +15205,7 @@ const devices = [
         fingerprint: [
             {modelID: 'TS011F', manufacturerName: '_TZ3000_wzauvbcs'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_1obwwnmq'},
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_4uf3d0ax'}, // Type J plug & socket
         ],
         model: 'HG06338',
         vendor: 'Silvercrest',


### PR DESCRIPTION
In Switzerland we have Type J Sockets which has a different fingerprint.
https://zigbeealliance.org/classic-product-search/#zigbeecertifiedproducts/productdetails3/5ea15274d8a12e0017eeae01/