### PR TITLE
adding device support for HEIMAN RC-EF-3.0

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3093,6 +3093,7 @@ const converters = {
         cluster: 'ssIasAce',
         type: 'commandArm',
         convert: (model, msg, publish, options, meta) => {
+            if (hasAlreadyProcessedMessage(msg, msg.data[1])) return;
             if (msg.data.armmode != null) {
                 const lookup = {
                     0: 'disarm',

--- a/devices.js
+++ b/devices.js
@@ -8952,7 +8952,7 @@ const devices = [
         exposes: [e.water_leak(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
-        fingerprint: [{modelID: 'RC-N', manufacturerName: 'HEIMAN'}],
+        zigbeeModel: ['RC-N', 'RC-EF-3.0'],
         model: 'HS1RC-N',
         vendor: 'HEIMAN',
         description: 'Smart remote controller',


### PR DESCRIPTION
adding support for HEIMAN RC-EF-3.0 bought on aliexpress 
https://fr.aliexpress.com/item/4000033157179.html?spm=a2g0s.9042311.0.0.25306c37bOjXK9

data/database.db:
`
{"id":32,"type":"EndDevice","ieeeAddr":"0xbc33acfffe058774","nwkAddr":685,"manufId":4619,"manufName":"HEIMAN","powerSource":"Battery","modelId":"RC-EF-3.0","epList":[1],"endpoints":{"1":{"profId":260,"epId":1,"devId":1025,"inClusterList":[0,1,3,1280,2821],"outClusterList":[25,1281],"clusters":{"genBasic":{"attributes":{"modelId":"RC-EF-3.0","manufacturerName":"HEIMAN","powerSource":3,"zclVersion":2,"appVersion":16,"stackVersion":2,"hwVersion":16,"dateCode":"2019.9.10"}},"ssIasZone":{"attributes":{"iasCieAddr":"0x00124b001ca1b3a9","zoneState":1}},"genPowerCfg":{"attributes":{"batteryPercentageRemaining":200}}},"binds":[{"cluster":1,"type":"endpoint","deviceIeeeAddress":"0x00124b001ca1b3a9","endpointID":1}],"meta":{}}},"appVersion":16,"stackVersion":2,"hwVersion":16,"dateCode":"2019.9.10","zclVersion":2,"interviewCompleted":true,"meta":{"configured":1},"lastSeen":1606772045721}'emergency'`




`Zigbee2MQTT:debug 2020-11-30 23:05:47: Device '0xbc33acfffe058774' announced itself`

there are 3-4 same signal receive from the remote, is there a way to keep only one ? (or its the hardware send multiple signal ?)
thanks :)