### PR TITLE
Add Philips Hue outdoor Impresss wall lamp (low-voltage)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3607,6 +3607,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['1745930P7'],
+        model: '1745930P7',
+        vendor: 'Philips',
+        description: 'Hue outdoor Impress wall lamp (low voltage)',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['1743230P7'],
         model: '1743230P7',
         vendor: 'Philips',


### PR DESCRIPTION
This pull request adds Zigbee device model 1745930P7 which is a low voltage version of the Hue Impress wall lamp. Copies the configuration of the other Hue Impress wall lamps, which seems to work fine.