### PR TITLE
scene_add should handle color_temp for ZCL version <= 6

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3685,13 +3685,27 @@ const converters = {
             const sceneid = value.ID;
             const scenename = '';
             const transtime = value.hasOwnProperty('transition') ? value.transition : 0;
-            let zclversion = 6;
-            if (value.hasOwnProperty('ZCL')) {
-                if (typeof value.ZCL !== 'number') {
-                    throw new Error('ZCL version must be a number.');
-                }
-                zclversion = value.ZCL;
-            }
+            /*
+             * ZCL version 7 added support for ColorTemperatureMireds
+             *
+             * Currently no devices seem to support this, so always
+             * fallback to XY conversion. In the future if a device
+             * supports this, or other features get added this can
+             * be uncomment to add version specific code paths.
+             *
+             * Conversion to XY is allowed according to the ZCL:
+             * `Since there is a direct relation between ColorTemperatureMireds and XY,
+             *  color temperature, if supported, is stored as XY in the scenes table.`
+             *
+             * See https://github.com/Koenkk/zigbee2mqtt/issues/4926#issuecomment-735947705
+             */
+            // let zclversion = 6;
+            // if (value.hasOwnProperty('ZCL')) {
+            //     if (typeof value.ZCL !== 'number') {
+            //         throw new Error('ZCL version must be a number.');
+            //     }
+            //     zclversion = value.ZCL;
+            // }
 
             const state = {};
             const extensionfieldsets = [];
@@ -3703,17 +3717,17 @@ const converters = {
                     extensionfieldsets.push({'clstId': 8, 'len': 1, 'extField': [val]});
                     state['brightness'] = val;
                 } else if (attribute === 'color_temp') {
-                    // ColorTemperatureMireds was added in ZCL Version 7
-                    // https://github.com/Koenkk/zigbee2mqtt/issues/4926#issuecomment-735947705
-                    if (zclversion >= 7) {
-                        extensionfieldsets.push({'clstId': 768, 'len': 13, 'extField': [0, 0, 0, 0, 0, 0, 0, val]});
-                    } else {
-                        const xy = utils.miredsToXY(val);
-                        extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [
-                            Math.round(xy.x * 65535),
-                            Math.round(xy.y * 65535),
-                        ]});
-                    }
+                    // if (zclversion >= 7) {
+                    //     // ColorTemperatureMireds was added in ZCL Version 7
+                    //     extensionfieldsets.push({'clstId': 768, 'len': 13, 'extField': [0, 0, 0, 0, 0, 0, 0, val]});
+                    // } else {
+                    // convert Mireds to XY as this is allowed by the ZCL
+                    const xy = utils.miredsToXY(val);
+                    extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [
+                        Math.round(xy.x * 65535),
+                        Math.round(xy.y * 65535),
+                    ]});
+                    // }
                     state['color_temp'] = val;
                 } else if (attribute === 'color') {
                     try {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3685,27 +3685,6 @@ const converters = {
             const sceneid = value.ID;
             const scenename = '';
             const transtime = value.hasOwnProperty('transition') ? value.transition : 0;
-            /*
-             * ZCL version 7 added support for ColorTemperatureMireds
-             *
-             * Currently no devices seem to support this, so always
-             * fallback to XY conversion. In the future if a device
-             * supports this, or other features get added this can
-             * be uncomment to add version specific code paths.
-             *
-             * Conversion to XY is allowed according to the ZCL:
-             * `Since there is a direct relation between ColorTemperatureMireds and XY,
-             *  color temperature, if supported, is stored as XY in the scenes table.`
-             *
-             * See https://github.com/Koenkk/zigbee2mqtt/issues/4926#issuecomment-735947705
-             */
-            // let zclversion = 6;
-            // if (value.hasOwnProperty('ZCL')) {
-            //     if (typeof value.ZCL !== 'number') {
-            //         throw new Error('ZCL version must be a number.');
-            //     }
-            //     zclversion = value.ZCL;
-            // }
 
             const state = {};
             const extensionfieldsets = [];
@@ -3717,17 +3696,21 @@ const converters = {
                     extensionfieldsets.push({'clstId': 8, 'len': 1, 'extField': [val]});
                     state['brightness'] = val;
                 } else if (attribute === 'color_temp') {
-                    // if (zclversion >= 7) {
-                    //     // ColorTemperatureMireds was added in ZCL Version 7
-                    //     extensionfieldsets.push({'clstId': 768, 'len': 13, 'extField': [0, 0, 0, 0, 0, 0, 0, val]});
-                    // } else {
-                    // convert Mireds to XY as this is allowed by the ZCL
+                    /*
+                     * ZCL version 7 added support for ColorTemperatureMireds
+                     *
+                     * Currently no devices seem to support this, so always fallback to XY conversion. In the future if a device
+                     * supports this, or other features get added this the following commit contains an implementation:
+                     * https://github.com/Koenkk/zigbee-herdsman-converters/pull/1837/commits/c22175b946b83230ce4e711c2a3796cf2029e78f
+                     *
+                     * Conversion to XY is allowed according to the ZCL:
+                     * `Since there is a direct relation between ColorTemperatureMireds and XY,
+                     *  color temperature, if supported, is stored as XY in the scenes table.`
+                     *
+                     * See https://github.com/Koenkk/zigbee2mqtt/issues/4926#issuecomment-735947705
+                     */
                     const xy = utils.miredsToXY(val);
-                    extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [
-                        Math.round(xy.x * 65535),
-                        Math.round(xy.y * 65535),
-                    ]});
-                    // }
+                    extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [Math.round(xy.x * 65535), Math.round(xy.y * 65535)]});
                     state['color_temp'] = val;
                 } else if (attribute === 'color') {
                     try {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3685,6 +3685,13 @@ const converters = {
             const sceneid = value.ID;
             const scenename = '';
             const transtime = value.hasOwnProperty('transition') ? value.transition : 0;
+            let zclversion = 6;
+            if (value.hasOwnProperty('ZCL')) {
+                if (typeof value.ZCL !== 'number') {
+                    throw new Error('ZCL version must be a number.');
+                }
+                zclversion = value.ZCL;
+            }
 
             const state = {};
             const extensionfieldsets = [];
@@ -3696,7 +3703,17 @@ const converters = {
                     extensionfieldsets.push({'clstId': 8, 'len': 1, 'extField': [val]});
                     state['brightness'] = val;
                 } else if (attribute === 'color_temp') {
-                    extensionfieldsets.push({'clstId': 768, 'len': 13, 'extField': [0, 0, 0, 0, 0, 0, 0, val]});
+                    // ColorTemperatureMireds was added in ZCL Version 7
+                    // https://github.com/Koenkk/zigbee2mqtt/issues/4926#issuecomment-735947705
+                    if (zclversion >= 7) {
+                        extensionfieldsets.push({'clstId': 768, 'len': 13, 'extField': [0, 0, 0, 0, 0, 0, 0, val]});
+                    } else {
+                        const xy = utils.miredsToXY(val);
+                        extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [
+                            Math.round(xy.x * 65535),
+                            Math.round(xy.y * 65535),
+                        ]});
+                    }
                     state['color_temp'] = val;
                 } else if (attribute === 'color') {
                     try {


### PR DESCRIPTION
ColorTemperatureMireds was added in ZCLv7, not many (any) currently support his.

```
Since there is a direct relation between ColorTemperatureMireds and XY, color temperature, if supported, is stored as XY in the scenes table.
```

Seems to indicate it is OK to store it as XY instead, this change introduces a new optional property `ZCL` that specifies the ZCL version.
We default it to v6 for most compatibility, but when set to >= 7 we will use the new attribute. This will also allow us to do other things in the future
if the ZCL gets updates again.

In practice the default of ZCLv6 should be fine for most people, bulb seem to properly report colorTemperature after the change.
(Tested on Trådfri WS)