### PR TITLE
scenes: implement scene_remove

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3743,6 +3743,32 @@ const converters = {
             return {state: {}};
         },
     },
+    scene_remove: {
+        key: ['scene_remove'],
+        convertSet: async (entity, key, value, meta) => {
+            const groupid = entity.constructor.name === 'Group' ? entity.groupID : 0;
+            const sceneid = value;
+            await entity.command('genScenes', 'remove', {groupid, sceneid}, getOptions(meta.mapped));
+
+            const isGroup = entity.constructor.name === 'Group';
+            const metaKey = `${sceneid}_${groupid}`;
+            if (isGroup) {
+                if (meta.membersState) {
+                    for (const member of entity.members) {
+                        if (member.meta.scenes && member.meta.scenes.hasOwnProperty(metaKey)) {
+                            delete member.meta.scenes[metaKey];
+                            member.save();
+                        }
+                    }
+                }
+            } else {
+                if (entity.meta.scenes && entity.meta.scenes.hasOwnProperty(metaKey)) {
+                    delete entity.meta.scenes[metaKey];
+                    entity.save();
+                }
+            }
+        },
+    },
     TS0003_curtain_switch: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices.js
+++ b/devices.js
@@ -15431,7 +15431,7 @@ module.exports = devices.map((device) => {
     }
 
     if (device.toZigbee.length > 0) {
-        device.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add);
+        device.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove);
     }
 
     if (device.exposes) {


### PR DESCRIPTION
This implements scene_remove, I had a lot of useless scenes from testing I wanted to remove properly.

I also would like to like at scene_remove_all and scene_view... but these don't really fit well as convertors I think.
I'm thinking more of a similar approach to the bind/unbind interface, at least for scene_view that would be needed, as I don't think dumping a `scenes` key into the device publish is the way to go!

Testing was done by add a scene, recalling it, removing the scene, changing the state and trying to recall it again.

z2m logged:
```
Zigbee2MQTT:warn  2020-12-03 21:17:35: Unknown scene was recalled for 0x14b457fffe301910, can't restore state.
Zigbee2MQTT:warn  2020-12-03 21:17:35: Unknown scene was recalled for 0x14b457fffe2fee7a, can't restore state.
Zigbee2MQTT:warn  2020-12-03 21:17:35: Unknown scene was recalled for 0xec1bbdfffe9f5f8f, can't restore state.
Zigbee2MQTT:warn  2020-12-03 21:17:35: Unknown scene was recalled for 0xec1bbdfffe189fde, can't restore state.
```

And the devices did not change scene.

Removing the scene multiple times does not generate an error, I guess the devices I used for testing treat it as a NOOP and return success... as the scene is already gone so removing it... again results in it being gone still.

I also verified the database got update correctly by grepping one of the devices and then comparing the pretty printed json

```patch
--- /tmp/old    2020-12-03 20:58:52.239394269 +0000
+++ /tmp/new    2020-12-03 21:00:23.975609494 +0000
@@ -85,11 +85,6 @@
       ],
       "meta": {
         "scenes": {
-          "32_10110": {
-            "state": {
-              "color_temp": "500"
-            }
-          },
           "42_10110": {
             "state": {
               "color": {
@@ -122,7 +117,7 @@
   "meta": {
     "reporting": 1
   },
-  "lastSeen": 1607028840580
+  "lastSeen": 1607029140616
 }
 {
   "id": 49,
```