### PR TITLE
Add fingerprint for HG06338 sold by Lidl CZ

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -15352,6 +15352,7 @@ const devices = [
             {modelID: 'TS011F', manufacturerName: '_TZ3000_wzauvbcs'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_1obwwnmq'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_4uf3d0ax'}, // Type J plug & socket
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_vzopcetz'}, // Lidl CZ
         ],
         model: 'HG06338',
         vendor: 'Lidl',


### PR DESCRIPTION
Adding fingerprint for https://www.zigbee2mqtt.io/devices/HG06338.html sold by Lidl CZ https://www.lidl-shop.cz/SILVERCREST-Zigbee-3-0-Smart-Home-Prodluzovaci-kabel-s-USB/p100306996 so it is recognised. 

More details in https://community.home-assistant.io/t/silvercrest-lidl-smarthome/243561/117?u=xpavli44