### PR TITLE
Add Silvercrest HG06338 Fingerprint for Lidl DE

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -15375,6 +15375,7 @@ const devices = [
             {modelID: 'TS011F', manufacturerName: '_TZ3000_1obwwnmq'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_4uf3d0ax'}, // Type J plug & socket
             {modelID: 'TS011F', manufacturerName: '_TZ3000_vzopcetz'}, // Lidl CZ
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_1obwwnmq'}, // Lidl DE
         ],
         model: 'HG06338',
         vendor: 'Lidl',


### PR DESCRIPTION
Not sure if this is correct. My Silvercrest 3 gang switch worked fine until I restarted Zigbee2MQTT and not I got the following error in the log:

````
WARNING: Device 'niklas/plug/powerstrip' with Zigbee model 'undefined' and manufacturer name '_TZ3000_1obwwnmq' is NOT supported, please follow https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html
````