### PR TITLE
Added support for Philips Hue 4" and 5/6" color downlights

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3422,6 +3422,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LCD002'],
+        model: '5996611U5',
+        vendor: 'Philips',
+        description: 'Hue white and color ambiance 5/6" retrofit recessed downlight',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LCW001'],
         model: '4090130P7',
         vendor: 'Philips',

--- a/devices.js
+++ b/devices.js
@@ -3422,6 +3422,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LCD001'],
+        model: '5996511U5',
+        vendor: 'Philips',
+        description: 'Hue white and color ambiance 4" retrofit recessed downlight',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LCD002'],
         model: '5996611U5',
         vendor: 'Philips',


### PR DESCRIPTION
Adding support for Philips Hue white and color ambient lights:
https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-downlight-4-inch/5996511U5
https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-downlight-5-6-inch/5996611U5