### PR TITLE
Adding support for RGB CTT LEXMAN ENKI Remote Control

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1323,6 +1323,11 @@ const converters = {
                 action: postfixWithEndpointName(`color_temperature_step_${direction}`, msg, model),
                 action_step_size: msg.data.stepsize,
             };
+
+            if (msg.data.hasOwnProperty('transtime')) {
+                payload.action_transition_time = msg.data.transtime / 100;
+            }
+
             addActionGroup(payload, msg, model);
             return payload;
         },
@@ -2714,6 +2719,52 @@ const converters = {
         type: ['raw'],
         convert: (model, msg, publish, options, meta) => {
             return {action: `scene_${msg.data[msg.data.length - 1]}`};
+        },
+    },
+    scenes_recall_scene_65024: {
+        cluster: 65024,
+        type: ['raw'],
+        convert: (model, msg, publish, options, meta) => {
+            return {action: `scene_${msg.data[msg.data.length - 2] - 9}`};
+        },
+    },
+    command_step_hue: {
+        cluster: 'lightingColorCtrl',
+        type: ['commandStepHue'],
+        convert: (model, msg, publish, options, meta) => {
+            const direction = msg.data.stepmode === 1 ? 'up' : 'down';
+            const payload = {
+                action: postfixWithEndpointName(`color_hue_step_${direction}`, msg, model),
+                action_step_size: msg.data.stepsize,
+                action_transition_time: msg.data.transtime/100,
+            };
+            addActionGroup(payload, msg, model);
+            return payload;
+        },
+    },
+    command_step_saturation: {
+        cluster: 'lightingColorCtrl',
+        type: ['commandStepSaturation'],
+        convert: (model, msg, publish, options, meta) => {
+            const direction = msg.data.stepmode === 1 ? 'up' : 'down';
+            const payload = {
+                action: postfixWithEndpointName(`color_saturation_step_${direction}`, msg, model),
+                action_step_size: msg.data.stepsize,
+                action_transition_time: msg.data.transtime/100,
+            };
+            addActionGroup(payload, msg, model);
+            return payload;
+        },
+    },
+    color_stop_raw: {
+        cluster: 'lightingColorCtrl',
+        type: ['raw'],
+        convert: (model, msg, publish, options, meta) => {
+            const payload = {
+                action: postfixWithEndpointName(`color_stop`, msg, model),
+            };
+            addActionGroup(payload, msg, model);
+            return payload;
         },
     },
     HS2SK_SKHMP30I1_power: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1348,6 +1348,34 @@ const converters = {
             return payload;
         },
     },
+    command_step_hue: {
+        cluster: 'lightingColorCtrl',
+        type: ['commandStepHue'],
+        convert: (model, msg, publish, options, meta) => {
+            const direction = msg.data.stepmode === 1 ? 'up' : 'down';
+            const payload = {
+                action: postfixWithEndpointName(`color_hue_step_${direction}`, msg, model),
+                action_step_size: msg.data.stepsize,
+                action_transition_time: msg.data.transtime/100,
+            };
+            addActionGroup(payload, msg, model);
+            return payload;
+        },
+    },
+    command_step_saturation: {
+        cluster: 'lightingColorCtrl',
+        type: ['commandStepSaturation'],
+        convert: (model, msg, publish, options, meta) => {
+            const direction = msg.data.stepmode === 1 ? 'up' : 'down';
+            const payload = {
+                action: postfixWithEndpointName(`color_saturation_step_${direction}`, msg, model),
+                action_step_size: msg.data.stepsize,
+                action_transition_time: msg.data.transtime/100,
+            };
+            addActionGroup(payload, msg, model);
+            return payload;
+        },
+    },
     command_color_loop_set: {
         cluster: 'lightingColorCtrl',
         type: 'commandColorLoopSet',
@@ -2726,34 +2754,6 @@ const converters = {
         type: ['raw'],
         convert: (model, msg, publish, options, meta) => {
             return {action: `scene_${msg.data[msg.data.length - 2] - 9}`};
-        },
-    },
-    command_step_hue: {
-        cluster: 'lightingColorCtrl',
-        type: ['commandStepHue'],
-        convert: (model, msg, publish, options, meta) => {
-            const direction = msg.data.stepmode === 1 ? 'up' : 'down';
-            const payload = {
-                action: postfixWithEndpointName(`color_hue_step_${direction}`, msg, model),
-                action_step_size: msg.data.stepsize,
-                action_transition_time: msg.data.transtime/100,
-            };
-            addActionGroup(payload, msg, model);
-            return payload;
-        },
-    },
-    command_step_saturation: {
-        cluster: 'lightingColorCtrl',
-        type: ['commandStepSaturation'],
-        convert: (model, msg, publish, options, meta) => {
-            const direction = msg.data.stepmode === 1 ? 'up' : 'down';
-            const payload = {
-                action: postfixWithEndpointName(`color_saturation_step_${direction}`, msg, model),
-                action_step_size: msg.data.stepsize,
-                action_transition_time: msg.data.transtime/100,
-            };
-            addActionGroup(payload, msg, model);
-            return payload;
         },
     },
     color_stop_raw: {

--- a/devices.js
+++ b/devices.js
@@ -15429,23 +15429,16 @@ const devices = [
         description: 'Livarno Lux E27 bulb RGB',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
+
+    // ADEO
     {
         zigbeeModel: ['LXEK-5'],
         model: 'HR-C99C-Z-C045',
         vendor: 'ADEO',
-        description: 'RGB CTT LEXMAN ENKI Remote Control',
+        description: 'RGB CTT LEXMAN ENKI remote control',
         fromZigbee: [
-            fz.battery,
-            fz.command_on,
-            fz.command_off,
-            fz.command_step,
-            fz.command_stop,
-            fz.command_step_color_temperature,
-            fz.command_step_hue,
-            fz.command_step_saturation,
-            fz.color_stop_raw,
-            fz.scenes_recall_scene_65024,
-            fz.ignore_genOta,
+            fz.battery, fz.command_on, fz.command_off, fz.command_step, fz.command_stop, fz.command_step_color_temperature,
+            fz.command_step_hue, fz.command_step_saturation, fz.color_stop_raw, fz.scenes_recall_scene_65024, fz.ignore_genOta,
         ],
         toZigbee: [],
         exposes: [e.battery(), e.action([
@@ -15459,13 +15452,8 @@ const devices = [
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            const binds = [
-                'genBasic', 'genOnOff', 'genPowerCfg',
-                'lightingColorCtrl', 'genLevelCtrl',
-                // 'genIdentify', 'haDiagnostic', 'genGroups', 'genOta',
-            ];
+            const binds = ['genBasic', 'genOnOff', 'genPowerCfg', 'lightingColorCtrl', 'genLevelCtrl'];
             await bind(endpoint, coordinatorEndpoint, binds);
-
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -15429,6 +15429,46 @@ const devices = [
         description: 'Livarno Lux E27 bulb RGB',
         extend: generic.light_onoff_brightness_colortemp_colorxy,
     },
+    {
+        zigbeeModel: ['LXEK-5'],
+        model: 'HR-C99C-Z-C045',
+        vendor: 'ADEO',
+        description: 'RGB CTT LEXMAN ENKI Remote Control',
+        fromZigbee: [
+            fz.battery,
+            fz.command_on,
+            fz.command_off,
+            fz.command_step,
+            fz.command_stop,
+            fz.command_step_color_temperature,
+            fz.command_step_hue,
+            fz.command_step_saturation,
+            fz.color_stop_raw,
+            fz.scenes_recall_scene_65024,
+            fz.ignore_genOta,
+        ],
+        toZigbee: [],
+        exposes: [e.battery(), e.action([
+            'on', 'off',
+            'scene_1', 'scene_2', 'scene_3', 'scene_4',
+            'color_saturation_step_up', 'color_saturation_step_down', 'color_stop',
+            'color_hue_step_up', 'color_hue_step_down',
+            'color_temperature_step_up', 'color_temperature_step_down',
+            'brightness_step_up', 'brightness_step_down', 'brightness_stop',
+        ])],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            const binds = [
+                'genBasic', 'genOnOff', 'genPowerCfg',
+                'lightingColorCtrl', 'genLevelCtrl',
+                // 'genIdentify', 'haDiagnostic', 'genGroups', 'genOta',
+            ];
+            await bind(endpoint, coordinatorEndpoint, binds);
+
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
 
     // LightSolutions
     {


### PR DESCRIPTION
Adds support for this (nice and inexpensive) remote https://www.leroymerlin.fr/v3/p/produits/telecommande-pour-ampoules-connectees-rgb-ctt-zigbee-lexman-enki-e1506791204