### PR TITLE
Aqara SSM-UO1 added binding of genDeviceTempCfg to coordinator

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1372,7 +1372,7 @@ const devices = [
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
             await configureReporting.onOff(endpoint);
             // Gives UNSUPPORTED_ATTRIBUTE on readEletricalMeasurementPowerConverterAttributes.
             await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);

--- a/devices.js
+++ b/devices.js
@@ -1365,7 +1365,7 @@ const devices = [
         zigbeeModel: ['lumi.switch.n0agl1'],
         model: 'SSM-U01',
         vendor: 'Xiaomi',
-        supports: 'on/off, power measurement, temperature',
+        description: 'Aqara single switch module T1 (with neutral)',
         fromZigbee: [fz.on_off, fz.metering_power, fz.electrical_measurement_power, fz.device_temperature],
         exposes: [e.switch(), e.energy(), e.power(), e.device_temperature()],
         toZigbee: [tz.on_off],

--- a/devices.js
+++ b/devices.js
@@ -1365,9 +1365,9 @@ const devices = [
         zigbeeModel: ['lumi.switch.n0agl1'],
         model: 'SSM-U01',
         vendor: 'Xiaomi',
-        description: 'Aqara single switch module T1 (with neutral)',
-        fromZigbee: [fz.on_off, fz.metering_power, fz.electrical_measurement_power],
-        exposes: [e.switch(), e.energy(), e.power()],
+        supports: 'on/off, power measurement, temperature',
+        fromZigbee: [fz.on_off, fz.metering_power, fz.electrical_measurement_power, fz.device_temperature],
+        exposes: [e.switch(), e.energy(), e.power(), e.device_temperature()],
         toZigbee: [tz.on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
@@ -1379,6 +1379,7 @@ const devices = [
             await readMeteringPowerConverterAttributes(endpoint);
             await configureReporting.currentSummDelivered(endpoint);
             await configureReporting.activePower(endpoint, {min: 5, max: 600, change: 10});
+            await configureReporting.deviceTemperature(endpoint);
         },
     },
 


### PR DESCRIPTION
The genDeviceTempCfg cluster needs binding to the coordinator for device temperature reporting to work