### PR TITLE
Support for ZBT-DimmableLight by Müller Licht

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9938,13 +9938,16 @@ const devices = [
         toZigbee: generic.light_onoff_brightness.toZigbee.concat([tz.tint_scene]),
     },
     {
-        zigbeeModel: ['ZBT-DimmableLight'],
+        // Identify through fingerprint as modelID is the same as Airam 4713407
+        fingerprint: [
+            {modelID: 'ZBT-DimmableLight', manufacturerName: 'MLI'},
+        ],
         model: '404001',
         vendor: 'Müller Licht',
         description: 'LED bulb E27 806 lumen, dimmable',
         extend: generic.light_onoff_brightness,
         toZigbee: generic.light_onoff_brightness.toZigbee.concat([tz.tint_scene]),
-    },    
+    },
     {
         zigbeeModel: ['ZBT-ExtendedColor'],
         model: '404000/404005/404012',

--- a/devices.js
+++ b/devices.js
@@ -9938,6 +9938,14 @@ const devices = [
         toZigbee: generic.light_onoff_brightness.toZigbee.concat([tz.tint_scene]),
     },
     {
+        zigbeeModel: ['ZBT-DimmableLight'],
+        model: '404001',
+        vendor: 'Müller Licht',
+        description: 'LED bulb E27 806 lumen, dimmable',
+        extend: generic.light_onoff_brightness,
+        toZigbee: generic.light_onoff_brightness.toZigbee.concat([tz.tint_scene]),
+    },    
+    {
         zigbeeModel: ['ZBT-ExtendedColor'],
         model: '404000/404005/404012',
         vendor: 'Müller Licht',


### PR DESCRIPTION
Added ZBT-DimmableLight by Müller Licht, used fingerprint als duplicated zigbeemodel name.