### PR TITLE
Add support for LEDVANCE AC25697

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5143,7 +5143,7 @@ const devices = [
         zigbeeModel: ['A60 RGBW Value II'],
         model: 'AC25697',
         vendor: 'LEDVANCE',
-        description: 'SMART+ CLASSIC E27 RGBW',
+        description: 'SMART+ classic E27 RGBW',
         extend: ledvance.light_onoff_brightness_colortemp_colorhs,
         ota: ota.ledvance,
     },

--- a/devices.js
+++ b/devices.js
@@ -5139,6 +5139,14 @@ const devices = [
         extend: ledvance.light_onoff_brightness_colortemp_colorxy,
         ota: ota.ledvance,
     },
+    {
+        zigbeeModel: ['A60 RGBW Value II'],
+        model: 'AC25697',
+        vendor: 'LEDVANCE',
+        description: 'SMART+ CLASSIC E27 RGBW',
+        extend: ledvance.light_onoff_brightness_colortemp_colorhs,
+        ota: ota.ledvance,
+    },
 
     // Hive
     {


### PR DESCRIPTION
add support for "LEDVANCE SMART+ CLASSIC E27 RGBW" light.

model: AC25697
product code: 4058075208391 (LEDVANCE)

See: https://www.ledvance.com/consumer/products/smart-home/smart-home-products-with-zigbee-technology/smart-home-lamps/classic-lamps-with-zigbee-technology/smart-classic-multicolour/index.jsp

I need some feedback on the "model" tag for this manufacture: In Ledvance section only product codes are used as "model", in OSRAM section the label written on the lamp is used (e.g. "AC10787").  Which one should be used/ is preferred?

Both npm tests mentioned in Readme are passed. Light is working in my setup with homeassistant (on/off, brightness, TW, colors).

