### PR TITLE
Correct "fan only" -> "fan_only" in common.js

### DIFF
--- a/converters/common.js
+++ b/converters/common.js
@@ -15,7 +15,7 @@ const thermostatSystemModes = {
     4: 'heat',
     5: 'emergency heating',
     6: 'precooling',
-    7: 'fan only',
+    7: 'fan_only',
     8: 'dry',
     9: 'Sleep',
 };
@@ -23,7 +23,7 @@ const thermostatRunningStates = {
     0: 'idle',
     1: 'heat',
     2: 'cool',
-    4: 'fan only',
+    4: 'fan_only',
     5: 'heat',
     6: 'cool',
     8: 'heat',


### PR DESCRIPTION
I'm trying to setup a [Zen-01-w](https://www.zigbee2mqtt.io/devices/Zen-01-W.html) thermostat with HomeAssistant + Zigbee2mqtt and noticed that it erroneously isn't reporting the `cool` and `fan_only` modes that it supports. This is already covered in [this](https://github.com/Koenkk/zigbee2mqtt/issues/4320) issue.

I was able to to successfully implement the workaround, but there is a discrepancy in what HomeAssistant refers to the fan-only mode as ([`fan_only`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/climate/const.py#L23)) and how its mapped to Zigbee codes in the changed file in this PR (`fan mode`). I think this is just a typo in `common.js` as the converter expects `fan_only` as seen [here](https://github.com/Koenkk/zigbee-herdsman-converters/blob/bfbf71c6efcbaa1e8f8148f991cfaadefff70247/lib/exposes.js#L249).

The result is that zigbee2mqtt can set the device to `fan_only` mode... and it doesn't do anything because that doesn't map to anything in the common converter. Conversely, setting the thermostat by hand to fan only mode results in `zigbee2mqtt` returning `fan only` as the `systemMode`... which HomeAssistant doesn't understand causing the system mode to display as an unknown state in thermostat widgets.

This will also need to be corrected in the documentation [here](https://github.com/Koenkk/zigbee2mqtt.io/search?p=1&q=fan+only) for all thermostats.

I guess nobody has noticed up to this point because I'm the only weirdo that ever runs their HVAC in fan only mode ¯\\\_(ツ)_/¯