### PR TITLE
Small improvements to scene_add/scene_remove

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3806,7 +3806,9 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const groupid = entity.constructor.name === 'Group' ? entity.groupID : 0;
             const sceneid = value;
-            await entity.command('genScenes', 'remove', {groupid, sceneid}, getOptions(meta.mapped));
+            const response = await entity.command(
+                'genScenes', 'remove', {groupid, sceneid}, getOptions(meta.mapped),
+            );
 
             const isGroup = entity.constructor.name === 'Group';
             const metaKey = `${sceneid}_${groupid}`;
@@ -3819,11 +3821,13 @@ const converters = {
                         }
                     }
                 }
-            } else {
+            } else if (response.status === 0) {
                 if (entity.meta.scenes && entity.meta.scenes.hasOwnProperty(metaKey)) {
                     delete entity.meta.scenes[metaKey];
                     entity.save();
                 }
+            } else {
+                throw new Error(`Scene remove not succesfull ('${common.zclStatus[response.status]}')`);
             }
         },
     },


### PR DESCRIPTION
- scene_remove should wait for response before updating meta
- scene_add should try and remove scene with provided I before adding

See koenkk/zigbee2mqtt#5268 if we do not remove the scene first and we do 2 or more scene_add calls for the same ID, there are unexpected results where the previous payload is not discarded.

```
DEV="0xec1bbdfffeaf89de"
CP="color_temp"
CPV=("250" "454")
#CP="color"
#CPV=("{\"x\":0.3818,\"y\":0.3797}" "{\"x\":0.5018,\"y\":0.4153}")

set -x
mosquitto_pub -t zigbee2mqtt/${DEV}/set  -m "{\"scene_remove\": 22}"
sleep 3
mosquitto_pub -t zigbee2mqtt/${DEV}/set  -m "{\"scene_add\": {\"ID\": 22, \"state\": \"ON\", \"${CP}\": ${CPV[1]}, \"brightness\": 254}}"
sleep 3
mosquitto_pub -t zigbee2mqtt/${DEV}/set  -m "{\"scene_recall\": 22}"
sleep 3
mosquitto_pub -t zigbee2mqtt/${DEV}/set  -m "{\"${CP}\": ${CPV[0]}}"
sleep 3
mosquitto_pub -t zigbee2mqtt/${DEV}/set  -m "{\"scene_add\": {\"ID\": 22, \"state\": \"ON\", \"brightness\": 32}}"
sleep 3
mosquitto_pub -t zigbee2mqtt/${DEV}/set  -m "{\"scene_recall\": 22}"
```

Now works as expected, the final state of the bulb is on at ~12% brightness with a ct of 250, before this change the ct would have been 454, which was not the expected result.