### PR TITLE
Implement #1850: Exposes `action` for Ubisys S1 and S2

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -12895,7 +12895,11 @@ const devices = [
         vendor: 'Ubisys',
         description: 'Power switch S1',
         exposes: [e.switch(), e.power()],
-        fromZigbee: [fz.on_off, fz.metering_power],
+        fromZigbee: [
+            fz.on_off, fz.metering_power,
+            fz.command_toggle, fz.command_on, fz.command_off,
+            fz.command_recall, fz.command_move, fz.command_stop,
+        ],
         toZigbee: [tz.on_off, tz.ubisys_device_setup],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint) => {
@@ -12929,10 +12933,14 @@ const devices = [
         vendor: 'Ubisys',
         description: 'Power switch S2',
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.power()],
-        fromZigbee: [fz.on_off, fz.metering_power],
+        fromZigbee: [
+            fz.on_off, fz.metering_power,
+            fz.command_toggle, fz.command_on, fz.command_off,
+            fz.command_recall, fz.command_move, fz.command_stop,
+        ],
         toZigbee: [tz.on_off, tz.ubisys_device_setup],
         endpoint: (device) => {
-            return {'l1': 1, 'l2': 2};
+            return {'l1': 1, 'l2': 2, 's1': 3, 's2': 4};
         },
         meta: {configureKey: 3, multiEndpoint: true},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -12894,7 +12894,10 @@ const devices = [
         model: 'S1',
         vendor: 'Ubisys',
         description: 'Power switch S1',
-        exposes: [e.switch(), e.power()],
+        exposes: [e.switch(), e.power(), e.action([
+            'toggle', 'on', 'off', 'recall_*',
+            'brightness_move_up', 'brightness_move_down', 'brightness_stop',
+        ])],
         fromZigbee: [
             fz.on_off, fz.metering_power,
             fz.command_toggle, fz.command_on, fz.command_off,
@@ -12932,7 +12935,15 @@ const devices = [
         model: 'S2',
         vendor: 'Ubisys',
         description: 'Power switch S2',
-        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.power()],
+        exposes: [
+            e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
+            e.power(), e.action([
+                'toggle_s1', 'toggle_s2', 'on_s1', 'on_s2', 'off_s1', 'off_s2',
+                'recall_*_s1', 'recal_*_s2', 'brightness_move_up_s1', 'brightness_move_up_s2',
+                'brightness_move_down_s1', 'brightness_move_down_s2',
+                'brightness_stop_s1', 'brightness_stop_s2',
+            ]),
+        ],
         fromZigbee: [
             fz.on_off, fz.metering_power,
             fz.command_toggle, fz.command_on, fz.command_off,


### PR DESCRIPTION
```
Zigbee2MQTT:info  2020-12-13 13:29:44: MQTT publish: topic 'zigbee2mqtt/office/lights/switch', payload '{"action":"toggle","action_group":10110,"linkquality":13,"power":19,"state":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:29:52: MQTT publish: topic 'zigbee2mqtt/office/lights/switch', payload '{"action":"brightness_move_down","action_group":10110,"action_rate":50,"linkquality":60,"power":75,"state":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:29:56: MQTT publish: topic 'zigbee2mqtt/office/lights/switch', payload '{"action":"brightness_stop","action_group":10110,"linkquality":13,"power":14,"state":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:30:05: MQTT publish: topic 'zigbee2mqtt/office/lights/switch', payload '{"action":"brightness_move_up","action_group":10110,"action_rate":50,"linkquality":70,"power":18,"state":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:30:09: MQTT publish: topic 'zigbee2mqtt/office/lights/switch', payload '{"action":"brightness_stop","action_group":10110,"linkquality":42,"power":18,"state":"ON","update":{"state":"idle"}}'


Zigbee2MQTT:info  2020-12-13 13:30:24: MQTT publish: topic 'zigbee2mqtt/livingroom/lights/switch', payload '{"action":"toggle_s1","action_group":10106,"linkquality":52,"power":5,"state_l1":"ON","state_l2":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:31:15: MQTT publish: topic 'zigbee2mqtt/livingroom/lights/switch', payload '{"action":"brightness_move_down_s1","action_group":10106,"action_rate":50,"linkquality":65,"power":6,"state_l1":"ON","state_l2":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:31:19: MQTT publish: topic 'zigbee2mqtt/livingroom/lights/switch', payload '{"action":"brightness_stop_s1","action_group":10106,"linkquality":65,"power":2,"state_l1":"ON","state_l2":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:31:25: MQTT publish: topic 'zigbee2mqtt/livingroom/lights/switch', payload '{"action":"brightness_move_up_s1","action_group":10106,"action_rate":50,"linkquality":68,"power":1,"state_l1":"ON","state_l2":"ON","update":{"state":"idle"}}'
Zigbee2MQTT:info  2020-12-13 13:31:30: MQTT publish: topic 'zigbee2mqtt/livingroom/lights/switch', payload '{"action":"brightness_stop_s1","action_group":10106,"linkquality":55,"power":6,"state_l1":"ON","state_l2":"ON","update":{"state":"idle"}}'
```

I noticed both my S1 and S2 switches had missing converters for command*, they only show up when the endpoints are bound to a group, looks like they are missing in the default binding config or when bound to a group. Still useful to have these.

I opted to use the default fz.command_* and endpoint mapping via postfixWithEndpointName to map the S2's multiple endpoints. This way I did not have to touch `fz.ubosys_c4_*` as they do the mapping in a non-standard way and  did not not to mess with that.

Something similar can probably be done for D1 and J1, but I own neither of those devices.

This closes #1850