### PR TITLE
add PSMP5_00.00.03.15TC to devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8845,7 +8845,7 @@ const devices = [
         exposes: [e.cover_position()],
     },
     {
-        zigbeeModel: ['PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC', 'PSMP5_00.00.05.01TC', 'PSMP5_00.00.05.10TC', 'PSMP5_00.00.03.16TC'],
+        zigbeeModel: ['PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC', 'PSMP5_00.00.05.01TC', 'PSMP5_00.00.05.10TC', 'PSMP5_00.00.03.15TC', 'PSMP5_00.00.03.16TC'],
         model: 'PSM-29ZBSR',
         vendor: 'Climax',
         description: 'Power plug',

--- a/devices.js
+++ b/devices.js
@@ -8845,7 +8845,10 @@ const devices = [
         exposes: [e.cover_position()],
     },
     {
-        zigbeeModel: ['PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC', 'PSMP5_00.00.05.01TC', 'PSMP5_00.00.05.10TC', 'PSMP5_00.00.03.15TC', 'PSMP5_00.00.03.16TC'],
+        zigbeeModel: [
+            'PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC', 'PSMP5_00.00.05.01TC',
+            'PSMP5_00.00.05.10TC', 'PSMP5_00.00.03.15TC', 'PSMP5_00.00.03.16TC'
+        ],
         model: 'PSM-29ZBSR',
         vendor: 'Climax',
         description: 'Power plug',

--- a/devices.js
+++ b/devices.js
@@ -8847,7 +8847,7 @@ const devices = [
     {
         zigbeeModel: [
             'PSM_00.00.00.35TC', 'PSMP5_00.00.02.02TC', 'PSMP5_00.00.05.01TC',
-            'PSMP5_00.00.05.10TC', 'PSMP5_00.00.03.15TC', 'PSMP5_00.00.03.16TC'
+            'PSMP5_00.00.05.10TC', 'PSMP5_00.00.03.15TC', 'PSMP5_00.00.03.16TC',
         ],
         model: 'PSM-29ZBSR',
         vendor: 'Climax',


### PR DESCRIPTION
I have Climax plug, that is identified as `PSMP5_00.00.03.15TC`. I have to modify devices everytime I want to use that plug, so it would be good to have it there by default.