### PR TITLE
Add Yale YRD216-HA2-619 Assure Lock

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10740,6 +10740,22 @@ const devices = [
         },
         exposes: [e.lock(), e.battery()],
     },
+    {
+        zigbeeModel: ['YRD216 PBDB'],
+        model: 'YRD216-HA2-619',
+        vendor: 'Yale',
+        description: 'Assure Lock - Push Button',
+        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery],
+        toZigbee: [tz.generic_lock],
+        meta: {configureKey: 3},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await configureReporting.lockState(endpoint);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+        exposes: [e.lock(), e.battery()],
+    },
 
     // JAVIS
     {


### PR DESCRIPTION
Adds support for the Yale YRD216-HA2-619 Push Button Assure Lock.

Tested using the 1.16.1 and 1.16.2 tagged containers. 