### PR TITLE
On branch bht-002-gclzb-sensor-tuning

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3123,13 +3123,13 @@ const converters = {
         key: ['sensor'],
         convertSet: async (entity, key, value, meta) => {
             if (typeof value === 'string') {
-                if (value === 'IN') value = 0;
-                else if (value === 'AL') value = 1;
-                else if (value === 'OU') value = 2;
-                else value = -1;
+                const lookup = {'IN': 0, 'AL': 1, 'OU': 2};
+                value = lookup.hasOwnProperty(value) ? lookup[value] : -1;
             }
             if ((typeof value === 'number') && (value >=0) && (value <=2)) {
                 await sendTuyaDataPointEnum(entity, common.TuyaDataPoints.moesSensor, value);
+            } else {
+                throw new Error(`Unsupported value: ${value}`);
             }
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3118,10 +3118,19 @@ const converters = {
         },
     },
     // send an mqtt message to topic '/sensor' to change the temperature sensor setting - options [0=IN|1=AL|2=OU]
+    // and string values is allowed too
     moes_thermostat_sensor: {
         key: ['sensor'],
         convertSet: async (entity, key, value, meta) => {
-            await sendTuyaDataPointEnum(entity, common.TuyaDataPoints.moesSensor, value);
+            if (typeof value === 'string') {
+                if (value === 'IN') value = 0;
+                else if (value === 'AL') value = 1;
+                else if (value === 'OU') value = 2;
+                else value = -1;
+            }
+            if ((typeof value === 'number') && (value >=0) && (value <=2)) {
+                await sendTuyaDataPointEnum(entity, common.TuyaDataPoints.moesSensor, value);
+            }
         },
     },
     etop_thermostat_system_mode: {


### PR DESCRIPTION
Added possibility to process string values 'IN','AL' and 'OU' in parallel
with the numeric ones 0,1,2 in toZigbee to be comply with the data returned
by fromZigbee. (see the [issue](https://github.com/Koenkk/zigbee-herdsman-converters/issues/1905) discussion)

Changes to be committed:
	modified:   converters/toZigbee.js

Fixes #1905 