### PR TITLE
Ignore reserved bits in occupancy condition

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -807,7 +807,7 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             if (msg.data.hasOwnProperty('occupancy')) {
-                return {occupancy: msg.data.occupancy === 1};
+                return {occupancy: (msg.data.occupancy % 2) > 0};
             }
         },
     },


### PR DESCRIPTION
The cluster attribute is described as follow:

4.8.2.2.1.1 Occupancy Attribute
The Occupancy attribute is a bitmap: map8 0b0000 000x RP - M
Bit 0 specifies the sensed occupancy as follows: 1 = occupied, 0 = unoccupied.
All other bits are reserved.

This change is proposed to ignore reserved bits that can be used by some vendors.