### PR TITLE
adds TS0601 model to NAS-AB02B0

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2213,7 +2213,8 @@ const devices = [
 
     // Neo
     {
-        zigbeeModel: ['0yu2xgi', 'TS0601'],
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_d0yu2xgi'}],
+        zigbeeModel: ['0yu2xgi'],
         model: 'NAS-AB02B0',
         vendor: 'Neo',
         description: 'Temperature & humidity sensor and alarm',

--- a/devices.js
+++ b/devices.js
@@ -2213,7 +2213,7 @@ const devices = [
 
     // Neo
     {
-        zigbeeModel: ['0yu2xgi'],
+        zigbeeModel: ['0yu2xgi', 'TS0601'],
         model: 'NAS-AB02B0',
         vendor: 'Neo',
         description: 'Temperature & humidity sensor and alarm',


### PR DESCRIPTION
I have a zigbee siren which looks exactly the same as https://www.zigbee2mqtt.io/devices/NAS-AB02B0.html
Added the model `TS0601` to the same device and now mine is also supported, everything seems to work fine.