### PR TITLE
Fix IKEA Controller toggle button after refactor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2594,6 +2594,13 @@ const converters = {
             return converters.occupancy_with_timeout.convert(model, msg, publish, options, meta);
         },
     },
+    E1524_E1810_toggle: {
+        cluster: 'genOnOff',
+        type: 'commandToggle',
+        convert: (model, msg, publish, options, meta) => {
+            return {action: postfixWithEndpointName('toggle', msg, model)};
+        },
+    },
     E1524_E1810_arrow_click: {
         cluster: 'genScenes',
         type: 'commandTradfriArrowSingle',
@@ -2634,7 +2641,7 @@ const converters = {
         cluster: 'genLevelCtrl',
         type: [
             'commandStepWithOnOff', 'commandStep', 'commandMoveWithOnOff', 'commandStopWithOnOff', 'commandMove', 'commandStop',
-            'commandMoveToLevelWithOnOff', 'commandToggle',
+            'commandMoveToLevelWithOnOff',
         ],
         convert: (model, msg, publish, options, meta) => {
             const lookup = {
@@ -2645,7 +2652,6 @@ const converters = {
                 commandMove: 'brightness_down_hold',
                 commandStop: 'brightness_down_release',
                 commandMoveToLevelWithOnOff: 'toggle_hold',
-                commandToggle: 'toggle',
             };
             return {action: lookup[msg.type]};
         },

--- a/devices.js
+++ b/devices.js
@@ -2611,7 +2611,8 @@ const devices = [
         description: 'TRADFRI remote control',
         vendor: 'IKEA',
         fromZigbee: [
-            fz.battery, fz.E1524_E1810_levelctrl, fz.E1524_E1810_arrow_click, fz.E1524_E1810_arrow_hold, fz.E1524_E1810_arrow_release,
+            fz.battery, fz.E1524_E1810_toggle, fz.E1524_E1810_levelctrl, fz.E1524_E1810_arrow_click, fz.E1524_E1810_arrow_hold,
+            fz.E1524_E1810_arrow_release,
         ],
         exposes: [e.battery(), e.action([
             'toggle', 'arrow_left_click', 'arrow_right_click', 'arrow_left_hold', 'arrow_right_hold', 'arrow_left_release',


### PR DESCRIPTION
Toggle button was incorrectly placed in `genLevelCtrl' endpoint instead of 'genOnOff'