### PR TITLE
Add lock_state to features of lock type in exposes information

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10656,7 +10656,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRD226 TSDB'],
@@ -10672,7 +10672,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRD256 TSDB'],
@@ -10688,7 +10688,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['iZBModule01', '0700000001'],
@@ -10705,7 +10705,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.battery(), e.lock(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRD210 PB DB'],
@@ -10721,7 +10721,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRL220 TS LL'],
@@ -10738,7 +10738,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRD226/246 TSDB'],
@@ -10754,7 +10754,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRD220/240 TSDB'],
@@ -10770,7 +10770,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRD246 TSDB'],
@@ -10786,7 +10786,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['YRD216 PBDB'],
@@ -10802,7 +10802,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
 
     // JAVIS
@@ -10834,7 +10834,7 @@ const devices = [
         },
         // Note - Keypad triggered deletions do not cause a zigbee event, though Adds work fine.
         onEvent: pincodeLock.readPinCodeAfterProgramming,
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['SMARTCODE_DEADBOLT_10T'],
@@ -10850,7 +10850,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
 
     // Keen Home
@@ -11591,7 +11591,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
 
     // NET2GRID
@@ -14477,7 +14477,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['SMARTCODE_DEADBOLT_10_L'],
@@ -14493,7 +14493,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['SMARTCODE_DEADBOLT_5'],
@@ -14511,7 +14511,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
     {
         zigbeeModel: ['SMARTCODE_DEADBOLT_5_L'],
@@ -14527,7 +14527,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
 
     // Schlage
@@ -14545,7 +14545,7 @@ const devices = [
             await configureReporting.lockState(endpoint);
             await configureReporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_state()],
+        exposes: [e.lock(), e.battery()],
     },
 
     // HORNBACH

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -64,6 +64,12 @@ class Lock extends Base {
         this.features.push(new Binary('state', access.ALL, valueOn, valueOff).withProperty(property).withDescription(description));
         return this;
     }
+
+    withLockState(property, description) {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        this.features.push(new Enum('lock_state', access.STATE, ['not_fully_locked', 'locked', 'unlocked']).withProperty(property).withDescription(description));
+        return this;
+    }
 }
 
 class Binary extends Base {
@@ -338,8 +344,7 @@ module.exports = {
         light_colorhs: () => new Light().withColor(['hs']),
         linkquality: () => new Numeric('linkquality', access.STATE).withUnit('lqi').withDescription('Link quality (signal strength)').withValueMin(0).withValueMax(255),
         local_temperature: () => new Numeric('local_temperature', access.STATE_GET).withUnit('°C').withDescription('Current temperature measured on the device'),
-        lock: () => new Lock().withState('state', 'LOCK', 'UNLOCK', 'State of the lock'),
-        lock_state: () => new Enum('lock_state', access.STATE, ['not_fully_locked', 'locked', 'unlocked']).withDescription('State of the lock'),
+        lock: () => new Lock().withState('state', 'LOCK', 'UNLOCK', 'State of the lock').withLockState('lock_state', 'Actual state of the lock'),
         occupancy: () => new Binary('occupancy', access.STATE, true, false).withDescription('Indicates whether the device detected occupancy'),
         pm10: () => new Numeric('pm10', access.STATE).withUnit('µg/m³').withDescription('Measured PM10 (particulate matter) concentration'),
         pm25: () => new Numeric('pm25', access.STATE).withUnit('µg/m³').withDescription('Measured PM2.5 (particulate matter) concentration'),


### PR DESCRIPTION
As mentioned in the comments of #1908, given that the `lock_state` is always present in a lock, I think it should be part of the lock type in the exposes information.