### PR TITLE
Added support for Philips Hue Iris (Generation 4) Copper

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3680,6 +3680,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['929002376801'],
+        model: '929002376801',
+        vendor: 'Philips',
+        description: 'Hue Iris (generation 4)',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['1742930P7'],
         model: '1742930P7',
         vendor: 'Philips',


### PR DESCRIPTION
Added support for [Hue Iris gen 4 Copper limited edition](https://www.philips-hue.com/en-gb/p/hue-white-and-colour-ambiance-iris-copper-limited-edition/8719514264564). 'zigbeeModel' is the same as 'Material number (12NC)' in the product specifications: 929002376801. Each color of the 4th gen seem to have different third last digit in the specs, but I can only confirm this one.