### PR TITLE
Add support for Philips Giant Globe

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3212,6 +3212,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LWO003'],
+        model: '929001873401',
+        vendor: 'Philips',
+        description: 'Hue white Filament bulb G125 E27 bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LST001'],
         model: '7299355PH',
         vendor: 'Philips',


### PR DESCRIPTION
I have copied the configuration for the Philips Globe (G93) to the Giant Globe (G125): supposedly, they are technically equal.

As for the model number, I am not sure.

The web site https://www.philips-hue.com/en-gb/p/hue-white-filament-1-pack-g125-e27-filament-globe/8719514279131
lists an EAN/UPC 8719514279131 and Material number 929002459001

I entered the first one, but I am not sure about the meaning. Please feel free to comment and ask for changes.