### PR TITLE
Added support Namron 89665

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7730,6 +7730,7 @@ const devices = [
         meta: {turnsOffAtBrightness1: true},
         extend: hue.light_onoff_brightness_colortemp_colorxy,
     },
+
     // SmartThings
     {
         zigbeeModel: ['PGC313'],

--- a/devices.js
+++ b/devices.js
@@ -7722,7 +7722,14 @@ const devices = [
         description: 'LED 5,3W CCT E14',
         extend: generic.light_onoff_brightness_colortemp,
     },
-
+    {
+        zigbeeModel: ['89665'],
+        model: '89665',
+        vendor: 'Namron',
+        description: 'LED Strip RGB+W (5m) IP20',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hue.light_onoff_brightness_colortemp_colorxy,
+    },
     // SmartThings
     {
         zigbeeModel: ['PGC313'],


### PR DESCRIPTION
Added support for Namron 89665 LED Strip RGB+W (5m) IP20. Philips Hue compatible.

