### PR TITLE
Support for Namron 3802962 RGBW E27 bulb

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6997,6 +6997,14 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['3802962'],
+        model: '3802962',
+        vendor: 'Namron',
+        description: 'LED 9W RGBW E27',
+        meta: {turnsOffAtBrightness1: true},
+        extend: preset.light_onoff_brightness_colortemp_colorxy,
+    },
+    {
         zigbeeModel: ['3802964'],
         model: '3802964',
         vendor: 'Namron',


### PR DESCRIPTION
Support for Namron 3802962 E27 RGBW bulb.
The shop I bought this device from lists it as 9.5W, however the packaging says 9W.