### PR TITLE
For bht-002-gclzb replacement the 'preset' key for toZigbee by 'preset_mode' to make it identical with fromZigbee

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3129,7 +3129,7 @@ const converters = {
         },
     },
     moes_thermostat_mode: {
-        key: ['preset_mode'], // to make it identical with fromZigbee
+        key: ['preset', 'preset_mode'], // to make it identical with fromZigbee
         convertSet: async (entity, key, value, meta) => {
             const hold = value === 'hold' ? 0 : 1;
             const schedule = value === 'program' ? 0 : 1;

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3129,7 +3129,7 @@ const converters = {
         },
     },
     moes_thermostat_mode: {
-        key: ['preset'],
+        key: ['preset_mode'], // to make it identical with fromZigbee
         convertSet: async (entity, key, value, meta) => {
             const hold = value === 'hold' ? 0 : 1;
             const schedule = value === 'program' ? 0 : 1;


### PR DESCRIPTION
For bht-002-gclzb replacement the 'preset' key for toZigbee by 'preset_mode' to make it identical with fromZigbee
