### PR TITLE
Add support for TRADFRI bulb GU10 CWS 345lm (LED1923R5)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2311,7 +2311,7 @@ const devices = [
         model: 'LED1923R5',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb GU10 345 lumen, dimmable, white spectrum, colour spectrum',
-        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        extend: preset.light_onoff_brightness_colortemp_colorxy,
         ota: ota.tradfri,
     },
 

--- a/devices.js
+++ b/devices.js
@@ -2306,6 +2306,14 @@ const devices = [
         ota: ota.tradfri,
         extend: preset.light_onoff_brightness_colortemp,
     },
+    {
+        zigbeeModel: ['TRADFRI bulb GU10 CWS 345lm'],
+        model: 'LED1923R5',
+        vendor: 'IKEA',
+        description: 'TRADFRI LED bulb GU10 345 lumen, dimmable, white spectrum, colour spectrum',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.tradfri,
+    },
 
     // Philips
     {


### PR DESCRIPTION
https://www.ikea.lv/en/products////tradfri-led-bulb-gu10-345-lumen-colour-and-white-spectrum-art-80439228
