### PR TITLE
Add support for LEDVANCE DIM - AC25706

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4589,6 +4589,15 @@ const devices = [
         extend: preset.ledvance.light_onoff_brightness_colortemp,
         ota: ota.ledvance,
     },
+    {
+        zigbeeModel: ['LEDVANCE DIM'],
+        model: '4058075208421',
+        vendor: 'LEDVANCE',
+        description: 'SMART+ candle E14 tunable white',
+        extend: ledvance.light_onoff_brightness,
+        ota: ota.ledvance,
+    },
+
 
     // Hive
     {


### PR DESCRIPTION
I added configuration for "LEDVANCE DIM".

On the bulb a product code is printed: "AC25706"
The packaging states : "4058075208421"
zigbee2mqtt-logs states: "LEDVANCE DIM"

adding these settings to devices.js made it work for me. 