### PR TITLE
Adding support for Ledvance ac25706

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4598,8 +4598,6 @@ const devices = [
         ota: ota.ledvance,
     },
 
-
-
     // Hive
     {
         zigbeeModel: ['MOT003'],

--- a/devices.js
+++ b/devices.js
@@ -4589,6 +4589,9 @@ const devices = [
         extend: preset.ledvance.light_onoff_brightness_colortemp,
         ota: ota.ledvance,
     },
+    {
+        zigbeeModel: ['LEDVANCE DIM'],
+        model: '4058075208421',
         vendor: 'LEDVANCE',
         description: 'SMART+ candle E14 tunable white',
         extend: preset.ledvance.light_onoff_brightness,

--- a/devices.js
+++ b/devices.js
@@ -4589,6 +4589,13 @@ const devices = [
         extend: preset.ledvance.light_onoff_brightness_colortemp,
         ota: ota.ledvance,
     },
+        vendor: 'LEDVANCE',
+        description: 'SMART+ candle E14 tunable white',
+        extend: preset.ledvance.light_onoff_brightness,
+        ota: ota.ledvance,
+    },
+
+
 
     // Hive
     {


### PR DESCRIPTION
I added configuration for "LEDVANCE DIM".

On the bulb a product code is printed: "AC25706"
The packaging states : "4058075208421"
zigbee2mqtt-logs states: "LEDVANCE DIM"

adding these settings to devices.js made it work for me.