### PR TITLE
New fingerprint for Immax 07703L 

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9827,6 +9827,7 @@ const devices = [
     },
     {
         zigbeeModel: ['losfena'],
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_wlosfena'}],
         model: '07703L',
         vendor: 'Immax',
         description: 'Radiator valve',


### PR DESCRIPTION
Hi, I just wanted to add my new Immax 07703L radiator valve, which shows as model TS0601 and manufacturer _TZE200_wlosfena.

Error message: "Received message from unsupported device with Zigbee model 'TS0601' and manufacturer name '_TZE200_wlosfena'"