### PR TITLE
Innr RS 230 C supports hue/sat

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5043,7 +5043,8 @@ const devices = [
         vendor: 'Innr',
         description: 'GU10 spot 350 lm, dimmable, RGBW',
         extend: preset.light_onoff_brightness_colortemp_colorxy,
-        meta: {applyRedFix: true, turnsOffAtBrightness1: true},
+        exposes: [e.light_brightness_colortemp_colorxyhs()],
+        meta: {enhancedHue: false, applyRedFix: true, turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['RB 145'],


### PR DESCRIPTION
Recently got an Innr RS 230 C to play with, the spot also support Hue/Sat.

I guess this might be the case for all color bulbs from Innr, but I don't own any strips.