### PR TITLE
Use consistent naming of Centralite devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8064,7 +8064,7 @@ const devices = [
     {
         zigbeeModel: ['3400-D', '3400'],
         model: '3400-D',
-        vendor: 'CentraLite',
+        vendor: 'Centralite',
         description: '3-Series security keypad',
         meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
         fromZigbee: [fz.command_arm_with_transaction, fz.temperature, fz.battery],


### PR DESCRIPTION
I'm not sure if this vendor property is important for the device to work properly but the different case types break the Table on the documenation page.

![image](https://user-images.githubusercontent.com/2886913/103233633-dc224c00-493d-11eb-92f0-9a63c12200e3.png)


A quick google search suggest that Centralite is the correct case and not CentraLite.