### PR TITLE
HEIMAN HS2CM-N-DC curtain new device id

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8997,7 +8997,7 @@ const devices = [
             e.device_temperature()],
     },
     {
-        zigbeeModel: ['CurtainMo-EF'],
+        zigbeeModel: ['CurtainMo-EF-3.0', 'CurtainMo-EF'],
         model: 'HS2CM-N-DC',
         vendor: 'HEIMAN',
         description: 'Gear window shade motor',


### PR DESCRIPTION
HS2CM-N-DC curtain motor is now also announcing as CurtainMo-EF-3.0.