### PR TITLE
Fix empty position value of the tuya curtain

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1378,7 +1378,7 @@ const converters = {
             case tuya.dataPoints.coverChange: // Started moving (triggered by transmitter oder pulling on curtain)
                 return {running: true};
             case tuya.dataPoints.coverArrived: { // Arrived at position
-                const position = options.invert_cover ? value : 100 - value;
+                const position = options.invert_cover ? (value & 0xFF) : 100 - (value & 0xFF);
 
                 if (position > 0 && position <= 100) {
                     return {running: false, position: position};


### PR DESCRIPTION
after change the position, TS0601 curtain returns 4 bytes with dp3
some cases this data has extra value in the second byte like;

`00 64 00 1b`

a last byte is position value, it would be safe with `& 0xFF` operation