### PR TITLE
Support for Sinope RM3250ZB 50 amps load controller

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11593,6 +11593,27 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['RM3250ZB'],
+        model: 'RM3250ZB',
+        vendor: 'Sinope',
+        description: '50A Smart Electrical Load Controller',
+        fromZigbee: [fz.on_off, fz.electrical_measurement_power, fz.metering_power],
+        toZigbee: [tz.on_off],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await configureReporting.onOff(endpoint);
+            await readEletricalMeasurementPowerConverterAttributes(endpoint);
+            await configureReporting.activePower(endpoint);
+            await configureReporting.rmsCurrent(endpoint);
+            await configureReporting.rmsVoltage(endpoint);
+            await readMeteringPowerConverterAttributes(endpoint);
+            await configureReporting.currentSummDelivered(endpoint);
+        },
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
+    },
+    {
         zigbeeModel: ['WL4200'],
         model: 'WL4200',
         vendor: 'Sinope',

--- a/devices.js
+++ b/devices.js
@@ -11602,7 +11602,7 @@ const devices = [
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint);

--- a/devices.js
+++ b/devices.js
@@ -11596,8 +11596,8 @@ const devices = [
         zigbeeModel: ['RM3250ZB'],
         model: 'RM3250ZB',
         vendor: 'Sinope',
-        description: '50A Smart Electrical Load Controller',
-        fromZigbee: [fz.on_off, fz.electrical_measurement_power, fz.metering_power],
+        description: '50A Smart electrical load controller',
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
         toZigbee: [tz.on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices.js
+++ b/devices.js
@@ -11603,13 +11603,13 @@ const devices = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
-            await configureReporting.onOff(endpoint);
-            await readEletricalMeasurementPowerConverterAttributes(endpoint);
-            await configureReporting.activePower(endpoint);
-            await configureReporting.rmsCurrent(endpoint);
-            await configureReporting.rmsVoltage(endpoint);
-            await readMeteringPowerConverterAttributes(endpoint);
-            await configureReporting.currentSummDelivered(endpoint);
+            await reporting.onOff(endpoint);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.activePower(endpoint);
+            await reporting.rmsCurrent(endpoint);
+            await reporting.rmsVoltage(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint);
         },
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
     },


### PR DESCRIPTION
Add support for Sinope RM3250ZB 50 amps load controller.

This has been tested successfully with the device.