### PR TITLE
Typo in spelling of triple in action enum values

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -217,7 +217,7 @@ const devices = [
         description: 'MiJia wireless switch',
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         fromZigbee: [fz.xiaomi_battery, fz.xiaomi_WXKG01LM_action, fz.legacy.WXKG01LM_click],
-        exposes: [e.battery(), e.action(['single', 'double', 'tripple', 'quadruple', 'hold', 'release'])],
+        exposes: [e.battery(), e.action(['single', 'double', 'triple', 'quadruple', 'hold', 'release'])],
         toZigbee: [],
     },
     {
@@ -226,7 +226,7 @@ const devices = [
         vendor: 'Xiaomi',
         description: 'Aqara wireless switch',
         meta: {battery: {voltageToPercentage: '3V_2100'}},
-        exposes: [e.battery(), e.action(['single', 'double', 'tripple', 'quadruple', 'hold', 'release'])],
+        exposes: [e.battery(), e.action(['single', 'double', 'triple', 'quadruple', 'hold', 'release'])],
         fromZigbee: [fz.xiaomi_multistate_action, fz.xiaomi_WXKG11LM_action, fz.xiaomi_battery,
             fz.legacy.WXKG11LM_click, fz.legacy.xiaomi_action_click_multistate],
         toZigbee: [],
@@ -3856,7 +3856,7 @@ const devices = [
             exposes.text('', exposes.access.STATE).withEndpoint('l6').withProperty('l6'),
             exposes.text('', exposes.access.STATE).withEndpoint('l7').withProperty('l7'),
             exposes.text('', exposes.access.STATE).withEndpoint('l8').withProperty('l8'),
-            e.temperature(), e.voltage(), e.pressure(), e.humidity(), e.action(['single', 'double', 'triple', 'hold'])],
+            e.temperature(), e.voltage(), e.pressure(), e.humidity(), e.action(['single', 'double', 'tripple', 'hold'])],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
             return {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5, l6: 6, l7: 7, l8: 8, action: 1};


### PR DESCRIPTION
The correct spelling is "triple", not "tripple".
Unfortunately, it seems the following converters have a typo in them:
 - `ptvo_multistate_action`
 - `qlwz_letv8key_switch`

I decided to only update the exposes information and *not* fix the typo in the converters, as this might break existing automations.
The exposes information should now contain the same spelling as the converter uses.