### PR TITLE
Ikea E1743 loses bind/reporting after powerloss

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2093,6 +2093,7 @@ const devices = [
             await reporting.batteryPercentageRemaining(endpoint);
         },
         ota: ota.tradfri,
+        onEvent: ikea.batteryDeviceOnEvent,
     },
     {
         zigbeeModel: ['TRADFRI transformer 10W', 'TRADFRI Driver 10W'],
@@ -2187,6 +2188,7 @@ const devices = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },
+        onEvent: ikea.batteryDeviceOnEvent,
     },
     {
         zigbeeModel: ['TRADFRI on/off switch'],
@@ -2209,6 +2211,7 @@ const devices = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },
+        onEvent: ikea.batteryDeviceOnEvent,
     },
     {
         zigbeeModel: ['TRADFRI SHORTCUT Button'],
@@ -2228,6 +2231,7 @@ const devices = [
             await reporting.bind(endpoint, defaultBindGroup, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },
+        onEvent: ikea.batteryDeviceOnEvent,
     },
     {
         zigbeeModel: ['SYMFONISK Sound Controller'],
@@ -2245,6 +2249,7 @@ const devices = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genLevelCtrl', 'genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },
+        onEvent: ikea.batteryDeviceOnEvent,
     },
     {
         zigbeeModel: ['TRADFRI motion sensor'],
@@ -2263,6 +2268,7 @@ const devices = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },
+        onEvent: ikea.batteryDeviceOnEvent,
     },
     {
         zigbeeModel: ['TRADFRI signal repeater'],
@@ -2331,6 +2337,7 @@ const devices = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },
+        onEvent: ikea.batteryDeviceOnEvent,
     },
     {
         zigbeeModel: ['GUNNARP panel round'],

--- a/lib/ikea.js
+++ b/lib/ikea.js
@@ -2,7 +2,7 @@ async function bulbOnEvent(type, data, device) {
     /**
      * IKEA bulbs lose their configured reportings when losing power.
      * A deviceAnnounce indicates they are powered on again.
-     * Reconfigure the configured reoprting here.
+     * Reconfigure the configured reporting here.
      * NOTE: binds are not lost so rebinding is not needed!
      */
     if (type === 'deviceAnnounce') {
@@ -17,6 +17,34 @@ async function bulbOnEvent(type, data, device) {
     }
 }
 
+async function batteryDeviceOnEvent(type, data, device) {
+    /**
+     * IKEA battery deivces sometimes lose the bind and
+     * reporting configuration after replacing the battery.
+     * A deviceAnnounce indicates they are powered on again.
+     * Reconfigure the bind and reporting here.
+     */
+    if (type === 'deviceAnnounce') {
+        for (const endpoint of device.endpoints) {
+            const b = endpoint.binds.find((b) => b.cluster.name === 'genPowerCfg');
+            if (b) {
+                await endpoint.bind('genPowerCfg', b.target);
+            }
+
+            const c = endpoint.configuredReportings.find(
+                (c) => c.cluster.name === 'genPowerCfg' && c.attribute.name === 'batteryPercentageRemaining',
+            );
+            if (c) {
+                await endpoint.configureReporting(c.cluster.name, [{
+                    attribute: c.attribute.name, minimumReportInterval: c.minimumReportInterval,
+                    maximumReportInterval: c.maximumReportInterval, reportableChange: c.reportableChange,
+                }]);
+            }
+        }
+    }
+}
+
 module.exports = {
     bulbOnEvent,
+    batteryDeviceOnEvent,
 };


### PR DESCRIPTION
This should fix #5477

Unfortunately I had issues doing the remind manually/via the frontend so I ended up repairing the device instead. But it was confirmed by @MattWestb that a rebind was also needed in addition to a re-reporting setup.

I wonder if we should also do this for:
- E1812: shortcut button
- E1524/E1810: 5 button puck