### PR TITLE
support colorTempPhysicalMin/Max

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3535,6 +3535,9 @@ const converters = {
                      *
                      * See https://github.com/Koenkk/zigbee2mqtt/issues/4926#issuecomment-735947705
                      */
+                    const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
+                    val = light.clampColorTemp(val, colorTempMin, colorTempMax, meta.logger);
+
                     const xy = utils.miredsToXY(val);
                     extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [Math.round(xy.x * 65535), Math.round(xy.y * 65535)]});
                     state['color_temp'] = val;

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -566,9 +566,49 @@ const converters = {
     light_colortemp: {
         key: ['color_temp', 'color_temp_percent'],
         convertSet: async (entity, key, value, meta) => {
+            let colorTempMin;
+            let colorTempMax;
+            if (entity.constructor.name === 'Group' && entity.members.length > 0) {
+                for (const m of entity.members) {
+                    const memberColorTempMin = m.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMin');
+                    const memberColorTempMax = m.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMax');
+
+                    /*
+                     * For groups we want the value to be in range for all devices
+                     * So we grab the highest min and lowest max so we are OK in mixed groups.
+                     */
+                    if ((memberColorTempMin !== undefined) && (memberColorTempMax !== undefined)) {
+                        if ((colorTempMin === undefined) || (memberColorTempMin > colorTempMin)) {
+                            colorTempMin = memberColorTempMin;
+                        }
+                        if ((colorTempMax === undefined) || (memberColorTempMax < colorTempMax)) {
+                            colorTempMax = memberColorTempMax;
+                        }
+                    } else {
+                        meta.logger.warn(`Missing colorTempPhysicalMin and/or colorTempPhysicalMax for ${m.deviceIeeeAddress}!`);
+                    }
+                }
+            } else {
+                colorTempMin = entity.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMin');
+                colorTempMax = entity.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMax');
+                if ((colorTempMin === undefined) || (colorTempMax === undefined)) {
+                    meta.logger.warn(`Missing colorTempPhysicalMin and/or colorTempPhysicalMax for ${entity.deviceIeeeAddress}!`);
+                }
+            }
+
             if (key === 'color_temp_percent') {
                 value = Number(value) * 3.46;
                 value = Math.round(value + 154).toString();
+            }
+
+            // ensure value withing range
+            if ((colorTempMin !== undefined) && (value < colorTempMin)) {
+                meta.logger.warn(`Requested color_temp ${value} is lower than minimum supported ${colorTempMin}, using minimum!`);
+                value = colorTempMin;
+            }
+            if ((colorTempMax !== undefined) && (value > colorTempMax)) {
+                meta.logger.warn(`Requested color_temp ${value} is higher than maximum supported ${colorTempMax}, using maximum!`);
+                value = colorTempMax;
             }
 
             value = Number(value);

--- a/devices.js
+++ b/devices.js
@@ -11016,12 +11016,6 @@ const devices = [
         vendor: 'Iluminize',
         description: 'ZigBee 3.0 LED-controller, 4 channel 5A, RGBW LED',
         extend: preset.light_onoff_brightness_colortemp_colorxy,
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(endpoint);
-        },
     },
     {
         zigbeeModel: ['ZG2819S-RGBW'],

--- a/devices.js
+++ b/devices.js
@@ -40,6 +40,7 @@ const constants = require('./lib/constants');
 const livolo = require('./lib/livolo');
 const legrand = require('./lib/legrand');
 const xiaomi = require('./lib/xiaomi');
+const light = require('./lib/light');
 const {repInterval, defaultBindGroup, OneJanuary2000} = require('./lib/constants');
 const reporting = require('./lib/reporting');
 
@@ -66,6 +67,12 @@ const preset = {
             tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
             tz.light_colortemp_step,
         ],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await light.readColorCapabilities(endpoint);
+            await light.readColorTempMinMax(endpoint);
+        },
     },
     light_onoff_brightness_colorxy: {
         exposes: [e.light_brightness_colorxy(), e.effect()],
@@ -75,6 +82,11 @@ const preset = {
             tz.light_brightness_move, tz.light_brightness_step,
             tz.light_hue_saturation_move, tz.light_hue_saturation_step,
         ],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await light.readColorCapabilities(endpoint);
+        },
     },
     light_onoff_brightness_colortemp_colorxy: {
         exposes: [e.light_brightness_colortemp_colorxy(), e.effect()],
@@ -84,6 +96,12 @@ const preset = {
             tz.effect, tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
             tz.light_colortemp_step, tz.light_hue_saturation_move, tz.light_hue_saturation_step,
         ],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await light.readColorCapabilities(endpoint);
+            await light.readColorTempMinMax(endpoint);
+        },
     },
 };
 {

--- a/devices.js
+++ b/devices.js
@@ -28,6 +28,7 @@
  *    {voltageToPercentage: '3V_2100'}: convert voltage to percentage using specified option. See utils.batteryVoltageToPercentage()
  */
 
+const assert = require('assert');
 const fz = {...require('./converters/fromZigbee'), legacy: require('./lib/legacy').fromZigbee};
 const tz = require('./converters/toZigbee');
 const utils = require('./lib/utils');
@@ -14909,14 +14910,21 @@ const devices = [
 
 module.exports = devices.map((device) => {
     if (device.extend) {
+        if (device.extend.hasOwnProperty('configure') && device.hasOwnProperty('configure')) {
+            assert.fail(`'${device.model}' has configure in extend and device, this is not allowed`);
+        }
+
         let deviceMeta = null;
         if (device.extend.hasOwnProperty('meta') && device.hasOwnProperty('meta')) {
             deviceMeta = Object.assign({}, device.extend.meta, device.meta);
         }
+
         device = Object.assign({}, device.extend, device);
+
         if (deviceMeta !== null) {
             device.meta = deviceMeta;
         }
+
         delete device.extend;
     }
 

--- a/devices.js
+++ b/devices.js
@@ -14891,7 +14891,14 @@ const devices = [
 
 module.exports = devices.map((device) => {
     if (device.extend) {
+        let deviceMeta = null;
+        if (device.extend.hasOwnProperty('meta') && device.hasOwnProperty('meta')) {
+            deviceMeta = Object.assign({}, device.extend.meta, device.meta);
+        }
         device = Object.assign({}, device.extend, device);
+        if (deviceMeta !== null) {
+            device.meta = deviceMeta;
+        }
         delete device.extend;
     }
 

--- a/lib/light.js
+++ b/lib/light.js
@@ -6,7 +6,49 @@ async function readColorTempMinMax(endpoint) {
     await endpoint.read('lightingColorCtrl', ['colorTempPhysicalMin', 'colorTempPhysicalMax']);
 }
 
+function findColorTempRange(entity, logger) {
+    let colorTempMin;
+    let colorTempMax;
+    if (entity.constructor.name === 'Group' && entity.members.length > 0) {
+        const minCandidates = entity.members.map(
+            (m) => m.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMin'),
+        ).filter((v) => v !== undefined);
+        if (minCandidates.length > 0) {
+            colorTempMin = Math.max(...minCandidates);
+        }
+        const maxCandidates = entity.members.map(
+            (m) => m.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMax'),
+        ).filter((v) => v !== undefined);
+        if (maxCandidates.length > 0) {
+            colorTempMax = Math.min(...maxCandidates);
+        }
+    } else {
+        colorTempMin = entity.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMin');
+        colorTempMax = entity.getClusterAttributeValue('lightingColorCtrl', 'colorTempPhysicalMax');
+    }
+    if ((colorTempMin === undefined) || (colorTempMax === undefined)) {
+        const entityType = entity.constructor.name.toLowerCase();
+        const entityId = (entityType === 'group') ? entity.groupID : entity.deviceIeeeAddress;
+        logger.warn(`Missing colorTempPhysicalMin and/or colorTempPhysicalMax for ${entityType} ${entityId}!`);
+    }
+    return [colorTempMin, colorTempMax];
+}
+
+function clampColorTemp(colorTemp, colorTempMin, colorTempMax, logger) {
+    if ((colorTempMin !== undefined) && (colorTemp < colorTempMin)) {
+        logger.warn(`Requested color_temp ${colorTemp} is lower than minimum supported ${colorTempMin}, using minimum!`);
+        return colorTempMin;
+    }
+    if ((colorTempMax !== undefined) && (colorTemp > colorTempMax)) {
+        logger.warn(`Requested color_temp ${colorTemp} is higher than maximum supported ${colorTempMax}, using maximum!`);
+        return colorTempMax;
+    }
+    return colorTemp;
+}
+
 module.exports = {
     readColorCapabilities,
     readColorTempMinMax,
+    findColorTempRange,
+    clampColorTemp,
 };

--- a/lib/light.js
+++ b/lib/light.js
@@ -1,0 +1,12 @@
+async function readColorCapabilities(endpoint) {
+    await endpoint.read('lightingColorCtrl', ['colorCapabilities']);
+}
+
+async function readColorTempMinMax(endpoint) {
+    await endpoint.read('lightingColorCtrl', ['colorTempPhysicalMin', 'colorTempPhysicalMax']);
+}
+
+module.exports = {
+    readColorCapabilities,
+    readColorTempMinMax,
+};


### PR DESCRIPTION
This PR is to implement #1928 but it turned out to have rather a lot of scope creep.

Opening this for some feedback so far it seems to work!

- configure() is used to read colorTempPhysicaMin/Max and colorCapabilities* while were at it 
- setting color_temp for a device now ensure to be withing the `ct_min-ct_max` range
- setting color_temp for a group is now ensured to be withing the `max(ct_min)-min(ct_max)` for all group members

*collecting these so we can try make meta.enhancedHue property obsolete in a follow up.

Note: I need  retesting as I have this on top of #2006 which I did first and tested separately.