### PR TITLE
add support for Hommyn WS-20-Z

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14627,7 +14627,7 @@ const devices = [
         fromZigbee: [fz.battery, fz.ias_occupancy_alarm_1_with_timeout],
         toZigbee: [],
         exposes: [e.battery(), e.occupancy(), e.battery_low(), e.tamper()],
-    },   
+    },
     {
         zigbeeModel: ['2f077707a13f4120846e0775df7e2efe'],
         model: 'WS-20-Z',

--- a/devices.js
+++ b/devices.js
@@ -14627,6 +14627,15 @@ const devices = [
         fromZigbee: [fz.battery, fz.ias_occupancy_alarm_1_with_timeout],
         toZigbee: [],
         exposes: [e.battery(), e.occupancy(), e.battery_low(), e.tamper()],
+    },   
+    {
+        zigbeeModel: ['2f077707a13f4120846e0775df7e2efe'],
+        model: 'WS-20-Z',
+        vendor: 'Hommyn',
+        description: 'Water leakage sensor',
+        fromZigbee: [fz.ias_water_leak_alarm_1],
+        toZigbee: [],
+        exposes: [e.water_leak(), e.battery_low(), e.tamper()],
     },
 
     // Lidl


### PR DESCRIPTION
It look like the device is made by ORVIBO but sold under the brand Hommyn (same as MS-20-Z)