### PR TITLE
Add support for StartUpColorTemperatureMireds

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -440,6 +440,11 @@ const converters = {
                 result.color_temp = msg.data['colorTemperature'];
             }
 
+            if (msg.data.hasOwnProperty('startUpColorTemperature')) {
+                result.color_temp_startup = msg.data['startUpColorTemperature'];
+                result.color_temp_startup = (result.color_temp_startup === 65535) ? 'previous' : result.color_temp_startup;
+            }
+
             if (msg.data.hasOwnProperty('colorMode')) {
                 result.color_mode = msg.data['colorMode'];
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -574,7 +574,7 @@ const converters = {
 
             value = Number(value);
 
-            // ensure value withing range
+            // ensure value within range
             const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
             value = light.clampColorTemp(value, colorTempMin, colorTempMax, meta.logger);
 
@@ -584,6 +584,27 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', ['colorTemperature']);
+        },
+    },
+    light_colortemp_startup: {
+        key: ['color_temp_startup'],
+        convertSet: async (entity, key, value, meta) => {
+            if (typeof value === 'string' && value.toLowerCase() == 'previous') {
+                // 0xffff = restore previous value
+                value = 65535;
+            }
+
+            value = Number(value);
+
+            // ensure value within range
+            const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
+            value = light.clampColorTemp(value, colorTempMin, colorTempMax, meta.logger);
+
+            await entity.write('lightingColorCtrl', {startUpColorTemperature: value}, utils.getOptions(meta.mapped, entity));
+            return {state: {color_temp_startup: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('lightingColorCtrl', ['startUpColorTemperature']);
         },
     },
     light_color: {

--- a/devices.js
+++ b/devices.js
@@ -66,7 +66,7 @@ const preset = {
         toZigbee: [
             tz.light_onoff_brightness, tz.light_colortemp, tz.ignore_transition, tz.ignore_rate, tz.effect,
             tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
-            tz.light_colortemp_step,
+            tz.light_colortemp_step, tz.light_colortemp_startup,
         ],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -109,6 +109,7 @@ const preset = {
             tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition, tz.ignore_rate,
             tz.effect, tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
             tz.light_colortemp_step, tz.light_hue_saturation_move, tz.light_hue_saturation_step,
+            tz.light_colortemp_startup,
         ],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -126,6 +127,7 @@ const preset = {
             tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition, tz.ignore_rate,
             tz.effect, tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
             tz.light_colortemp_step, tz.light_hue_saturation_move, tz.light_hue_saturation_step,
+            tz.light_colortemp_startup,
         ],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -118,6 +118,12 @@ class Numeric extends Base {
         this.value_step = value;
         return this;
     }
+
+    withPreset(name, value, description) {
+        if (!this.presets) this.presets = [];
+        this.presets.push({name, value, description});
+        return this;
+    }
 }
 
 class Enum extends Base {
@@ -179,8 +185,9 @@ class Light extends Base {
 
     withColorTempStartup() {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
-        this.features.push(new Numeric('color_temp_startup', access.ALL).withUnit('mired').withValueMin(150).withValueMax(500).withDescription('Color temperature after cold power on of this light.'));
-        this.features.push(new Enum('color_temp_startup', access.ALL, ['previous']).withDescription('Restore previous color temperature after cold power on of this light.'));
+        this.features.push(new Numeric('color_temp_startup', access.ALL).withUnit('mired').withValueMin(150).withValueMax(500)
+            .withDescription('Color temperature after cold power on of this light')
+            .withPreset('previous', 65535, 'Restore previous color_temp on cold power on'));
         return this;
     }
 

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -177,6 +177,13 @@ class Light extends Base {
         return this;
     }
 
+    withColorTempStartup() {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        this.features.push(new Numeric('color_temp_startup', access.ALL).withUnit('mired').withValueMin(150).withValueMax(500).withDescription('Color temperature after cold power on of this light.'));
+        this.features.push(new Enum('color_temp_startup', access.ALL, ['previous']).withDescription('Restore previous color temperature after cold power on of this light.'));
+        return this;
+    }
+
     withColor(types) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         if (types.includes('xy')) {
@@ -361,10 +368,10 @@ module.exports = {
         light_brightness: () => new Light().withBrightness(),
         light_brightness_color: () => new Light().withBrightness().withColor((['xy', 'hs'])),
         light_brightness_colorhs: () => new Light().withBrightness().withColor(['hs']),
-        light_brightness_colortemp: () => new Light().withBrightness().withColorTemp(),
-        light_brightness_colortemp_color: () => new Light().withBrightness().withColorTemp().withColor(['xy', 'hs']),
-        light_brightness_colortemp_colorhs: () => new Light().withBrightness().withColorTemp().withColor(['hs']),
-        light_brightness_colortemp_colorxy: () => new Light().withBrightness().withColorTemp().withColor(['xy']),
+        light_brightness_colortemp: () => new Light().withBrightness().withColorTemp().withColorTempStartup(),
+        light_brightness_colortemp_color: () => new Light().withBrightness().withColorTemp().withColorTempStartup().withColor(['xy', 'hs']),
+        light_brightness_colortemp_colorhs: () => new Light().withBrightness().withColorTemp().withColorTempStartup().withColor(['hs']),
+        light_brightness_colortemp_colorxy: () => new Light().withBrightness().withColorTemp().withColorTempStartup().withColor(['xy']),
         light_brightness_colorxy: () => new Light().withBrightness().withColor((['xy'])),
         light_colorhs: () => new Light().withColor(['hs']),
         linkquality: () => new Numeric('linkquality', access.STATE).withUnit('lqi').withDescription('Link quality (signal strength)').withValueMin(0).withValueMax(255),


### PR DESCRIPTION
Depends on koenkk/zigbee-herdsman#281

NOTE: startUp here refers to a physical off -> on cycle, not via genOnOff cluster.

`previous` is mapped to 0xFFFF which switches to the last set color.

Tested with:
- Innr CWS: works as expected
- IKEA GU10 WS: can set/get... but has no effect
- IKEA GUNTARP WS: can set/get... but as no effect
- IKEA FLOALT (no firmware update): UNSUPPORTED_ATTRIBUTE
- Hue E14 candle: works as expected
- Müller Licht Tint E27: works as expected, but needs to be powered of for ~30-60sec.
- OSRAM SMART+ LED CLASSIC E27 RGBW: UNSUPPORTED_ATTRIBUTE

Default values (of interest)
- Innr: previous
- Hue: 366
- IKEA: 370
- Tint: previous

There is a mixed bag of support on the bulbs, but since it's part of the spec, seems like a nice thing to have.