### PR TITLE
Add automatic trigger to get Peanut Plug OTA check to work

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10525,7 +10525,7 @@ const devices = [
         description: 'Peanut Smart Plug',
         fromZigbee: [fz.on_off, fz.electrical_measurement],
         toZigbee: [tz.on_off],
-        ota: ota.zigbeeOTA,
+        ota: ota.securifi,
         meta: {configureKey: 4},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/lib/ota/index.js
+++ b/lib/ota/index.js
@@ -1,8 +1,8 @@
 module.exports = {
     ledvance: require('./ledvance'),
     salus: require('./salus'),
+    securifi: require('./securifi'),
     tradfri: require('./tradfri'),
     ubisys: require('./ubisys'),
     zigbeeOTA: require('./zigbeeOTA'),
 };
-

--- a/lib/ota/securifi.js
+++ b/lib/ota/securifi.js
@@ -1,0 +1,25 @@
+const common = require('./common');
+const zigbeeOTA = require('./zigbeeOTA');
+
+async function isUpdateAvailable(device, logger, requestPayload=null) {
+    if (device.modelID === 'PP-WHT-US') {
+        // see https://github.com/Koenkk/zigbee-OTA/pull/14
+        const scenesEndpoint = device.endpoints.find((e) => e.supportsOutputCluster('genScenes'));
+        await scenesEndpoint.write('genScenes', {currentGroup: 49502});
+    }
+    return common.isUpdateAvailable(device, logger, common.isNewImageAvailable, requestPayload, zigbeeOTA.getImageMeta);
+}
+
+async function updateToLatest(device, logger, onProgress) {
+    if (device.modelID === 'PP-WHT-US') {
+        // see https://github.com/Koenkk/zigbee-OTA/pull/14
+        const scenesEndpoint = device.endpoints.find((e) => e.supportsOutputCluster('genScenes'));
+        await scenesEndpoint.write('genScenes', {currentGroup: 49502});
+    }
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, zigbeeOTA.getImageMeta);
+}
+
+module.exports = {
+    isUpdateAvailable,
+    updateToLatest,
+};

--- a/lib/ota/zigbeeOTA.js
+++ b/lib/ota/zigbeeOTA.js
@@ -33,6 +33,7 @@ async function updateToLatest(device, logger, onProgress) {
 }
 
 module.exports = {
+    getImageMeta,
     isUpdateAvailable,
     updateToLatest,
 };


### PR DESCRIPTION
Hi Koen,
Here's a crack at fixing https://github.com/Koenkk/zigbee2mqtt/issues/4846.

Note that I did _not_ do what you suggested in that issue (add code to `toZigbee.js` and then manually trigger with an MQTT message); instead, I am automatically triggering the zigbee message whenever an OTA update is checked.

While I think this is easier for the end user, I did have to export `zigbeeOTA.getImageMeta` so I could use it. I'm also not very familiar with Zigbee endpoints (or the z2m implementation thereof), so I just kinda guessed at how to write to the `genScenes` endpoint and it ended up working out.

If you don't like this implementation, please let me know what you want changed. Alternatively, I can switch to your original suggestion if you'd still prefer that.

One more note: I haven't tested actually updating a Peanut Plug yet, as I only have one that needs an update. Once you approve this PR, I'll test the full update process and make sure everything works like we expect it to.