### PR TITLE
Add scene_remove_all / Allow hue/sat in scene_add

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3619,6 +3619,34 @@ const converters = {
             }
         },
     },
+    scene_remove_all: {
+        key: ['scene_remove_all'],
+        convertSet: async (entity, key, value, meta) => {
+            const groupid = entity.constructor.name === 'Group' ? entity.groupID : 0;
+            const response = await entity.command(
+                'genScenes', 'removeAll', {groupid}, utils.getOptions(meta.mapped),
+            );
+
+            const isGroup = entity.constructor.name === 'Group';
+            if (isGroup) {
+                if (meta.membersState) {
+                    for (const member of entity.members) {
+                        if (member.meta.scenes) {
+                            member.meta.scenes = {};
+                            member.save();
+                        }
+                    }
+                }
+            } else if (response.status === 0) {
+                if (entity.meta.scenes) {
+                    entity.meta.scenes = {};
+                    entity.save();
+                }
+            } else {
+                throw new Error(`Scene remove all not succesfull ('${herdsman.Zcl.Status[response.status]}')`);
+            }
+        },
+    },
     TS0003_curtain_switch: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3584,7 +3584,7 @@ const converters = {
                 'genScenes', 'remove', {groupid, sceneid}, utils.getOptions(meta.mapped),
             );
 
-            if (isGroup || (removeresp.status === 0 || removeresp.status == 139)) {
+            if (isGroup || (removeresp.status === 0 || removeresp.status == 133 || removeresp.status == 139)) {
                 const response = await entity.command(
                     'genScenes', 'add', {groupid, sceneid, scenename, transtime, extensionfieldsets}, utils.getOptions(meta.mapped),
                 );

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3547,9 +3547,27 @@ const converters = {
                     } catch (e) {
                         e;
                     }
-                    const xy = typeof val === 'string' ? utils.hexToXY(val) : val;
-                    extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [Math.round(xy.x * 65535), Math.round(xy.y * 65535)]});
-                    state['color'] = xy;
+                    const color = typeof val === 'string' ? utils.hexToXY(val) : val;
+                    if (color.hasOwnProperty('x') && color.hasOwnProperty('y')) {
+                        extensionfieldsets.push(
+                            {
+                                'clstId': 768,
+                                'len': 4,
+                                'extField': [Math.round(color.x * 65535), Math.round(color.y * 65535)],
+                            },
+                        );
+                        state['color'] = {x: color.x, y: color.y};
+                    } else if (color.hasOwnProperty('hue') && color.hasOwnProperty('saturation')) {
+                        const hsv = utils.gammaCorrectHSV(utils.correctHue(color.hue, meta), color.saturation, 100);
+                        extensionfieldsets.push(
+                            {
+                                'clstId': 768,
+                                'len': 13,
+                                'extField': [0, 0, (hsv.h % 360 * (65535 / 360)), (hsv.s * (2.54)), 0, 0, 0, 0],
+                            },
+                        );
+                        state['color'] = {hue: color.hue, saturation: color.saturation};
+                    }
                 }
             }
 

--- a/devices.js
+++ b/devices.js
@@ -14997,7 +14997,7 @@ module.exports = devices.map((device) => {
     }
 
     if (device.toZigbee.length > 0) {
-        device.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove);
+        device.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all);
     }
 
     if (device.exposes) {


### PR DESCRIPTION
Although I'm wondering more and more if something like the following would be better:

`{"id": 123, "group":"my_group", "state": "ON", "color_temp: 360}` => zigbee2mqtt/bridge/request/scenes/add
`{"id": 123, "device":"my_device"}` => zigbee2mqtt/bridge/request/scenes/store
`{"id": 123, "device":"my_device"}` => zigbee2mqtt/bridge/request/scenes/recall
`{"id": 123, "device":"my_device"}` => zigbee2mqtt/bridge/request/scenes/remove
`{"group":"my_group"}` => zigbee2mqtt/bridge/request/scenes/remove_all

That opens the door to implement `view`, `get_membership`, ...