### PR TITLE
Added Müller Licht remote control support (404022)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9652,6 +9652,16 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['tint-Remote-white'],
+        model: '404022',
+        description: 'Tint dim remote control',
+        vendor: 'Müller Licht',
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.command_move_to_color_temp],
+        exposes: [e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up', 'brightness_move_down',
+            'brightness_stop'])],
+        toZigbee: [],
+    },
+    {
         zigbeeModel: ['tint-ColorTemperature'],
         model: '404037',
         vendor: 'Müller Licht',

--- a/devices.js
+++ b/devices.js
@@ -9658,7 +9658,7 @@ const devices = [
         vendor: 'Müller Licht',
         fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.command_move_to_color_temp],
         exposes: [e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up', 'brightness_move_down',
-            'brightness_stop'])],
+            'brightness_stop', 'color_temperature_move'])],
         toZigbee: [],
     },
     {


### PR DESCRIPTION
Hi,

My device is the following:
https://zigbee.blakadder.com/Muller_Licht_404022.html

It should be supported but device's config is missing from `devices.js` file...

This configuration is taken from `404002`'s model which is similar but the `404022` remote also has two buttons for _color temperature_ which are not bound with this configuration. I am not sure how to implement that in `converters/fromZigbee.js`.

Cluster: `lightingColorCtrl`
Command: `commandMoveToColorTemp`

In the meantime, on/off and step up/down are working as expected with this PR.