### PR TITLE
Müller Licht Tint supports hue/saturation

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9587,8 +9587,9 @@ const devices = [
         model: '404006/404008/404004',
         vendor: 'Müller Licht',
         description: 'Tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, opal white',
-        extend: preset.light_onoff_brightness_colortemp,
-        toZigbee: preset.light_onoff_brightness_colortemp.toZigbee.concat([tz.tint_scene]),
+        extend: preset.light_onoff_brightness_colortemp_color,
+        toZigbee: preset.light_onoff_brightness_colortemp_color.toZigbee.concat([tz.tint_scene]),
+        meta: {enhancedHue: false},
     },
     {
         zigbeeModel: ['ZBT-CCTLight-GU100000'],


### PR DESCRIPTION
On adventure in colorCapabilities, I found out these do support hue/saturation! (Tested both a GU10 and an E27)

They do need enhancedHue set to false though, which is annoying as that means we can't trust colorCapabilities! It is set to 31 for this both E27 and GU10 but neither change color when setting via enhancedHue, but they also don't reject it with UNSUPPORTED_ATTRIBUTE *sad all around* 