### PR TITLE
feat: support timed on/off commands in _TYZB01 switches

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -147,48 +147,6 @@ const converters = {
             await entity.read('genOnOff', ['onOff']);
         },
     },
-    TYZB01_on_off: {
-        key: ['state', 'time_in_seconds'],
-        convertSet: async (entity, key, value, meta) => {
-            const result = await converters.on_off.convertSet(entity, key, value, meta);
-            const lowerCaseValue = value.toLowerCase();
-            if (!['on', 'off'].includes(lowerCaseValue)) {
-                return result;
-            }
-            const messageKeys = Object.keys(meta.message);
-            const timeInSecondsValue = function() {
-                if (messageKeys.includes('state')) {
-                    return meta.message.time_in_seconds;
-                }
-                if (meta.endpoint_name) {
-                    return meta.message[`time_in_seconds_${meta.endpoint_name}`];
-                }
-                return null;
-            }();
-            if (!timeInSecondsValue) {
-                return result;
-            }
-            const timeInSeconds = Number(timeInSecondsValue);
-            if (!Number.isInteger(timeInSeconds) || timeInSeconds < 0 || timeInSeconds > 0xfffe) {
-                throw Error('The time_in_seconds value must be convertible to an integer in the '+
-                            'range: <0x0000, 0xFFFE>');
-            }
-            const on = lowerCaseValue === 'on';
-            await entity.command(
-                'genOnOff',
-                'onWithTimedOff',
-                {
-                    ctrlbits: 0,
-                    ontime: (on ? 0 : timeInSeconds.valueOf()),
-                    offwaittime: (on ? timeInSeconds.valueOf() : 0),
-                },
-                utils.getOptions(meta.mapped, entity));
-            return result;
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('genOnOff', ['onOff']);
-        },
-    },
     cover_via_brightness: {
         key: ['position', 'state'],
         convertSet: async (entity, key, value, meta) => {
@@ -3326,6 +3284,48 @@ const converters = {
             await entity.write('genOnOffSwitchCfg', payloads[key]);
 
             return {state: {[`${key}_${meta.endpoint_name}`]: value}};
+        },
+    },
+    TYZB01_on_off: {
+        key: ['state', 'time_in_seconds'],
+        convertSet: async (entity, key, value, meta) => {
+            const result = await converters.on_off.convertSet(entity, key, value, meta);
+            const lowerCaseValue = value.toLowerCase();
+            if (!['on', 'off'].includes(lowerCaseValue)) {
+                return result;
+            }
+            const messageKeys = Object.keys(meta.message);
+            const timeInSecondsValue = function() {
+                if (messageKeys.includes('state')) {
+                    return meta.message.time_in_seconds;
+                }
+                if (meta.endpoint_name) {
+                    return meta.message[`time_in_seconds_${meta.endpoint_name}`];
+                }
+                return null;
+            }();
+            if (!timeInSecondsValue) {
+                return result;
+            }
+            const timeInSeconds = Number(timeInSecondsValue);
+            if (!Number.isInteger(timeInSeconds) || timeInSeconds < 0 || timeInSeconds > 0xfffe) {
+                throw Error('The time_in_seconds value must be convertible to an integer in the '+
+                            'range: <0x0000, 0xFFFE>');
+            }
+            const on = lowerCaseValue === 'on';
+            await entity.command(
+                'genOnOff',
+                'onWithTimedOff',
+                {
+                    ctrlbits: 0,
+                    ontime: (on ? 0 : timeInSeconds.valueOf()),
+                    offwaittime: (on ? timeInSeconds.valueOf() : 0),
+                },
+                utils.getOptions(meta.mapped, entity));
+            return result;
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('genOnOff', ['onOff']);
         },
     },
     diyruz_geiger_config: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -154,9 +154,9 @@ const converters = {
                 return converters.on_off.convertSet(entity, key, value, meta);
             }
             utils.validateValue(value.state, ['on', 'off']);
-            const timeInSeconds = Number(value.time_in_seconds);
+            const timeInSeconds = Number(value.transition);
             if (!Number.isInteger(timeInSeconds) || timeInSeconds < 0 || timeInSeconds > 0xfffe) {
-                throw Error('The JSON object must have \'time_in_seconds\' property which is ' +
+                throw Error('The JSON object must have \'transition\' property which is ' +
                             'convertible to an integer in the range: <0x0000, 0xFFFE>');
             }
             const result = await converters.on_off.convertSet(entity, key, value.state, meta);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -148,7 +148,7 @@ const converters = {
         },
     },
     TYZB01_on_off: {
-        key: ['state', 'transition'],
+        key: ['state', 'time_in_seconds'],
         convertSet: async (entity, key, value, meta) => {
             const result = await converters.on_off.convertSet(entity, key, value, meta);
             const lowerCaseValue = value.toLowerCase();
@@ -156,21 +156,21 @@ const converters = {
                 return result;
             }
             const messageKeys = Object.keys(meta.message);
-            const transitionValue = function() {
+            const timeInSecondsValue = function() {
                 if (messageKeys.includes('state')) {
-                    return meta.message.transition;
+                    return meta.message.time_in_seconds;
                 }
                 if (meta.endpoint_name) {
-                    return meta.message[`transition_${meta.endpoint_name}`];
+                    return meta.message[`time_in_seconds_${meta.endpoint_name}`];
                 }
                 return null;
             }();
-            if (!transitionValue) {
+            if (!timeInSecondsValue) {
                 return result;
             }
-            const timeInSeconds = Number(transitionValue);
+            const timeInSeconds = Number(timeInSecondsValue);
             if (!Number.isInteger(timeInSeconds) || timeInSeconds < 0 || timeInSeconds > 0xfffe) {
-                throw Error('The transition value must be convertible to an integer in the '+
+                throw Error('The time_in_seconds value must be convertible to an integer in the '+
                             'range: <0x0000, 0xFFFE>');
             }
             const on = lowerCaseValue === 'on';

--- a/devices.js
+++ b/devices.js
@@ -1980,6 +1980,7 @@ const devices = [
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
+        toZigbee: [tz.TYZB01_on_off],
         meta: {configureKey: 1, multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
@@ -1992,6 +1993,7 @@ const devices = [
         vendor: 'Lonsonho',
         description: '1 gang switch module with neutral wire',
         extend: preset.switch,
+        toZigbee: [tz.TYZB01_on_off],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
@@ -13680,6 +13682,7 @@ const devices = [
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
+        toZigbee: [tz.TYZB01_on_off],
         meta: {configureKey: 1, multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);


### PR DESCRIPTION
Switch modules representing themselves as `modelID: 'TS0003', manufacturerName: '_TYZB01_*'` are capable of receiving **onWithTimedOff** command in **onOff** cluster. However, they interpret the command on their own, non-standard way. This PR adds support for timed on and timed off commands for these devices. In order to issue timed on or off command, the following mqtt message would need to be sent: `{ "topic": "zigbee2mqtt/${friendly_name}/set", "payload": { "state(_${endpoint_name}": {"state": "(on|off)", "time_in_seconds": ${seconds}}}}`.