### PR TITLE
Fix Müller Licht Tint remote (model 404002) 

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9631,6 +9631,11 @@ const devices = [
         exposes: [e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up', 'brightness_move_down',
             'brightness_stop'])],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genOnOff', 'genLevelCtrl', 'genScenes']);
+        },
     },
     {
         zigbeeModel: ['tint Smart Switch'],


### PR DESCRIPTION
Hello,

after having the same problems with the Müller Licht Tint remote (model 404002) like described in #1879 by @JLFN (pairing was successful after doing a reset with the small button on the back but no messages were received) I copied the "configure" of the "ZBT-Remote-EU-DIMV2A2" device and in my case it solved the problem of not getting any messages from the remote control. 

The Müller Licht remote visually looks the same like the "ZBT-Remote-EU-DIMV2A2" and also features direct pairing.

I successfully tested this with two different CC2531 dongles (at channel 25) and two newly bought remotes with the latest development version of zigbee2mqtt.


Best regards,

Andreas