### PR TITLE
Müller Licht Tint remote (model 404002) "recall" messages

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9640,9 +9640,9 @@ const devices = [
         model: '404002',
         description: 'Tint dim remote control',
         vendor: 'Müller Licht',
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop],
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.command_recall],
         exposes: [e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up', 'brightness_move_down',
-            'brightness_stop'])],
+            'brightness_stop', 'recall_*'])],
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
Hello,

I just added the "recall" command from "ZBT-Remote-EU-DIMV2A2" to "ZBT-DIMController-D0800" I didn't add and thus were not sent via MQTT.

The only difference now to "ZBT-Remote-EU-DIMV2A2" should be the missing "fz.ignore_basic_report". Is it required (I didn't get any errors until now)? If yes, it could also be added.


Best regards,

Andreas