### PR TITLE
Ubisys D1 - Add onOffTransitionTime and startUpCurrentLevel support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -438,24 +438,24 @@ const converters = {
 
             // onOffTransitionTime - range 0x0000 to 0xffff - optional
             if (msg.data.hasOwnProperty('onOffTransitionTime') && (msg.data['onOffTransitionTime'] !== undefined)) {
-                result.level_config.onOffTransitionTime = msg.data['onOffTransitionTime'];
+                result.level_config.on_off_transition_time = Number(msg.data['onOffTransitionTime']);
             }
 
             // onTransitionTime - range 0x0000 to 0xffff - optional
             //                    0xffff = use onOffTransitionTime
             if (msg.data.hasOwnProperty('onTransitionTime') && (msg.data['onTransitionTime'] !== undefined)) {
-                result.level_config.onTransitionTime = msg.data['onTransitionTime'];
-                if (result.level_config.onTransitionTime == 65535) {
-                    result.level_config.onTransitionTime = 'disabled';
+                result.level_config.on_transition_time = Number(msg.data['onTransitionTime']);
+                if (result.level_config.on_transition_time == 65535) {
+                    result.level_config.on_transition_time = 'disabled';
                 }
             }
 
             // offTransitionTime - range 0x0000 to 0xffff - optional
             //                    0xffff = use onOffTransitionTime
             if (msg.data.hasOwnProperty('offTransitionTime') && (msg.data['offTransitionTime'] !== undefined)) {
-                result.level_config.offTransitionTime = msg.data['offTransitionTime'];
-                if (result.level_config.offTransitionTime == 65535) {
-                    result.level_config.offTransitionTime = 'disabled';
+                result.level_config.off_transition_time = Number(msg.data['offTransitionTime']);
+                if (result.level_config.off_transition_time == 65535) {
+                    result.level_config.off_transition_time = 'disabled';
                 }
             }
 
@@ -463,12 +463,12 @@ const converters = {
             //                       0x00 = return to minimum supported level
             //                       0xff - return to previous previous
             if (msg.data.hasOwnProperty('startUpCurrentLevel') && (msg.data['startUpCurrentLevel'] !== undefined)) {
-                result.level_config.startUpCurrentLevel = msg.data['startUpCurrentLevel'];
-                if (result.level_config.startUpCurrentLevel == 255) {
-                    result.level_config.startUpCurrentLevel = 'previous';
+                result.level_config.current_level_startup = Number(msg.data['startUpCurrentLevel']);
+                if (result.level_config.current_level_startup == 255) {
+                    result.level_config.current_level_startup = 'previous';
                 }
-                if (result.level_config.startUpCurrentLevel == 0) {
-                    result.level_config.startUpCurrentLevel = 'minimum';
+                if (result.level_config.current_level_startup == 0) {
+                    result.level_config.current_level_startup = 'minimum';
                 }
             }
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -430,6 +430,53 @@ const converters = {
             }
         },
     },
+    level_config: {
+        cluster: 'genLevelCtrl',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result = {'level_config': {}};
+
+            // onOffTransitionTime - range 0x0000 to 0xffff - optional
+            if (msg.data.hasOwnProperty('onOffTransitionTime') && (msg.data['onOffTransitionTime'] !== undefined)) {
+                result.level_config.onOffTransitionTime = msg.data['onOffTransitionTime'];
+            }
+
+            // onTransitionTime - range 0x0000 to 0xffff - optional
+            //                    0xffff = use onOffTransitionTime
+            if (msg.data.hasOwnProperty('onTransitionTime') && (msg.data['onTransitionTime'] !== undefined)) {
+                result.level_config.onTransitionTime = msg.data['onTransitionTime'];
+                if (result.level_config.onTransitionTime == 65535) {
+                    result.level_config.onTransitionTime = 'disabled';
+                }
+            }
+
+            // offTransitionTime - range 0x0000 to 0xffff - optional
+            //                    0xffff = use onOffTransitionTime
+            if (msg.data.hasOwnProperty('offTransitionTime') && (msg.data['offTransitionTime'] !== undefined)) {
+                result.level_config.offTransitionTime = msg.data['offTransitionTime'];
+                if (result.level_config.offTransitionTime == 65535) {
+                    result.level_config.offTransitionTime = 'disabled';
+                }
+            }
+
+            // startUpCurrentLevel - range 0x00 to 0xff - optional
+            //                       0x00 = return to minimum supported level
+            //                       0xff - return to previous previous
+            if (msg.data.hasOwnProperty('startUpCurrentLevel') && (msg.data['startUpCurrentLevel'] !== undefined)) {
+                result.level_config.startUpCurrentLevel = msg.data['startUpCurrentLevel'];
+                if (result.level_config.startUpCurrentLevel == 255) {
+                    result.level_config.startUpCurrentLevel = 'previous';
+                }
+                if (result.level_config.startUpCurrentLevel == 0) {
+                    result.level_config.startUpCurrentLevel = 'minimum';
+                }
+            }
+
+            if (Object.keys(result.level_config).length > 0) {
+                return result;
+            }
+        },
+    },
     color_colortemp: {
         cluster: 'lightingColorCtrl',
         type: ['attributeReport', 'readResponse'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -245,26 +245,28 @@ const converters = {
             const state = {};
 
             // parse payload to grab the keys
-            try {
-                value = JSON.parse(value);
-            } catch (e) {
-                e;
+            if (typeof value === 'string') {
+                try {
+                    value = JSON.parse(value);
+                } catch (e) {
+                    throw new Error('Payload is not valid JSON');
+                }
             }
 
             // onOffTransitionTime - range 0x0000 to 0xffff - optional
-            if (value.hasOwnProperty('onOffTransitionTime')) {
-                let onOffTransitionTimeValue = Number(value.onOffTransitionTime);
+            if (value.hasOwnProperty('on_off_transition_time')) {
+                let onOffTransitionTimeValue = Number(value.on_off_transition_time);
                 if (onOffTransitionTimeValue > 65535) onOffTransitionTimeValue = 65535;
                 if (onOffTransitionTimeValue < 0) onOffTransitionTimeValue = 0;
 
                 await entity.write('genLevelCtrl', {onOffTransitionTime: onOffTransitionTimeValue}, utils.getOptions(meta.mapped, entity));
-                Object.assign(state, {onOffTransitionTime: onOffTransitionTimeValue});
+                Object.assign(state, {on_off_transition_time: onOffTransitionTimeValue});
             }
 
             // onTransitionTime - range 0x0000 to 0xffff - optional
             //                    0xffff = use onOffTransitionTime
-            if (value.hasOwnProperty('onTransitionTime')) {
-                let onTransitionTimeValue = value.onTransitionTime;
+            if (value.hasOwnProperty('on_transition_time')) {
+                let onTransitionTimeValue = value.on_transition_time;
                 if (typeof onTransitionTimeValue === 'string' && onTransitionTimeValue.toLowerCase() == 'disabled') {
                     onTransitionTimeValue = 65535;
                 } else {
@@ -274,13 +276,18 @@ const converters = {
                 if (onTransitionTimeValue < 0) onTransitionTimeValue = 0;
 
                 await entity.write('genLevelCtrl', {onTransitionTime: onTransitionTimeValue}, utils.getOptions(meta.mapped, entity));
-                Object.assign(state, {onTransitionTime: value.onTransitionTime});
+
+                // reverse translate number -> preset
+                if (onTransitionTimeValue == 65535) {
+                    onTransitionTimeValue = 'disabled';
+                }
+                Object.assign(state, {on_transition_time: onTransitionTimeValue});
             }
 
             // offTransitionTime - range 0x0000 to 0xffff - optional
             //                    0xffff = use onOffTransitionTime
-            if (value.hasOwnProperty('offTransitionTime')) {
-                let offTransitionTimeValue = value.offTransitionTime;
+            if (value.hasOwnProperty('off_transition_time')) {
+                let offTransitionTimeValue = value.off_transition_time;
                 if (typeof offTransitionTimeValue === 'string' && offTransitionTimeValue.toLowerCase() == 'disabled') {
                     offTransitionTimeValue = 65535;
                 } else {
@@ -290,14 +297,19 @@ const converters = {
                 if (offTransitionTimeValue < 0) offTransitionTimeValue = 0;
 
                 await entity.write('genLevelCtrl', {offTransitionTime: offTransitionTimeValue}, utils.getOptions(meta.mapped, entity));
-                Object.assign(state, {offTransitionTime: value.offTransitionTime});
+
+                // reverse translate number -> preset
+                if (offTransitionTimeValue == 65535) {
+                    offTransitionTimeValue = 'disabled';
+                }
+                Object.assign(state, {off_transition_time: offTransitionTimeValue});
             }
 
             // startUpCurrentLevel - range 0x00 to 0xff - optional
             //                       0x00 = return to minimum supported level
             //                       0xff = return to previous previous
-            if (value.hasOwnProperty('startUpCurrentLevel')) {
-                let startUpCurrentLevelValue = value.startUpCurrentLevel;
+            if (value.hasOwnProperty('current_level_startup')) {
+                let startUpCurrentLevelValue = value.current_level_startup;
                 if (typeof startUpCurrentLevelValue === 'string' && startUpCurrentLevelValue.toLowerCase() == 'previous') {
                     startUpCurrentLevelValue = 255;
                 } else if (typeof startUpCurrentLevelValue === 'string' && startUpCurrentLevelValue.toLowerCase() == 'minimum') {
@@ -309,7 +321,15 @@ const converters = {
                 if (startUpCurrentLevelValue < 0) startUpCurrentLevelValue = 1;
 
                 await entity.write('genLevelCtrl', {startUpCurrentLevel: startUpCurrentLevelValue}, utils.getOptions(meta.mapped, entity));
-                Object.assign(state, {startUpCurrentLevel: value.startUpCurrentLevel});
+
+                // reverse translate number -> preset
+                if (startUpCurrentLevelValue == 255) {
+                    startUpCurrentLevelValue = 'previous';
+                }
+                if (startUpCurrentLevelValue == 0) {
+                    startUpCurrentLevelValue = 'minimum';
+                }
+                Object.assign(state, {current_level_startup: startUpCurrentLevelValue});
             }
 
             if (Object.keys(state).length > 0) {

--- a/devices.js
+++ b/devices.js
@@ -12292,9 +12292,9 @@ const devices = [
         vendor: 'Ubisys',
         description: 'Universal dimmer D1',
         fromZigbee: [fz.on_off, fz.brightness, fz.metering, fz.command_toggle, fz.command_on, fz.command_off, fz.command_recall,
-            fz.command_move, fz.command_stop, fz.lighting_ballast_configuration, fz.ubisys_dimmer_setup],
-        toZigbee: [tz.light_onoff_brightness, tz.ballast_config, tz.ubisys_dimmer_setup, tz.ubisys_device_setup],
-        exposes: [e.light_brightness(), e.power(),
+            fz.command_move, fz.command_stop, fz.lighting_ballast_configuration, fz.level_config, fz.ubisys_dimmer_setup],
+        toZigbee: [tz.light_onoff_brightness, tz.ballast_config, tz.level_config, tz.ubisys_dimmer_setup, tz.ubisys_device_setup],
+        exposes: [e.light_brightness().withLevelConfig(), e.power(),
             exposes.numeric('ballast_physical_minimum_level', exposes.access.STATE_GET).withValueMin(1).withValueMax(254)
                 .withDescription('Specifies the minimum light output the ballast can achieve.'),
             exposes.numeric('ballast_physical_maximum_level', exposes.access.STATE_GET).withValueMin(1).withValueMax(254)

--- a/devices.js
+++ b/devices.js
@@ -54,19 +54,19 @@ const preset = {
     },
     light_onoff_brightness: {
         exposes: [e.light_brightness(), e.effect()],
-        fromZigbee: [fz.on_off, fz.brightness, fz.ignore_basic_report],
+        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.ignore_transition, tz.ignore_rate, tz.effect,
-            tz.light_brightness_move, tz.light_brightness_step,
+            tz.light_brightness_move, tz.light_brightness_step, tz.level_config,
         ],
     },
     light_onoff_brightness_colortemp: {
         exposes: [e.light_brightness_colortemp(), e.effect()],
-        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.ignore_basic_report],
+        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_colortemp, tz.ignore_transition, tz.ignore_rate, tz.effect,
             tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
-            tz.light_colortemp_step, tz.light_colortemp_startup,
+            tz.light_colortemp_step, tz.light_colortemp_startup, tz.level_config,
         ],
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -78,19 +78,19 @@ const preset = {
     },
     light_onoff_brightness_color: {
         exposes: [e.light_brightness_color(), e.effect()],
-        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.ignore_basic_report],
+        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_color, tz.ignore_transition, tz.ignore_rate, tz.effect,
-            tz.light_brightness_move, tz.light_brightness_step,
+            tz.light_brightness_move, tz.light_brightness_step, tz.level_config,
             tz.light_hue_saturation_move, tz.light_hue_saturation_step,
         ],
     },
     light_onoff_brightness_colorxy: {
         exposes: [e.light_brightness_colorxy(), e.effect()],
-        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.ignore_basic_report],
+        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_color, tz.ignore_transition, tz.ignore_rate, tz.effect,
-            tz.light_brightness_move, tz.light_brightness_step,
+            tz.light_brightness_move, tz.light_brightness_step, tz.level_config,
             tz.light_hue_saturation_move, tz.light_hue_saturation_step,
         ],
         meta: {configureKey: 2},
@@ -102,12 +102,12 @@ const preset = {
     },
     light_onoff_brightness_colortemp_color: {
         exposes: [e.light_brightness_colortemp_color(), e.effect()],
-        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.ignore_basic_report],
+        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition, tz.ignore_rate,
             tz.effect, tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
             tz.light_colortemp_step, tz.light_hue_saturation_move, tz.light_hue_saturation_step,
-            tz.light_colortemp_startup,
+            tz.light_colortemp_startup, tz.level_config,
         ],
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -119,12 +119,12 @@ const preset = {
     },
     light_onoff_brightness_colortemp_colorxy: {
         exposes: [e.light_brightness_colortemp_colorxy(), e.effect()],
-        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.ignore_basic_report],
+        fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition, tz.ignore_rate,
             tz.effect, tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
             tz.light_colortemp_step, tz.light_hue_saturation_move, tz.light_hue_saturation_step,
-            tz.light_colortemp_startup,
+            tz.light_colortemp_startup, tz.level_config,
         ],
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -177,6 +177,32 @@ class Light extends Base {
         return this;
     }
 
+    withLevelConfig() {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        const levelConfig = new Composite('level_config', 'level_config')
+            .withFeature(new Numeric('onOffTransitionTime', access.ALL)
+                .withDescription('Represents the time taken to move to or from the target level when On of Off commands are received by an On/Off cluster'),
+            )
+            .withFeature(new Numeric('onTransitionTime', access.ALL)
+                .withPreset('disabled', 65535, 'Use onOffTransitionTime value')
+                .withDescription('Represents the time taken to move the current level from the minimum level to the maximum level when an On command is received'),
+            )
+            .withFeature(new Numeric('offTransitionTime', access.ALL)
+                .withPreset('disabled', 65535, 'Use onOffTransitionTime value')
+                .withDescription('Represents the time taken to move the current level from the maximum level to the minimum level when an Off command is received'),
+            )
+            .withFeature(new Numeric('startUpCurrentLevel', access.ALL)
+                .withValueMin(1).withValueMax(254)
+                .withPreset('minimum', 0, 'Use minimum permitted value')
+                .withPreset('previous', 255, 'Use previous value')
+                .withDescription('Defines the desired startup level for a device when it is supplied with power'),
+            )
+            .withDescription('Configure genLevelCtrl');
+        this.features.push(levelConfig);
+
+        return this;
+    }
+
     withColorTemp() {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         this.features.push(new Numeric('color_temp', access.ALL).withUnit('mired').withValueMin(150).withValueMax(500).withDescription('Color temperature of this light'));

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -180,18 +180,18 @@ class Light extends Base {
     withLevelConfig() {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         const levelConfig = new Composite('level_config', 'level_config')
-            .withFeature(new Numeric('onOffTransitionTime', access.ALL)
+            .withFeature(new Numeric('on_off_transition_time', access.ALL)
                 .withDescription('Represents the time taken to move to or from the target level when On of Off commands are received by an On/Off cluster'),
             )
-            .withFeature(new Numeric('onTransitionTime', access.ALL)
-                .withPreset('disabled', 65535, 'Use onOffTransitionTime value')
+            .withFeature(new Numeric('on_transition_time', access.ALL)
+                .withPreset('disabled', 65535, 'Use on_off_transition_time value')
                 .withDescription('Represents the time taken to move the current level from the minimum level to the maximum level when an On command is received'),
             )
-            .withFeature(new Numeric('offTransitionTime', access.ALL)
-                .withPreset('disabled', 65535, 'Use onOffTransitionTime value')
+            .withFeature(new Numeric('off_transition_time', access.ALL)
+                .withPreset('disabled', 65535, 'Use on_off_transition_time value')
                 .withDescription('Represents the time taken to move the current level from the maximum level to the minimum level when an Off command is received'),
             )
-            .withFeature(new Numeric('startUpCurrentLevel', access.ALL)
+            .withFeature(new Numeric('current_level_startup', access.ALL)
                 .withValueMin(1).withValueMax(254)
                 .withPreset('minimum', 0, 'Use minimum permitted value')
                 .withPreset('previous', 255, 'Use previous value')


### PR DESCRIPTION
Depends on https://github.com/Koenkk/zigbee-herdsman/pull/283

- [x] testing
- [x] exposes

I don't have the device to test, I saw https://github.com/Koenkk/zigbee2mqtt/discussions/5555 and it looks like it's just standard ZCL so I added it.

@Koenkk not sure how I feel about the cameCase inside level_config, I kept it to simple match what we define in herdsman, if we ever allow more values we can easily add it. Looks similar to than what ballast_config did.