### PR TITLE
Added support for Iluminize 511.000 (ZigBee 3.0 LED-controller)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11180,6 +11180,19 @@ const devices = [
         extend: preset.light_onoff_brightness_colortemp_colorxy,
     },
     {
+        zigbeeModel: ['HK-ZD-RGBCCT-A', '511.000'],
+        model: '511.000',
+        vendor: 'Iluminize',
+        description: 'ZigBee 3.0 Universal LED-controller, 5 channel 4A, RGBCCT LED',
+        extend: preset.light_onoff_brightness_colortemp_colorxy,
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.onOff(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['ZG2819S-RGBW'],
         model: '511.344',
         vendor: 'Iluminize',

--- a/devices.js
+++ b/devices.js
@@ -11183,14 +11183,8 @@ const devices = [
         zigbeeModel: ['HK-ZD-RGBCCT-A', '511.000'],
         model: '511.000',
         vendor: 'Iluminize',
-        description: 'ZigBee 3.0 Universal LED-controller, 5 channel 4A, RGBCCT LED',
+        description: 'Zigbee 3.0 universal LED-controller, 5 channel 4A, RGBCCT LED',
         extend: preset.light_onoff_brightness_colortemp_colorxy,
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(endpoint);
-        },
     },
     {
         zigbeeModel: ['ZG2819S-RGBW'],


### PR DESCRIPTION
Added support for Iluminize 511.000 (ZigBee 3.0 Universal LED-controller, 5 channel 4A, RGBCCT LED)

Basically same as '511.040' just changing model and description.
Tested and works great.
More info about the device:
https://www.iluminize.com/de/shop/led-steuerung/led-controller/product/596-511-000-zigbee-controller-4a.html