### PR TITLE
Remove OTA from Sengled E12-N1E

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5850,7 +5850,6 @@ const devices = [
         vendor: 'Sengled',
         description: 'Smart LED multicolor (BR30)',
         extend: preset.light_onoff_brightness_colortemp_colorxy,
-        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['E11-U21U31'],


### PR DESCRIPTION
Issue: https://github.com/Koenkk/zigbee-herdsman-converters/issues/2076

I'm very sorry for making the bad PR before.

I believe removing this line will benefit anyone using this bulb. At its current state, it spams the logs.

Thanks