### PR TITLE
Add support for Niko Smart plug with earthing pin

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14796,18 +14796,20 @@ const devices = [
         model: '552-80699',
         vendor: 'Niko',
         description: 'Smart plug with earthing pin',
-        fromZigbee: [fz.on_off, fz.electrical_measurement],
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
         toZigbee: [tz.on_off, tz.power_on_behavior],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             // only activePower seems to be support, although compliance document states otherwise
             await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await reporting.activePower(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint, {min: 60, change: 1});
         },
         exposes: [
-            e.switch(), e.power(),
+            e.switch(), e.power(), e.energy(),
             exposes.enum('power_on_behavior', exposes.access.STATE_SET, ['off', 'previous', 'on'])
                 .withDescription('Controls the behaviour when the device is powered on'),
         ],

--- a/devices.js
+++ b/devices.js
@@ -14791,6 +14791,23 @@ const devices = [
         },
         exposes: [e.switch(), e.power(), e.current(), e.voltage()],
     },
+    {
+        zigbeeModel: ['Smart plug Zigbee PE'],
+        model: '552-80699',
+        vendor: 'Niko',
+        description: 'Smart plug with earthing pin',
+        fromZigbee: [fz.on_off, fz.electrical_measurement],
+        toZigbee: [tz.on_off],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
+            // only activePower seems to be support, although compliance document states otherwise
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
+            await reporting.activePower(endpoint);
+        },
+        exposes: [e.switch(), e.power()],
+    },
 
     // QMotion products - http://www.qmotionshades.com/
     {

--- a/devices.js
+++ b/devices.js
@@ -14797,7 +14797,7 @@ const devices = [
         vendor: 'Niko',
         description: 'Smart plug with earthing pin',
         fromZigbee: [fz.on_off, fz.electrical_measurement],
-        toZigbee: [tz.on_off],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -14806,7 +14806,11 @@ const devices = [
             await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
             await reporting.activePower(endpoint);
         },
-        exposes: [e.switch(), e.power()],
+        exposes: [
+            e.switch(), e.power(),
+            exposes.enum('power_on_behavior', exposes.access.STATE_SET, ['off', 'previous', 'on'])
+                .withDescription('Controls the behaviour when the device is powered on'),
+        ],
     },
 
     // QMotion products - http://www.qmotionshades.com/


### PR DESCRIPTION
Although the compliance document for the 552-80699 looks nearly identical to 170-33505 (suspicious) and claims rmsVoltage/rmsCurrent is supported, we get UNSUPPORTED_ATTRIBUTE while trying to setup reporting or reading the  linked attributes in readEletricalMeasurementMultiplierDivisors.

seMetering also cleans support for a few properties, but same story there, although currentSummDelivered did seem to take a reporting config. It never reported anything for me.

Just configuring activePower separately does seem to yield a somewhat correct power reading. My 1000lm Tradfri bulb reads 13 watt, behind an Ubisys S1 it reads 12-13 watt depending on the device. So it looks to be within expected variance of ~4W < 100 watt load and ~5% for > 100 watt loads.