### PR TITLE
Add support for Philips Hue spot "Fugato" (5063331P7)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3605,7 +3605,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue Bluetooth White & Color Ambiance spot Fugato',
         meta: {turnsOffAtBrightness1: true},
-        extend: preset.hue.light_onoff_brightness_colortemp_color,
+        extend: preset.hue.light_onoff_brightness_colortemp_color(),
         ota: ota.zigbeeOTA,
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -3605,7 +3605,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue Bluetooth White & Color Ambiance spot Fugato',
         meta: {turnsOffAtBrightness1: true},
-        extend: preset.hue.light_onoff_brightness_colortemp_colorxy,
+        extend: preset.hue.light_onoff_brightness_colortemp_color,
         ota: ota.zigbeeOTA,
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -3600,6 +3600,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['5063331P7'],
+        model: '5063331P7',
+        vendor: 'Philips',
+        description: 'Hue Bluetooth White & Color Ambiance spot Fugato',
+        meta: {turnsOffAtBrightness1: true},
+        extend: preset.hue.light_onoff_brightness_colortemp_colorxy,
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['5045131P7'],
         model: '5045131P7',
         vendor: 'Philips',


### PR DESCRIPTION
This is just another Hue spot with a different id that reflects the design of the lamp instead of the bulbs. I just copied the definition and adjusted id and name. Now it works perfectly.

(Just set up my first zigbee2mqtt system a few days ago and this was the only device not working out of the box. Thanks a lot for this fantastic project and the freedom it offers!)