### PR TITLE
Add additional zigbeeModel for for ORVIBO SM10ZW

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -12755,7 +12755,7 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['fdd76effa0e146b4bdafa0c203a37192', 'c670e231d1374dbc9e3c6a9fffbd0ae6'],
+        zigbeeModel: ['fdd76effa0e146b4bdafa0c203a37192', 'c670e231d1374dbc9e3c6a9fffbd0ae6', '75a4bfe8ef9c4350830a25d13e3ab068'],
         model: 'SM10ZW',
         vendor: 'ORVIBO',
         description: 'Door or window contact switch',


### PR DESCRIPTION
Related to https://github.com/Koenkk/zigbee2mqtt/issues/5212

I found out that the buggy firmware seems to automatically use the coordinatorEndpoint as `iasCieAddr`, so I just needed to add the `zigbeeModel` and use a recent version of zigbee-herdsman for the device to work (interview still fails, will update documentation for that).