### PR TITLE
Change default group of E1766 so it doesn't control group 0 devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2490,6 +2490,11 @@ const devices = [
         ota: ota.tradfri,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
+            // By default this device controls group 0, some devices are by default in
+            // group 0 causing the remote to control them.
+            // By binding it to a random group, e.g. 901, it will send the commands to group 901 instead of 0
+            // https://github.com/Koenkk/zigbee2mqtt/issues/2772#issuecomment-577389281
+            await endpoint.bind('genOnOff', defaultBindGroup);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },


### PR DESCRIPTION
I recently added an Aqara curtain motor to my setup and I noticed that my Ikea E1766 switches started controlling them. Upon further investigation, I stumbled upon https://github.com/Koenkk/zigbee2mqtt/issues/2772 which changes the default group for a couple of Ikea switches but not E1766. In this PR I am fixing it for Ikea E1766.