### PR TITLE
Add cool, neutral, and warm presets for color_temp(_startup)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -489,7 +489,6 @@ const converters = {
 
             if (msg.data.hasOwnProperty('startUpColorTemperature')) {
                 result.color_temp_startup = msg.data['startUpColorTemperature'];
-                result.color_temp_startup = (result.color_temp_startup === 65535) ? 'previous' : result.color_temp_startup;
             }
 
             if (msg.data.hasOwnProperty('colorMode')) {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -691,7 +691,8 @@ const converters = {
     light_colortemp: {
         key: ['color_temp', 'color_temp_percent'],
         convertSet: async (entity, key, value, meta) => {
-            const preset = {'warm': 454, 'neutral': 370, 'cool': 250};
+            const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
+            const preset = {'warmest': colorTempMax, 'warm': 454, 'neutral': 370, 'cool': 250, 'coolest': colorTempMin};
 
             if (key === 'color_temp_percent') {
                 value = Number(value) * 3.46;
@@ -709,7 +710,6 @@ const converters = {
             value = Number(value);
 
             // ensure value within range
-            const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
             value = light.clampColorTemp(value, colorTempMin, colorTempMax, meta.logger);
 
             const payload = {colortemp: value, transtime: utils.getTransition(entity, key, meta).time};
@@ -724,7 +724,8 @@ const converters = {
         key: ['color_temp_startup'],
         convertSet: async (entity, key, value, meta) => {
             // 0xffff = restore previous value
-            const preset = {'warm': 454, 'neutral': 370, 'cool': 250, 'previous': 65535};
+            const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
+            const preset = {'warmest': colorTempMax, 'warm': 454, 'neutral': 370, 'cool': 250, 'coolest': colorTempMin, 'previous': 65535};
 
             if (typeof value === 'string') {
                 if (preset.includes(value.toLowerCase())) {
@@ -737,7 +738,6 @@ const converters = {
             value = Number(value);
 
             // ensure value within range
-            const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
             value = light.clampColorTemp(value, colorTempMin, colorTempMax, meta.logger);
 
             await entity.write('lightingColorCtrl', {startUpColorTemperature: value}, utils.getOptions(meta.mapped, entity));

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -691,9 +691,19 @@ const converters = {
     light_colortemp: {
         key: ['color_temp', 'color_temp_percent'],
         convertSet: async (entity, key, value, meta) => {
+            const preset = {'warm': 454, 'neutral': 370, 'cool': 250};
+
             if (key === 'color_temp_percent') {
                 value = Number(value) * 3.46;
                 value = Math.round(value + 154).toString();
+            }
+
+            if (typeof value === 'string') {
+                if (preset.includes(value.toLowerCase())) {
+                    value = preset[value.toLowerCase()];
+                } else {
+                    throw new Error(`Unknown preset '${value}'`);
+                }
             }
 
             value = Number(value);
@@ -713,9 +723,15 @@ const converters = {
     light_colortemp_startup: {
         key: ['color_temp_startup'],
         convertSet: async (entity, key, value, meta) => {
-            if (typeof value === 'string' && value.toLowerCase() == 'previous') {
-                // 0xffff = restore previous value
-                value = 65535;
+            // 0xffff = restore previous value
+            const preset = {'warm': 454, 'neutral': 370, 'cool': 250, 'previous': 65535};
+
+            if (typeof value === 'string') {
+                if (preset.includes(value.toLowerCase())) {
+                    value = preset[value.toLowerCase()];
+                } else {
+                    throw new Error(`Unknown preset '${value}'`);
+                }
             }
 
             value = Number(value);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -723,7 +723,6 @@ const converters = {
     light_colortemp_startup: {
         key: ['color_temp_startup'],
         convertSet: async (entity, key, value, meta) => {
-            // 0xffff = restore previous value
             const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
             const preset = {'warmest': colorTempMax, 'warm': 454, 'neutral': 370, 'cool': 250, 'coolest': colorTempMin, 'previous': 65535};
 
@@ -738,7 +737,10 @@ const converters = {
             value = Number(value);
 
             // ensure value within range
-            value = light.clampColorTemp(value, colorTempMin, colorTempMax, meta.logger);
+            // we do allow one exception for 0xffff, which is to restore the previous value
+            if (value != 65535) {
+                value = light.clampColorTemp(value, colorTempMin, colorTempMax, meta.logger);
+            }
 
             await entity.write('lightingColorCtrl', {startUpColorTemperature: value}, utils.getOptions(meta.mapped, entity));
             return {state: {color_temp_startup: value}};

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -232,9 +232,11 @@ class Light extends Base {
         }
         this.features.push(new Numeric('color_temp', access.ALL).withUnit('mired').withValueMin(range[0]).withValueMax(range[1])
             .withDescription('Color temperature of this light')
+            .withPreset('coolest', range[0])
             .withPreset('cool', 250)
             .withPreset('neutral', 370)
-            .withPreset('warm', 454));
+            .withPreset('warm', 454)
+            .withPreset('warmest', range[1]));
         return this;
     }
 
@@ -245,9 +247,11 @@ class Light extends Base {
         }
         this.features.push(new Numeric('color_temp_startup', access.ALL).withUnit('mired').withValueMin(range[0]).withValueMax(range[1])
             .withDescription('Color temperature after cold power on of this light')
+            .withPreset('coolest', range[0])
             .withPreset('cool', 250)
             .withPreset('neutral', 370)
             .withPreset('warm', 454)
+            .withPreset('warmest', range[1])
             .withPreset('previous', 65535, 'Restore previous color_temp on cold power on'));
         return this;
     }

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -232,11 +232,11 @@ class Light extends Base {
         }
         this.features.push(new Numeric('color_temp', access.ALL).withUnit('mired').withValueMin(range[0]).withValueMax(range[1])
             .withDescription('Color temperature of this light')
-            .withPreset('coolest', range[0])
-            .withPreset('cool', 250)
-            .withPreset('neutral', 370)
-            .withPreset('warm', 454)
-            .withPreset('warmest', range[1]));
+            .withPreset('coolest', range[0], 'Coolest temperature supported')
+            .withPreset('cool', 250, 'Cool temperature (250 mireds / 4000 Kelvin)')
+            .withPreset('neutral', 370, 'Neutral temperature (370 mireds / 2700 Kelvin)')
+            .withPreset('warm', 454, 'Warm temperature (454 mireds / 2200 Kelvin)')
+            .withPreset('warmest', range[1], 'Warmest temperature supported'));
         return this;
     }
 
@@ -247,11 +247,11 @@ class Light extends Base {
         }
         this.features.push(new Numeric('color_temp_startup', access.ALL).withUnit('mired').withValueMin(range[0]).withValueMax(range[1])
             .withDescription('Color temperature after cold power on of this light')
-            .withPreset('coolest', range[0])
-            .withPreset('cool', 250)
-            .withPreset('neutral', 370)
-            .withPreset('warm', 454)
-            .withPreset('warmest', range[1])
+            .withPreset('coolest', range[0], 'Coolest temperature supported')
+            .withPreset('cool', 250, 'Cool temperature (250 mireds / 4000 Kelvin)')
+            .withPreset('neutral', 370, 'Neutral temperature (370 mireds / 2700 Kelvin)')
+            .withPreset('warm', 454, 'Warm temperature (454 mireds / 2200 Kelvin)')
+            .withPreset('warmest', range[1], 'Warmest temperature supported')
             .withPreset('previous', 65535, 'Restore previous color_temp on cold power on'));
         return this;
     }

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -230,7 +230,11 @@ class Light extends Base {
         if (range === undefined) {
             range = [150, 500];
         }
-        this.features.push(new Numeric('color_temp', access.ALL).withUnit('mired').withValueMin(range[0]).withValueMax(range[1]).withDescription('Color temperature of this light'));
+        this.features.push(new Numeric('color_temp', access.ALL).withUnit('mired').withValueMin(range[0]).withValueMax(range[1])
+            .withDescription('Color temperature of this light')
+            .withPreset('cool', 250)
+            .withPreset('neutral', 370)
+            .withPreset('warm', 454));
         return this;
     }
 
@@ -241,6 +245,9 @@ class Light extends Base {
         }
         this.features.push(new Numeric('color_temp_startup', access.ALL).withUnit('mired').withValueMin(range[0]).withValueMax(range[1])
             .withDescription('Color temperature after cold power on of this light')
+            .withPreset('cool', 250)
+            .withPreset('neutral', 370)
+            .withPreset('warm', 454)
             .withPreset('previous', 65535, 'Restore previous color_temp on cold power on'));
         return this;
     }


### PR DESCRIPTION
I also removed the reverse mapping we had for color_temp_startup.
It didn't make sense for me for color_temp to have it report 248,249,'cool',251,252, ... so I brought color_temp_startup inline with this.

You can of course still set it by the preset name.