### PR TITLE
Update devices.js for Trust devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7941,14 +7941,14 @@ const devices = [
     {
         zigbeeModel: ['ZLL-DimmableLigh'],
         model: 'ZLED-2709',
-        vendor: 'Trust',
+        vendor: 'Trust International B.V.',
         description: 'Smart Dimmable LED Bulb',
         extend: preset.light_onoff_brightness(),
     },
     {
         zigbeeModel: ['ZLL-ColorTempera', 'ZLL-ColorTemperature'],
         model: 'ZLED-TUNE9',
-        vendor: 'Trust',
+        vendor: 'Trust International B.V.',
         description: 'Smart tunable LED bulb',
         extend: preset.light_onoff_brightness_colortemp(),
     },


### PR DESCRIPTION
Hello. After joined Trust devices ZLL-ColorTempera and and ZLL-DimmableLigh i'm have unsupported devices. Analysis of the situation showed that in devices.js set vendor Trust, but devices get vendor Trust International B.V. I fix it and i'm have supported devices! Perhaps other devices Trust are returned to the manufacturer as well, but I do not have them and cannot verify them.