### PR TITLE
Periodically update Tuya Thermostat with a time

### DIFF
--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const constants = require('./constants');
+const globalStore = require('./store');
 
 const dataTypes = {
     raw: 0, // [ bytes ]
@@ -84,8 +85,14 @@ async function onEventSetTime(type, data, device) {
 }
 
 // set UTC and Local Time as total number of seconds from 00: 00: 00 on January 01, 1970
+// force to update every device time every hour due to very poor clock
 async function onEventSetLocalTime(type, data, device) {
-    if (data.type === 'commandSetTimeRequest' && data.cluster === 'manuSpecificTuya') {
+    const nextLocalTimeUpdate = globalStore.getValue(device, 'nextLocalTimeUpdate');
+    const forceTimeUpdate = nextLocalTimeUpdate == null || nextLocalTimeUpdate < new Date().getTime();
+
+    if ((data.type === 'commandSetTimeRequest' && data.cluster === 'manuSpecificTuya') || forceTimeUpdate) {
+        globalStore.putValue(device, 'nextLocalTimeUpdate', new Date().getTime() + 3600 * 1000);
+
         try {
             const utcTime = Math.round(((new Date()).getTime()) / 1000);
             const localTime = utcTime - (new Date()).getTimezoneOffset() * 60;


### PR DESCRIPTION
It appears that Tuya thermostat pretty quickly
offsyncs it is internal clock resulting in a schedule
not executed properly.

This makes us to send a new updated time every hour
when a new notification from device is received (which do happen
pretty often).
