### PR TITLE
update device local time on Moes room thermostat device

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13517,6 +13517,7 @@ const devices = [
         model: 'BHT-002-GCLZB',
         vendor: 'Moes',
         description: 'Moes BHT series Thermostat',
+        onEvent: tuya.onEventSetLocalTime,
         fromZigbee: [fz.moes_thermostat],
         toZigbee: [tz.moes_thermostat_child_lock, tz.moes_thermostat_current_heating_setpoint, tz.moes_thermostat_mode,
             tz.moes_thermostat_standby, tz.moes_thermostat_sensor, tz.moes_thermostat_calibration, tz.moes_thermostat_min_temperature],


### PR DESCRIPTION
This PR will update the Moes Room thermostat device with the correct time. A function that was missing from the initial onboarding of the device to Z2m

