### PR TITLE
add support for IKEA KNYCKLAN reciver and the remote

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2442,6 +2442,43 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['KNYCKLAN Open/Close remote'],
+        model: 'E1841',
+        vendor: 'IKEA',
+        description: 'A remote by which you can remotely turn on and of the water valve.',
+        fromZigbee: [fz.command_on, fz.command_off, fz.battery],
+        exposes: [e.battery(), e.action(['on', 'off'])],
+        toZigbee: [],
+        ota: ota.tradfri,
+        meta: {configureKey: 1, disableActionGroup: true, battery: {dontDividePercentage: true}},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            // By default this device controls group 0, some devices are by default in
+            // group 0 causing the remote to control them.
+            // By binding it to a random group, e.g. 901, it will send the commands to group 901 instead of 0
+            // https://github.com/Koenkk/zigbee2mqtt/issues/2772#issuecomment-577389281
+            await endpoint.bind('genOnOff', defaultBindGroup);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['KNYCKLAN receiver'],
+        model: 'E 1842',
+        description: 'An electronic water valve shut-off',
+        vendor: 'IKEA',
+        exposes: [e.switch()],
+        fromZigbee: [fz.on_off],
+        toZigbee: [tz.on_off],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        },
+        ota: ota.tradfri,
+    },
+    {
         zigbeeModel: ['TRADFRI SHORTCUT Button'],
         model: 'E1812',
         vendor: 'IKEA',

--- a/devices.js
+++ b/devices.js
@@ -2445,7 +2445,7 @@ const devices = [
         zigbeeModel: ['KNYCKLAN Open/Close remote'],
         model: 'E1841',
         vendor: 'IKEA',
-        description: 'A remote by which you can remotely turn on and of the water valve.',
+        description: 'KNYCKLAN open/close remote water valve',
         fromZigbee: [fz.command_on, fz.command_off, fz.battery],
         exposes: [e.battery(), e.action(['on', 'off'])],
         toZigbee: [],
@@ -2464,12 +2464,10 @@ const devices = [
     },
     {
         zigbeeModel: ['KNYCKLAN receiver'],
-        model: 'E 1842',
-        description: 'An electronic water valve shut-off',
+        model: 'E1842',
+        description: 'KNYCKLAN receiver electronic water valve shut-off',
         vendor: 'IKEA',
-        exposes: [e.switch()],
-        fromZigbee: [fz.on_off],
-        toZigbee: [tz.on_off],
+        extend: preset.switch(),
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Add support for the **IKEA Nycklan** water valve receiver and the remote
KNYCKLAN receiver: `E 1842 `
KNYCKLAN remote: `E1841`


![knycklan](https://user-images.githubusercontent.com/20070414/105564506-c167ab00-5d22-11eb-9fcf-421447f5407b.jpg)
