### PR TITLE
Add support for yookee cover

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13137,6 +13137,24 @@ const devices = [
         exposes: [e.cover_position(), e.battery()],
     },
 
+    // Yookee
+    {
+        zigbeeModel: ['D10110'],
+        model: 'D10110',
+        vendor: 'Yookee',
+        description: 'Smart blind controller',
+        fromZigbee: [fz.cover_position_tilt, fz.battery],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.currentPositionLiftPercentage(endpoint);
+        },
+        exposes: [e.cover_position(), e.battery()],
+    },
+
     // SONOFF
     {
         zigbeeModel: ['BASICZBR3'],


### PR DESCRIPTION
Support for Yoolax smart blinds

https://smile.amazon.com/Yoolax-Motorized-Rechargeable-Restaurant-Customized/dp/B07QW65LTC?sa-no-redirect=1

They appear as "Yookee" for the manufacturer even though they sell as "Yoolax" 🤷‍♂️ 

The instruction manual actually shows Orvibo as the manufacturer for adding to alexa. so I used a nearly identical config. 