### PR TITLE
Undo #2036 which was applied to the wrong bulb

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9956,9 +9956,8 @@ const devices = [
         model: '404006/404008/404004',
         vendor: 'Müller Licht',
         description: 'Tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, opal white',
-        extend: preset.light_onoff_brightness_colortemp_color(),
-        toZigbee: preset.light_onoff_brightness_colortemp_color().toZigbee.concat([tz.tint_scene]),
-        meta: {enhancedHue: false},
+        extend: preset.light_onoff_brightness_colortemp(),
+        toZigbee: preset.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
     },
     {
         zigbeeModel: ['ZBT-CCTLight-GU100000'],


### PR DESCRIPTION
While looking into https://github.com/Koenkk/zigbee-herdsman-converters/issues/2129#issuecomment-766093179 I noticed there was a previous attempt (#2036) that was just wrong and ended up on the WS bulb instead of the color bulb.

This reverts that change.