### PR TITLE
[WIP] Split Müller Licht Tint 404005 from 404012/404000

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -758,6 +758,7 @@ const converters = {
 
             // Set correct meta.mapped for groups
             meta = utils.updateGroupMetaMapped(entity, meta);
+            const metaMapped = utils.getOptions(meta.mapped, entity);
 
             if (value.hasOwnProperty('r') && value.hasOwnProperty('g') && value.hasOwnProperty('b')) {
                 const xy = utils.rgbToXY(value.r, value.g, value.b);
@@ -779,7 +780,7 @@ const converters = {
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
 
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -794,7 +795,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -807,7 +808,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -821,7 +822,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -834,7 +835,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -848,7 +849,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -859,7 +860,7 @@ const converters = {
                 newState.color = {h: value.h, s: value.s};
                 const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), value.s, 100);
                 value.saturation = hsv.s * (2.54);
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturation';
                 } else {
@@ -869,7 +870,7 @@ const converters = {
             } else if (value.hasOwnProperty('h')) {
                 newState.color = {h: value.h};
                 const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), 100, 100);
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHue';
                 } else {
@@ -885,7 +886,7 @@ const converters = {
                 newState.color = {hue: value.hue, saturation: value.saturation};
                 const hsv = utils.gammaCorrectHSV(utils.correctHue(value.hue, meta), value.saturation, 100);
                 value.saturation = hsv.s * (2.54);
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturation';
                 } else {
@@ -895,7 +896,7 @@ const converters = {
             } else if (value.hasOwnProperty('hue')) {
                 newState.color = {hue: value.hue};
                 const hsv = utils.gammaCorrectHSV(utils.correctHue(value.hue, meta), 100, 100);
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (metaMapped && metaMapped.enhancedHue === false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHue';
                 } else {
@@ -3770,7 +3771,8 @@ const converters = {
                         );
                         state['color'] = {x: color.x, y: color.y};
                     } else if (color.hasOwnProperty('hue') && color.hasOwnProperty('saturation')) {
-                        if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                        const metaMapped = utils.getOptions(meta.mapped, entity);
+                        if (metaMapped && metaMapped.enhancedHue === false) {
                             // The extensionFieldSet is always EnhancedCurrentHue according to ZCL
                             // When the bulb or all bulbs in a group do not support enhanchedHue,
                             // a fallback to XY is done by converting HSV -> RGB -> XY

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -757,18 +757,7 @@ const converters = {
             const newState = {};
 
             // Set correct meta.mapped for groups
-            // * all definition metas are the same -> copy meta.mapped[0]
-            // * mixed device models -> meta.mapped = null
-            if (entity.constructor.name === 'Group' && entity.members.length > 0) {
-                for (const memberMeta of Object.values(meta.mapped)) {
-                    // check all members are the same device
-                    if (meta.mapped[0] != memberMeta) {
-                        meta.mapped = [null];
-                        break;
-                    }
-                }
-                meta.mapped = meta.mapped[0];
-            }
+            meta = utils.updateGroupMetaMapped(entity, meta);
 
             if (value.hasOwnProperty('r') && value.hasOwnProperty('g') && value.hasOwnProperty('b')) {
                 const xy = utils.rgbToXY(value.r, value.g, value.b);
@@ -3733,18 +3722,7 @@ const converters = {
             const transtime = value.hasOwnProperty('transition') ? value.transition : 0;
 
             // Set correct meta.mapped for groups
-            // * all definition metas are the same -> copy meta.mapped[0]
-            // * mixed device models -> meta.mapped = null
-            if (isGroup && entity.members.length > 0) {
-                for (const memberMeta of Object.values(meta.mapped)) {
-                    // check all members are the same device
-                    if (meta.mapped[0] != memberMeta) {
-                        meta.mapped = [null];
-                        break;
-                    }
-                }
-                meta.mapped = meta.mapped[0];
-            }
+            meta = utils.updateGroupMetaMapped(entity, meta);
 
             const state = {};
             const extensionfieldsets = [];
@@ -3796,7 +3774,7 @@ const converters = {
                             // The extensionFieldSet is always EnhancedCurrentHue according to ZCL
                             // When the bulb or all bulbs in a group do not support enhanchedHue,
                             // a fallback to XY is done by converting HSV -> RGB -> XY
-                            const colorXY = utils.rgbToXY(...Object.values(utils.hsvToRGB(color.hue, color.saturation, 100)));
+                            const colorXY = utils.rgbToXY(...Object.values(utils.hsvToRgb(color.hue, color.saturation, 100)));
                             extensionfieldsets.push(
                                 {
                                     'clstId': 768,

--- a/devices.js
+++ b/devices.js
@@ -9965,8 +9965,10 @@ const devices = [
         model: '404000/404005/404012',
         vendor: 'Müller Licht',
         description: 'Tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, color, opal white',
-        extend: preset.light_onoff_brightness_colortemp_colorxy(),
-        toZigbee: preset.light_onoff_brightness_colortemp_colorxy().toZigbee.concat([tz.tint_scene]),
+        extend: preset.light_onoff_brightness_colortemp_color(),
+        toZigbee: preset.light_onoff_brightness_colortemp_color().toZigbee.concat([tz.tint_scene]),
+        // GU10 variant that has a haDiagnostic cluster does not support enhancedHue
+        meta: {enhancedHue: (entity) => !entity.getDevice().getEndpoint(1).inputClusters.includes(2821)},
     },
     {
         zigbeeModel: ['ZBT-ColorTemperature'],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -215,7 +215,7 @@ function gammaCorrectRGB(r, g, b) {
     return {r: Math.round(r*255), g: Math.round(g*255), b: Math.round(b*255)};
 }
 
-function hsvToRGB(h, s, v) {
+function hsvToRgb(h, s, v) {
     h = h % 360 / 360;
     s = s / 100;
     v = v / 100;
@@ -263,7 +263,7 @@ function rgbToHSV(r, g, b) {
 function gammaCorrectHSV(h, s, v) {
     return rgbToHSV(
         ...Object.values(gammaCorrectRGB(
-            ...Object.values(hsvToRGB(h, s, v)))));
+            ...Object.values(hsvToRgb(h, s, v)))));
 }
 
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -458,7 +458,7 @@ function getTransition(entity, key, meta) {
 
 function getOptions(definition, entity, options={}) {
     const result = {...options};
-    const allowed = ['disableDefaultResponse', 'timeout'];
+    const allowed = ['disableDefaultResponse', 'timeout', 'enhancedHue'];
     if (definition && definition.meta) {
         for (const key of Object.keys(definition.meta)) {
             if (allowed.includes(key)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -486,6 +486,24 @@ function validateValue(value, allowed) {
     }
 }
 
+function updateGroupMetaMapped(entity, meta) {
+    // Set correct meta.mapped for groups
+    // * all definition metas are the same -> copy meta.mapped[0]
+    // * mixed device models -> meta.mapped = null
+    if (entity.constructor.name === 'Group' && entity.members.length > 0) {
+        for (const memberMeta of Object.values(meta.mapped)) {
+            // check all members are the same device
+            if (meta.mapped[0] != memberMeta) {
+                meta.mapped = [null];
+                break;
+            }
+        }
+        meta.mapped = meta.mapped[0];
+    }
+
+    return meta;
+}
+
 module.exports = {
     correctHue,
     getOptions,
@@ -507,6 +525,7 @@ module.exports = {
     validateValue,
     hexToXY,
     hexToRgb,
+    hsvToRgb,
     hslToHSV,
     interpolateHue,
     hasEndpoints,
@@ -521,4 +540,5 @@ module.exports = {
     sleep,
     toSnakeCase,
     toCamelCase,
+    updateGroupMetaMapped,
 };


### PR DESCRIPTION
The Müller Licht Tint 404005 (GU10) does not support enhancedHue. The MLI Tint 404000 (E27) does (No E14 to test)

Switching to fingreprints allows us to differentiate between them, we also expose Hue/Sat support now.


<img width="1179" alt="image" src="https://user-images.githubusercontent.com/379665/105611853-2f11e680-5db8-11eb-892b-4414643ae6c8.png">
<img width="1183" alt="image" src="https://user-images.githubusercontent.com/379665/105611859-35a05e00-5db8-11eb-85f8-b23278d81343.png">

Both are now recognizes correctly, the trick was switching both to fingerprint and adding the 2nd endpoint for the GU10.
I also verified frontend could set XY and HS on both, it now works as expected.