### PR TITLE
Fallback to XY when calling scene_add with hue/sat when bulb does not support enhancedHue

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -760,18 +760,7 @@ const converters = {
             const newState = {};
 
             // Set correct meta.mapped for groups
-            // * all definition metas are the same -> copy meta.mapped[0]
-            // * mixed device models -> meta.mapped = null
-            if (entity.constructor.name === 'Group' && entity.members.length > 0) {
-                for (const memberMeta of Object.values(meta.mapped)) {
-                    // check all members are the same device
-                    if (meta.mapped[0] != memberMeta) {
-                        meta.mapped = [null];
-                        break;
-                    }
-                }
-                meta.mapped = meta.mapped[0];
-            }
+            utils.updateGroupMetaMapped(entity, meta);
 
             if (value.hasOwnProperty('r') && value.hasOwnProperty('g') && value.hasOwnProperty('b')) {
                 const xy = utils.rgbToXY(value.r, value.g, value.b);
@@ -3735,6 +3724,9 @@ const converters = {
             const scenename = '';
             const transtime = value.hasOwnProperty('transition') ? value.transition : 0;
 
+            // Set correct meta.mapped for groups
+            utils.updateGroupMetaMapped(entity, meta);
+
             const state = {};
             const extensionfieldsets = [];
             for (let [attribute, val] of Object.entries(value)) {
@@ -3781,14 +3773,28 @@ const converters = {
                         );
                         state['color'] = {x: color.x, y: color.y};
                     } else if (color.hasOwnProperty('hue') && color.hasOwnProperty('saturation')) {
-                        const hsv = utils.gammaCorrectHSV(utils.correctHue(color.hue, meta), color.saturation, 100);
-                        extensionfieldsets.push(
-                            {
-                                'clstId': 768,
-                                'len': 13,
-                                'extField': [0, 0, (hsv.h % 360 * (65535 / 360)), (hsv.s * (2.54)), 0, 0, 0, 0],
-                            },
-                        );
+                        if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                            // The extensionFieldSet is always EnhancedCurrentHue according to ZCL
+                            // When the bulb or all bulbs in a group do not support enhanchedHue,
+                            // a fallback to XY is done by converting HSV -> RGB -> XY
+                            const colorXY = utils.rgbToXY(...Object.values(utils.hsvToRgb(color.hue, color.saturation, 100)));
+                            extensionfieldsets.push(
+                                {
+                                    'clstId': 768,
+                                    'len': 4,
+                                    'extField': [Math.round(colorXY.x * 65535), Math.round(colorXY.y * 65535)],
+                                },
+                            );
+                        } else {
+                            const hsv = utils.gammaCorrectHSV(utils.correctHue(color.hue, meta), color.saturation, 100);
+                            extensionfieldsets.push(
+                                {
+                                    'clstId': 768,
+                                    'len': 13,
+                                    'extField': [0, 0, (hsv.h % 360 * (65535 / 360)), (hsv.s * (2.54)), 0, 0, 0, 0],
+                                },
+                            );
+                        }
                         state['color'] = {hue: color.hue, saturation: color.saturation};
                     }
                 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -215,7 +215,7 @@ function gammaCorrectRGB(r, g, b) {
     return {r: Math.round(r*255), g: Math.round(g*255), b: Math.round(b*255)};
 }
 
-function hsvToRGB(h, s, v) {
+function hsvToRgb(h, s, v) {
     h = h % 360 / 360;
     s = s / 100;
     v = v / 100;
@@ -263,7 +263,7 @@ function rgbToHSV(r, g, b) {
 function gammaCorrectHSV(h, s, v) {
     return rgbToHSV(
         ...Object.values(gammaCorrectRGB(
-            ...Object.values(hsvToRGB(h, s, v)))));
+            ...Object.values(hsvToRgb(h, s, v)))));
 }
 
 
@@ -486,6 +486,22 @@ function validateValue(value, allowed) {
     }
 }
 
+function updateGroupMetaMapped(entity, meta) {
+    // Set correct meta.mapped for groups
+    // * all definition metas are the same -> copy meta.mapped[0]
+    // * mixed device models -> meta.mapped = null
+    if (entity.constructor.name === 'Group' && entity.members.length > 0) {
+        for (const memberMeta of Object.values(meta.mapped)) {
+            // check all members are the same device
+            if (meta.mapped[0] != memberMeta) {
+                meta.mapped = [null];
+                break;
+            }
+        }
+        meta.mapped = meta.mapped[0];
+    }
+}
+
 module.exports = {
     correctHue,
     getOptions,
@@ -507,6 +523,7 @@ module.exports = {
     validateValue,
     hexToXY,
     hexToRgb,
+    hsvToRgb,
     hslToHSV,
     interpolateHue,
     hasEndpoints,
@@ -521,4 +538,5 @@ module.exports = {
     sleep,
     toSnakeCase,
     toCamelCase,
+    updateGroupMetaMapped,
 };


### PR DESCRIPTION
While retesting applyRexFix for #2128 which looks like it is not needed when using scene_add (scenes certainly different on a lot of fronts 😞 ).

But while testing I was comparing XY and HS I noticed the same odd bulb crashing behavior discovered here https://github.com/Koenkk/zigbee-herdsman-converters/issues/2037#issuecomment-755516717 with bulbs that lie about enhancedHue support (hello Innr RB 250 C and Tint GU10).

```
[root@amethyst /opt/zigbee2mqtt]# mosquitto_pub -t zigbee2mqtt/office/light/desk/set/scene_add -m '{"ID": 123, "color": {"x": 0.701, "y": 0.299}}'
[root@amethyst /opt/zigbee2mqtt]# mosquitto_pub -t zigbee2mqtt/office/light/desk/set/scene_recall -m 123
[root@amethyst /opt/zigbee2mqtt]# mosquitto_pub -t zigbee2mqtt/office/light/desk/set/scene_add -m '{"ID": 124, "color": {"hue": 0, "saturation": 100}}'
[root@amethyst /opt/zigbee2mqtt]# mosquitto_pub -t zigbee2mqtt/office/light/desk/set/scene_recall -m 124
```

Now that with #2139 we correctly set enhancedHue=false for tint, I added a fallback. Both hs or xy in scene_add now result in the same result* for Innr RB 250 C, Tint GU10, Innr RB 285 C, Tint E27, Osram E27.

*objectively the same, the bulbs turn red/green/blue respectively when setting to the prime colors, Tint GU10 in particular still produces inconsistent results between XY and HS when **not** using scenes but are now the same when using scenes (which makes sense as both are now XY for scenes).
