### PR TITLE
Add support for Philips Hue Milliskin Spot (square): 5042131P9.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4090,6 +4090,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['5042131P9'],
+        model: '5042131P9',
+        vendor: 'Philips',
+        description: 'Hue White ambiance Milliskin (square)',
+        meta: {turnsOffAtBrightness1: true},
+        extend: preset.hue.light_onoff_brightness_colortemp(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['HML006'],
         model: '7531609',
         vendor: 'Philips',


### PR DESCRIPTION
Philips Hue Milliskin Spot (square): [50421/31/P9](https://www.philips-hue.com/cs-cz/p/hue-white-ambiance-zapustne-bodove-svitidlo-milliskin--rozsirene/5042131P9) is just a square version of [50411/31/P9](https://www.philips-hue.com/cs-cz/p/hue-white-ambiance-zapustne-bodove-svitidlo-milliskin--rozsirene/5041131P9).

