### PR TITLE
Converter definition runtime validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const devices = require('./devices');
 const exposes = require('./lib/exposes');
 const toZigbee = require('./converters/toZigbee');
 const fromZigbee = require('./converters/fromZigbee');
+const assert = require('assert');
 
 // key: zigbeeModel, value: array of definitions (most of the times 1)
 const lookup = new Map();
@@ -36,7 +37,26 @@ function getFromLookup(zigbeeModel) {
     return lookup.get(zigbeeModel);
 }
 
+const converterRequiredFields = {
+    model: 'String',
+    vendor: 'String',
+    description: 'String',
+    fromZigbee: 'Array',
+    toZigbee: 'Array',
+    exposes: 'Array',
+};
+
+function validateDefinition(definition) {
+    for (const [field, expectedType] of Object.entries(converterRequiredFields)) {
+        assert.notStrictEqual(null, definition[field], `Converter field ${field} is null`);
+        assert.notStrictEqual(undefined, definition[field], `Converter field ${field} is undefined`);
+        const msg = `Converter field ${field} expected type doenst match to ${definition[field]}`;
+        assert.strictEqual(definition[field].constructor.name, expectedType, msg);
+    }
+}
+
 function addDefinition(definition) {
+    validateDefinition(definition);
     definitions.push(definition);
 
     if (definition.hasOwnProperty('fingerprint')) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -283,13 +283,22 @@ describe('index.js', () => {
 
     it('Verify addDeviceDefinition', () => {
         const mockZigbeeModel = 'my-mock-device';
-        const mockDevice = {
-            zigbeeModel: [mockZigbeeModel],
-            model: 'mock-model'
-        };
+        let mockDevice = {};
         const undefinedDevice = index.findByZigbeeModel(mockDevice.model);
         expect(undefinedDevice).toBeNull();
         const beforeAdditionDeviceCount = index.devices.length;
+        expect(()=> index.addDeviceDefinition(mockDevice)).toThrow("Converter field model is undefined");
+        mockDevice.model = 'mock-model';
+        expect(()=> index.addDeviceDefinition(mockDevice)).toThrow("Converter field vendor is undefined");
+        mockDevice = {
+            model: 'mock-model',
+            vendor: 'dummy',
+            zigbeeModel: [mockZigbeeModel],
+            description: 'dummy',
+            fromZigbee: [],
+            toZigbee: [],
+            exposes: []
+        };
         index.addDeviceDefinition(mockDevice);
         expect(beforeAdditionDeviceCount + 1).toBe(index.devices.length);
         const device = index.findByZigbeeModel(mockZigbeeModel);


### PR DESCRIPTION
Validate converter, since we're exposing addDeviceDefinition for external converters, there are cases when users can add converter with invalid structure and crash frontend

example: https://github.com/nurikk/z2m-frontend/issues/279