### PR TITLE
Set enhancedHue=false for MLI Tint GU10

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -759,8 +759,6 @@ const converters = {
             let command;
             const newState = {};
 
-            // Set correct meta.mapped for groups
-            utils.updateGroupMetaMapped(entity, meta);
 
             if (value.hasOwnProperty('r') && value.hasOwnProperty('g') && value.hasOwnProperty('b')) {
                 const xy = utils.rgbToXY(value.r, value.g, value.b);
@@ -782,7 +780,7 @@ const converters = {
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
 
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -797,7 +795,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -810,7 +808,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -824,7 +822,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -837,7 +835,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -851,7 +849,7 @@ const converters = {
                 value.saturation = hsv.s * (2.54);
                 value.brightness = hsv.v * (2.54);
                 newState.brightness = value.brightness;
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturationAndBrightness';
                 } else {
@@ -862,7 +860,7 @@ const converters = {
                 newState.color = {h: value.h, s: value.s};
                 const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), value.s, 100);
                 value.saturation = hsv.s * (2.54);
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturation';
                 } else {
@@ -872,7 +870,7 @@ const converters = {
             } else if (value.hasOwnProperty('h')) {
                 newState.color = {h: value.h};
                 const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), 100, 100);
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHue';
                 } else {
@@ -888,7 +886,7 @@ const converters = {
                 newState.color = {hue: value.hue, saturation: value.saturation};
                 const hsv = utils.gammaCorrectHSV(utils.correctHue(value.hue, meta), value.saturation, 100);
                 value.saturation = hsv.s * (2.54);
-                if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                     value.hue = Math.round(hsv.h / 360 * 254);
                     command = 'moveToHueAndSaturation';
                 } else {
@@ -3738,9 +3736,6 @@ const converters = {
             const scenename = '';
             const transtime = value.hasOwnProperty('transition') ? value.transition : 0;
 
-            // Set correct meta.mapped for groups
-            utils.updateGroupMetaMapped(entity, meta);
-
             const state = {};
             const extensionfieldsets = [];
             for (let [attribute, val] of Object.entries(value)) {
@@ -3787,7 +3782,7 @@ const converters = {
                         );
                         state['color'] = {x: color.x, y: color.y};
                     } else if (color.hasOwnProperty('hue') && color.hasOwnProperty('saturation')) {
-                        if (meta.mapped && meta.mapped.meta && meta.mapped.meta.enhancedHue === false) {
+                        if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual') == false) {
                             // The extensionFieldSet is always EnhancedCurrentHue according to ZCL
                             // When the bulb or all bulbs in a group do not support enhanchedHue,
                             // a fallback to XY is done by converting HSV -> RGB -> XY

--- a/devices.js
+++ b/devices.js
@@ -10144,8 +10144,11 @@ const devices = [
         model: '404000/404005/404012',
         vendor: 'Müller Licht',
         description: 'Tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, color, opal white',
-        extend: preset.light_onoff_brightness_colortemp_colorxy(),
-        toZigbee: preset.light_onoff_brightness_colortemp_colorxy().toZigbee.concat([tz.tint_scene]),
+        extend: preset.light_onoff_brightness_colortemp_color(),
+        toZigbee: preset.light_onoff_brightness_colortemp_color().toZigbee.concat([tz.tint_scene]),
+        // GU10 bulb does not support enhancedHue,
+        // we can identify these based on the presense of haDiagnostic input cluster
+        meta: {enhancedHue: (entity) => !entity.getDevice().getEndpoint(1).inputClusters.includes(2821)},
     },
     {
         zigbeeModel: ['ZBT-ColorTemperature'],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -486,22 +486,6 @@ function validateValue(value, allowed) {
     }
 }
 
-function updateGroupMetaMapped(entity, meta) {
-    // Set correct meta.mapped for groups
-    // * all definition metas are the same -> copy meta.mapped[0]
-    // * mixed device models -> meta.mapped = null
-    if (entity.constructor.name === 'Group' && entity.members.length > 0) {
-        for (const memberMeta of Object.values(meta.mapped)) {
-            // check all members are the same device
-            if (meta.mapped[0] != memberMeta) {
-                meta.mapped = [null];
-                break;
-            }
-        }
-        meta.mapped = meta.mapped[0];
-    }
-}
-
 module.exports = {
     correctHue,
     getOptions,
@@ -538,5 +522,4 @@ module.exports = {
     sleep,
     toSnakeCase,
     toCamelCase,
-    updateGroupMetaMapped,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -458,7 +458,7 @@ function getTransition(entity, key, meta) {
 
 function getOptions(definition, entity, options={}) {
     const result = {...options};
-    const allowed = ['disableDefaultResponse', 'timeout'];
+    const allowed = ['disableDefaultResponse', 'timeout', 'enhancedHue'];
     if (definition && definition.meta) {
         for (const key of Object.keys(definition.meta)) {
             if (allowed.includes(key)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -148,13 +148,14 @@ function batteryVoltageToPercentage(voltage, option) {
 function getMetaValue(entity, definition, key, groupStrategy='first') {
     if (entity.constructor.name === 'Group' && entity.members.length > 0) {
         const values = [];
-        for (const memberMeta of definition) {
-            if (memberMeta.meta && memberMeta.meta.hasOwnProperty(key)) {
+        for (let i = 0; i < entity.members.length; i++) {
+            const memberMetaMeta = getOptions(definition[i], entity.members[i]);
+            if (memberMetaMeta && memberMetaMeta.hasOwnProperty(key)) {
                 if (groupStrategy === 'first') {
-                    return memberMeta.meta[key];
+                    return memberMetaMeta[key];
                 }
 
-                values.push(memberMeta.meta[key]);
+                values.push(memberMetaMeta[key]);
             } else {
                 values.push(undefined);
             }
@@ -163,8 +164,11 @@ function getMetaValue(entity, definition, key, groupStrategy='first') {
         if (groupStrategy === 'allEqual' && (new Set(values)).size === 1) {
             return values[0];
         }
-    } else if (definition && definition.meta && definition.meta.hasOwnProperty(key)) {
-        return definition.meta[key];
+    } else {
+        const definitionMeta = getOptions(definition, entity);
+        if (definitionMeta && definitionMeta.hasOwnProperty(key)) {
+            return definitionMeta[key];
+        }
     }
 
     return undefined;


### PR DESCRIPTION
3rd attempt at fixing this bulb.
- [x] drop `updateGroupMetaMapped` as we have `getMetaValue` which is better
- [x] `getMetaValue` should expand functions in meta
- [x]  target haDiagnostic cluster to id GU10 bulb