### PR TITLE
Fix for Moes BHT-002-GCLZB clock sync

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13955,7 +13955,7 @@ const devices = [
             .withLocalTemperature(ea.STATE)
             .withSystemMode(['off', 'heat'], ea.STATE_SET).withRunningState(['idle', 'heat', 'cool'], ea.STATE)
             .withPreset(['hold', 'program'])],
-        onEvent: tuya.onEventSetTime,
+        onEvent: tuya.onEventSetLocalTime,
     },
     {
         fingerprint: [{modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'},


### PR DESCRIPTION
Moes BHT-002-GCLZB thermostats have terrible internal clocks, normally remedied by Tuya syncing time information with them. Similar issues exist for other TS0601 thermostats and are fixed by forcing regular time updates in the following commit: https://github.com/Koenkk/zigbee-herdsman-converters/pull/2124

This commit only fixes devices that use `onEventSetLocalTime` which calculates time from epoch. The Moes thermostat normally uses `onEventSetTime` which calculates time from Jan 1 2000.

This temporary fix changes the Moes thermostat to use the fixed `onEventSetLocalTime` function. It updates the thermostats with the correct time; however as it calculates time since epoch, not Jan 1 2000, the displayed day is incorrect. This however is better than having both incorrect day AND incorrect time.

A complete solution would be to keep the Moes thermostat using `onEventSetTime` and then using the following code in `tuya.js`:

```
async function onEventSetTime(type, data, device) {
    const nextTimeUpdate = globalStore.getValue(device, 'nextTimeUpdate');
    const forceTimeUpdate = nextTimeUpdate == null || nextTimeUpdate < new Date().getTime();
    
    if (data.type === 'commandSetTimeRequest' && data.cluster === 'manuSpecificTuya') || forceTimeUpdate) {
        globalStore.putValue(device, 'nextTimeUpdate', new Date().getTime() + 3600 * 1000);{
        
            try {
            const utcTime = Math.round(((new Date()).getTime() - constants.OneJanuary2000) / 1000);
            const localTime = utcTime - (new Date()).getTimezoneOffset() * 60;
            const endpoint = device.getEndpoint(1);
            const payload = {
                payloadSize: 8,
                payload: [
                    ...convertDecimalValueTo4ByteHexArray(utcTime),
                    ...convertDecimalValueTo4ByteHexArray(localTime),
                ],
            };
            await endpoint.command('manuSpecificTuya', 'setTime', payload, {});
        } catch (error) {
            // endpoint.command can throw an error which needs to
            // be caught or the zigbee-herdsman may crash
            // Debug message is handled in the zigbee-herdsman
        }
    }
}

```

Unfortunately I am unable to test this more robust fix with my current setup and testing environment (running Z2M Edge as Home Assistant add-on). I would appreciate any advice on how I could test a modified `tuya.js` if anyone could spare the time!