### PR TITLE
Device config added for Bitron AV2010/26 wireless socket and brightne…

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8415,9 +8415,7 @@ const devices = [
         model: 'AV2010/26',
         vendor: 'Bitron',
         description: 'Wireless socket and brightness regulator',
-        fromZigbee: [fz.on_off, fz.brightness],
-        toZigbee: [tz.light_onoff_brightness],
-        exposes: [e.switch()],
+        extend: preset.light_onoff_brightness(),
         meta: {configureKey: 1},
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -8416,7 +8416,12 @@ const devices = [
         vendor: 'Bitron',
         description: 'Wireless socket and brightness regulator',
         extend: preset.light_onoff_brightness(),
-        meta: {configureKey: 1},
+        meta: {configureKey: 2},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        },
     },
     {
         zigbeeModel: ['902010/28'],

--- a/devices.js
+++ b/devices.js
@@ -8416,12 +8416,6 @@ const devices = [
         vendor: 'Bitron',
         description: 'Wireless socket and brightness regulator',
         extend: preset.light_onoff_brightness(),
-        meta: {configureKey: 2},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
-            await reporting.onOff(endpoint);
-        },
     },
     {
         zigbeeModel: ['902010/28'],

--- a/devices.js
+++ b/devices.js
@@ -8411,6 +8411,16 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['902010/26'],
+        model: 'AV2010/26',
+        vendor: 'Bitron',
+        description: 'Wireless socket and brightness regulator',
+        fromZigbee: [fz.on_off, fz.brightness],
+        toZigbee: [tz.light_onoff_brightness],
+        exposes: [e.switch()],
+        meta: {configureKey: 1},
+    },
+    {
         zigbeeModel: ['902010/28'],
         model: '902010/128',
         vendor: 'Bitron',


### PR DESCRIPTION
…ss regulator

The Bitron AV2010/26 device is now supported to switch the "state" "ON" or "OFF". 
I did not test the brightness change.