### PR TITLE
SR-ZG9101EA-5C and SR-ZG1029-5C from Sunricher

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11849,7 +11849,8 @@ const devices = [
         zigbeeModel: ['HK-ZD-RGBCCT-A', '511.000'],
         model: '511.000',
         vendor: 'Iluminize',
-        description: 'Zigbee 3.0 universal LED-controller, 5 channel 4A, RGBCCT LED',
+        whiteLabel: [{vendor: 'Sunricher', model: 'HK-ZD-RGBCCT-A'}],
+        description: 'Zigbee 3.0 universal LED-controller, 5 channel, RGBCCT LED',
         extend: preset.light_onoff_brightness_colortemp_colorxy(),
     },
     {


### PR DESCRIPTION
Add support for SR-ZG9101EA-5C and SR-ZG1029-5C from Sunricher.
One of them is exactly the same as 511.00 from Iluminize. Sunricher is the actual manufacturer.
The other is the same with higher amperage. Both (SR-ZG9101EA-5C and SR-ZG1029-5C) are identified as HK-ZD-RGBCCT-A.