### PR TITLE
Add support for RGBCCT and CCT Sunricher remotes

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11607,7 +11607,43 @@ const devices = [
             await reporting.onOff(endpoint);
         },
     },
-
+    {
+        zigbeeModel: ['ZG2819S-CCT'],
+        model: 'ZG2819S-CCT',
+        vendor: 'Sunricher',
+        description: 'Zigbee handheld remote CCT 4 channels',
+        fromZigbee: [fz.battery, fz.command_move_to_color, fz.command_move_to_color_temp, fz.command_move_hue,
+            fz.command_step, fz.command_recall, fz.command_on, fz.command_off,
+            fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move, 
+            fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation, fz.tint_scene],
+        exposes: [e.battery(), e.action([
+            'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down', 'recall_*', 'on', 'off', 'toggle',
+            'brightness_stop', 'brightness_move_up', 'brightness_move_down', 'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
+        toZigbee: [],
+        meta: {multiEndpoint: true},
+        endpoint: (device) => {
+            return {ep1: 1, ep2: 2, ep3: 3, ep4: 4};
+        },
+    },
+    {
+        zigbeeModel: ['ZG2858A'],
+        model: 'ZG2858A',
+        vendor: 'Sunricher',
+        description: 'Zigbee handheld remote RGBCCT 3 channels',
+        fromZigbee: [fz.battery, fz.command_move_to_color, fz.command_move_to_color_temp, fz.command_move_hue,
+            fz.command_step, fz.command_recall, fz.command_on, fz.command_off,
+            fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move, 
+            fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation, fz.tint_scene],
+        exposes: [e.battery(), e.action([
+            'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down', 'recall_*', 'on', 'off', 'toggle',
+            'brightness_stop', 'brightness_move_up', 'brightness_move_down', 'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
+        toZigbee: [],
+        meta: {multiEndpoint: true},
+        endpoint: (device) => {
+            return {ep1: 1, ep2: 2, ep3: 3};
+        },
+    },
+    
     // Samotech
     {
         zigbeeModel: ['SM308'],

--- a/devices.js
+++ b/devices.js
@@ -11614,11 +11614,12 @@ const devices = [
         description: 'Zigbee handheld remote CCT 4 channels',
         fromZigbee: [fz.battery, fz.command_move_to_color, fz.command_move_to_color_temp, fz.command_move_hue,
             fz.command_step, fz.command_recall, fz.command_on, fz.command_off,
-            fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move, 
+            fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move,
             fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation, fz.tint_scene],
         exposes: [e.battery(), e.action([
-            'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down', 'recall_*', 'on', 'off', 'toggle',
-            'brightness_stop', 'brightness_move_up', 'brightness_move_down', 'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
+            'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down',
+            'recall_*', 'on', 'off', 'toggle', 'brightness_stop', 'brightness_move_up', 'brightness_move_down',
+            'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
         toZigbee: [],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
@@ -11632,18 +11633,19 @@ const devices = [
         description: 'Zigbee handheld remote RGBCCT 3 channels',
         fromZigbee: [fz.battery, fz.command_move_to_color, fz.command_move_to_color_temp, fz.command_move_hue,
             fz.command_step, fz.command_recall, fz.command_on, fz.command_off,
-            fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move, 
+            fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move,
             fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation, fz.tint_scene],
         exposes: [e.battery(), e.action([
-            'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down', 'recall_*', 'on', 'off', 'toggle',
-            'brightness_stop', 'brightness_move_up', 'brightness_move_down', 'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
+            'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down',
+            'recall_*', 'on', 'off', 'toggle', 'brightness_stop', 'brightness_move_up', 'brightness_move_down',
+            'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
         toZigbee: [],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
             return {ep1: 1, ep2: 2, ep3: 3};
         },
     },
-    
+
     // Samotech
     {
         zigbeeModel: ['SM308'],

--- a/devices.js
+++ b/devices.js
@@ -11615,11 +11615,11 @@ const devices = [
         fromZigbee: [fz.battery, fz.command_move_to_color, fz.command_move_to_color_temp, fz.command_move_hue,
             fz.command_step, fz.command_recall, fz.command_on, fz.command_off,
             fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move,
-            fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation, fz.tint_scene],
+            fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation],
         exposes: [e.battery(), e.action([
             'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down',
             'recall_*', 'on', 'off', 'toggle', 'brightness_stop', 'brightness_move_up', 'brightness_move_down',
-            'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
+            'color_loop_set', 'enhanced_move_to_hue_and_saturation'])],
         toZigbee: [],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
@@ -11634,11 +11634,11 @@ const devices = [
         fromZigbee: [fz.battery, fz.command_move_to_color, fz.command_move_to_color_temp, fz.command_move_hue,
             fz.command_step, fz.command_recall, fz.command_on, fz.command_off,
             fz.command_on, fz.command_off, fz.command_toggle, fz.command_stop, fz.command_move,
-            fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation, fz.tint_scene],
+            fz.command_color_loop_set, fz.command_ehanced_move_to_hue_and_saturation],
         exposes: [e.battery(), e.action([
             'color_move', 'color_temperature_move', 'hue_move', 'brightness_step_up', 'brightness_step_down',
             'recall_*', 'on', 'off', 'toggle', 'brightness_stop', 'brightness_move_up', 'brightness_move_down',
-            'color_loop_set', 'enhanced_move_to_hue_and_saturation', 'scene_*'])],
+            'color_loop_set', 'enhanced_move_to_hue_and_saturation'])],
         toZigbee: [],
         meta: {multiEndpoint: true},
         endpoint: (device) => {


### PR DESCRIPTION
Add support for RGBCCT and CCT Sunricher remotes:
- Model: ZG2858A
- Model: ZG2819S-CCT (very similar to ZG2819S-RGBW from Iluminize, which is manufactured as well from Sunricher).