### PR TITLE
Verify checksums of Zigbee-OTA images

### DIFF
--- a/lib/ota/common.js
+++ b/lib/ota/common.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const upgradeFileIdentifier = Buffer.from([0x1E, 0xF1, 0xEE, 0x0B]);
 const HttpsProxyAgent = require('https-proxy-agent');
 const assert = require('assert');
@@ -413,6 +414,12 @@ async function getNewImage(current, logger, device, getImageMeta, downloadImage)
 
     const download = downloadImage ? await downloadImage(meta, logger) :
         await getAxios().get(meta.url, {responseType: 'arraybuffer'});
+
+    if (meta.sha512) {
+        const hash = crypto.createHash('sha512');
+        hash.update(download.data);
+        assert(hash.digest('hex') === meta.sha512, 'File checksum validation failed');
+    }
 
     const start = download.data.indexOf(upgradeFileIdentifier);
     const image = parseImage(download.data.slice(start));

--- a/lib/ota/zigbeeOTA.js
+++ b/lib/ota/zigbeeOTA.js
@@ -24,6 +24,7 @@ async function getImageMeta(current, logger, device) {
         fileVersion: image.fileVersion,
         fileSize: image.fileSize,
         url: image.url,
+        sha512: image.sha512,
     };
 }
 

--- a/test/otaCommon.test.js
+++ b/test/otaCommon.test.js
@@ -1,3 +1,6 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require("path");
 const common = require("../lib/ota/common");
 const otaImages = require("./stub/otaImages");
 
@@ -16,4 +19,50 @@ describe("ota/common.js", () => {
 
         expect(image.elements.length).toBe(otaImage.elements);
     });
+
+    describe('Image checksum validation', () => {
+        const data = fs.readFileSync(
+            path.join(__dirname, "stub", "otaImageFiles", "SAL2PU1_02015120_OTA.ota")
+        );
+        const hash = crypto.createHash('sha512');
+        hash.update(data);
+
+        const start = data.indexOf(common.upgradeFileIdentifier);
+        const image = common.parseImage(data.slice(start));
+
+        const mockLogger = { debug: jest.fn() }
+        const mockGetImageMeta = jest.fn().mockResolvedValue({
+            fileVersion: image.header.fileVersion,
+            sha512: hash.digest('hex'),
+        });
+        const device = { ieeeAddr: '0x000000000000000' };
+
+        it("Valid OTA image file passes checksum verification", async () => {
+            const mockDownloadImage = jest.fn().mockResolvedValue({ data });
+            await expect(common.getNewImage(
+                {
+                    manufacturerCode: image.header.manufacturerCode,
+                    imageType: image.header.imageType,
+                    fileVersion: image.header.fileVersion - 1,
+                },
+                mockLogger,
+                device,
+                mockGetImageMeta,
+                mockDownloadImage
+            )).resolves.toBeInstanceOf(Object);
+        });
+
+        it("Invalid OTA image file fails checksum verification", async () => {
+            const mockDownloadImage = jest.fn().mockResolvedValue({ data: 'invalid data' });
+
+            await expect(common.getNewImage(
+                { fileVersion: image.header.fileVersion - 1 },
+                mockLogger,
+                { ieeeAddr: '0x000000000000000' },
+                mockGetImageMeta,
+                mockDownloadImage
+            )).rejects.toThrow(/File checksum validation failed/);
+        });
+    });
+
 });


### PR DESCRIPTION
This implements #1998 - this PR verifies the checksum of OTA images after download, throwing an error if the validation fails and passes through the sha512 checksums for the Zigbee-OTA images.  Tests are included to test successful and non-successful validation use cases.

Other OTA providers can use this as a base and have hash validation added too -- a quick look into the API of Ledvance shows they return a sha256 hash.