### PR TITLE
Add sha256 validation for Ledvance OTA updates

### DIFF
--- a/lib/ota/common.js
+++ b/lib/ota/common.js
@@ -415,10 +415,12 @@ async function getNewImage(current, logger, device, getImageMeta, downloadImage)
     const download = downloadImage ? await downloadImage(meta, logger) :
         await getAxios().get(meta.url, {responseType: 'arraybuffer'});
 
-    if (meta.sha512) {
-        const hash = crypto.createHash('sha512');
+    const checksum = (meta.sha512 || meta.sha256);
+    if (checksum) {
+        const hash = crypto.createHash(meta.sha512 ? 'sha512' : 'sha256');
         hash.update(download.data);
-        assert(hash.digest('hex') === meta.sha512, 'File checksum validation failed');
+        assert(hash.digest('hex') === checksum, 'File checksum validation failed');
+        logger.debug(`OTA update checksum validation succeeded for '${device.ieeeAddr}'`);
     }
 
     const start = download.data.indexOf(upgradeFileIdentifier);

--- a/lib/ota/ledvance.js
+++ b/lib/ota/ledvance.js
@@ -17,7 +17,8 @@ async function getImageMeta(current, logger, device) {
     assert(data && data.firmwares && data.firmwares.length > 0,
         `No image available for manufacturerCode '${manufacturerCode}' imageType '${imageType}'`);
 
-    const {identity, fullName, length} = data.firmwares[0];
+    // Ledvance's API docs state the checksum should be `sha_256` but it is actually `shA256`
+    const {identity, fullName, length, shA256: sha256} = data.firmwares[0];
 
     const fileVersionMatch = /\/(\d+)\//.exec(fullName);
     const fileVersion = parseInt(`0x${fileVersionMatch[1]}`, 16);
@@ -29,6 +30,7 @@ async function getImageMeta(current, logger, device) {
         fileSize: length,
         url: updateDownloadUrl +
             `?company=${identity.company}&product=${identity.product}&version=${versionString}`,
+        sha256,
     };
 }
 


### PR DESCRIPTION
This PR continues on from #1998 by adding vendor-supplied sha256 checksum validation for Ledvance API OTA updates (none of the other vendors appear to publish checksums at this point).

The hash algorithm selection in `common.js` is simplistic at present - working with sha512 and sha256 - but can be added to (and refactored) when other checksum algorithms are needed.