### PR TITLE
Ignore basic report for HS2WD-E siren

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9347,7 +9347,7 @@ const devices = [
         model: 'HS2WD-E',
         vendor: 'HEIMAN',
         description: 'Smart siren',
-        fromZigbee: [fz.battery],
+        fromZigbee: [fz.battery, fz.ignore_basic_report],
         toZigbee: [tz.warning],
         meta: {disableDefaultResponse: true, configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
This device periodically sends the following type of message when availability checking is enabled:

```nginx
debug 2021-02-07 14:21:05: Received Zigbee message from 'siren', type 'readResponse', cluster 'genBasic', data '{"zclVersion":1}' from endpoint 1 with groupID 0
debug 2021-02-07 14:21:05: No converter available for 'HS2WD-E' with cluster 'genBasic' and type 'readResponse' and data '{"zclVersion":1}'
debug 2021-02-07 14:21:05: Successfully pinged 'siren'
```
This PR ensures the 'No converter' debug message is ignored.