### PR TITLE
ROB_200-008-0: Added zigbeeModel, added battery report

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7632,7 +7632,7 @@ const devices = [
         whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K8-DIM'}],
     },
     {
-        zigbeeModel: ['ZG2833K4_EU06'],
+        zigbeeModel: ['ZG2833K4_EU06', 'ROB_200-008'],
         model: 'ROB_200-008-0',
         vendor: 'ROBB',
         description: 'Zigbee 4 button wall switch',
@@ -7641,7 +7641,7 @@ const devices = [
             'on_1', 'off_1', 'stop_1', 'brightness_move_up_1', 'brightness_move_down_1', 'brightness_stop_1',
             'on_2', 'off_2', 'stop_2', 'brightness_move_up_2', 'brightness_move_down_2', 'brightness_stop_2'])],
         toZigbee: [],
-        meta: {multiEndpoint: true},
+        meta: {multiEndpoint: true, battery: {dontDividePercentage: true}},
         whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K4-DIM2'}],
     },
     {


### PR DESCRIPTION
I recently purchased this device, and initially Zigbee2Mqtt reported it as unsupported. Turns out the device is already supported, just that the version I bought identifies under a different zigbee model, so I've added it. Now it shows up recognised and works as expected.

Since these keypads are whitelabels similar to the iCasa series that I've previously added to my setup, I also knew they can report battery state during regular button presses, so I copied over that behaviour too after testing it.

On another note; would it be useful if I were to make another PR for adding a `whiteLabel` attribute to the iCasa ICZB-KPD12 device that I own? These ROBB products have this attribute listed but the iCasa products do not, yet it's quite clear they are made by the same manufacturer judging from the products themselves, their packaging, and their instruction booklet.