### PR TITLE
ICZB-KPD12: Added whiteLabel attribute

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10112,6 +10112,7 @@ const devices = [
         fromZigbee: [fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.battery],
         exposes: [e.battery(), e.action(['on', 'off', 'brightness_move_up', 'brightenss_move_down', 'brightness_stop'])],
         toZigbee: [],
+        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K2-DIM'}],
     },
     {
         zigbeeModel: ['ICZB-KPD14S'],


### PR DESCRIPTION
I have a setup here with both products from iCasa and ROBB, and I noticed from the ROBB entries in `devices.js` that there is a an optional `whiteLabel` attribute defined for some of the products. The iCasa product series are also whitelabels from Sunricher, so I added the respective entry for the device that I own.