### PR TITLE
Fix battery reporting for model 3325-S

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -7885,16 +7885,16 @@ const devices = [
         model: '3325-S',
         vendor: 'SmartThings',
         description: 'Motion sensor (2015 model)',
-        fromZigbee: [fz.temperature, fz.ias_occupancy_alarm_2],
+        fromZigbee: [fz.temperature, fz.ias_occupancy_alarm_2, fz.battery],
         toZigbee: [],
-        meta: {configureKey: 1},
+        meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
             await reporting.temperature(endpoint);
-            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.batteryVoltage(endpoint);
         },
-        exposes: [e.temperature(), e.occupancy(), e.battery_low(), e.tamper()],
+        exposes: [e.temperature(), e.occupancy(), e.battery(), e.tamper()],
     },
     {
         zigbeeModel: ['3321-S'],


### PR DESCRIPTION
Changed model for `3325-S` to read `batteryVoltage` instead of `batteryPercentageRemaining`, just like the [SmartThings DTH](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy) does.
Expose `battery` property (set by `fz.battery`), remove `battery_low` property as it is superseded by `battery` property.
