### PR TITLE
invert yookee cover reporting

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13758,7 +13758,7 @@ const devices = [
         description: 'Smart blind controller',
         fromZigbee: [fz.cover_position_tilt, fz.battery],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        meta: {configureKey: 1},
+        meta: {configureKey: 1, coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);


### PR DESCRIPTION
Follow up to this pr: https://github.com/Koenkk/zigbee-herdsman-converters/pull/2131

After using it for a while, noticed that positions were being reported backwards.