### PR TITLE
Always expose `previous` for color_temp_startup

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -261,8 +261,8 @@ class Light extends Base {
             {name: 'neutral', value: 370, description: 'Neutral temperature (370 mireds / 2700 Kelvin)'},
             {name: 'warm', value: 454, description: 'Warm temperature (454 mireds / 2200 Kelvin)'},
             {name: 'warmest', value: range[1], description: 'Warmest temperature supported'},
-            {name: 'previous', value: 65535, description: 'Restore previous color_temp on cold power on'},
         ].filter((p) => p.value >= range[0] && p.value <= range[1]).forEach((p) => feature.withPreset(p.name, p.value, p.description));
+        feature.withPreset('previous', 65535, 'Restore previous color_temp on cold power on');
 
         this.features.push(feature);
         return this;


### PR DESCRIPTION
Got filtered out in 3bcc1080b44749e6e0f7bf4351b88da22739e9d1, but 65535 is special as it lies outside the normal allowed range of color_temp so it will never be within min/max range!

It means use previous color_temperature.

![image](https://user-images.githubusercontent.com/379665/107874461-33628880-6eba-11eb-9789-c98eaf146b96.png)
