### PR TITLE
Added Tradfri occupancy_timeout device config option

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4360,7 +4360,10 @@ const converters = {
         type: 'commandOnWithTimedOff',
         convert: (model, msg, publish, options, meta) => {
             if (msg.data.ctrlbits === 1) return;
-            const timeout = msg.data.ontime / 10;
+
+            const timeout = options && options.hasOwnProperty('occupancy_timeout') ?
+            options.occupancy_timeout : msg.data.ontime / 10;
+
             // Stop existing timer because motion is detected and set a new one.
             clearTimeout(globalStore.getValue(msg.endpoint, 'timer'));
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4362,7 +4362,7 @@ const converters = {
             if (msg.data.ctrlbits === 1) return;
 
             const timeout = options && options.hasOwnProperty('occupancy_timeout') ?
-            options.occupancy_timeout : msg.data.ontime / 10;
+                options.occupancy_timeout : msg.data.ontime / 10;
 
             // Stop existing timer because motion is detected and set a new one.
             clearTimeout(globalStore.getValue(msg.endpoint, 'timer'));


### PR DESCRIPTION
Similar to Xiaomi Aqara motion sensor device option, added the ability to override the default detection cooldown timeout.
This allows custom motion detection loop control in HA automation by setting the value lower than the re-trigger interval of the device.

Related PR:
https://github.com/Koenkk/zigbee2mqtt.io/pull/629