### PR TITLE
Setup lightingColorCtrl options

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -78,12 +78,13 @@ const preset = {
             exposes,
             fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
             toZigbee,
-            meta: {configureKey: 2},
+            meta: {configureKey: 3},
             configure: async (device, coordinatorEndpoint, logger) => {
                 for (const endpoint of device.endpoints.filter((e) => e.supportsInputCluster('lightingColorCtrl'))) {
                     try {
                         await light.readColorCapabilities(endpoint);
                         await light.readColorTempMinMax(endpoint);
+                        await light.setupLightOptions(endpoint);
                     } catch (e) {/* Fails for some, e.g. https://github.com/Koenkk/zigbee2mqtt/issues/5717 */}
                 }
             },
@@ -97,6 +98,15 @@ const preset = {
             tz.light_brightness_move, tz.light_brightness_step, tz.level_config,
             tz.light_hue_saturation_move, tz.light_hue_saturation_step,
         ],
+        meta: {configureKey: 3},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            for (const endpoint of device.endpoints.filter((e) => e.supportsInputCluster('lightingColorCtrl'))) {
+                try {
+                    await light.readColorCapabilities(endpoint);
+                    await light.setupLightOptions(endpoint);
+                } catch (e) {/* Fails for some, e.g. https://github.com/Koenkk/zigbee2mqtt/issues/5717 */}
+            }
+        },
     }),
     light_onoff_brightness_colorxy: (options={}) => ({
         exposes: [e.light_brightness_colorxy(), e.effect()],
@@ -106,11 +116,12 @@ const preset = {
             tz.light_brightness_move, tz.light_brightness_step, tz.level_config,
             tz.light_hue_saturation_move, tz.light_hue_saturation_step,
         ],
-        meta: {configureKey: 2},
+        meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint, logger) => {
             for (const endpoint of device.endpoints.filter((e) => e.supportsInputCluster('lightingColorCtrl'))) {
                 try {
                     await light.readColorCapabilities(endpoint);
+                    await light.setupLightOptions(endpoint);
                 } catch (e) {/* Fails for some, e.g. https://github.com/Koenkk/zigbee2mqtt/issues/5717 */}
             }
         },
@@ -133,12 +144,13 @@ const preset = {
             exposes,
             fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
             toZigbee,
-            meta: {configureKey: 2},
+            meta: {configureKey: 3},
             configure: async (device, coordinatorEndpoint, logger) => {
                 for (const endpoint of device.endpoints.filter((e) => e.supportsInputCluster('lightingColorCtrl'))) {
                     try {
                         await light.readColorCapabilities(endpoint);
                         await light.readColorTempMinMax(endpoint);
+                        await light.setupLightOptions(endpoint);
                     } catch (e) {/* Fails for some, e.g. https://github.com/Koenkk/zigbee2mqtt/issues/5717 */}
                 }
             },
@@ -162,12 +174,13 @@ const preset = {
             exposes,
             fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.ignore_basic_report],
             toZigbee,
-            meta: {configureKey: 2},
+            meta: {configureKey: 3},
             configure: async (device, coordinatorEndpoint, logger) => {
                 for (const endpoint of device.endpoints.filter((e) => e.supportsInputCluster('lightingColorCtrl'))) {
                     try {
                         await light.readColorCapabilities(endpoint);
                         await light.readColorTempMinMax(endpoint);
+                        await light.setupLightOptions(endpoint);
                     } catch (e) {/* Fails for some, e.g. https://github.com/Koenkk/zigbee2mqtt/issues/5717 */}
                 }
             },

--- a/lib/light.js
+++ b/lib/light.js
@@ -46,9 +46,22 @@ function clampColorTemp(colorTemp, colorTempMin, colorTempMax, logger) {
     return colorTemp;
 }
 
+async function setupLightOptions(endpoint) {
+    /*
+     * Options Bitmap
+     * ---------------------
+     * 0: ExecuteIfOff
+     */
+    // try to set ExecuteIfOff to true
+    try {
+        await endpoint.write('lightingColorCtrl', {options: 1});
+    } catch (e) {/* ZCL marks this as RW and mandatory, but we watch it just to be safe */}
+}
+
 module.exports = {
     readColorCapabilities,
     readColorTempMinMax,
     findColorTempRange,
     clampColorTemp,
+    setupLightOptions,
 };


### PR DESCRIPTION
See #2253, we can still go the other way if you want. But I don't think having this as yet another payload attribute is useful.
No errors as we have this behind a try/catch, works OK for all my CWS bulbs with the exception of Hue.

It also works on my Trådfri panels! But not my Trådfri GU10 bulbs. Still nice to have though.