### PR TITLE
TERNCY-DC01: add battery percentage readout

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13498,9 +13498,10 @@ const devices = [
         model: 'TERNCY-DC01',
         vendor: 'TERNCY',
         description: 'Temperature & contact sensor ',
-        fromZigbee: [fz.terncy_temperature, fz.terncy_contact],
+        fromZigbee: [fz.terncy_temperature, fz.terncy_contact, fz.battery],
         toZigbee: [],
-        exposes: [e.temperature(), e.contact()],
+        exposes: [e.temperature(), e.contact(), e.battery()],
+        meta: {battery: {dontDividePercentage: true}},
     },
     {
         zigbeeModel: ['TERNCY-PP01'],


### PR DESCRIPTION
I was surprised that Terncy DC-01 door sensor does not expose battery status. Indeed it does, just have to add corresponding converters.
I have also tried to set up reporting, but it fails -> I think it is not supported by the sensor.