### PR TITLE
updates SR-ZG9040A to add power measurements

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11705,7 +11705,7 @@ const devices = [
         fromZigbee: preset.light_onoff_brightness().fromZigbee.concat([fz.electrical_measurement, fz.metering, fz.ignore_genOta]),
         toZigbee: preset.light_onoff_brightness().toZigbee,
         meta: {configureKey: 2},
-        exposes: [e.light_brightness(), e.power(), e.energy()],
+        exposes: [e.light_brightness(), e.power(), e.voltage(), e.current(), e.energy()],
         whiteLabel: [{vendor: 'YPHIX', model: '50208695'}, {vendor: 'Samotech', model: 'SM311'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -11738,7 +11738,7 @@ const devices = [
         fromZigbee: preset.light_onoff_brightness().fromZigbee.concat([fz.electrical_measurement, fz.metering, fz.ignore_genOta]),
         toZigbee: preset.light_onoff_brightness().toZigbee,
         meta: {configureKey: 2},
-        exposes: [e.light_brightness(), e.power(), e.energy()],
+        exposes: [e.light_brightness(), e.power(), e.voltage(), e.current(), e.energy()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const binds = ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering'];

--- a/devices.js
+++ b/devices.js
@@ -11735,7 +11735,23 @@ const devices = [
         model: 'SR-ZG9040A',
         vendor: 'Sunricher',
         description: 'Zigbee micro smart dimmer',
-        extend: preset.light_onoff_brightness(),
+        fromZigbee: preset.light_onoff_brightness().fromZigbee.concat([fz.electrical_measurement, fz.metering, fz.ignore_genOta]),
+        toZigbee: preset.light_onoff_brightness().toZigbee,
+        meta: {configureKey: 2},
+        exposes: [e.light_brightness(), e.power(), e.energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            const binds = ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering'];
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.activePower(endpoint);
+            await reporting.rmsCurrent(endpoint, {min: 10, change: 10});
+            await reporting.rmsVoltage(endpoint, {min: 10});
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint);
+        },
     },
     {
         zigbeeModel: ['HK-ZD-DIM-A'],


### PR DESCRIPTION
Besides this it should (according to [documentation](https://www.m.nu/Common/File/Download?guid=7FD33DFB-BA0E-4987-A5A9-7B1620B0C211) support switching between `push switch`, `Normal on/off switch` and `3-Way switch`). Do you think it could be done or is this done at construction/initial flash?

And maybe I should create a sunricher.preset instead. 

From docs.
<img width="628" alt="image" src="https://user-images.githubusercontent.com/5699172/108431892-cfd2b500-7243-11eb-8250-1ac127181dad.png">

<img width="847" alt="image" src="https://user-images.githubusercontent.com/5699172/108431992-f7c21880-7243-11eb-8c0e-47cf4b4c61fb.png">

