### PR TITLE
Fix moes thermostat negative local temp

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2739,7 +2739,8 @@ const converters = {
             case tuya.dataPoints.moesMinTemp:
                 return {min_temperature: value};
             case tuya.dataPoints.moesLocalTemp:
-                return {local_temperature: parseFloat((value / 10).toFixed(1))};
+                temperature = value & 1<<15 ? value - (1<<16) + 1 : value;
+                return {local_temperature: parseFloat((temperature / 10).toFixed(1))};
             case tuya.dataPoints.moesTempCalibration:
                 temperature = value;
                 // for negative values produce complimentary hex (equivalent to negative values)


### PR DESCRIPTION
Local temperature comes as a 16bit signed integer with the last digit as a fraction. When chunks are saved into JS's integer sign bit is lost. As a result, for example, at -2.9 local temperature zigbee converter outputs 6550.6. This change fixes this problem.