### PR TITLE
Allow get/power for Ubisys S1/S2

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1301,6 +1301,12 @@ const converters = {
             await entity.read('haElectricalMeasurement', ['activePower']);
         },
     },
+    metering_power: {
+        key: ['power'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('seMetering', ['instantaneousDemand']);
+        },
+    },
     // #endregion
 
     // #region Non-generic converters

--- a/devices.js
+++ b/devices.js
@@ -13318,13 +13318,17 @@ const devices = [
         model: 'S1',
         vendor: 'Ubisys',
         description: 'Power switch S1',
-        exposes: [e.switch(), e.power(), e.action([
-            'toggle', 'on', 'off', 'recall_*',
-            'brightness_move_up', 'brightness_move_down', 'brightness_stop',
-        ])],
+        exposes: [e.switch(), e.power().withAccess(ea.STATE_GET).withEndpoint('meter').withProperty('power'),
+            e.action([
+                'toggle', 'on', 'off', 'recall_*',
+                'brightness_move_up', 'brightness_move_down', 'brightness_stop',
+            ])],
         fromZigbee: [fz.on_off, fz.metering, fz.command_toggle, fz.command_on, fz.command_off, fz.command_recall, fz.command_move,
             fz.command_stop],
-        toZigbee: [tz.on_off, tz.ubisys_device_setup],
+        toZigbee: [tz.on_off, tz.metering_power, tz.ubisys_device_setup],
+        endpoint: (device) => {
+            return {'l1': 1, 's1': 2, 'meter': 3};
+        },
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(3);
@@ -13357,15 +13361,16 @@ const devices = [
         vendor: 'Ubisys',
         description: 'Power switch S2',
         exposes: [
-            e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.power(),
+            e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
+            e.power().withAccess(ea.STATE_GET).withEndpoint('meter').withProperty('power'),
             e.action(['toggle_s1', 'toggle_s2', 'on_s1', 'on_s2', 'off_s1', 'off_s2', 'recall_*_s1', 'recal_*_s2', 'brightness_move_up_s1',
                 'brightness_move_up_s2', 'brightness_move_down_s1', 'brightness_move_down_s2', 'brightness_stop_s1',
                 'brightness_stop_s2'])],
         fromZigbee: [fz.on_off, fz.metering, fz.command_toggle, fz.command_on, fz.command_off, fz.command_recall, fz.command_move,
             fz.command_stop],
-        toZigbee: [tz.on_off, tz.ubisys_device_setup],
+        toZigbee: [tz.on_off, tz.metering_power, tz.ubisys_device_setup],
         endpoint: (device) => {
-            return {'l1': 1, 'l2': 2, 's1': 3, 's2': 4};
+            return {'l1': 1, 'l2': 2, 's1': 3, 's2': 4, 'meter': 5};
         },
         meta: {configureKey: 3, multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
Ubisys support verified that we should indeed be able to read this.

Did some more digging and found the issue, well there is no issue, you just have to specify the correct EP.

```
[root@amethyst ~]# mosquitto_pub -t zigbee2mqtt/office/light/main/switch/3/get/power -m ''
```

```
Zigbee2MQTT:debug 2021-02-21 17:59:52: Received MQTT message on 'zigbee2mqtt/office/light/main/switch/3/get/power' with data ''
Zigbee2MQTT:debug 2021-02-21 17:59:52: Publishing get 'get' 'power' to 'office/light/main/switch'
Zigbee2MQTT:debug 2021-02-21 17:59:52: Received Zigbee message from 'office/light/main/switch', type 'readResponse', cluster 'seMetering', data '{"instantaneousDemand":1}' from endpoint 3 with groupID 0
Zigbee2MQTT:info  2021-02-21 17:59:52: MQTT publish: topic 'zigbee2mqtt/office/light/main/switch', payload '{"linkquality":57,"power":1,"state":"ON","update":{"state":"idle"}}'
```