### PR TITLE
Added BTicino K4027C support

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14806,7 +14806,7 @@ const devices = [
         // The cover position is not reliable yet
         // https://github.com/Koenkk/zigbee-herdsman-converters/pull/2214
         zigbeeModel: [' Shutter SW with level control\u0000'],
-        model: 'L4027C/N4027C/NT4027C',
+        model: 'K4027C/L4027C/N4027C/NT4027C',
         vendor: 'BTicino',
         description: 'Shutter SW with level control',
         fromZigbee: [fz.identify, fz.ignore_basic_report, fz.ignore_zclversion_read, fz.legrand_binary_input_moving,


### PR DESCRIPTION
The K4027C has the same pattern as the other ;). Tested, however as stated in the comment, the position is not reliable yet.