### PR TITLE
Support 1746230V7

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4229,6 +4229,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['1746230V7'],
+        model: '1746230V7',
+        vendor: 'Philips',
+        description: 'Hue Lily XL outdoor spot light',
+        meta: {turnsOffAtBrightness1: true},
+        extend: preset.hue.light_onoff_brightness_colortemp_color(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LCL003'],
         model: '9290022891',
         vendor: 'Philips',

--- a/devices.js
+++ b/devices.js
@@ -4234,7 +4234,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue Lily XL outdoor spot light',
         meta: {turnsOffAtBrightness1: true},
-        extend: preset.hue.light_onoff_brightness_colortemp_color(),
+        extend: preset.hue.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,
     },
     {


### PR DESCRIPTION
Added support for Philips Hue Lily XL outdoor spot light (1746230V7)
Here's a product page: https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-lily-xl-outdoor-spot-light/1746230V7
Tested it by making zigbee2mqtt recognize and control the light.