### PR TITLE
Add support for Hue white BR30 flood light (LWB022)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3329,6 +3329,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LWB022'],
+        model: '9290018194',
+        vendor: 'Philips',
+        description: 'Hue white BR30',
+        meta: {turnsOffAtBrightness1: true},
+        extend: preset.hue.light_onoff_brightness(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LCT003'],
         model: '8718696485880',
         vendor: 'Philips',


### PR DESCRIPTION
This is very similar to the existing support for the Philips Hue White Ambiance BR30 bulb, but this bulb doesn't have a tunable temperature.

Works on my local zigbee network.