### PR TITLE
remove erroneously added etop error status code

### DIFF
--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -239,7 +239,6 @@ const dataPoints = {
     moesChildLock: 40,
     moesSensor: 43,
     moesSchedule: 101,
-    etopErrorStatus: 13,
     // Neo T&H
     neoPowerType: 101,
     neoMelody: 102,


### PR DESCRIPTION
looks like it originated from here:

https://github.com/drzony/zigbee-herdsman-converters/blob/f3709f9a3b5ed8d3607e921bbe8ebe32714bdac1/converters/fromZigbee.js#L315