### PR TITLE
SmartThings F-MLT-US-2 (multiv4): fix battery readings

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8187,7 +8187,7 @@ const devices = [
         description: 'Multipurpose sensor (2016 model)',
         fromZigbee: [fz.temperature, fz.battery, fz.ias_contact_alarm_1, fz.smartthings_acceleration],
         toZigbee: [],
-        meta: {configureKey: 2, battery: {voltageToPercentage: '3V_2500'}},
+        meta: {configureKey: 2, battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const options = {manufacturerCode: 0x110A};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -134,6 +134,14 @@ function batteryVoltageToPercentage(voltage, option) {
         percentage = toPercentage(voltage, 2500, 3000);
     } else if (option === '3V_2500_3200') {
         percentage = toPercentage(voltage, 2500, 3200);
+    } else if (option === '3V_1500_2800') {
+        percentage = 235 - 370000 / voltage;
+        if (percentage > 100) {
+            percentage = 100;
+        } else if (percentage < 0) {
+            percentage = 0;
+        }
+        percentage = Math.round(percentage);
     } else if (option === '4LR6AA1_5v') {
         percentage = toPercentage(voltage, 3000, 4200);
     } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,7 +135,7 @@ function batteryVoltageToPercentage(voltage, option) {
     } else if (option === '3V_2500_3200') {
         percentage = toPercentage(voltage, 2500, 3200);
     } else if (option === '3V_1500_2800') {
-        percentage = 235 - 370000 / voltage;
+        percentage = 235 - 370000 / (voltage + 1);
         if (percentage > 100) {
             percentage = 100;
         } else if (percentage < 0) {


### PR DESCRIPTION
I did a try to fix battery readings from F-MLT-US-2, instead of table lookup I introduced a function, here is a comparison with original implementation:

```
  V  | Ori |  Fun
2800 | 100 | 100
2700 | 100 |  98
2600 | 100 |  93
2500 |  90 |  87
2400 |  90 |  81
2300 |  70 |  74
2200 |  70 |  67
2100 |  50 |  59
2000 |  50 |  50
1900 |  30 |  40
1800 |  30 |  29
1700 |  15 |  17
1600 |   1 |   4
1500 |   0 |   0
```
I think It's not bad, at least one can see a trend even if the percentage is not changing in the original table.

Not sure that '3V_1500_2800' option name is good, any feedback is welcome.
PS 'Power source' is still not showing, have to figure out how to fix it.