### PR TITLE
Update constants.js

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -103,14 +103,13 @@ const armMode = {
     1: 'arm_day_zones',
     2: 'arm_night_zones',
     3: 'arm_all_zones',
-    4: 'invalid_code',
-    5: 'exit_delay',
-    6: 'entry_delay',
-    7: 'not_ready',
-    8: 'in_alarm',
-    9: 'arming_stay',
-    10: 'arming_night',
-    11: 'arming_away',
+    4: 'exit_delay',
+    5: 'entry_delay',
+    6: 'not_ready',
+    7: 'in_alarm',
+    8: 'arming_stay',
+    9: 'arming_night',
+    10: 'arming_away',
 };
 
 module.exports = {


### PR DESCRIPTION
Updating the panelstatus constants to match 8-16 in the zigbee cluster library for PanelStatus field values. The existing implementation has an extra field which does not belong there (invalid_code)

![image](https://user-images.githubusercontent.com/14173108/109175497-d079c700-77c0-11eb-9a26-c1ceae91beb2.png)
