### PR TITLE
(WIP) adds xyz for samsung smartthings M6001_MPP01

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8216,7 +8216,7 @@ const devices = [
         model: 'IM6001-MPP01',
         vendor: 'SmartThings',
         description: 'Multipurpose sensor (2018 model)',
-        fromZigbee: [fz.temperature, fz.ias_contact_alarm_1, fz.battery, fz.smartthings_acceleration],
+        fromZigbee: [fz.temperature, fz.battery, fz.ias_contact_alarm_1, fz.smartthings_acceleration],
         toZigbee: [],
         meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -8227,10 +8227,19 @@ const devices = [
             await endpoint.write('manuSpecificSamsungAccelerometer', {0x0000: {value: 0x14, type: 0x20}}, options);
             await reporting.temperature(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
-            const payload = reporting.payload('acceleration', 10, repInterval.MINUTE, 1);
-            await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payload, options);
+            const payloadA = reporting.payload('acceleration', 10, repInterval.MINUTE, 1);
+            await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadA, options);
+            const payloadX = reporting.payload('x_axis', 10, repInterval.MINUTE, 1);
+            await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadX, options);
+            const payloadY = reporting.payload('y_axis', 10, repInterval.MINUTE, 1);
+            await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadY, options);
+            const payloadZ = reporting.payload('z_axis', 10, repInterval.MINUTE, 1);
+            await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadZ, options);
         },
-        exposes: [e.temperature(), e.contact(), e.battery_low(), e.tamper(), e.battery(), e.moving()],
+        exposes: [
+            e.temperature(), e.contact(), e.battery_low(), e.tamper(), e.battery(),
+            e.moving(), e.x_axis(), e.y_axis(), e.z_axis(),
+        ],
     },
     {
         zigbeeModel: ['3310-S'],


### PR DESCRIPTION
I'm missing something

In the log:
`Received Zigbee message from 'Hall Farstu', type 'attributeReport', cluster 'manuSpecificSamsungAccelerometer', data '{"x_axis":41,"y_axis":-1073,"z_axis":17}' from endpoint 1 with groupID 0`

On the device:
<img width="547" alt="image" src="https://user-images.githubusercontent.com/5699172/109210336-f85f2f80-77ac-11eb-8f4b-b7c351c4f014.png">
