### PR TITLE
Add a new Legrand device, Legrand 412170 (Drivia with Netatmo connected teleruptor)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14660,6 +14660,27 @@ const devices = [
         },
     },
     {
+        zigbeeModel: [' Teleruptor\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'+
+            '\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
+        model: 'FC80RC',
+        description: 'Legrand (or Bticino) DIN smart relay for light control (note: Legrand 412170 may be similar to Bticino FC80RC)',
+        vendor: 'Legrand',
+        extend: preset.switch(),
+        fromZigbee: [fz.identify, fz.on_off, fz.electrical_measurement, fz.legrand_device_mode, fz.ignore_basic_report, fz.ignore_genOta],
+        toZigbee: [tz.legrand_deviceMode, tz.on_off, tz.legrand_identify, tz.electrical_measurement_power],
+        exposes: [exposes.switch().withState('state', true, 'On/off (works only if device is in "switch" mode)'),
+            e.power().withAccess(ea.STATE_GET), exposes.enum( 'device_mode', ea.ALL, ['switch', 'auto'])
+                .withDescription('switch: allow on/off, auto will use wired action via C1/C2 on teleruptor with buttons')],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'haElectricalMeasurement']);
+            await reporting.onOff(endpoint);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.activePower(endpoint);
+        },
+    },
+    {
         zigbeeModel: [' Shutters central remote switch'],
         model: '067646',
         vendor: 'Legrand',


### PR DESCRIPTION
Add a new Legrand device, Legrand 412170 (Drivia with Netatmo connected teleruptor).
This is a clone of the existing Legrand 412171 (Drivia with Netatmo connected contactor) with different zigbeeModel and model.
Same feature set, difference is lower power capacity (16A vs 20A).