### PR TITLE
expose: drop light_color_options

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -62,7 +62,7 @@ const preset = {
         ],
     }),
     light_onoff_brightness_colortemp: (options={}) => {
-        const exposes = [e.light_brightness_colortemp(options.colorTempRange), e.effect(), e.light_color_options()];
+        const exposes = [e.light_brightness_colortemp(options.colorTempRange), e.effect()];
         const toZigbee = [
             tz.light_onoff_brightness, tz.light_colortemp, tz.ignore_transition, tz.ignore_rate, tz.effect,
             tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
@@ -91,7 +91,7 @@ const preset = {
         };
     },
     light_onoff_brightness_color: (options={}) => ({
-        exposes: [e.light_brightness_color(), e.effect(), e.light_color_options()],
+        exposes: [e.light_brightness_color(), e.effect()],
         fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.power_on_behavior, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_color, tz.ignore_transition, tz.ignore_rate,
@@ -101,7 +101,7 @@ const preset = {
         ],
     }),
     light_onoff_brightness_colorxy: (options={}) => ({
-        exposes: [e.light_brightness_colorxy(), e.effect(), e.light_color_options()],
+        exposes: [e.light_brightness_colorxy(), e.effect()],
         fromZigbee: [fz.color_colortemp, fz.on_off, fz.brightness, fz.level_config, fz.power_on_behavior, fz.ignore_basic_report],
         toZigbee: [
             tz.light_onoff_brightness, tz.light_color, tz.ignore_transition, tz.ignore_rate,
@@ -119,7 +119,7 @@ const preset = {
         },
     }),
     light_onoff_brightness_colortemp_color: (options={}) => {
-        const exposes = [e.light_brightness_colortemp_color(options.colorTempRange), e.effect(), e.light_color_options()];
+        const exposes = [e.light_brightness_colortemp_color(options.colorTempRange), e.effect()];
         const toZigbee = [
             tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition, tz.ignore_rate,
             tz.effect, tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,
@@ -148,7 +148,7 @@ const preset = {
         };
     },
     light_onoff_brightness_colortemp_colorxy: (options={}) => {
-        const exposes = [e.light_brightness_colortemp_colorxy(options.colorTempRange), e.effect(), e.light_color_options()];
+        const exposes = [e.light_brightness_colortemp_colorxy(options.colorTempRange), e.effect()];
         const toZigbee = [
             tz.light_onoff_brightness, tz.light_color_colortemp, tz.ignore_transition, tz.ignore_rate,
             tz.effect, tz.light_brightness_move, tz.light_colortemp_move, tz.light_brightness_step,

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -479,9 +479,6 @@ module.exports = {
         light_brightness_colortemp_colorxy: (colorTempRange) => new Light().withBrightness().withColorTemp(colorTempRange).withColorTempStartup(colorTempRange).withColor(['xy']),
         light_brightness_colorxy: () => new Light().withBrightness().withColor((['xy'])),
         light_colorhs: () => new Light().withColor(['hs']),
-        light_color_options: () => new Composite('color_options', 'color_options')
-            .withDescription('Configure lighting cluster options attribute.')
-            .withFeature(new Binary('execute_if_off', access.ALL, true, false).withDescription('Execute color/color_temp changes even when light is off')),
         linkquality: () => new Numeric('linkquality', access.STATE).withUnit('lqi').withDescription('Link quality (signal strength)').withValueMin(0).withValueMax(255),
         local_temperature: () => new Numeric('local_temperature', access.STATE_GET).withUnit('°C').withDescription('Current temperature measured on the device'),
         lock: () => new Lock().withState('state', 'LOCK', 'UNLOCK', 'State of the lock').withLockState('lock_state', 'Actual state of the lock'),


### PR DESCRIPTION
Suppor varies between bulbs, my E27 seems to suport it, my tradfri panels also.
Tradfi GU10 accepts it but ignores the bit, As per koenkk/zigbee2mqtt#6402 Osram
seems to barf at it for there GU10 and non bulb shaped lamps.