### PR TITLE
devices: Ubisys S2-R has wrong endpoint definition

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -13455,7 +13455,7 @@ const devices = [
             fz.command_stop],
         toZigbee: [tz.on_off, tz.metering_power, tz.ubisys_device_setup],
         endpoint: (device) => {
-            return {'l1': 1, 's1': 2, 'meter': 3};
+            return {'l1': 1, 's1': 2, 'meter': 4};
         },
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
#2299 forgot to update the endpoint function.

I also double checked the tech docs for the S2/S2-R these have the same endpoints according to it.
The S1-R has an additional client cluster endpoint that is why the meter is shifted further back... it is unclear to me from the tech docs if this is hooked up to a hardware action somehow, it appears it is not ? Would be nice if someone with access to the hardware could double check that. If there is we might need to add a to update the endpount return value to:

```return {'l1': 1, 's1': 2, 's2': 3, 'meter': 4};``` so the toggle actions can be distinguished. 
