### PR TITLE
Add revision to version-field

### DIFF
--- a/lib/ota/ledvance.js
+++ b/lib/ota/ledvance.js
@@ -23,7 +23,7 @@ async function getImageMeta(current, logger, device) {
     const fileVersionMatch = /\/(\d+)\//.exec(fullName);
     const fileVersion = parseInt(`0x${fileVersionMatch[1]}`, 16);
 
-    const versionString = `${identity.version.major}.${identity.version.minor}.${identity.version.build}`;
+    const versionString = `${identity.version.major}.${identity.version.minor}.${identity.version.build}.${identity.version.revision}`;
 
     return {
         fileVersion,


### PR DESCRIPTION
The version-field of Ledvance update API has an additional part "revision" which has to be added to the version field of the download URL. 
OTA-files which have a revision of "0" are working without it but as soon as a specific device has revision unequal to "0" the download link isn't working.