### PR TITLE
Hama thermostatic radiator valve 00176592 with modelId w7cahqs

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14564,6 +14564,7 @@ const devices = [
         fingerprint: [{modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'},
             {modelID: 'uhszj9s\u0000', manufacturerName: '_TYST11_zuhszj9s'},
             {modelID: '88teujp\u0000', manufacturerName: '_TYST11_c88teujp'},
+            {modelID: 'w7cahqs\u0000', manufacturerName: '_TYST11_yw7cahqs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_c88teujp'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'}],
         model: 'SEA801-Zigbee/SEA802-Zigbee',


### PR DESCRIPTION
Hi,

tried to pair with a Hama thermostatic radiator valve 00176592 and the device was not recognized with a modelId w7cahqs. Added the modelId in the fingerprint for the model SEA801-Zigbee/SEA802-Zigbee and now the device works flawlessly.

Kind regards

Thomas