### PR TITLE
[BHT-002-GCLZB] Enable Local Temperature Calibration 

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14542,7 +14542,7 @@ const devices = [
         toZigbee: [tz.moes_thermostat_child_lock, tz.moes_thermostat_current_heating_setpoint, tz.moes_thermostat_mode,
             tz.moes_thermostat_standby, tz.moes_thermostat_sensor, tz.moes_thermostat_calibration, tz.moes_thermostat_min_temperature],
         exposes: [e.child_lock(), exposes.climate().withSetpoint('current_heating_setpoint', 5, 30, 1, ea.STATE_SET)
-            .withLocalTemperature(ea.STATE).withLocalTemperatureCalibration()
+            .withLocalTemperature(ea.STATE).withLocalTemperatureCalibration(ea.STATE_SET)
             .withSystemMode(['off', 'heat'], ea.STATE_SET).withRunningState(['idle', 'heat', 'cool'], ea.STATE)
             .withPreset(['hold', 'program'])],
         onEvent: tuya.onEventSetLocalTime,

--- a/devices.js
+++ b/devices.js
@@ -14542,7 +14542,7 @@ const devices = [
         toZigbee: [tz.moes_thermostat_child_lock, tz.moes_thermostat_current_heating_setpoint, tz.moes_thermostat_mode,
             tz.moes_thermostat_standby, tz.moes_thermostat_sensor, tz.moes_thermostat_calibration, tz.moes_thermostat_min_temperature],
         exposes: [e.child_lock(), exposes.climate().withSetpoint('current_heating_setpoint', 5, 30, 1, ea.STATE_SET)
-            .withLocalTemperature(ea.STATE)
+            .withLocalTemperature(ea.STATE).withLocalTemperatureCalibration()
             .withSystemMode(['off', 'heat'], ea.STATE_SET).withRunningState(['idle', 'heat', 'cool'], ea.STATE)
             .withPreset(['hold', 'program'])],
         onEvent: tuya.onEventSetLocalTime,


### PR DESCRIPTION
Enable Local Temperature Calibration in zigbee2mqtt interface for Moes Thermostat BHT-002-GCLZB.

It was already working while pushing a payload via MQTT, but more user friendly via the interface.

Thanks @presslab-us for giving me the right direction 👍 