### PR TITLE
support Climax IR-9ZBS-SL motion sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8625,13 +8625,14 @@ const devices = [
         },
     },
     {
-        zigbeeModel: ['902010/22'],
+        zigbeeModel: ['902010/22', 'IR_00.00.03.12TC'],
         model: 'AV2010/22',
         vendor: 'Bitron',
         description: 'Wireless motion detector',
         fromZigbee: [fz.ias_occupancy_alarm_1_with_timeout],
         toZigbee: [],
         exposes: [e.occupancy(), e.battery_low(), e.tamper()],
+        whiteLabel: [{vendor: 'ClimaxTechnology', model: 'IR-9ZBS-SL'}],
     },
     {
         zigbeeModel: ['AV2010/22A'],


### PR DESCRIPTION
added support for "Climax IR-9ZBS-SL" motion detector.  
from looking at the pictures it became clear, this is the same product as Bitron AV2010/22 and adding the zigbee model number was the only thing needed to get the device working.  

I hope that this is the correct use of the property "whiteLabel", unfortunately i couldn't find any documentation on that.