### PR TITLE
Cleanup/Optimizaiton for Viessmann ZK03840

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -15934,12 +15934,13 @@ const devices = [
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'genPollCtrl',
-                'hvacThermostat', 'hvacUserInterfaceCfg']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'hvacThermostat']);
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
-            await reporting.thermostatKeypadLockMode(endpoint);
+
+            // read keypadLockout, we don't need reporting as it cannot be set physically on the device
+            await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);
         },
     },
 

--- a/devices.js
+++ b/devices.js
@@ -15930,8 +15930,8 @@ const devices = [
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation,
             tz.thermostat_system_mode, tz.thermostat_keypad_lockout],
         exposes: [exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
-            .withSystemMode(['heat', 'sleep']).withRunningState(['idle', 'heat'], ea.STATE)],
-        meta: {configureKey: 1},
+            .withSystemMode(['heat', 'sleep'])],
+        meta: {configureKey: 2},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'hvacThermostat']);

--- a/devices.js
+++ b/devices.js
@@ -15930,7 +15930,7 @@ const devices = [
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation,
             tz.thermostat_system_mode, tz.thermostat_keypad_lockout],
         exposes: [exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
-            .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat'], ea.STATE)],
+            .withSystemMode(['heat', 'sleep']).withRunningState(['idle', 'heat'], ea.STATE)],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices.js
+++ b/devices.js
@@ -15935,9 +15935,10 @@ const devices = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'hvacThermostat']);
-            await reporting.thermostatTemperature(endpoint);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint, {min: 60, max: 43200, change: 1});
+            await reporting.thermostatTemperature(endpoint, {min: 90, max: 900, change: 10});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: 65534, change: 1});
+            await reporting.thermostatPIHeatingDemand(endpoint, {min: 60, max: 3600, change: 1});
 
             // read keypadLockout, we don't need reporting as it cannot be set physically on the device
             await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -350,7 +350,7 @@ class Climate extends Base {
 
     withSystemMode(modes, access=a.ALL) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
-        const allowed = ['off', 'heat', 'cool', 'auto', 'dry', 'fan_only'];
+        const allowed = ['off', 'heat', 'cool', 'auto', 'dry', 'fan_only', 'sleep'];
         modes.forEach((m) => assert(allowed.includes(m)));
         this.features.push(new Enum('system_mode', access, modes).withDescription('Mode of this device'));
         return this;


### PR DESCRIPTION
While looking into #2275  I noticed there were a lot of manufacturer specific attributes, I have not gotten very far with those yet. 

However digging into the dumps I discovered:
- battery percent remaining reporting
- keypadLockout was read by the gateway and written, but not setup for reporting (makes sense, can't change it unless via the gateway)
- system_mode is limited to 'heat' and 'sleep'
- running_mode seems to return UNSUPPORTED_ATTRIBUTE on both read or reporting setup.

This PR does some general house keeping for the device configuration of the ZK03840, no functionality is gained or lost. (Just one broken expose)

Well technically we can now set the device to 'sleep' which seems to be a soft 'off'. Also battery reporting now works so I guess we gained some functionality :)