### PR TITLE
expose: color_temp range for Müller Licht 404006/404008/404004

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10545,7 +10545,7 @@ const devices = [
         model: '404006/404008/404004',
         vendor: 'Müller Licht',
         description: 'Tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, opal white',
-        extend: preset.light_onoff_brightness_colortemp(),
+        extend: preset.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
         toZigbee: preset.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
     },
     {


### PR DESCRIPTION
database.db entry from https://github.com/Koenkk/zigbee-herdsman-converters/issues/2217#issuecomment-790531363