### PR TITLE
Add support for VL-ZP07017/VL-XJ001 Livolo roller blind motor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2042,13 +2042,13 @@ const converters = {
         type: ['raw'],
         convert: (model, msg, publish, options, meta) => {
             const dp = msg.data[10];
-            if (msg.data.indexOf(Buffer.from([0x7a, 0xd1])) === 0) { // Normal operation messages
+            if (msg.data[0] === 0x7a & msg.data[1] === 0xd1) {
                 const reportType = msg.data[12];
                 switch (dp) {
                 case 0x0c:
                 case 0x0f:
                     if (reportType === 0x04) { // Position report
-                        const position = options.invert_cover ? 100 - msg.data[13] : msg.data[13];
+                        const position = meta.state.motor_direction === 'FORWARD' ? msg.data[13] : 100 - msg.data[13];
                         const state = position > 0 ? 'OPEN' : 'CLOSE';
                         return {position, state};
                     }
@@ -2058,9 +2058,9 @@ const converters = {
                     } else if (reportType === 0x13) { // Direction report
                         const direction = msg.data[13];
                         if (direction === 0x70) {
-                            options.invert_cover = false;
+                            return {motor_direction: 'REVERSE'};
                         } else if (direction === 0xf0) {
-                            options.invert_cover = true;
+                            return {motor_direction: 'FORWARD'};
                         }
                     }
                     break;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2037,6 +2037,23 @@ const converters = {
             }
         },
     },
+    livolo_cover_state: {
+        cluster: 'genPowerCfg',
+        type: ['raw'],
+        convert: (model, msg, publish, options, meta) => {
+            const stateHeader = Buffer.from([122, 209]);
+            if (msg.data.indexOf(stateHeader) === 0) {
+                const dp = msg.data[10];
+                if (dp === 12 || dp === 15) {
+                    const position = 100 - msg.data[13];
+                    const state = position > 0 ? 'OPEN' : 'CLOSE';
+                    return {position, state};
+                } else { // TODO: Unknown dps
+                    meta.logger.warn(`livolo_cover_state: Unhandled DP ${dp} for ${meta.device.manufacturerName}: ${msg.data.toString('hex')}`);
+                }
+            }
+        },
+    },
     livolo_switch_state_raw: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2088,6 +2105,10 @@ const converters = {
                 if (msg.data.includes(Buffer.from([19, 20, 0]), 13)) {
                     // new dimmer, hack
                     meta.device.modelID = 'TI0001-dimmer';
+                    meta.device.save();
+                }
+                if (msg.data.includes(Buffer.from([19, 21, 0]), 13)) {
+                    meta.device.modelID = 'TI0001-cover';
                     meta.device.save();
                 }
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1417,6 +1417,24 @@ const converters = {
             await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
         },
     },
+    livolo_cover_position: {
+        key: ['position'],
+        convertSet: async (entity, key, value, meta) => {
+            const position = 100 - value;
+            await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
+            const payload = {0x0401: {value: Buffer.from([position, 0, 0, 0, 0, 0, 0, 0]), type: 1}};
+            await entity.write('genPowerCfg', payload,
+                {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
+                    reservedBits: 3, direction: 1, transactionSequenceNumber: 0xe9, writeUndiv: true});
+            return {
+                state: {position},
+                readAfterWriteTime: 250,
+            };
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
+        },
+    },
     gledopto_light_onoff_brightness: {
         key: ['state', 'brightness', 'brightness_percent'],
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1421,24 +1421,24 @@ const converters = {
         key: ['state', 'position'],
         convertSet: async (entity, key, value, meta) => {
             if (key === 'position') {
-                const position = 100 - value;
+                const position = meta.state.motor_direction === 'FORWARD' ? value : 100 - value;
                 await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
                 const payload = {0x0401: {value: Buffer.from([position, 0, 0, 0, 0, 0, 0, 0]), type: 1}};
                 await entity.write('genPowerCfg', payload,
                     {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
                         reservedBits: 3, direction: 1, transactionSequenceNumber: 0xe9, writeUndiv: true});
                 return {
-                    state: {position},
+                    state: {position: value},
                     readAfterWriteTime: 250,
                 };
             } else if (key === 'state') {
                 let position;
                 switch (value) {
                 case 'OPEN':
-                    position = 0;
+                    position = 100;
                     break;
                 case 'CLOSE':
-                    position = 100;
+                    position = 0;
                     break;
                 default:
                     throw new Error(`Value '${value}' is not a valid cover position (must be one of 'OPEN' or 'CLOSE')`);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1418,18 +1418,33 @@ const converters = {
         },
     },
     livolo_cover_position: {
-        key: ['position'],
+        key: ['state', 'position'],
         convertSet: async (entity, key, value, meta) => {
-            const position = 100 - value;
-            await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
-            const payload = {0x0401: {value: Buffer.from([position, 0, 0, 0, 0, 0, 0, 0]), type: 1}};
-            await entity.write('genPowerCfg', payload,
-                {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
-                    reservedBits: 3, direction: 1, transactionSequenceNumber: 0xe9, writeUndiv: true});
-            return {
-                state: {position},
-                readAfterWriteTime: 250,
-            };
+            if (key === 'position') {
+                const position = 100 - value;
+                await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
+                const payload = {0x0401: {value: Buffer.from([position, 0, 0, 0, 0, 0, 0, 0]), type: 1}};
+                await entity.write('genPowerCfg', payload,
+                    {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
+                        reservedBits: 3, direction: 1, transactionSequenceNumber: 0xe9, writeUndiv: true});
+                return {
+                    state: {position},
+                    readAfterWriteTime: 250,
+                };
+            } else if (key === 'state') {
+                let position;
+                switch (value) {
+                case 'OPEN':
+                    position = 0;
+                    break;
+                case 'CLOSE':
+                    position = 100;
+                    break;
+                default:
+                    throw new Error(`Value '${value}' is not a valid cover position (must be one of 'OPEN' or 'CLOSE')`);
+                }
+                return await converters.livolo_cover_position.convertSet(entity, 'position', position, meta);
+            }
         },
         convertGet: async (entity, key, meta) => {
             await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});

--- a/devices.js
+++ b/devices.js
@@ -11156,7 +11156,7 @@ const devices = [
             // it from disconnecting from the Zigbee network.
             if (data.cluster === 'genPowerCfg' && data.type === 'raw') {
                 const dp = data.data[10];
-                if (data.data.indexOf(Buffer.from([0x7a, 0xd1])) === 0) {
+                if (data.data[0] === 0x7a && data.data[1] === 0xd1) {
                     const endpoint = device.getEndpoint(6);
                     if (dp === 0x02) {
                         const options = {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,

--- a/devices.js
+++ b/devices.js
@@ -11138,7 +11138,7 @@ const devices = [
         vendor: 'Livolo',
         fromZigbee: [fz.livolo_cover_state, fz.command_off],
         toZigbee: [tz.livolo_cover_position],
-        exposes: [e.cover_position()],
+        exposes: [e.cover_position().setAccess('state', ea.ALL)],
         meta: {configureKey: 1},
         configure: livolo.poll,
         onEvent: async (type, data, device) => {

--- a/devices.js
+++ b/devices.js
@@ -11131,6 +11131,29 @@ const devices = [
             }
         },
     },
+    {
+        zigbeeModel: ['TI0001-cover'],
+        model: 'TI0001-cover',
+        description: 'Zigbee roller blind motor',
+        vendor: 'Livolo',
+        fromZigbee: [fz.livolo_cover_state],
+        toZigbee: [tz.livolo_cover_position],
+        exposes: [e.cover_position()],
+        meta: {configureKey: 1},
+        configure: livolo.poll,
+        onEvent: async (type, data, device) => {
+            if (type === 'stop') {
+                clearInterval(globalStore.getValue(device, 'interval'));
+            }
+            if (!globalStore.hasValue(device, 'interval')) {
+                await livolo.poll(device);
+                const interval = setInterval(async () => {
+                    await livolo.poll(device);
+                }, 300*1000); // Every 300 seconds
+                globalStore.putValue(device, 'interval', interval);
+            }
+        },
+    },
 
     // Bosch
     {

--- a/devices.js
+++ b/devices.js
@@ -11136,7 +11136,7 @@ const devices = [
         model: 'TI0001-cover',
         description: 'Zigbee roller blind motor',
         vendor: 'Livolo',
-        fromZigbee: [fz.livolo_cover_state],
+        fromZigbee: [fz.livolo_cover_state, fz.command_off],
         toZigbee: [tz.livolo_cover_position],
         exposes: [e.cover_position()],
         meta: {configureKey: 1},


### PR DESCRIPTION
## Warnings

- This PR is still a work-in-progress.
- This works for Livolo roller blind motor model `VL-ZP07017` or `VL-XJ001` ([this on AliExpress][ali]).
- Livolo devices require an ad-hoc `pan_id` / `ext_pan_id` and only operate on channel `26`. [More info here][livolo-panid].
- I have tested this with a dedicated CC2531 coordinator.
- I don't own the original Livolo gateway, so I had to figure out some stuff by pure trial and error (e.g. had to bruteforce the `0x0401` payload).
- When I bought this model, the seller tried to sell me Livolo's gateway and warned me that this wouldn't work with 3rd party gateways. I stubbornly told them that I knew what I was doing. Obviously I didn't, so I'm trying hard here to make this work hahahaha, 

## What works

- Device can be discovered and interviewed
- Position (percentage of cover opening) and state (`OPEN` / `CLOSE`) events are received when the motor stops.
- Position can be changed through MQTT, so the main feature works! :D

## What does not work

- Everything stops working once the device goes out of pairing mode. 
- Reading position/state on demand or at pairing time.
- I have never used this with the original Livolo gateway and app, so I don't really know what the original features are. From the manual, I can imagine:
  - Stopping the motor while it's moving.
  - Change drive direction of the motor.
  - Set upper / lower limit for the roller blind.
  - Set moving speed.
  - Reading current value of all these settings.
  - Battery / power / solar panel status?

## Next steps

I know the issue about losing connection after a minute or so also affected others trying to implement the [Livolo dimmer][dimmer] and [Livolo switch][switch]. I don't know why in this case none of their solutions worked. Communication is immediately dropped once pairing is over. 

This device has a LED indicator on the front that blinks blue and red while pairing. After 1 minute, it stays red for 3 seconds. To me, it looks like the device is considering that it couldn't pair correctly because it was waiting for some special configuration command from the gateway and it never received it.

Do you have any clue on this? I know @whitepail had a similar "heartbeat" problem with the dimmer and it was [magically fixed by pairing once with the original gateway][fix].

What do you think I should do next? I'm trying at all costs not to buy the Livolo gateway just to pair it once and get it properly configured. If I buy it, I could try to sniff the traffic and look for the message that I'm missing. But I think @whitepail already tried and didn't find anything special, so I don't think I have better luck with that :man_shrugging: 

[ali]: https://es.aliexpress.com/item/1005001702490864.html
[livolo-panid]: https://www.zigbee2mqtt.io/devices/TI0001-dimmer.html#important
[dimmer]: https://github.com/Koenkk/zigbee2mqtt/issues/5516
[switch]: https://github.com/Koenkk/zigbee2mqtt/issues/592
[fix]: https://github.com/Koenkk/zigbee2mqtt/issues/5516#issuecomment-770883164