### PR TITLE
Add support for onWithTimedOff command to IKEA E1603/E1702

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -164,6 +164,40 @@ const converters = {
             await entity.read('genOnOff', ['onOff']);
         },
     },
+    on_off_timed: {
+        key: ['state', 'on_time', 'off_wait_time'],
+        convertSet: async (entity, key, value, meta) => {
+            const {message} = meta;
+            const state = message.hasOwnProperty('state') ? message.state : null;
+
+            if (state !== 'onWithTimedOff') {
+                return await converters.on_off.convertSet(entity, key, value, meta);
+            }
+
+            const onTime = message.hasOwnProperty('on_time') ? message.on_time : 0;
+            const offWaitTime = message.hasOwnProperty('off_wait_time') ? message.off_wait_time : 0;
+
+            if (!Number.isInteger(onTime)) {
+                throw Error('The on_time value must be convertible to an integer');
+            }
+            if (!Number.isInteger(offWaitTime)) {
+                throw Error('The off_wait_time value must be convertible to an integer');
+            }
+
+            await entity.command(
+                'genOnOff',
+                'onWithTimedOff',
+                {
+                    ctrlbits: 0,
+                    ontime: onTime,
+                    offwaittime: offWaitTime,
+                },
+                utils.getOptions(meta.mapped, entity));
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('genOnOff', ['onOff']);
+        },
+    },
     cover_via_brightness: {
         key: ['position', 'state'],
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -164,15 +164,8 @@ const converters = {
                     throw Error('The off_wait_time value must be a number!');
                 }
 
-                await entity.command(
-                    'genOnOff',
-                    'onWithTimedOff',
-                    {
-                        ctrlbits: 0,
-                        ontime: Math.round(onTime * 10),
-                        offwaittime: Math.round(offWaitTime * 10),
-                    },
-                    utils.getOptions(meta.mapped, entity));
+                const payload = {ctrlbits: 0, ontime: Math.round(onTime * 10), offwaittime: Math.round(offWaitTime * 10)};
+                await entity.command('genOnOff', 'onWithTimedOff', payload, utils.getOptions(meta.mapped, entity));
             } else {
                 await entity.command('genOnOff', state, {}, utils.getOptions(meta.mapped, entity));
                 if (state === 'toggle') {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -177,7 +177,7 @@ const converters = {
                 await entity.command('genOnOff', value, {}, utils.getOptions(meta.mapped, entity));
                 if (value === 'toggle') {
                     const currentState = meta.state[`state${meta.endpoint_name ? `_${meta.endpoint_name}` : ''}`];
-                    return currentState ? { state: { state: currentState === 'OFF' ? 'ON' : 'OFF' } } : {};
+                    return currentState ? {state: {state: currentState === 'OFF' ? 'ON' : 'OFF'}} : {};
                 } else {
                     return {state: {state: value.toUpperCase()}};
                 }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -148,12 +148,12 @@ const converters = {
         },
     },
     on_off: {
-        key: ['state'],
+        key: ['state', 'on_time', 'off_wait_time'],
         convertSet: async (entity, key, value, meta) => {
-            value = value.toLowerCase();
-            utils.validateValue(value, ['toggle', 'off', 'on']);
+            const state = meta.message.hasOwnProperty('state') ? meta.message.state.toLowerCase() : null;
+            utils.validateValue(state, ['toggle', 'off', 'on']);
 
-            if (value === 'on' && (meta.message.hasOwnProperty('on_time') || meta.message.hasOwnProperty('off_wait_time'))) {
+            if (state === 'on' && (meta.message.hasOwnProperty('on_time') || meta.message.hasOwnProperty('off_wait_time'))) {
                 const onTime = meta.message.hasOwnProperty('on_time') ? meta.message.on_time : 0;
                 const offWaitTime = meta.message.hasOwnProperty('off_wait_time') ? meta.message.off_wait_time : 0;
 
@@ -174,12 +174,12 @@ const converters = {
                     },
                     utils.getOptions(meta.mapped, entity));
             } else {
-                await entity.command('genOnOff', value, {}, utils.getOptions(meta.mapped, entity));
-                if (value === 'toggle') {
+                await entity.command('genOnOff', state, {}, utils.getOptions(meta.mapped, entity));
+                if (state === 'toggle') {
                     const currentState = meta.state[`state${meta.endpoint_name ? `_${meta.endpoint_name}` : ''}`];
                     return currentState ? {state: {state: currentState === 'OFF' ? 'ON' : 'OFF'}} : {};
                 } else {
-                    return {state: {state: value.toUpperCase()}};
+                    return {state: {state: state.toUpperCase()}};
                 }
             }
         },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -153,9 +153,9 @@ const converters = {
             value = value.toLowerCase();
             utils.validateValue(value, ['toggle', 'off', 'on']);
 
-            if (value === 'on' && (message.hasOwnProperty('on_time') || message.hasOwnProperty('off_wait_time'))) {
-                const onTime = message.hasOwnProperty('on_time') ? message.on_time : 0;
-                const offWaitTime = message.hasOwnProperty('off_wait_time') ? message.off_wait_time : 0;
+            if (value === 'on' && (meta.message.hasOwnProperty('on_time') || meta.message.hasOwnProperty('off_wait_time'))) {
+                const onTime = meta.message.hasOwnProperty('on_time') ? meta.message.on_time : 0;
+                const offWaitTime = meta.message.hasOwnProperty('off_wait_time') ? meta.message.off_wait_time : 0;
 
                 if (typeof onTime !== 'number') {
                     throw Error('The on_time value must be a number!');
@@ -173,14 +173,13 @@ const converters = {
                         offwaittime: Math.round(offWaitTime * 10),
                     },
                     utils.getOptions(meta.mapped, entity));
-            }
-            else {
+            } else {
                 await entity.command('genOnOff', value, {}, utils.getOptions(meta.mapped, entity));
                 if (value === 'toggle') {
                     const currentState = meta.state[`state${meta.endpoint_name ? `_${meta.endpoint_name}` : ''}`];
                     return currentState ? { state: { state: currentState === 'OFF' ? 'ON' : 'OFF' } } : {};
                 } else {
-                    return { state: { state: value.toUpperCase() } };
+                    return {state: {state: value.toUpperCase()}};
                 }
             }
         },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -177,11 +177,11 @@ const converters = {
             const onTime = message.hasOwnProperty('on_time') ? message.on_time : 0;
             const offWaitTime = message.hasOwnProperty('off_wait_time') ? message.off_wait_time : 0;
 
-            if (!Number.isInteger(onTime)) {
-                throw Error('The on_time value must be convertible to an integer');
+            if (typeof onTime !== 'number') {
+                throw Error('The on_time value must be a number!');
             }
-            if (!Number.isInteger(offWaitTime)) {
-                throw Error('The off_wait_time value must be convertible to an integer');
+            if (typeof offWaitTime !== 'number') {
+                throw Error('The off_wait_time value must be a number!');
             }
 
             await entity.command(
@@ -189,8 +189,8 @@ const converters = {
                 'onWithTimedOff',
                 {
                     ctrlbits: 0,
-                    ontime: onTime,
-                    offwaittime: offWaitTime,
+                    ontime: Math.round(onTime * 10),
+                    offwaittime: Math.round(offWaitTime * 10),
                 },
                 utils.getOptions(meta.mapped, entity));
         },

--- a/devices.js
+++ b/devices.js
@@ -2585,7 +2585,7 @@ const devices = [
         description: 'TRADFRI control outlet',
         vendor: 'IKEA',
         extend: preset.switch(),
-        toZigbee: preset.switch().toZigbee.concat([tz.power_on_behavior]),
+        toZigbee: [tz.on_off_timed, tz.power_on_behavior],
         fromZigbee: preset.switch().fromZigbee.concat([fz.power_on_behavior]),
         // power_on_behavior 'toggle' does not seem to be supported
         exposes: preset.switch().exposes.concat([exposes.enum('power_on_behavior', ea.ALL, ['off', 'previous', 'on'])

--- a/devices.js
+++ b/devices.js
@@ -2585,7 +2585,7 @@ const devices = [
         description: 'TRADFRI control outlet',
         vendor: 'IKEA',
         extend: preset.switch(),
-        toZigbee: [tz.on_off_timed, tz.power_on_behavior],
+        toZigbee: preset.switch().toZigbee.concat([fz.power_on_behavior]),
         fromZigbee: preset.switch().fromZigbee.concat([fz.power_on_behavior]),
         // power_on_behavior 'toggle' does not seem to be supported
         exposes: preset.switch().exposes.concat([exposes.enum('power_on_behavior', ea.ALL, ['off', 'previous', 'on'])

--- a/devices.js
+++ b/devices.js
@@ -2585,7 +2585,7 @@ const devices = [
         description: 'TRADFRI control outlet',
         vendor: 'IKEA',
         extend: preset.switch(),
-        toZigbee: preset.switch().toZigbee.concat([fz.power_on_behavior]),
+        toZigbee: preset.switch().toZigbee.concat([tz.power_on_behavior]),
         fromZigbee: preset.switch().fromZigbee.concat([fz.power_on_behavior]),
         // power_on_behavior 'toggle' does not seem to be supported
         exposes: preset.switch().exposes.concat([exposes.enum('power_on_behavior', ea.ALL, ['off', 'previous', 'on'])


### PR DESCRIPTION
I've recently come across the _onWithTimedOff_ command which I wanted to add to the IKEA [wall plug](https://www.zigbee2mqtt.io/devices/E1603_E1702.html). In fact, the command is also supported by all my IKEA lamps.

Short summary: the command will on a device for the value (in 1/10 secs) specified by the parameter _on_time_ after which the device will turn off. There is also the param _off_wait_time_ which will discard any further _onWithTimedOff_  commands within the specified time. This could be very useful if you want to temporarily force off a device activated by a motion detector for example. Subsequent _onWithTimedOff_ commands update the respective timings.

As a starting point I've built this simple converter and changed the toZigbee spec of the wall plug. It is also my first time exploring the internals of z2m.

I've decided to stick to the original wording used by the zigbee spec:
* Turn on for 1 sec: `{"state":"onWithTimedOff","on_time":10}`
* Keep off for 1 min: `{"state":"onWithTimedOff","off_wait_time":600}`

It works but there are probably some shortcomings:
1. After sending the command the command doesn't return a new state. This is not trivial because of the whole _off_wait_time_ thing.
2. Maybe this should be part of the generic _on_off_ and _light_onoff_brightness_ converters? 😮 😄 


Cheers!