### PR TITLE
Support Leviton DG6HD Zigbee 3.0 dimmer

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6286,6 +6286,19 @@ const devices = [
         },
     },
     {
+        zigbeeModel: ['DG6HD'],
+        model: 'DG6HD-1BW',
+        vendor: 'Leviton',
+        description: 'Zigbee in-wall smart dimmer',
+        extend: preset.light_onoff_brightness({disableEffect: true}),
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['65A01-1'],
         model: 'RC-2000WH',
         vendor: 'Leviton',


### PR DESCRIPTION
Heavily adapted from https://github.com/Koenkk/zigbee-herdsman-converters/pull/2324

Full disclosure: I don't know Zigbee protocol, so this may be only extremely basic support. I've tested this change and it does provide dimmer support, but nothing beyond that. As such, please review with maximum scrutiny.