### PR TITLE
expose: prvide colorTempRange for Hue LCT024, Gledopto GL-FL-004TZS, and Gledopto GL-FL-006P

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3360,7 +3360,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue White and color ambiance Play Lightbar',
         meta: {turnsOffAtBrightness1: true},
-        extend: preset.hue.light_onoff_brightness_colortemp_color(),
+        extend: preset.hue.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,
     },
     {
@@ -7576,7 +7576,7 @@ const devices = [
         model: 'GL-FL-004TZS',
         vendor: 'Gledopto',
         description: 'Zigbee 10W Floodlight RGB+CCT (plus)',
-        extend: preset.gledopto.light_onoff_brightness_colortemp_color(),
+        extend: preset.gledopto.light_onoff_brightness_colortemp_color({colorTempRange: [155, 495]}),
     },
     {
         zigbeeModel: ['GL-FL-004P', 'GL-FL-004TZP'],
@@ -7628,7 +7628,7 @@ const devices = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee 60W Floodlight RGB+CCT (pro)',
-        extend: preset.gledopto.light_onoff_brightness_colortemp_color(),
+        extend: preset.gledopto.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495]}),
     },
     {
         zigbeeModel: ['GL-G-001Z'],


### PR DESCRIPTION
Thanks to @itavero for providing the database entries here: https://github.com/itavero/homebridge-z2m/issues/88#issuecomment-792329328


```
{"id":11,"type":"Router","ieeeAddr":"0x0017880100d9b08f","nwkAddr":13203,"manufId":4107,"manufName":"Philips","powerSource":"Mains (single phase)","modelId":"LCT001","epList":[11,242],"endpoints":{"11":{"profId":49246,"epId":11,"devId":528,"inClusterList":[0,3,4,5,6,8,4096,768,64513],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"LCT001","manufacturerName":"Philips","powerSource":1,"zclVersion":1,"appVersion":2,"stackVersion":1,"hwVersion":8,"dateCode":"20191216","swBuildId":"5.130.1.30000"}},"genOnOff":{"attributes":{"onOff":1}},"genLevelCtrl":{"attributes":{"currentLevel":104}},"lightingColorCtrl":{"attributes":{"colorTemperature":366,"currentX":29980,"currentY":26875,"currentHue":58,"currentSaturation":141,"colorCapabilities":31,"colorTempPhysicalMin":153,"colorTempPhysicalMax":500}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b001caa69fb","endpointID":1}],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[33],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":2,"stackVersion":1,"hwVersion":8,"dateCode":"20191216","swBuildId":"5.130.1.30000","zclVersion":1,"interviewCompleted":true,"meta":{"configured":2},"lastSeen":1615139269993}
{"id":13,"type":"Router","ieeeAddr":"0x0017880106117ff9","nwkAddr":46616,"manufId":4107,"manufName":"Philips","powerSource":"Mains (single phase)","modelId":"LCT024","epList":[11,242],"endpoints":{"11":{"profId":49246,"epId":11,"devId":528,"inClusterList":[0,3,4,5,6,8,4096,768,64513],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"LCT024","manufacturerName":"Philips","powerSource":1,"zclVersion":1,"appVersion":2,"stackVersion":1,"hwVersion":1,"dateCode":"20191218","swBuildId":"1.50.2_r30933"}},"genOnOff":{"attributes":{"onOff":1}},"genLevelCtrl":{"attributes":{"currentLevel":254}},"lightingColorCtrl":{"attributes":{"colorTemperature":274,"currentX":26077,"currentY":25450,"currentHue":37,"currentSaturation":38,"colorCapabilities":31,"colorTempPhysicalMin":153,"colorTempPhysicalMax":500}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b001caa69fb","endpointID":1}],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[33],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":2,"stackVersion":1,"hwVersion":1,"dateCode":"20191218","swBuildId":"1.50.2_r30933","zclVersion":1,"interviewCompleted":true,"meta":{"configured":2},"lastSeen":1615139283066}
{"id":30,"type":"Router","ieeeAddr":"0x00124b001eae05e7","nwkAddr":52239,"manufId":0,"manufName":"GLEDOPTO","powerSource":"Mains (single phase)","modelId":"GL-FL-004TZS","epList":[11,13],"endpoints":{"11":{"profId":49246,"epId":11,"devId":528,"inClusterList":[0,3,4,5,6,8,768],"outClusterList":[],"clusters":{"genBasic":{"attributes":{"modelId":"GL-FL-004TZS","manufacturerName":"GLEDOPTO","powerSource":1,"zclVersion":1,"appVersion":1,"stackVersion":2,"hwVersion":1,"dateCode":"20131206","swBuildId":"1.0.4"}},"genOnOff":{"attributes":{"onOff":0}},"genLevelCtrl":{"attributes":{"currentLevel":1}},"lightingColorCtrl":{"attributes":{"colorTemperature":495,"currentX":34524,"currentY":29712,"colorCapabilities":31,"colorTempPhysicalMin":155,"colorTempPhysicalMax":495}}},"binds":[],"configuredReportings":[],"meta":{}},"13":{"profId":49246,"epId":13,"devId":528,"inClusterList":[4096],"outClusterList":[4096],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":1,"stackVersion":2,"hwVersion":1,"dateCode":"20131206","swBuildId":"1.0.4","zclVersion":1,"interviewCompleted":true,"meta":{"configured":2},"lastSeen":1615139270112}
{"id":48,"type":"Router","ieeeAddr":"0x60a423fffe04207d","nwkAddr":44129,"manufId":4687,"manufName":"GLEDOPTO","powerSource":"Unknown","modelId":"GL-FL-006P","epList":[11,242],"endpoints":{"11":{"profId":260,"epId":11,"devId":269,"inClusterList":[0,3,4,5,6,8,768,4096],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"GL-FL-006P","manufacturerName":"GLEDOPTO","powerSource":0,"zclVersion":3,"appVersion":0,"stackVersion":0,"hwVersion":0,"dateCode":"20201201","swBuildId":"V_1_2"}},"lightingColorCtrl":{"attributes":{"colorCapabilities":31,"colorTempPhysicalMin":158,"colorTempPhysicalMax":495,"colorTemperature":250,"currentX":17623,"currentY":43739}},"genLevelCtrl":{"attributes":{"currentLevel":254}},"genOnOff":{"attributes":{"onOff":1}}},"binds":[],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":0,"stackVersion":0,"hwVersion":0,"dateCode":"20201201","swBuildId":"V_1_2","zclVersion":3,"interviewCompleted":true,"meta":{"configured":2},"lastSeen":1614450095002}
```