### PR TITLE
Update 067776 to fix inverted working mode

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14860,7 +14860,7 @@ const devices = [
             // support binary report on moving state (supposed)
             fz.legrand_binary_input_moving, fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingAlwaysEnableLed],
-        meta: {configureKey: 1, coverInverted: true},
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);


### PR DESCRIPTION
coverInverted is not needed. It actually breaks device making unusable through HA, but works in Zigbee2MQTT.

I've observed a few things that don't work in this device properly. I'll open an issue to try to get some help.