### PR TITLE
Add support for SOHAN Electric DIN Circuit Breaker (1 Pole / 2 Poles)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -16893,6 +16893,16 @@ const devices = [
         extend: preset.light_onoff_brightness_colortemp_color({disableColorTempStartup: true}),
         meta: {applyRedFix: true},
     },
+
+    // SOHAN Electric
+    {
+        fingerprint: [{modelID: 'TS0001', manufacturerName: '_TZ3000_bezfthwc'}],
+        model: 'RDCBC/Z',
+        vendor: 'SOHAN Electric',
+        description: 'SOHAN Electric DIN Circuit Breaker (1 Pole / 2 Poles)',
+        extend: preset.switch(),
+        fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
+    },
 ];
 
 module.exports = devices.map((device) => {

--- a/devices.js
+++ b/devices.js
@@ -16899,7 +16899,7 @@ const devices = [
         fingerprint: [{modelID: 'TS0001', manufacturerName: '_TZ3000_bezfthwc'}],
         model: 'RDCBC/Z',
         vendor: 'SOHAN Electric',
-        description: 'SOHAN Electric DIN Circuit Breaker (1 Pole / 2 Poles)',
+        description: 'DIN circuit breaker (1 pole / 2 poles)',
         extend: preset.switch(),
         fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
     },


### PR DESCRIPTION
This is the product in question:
- https://zigbee.blakadder.com/Sohan_RDCBC-1P.html
- [AliExpress](https://es.aliexpress.com/item/1005002000274162.html?aff_platform=link-c-tool&cpt=1579460387259&sk=_sPA71V&aff_trace_key=1ea588879adf4a71b69472fcc8469bea-1579460387259-01187-_sPA71V&terminal_id=5ab3b3bf703c438dac102dcfef054d7e)

Even if all Zigbee versions of this product (1P/2P and 32A/50A) identify themselves as the ubiquous `TS0001` Tuya switch, they are actually implemented as a perfectly class compliant Zigbee switch, so it took me no more than 2 minutes to get this set up.

This has been tested with version RDCBC/Z-2P 32A. Really nice product by the way!