### PR TITLE
SmartThings F-MLT-US-2 (multiv4): force power source

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -8261,6 +8261,9 @@ const devices = [
             await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadY, options);
             const payloadZ = reporting.payload('z_axis', 10, repInterval.MINUTE, 1);
             await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadZ, options);
+            // Has Unknown power source, force it.
+            device.powerSource = 'Battery';
+            device.save();
         },
         exposes: [
             e.temperature(), e.contact(), e.battery_low(), e.tamper(), e.battery(),


### PR DESCRIPTION
Follow up for https://github.com/Koenkk/zigbee-herdsman-converters/pull/2291
Confirmed here https://github.com/Koenkk/zigbee2mqtt/issues/6021 that the sensor indeed reports an 'unknown' power source.