### PR TITLE
cc2538.router.v2 support

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4452,12 +4452,21 @@ const devices = [
     },
     {
         zigbeeModel: ['cc2538.router.v1'],
-        model: 'CC2538.ROUTER',
+        model: 'CC2538.ROUTER.V1',
         vendor: 'Custom devices (DiY)',
         description: '[MODKAM stick СС2538 router](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/router/cc2538_cc2592)',
         fromZigbee: [fz.ignore_basic_report],
         toZigbee: [],
         exposes: [],
+    },
+    {
+        zigbeeModel: ['cc2538.router.v2'],
+        model: 'CC2538.ROUTER.V2',
+        vendor: 'Custom devices (DiY)',
+        description: '[MODKAM stick СС2538 router with temperature sensor](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/router/cc2538_cc2592)',
+        fromZigbee: [fz.ignore_basic_report, fz.device_temperature],
+        toZigbee: [],
+        exposes: [e.device_temperature(), e.linkquality()],
     },
     {
         zigbeeModel: ['ptvo.switch'],

--- a/devices.js
+++ b/devices.js
@@ -4463,7 +4463,8 @@ const devices = [
         zigbeeModel: ['cc2538.router.v2'],
         model: 'CC2538.ROUTER.V2',
         vendor: 'Custom devices (DiY)',
-        description: '[MODKAM stick СС2538 router with temperature sensor](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/router/cc2538_cc2592)',
+        description: '[MODKAM stick СС2538 router with temperature sensor]' +
+            '(https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/router/cc2538_cc2592)',
         fromZigbee: [fz.ignore_basic_report, fz.device_temperature],
         toZigbee: [],
         exposes: [e.device_temperature(), e.linkquality()],


### PR DESCRIPTION
Support new router firmware for сс2538 (jh_2538_router_20210115.hex, jh_2538_router_20210310.hex) that exposes temperature and lqi

https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/router/cc2538_cc2592
