### PR TITLE
devices: SNZB-02 and SNZB-04 should use batteryPercentageRemaining

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14230,6 +14230,7 @@ const devices = [
         vendor: 'SONOFF',
         whiteLabel: [{vendor: 'eWeLink', model: 'RHK06'}],
         description: 'Contact sensor',
+        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery(), e.battery_voltage()],
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
         meta: {configureKey: 1},
@@ -14239,7 +14240,6 @@ const devices = [
             await reporting.batteryVoltage(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
         zigbeeModel: ['WB01', 'WB-01'],

--- a/devices.js
+++ b/devices.js
@@ -14232,11 +14232,12 @@ const devices = [
         description: 'Contact sensor',
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
-        meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2500'}},
+        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryVoltage(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
     },
@@ -14278,7 +14279,7 @@ const devices = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
         fromZigbee: [fz.temperature, fz.humidity, fz.battery],
         toZigbee: [],
-        meta: {configureKey: 2, battery: {voltageToPercentage: '3V_2500'}},
+        meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint, logger) => {
             try {
                 const endpoint = device.getEndpoint(1);
@@ -14287,6 +14288,7 @@ const devices = [
                 await reporting.temperature(endpoint, {min: 5, max: repInterval.MINUTES_30, change: 50});
                 await reporting.humidity(endpoint);
                 await reporting.batteryVoltage(endpoint);
+                await reporting.batteryPercentageRemaining(endpoint);
             } catch (e) {/* Not required for all: https://github.com/Koenkk/zigbee2mqtt/issues/5562 */}
         },
     },


### PR DESCRIPTION
Both SNZB-02 and SNZB-4 have batteryPrecentageRemaining in the database.db and seem to report it daily.
This would explain the battery % variang a bit as mentioned in koenkk/zigbee2mqtt#6657

The SNZB-02 was easy to configure most will do it on the first new message or when the button is hit.
The SNZB-04 was annoying, you need to either remove + join or remove the battery for it to  take the new reporting values. They also seem to apply when either batteryVoltage or batteryPercentageRemaining come in via attReport. But they don't apply when the ias_contact_alarm is triggered.

The configureKey for SNZB-04 was not bumpbed to not have to many errors in the logs. But even without reconfigure batteryPercentageRemaining is reported, usually shut before batteryVoltage, so it should be fine.