### PR TITLE
Add Eurotronic specific attributes to documentation

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -10889,8 +10889,14 @@ const devices = [
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
             .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withLocalTemperatureCalibration()
             .withPiHeatingDemand(),
-			exposes.enum('eurotronic_trv_mode', exposes.access.STATE_SET, [1, 2]).withDescription('Select between direct control of the valve via the `eurotronic_valve_position` or automatic control of the valve based on the `current_heating_setpoint`. For manual control set the value to 1, for automatic control set the value to 2 (the default). When switched to manual mode the display shows a value from 0 (valve closed) to 100 (valve fully open) and the buttons on the device are disabled.'),
-			exposes.numeric('eurotronic_valve_position', exposes.access.ALL).withValueMin(0).withValueMax(255).withDescription('Directly control the radiator valve when `eurotronic_trv_mode` is set to 1. The values range from 0 (valve closed) to 255 (valve fully open)')],
+        exposes.enum('eurotronic_trv_mode', exposes.access.ALL, [1, 2])
+            .withDescription('Select between direct control of the valve via the `eurotronic_valve_position` or automatic control of the '+
+            'valve based on the `current_heating_setpoint`. For manual control set the value to 1, for automatic control set the value '+
+            'to 2 (the default). When switched to manual mode the display shows a value from 0 (valve closed) to 100 (valve fully open) '+
+            'and the buttons on the device are disabled.'),
+        exposes.numeric('eurotronic_valve_position', exposes.access.ALL).withValueMin(0).withValueMax(255)
+            .withDescription('Directly control the radiator valve when `eurotronic_trv_mode` is set to 1. The values range from 0 (valve '+
+            'closed) to 255 (valve fully open)')],
         meta: {configureKey: 3},
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices.js
+++ b/devices.js
@@ -10888,7 +10888,9 @@ const devices = [
             tz.eurotronic_current_heating_setpoint, tz.eurotronic_trv_mode, tz.eurotronic_valve_position],
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
             .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withLocalTemperatureCalibration()
-            .withPiHeatingDemand()],
+            .withPiHeatingDemand(),
+			exposes.enum('eurotronic_trv_mode', exposes.access.STATE_SET, [1, 2]).withDescription('Select between direct control of the valve via the `eurotronic_valve_position` or automatic control of the valve based on the `current_heating_setpoint`. For manual control set the value to 1, for automatic control set the value to 2 (the default). When switched to manual mode the display shows a value from 0 (valve closed) to 100 (valve fully open) and the buttons on the device are disabled.'),
+			exposes.numeric('eurotronic_valve_position', exposes.access.ALL).withValueMin(0).withValueMax(255).withDescription('Directly control the radiator valve when `eurotronic_trv_mode` is set to 1. The values range from 0 (valve closed) to 255 (valve fully open)')],
         meta: {configureKey: 3},
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
Added documentation for eurotronic_trv_mode and eurotronic_valve_position proprties based on the installation manual page 14: https://eurotronic.org/wp-content/uploads/2021/02/Spirit_ZigBee_BDA_web_EN_2021.pdf