### PR TITLE
Enable window_open detection for Viessman TRV

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1745,11 +1745,20 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             const result = converters.thermostat.convert(model, msg, publish, options, meta);
+
             // ViessMann TRVs report piHeatingDemand from 0-5
             // NOTE: remove the result for now, but leave it configure for reporting
             //       it will show up in the debug log still to help try and figure out
             //       what this value potentially means.
             delete result.pi_heating_demand;
+
+            // viessmannCustom0
+            // 0-2: unknown
+            // 3: window open (OO on display)
+            if (msg.data.hasOwnProperty('viessmannCustom0')) {
+                result.window_open = (msg.data['viessmannCustom0'] == 3);
+            }
+
             return result;
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4501,6 +4501,12 @@ const converters = {
             return {state: {sensitivity: value}};
         },
     },
+    viessmann_window_open: {
+        key: ['window_open'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['viessmannCustom0'], {manufacturerCode: 0x1221});
+        },
+    },
 
     // #endregion
 

--- a/devices.js
+++ b/devices.js
@@ -16070,8 +16070,13 @@ const devices = [
         fromZigbee: [fz.legacy.viessmann_thermostat_att_report, fz.battery, fz.legacy.hvac_user_interface],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation,
             tz.thermostat_system_mode, tz.thermostat_keypad_lockout, tz.viessmann_window_open],
-        exposes: [exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
-            .withSystemMode(['heat', 'sleep']), e.keypad_lockout()],
+        exposes: [
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1)
+                .withLocalTemperature().withSystemMode(['heat', 'sleep']),
+            exposes.binary('window_open', ea.STATE_GET, true, false)
+                .withDescription('A window was opened (detected based on sudden temperature drop).'),
+            e.keypad_lockout(),
+        ],
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Not sure what the other values for viessmannCustom0 are yet, so not renaming that at this time.

Reporting values taken from the pcap.