### PR TITLE
Support for LK FUGA Wiser Wireless Double Relay

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1602,6 +1602,16 @@ const converters = {
             return result;
         },
     },
+    wiser_fuga_relay_command: {
+        cluster: 'genOnOff',
+        type: ['commandOn', 'commandOff'],
+        convert: (model, msg, publish, options, meta) => {
+            const button = getKey(model.endpoint(msg.device), msg.endpoint.ID);
+            return {
+                action: `${button}_single`,
+            };
+        },
+    },
     tuya_doorbell_button: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1602,16 +1602,6 @@ const converters = {
             return result;
         },
     },
-    wiser_fuga_relay_command: {
-        cluster: 'genOnOff',
-        type: ['commandOn', 'commandOff'],
-        convert: (model, msg, publish, options, meta) => {
-            const button = getKey(model.endpoint(msg.device), msg.endpoint.ID);
-            return {
-                action: `${button}_single`,
-            };
-        },
-    },
     tuya_doorbell_button: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/devices.js
+++ b/devices.js
@@ -14857,7 +14857,7 @@ const devices = [
     },
     {
         zigbeeModel: ['LK Switch'],
-        model: 'LK Switch',
+        model: '545D6514',
         vendor: 'Schneider Electric',
         description: 'LK FUGA Wiser Wireless Double Relay',
         meta: {multiEndpoint: true, configureKey: 1},

--- a/devices.js
+++ b/devices.js
@@ -14855,6 +14855,29 @@ const devices = [
             await reporting.currentPositionLiftPercentage(endpoint);
         },
     },
+    {
+        zigbeeModel: ['LK Switch'],
+        model: 'LK Switch',
+        vendor: 'Schneider Electric',
+        description: 'LK FUGA® Wiser wireless double relay',
+        meta: {multiEndpoint: true, configureKey: 1},
+        fromZigbee: [fz.on_off, fzLocal.wiser_fuga_relay_command],
+        toZigbee: [tz.on_off],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2, 's1': 21, 's2': 22, 's3': 23, 's4': 24};
+        },
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.action(['button_*_single'])],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            device.endpoints.forEach(async (ep) => {
+                if (ep.outputClusters.includes(6)) {
+                    await reporting.bind(ep, coordinatorEndpoint, ['genOnOff']);
+                    if (ep.ID <= 2) {
+                        await reporting.onOff(ep);
+                    }
+                }
+            });
+        },
+    },
 
     // Legrand
     {

--- a/devices.js
+++ b/devices.js
@@ -14859,7 +14859,7 @@ const devices = [
         zigbeeModel: ['LK Switch'],
         model: 'LK Switch',
         vendor: 'Schneider Electric',
-        description: 'LK FUGA® Wiser wireless double relay',
+        description: 'LK FUGA Wiser Wireless Double Relay',
         meta: {multiEndpoint: true, configureKey: 1},
         fromZigbee: [fz.on_off, fzLocal.wiser_fuga_relay_command],
         toZigbee: [tz.on_off],

--- a/devices.js
+++ b/devices.js
@@ -14866,7 +14866,7 @@ const devices = [
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2, 's1': 21, 's2': 22, 's3': 23, 's4': 24};
         },
-        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.action(['button_*_single'])],
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.action(['s*_single'])],
         configure: async (device, coordinatorEndpoint, logger) => {
             device.endpoints.forEach(async (ep) => {
                 if (ep.outputClusters.includes(6)) {

--- a/devices.js
+++ b/devices.js
@@ -14861,12 +14861,12 @@ const devices = [
         vendor: 'Schneider Electric',
         description: 'LK FUGA Wiser Wireless Double Relay',
         meta: {multiEndpoint: true, configureKey: 1},
-        fromZigbee: [fz.on_off, fz.wiser_fuga_relay_command],
+        fromZigbee: [fz.on_off, fz.command_on, fz.command_off],
         toZigbee: [tz.on_off],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2, 's1': 21, 's2': 22, 's3': 23, 's4': 24};
         },
-        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.action(['s*_single'])],
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.action(['on_s*', 'off_s*'])],
         configure: async (device, coordinatorEndpoint, logger) => {
             device.endpoints.forEach(async (ep) => {
                 if (ep.outputClusters.includes(6)) {

--- a/devices.js
+++ b/devices.js
@@ -14859,7 +14859,7 @@ const devices = [
         zigbeeModel: ['LK Switch'],
         model: '545D6514',
         vendor: 'Schneider Electric',
-        description: 'LK FUGA Wiser Wireless Double Relay',
+        description: 'LK FUGA wiser wireless double relay',
         meta: {multiEndpoint: true, configureKey: 1},
         fromZigbee: [fz.on_off, fz.command_on, fz.command_off],
         toZigbee: [tz.on_off],

--- a/devices.js
+++ b/devices.js
@@ -14861,7 +14861,7 @@ const devices = [
         vendor: 'Schneider Electric',
         description: 'LK FUGA Wiser Wireless Double Relay',
         meta: {multiEndpoint: true, configureKey: 1},
-        fromZigbee: [fz.on_off, fzLocal.wiser_fuga_relay_command],
+        fromZigbee: [fz.on_off, fz.wiser_fuga_relay_command],
         toZigbee: [tz.on_off],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2, 's1': 21, 's2': 22, 's3': 23, 's4': 24};


### PR DESCRIPTION
This PR adds support for LK FUGA Wiser Wireless Double Relay:
https://zigbeealliance.org/zigbee_products/lk-fuga-wiser-wireless-double-relay/

I have not been able to get other action than single press from the buttons. I hope in the future also to be able to detect long presses and double presses. From the factory the 4 buttons are bound to the two relays. If you want to decouple them you have to unbind the relation.