### PR TITLE
Removing tamper exposure of SNZB-04

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14261,7 +14261,7 @@ const devices = [
         vendor: 'SONOFF',
         whiteLabel: [{vendor: 'eWeLink', model: 'RHK06'}],
         description: 'Contact sensor',
-        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery(), e.battery_voltage()],
+        exposes: [e.contact(), e.battery_low(), e.battery(), e.battery_voltage()],
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
         meta: {configureKey: 1},


### PR DESCRIPTION
The SNZB-04 contact sensor just has a reed, LED and a push button (see. e.g [here](https://community.hubitat.com/t/sonoff-snzb-04-zigbee-door-window-contact-sensor-internal/47475)). There is no component inside that could trigger a tamper warning therefore i would suggest removing the exposure of tamper because it seems to be not existing.