### PR TITLE
Add/fix support for occupancy with timeout for Centralite and Xfinity keypads

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -849,14 +849,6 @@ const converters = {
             };
         },
     },
-    ias_ace_occupancy_with_timeout: {
-        cluster: 'ssIasAce',
-        type: 'commandGetPanelStatus',
-        convert: (model, msg, publish, options, meta) => {
-            msg.data.occupancy = 1;
-            return converters.occupancy_with_timeout.convert(model, msg, publish, options, meta);
-        },
-    },
     command_recall: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -1504,6 +1496,14 @@ const converters = {
                 meta.logger.warn(`zigbee-herdsman-converters:hy_thermostat: NOT RECOGNIZED DP #${
                     dp} with data ${JSON.stringify(msg.data)}`);
             }
+        },
+    },
+    ias_ace_occupancy_with_timeout: {
+        cluster: 'ssIasAce',
+        type: 'commandGetPanelStatus',
+        convert: (model, msg, publish, options, meta) => {
+            msg.data.occupancy = 1;
+            return converters.occupancy_with_timeout.convert(model, msg, publish, options, meta);
         },
     },
     tuya_led_controller: {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -849,6 +849,14 @@ const converters = {
             };
         },
     },
+    ias_ace_occupancy_with_timeout: {
+        cluster: 'ssIasAce',
+        type: 'commandGetPanelStatus',
+        convert: (model, msg, publish, options, meta) => {
+            msg.data.occupancy = 1;
+            return converters.occupancy_with_timeout.convert(model, msg, publish, options, meta);
+        },
+    },
     command_recall: {
         cluster: 'genScenes',
         type: 'commandRecall',

--- a/devices.js
+++ b/devices.js
@@ -9223,7 +9223,7 @@ const devices = [
         description: 'Alarm security keypad',
         meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
         fromZigbee: [fz.command_arm, fz.temperature, fz.battery, fz.ias_occupancy_alarm_1, fz.identify, fz.ias_contact_alarm_1,
-            fz.ias_occupancy_alarm_2, fz.ias_occupancy_alarm_1_with_timeout],
+            fz.ias_ace_occupancy_with_timeout],
         exposes: [e.battery(), e.battery_voltage(), e.occupancy(), e.battery_low(), e.tamper(), e.presence(), e.contact(),
             exposes.numeric('action_code', ea.STATE), exposes.text('action_zone', ea.STATE), e.temperature(), e.action([
                 'disarm', 'arm_day_zones', 'identify', 'arm_night_zones', 'arm_all_zones', 'exit_delay', 'emergency',

--- a/devices.js
+++ b/devices.js
@@ -9147,8 +9147,8 @@ const devices = [
         vendor: 'Centralite',
         description: '3-Series security keypad',
         meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
-        fromZigbee: [fz.command_arm_with_transaction, fz.temperature, fz.battery],
-        exposes: [e.battery(), e.temperature(), e.action([
+        fromZigbee: [fz.command_arm_with_transaction, fz.temperature, fz.battery, fz.ias_ace_occupancy_with_timeout],
+        exposes: [e.battery(), e.temperature(), e.occupancy(), e.action([
             'disarm', 'arm_day_zones', 'arm_night_zones', 'arm_all_zones', 'exit_delay', 'emergency'])],
         toZigbee: [tz.arm_mode],
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
This PR adds/fixes the support for occupancy with timeout for the keypads Centralite 3400-D and Xfinity URC4450BC0-X-R.

Both keypads have an occupancy sensor that sends the following message when triggered:

```
Received Zigbee message from '<IEEE address>', type 'commandGetPanelStatus', cluster 'ssIasAce', data '{}' from endpoint 1 with groupID 0
```

The new converter just reuses the functoinality of `occupancy_with_timeout`.

Thanks @aesedepece for helping me with the PR! ;-)