### PR TITLE
Cleanup versions for Heiman HS1DS and HS3DS

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9573,7 +9573,7 @@ const devices = [
         exposes: [e.gas(), e.battery_low(), e.tamper()],
     },
     {
-        zigbeeModel: ['DoorSensor-N','DoorSensor-N-3.0'],
+        zigbeeModel: ['DoorSensor-N', 'DoorSensor-N-3.0'],
         model: 'HS3DS',
         vendor: 'HEIMAN',
         description: 'Door sensor',
@@ -9589,7 +9589,7 @@ const devices = [
         exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper()],
     },
     {
-        zigbeeModel: ['DoorSensor-EM','DoorSensor-EF-3.0'],
+        zigbeeModel: ['DoorSensor-EM', 'DoorSensor-EF-3.0'],
         model: 'HS1DS',
         vendor: 'HEIMAN',
         description: 'Door sensor',

--- a/devices.js
+++ b/devices.js
@@ -9573,8 +9573,8 @@ const devices = [
         exposes: [e.gas(), e.battery_low(), e.tamper()],
     },
     {
-        zigbeeModel: ['DoorSensor-N'],
-        model: 'HS1DS/HS3DS',
+        zigbeeModel: ['DoorSensor-N','DoorSensor-N-3.0'],
+        model: 'HS3DS',
         vendor: 'HEIMAN',
         description: 'Door sensor',
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
@@ -9589,8 +9589,8 @@ const devices = [
         exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper()],
     },
     {
-        fingerprint: [{modelID: 'DoorSensor-EF-3.0', manufacturerName: 'HEIMAN'}],
-        model: 'HS1DS-EF',
+        zigbeeModel: ['DoorSensor-EM','DoorSensor-EF-3.0'],
+        model: 'HS1DS',
         vendor: 'HEIMAN',
         description: 'Door sensor',
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
@@ -9612,31 +9612,6 @@ const devices = [
         fromZigbee: [fz.ias_contact_alarm_1],
         toZigbee: [],
         exposes: [e.contact(), e.battery_low(), e.tamper()],
-    },
-    {
-        zigbeeModel: ['DoorSensor-EM'],
-        model: 'HS1DS-E',
-        vendor: 'HEIMAN',
-        description: 'Door sensor',
-        fromZigbee: [fz.ias_contact_alarm_1],
-        toZigbee: [],
-        exposes: [e.contact(), e.battery_low(), e.tamper()],
-    },
-    {
-        fingerprint: [{modelID: 'DoorSensor-N-3.0', manufacturerName: 'HEIMAN'}],
-        model: 'HS3DS',
-        vendor: 'HEIMAN',
-        description: 'Door sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
-        toZigbee: [],
-        meta: {configureKey: 1},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: repInterval.MINUTES_5, max: repInterval.HOUR});
-            await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
-        },
-        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
         zigbeeModel: ['WaterSensor-N'],


### PR DESCRIPTION
This also adds battery percentage for the Heiman HS1DS-E

Heiman has only 2 doorsensors in their portfolio: HS1DS and the HS3DS. 
All sub versions as HS1DS-E or HS1DS-EF-3.0 are still HS1DS's and uses the same code. No need to specify every subversion. If there is a new subversion just add it to existing sensor.

Heiman really likes to play with subversioning. If you specify these all separately it will become a mess and the devices,js unnecessary big.