### PR TITLE
Update devices.js for Innr RB 172 W light

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -5827,6 +5827,14 @@ const devices = [
         meta: {turnsOffAtBrightness1: true},
     },
     {
+        zigbeeModel: ['RB 172 W'],
+        model: 'RB 172 W',
+        vendor: 'Innr',
+        description: 'ZigBee E27 retrofit bulb, warm dimmable 2200-2700K, 806 Lm', # Taken from EU CE Declaration of Conformity
+        extend: preset.light_onoff_brightness(),
+        meta: {turnsOffAtBrightness1: true},
+    },
+    {
         zigbeeModel: ['RB 175 W'],
         model: 'RB 175 W',
         vendor: 'Innr',

--- a/devices.js
+++ b/devices.js
@@ -5830,7 +5830,7 @@ const devices = [
         zigbeeModel: ['RB 172 W'],
         model: 'RB 172 W',
         vendor: 'Innr',
-        description: 'ZigBee E27 retrofit bulb, warm dimmable 2200-2700K, 806 Lm', # Taken from EU CE Declaration of Conformity
+        description: 'ZigBee E27 retrofit bulb, warm dimmable 2200-2700K, 806 Lm',
         extend: preset.light_onoff_brightness(),
         meta: {turnsOffAtBrightness1: true},
     },


### PR DESCRIPTION
Support Innr RB 172 W light bulb.
Full description: 'ZigBee E27 retrofit bulb, warm dimmable 2200-2700K, 806 Lm'
URL: https://www.innr.com/wp-content/uploads/2019/12/1530107097_innr-SAR-001-1001-EU-DoC-RB-162-172-W-v1.0.pdf