### PR TITLE
Fix EchoStar SAGE206612 Doorbell channels state

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4510,7 +4510,7 @@ const converters = {
     },
     SAGE206612_state: {
         cluster: 'genOnOff',
-        type: 'commandOn',
+        type: ['commandOn', 'commandOff'],
         convert: (model, msg, publish, options, meta) => {
             const timeout = 28;
 
@@ -4518,13 +4518,13 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'action', []);
             }
 
-
+            const lookup = {'commandOn': 'bell1', 'commandOff': 'bell2'};
             const timer = setTimeout(() => globalStore.getValue(msg.endpoint, 'action').pop(), timeout * 1000);
 
             const list = globalStore.getValue(msg.endpoint, 'action');
             if (list.length === 0 || list.length > 4) {
                 list.push(timer);
-                return {action: 'on'};
+                return {action: lookup[msg.type]};
             } else if (timeout > 0) {
                 list.push(timer);
             }

--- a/devices.js
+++ b/devices.js
@@ -16384,7 +16384,7 @@ const devices = [
         vendor: 'EchoStar',
         description: 'SAGE by Hughes doorbell sensor',
         fromZigbee: [fz.SAGE206612_state, fz.battery],
-        exposes: [e.battery(), e.action(['on'])],
+        exposes: [e.battery(), e.action(['bell1', 'bell2'])],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
     },


### PR DESCRIPTION
Fixed a bug that did not allow to view the correct channel (the one that correspond to the doorbell rang).
Now on HomeAssistant (or via mqtt) the states are sets to "bell1" and "bell2" (and not more to "on")