### PR TITLE
Update devices.js - UK ClickSmart 2 gang wall socket

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1174,7 +1174,7 @@ const devices = [
     },
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_mvn6jl7x'},
-            {modelID: 'TS011F', manufacturerName: '_TZ3000_raviyuvk'}],
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_raviyuvk'},{modelID: 'TS011F', manufacturerName: '_TYZB01_hlla45kx'}],
         model: 'TS011F_2_gang_wall',
         vendor: 'TuYa',
         description: '2 gang wall outlet',

--- a/devices.js
+++ b/devices.js
@@ -1174,7 +1174,7 @@ const devices = [
     },
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_mvn6jl7x'},
-            {modelID: 'TS011F', manufacturerName: '_TZ3000_raviyuvk'},{modelID: 'TS011F', manufacturerName: '_TYZB01_hlla45kx'}],
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_raviyuvk'}, {modelID: 'TS011F', manufacturerName: '_TYZB01_hlla45kx'}],
         model: 'TS011F_2_gang_wall',
         vendor: 'TuYa',
         description: '2 gang wall outlet',


### PR DESCRIPTION
Adds support for 2 gang wall socket sold by UK company ClickSmart. It reports as a TS011F so though best to clump together with other Tuya devices.

https://www.click4electrics.co.uk/click-smart-home-accessories-c-957_1117/click-smart-13a-2-gang-zigbee-smart-switched-socket-outlet-p-10502
