### PR TITLE
Add support for Orvibo SP20-0 CO Sensor

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9509,7 +9509,7 @@ const devices = [
 
     // HEIMAN
     {
-        zigbeeModel: ['CO_V15', 'CO_YDLV10', 'CO_V16'],
+        zigbeeModel: ['CO_V15', 'CO_YDLV10', 'CO_V16', '1ccaa94c49a84abaa9e38687913947ba'],
         model: 'HS1CA-M',
         description: 'Smart carbon monoxide sensor',
         vendor: 'HEIMAN',


### PR DESCRIPTION
The Orvibo SP20-0 Carbon Monoxide Sensor is in fact a Heiman HS1CA-M sensor. This change adds support for this sensor with all its exposed functionalities.