### PR TITLE
Centralite 3400-D add tamper button

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1507,6 +1507,16 @@ const converters = {
             return converters.occupancy_with_timeout.convert(model, msg, publish, options, meta);
         },
     },
+    ias_zone_tamper: {
+        cluster: 'ssIasZone',
+        type: 'commandStatusChangeNotification',
+        convert: (model, msg, publish, options, meta) => {
+            const zoneStatus = msg.data.zonstatus;
+            return {
+                tamper: zoneStatus == 4 ? true : false   
+            };
+        },
+    },
     tuya_led_controller: {
         cluster: 'lightingColorCtrl',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1513,7 +1513,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const zoneStatus = msg.data.zonstatus;
             return {
-                tamper: zoneStatus == 4 ? true : false
+                tamper: zoneStatus == 4 ? true : false,
             };
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1513,7 +1513,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const zoneStatus = msg.data.zonstatus;
             return {
-                tamper: zoneStatus == 4 ? true : false   
+                tamper: zoneStatus == 4 ? true : false
             };
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -9208,8 +9208,8 @@ const devices = [
         vendor: 'Centralite',
         description: '3-Series security keypad',
         meta: {configureKey: 1, battery: {voltageToPercentage: '3V_2100'}},
-        fromZigbee: [fz.command_arm_with_transaction, fz.temperature, fz.battery, fz.ias_ace_occupancy_with_timeout],
-        exposes: [e.battery(), e.temperature(), e.occupancy(), e.action([
+        fromZigbee: [fz.command_arm_with_transaction, fz.temperature, fz.battery, fz.ias_ace_occupancy_with_timeout, fz.ias_zone_tamper],
+        exposes: [e.battery(), e.temperature(), e.occupancy(), e.tamper(), e.action([
             'disarm', 'arm_day_zones', 'arm_night_zones', 'arm_all_zones', 'exit_delay', 'emergency'])],
         toZigbee: [tz.arm_mode],
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
Pressing the tamper button triggers the following event:
```
type 'commandStatusChangeNotification', cluster 'ssIasZone', data '{"extendedstatus":0,"zonestatus":0}' from endpoint 1 with groupID 0
```
Releasing the tamper button triggers the following event:
```
type 'commandStatusChangeNotification', cluster 'ssIasZone', data '{"extendedstatus":0,"zonestatus":4}' from endpoint 1 with groupID 0
```

I am still new to this code base. Should I also explicitly check for the extendedstatus field? Should I coin the converter method name to the centralite 3400-D?