### PR TITLE
Add support for Tradfri 470lm E14 light

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2843,7 +2843,6 @@ const devices = [
         onEvent: ikea.bulbOnEvent,
     },
 
-
     // Philips
     {
         zigbeeModel: ['LWU001'],

--- a/devices.js
+++ b/devices.js
@@ -2833,6 +2833,16 @@ const devices = [
         ota: ota.tradfri,
         onEvent: ikea.bulbOnEvent,
     },
+    {
+        zigbeeModel: ['TRADFRI bulb E14 CWS 470lm'],
+        model: 'LED1925G6',
+        vendor: 'IKEA',
+        description: 'TRADFRI LED bulb E14 470 lumen, dimmable, white spectrum, colour spectrum',
+        extend: preset.light_onoff_brightness_colortemp_color(),
+        ota: ota.tradfri,
+        onEvent: ikea.bulbOnEvent,
+    },
+
 
     // Philips
     {


### PR DESCRIPTION
Ikea article number 704.3913.96
https://www.ikea.com/fr/fr/p/tradfri-ampoule-a-led-e14-470-lumen-sans-fil-a-variateur-dintensite-spectre-couleur-et-blanc-globe-opalin-70439196/