### PR TITLE
Adds support for Philips Hue Adore BT 3418411P6 variant

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -3529,7 +3529,7 @@ const devices = [
         vendor: 'Philips',
         description: 'Hue white ambiance bathroom ceiling light Adore with Bluetooth',
         meta: {turnsOffAtBrightness1: true},
-        extend: preset.hue.light_onoff_brightness_colortemp(),
+        extend: preset.hue.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -3524,6 +3524,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['3418411P6'],
+        model: '3418411P6',
+        vendor: 'Philips',
+        description: 'Hue white ambiance bathroom ceiling light Adore with Bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: preset.hue.light_onoff_brightness_colortemp(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTC021'],
         model: '3435011P7',
         vendor: 'Philips',


### PR DESCRIPTION
I bought a set of these Hue Adore lights and they didn't pair initially. After adding an `external_converter` with the proper model number and the same metadata as the Philips 3435011P7, they paired just fine and work with Zigbee2MQTT & HA as expected.

This PR adds the device-details to the `devices.js` file. 

If anything else is required to complete this PR, let me know.