### PR TITLE
Add HG06335 battery voltage and percentage reporting

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -16919,6 +16919,8 @@ const devices = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryVoltage(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
         },
     },
     {


### PR DESCRIPTION
Hi, i've tested batteryPercentageRemaining and batteryVoltage reporting with [HG06335](https://www.zigbee2mqtt.io/devices/HG06335.html). Seems like both is working (i tested with reporting once per minute separately on both). Because other Motion Sensors are also configured with reporting one of those attributes (like the IKEA one) i've added this.