### PR TITLE
Updated Datek AMS Meter Reader, also with correct model

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -17327,17 +17327,17 @@ const devices = [
     },
 
     {
-        zigbeeModel: ['HAN'],
-        model: 'Datek_HAN',
+        zigbeeModel: ['Meter Reader'],
+        model: 'HSE2905E',
         vendor: 'Datek',
-        description: 'Eva AMS HAN power-meter sensor',
-        fromZigbee: [fz.metering, fz.electrical_measurement],
+        description: 'Datek Eva AMS HAN power-meter sensor',
+        fromZigbee: [fz.metering, fz.electrical_measurement, fz.temperature],
         toZigbee: [],
         ota: ota.zigbeeOTA,
         meta: {configureKey: 3},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering', 'msTemperatureMeasurement']);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.rmsVoltage(endpoint);
             await reporting.rmsCurrent(endpoint);
@@ -17345,9 +17345,10 @@ const devices = [
             await reporting.instantaneousDemand(endpoint);
             await reporting.currentSummDelivered(endpoint);
             await reporting.currentSummReceived(endpoint);
+            await reporting.temperature(endpoint);
         },
         exposes: [e.power(), e.energy(), e.current(), e.voltage(), e.current_phase_b(), e.voltage_phase_b(), e.current_phase_c(),
-            e.voltage_phase_c()],
+            e.voltage_phase_c(), e.temperature()],
     },
 
     // Prolight


### PR DESCRIPTION
@Koenkk Through the Zigbee Alliance, I found the actual model `HSE2905E `
Now all should be OK with this new adapter :)

https://zigbeealliance.org/zigbee_products/eva-meter-reader/

Updated doc's also, PR should be ready now.