### PR TITLE
Add model ID for metallic Hue Appear outdoor wall light.

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4372,7 +4372,7 @@ const devices = [
         extend: preset.hue.light_onoff_brightness_colortemp_color(),
     },
     {
-        zigbeeModel: ['1746330P7'],
+        zigbeeModel: ['1746330P7', '1746347P7'],
         model: '1746330P7',
         vendor: 'Philips',
         description: 'Hue Appear outdoor wall light',


### PR DESCRIPTION
Just one line changed: Added another model ID to the already existent Hue Appear outdoor wall light. Not sure if mine differs because of the color (I have the metallic one) or if this is a new revision, but it works perfectly.