### PR TITLE
add support for Teekar/Tuya in-wall outlet

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1319,6 +1319,14 @@ const devices = [
         whiteLabel: [{vendor: 'LoraTap', model: 'RR400ZB'}],
     },
     {
+        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_wxtp7c5y'}],
+        model: 'TS011F_wall_outlet',
+        vendor: 'TuYa',
+        description: 'In-wall outlet',
+        extend: preset.switch(),
+        whiteLabel: [{vendor: 'Teekar', model: 'SWP86-01OG'}],
+    },
+    {
         zigbeeModel: ['TS130F'],
         model: 'TS130F',
         vendor: 'TuYa',


### PR DESCRIPTION
Hi,

I found this in-wall outlet at [german amazon](https://www.amazon.de/gp/product/B08VRGLKYF).

It's harder to find any model-id for this device than adding support for it… 

The whitelabel's website doesn't even list this device (or they did confuse zigbee with wlan, as the hole packaging and manual says "this is a WLAN device").

Whatever, with this additions to `devices.js` the switch works via zigbee2mqtt.