### PR TITLE
Livarno Lux E27 bulb RGB does not support enhancedHue

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -17117,9 +17117,9 @@ const devices = [
         vendor: 'Lidl',
         description: 'Livarno Lux E27 bulb RGB',
         ...preset.light_onoff_brightness_colortemp_color({disableColorTempStartup: true}),
-        meta: {applyRedFix: true, configureKey: 1},
+        meta: {applyRedFix: true, enhancedHue: false, configureKey: 2},
         configure: async (device, coordinatorEndpoint, logger) => {
-            device.getEndpoint(1).saveClusterAttributeKeyValue('lightingColorCtrl', {colorCapabilities: 31});
+            device.getEndpoint(1).saveClusterAttributeKeyValue('lightingColorCtrl', {colorCapabilities: 29});
         },
     },
     {


### PR DESCRIPTION
As discovered in https://github.com/Koenkk/zigbee2mqtt/issues/6921 these bulbs do not support enhancedHue.

- [x] Update the saveClusterAttributeKeyValue (Wy are we even setting this if we can't read it?)
- [x] Mark enhacedHue as not support in meta