### PR TITLE
Move common operations on colors to `lib/color.js`

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -929,7 +929,7 @@ const converters = {
                 const hsv = newColor.hsv;
                 const hsvCorrected = hsv.colorCorrected(meta);
                 newState.color_mode = constants.colorMode[0];
-                newState.color = hsv.toObject(true);
+                newState.color = hsv.toObject(false);
 
                 if (hsv.hue !== null) {
                     if (enhancedHue) {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1568,7 +1568,7 @@ const converters = {
                 return result;
             } else if (key == 'color_temp' || key == 'color_temp_percent') {
                 const result = await converters.gledopto_light_colortemp.convertSet(entity, key, value, meta);
-                result.state.color = libColor.miredsToXY(result.state.color_temp);
+                result.state.color = libColor.ColorXY.fromMireds(result.state.color_temp).rounded(4).toObject();
                 return result;
             }
         },
@@ -4142,9 +4142,9 @@ const converters = {
                     } catch (e) {
                         e;
                     }
-                    const newColor = libColor.Color.fromConverterArg(val);
 
-                    if (newColor.xy !== null) {
+                    const newColor = libColor.Color.fromConverterArg(val);
+                    if (newColor.isXY()) {
                         const xScaled = utils.mapNumberRange(newColor.xy.x, 0, 1, 0, 65535);
                         const yScaled = utils.mapNumberRange(newColor.xy.y, 0, 1, 0, 65535);
                         extensionfieldsets.push(
@@ -4155,7 +4155,7 @@ const converters = {
                             },
                         );
                         state['color'] = newColor.xy.toObject();
-                    } else if (newColor.hsv !== null) {
+                    } else if (newColor.isHSV()) {
                         const hsvCorrected = newColor.hsv.colorCorrected(meta);
                         if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
                             const hScaled = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 65535);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -929,7 +929,7 @@ const converters = {
                 const hsv = newColor.hsv;
                 const hsvCorrected = hsv.colorCorrected(meta);
                 newState.color_mode = constants.colorMode[0];
-                newState.color = hsv.toObject();
+                newState.color = hsv.toObject(true);
 
                 if (hsv.hue !== null) {
                     if (enhancedHue) {
@@ -4181,7 +4181,7 @@ const converters = {
                                 },
                             );
                         }
-                        state['color'] = newColor.hsv.toObject();
+                        state['color'] = newColor.hsv.toObject(true);
                     }
                 }
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -908,7 +908,7 @@ const converters = {
 
             if (newColor.isRGB() || newColor.isXY()) {
                 // Convert RGB to XY color mode because Zigbee doesn't support RGB (only x/y and hue/saturation)
-                const xy = newColor.isRGB() ? newColor.rgb.gammaCorrected().toXY() : newColor.xy;
+                const xy = newColor.isRGB() ? newColor.rgb.gammaCorrected().toXY().rounded(4) : newColor.xy;
 
                 // Some bulbs e.g. RB 185 C don't turn to red (they don't respond at all) when x: 0.701 and y: 0.299
                 // is send. These values are e.g. send by Home Assistant when clicking red in the color wheel.
@@ -920,7 +920,7 @@ const converters = {
                 }
 
                 newState.color_mode = constants.colorMode[1];
-                newState.color = xy.toObject(4);
+                newState.color = xy.toObject();
                 zclData.colorx = utils.mapNumberRange(xy.x, 0, 1, 0, 65535);
                 zclData.colory = utils.mapNumberRange(xy.y, 0, 1, 0, 65535);
                 command = 'moveToColor';
@@ -929,7 +929,7 @@ const converters = {
                 const hsv = newColor.hsv;
                 const hsvCorrected = hsv.colorCorrected(meta);
                 newState.color_mode = constants.colorMode[0];
-                newState.color = hsv.toObject(0);
+                newState.color = hsv.toObject();
 
                 if (hsv.hue !== null) {
                     if (enhancedHue) {
@@ -1037,7 +1037,7 @@ const converters = {
                 return result;
             } else if (key == 'color_temp' || key == 'color_temp_percent') {
                 const result = await converters.light_colortemp.convertSet(entity, key, value, meta);
-                result.state.color = libColor.ColorXY.fromMireds(result.state.color_temp).toObject(4);
+                result.state.color = libColor.ColorXY.fromMireds(result.state.color_temp).rounded(4).toObject();
                 return result;
             }
         },
@@ -4154,7 +4154,7 @@ const converters = {
                                 'extField': [xScaled, yScaled],
                             },
                         );
-                        state['color'] = newColor.xy.toObject(4);
+                        state['color'] = newColor.xy.toObject();
                     } else if (newColor.hsv !== null) {
                         const hsvCorrected = newColor.hsv.colorCorrected(meta);
                         if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
@@ -4181,7 +4181,7 @@ const converters = {
                                 },
                             );
                         }
-                        state['color'] = newColor.hsv.toObject(0);
+                        state['color'] = newColor.hsv.toObject();
                     }
                 }
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -7,6 +7,7 @@ const herdsman = require('zigbee-herdsman');
 const legacy = require('../lib/legacy');
 const light = require('../lib/light');
 const constants = require('../lib/constants');
+const libColor = require('../lib/color');
 
 const manufacturerOptions = {
     xiaomi: {manufacturerCode: herdsman.Zcl.ManufacturerCode.LUMI_UNITED_TECH, disableDefaultResponse: true},
@@ -899,234 +900,81 @@ const converters = {
     light_color: {
         key: ['color'],
         convertSet: async (entity, key, value, meta) => {
-            // Check if we need to convert from RGB to XY and which cmd to use
             let command;
+            const newColor = libColor.Color.fromConverterArg(value);
             const newState = {};
-
-
-            if (value.hasOwnProperty('r') && value.hasOwnProperty('g') && value.hasOwnProperty('b')) {
-                const xy = utils.rgbToXY(value.r, value.g, value.b);
-                value.x = xy.x;
-                value.y = xy.y;
-            } else if (value.hasOwnProperty('rgb')) {
-                const rgb = value.rgb.split(',').map((i) => parseInt(i));
-                const xy = utils.rgbToXY(rgb[0], rgb[1], rgb[2]);
-                value.x = xy.x;
-                value.y = xy.y;
-            } else if (value.hasOwnProperty('hex') || (typeof value === 'string' && value.startsWith('#'))) {
-                const xy = utils.hexToXY(typeof value === 'string' && value.startsWith('#') ? value : value.hex);
-                value = {x: xy.x, y: xy.y};
-            } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('l')) {
-                newState.color = {h: value.h, s: value.s, l: value.l};
-                const hsv = utils.gammaCorrectHSV(...Object.values(
-                    utils.hslToHSV(utils.correctHue(value.h, meta), value.s, value.l)));
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                value.brightness = utils.mapNumberRange(hsv.v, 0, 100, 0, 254);
-                newState.brightness = value.brightness;
-
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturationAndBrightness';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturationAndBrightness';
-                }
-            } else if (value.hasOwnProperty('hsl')) {
-                newState.color = {hsl: value.hsl};
-                const hsl = value.hsl.split(',').map((i) => parseInt(i));
-                const hsv = utils.gammaCorrectHSV(...Object.values(
-                    utils.hslToHSV(utils.correctHue(hsl[0], meta), hsl[1], hsl[2])));
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                value.brightness = utils.mapNumberRange(hsv.v, 0, 100, 0, 254);
-                newState.brightness = value.brightness;
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturationAndBrightness';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturationAndBrightness';
-                }
-            } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('b')) {
-                newState.color = {h: value.h, s: value.s, v: value.b};
-                const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), value.s, value.b);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                value.brightness = utils.mapNumberRange(hsv.v, 0, 100, 0, 254);
-                newState.brightness = value.brightness;
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturationAndBrightness';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturationAndBrightness';
-                }
-            } else if (value.hasOwnProperty('hsb')) {
-                let hsv = value.hsb.split(',').map((i) => parseInt(i));
-                newState.color = {h: hsv[0], s: hsv[1], v: hsv[2]};
-                hsv = utils.gammaCorrectHSV(utils.correctHue(hsv[0], meta), hsv[1], hsv[2]);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                value.brightness = utils.mapNumberRange(hsv.v, 0, 100, 0, 254);
-                newState.brightness = value.brightness;
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturationAndBrightness';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturationAndBrightness';
-                }
-            } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('v')) {
-                newState.color = {h: value.h, s: value.s, v: value.v};
-                const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), value.s, value.v);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                value.brightness = utils.mapNumberRange(hsv.v, 0, 100, 0, 254);
-                newState.brightness = value.brightness;
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturationAndBrightness';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturationAndBrightness';
-                }
-            } else if (value.hasOwnProperty('hsv')) {
-                let hsv = value.hsv.split(',').map((i) => parseInt(i));
-                newState.color = {h: hsv[0], s: hsv[1], v: hsv[2]};
-                hsv = utils.gammaCorrectHSV(utils.correctHue(hsv[0], meta), hsv[1], hsv[2]);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                value.brightness = utils.mapNumberRange(hsv.v, 0, 100, 0, 254);
-                newState.brightness = value.brightness;
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturationAndBrightness';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturationAndBrightness';
-                }
-            } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s')) {
-                newState.color = {h: value.h, s: value.s};
-                const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), value.s, 100);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturation';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturation';
-                }
-            } else if (value.hasOwnProperty('h')) {
-                newState.color = {h: value.h};
-                const hsv = utils.gammaCorrectHSV(utils.correctHue(value.h, meta), 100, 100);
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHue';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHue';
-                }
-            } else if (value.hasOwnProperty('s')) {
-                newState.color = {s: value.s};
-                const hsv = utils.gammaCorrectHSV(360, value.s, 100);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                command = 'moveToSaturation';
-            } else if (value.hasOwnProperty('hue') && value.hasOwnProperty('saturation')) {
-                newState.color = {hue: value.hue, saturation: value.saturation};
-                const hsv = utils.gammaCorrectHSV(utils.correctHue(value.hue, meta), value.saturation, 100);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHueAndSaturation';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHueAndSaturation';
-                }
-            } else if (value.hasOwnProperty('hue')) {
-                newState.color = {hue: value.hue};
-                const hsv = utils.gammaCorrectHSV(utils.correctHue(value.hue, meta), 100, 100);
-                if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                    value.hue = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                    command = 'enhancedMoveToHue';
-                } else {
-                    value.hue = utils.mapNumberRange(hsv.h, 0, 360, 0, 254);
-                    command = 'moveToHue';
-                }
-            } else if (value.hasOwnProperty('saturation')) {
-                newState.color = {saturation: value.saturation};
-                const hsv = utils.gammaCorrectHSV(360, value.saturation, 100);
-                value.saturation = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
-                command = 'moveToSaturation';
-            }
 
             const zclData = {transtime: utils.getTransition(entity, key, meta).time};
 
-            switch (command) {
-            case 'enhancedMoveToHueAndSaturationAndBrightness':
-                newState.color_mode = constants.colorMode[0];
-                await entity.command(
-                    'genLevelCtrl',
-                    'moveToLevelWithOnOff',
-                    {level: Number(value.brightness), transtime: utils.getTransition(entity, key, meta).time},
-                    utils.getOptions(meta.mapped, entity),
-                );
-                zclData.enhancehue = value.hue;
-                zclData.saturation = value.saturation;
-                zclData.direction = value.direction || 0;
-                command = 'enhancedMoveToHueAndSaturation';
-                break;
-            case 'enhancedMoveToHueAndSaturation':
-                newState.color_mode = constants.colorMode[0];
-                zclData.enhancehue = value.hue;
-                zclData.saturation = value.saturation;
-                zclData.direction = value.direction || 0;
-                break;
-            case 'enhancedMoveToHue':
-                newState.color_mode = constants.colorMode[0];
-                zclData.enhancehue = value.hue;
-                zclData.direction = value.direction || 0;
-                break;
-            case 'moveToHueAndSaturationAndBrightness':
-                newState.color_mode = constants.colorMode[0];
-                await entity.command(
-                    'genLevelCtrl',
-                    'moveToLevelWithOnOff',
-                    {level: Number(value.brightness), transtime: utils.getTransition(entity, key, meta).time},
-                    utils.getOptions(meta.mapped, entity),
-                );
-                zclData.hue = value.hue;
-                zclData.saturation = value.saturation;
-                zclData.direction = value.direction || 0;
-                command = 'moveToHueAndSaturation';
-                break;
-            case 'moveToHueAndSaturation':
-                newState.color_mode = constants.colorMode[0];
-                zclData.hue = value.hue;
-                zclData.saturation = value.saturation;
-                zclData.direction = value.direction || 0;
-                break;
-            case 'moveToHue':
-                newState.color_mode = constants.colorMode[0];
-                zclData.hue = value.hue;
-                zclData.direction = value.direction || 0;
-                break;
-            case 'moveToSaturation':
-                newState.color_mode = constants.colorMode[0];
-                zclData.saturation = value.saturation;
-                break;
-
-            default:
-                command = 'moveToColor';
+            if (newColor.isRGB() || newColor.isXY()) {
+                // Convert RGB to XY color mode because Zigbee doesn't support RGB (only x/y and hue/saturation)
+                const xy = newColor.isRGB() ? newColor.rgb.gammaCorrected().toXY() : newColor.xy;
 
                 // Some bulbs e.g. RB 185 C don't turn to red (they don't respond at all) when x: 0.701 and y: 0.299
                 // is send. These values are e.g. send by Home Assistant when clicking red in the color wheel.
                 // If we slighlty modify these values the bulb will respond.
                 // https://github.com/home-assistant/home-assistant/issues/31094
-                if (utils.getMetaValue(entity, meta.mapped, 'applyRedFix', 'allEqual', false) && value.x == 0.701 && value.y === 0.299) {
-                    value.x = 0.7006;
-                    value.y = 0.2993;
+                if (utils.getMetaValue(entity, meta.mapped, 'applyRedFix', 'allEqual', false) && xy.x == 0.701 && xy.y === 0.299) {
+                    xy.x = 0.7006;
+                    xy.y = 0.2993;
                 }
 
-                newState.color = {x: value.x, y: value.y};
                 newState.color_mode = constants.colorMode[1];
-                zclData.colorx = utils.mapNumberRange(value.x, 0, 1, 0, 65535);
-                zclData.colory = utils.mapNumberRange(value.y, 0, 1, 0, 65535);
+                newState.color = xy.toObject(4);
+                zclData.colorx = utils.mapNumberRange(xy.x, 0, 1, 0, 65535);
+                zclData.colory = utils.mapNumberRange(xy.y, 0, 1, 0, 65535);
+                command = 'moveToColor';
+            } else if (newColor.isHSV()) {
+                const enhancedHue = utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true);
+                const hsv = newColor.hsv;
+                const hsvCorrected = hsv.colorCorrected(meta);
+                newState.color_mode = constants.colorMode[0];
+                newState.color = hsv.toObject(0);
+
+                if (hsv.hue !== null) {
+                    if (enhancedHue) {
+                        zclData.enhancehue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 65535);
+                    } else {
+                        zclData.hue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 254);
+                    }
+                    zclData.direction = value.direction || 0;
+                }
+
+                if (hsv.saturation != null) {
+                    zclData.saturation = utils.mapNumberRange(hsvCorrected.saturation, 0, 100, 0, 254);
+                }
+
+                if (hsv.value !== null) {
+                    // fallthrough to genLevelCtrl
+                    value.brightness = utils.mapNumberRange(hsvCorrected.value, 0, 100, 0, 254);
+                }
+
+                if (hsv.hue !== null && hsv.saturation !== null) {
+                    if (enhancedHue) {
+                        command = 'enhancedMoveToHueAndSaturation';
+                    } else {
+                        command = 'moveToHueAndSaturation';
+                    }
+                } else if (hsv.hue !== null) {
+                    if (enhancedHue) {
+                        command = 'enhancedMoveToHue';
+                    } else {
+                        command = 'moveToHue';
+                    }
+                } else if (hsv.saturation !== null) {
+                    command = 'moveToSaturation';
+                }
             }
+
+            if (value.hasOwnProperty('brightness')) {
+                await entity.command(
+                    'genLevelCtrl',
+                    'moveToLevelWithOnOff',
+                    {level: Number(value.brightness), transtime: utils.getTransition(entity, key, meta).time},
+                    utils.getOptions(meta.mapped, entity),
+                );
+            }
+
             await entity.command('lightingColorCtrl', command, zclData, utils.getOptions(meta.mapped, entity));
             return {state: newState, readAfterWriteTime: zclData.transtime * 100};
         },
@@ -1183,13 +1031,13 @@ const converters = {
             if (key == 'color') {
                 const result = await converters.light_color.convertSet(entity, key, value, meta);
                 if (result.state && result.state.color.hasOwnProperty('x') && result.state.color.hasOwnProperty('y')) {
-                    result.state.color_temp = utils.xyToMireds(result.state.color.x, result.state.color.y);
+                    result.state.color_temp = Math.round(libColor.ColorXY.fromObject(result.state.color).toMireds());
                 }
 
                 return result;
             } else if (key == 'color_temp' || key == 'color_temp_percent') {
                 const result = await converters.light_colortemp.convertSet(entity, key, value, meta);
-                result.state.color = utils.miredsToXY(result.state.color_temp);
+                result.state.color = libColor.ColorXY.fromMireds(result.state.color_temp).toObject(4);
                 return result;
             }
         },
@@ -1714,13 +1562,13 @@ const converters = {
             if (key == 'color') {
                 const result = await converters.gledopto_light_color.convertSet(entity, key, value, meta);
                 if (result.state && result.state.color.hasOwnProperty('x') && result.state.color.hasOwnProperty('y')) {
-                    result.state.color_temp = utils.xyToMireds(result.state.color.x, result.state.color.y);
+                    result.state.color_temp = Math.round(libColor.ColorXY.fromObject(result.state).toMireds());
                 }
 
                 return result;
             } else if (key == 'color_temp' || key == 'color_temp_percent') {
                 const result = await converters.gledopto_light_colortemp.convertSet(entity, key, value, meta);
-                result.state.color = utils.miredsToXY(result.state.color_temp);
+                result.state.color = libColor.miredsToXY(result.state.color_temp);
                 return result;
             }
         },
@@ -4283,7 +4131,7 @@ const converters = {
                     const [colorTempMin, colorTempMax] = light.findColorTempRange(entity, meta.logger);
                     val = light.clampColorTemp(val, colorTempMin, colorTempMax, meta.logger);
 
-                    const xy = utils.miredsToXY(val);
+                    const xy = libColor.ColorXY.fromMireds(val);
                     const xScaled = utils.mapNumberRange(xy.x, 0, 1, 0, 65535);
                     const yScaled = utils.mapNumberRange(xy.y, 0, 1, 0, 65535);
                     extensionfieldsets.push({'clstId': 768, 'len': 4, 'extField': [xScaled, yScaled]});
@@ -4294,10 +4142,11 @@ const converters = {
                     } catch (e) {
                         e;
                     }
-                    const color = typeof val === 'string' ? utils.hexToXY(val) : val;
-                    if (color.hasOwnProperty('x') && color.hasOwnProperty('y')) {
-                        const xScaled = utils.mapNumberRange(color.x, 0, 1, 0, 65535);
-                        const yScaled = utils.mapNumberRange(color.y, 0, 1, 0, 65535);
+                    const newColor = libColor.Color.fromConverterArg(val);
+
+                    if (newColor.xy !== null) {
+                        const xScaled = utils.mapNumberRange(newColor.xy.x, 0, 1, 0, 65535);
+                        const yScaled = utils.mapNumberRange(newColor.xy.y, 0, 1, 0, 65535);
                         extensionfieldsets.push(
                             {
                                 'clstId': 768,
@@ -4305,12 +4154,12 @@ const converters = {
                                 'extField': [xScaled, yScaled],
                             },
                         );
-                        state['color'] = {x: color.x, y: color.y};
-                    } else if (color.hasOwnProperty('hue') && color.hasOwnProperty('saturation')) {
+                        state['color'] = newColor.xy.toObject(4);
+                    } else if (newColor.hsv !== null) {
+                        const hsvCorrected = newColor.hsv.colorCorrected(meta);
                         if (utils.getMetaValue(entity, meta.mapped, 'enhancedHue', 'allEqual', true)) {
-                            const hsv = utils.gammaCorrectHSV(utils.correctHue(color.hue, meta), color.saturation, 100);
-                            const hScaled = utils.mapNumberRange(hsv.h % 360, 0, 360, 0, 65535);
-                            const sScaled = utils.mapNumberRange(hsv.s, 0, 100, 0, 254);
+                            const hScaled = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 65535);
+                            const sScaled = utils.mapNumberRange(hsvCorrected.saturation, 0, 100, 0, 254);
                             extensionfieldsets.push(
                                 {
                                     'clstId': 768,
@@ -4321,8 +4170,7 @@ const converters = {
                         } else {
                             // The extensionFieldSet is always EnhancedCurrentHue according to ZCL
                             // When the bulb or all bulbs in a group do not support enhanchedHue,
-                            // a fallback to XY is done by converting HSV -> RGB -> XY
-                            const colorXY = utils.rgbToXY(...Object.values(utils.hsvToRgb(color.hue, color.saturation, 100)));
+                            const colorXY = hsvCorrected.toXY();
                             const xScaled = utils.mapNumberRange(colorXY.x, 0, 1, 0, 65535);
                             const yScaled = utils.mapNumberRange(colorXY.y, 0, 1, 0, 65535);
                             extensionfieldsets.push(
@@ -4333,7 +4181,7 @@ const converters = {
                                 },
                             );
                         }
-                        state['color'] = {hue: color.hue, saturation: color.saturation};
+                        state['color'] = newColor.hsv.toObject(0);
                     }
                 }
             }

--- a/lib/color.js
+++ b/lib/color.js
@@ -90,20 +90,28 @@ class ColorRGB {
     }
 
     /**
+     * Return this color with values rounded to given precision
+     * @param {number} precision decimal places to round to
+     * @return {ColorRGB}
+     */
+    rounded(precision) {
+        return new ColorRGB(
+            precisionRound(this.red, precision),
+            precisionRound(this.green, precision),
+            precisionRound(this.blue, precision),
+        );
+    }
+
+    /**
      * Convert to Object
-     * @param {?number} [precision=null] round result to given precision
      * @return {ColorRGBT} object with properties red, green and blue
      */
-    toObject(precision=null) {
-        if (precision === null) {
-            return {red: this.red, green: this.green, blue: this.blue};
-        } else {
-            return {
-                red: precisionRound(this.red, precision),
-                green: precisionRound(this.green, precision),
-                blue: precisionRound(this.blue, precision),
-            };
-        }
+    toObject() {
+        return {
+            red: this.red,
+            green: this.green,
+            blue: this.blue,
+        };
     }
 
     /**
@@ -212,16 +220,26 @@ class ColorXY {
     }
 
     /**
+     * Return this color with value rounded to given precision
+     * @param {number} precision decimal places to round to
+     * @return {ColorXY}
+     */
+    rounded(precision) {
+        return new ColorXY(
+            precisionRound(this.x, precision),
+            precisionRound(this.y, precision),
+        );
+    }
+
+    /**
      * Convert to object
-     * @param {?number} [precision=null] round result to given precision
      * @return {ColorXYT} object with properties x and y
      */
-    toObject(precision=null) {
-        if (precision === null) {
-            return {x: this.x, y: this.y};
-        } else {
-            return {x: precisionRound(this.x, precision), y: precisionRound(this.y, precision)};
-        }
+    toObject() {
+        return {
+            x: this.x,
+            y: this.y,
+        };
     }
 }
 
@@ -275,20 +293,32 @@ class ColorHSV {
     }
 
     /**
+     * Return this color with value rounded to given precision
+     * @param {number} precision decimal places to round to
+     * @return {ColorHSV}
+     */
+    rounded(precision) {
+        return new ColorHSV(
+            this.hue === null ? null : precisionRound(this.hue, precision),
+            this.saturation === null ? null : precisionRound(this.saturation, precision),
+            this.value === null ? null : precisionRound(this.value, precision),
+        );
+    }
+
+    /**
      * Convert to object
-     * @param {?number} [precision=null] round result to given precision
      * @return {ColorHSVT}
      */
-    toObject(precision=null) {
+    toObject() {
         const ret = {};
         if (this.hue !== null) {
-            ret.hue = (precision === null) ? this.hue : precisionRound(this.hue, precision);
+            ret.hue = this.hue;
         }
         if (this.saturation !== null) {
-            ret.saturation = (precision === null) ? this.saturation : precisionRound(this.saturation, precision);
+            ret.saturation = this.saturation;
         }
         if (this.value !== null) {
-            ret.value = (precision === null) ? this.value : precisionRound(this.value, precision);
+            ret.value = this.value;
         }
         return ret;
     }

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,0 +1,528 @@
+const kelvinToXyLookup = require('./kelvinToXy');
+const {precisionRound} = require('./utils');
+
+/**
+ * Color represented in HSV space
+ * @typedef {Object} ColorHSVT
+ * @property {number} hue hue component (0..360)
+ * @property {number} saturation saturation component (0..100)
+ * @property {?number} value value component (0..100)
+ */
+
+/**
+ * Color represented in HSL space
+ * @typedef {Object} ColorHSLT
+ * @property {number} hue hue component (0..360)
+ * @property {number} saturation saturation component (0..100)
+ * @property {number} lightness lightness component (0..100)
+ */
+
+/**
+ * Color represented in CIE space
+ * @typedef {Object} ColorXYT
+ * @property {number} x X component (0..1)
+ * @property {number} y Y component (0..1)
+ */
+
+/**
+ * Color represented with red, green and blue components
+ * @typedef {Object} ColorRGBT
+ * @property {number} red red component (0..1)
+ * @property {number} green green component (0..1)
+ * @property {number} blue blue component (0..1)
+ */
+
+/**
+ * Converts color temp mireds to Kelvins
+ * @param {number} mireds color temp in mireds
+ * @return {number} color temp in Kelvins
+ */
+function miredsToKelvin(mireds) {
+    return 1000000 / mireds;
+}
+
+/**
+ * Converts color temp in Kelvins to mireds
+ * @param {number} kelvin color temp in Kelvins
+ * @return {number} color temp in mireds
+ */
+function kelvinToMireds(kelvin) {
+    return 1000000 / kelvin;
+}
+
+class ColorRGB {
+    /**
+     * Create RGB color
+     * @param {number} red
+     * @param {number} green
+     * @param {number} blue
+     */
+    constructor(red, green, blue) {
+        /** red component (0..1) */
+        this.red = red;
+        /** green component (0..1) */
+        this.green = green;
+        /** blue component (0..1) */
+        this.blue = blue;
+    }
+
+    /**
+     * Create RGB color from object
+     * @param {ColorRGBT} rgb object with properties red, green and blue
+     * @return {ColorRGB} new ColoRGB object
+     */
+    static fromObject(rgb) {
+        if (!rgb.hasOwnProperty('red') || !rgb.hasOwnProperty('green') || !rgb.hasOwnProperty('blue')) {
+            throw new Error('One or more required properties missing. Required properties: "red", "green", "blue"');
+        }
+        return new ColorRGB(rgb.red, rgb.green, rgb.blue);
+    }
+
+    /**
+     * Create RGB color from hex string
+     * @param {string} hex hex encoded RGB color
+     * @return {ColorRGB} new ColoRGB object
+     */
+    static fromHex(hex) {
+        hex = hex.replace('#', '');
+        const bigint = parseInt(hex, 16);
+        return new ColorRGB(((bigint >> 16) & 255) / 255, ((bigint >> 8) & 255) / 255, (bigint & 255) / 255);
+    }
+
+    /**
+     * Convert to Object
+     * @param {?number} [precision=null] round result to given precision
+     * @return {ColorRGBT} object with properties red, green and blue
+     */
+    toObject(precision=null) {
+        if (precision === null) {
+            return {red: this.red, green: this.green, blue: this.blue};
+        } else {
+            return {
+                red: precisionRound(this.red, precision),
+                green: precisionRound(this.green, precision),
+                blue: precisionRound(this.blue, precision),
+            };
+        }
+    }
+
+    /**
+     * Convert to HSV
+     * @return {ColorHSV} color in HSV space
+     */
+    toHSV() {
+        const r = this.red;
+        const g = this.green;
+        const b = this.blue;
+
+        const max = Math.max(r, g, b); const min = Math.min(r, g, b);
+        const d = max - min;
+        let h;
+        const s = (max === 0 ? 0 : d / max);
+        const v = max;
+
+        switch (max) {
+        case min: h = 0; break;
+        case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
+        case g: h = (b - r) + d * 2; h /= 6 * d; break;
+        case b: h = (r - g) + d * 4; h /= 6 * d; break;
+        }
+
+        return new ColorHSV(h * 360, s * 100, v * 100);
+    }
+
+    /**
+     * Convert to CIE
+     * @return {ColorXY} color in CIE space
+     */
+    toXY() {
+        // From: https://github.com/usolved/cie-rgb-converter/blob/master/cie_rgb_converter.js
+
+        // RGB values to XYZ using the Wide RGB D65 conversion formula
+        const X = this.red * 0.664511 + this.green * 0.154324 + this.blue * 0.162028;
+        const Y = this.red * 0.283881 + this.green * 0.668433 + this.blue * 0.047685;
+        const Z = this.red * 0.000088 + this.green * 0.072310 + this.blue * 0.986039;
+        const sum = X + Y + Z;
+
+        const retX = (sum == 0) ? 0 : X / sum;
+        const retY = (sum == 0) ? 0 : Y / sum;
+
+        return new ColorXY(retX, retY);
+    }
+
+    /**
+     * Returns color after sRGB gamma correction
+     * @return {ColorRGB} corrected RGB
+     */
+    gammaCorrected() {
+        function transform(v) {
+            return (v > 0.04045) ? Math.pow((v + 0.055) / (1.0 + 0.055), 2.4) : (v / 12.92);
+        }
+        return new ColorRGB(transform(this.red), transform(this.green), transform(this.blue));
+    }
+}
+
+/**
+ *  Class representing color in CIE space
+ */
+class ColorXY {
+    /**
+     * Create CIE color
+     * @param {number} x
+     * @param {number} y
+     */
+    constructor(x, y) {
+        /** x component (0..1) */
+        this.x = x;
+        /** y component (0..1) */
+        this.y = y;
+    }
+
+    /**
+     * Create CIE color from object
+     * @param {ColorXYT} xy object with properties x and y
+     * @return {ColorXY} new ColorXY object
+     */
+    static fromObject(xy) {
+        if (!xy.hasOwnProperty('x') || !xy.hasOwnProperty('y')) {
+            throw new Error('One or more required properties missing. Required properties: "x", "y"');
+        }
+        return new ColorXY(xy.x, xy.y);
+    }
+
+    /**
+     * Create XY object from color temp in mireds
+     * @param {number} mireds color temp in mireds
+     * @return {ColorXY} color in XY space
+     */
+    static fromMireds(mireds) {
+        const kelvin = miredsToKelvin(mireds);
+        return ColorXY.fromObject(kelvinToXyLookup[Math.round(kelvin)]);
+    }
+
+    /**
+     * Converts color in XY space to temperature in mireds
+     * @param {ColorXYT} xy color in XY space
+     * @return {number} color temp in mireds
+     */
+    toMireds() {
+        const n = (this.x - 0.3320) / (0.1858 - this.y);
+        const kelvin = Math.abs(437 * Math.pow(n, 3) + 3601 * Math.pow(n, 2) + 6861 * n + 5517);
+        return kelvinToMireds(kelvin);
+    }
+
+    /**
+     * Convert to object
+     * @param {?number} [precision=null] round result to given precision
+     * @return {ColorXYT} object with properties x and y
+     */
+    toObject(precision=null) {
+        if (precision === null) {
+            return {x: this.x, y: this.y};
+        } else {
+            return {x: precisionRound(this.x, precision), y: precisionRound(this.y, precision)};
+        }
+    }
+}
+
+/**
+ * Class representing color in HSV space
+ */
+class ColorHSV {
+    /**
+     * Create color in HSV space
+     * @param {?number} hue
+     * @param {?number} [saturation=null]
+     * @param {?number} [value=null]
+     */
+    constructor(hue, saturation=null, value=null) {
+        /** hue component (0..360) */
+        this.hue = (hue === null) ? null : hue % 360;
+        /** saturation component (0..100) */
+        this.saturation = saturation;
+        /** value component (0..100) */
+        this.value = value;
+    }
+
+    /**
+     * Create HSV color from object
+     * @param {object} hsv
+     * @param {number} [hsv.hue]
+     * @param {number} [hsv.saturation]
+     * @param {number} [hsv.value]
+     * @return {ColorHSV}
+     */
+    static fromObject(hsv) {
+        if (!hsv.hasOwnProperty('hue') && !hsv.hasOwnProperty('saturation')) {
+            throw new Error('HSV color must specify at least hue or saturation.');
+        }
+        return new ColorHSV((hsv.hue === undefined) ? null : hsv.hue, hsv.saturation, hsv.value);
+    }
+
+    /**
+     * Create HSV color from HSL
+     * @param {ColorHSL} hsl color in HSL space
+     * @return {ColorHSV} color in HSV space
+     */
+    static fromHSL(hsl) {
+        if (!hsl.hasOwnProperty('hue') || !hsl.hasOwnProperty('saturation') || !hsl.hasOwnProperty('lightness')) {
+            throw new Error('One or more required properties missing. Required properties: "hue", "saturation", "lightness"');
+        }
+        const retH = hsl.hue;
+        const retV = hsl.saturation * Math.min(hsl.lightness, 100 - hsl.lightness) / 100 + hsl.lightness;
+        const retS = retV ? (200 * (1 - hsl.lightness / retV)) : 0;
+        return new ColorHSV(retH, retS, retV);
+    }
+
+    /**
+     * Convert to object
+     * @param {?number} [precision=null] round result to given precision
+     * @return {ColorHSVT}
+     */
+    toObject(precision=null) {
+        const ret = {};
+        if (this.hue !== null) {
+            ret.hue = (precision === null) ? this.hue : precisionRound(this.hue, precision);
+        }
+        if (this.saturation !== null) {
+            ret.saturation = (precision === null) ? this.saturation : precisionRound(this.saturation, precision);
+        }
+        if (this.value !== null) {
+            ret.value = (precision === null) ? this.value : precisionRound(this.value, precision);
+        }
+        return ret;
+    }
+
+    /**
+     * Convert RGB color
+     * @return {ColorRGB}
+     */
+    toRGB() {
+        const hsvComplete = this.complete();
+        const h = hsvComplete.hue / 360;
+        const s = hsvComplete.saturation / 100;
+        const v = hsvComplete.value / 100;
+
+        let r; let g; let b;
+        const i = Math.floor(h * 6);
+        const f = h * 6 - i;
+        const p = v * (1 - s);
+        const q = v * (1 - f * s);
+        const t = v * (1 - (1 - f) * s);
+        switch (i % 6) {
+        case 0: r = v, g = t, b = p; break;
+        case 1: r = q, g = v, b = p; break;
+        case 2: r = p, g = v, b = t; break;
+        case 3: r = p, g = q, b = v; break;
+        case 4: r = t, g = p, b = v; break;
+        case 5: r = v, g = p, b = q; break;
+        }
+        return new ColorRGB(r, g, b);
+    }
+
+    /**
+     * Create CIE color from HSV
+     * @return {ColorXY}
+     */
+    toXY() {
+        return this.toRGB().toXY();
+    }
+
+    /**
+     * Returns color with missing properties set to defaults
+     * @return {ColorHSV} HSV color
+     */
+    complete() {
+        const hue = this.hue !== null ? this.hue : 0;
+        const saturation = this.saturation !== null ? this.saturation : 100;
+        const value = this.value !== null ? this.value : 100;
+        return new ColorHSV(hue, saturation, value);
+    }
+
+    /**
+     * Returns color after sRGB gamma correction
+     * @return {ColorHSV} corrected color in HSV space
+     */
+    gammaCorrected() {
+        return this.toRGB().gammaCorrected().toHSV();
+    }
+
+    /**
+     * Interpolates hue value based on correction map through ranged linear interpolation
+     * @param {Nnmber} hue hue to be corrected
+     * @param {Array} correctionMap array of hueIn -> hueOut mappings; example: [ {"in": 20, "out": 25}, {"in": 109, "out": 104}]
+     * @return {number} corrected hue value
+     */
+    static interpolateHue(hue, correctionMap) {
+        if (correctionMap.length < 2) return hue;
+
+        // retain immutablity
+        const clonedCorrectionMap = [...correctionMap];
+
+        // reverse sort calibration map and find left edge
+        clonedCorrectionMap.sort((a, b) => b.in - a.in);
+        const correctionLeft = clonedCorrectionMap.find((m) => m.in <= hue) || {'in': 0, 'out': 0};
+
+        // sort calibration map and find right edge
+        clonedCorrectionMap.sort((a, b) => a.in - b.in);
+        const correctionRight = clonedCorrectionMap.find((m) => m.in > hue) || {'in': 359, 'out': 359};
+
+        const ratio = 1 - (correctionRight.in - hue) / (correctionRight.in - correctionLeft.in);
+        return Math.round(correctionLeft.out + ratio * (correctionRight.out - correctionLeft.out));
+    }
+
+    /**
+     * Applies hue interpolation if entity has hue correction data
+     * @param {number} hue hue component of HSV color
+     * @param {Object} meta entity meta object
+     * @param {Object} meta.options meta object's options property
+     * @param {Object} [meta.options.hue_correction] hue correction data
+     * @return {number} corrected hue component of HSV color
+     */
+    static correctHue(hue, meta) {
+        const {options} = meta;
+        if (options.hasOwnProperty('hue_correction')) {
+            return this.interpolateHue(hue, options.hue_correction);
+        } else {
+            return hue;
+        }
+    }
+
+    /**
+     * Returns HSV color after hue correction
+     * @param {Object} meta entity meta object
+     * @return {ColorHSV} hue corrected color
+     */
+    hueCorrected(meta) {
+        return new ColorHSV(ColorHSV.correctHue(this.hue, meta), this.saturation, this.brightness);
+    }
+
+    /**
+     * Returns HSV color after gamma and hue corrections
+     * @param {Object} meta entity meta object
+     * @return {ColorHSV} corrected color in HSV space
+     */
+    colorCorrected(meta) {
+        return this.hueCorrected(meta).gammaCorrected();
+    }
+}
+
+class Color {
+    /**
+     * Create Color object
+     * @param {?ColorHSV} hsv ColorHSV instance
+     * @param {?ColorRGB} rgb ColorRGB instance
+     * @param {?ColorXY} xy ColorXY instance
+     */
+    constructor(hsv, rgb, xy) {
+        if ((hsv !== null) + (rgb !== null) + (xy !== null) != 1) {
+            throw new Error('Color object should have exactly only one of hsv, rgb or xy properties');
+        } else if (hsv !== null) {
+            if (!(hsv instanceof ColorHSV)) {
+                throw new Error('hsv argument must be an instance of ColorHSV class');
+            }
+        } else if (rgb !== null) {
+            if (!(rgb instanceof ColorRGB)) {
+                throw new Error('rgb argument must be an instance of ColorRGB class');
+            }
+        } else /* if (xy !== null) */ {
+            if (!(xy instanceof ColorXY)) {
+                throw new Error('xy argument must be an instance of ColorXY class');
+            }
+        }
+        this.hsv = hsv;
+        this.rgb = rgb,
+        this.xy = xy;
+    }
+
+    /**
+     * Create Color object from converter's value argument
+     * @param {Object} value converter value argument
+     * @return {Color} Color object
+     */
+    static fromConverterArg(value) {
+        if (value.hasOwnProperty('x') && value.hasOwnProperty('y')) {
+            const xy = ColorXY.fromObject(value);
+            return new Color(null, null, xy);
+        } else if (value.hasOwnProperty('r') && value.hasOwnProperty('g') && value.hasOwnProperty('b')) {
+            const rgb = new ColorRGB(value.r / 255, value.g / 255, value.b / 255);
+            return new Color(null, rgb, null);
+        } else if (value.hasOwnProperty('rgb')) {
+            const [r, g, b] = value.rgb.split(',').map((i) => parseInt(i));
+            const rgb = new ColorRGB(r / 255, g / 255, b / 255);
+            return new Color(null, rgb, null);
+        } else if (value.hasOwnProperty('hex')) {
+            const rgb = ColorRGB.fromHex(value.hex);
+            return new Color(null, rgb, null);
+        } else if (typeof value === 'string' && value.startsWith('#')) {
+            const rgb = ColorRGB.fromHex(value);
+            return new Color(null, rgb, null);
+        } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('l')) {
+            const hsv = ColorHSV.fromHSL({hue: value.h, saturation: value.s, lightness: value.l});
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('hsl')) {
+            const [h, s, l] = value.hsl.split(',').map((i) => parseInt(i));
+            const hsv = ColorHSV.fromHSL({hue: h, saturation: s, lightness: l});
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('b')) {
+            const hsv = new ColorHSV(value.h, value.s, value.b);
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('hsb')) {
+            const [h, s, b] = value.hsb.split(',').map((i) => parseInt(i));
+            const hsv = new ColorHSV(h, s, b);
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s') && value.hasOwnProperty('v')) {
+            const hsv = new ColorHSV(value.h, value.s, value.v);
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('hsv')) {
+            const [h, s, v] = value.hsv.split(',').map((i) => parseInt(i));
+            const hsv = new ColorHSV(h, s, v);
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('h') && value.hasOwnProperty('s')) {
+            const hsv = new ColorHSV(value.h, value.s);
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('h')) {
+            const hsv = new ColorHSV(value.h);
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('s')) {
+            const hsv = new ColorHSV(null, value.s);
+            return new Color(hsv, null, null);
+        } else if (value.hasOwnProperty('hue') || value.hasOwnProperty('saturation')) {
+            const hsv = ColorHSV.fromObject(value);
+            return new Color(hsv, null, null);
+        } else {
+            throw new Error('Value does not contain valid color definition');
+        }
+    }
+
+    /**
+     * Returns true if color is HSV
+     * @return {boolean} is HSV color
+     */
+    isHSV() {
+        return this.hsv !== null;
+    }
+
+    /**
+     * Returns true if color is RGB
+     * @return {boolean} is RGB color
+     */
+    isRGB() {
+        return this.rgb !== null;
+    }
+
+    /**
+     * Returns true if color is XY
+     * @return {boolean} is XY color
+     */
+    isXY() {
+        return this.xy !== null;
+    }
+}
+
+module.exports = {
+    ColorRGB,
+    ColorXY,
+    ColorHSV,
+    Color,
+};

--- a/lib/color.js
+++ b/lib/color.js
@@ -307,18 +307,31 @@ class ColorHSV {
 
     /**
      * Convert to object
+     * @param {boolean} short return h, s, v instead of hue, saturation, value
      * @return {ColorHSVT}
      */
-    toObject() {
+    toObject(short=false) {
         const ret = {};
         if (this.hue !== null) {
-            ret.hue = this.hue;
+            if (short) {
+                ret.h = this.hue;
+            } else {
+                ret.hue = this.hue;
+            }
         }
         if (this.saturation !== null) {
-            ret.saturation = this.saturation;
+            if (short) {
+                ret.s = this.saturation;
+            } else {
+                ret.saturation = this.saturation;
+            }
         }
         if (this.value !== null) {
-            ret.value = this.value;
+            if (short) {
+                ret.v = this.value;
+            } else {
+                ret.value = this.value;
+            }
         }
         return ret;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -198,172 +198,6 @@ function getMetaValue(entity, definition, key, groupStrategy='first', defaultVal
     return defaultValue;
 }
 
-/**
- * From: https://github.com/usolved/cie-rgb-converter/blob/master/cie_rgb_converter.js
- * Converts RGB color space to CIE color space
- * @param {Number} red
- * @param {Number} green
- * @param {Number} blue
- * @return {Array} Array that contains the CIE color values for x and y
- */
-function rgbToXY(red, green, blue) {
-    // Apply a gamma correction to the RGB values, which makes the color
-    // more vivid and more the like the color displayed on the screen of your device
-    const rgb = gammaCorrectRGB(red, green, blue);
-
-    // RGB values to XYZ using the Wide RGB D65 conversion formula
-    const X = rgb.r * 0.664511 + rgb.g * 0.154324 + rgb.b * 0.162028;
-    const Y = rgb.r * 0.283881 + rgb.g * 0.668433 + rgb.b * 0.047685;
-    const Z = rgb.r * 0.000088 + rgb.g * 0.072310 + rgb.b * 0.986039;
-
-    // Calculate the xy values from the XYZ values
-    let x = (X / (X + Y + Z)).toFixed(4);
-    let y = (Y / (X + Y + Z)).toFixed(4);
-
-    if (isNaN(x)) {
-        x = 0;
-    }
-
-    if (isNaN(y)) {
-        y = 0;
-    }
-
-    return {x: Number.parseFloat(x), y: Number.parseFloat(y)};
-}
-
-function gammaCorrectRGB(r, g, b) {
-    // The RGB values should be between 0 and 1. So convert them.
-    // The RGB color (255, 0, 100) becomes (1.0, 0.0, 0.39)
-    r /= 255; g /= 255; b /= 255;
-
-    r = (r > 0.04045) ? Math.pow((r + 0.055) / (1.0 + 0.055), 2.4) : (r / 12.92);
-    g = (g > 0.04045) ? Math.pow((g + 0.055) / (1.0 + 0.055), 2.4) : (g / 12.92);
-    b = (b > 0.04045) ? Math.pow((b + 0.055) / (1.0 + 0.055), 2.4) : (b / 12.92);
-
-    return {r: Math.round(r*255), g: Math.round(g*255), b: Math.round(b*255)};
-}
-
-function hsvToRgb(h, s, v) {
-    h = h % 360 / 360;
-    s = s / 100;
-    v = v / 100;
-
-    let r; let g; let b;
-    if (arguments.length === 1) {
-        s = h.s, v = h.v, h = h.h;
-    }
-    const i = Math.floor(h * 6);
-    const f = h * 6 - i;
-    const p = v * (1 - s);
-    const q = v * (1 - f * s);
-    const t = v * (1 - (1 - f) * s);
-    switch (i % 6) {
-    case 0: r = v, g = t, b = p; break;
-    case 1: r = q, g = v, b = p; break;
-    case 2: r = p, g = v, b = t; break;
-    case 3: r = p, g = q, b = v; break;
-    case 4: r = t, g = p, b = v; break;
-    case 5: r = v, g = p, b = q; break;
-    }
-    return {r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255)};
-}
-
-function rgbToHSV(r, g, b) {
-    if (arguments.length === 1) {
-        g = r.g, b = r.b, r = r.r;
-    }
-    const max = Math.max(r, g, b); const min = Math.min(r, g, b);
-    const d = max - min;
-    let h;
-    const s = (max === 0 ? 0 : d / max);
-    const v = max / 255;
-
-    switch (max) {
-    case min: h = 0; break;
-    case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
-    case g: h = (b - r) + d * 2; h /= 6 * d; break;
-    case b: h = (r - g) + d * 4; h /= 6 * d; break;
-    }
-
-    return {h: (h * 360).toFixed(3), s: (s * 100).toFixed(3), v: (v * 100).toFixed(3)};
-}
-
-function gammaCorrectHSV(h, s, v) {
-    return rgbToHSV(
-        ...Object.values(gammaCorrectRGB(
-            ...Object.values(hsvToRgb(h, s, v)))));
-}
-
-
-function hexToXY(hex) {
-    const rgb = hexToRgb(hex);
-    return rgbToXY(rgb.r, rgb.g, rgb.b);
-}
-
-function miredsToKelvin(mireds) {
-    return 1000000 / mireds;
-}
-
-const kelvinToXyLookup = require('./kelvinToXy');
-function miredsToXY(mireds) {
-    const kelvin = miredsToKelvin(mireds);
-    return kelvinToXyLookup[Math.round(kelvin)];
-}
-
-function kelvinToMireds(kelvin) {
-    return 1000000 / kelvin;
-}
-
-function xyToMireds(x, y) {
-    const n = (x-0.3320)/(0.1858-y);
-    const kelvin = 437*n^3 + 3601*n^2 + 6861*n + 5517;
-    return Math.round(kelvinToMireds(Math.abs(kelvin)));
-}
-
-function hslToHSV(h, s, l) {
-    h = h % 360;
-    s = s / 100;
-    l = l / 100;
-    const retH = h;
-    const retV = s * Math.min(l, 1-l) + l;
-    const retS = retV ? 2-2*l/retV : 0;
-    return {h: retH, s: retS, v: retV};
-}
-
-function hexToRgb(hex) {
-    hex = hex.replace('#', '');
-    const bigint = parseInt(hex, 16);
-    const r = (bigint >> 16) & 255;
-    const g = (bigint >> 8) & 255;
-    const b = bigint & 255;
-
-    return {r: r, g: g, b: b};
-}
-
-/**
- * interpolates hue value based on correction map through ranged linear interpolation
- * @param {Number} hue hue to be corrected
- * @param {Array} correctionMap array of hueIn -> hueOut mappings; example: [ {"in": 20, "out": 25}, {"in": 109, "out": 104}]
- * @return {Number} corrected hue value
- */
-function interpolateHue(hue, correctionMap) {
-    if (correctionMap.length < 2) return hue;
-
-    // retain immutablity
-    const clonedCorrectionMap = [...correctionMap];
-
-    // reverse sort calibration map and find left edge
-    clonedCorrectionMap.sort((a, b) => b.in - a.in);
-    const correctionLeft = clonedCorrectionMap.find((m) => m.in <= hue) || {'in': 0, 'out': 0};
-
-    // sort calibration map and find right edge
-    clonedCorrectionMap.sort((a, b) => a.in - b.in);
-    const correctionRight = clonedCorrectionMap.find((m) => m.in > hue) || {'in': 359, 'out': 359};
-
-    const ratio = 1 - (correctionRight.in - hue) / (correctionRight.in - correctionLeft.in);
-    return Math.round(correctionLeft.out + ratio * (correctionRight.out - correctionLeft.out));
-}
-
 function hasEndpoints(device, endpoints) {
     const eps = device.endpoints.map((e) => e.ID);
     for (const endpoint of endpoints) {
@@ -503,15 +337,6 @@ function getMetaValues(definition, entity, allowed, options={}) {
     return result;
 }
 
-const correctHue = (hue, meta) => {
-    const {options} = meta;
-    if (options.hasOwnProperty('hue_correction')) {
-        return interpolateHue(hue, options.hue_correction);
-    } else {
-        return hue;
-    }
-};
-
 function getObjectProperty(object, key, defaultValue) {
     return object && object.hasOwnProperty(key) ? object[key] : defaultValue;
 }
@@ -523,7 +348,6 @@ function validateValue(value, allowed) {
 }
 
 module.exports = {
-    correctHue,
     getOptions,
     isLegacyEnabled,
     precisionRound,
@@ -541,18 +365,8 @@ module.exports = {
     getEntityOrFirstGroupMember,
     getTransition,
     getMetaValue,
-    rgbToXY,
     validateValue,
-    hexToXY,
-    hexToRgb,
-    hsvToRgb,
-    hslToHSV,
-    interpolateHue,
     hasEndpoints,
-    miredsToXY,
-    xyToMireds,
-    gammaCorrectHSV,
-    gammaCorrectRGB,
     isInRange,
     replaceInArray,
     filterObject,

--- a/test/color.test.js
+++ b/test/color.test.js
@@ -1,0 +1,153 @@
+const libColor = require('../lib/color');
+
+describe('lib/color.js', () => {
+    describe('ColorRGB', () => {
+        test.each([
+            [{red: 0.5, green: 0.5, blue: 0.5}],
+        ])('.{from,to}Object() - %j', (color) => {
+            expect(libColor.ColorRGB.fromObject(color).toObject()).toEqual(color);
+        });
+
+        test.each([
+            ['red', {red: 1.0, green: 0, blue: 0}, {hue: 0, saturation: 100, value: 100}],
+            ['green', {red: 0, green: 1.0, blue: 0}, {hue: 120, saturation: 100, value: 100}],
+            ['blue', {red: 0, green: 0, blue: 1.0}, {hue: 240, saturation: 100, value: 100}],
+            ['white', {red: 1.0, green: 1.0, blue: 1.0}, {hue: 0, saturation: 0, value: 100}],
+            ['black', {red: 0, green: 0, blue: 0}, {hue: 0, saturation: 0, value: 0}],
+        ])('.toHSV() - %s', (_name, rgb, hsv) => {
+            expect(libColor.ColorRGB.fromObject(rgb).toHSV().toObject()).toStrictEqual(hsv);
+        });
+
+        test.each([
+            ['red', {red: 1.0, green: 0, blue: 0}, {x: 0.7006, y: 0.2993}],
+            ['green', {red: 0, green: 1.0, blue: 0}, {x: 0.1724, y: 0.7468}],
+            ['blue', {red: 0, green: 0, blue: 1.0}, {x: 0.1355, y: 0.0399}],
+            ['white', {red: 1.0, green: 1.0, blue: 1.0}, {x: 0.3227, y: 0.329}],
+            ['black', {red: 0, green: 0, blue: 0}, {x: 0, y: 0}],
+        ])('.toXY() - %s', (_name, rgb, xy) => {
+            expect(libColor.ColorRGB.fromObject(rgb).toXY().toObject(4)).toStrictEqual(xy);
+        });
+
+        test.each([
+            [{red: 1.0, green: 1.0, blue: 1.0}, {red: 1.0, green: 1.0, blue: 1.0}],
+            [{red: 0.5, green: 0.5, blue: 0.5}, {red: 0.2140, green: 0.2140, blue: 0.2140}],
+            [{red: 0.0, green: 0.0, blue: 0.0}, {red: 0.0, green: 0.0, blue: 0.0}],
+        ])('.gammaCorrected - %j', (input, output) => {
+            expect(libColor.ColorRGB.fromObject(input).gammaCorrected().toObject(4)).toStrictEqual(output);
+        });
+    });
+
+    describe('ColorHSV', () => {
+        test.each([
+            [null, {hue: 0, saturation: 100, value: 100}, null],
+            [null, {hue: 0, saturation: 100}, null],
+            [null, {hue: 0}, null],
+            [null, {saturation: 100}, null],
+            [1, {hue: 359.31231, saturation: 99.969123, value: 99.983131}, {hue: 359.3, saturation: 100, value: 100}]
+        ])('.{from,to}Object() - %j', (precision, input, output) => {
+            expect(libColor.ColorHSV.fromObject(input).toObject(precision)).toStrictEqual(output || input);
+        });
+
+        test.each([
+            ['red', {hue: 0, saturation: 100, value: 100}, {red: 1.0, green: 0, blue: 0}],
+            ['red (only hue)', {hue: 0}, {red: 1.0, green: 0.0, blue: 0.0}],
+            ['green', {hue: 120, saturation: 100, value: 100}, {red: 0, green: 1.0, blue: 0}],
+            ['blue', {hue: 240, saturation: 100, value: 100}, {red: 0, green: 0, blue: 1.0}],
+            ['white (red hue)', {hue: 0, saturation: 0, value: 100}, {red: 1.0, green: 1.0, blue: 1.0}],
+            ['white (blue hue)', {hue: 120, saturation: 0, value: 100}, {red: 1.0, green: 1.0, blue: 1.0}],
+            ['white (green hue)', {hue: 240, saturation: 0, value: 100}, {red: 1.0, green: 1.0, blue: 1.0}],
+            ['white (only saturation)', {saturation: 0}, {red: 1.0, green: 1.0, blue: 1.0}],
+            ['black', {hue: 0, saturation: 0, value: 0}, {red: 0, green: 0, blue: 0}],
+        ])('.toRGB() - %s', (_name, hsv, rgb) => {
+            expect(libColor.ColorHSV.fromObject(hsv).toRGB().toObject()).toStrictEqual(rgb);
+        });
+
+        test.each([
+            ['red', {hue: 0, saturation: 100, value: 100}, {x: 0.7006, y: 0.2993}],
+            ['red (only hue)', {hue: 0}, {x: 0.7006, y: 0.2993}],
+            ['green', {hue: 120, saturation: 100, value: 100}, {x: 0.1724, y: 0.7468}],
+            ['blue', {hue: 240, saturation: 100, value: 100}, {x: 0.1355, y: 0.0399}],
+            ['white (red hue)', {hue: 0, saturation: 0, value: 100}, {x: 0.3227, y: 0.329}],
+            ['white (blue hue)', {hue: 120, saturation: 0, value: 100}, {x: 0.3227, y: 0.329}],
+            ['white (green hue)', {hue: 240, saturation: 0, value: 100}, {x: 0.3227, y: 0.329}],
+            ['white (only saturation)', {saturation: 0}, {x: 0.3227, y: 0.329}],
+            ['black', {hue: 0, saturation: 0, value: 0}, {x: 0, y: 0}],
+        ])('.toXY() - %s', (_name, hsv, xy) => {
+            expect(libColor.ColorHSV.fromObject(hsv).toXY().toObject(4)).toStrictEqual(xy);
+        });
+    });
+
+    describe('ColorXY', () => {
+        test.each([
+            [{x: 5, y: 0.5}],
+        ])('.{from,to}Object() - %j', (color) => {
+            expect(libColor.ColorXY.fromObject(color).toObject()).toStrictEqual(color);
+        });
+
+        test.each([
+            [500],
+            [370],
+            [150],
+        ])('.{to,from}Mireds() - %j', (mireds) => {
+            const asXY = libColor.ColorXY.fromMireds(mireds);
+            const backConv = asXY.toMireds();
+            const error = Math.abs(backConv - mireds);
+            // better precision would require better lookup table or continuous conversion function
+            expect(error).toBeLessThan(2.3);
+        });
+    });
+
+    describe('Color', () => {
+        test.each([
+            [{x: 0.4969, y: 0.4719}, {xy: {x: 0.4969, y: 0.4719}}],
+            [{r: 255, g: 213, b: 0}, {rgb: {red: 1.0, green: 0.8353, blue: 0}}],
+            [{rgb: '255,213,0'}, {rgb: {red: 1.0, green: 0.8353, blue: 0}}],
+            [{hex: 'FFD500'}, {rgb: {red: 1.0, green: 0.8353, blue: 0}}],
+            ['#FFD500', {rgb: {red: 1.0, green: 0.8353, blue: 0}}],
+            [{h: 50, s: 100, l: 50}, {hsv: {hue: 50, saturation: 100, value: 100}}],
+            [{hsl: '50,100,50'}, {hsv: {hue: 50, saturation: 100, value: 100}}],
+            [{h: 50, s: 100, b: 100}, {hsv: {hue: 50, saturation: 100, value: 100}}],
+            [{hsb: '180,50,50'}, {hsv: {hue: 180, saturation: 50, value: 50}}],
+            [{h: 50, s: 100, v: 100}, {hsv: {hue: 50, saturation: 100, value: 100}}],
+            [{hsv: '50,100,100'}, {hsv: {hue: 50, saturation: 100, value: 100}}],
+            [{h: 50, s: 100}, {hsv: {hue: 50, saturation: 100}}],
+            [{h: 50}, {hsv: {hue: 50}}],
+            [{s: 100}, {hsv: {saturation: 100}}],
+            [{hue: 50, saturation: 100}, {hsv: {hue: 50, saturation: 100}}],
+            [{hue: 50}, {hsv: {hue: 50}}],
+            [{saturation: 100}, {hsv: {saturation: 100}}],
+        ])('.fromConverterArg() - %j', (value, expected) => {
+            // conversions reference: https://colordesigner.io/convert/hsltohsv
+            const extracted = libColor.Color.fromConverterArg(value);
+
+            if (expected.hsv === undefined) {
+                expect(extracted.isHSV()).toBe(false);
+            } else {
+                expect(extracted.isHSV()).toBe(true);
+                expect(extracted.hsv.toObject()).toStrictEqual(expected.hsv);
+            }
+
+            if (expected.rgb === undefined) {
+                expect(extracted.isRGB()).toBe(false);
+            } else {
+                expect(extracted.isRGB()).toBe(true);
+                expect(extracted.rgb.toObject(4)).toStrictEqual(expected.rgb);
+            }
+
+            if (expected.xy === undefined) {
+                expect(extracted.isXY()).toBe(false);
+            } else {
+                expect(extracted.isXY()).toBe(true);
+                expect(extracted.xy.toObject(4)).toStrictEqual(expected.xy);
+            }
+        });
+
+        test.each([
+            [{}],
+            [{v: 100}],
+            [{unknown_property: 42}],
+        ])('.fromConverterArg() invalid - %j', (value) => {
+            expect(() => libColor.Color.fromConverterArg(value)).toThrow();
+        });
+    });
+});

--- a/test/color.test.js
+++ b/test/color.test.js
@@ -25,7 +25,7 @@ describe('lib/color.js', () => {
             ['white', {red: 1.0, green: 1.0, blue: 1.0}, {x: 0.3227, y: 0.329}],
             ['black', {red: 0, green: 0, blue: 0}, {x: 0, y: 0}],
         ])('.toXY() - %s', (_name, rgb, xy) => {
-            expect(libColor.ColorRGB.fromObject(rgb).toXY().toObject(4)).toStrictEqual(xy);
+            expect(libColor.ColorRGB.fromObject(rgb).toXY().rounded(4).toObject()).toStrictEqual(xy);
         });
 
         test.each([
@@ -33,19 +33,27 @@ describe('lib/color.js', () => {
             [{red: 0.5, green: 0.5, blue: 0.5}, {red: 0.2140, green: 0.2140, blue: 0.2140}],
             [{red: 0.0, green: 0.0, blue: 0.0}, {red: 0.0, green: 0.0, blue: 0.0}],
         ])('.gammaCorrected - %j', (input, output) => {
-            expect(libColor.ColorRGB.fromObject(input).gammaCorrected().toObject(4)).toStrictEqual(output);
+            expect(libColor.ColorRGB.fromObject(input).gammaCorrected().rounded(4).toObject()).toStrictEqual(output);
         });
     });
 
     describe('ColorHSV', () => {
+        const cases = [
+            [{hue: 0, saturation: 100, value: 100}, null],
+            [{hue: 0, saturation: 100}, null],
+            [{hue: 0}, null],
+            [{saturation: 100}, null],
+        ];
+
+        test.each(cases)('.{from,to}Object() - %j', (input, output) => {
+            expect(libColor.ColorHSV.fromObject(input).toObject()).toStrictEqual(output || input);
+        });
+
         test.each([
-            [null, {hue: 0, saturation: 100, value: 100}, null],
-            [null, {hue: 0, saturation: 100}, null],
-            [null, {hue: 0}, null],
-            [null, {saturation: 100}, null],
-            [1, {hue: 359.31231, saturation: 99.969123, value: 99.983131}, {hue: 359.3, saturation: 100, value: 100}]
-        ])('.{from,to}Object() - %j', (precision, input, output) => {
-            expect(libColor.ColorHSV.fromObject(input).toObject(precision)).toStrictEqual(output || input);
+            ...cases,
+            [{hue: 359.31231, saturation: 99.969123, value: 99.983131}, {hue: 359.3, saturation: 100, value: 100}]
+        ])('.{from,to}Object(), rounded - %j', (input, output) => {
+            expect(libColor.ColorHSV.fromObject(input).rounded(1).toObject()).toStrictEqual(output || input);
         });
 
         test.each([
@@ -73,7 +81,7 @@ describe('lib/color.js', () => {
             ['white (only saturation)', {saturation: 0}, {x: 0.3227, y: 0.329}],
             ['black', {hue: 0, saturation: 0, value: 0}, {x: 0, y: 0}],
         ])('.toXY() - %s', (_name, hsv, xy) => {
-            expect(libColor.ColorHSV.fromObject(hsv).toXY().toObject(4)).toStrictEqual(xy);
+            expect(libColor.ColorHSV.fromObject(hsv).toXY().rounded(4).toObject()).toStrictEqual(xy);
         });
     });
 
@@ -131,14 +139,14 @@ describe('lib/color.js', () => {
                 expect(extracted.isRGB()).toBe(false);
             } else {
                 expect(extracted.isRGB()).toBe(true);
-                expect(extracted.rgb.toObject(4)).toStrictEqual(expected.rgb);
+                expect(extracted.rgb.rounded(4).toObject()).toStrictEqual(expected.rgb);
             }
 
             if (expected.xy === undefined) {
                 expect(extracted.isXY()).toBe(false);
             } else {
                 expect(extracted.isXY()).toBe(true);
-                expect(extracted.xy.toObject(4)).toStrictEqual(expected.xy);
+                expect(extracted.xy.rounded(4).toObject()).toStrictEqual(expected.xy);
             }
         });
 

--- a/test/color.test.js
+++ b/test/color.test.js
@@ -57,6 +57,15 @@ describe('lib/color.js', () => {
         });
 
         test.each([
+            [{hue: 0, saturation: 100, value: 100}, {h: 0, s: 100, v: 100}],
+            [{hue: 0, saturation: 100}, {h: 0, s: 100}],
+            [{hue: 0}, {h: 0}],
+            [{saturation: 100}, {s: 100}],
+        ])('.toObject() short - %j', (input, output) => {
+            expect(libColor.ColorHSV.fromObject(input).toObject(true)).toStrictEqual(output);
+        });
+
+        test.each([
             ['red', {hue: 0, saturation: 100, value: 100}, {red: 1.0, green: 0, blue: 0}],
             ['red (only hue)', {hue: 0}, {red: 1.0, green: 0.0, blue: 0.0}],
             ['green', {hue: 120, saturation: 100, value: 100}, {red: 0, green: 1.0, blue: 0}],


### PR DESCRIPTION
In this PR I've extracted color input normalization into z separate utility functions `light.extractColorFromValue` and `light.colorCorrectionsHSV`.

Main reason was to enable code reuse between `lightingColorCtrl` cluster and manufacturer specific Tuya API on which I'm working in #2437.

Also extracted piece of code can be tested individually and I found a bug with HSL->HSV conversion which I also fixed.