### PR TITLE
Add RTX ZB-RT1 thermostat (SEA801-Zigbee/SEA802-Zigbee white label)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -15048,7 +15048,11 @@ const devices = [
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',
         description: 'Thermostatic radiator valve',
-        whiteLabel: [{vendor: 'HiHome', model: 'WZB-TRVL'}, {vendor: 'Hama', model: '00176592'}],
+        whiteLabel: [
+            {vendor: 'HiHome', model: 'WZB-TRVL'},
+            {vendor: 'Hama', model: '00176592'},
+            {vendor: 'RTX', model: 'ZB-RT1'},
+        ],
         fromZigbee: [fz.saswell_thermostat, fz.ignore_tuya_set_time, fz.ignore_basic_report, fz.legacy.tuya_thermostat_weekly_schedule],
         toZigbee: [tz.saswell_thermostat_current_heating_setpoint, tz.saswell_thermostat_mode, tz.saswell_thermostat_away,
             tz.saswell_thermostat_child_lock, tz.saswell_thermostat_window_detection, tz.saswell_thermostat_frost_detection,

--- a/devices.js
+++ b/devices.js
@@ -15048,11 +15048,8 @@ const devices = [
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',
         description: 'Thermostatic radiator valve',
-        whiteLabel: [
-            {vendor: 'HiHome', model: 'WZB-TRVL'},
-            {vendor: 'Hama', model: '00176592'},
-            {vendor: 'RTX', model: 'ZB-RT1'},
-        ],
+        whiteLabel: [{vendor: 'HiHome', model: 'WZB-TRVL'}, {vendor: 'Hama', model: '00176592'},
+            {vendor: 'RTX', model: 'ZB-RT1'}],
         fromZigbee: [fz.saswell_thermostat, fz.ignore_tuya_set_time, fz.ignore_basic_report, fz.legacy.tuya_thermostat_weekly_schedule],
         toZigbee: [tz.saswell_thermostat_current_heating_setpoint, tz.saswell_thermostat_mode, tz.saswell_thermostat_away,
             tz.saswell_thermostat_child_lock, tz.saswell_thermostat_window_detection, tz.saswell_thermostat_frost_detection,


### PR DESCRIPTION
Adds new white label to [SEA801-Zigbee/SEA802-Zigbee](https://www.zigbee2mqtt.io/devices/SEA801-Zigbee_SEA802-Zigbee.html).

product page (in Polish): https://www.rtx24.pl/glowica-termostatyczna-termostat-zigbee-tuya-smart-p-434.html