### PR TITLE
Aldi_MEGOS_switch_dimming_light_remote_control

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -17545,6 +17545,16 @@ const devices = [
         extend: preset.light_onoff_brightness_colortemp_color({disableColorTempStartup: true}),
         meta: {applyRedFix: true},
     },
+    {
+        fingerprint: [{modelID: 'TS1001', manufacturerName: '_TZ3000_ztrfrcsu'}],
+        model: '141L100RC',
+        vendor: 'Aldi',
+        description: 'MEGOS switch and dimming light remote control',
+        exposes: [e.action(['on', 'off', 'brightness_stop', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up',
+            'brightness_move_down'])],
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop],
+        toZigbee: [],
+    },
 
     // SOHAN Electric
     {


### PR DESCRIPTION
Just Device Support for the Megos Smart control sold by Aldi