### PR TITLE
Enhance support for the Yookee D10110 and add position_min/position_max

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4836,6 +4836,17 @@ const converters = {
             return result;
         },
     },
+    D10110_cover_position_tilt: {
+        cluster: 'closuresWindowCovering',
+        type: ['attributeReport', 'readResponse'],
+        convert: async (model, msg, publish, options, meta) => {
+            if (msg.data.hasOwnProperty('currentPositionLiftPercentage') && msg.data['currentPositionLiftPercentage'] <= 100) {
+                // The Yookee D10110 SENDs it's position reversed, relative to the spec.
+                msg.data['currentPositionLiftPercentage'] = 100 - (msg.data['currentPositionLiftPercentage'] + 1);
+            }
+            return await converters.cover_position_tilt.convert(model, msg, publish, options, meta);
+        },
+    },
     PGC410EU_presence: {
         cluster: 'manuSpecificSmartThingsArrivalSensor',
         type: 'commandArrivalSensorNotify',

--- a/devices/yookee.js
+++ b/devices/yookee.js
@@ -10,9 +10,9 @@ module.exports = [
         model: 'D10110',
         vendor: 'Yookee',
         description: 'Smart blind controller',
-        fromZigbee: [fz.cover_position_tilt, fz.battery],
+        fromZigbee: [fz.D10110_cover_position_tilt, fz.battery],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        meta: {coverInverted: true},
+        meta: {coverInverted: false},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);

--- a/devices/yookee.js
+++ b/devices/yookee.js
@@ -12,7 +12,6 @@ module.exports = [
         description: 'Smart blind controller',
         fromZigbee: [fz.D10110_cover_position_tilt, fz.battery],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        meta: {coverInverted: false},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);


### PR DESCRIPTION
I have a mix of IKEA Tradfri and Yookee (Yoolax/Graywind on Amazon) blinds. 
In:
https://github.com/Koenkk/zigbee2mqtt/issues/4611
There was a discussion of the max/min length problem with blinds. Setting max lengths for the IKEA blinds works great. But, for Yookee setting the max length does not translate to Zigbee. Sending a Zigbee 100% still unfurls the blind to maximum length. Sending a zigbee 0% goes past the minimum length set and completely rolls up the blind.

The original patch was a noted to be a little kludgy - e.g. not supporting open/close. However I primarily use HomeKit via homebridge-z2m to control my blinds which always sets {position: 100} or {position: 0} and never uses open/close. 

Therefore I resurrected the patch from here:
https://github.com/Koenkk/zigbee2mqtt/issues/4611
And polished it out a little. It's been tested with both IKEA and Yookee blinds that I have here.

While I was there I added a couple of other flags for quirks of these Yookee blinds (coverReceiveInverted and offByOne). Since otherwise these blinds are great and are about the cheapest Zigbee blinds you can buy; I hope this patch can be integrated!