### PR TITLE
Reduce the noise coming from small voltage changes on AU-A1ZBPIA

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -16402,7 +16402,8 @@ const devices = [
             await reporting.deviceTemperature(endpoint);
 
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
-            await reporting.rmsVoltage(endpoint, {change: 100});
+            // Report 5v voltage change, 5a current, 5 watt power change to reduce the noise
+            await reporting.rmsVoltage(endpoint, {change: 500});
             await reporting.rmsCurrent(endpoint, {change: 500});
             await reporting.activePower(endpoint, {change: 5});
 


### PR DESCRIPTION
Change the voltage change threshold from 1 volt to 5 volts to reduce the amount of messages coming from the device