### PR TITLE
feat: add suport for WETEN 1 gang switch

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -17577,6 +17577,16 @@ const devices = [
         extend: preset.switch(),
         fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
     },
+
+    // WETEN
+    {
+        fingerprint: [{modelID: 'TS0001', manufacturerName: '_TZ3000_wrhhi5h2'}],
+        model: '1GNNTS',
+        vendor: 'WETEN',
+        description: '1 gang no neutral touch wall switch',
+        extend: preset.switch(),
+        fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
+    },
 ];
 
 module.exports = devices.map((device) => {


### PR DESCRIPTION
This is the device in question:
https://www.aliexpress.com/item/1005001979915069.html

It's basically a compliant `genOnOff` no neutral touch switch. It uses the `TYZS3` chip by TuYa, and announces itself as a `TS0001` with manufacturer name `_TZ3000_wrhhi5h2`.

I tested the converters with a sample unit kindly provided by WETEN.