### PR TITLE
Add NEXENTRO Blind Actuator and reporting.currentPositionTiltPercentage

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -12751,13 +12751,11 @@ const devices = [
         toZigbee: [],
         ota: ota.zigbeeOTA,
     },
-
-    // NEXENTRO by Insta
     {
         zigbeeModel: ['Generic UP Device'],
         model: '57008000',
-        vendor: 'Insta GmbH',
-        description: 'Blinds actor with Lift/Tilt Calibration & with with inputs for wall switches',
+        vendor: 'Insta',
+        description: 'Blinds actor with lift/tilt calibration & with with inputs for wall switches',
         fromZigbee: [fz.cover_position_tilt, fz.command_cover_open, fz.command_cover_close, fz.command_cover_stop],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
         exposes: [e.cover_position_tilt()],

--- a/devices.js
+++ b/devices.js
@@ -12752,6 +12752,28 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
 
+    // NEXENTRO by Insta
+    {
+        zigbeeModel: ['Generic UP Device'],
+        model: '57008000',
+        vendor: 'Insta GmbH',
+        description: 'Blinds actor with Lift/Tilt Calibration & with with inputs for wall switches',
+        fromZigbee: [fz.cover_position_tilt, fz.command_cover_open, fz.command_cover_close, fz.command_cover_stop],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt],
+        exposes: [e.cover_position_tilt()],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(6), coordinatorEndpoint, ['closuresWindowCovering']);
+            await reporting.bind(device.getEndpoint(7), coordinatorEndpoint, ['closuresWindowCovering']);
+            await reporting.currentPositionLiftPercentage(device.getEndpoint(6));
+            await reporting.currentPositionTiltPercentage(device.getEndpoint(6));
+
+            // Has Unknown power source, force it here.
+            device.powerSource = 'Mains (single phase)';
+            device.save();
+        },
+    },
+
     // RGB Genie
     {
         zigbeeModel: ['RGBgenie ZB-5121'],

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -45,6 +45,7 @@ module.exports = {
     },
     currentPositionTiltPercentage: async (endpoint, overrides) => {
         const p = payload('currentPositionTiltPercentage', 1, repInterval.MAX, 1, overrides);
+	await endpoint.configureReporting('closuresWindowCovering', p);
     },
     batteryPercentageRemaining: async (endpoint, overrides) => {
         const p = payload(

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -43,6 +43,9 @@ module.exports = {
         const p = payload('currentPositionLiftPercentage', 1, repInterval.MAX, 1, overrides);
         await endpoint.configureReporting('closuresWindowCovering', p);
     },
+    currentPositionTiltPercentage: async (endpoint, overrides) => {
+        const p = payload('currentPositionTiltPercentage', 1, repInterval.MAX, 1, overrides);
+    },
     batteryPercentageRemaining: async (endpoint, overrides) => {
         const p = payload(
             'batteryPercentageRemaining', repInterval.HOUR, repInterval.MAX, 0, overrides,

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -45,7 +45,7 @@ module.exports = {
     },
     currentPositionTiltPercentage: async (endpoint, overrides) => {
         const p = payload('currentPositionTiltPercentage', 1, repInterval.MAX, 1, overrides);
-	await endpoint.configureReporting('closuresWindowCovering', p);
+        await endpoint.configureReporting('closuresWindowCovering', p);
     },
     batteryPercentageRemaining: async (endpoint, overrides) => {
         const p = payload(


### PR DESCRIPTION
I aim to support a new flush-mounted blinds actuator with this PR (https://www.insta.de/files/Insta/media/product_docs/datenblaetter/DB_57008000_EN.pdf)

ZCL seems to be followed rather well, I could re-use most fromZigbee and toZigbee stuff, but additionally implemented a new reporting function, because I have use-cases where I only change the angle of the blinds but not the positions of the whole window cover and I want these (possibly external) changes reflected.

What I don't like is the modelId name "Generic UP Device". The manufacturer has promised to change this is the near future, and I will likely follow up with a new PR then. While the manufacturer name is "Insta GmbH", it indeed is "Insta" (whitelabel Gira and Jung products), as the manufacturer ID (4474) matches - is it best practice to name new products after an existing manufacturer, or use the supplied manufName even if it doesn't match in this case? 

What currently does not work, and I don't know why, is setting the tilt value, as `tz.cover_position_tilt` should support this.