### PR TITLE
Fix Bitron 902010/29 outdoor siren

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -9042,9 +9042,9 @@ const devices = [
         model: '902010/29',
         vendor: 'Bitron',
         description: 'Zigbee outdoor siren',
-        fromZigbee: [fz.ias_smoke_alarm_1],
+        fromZigbee: [fz.battery],
         toZigbee: [tz.warning],
-        exposes: [e.smoke(), e.battery_low(), e.tamper(), e.warning()],
+        exposes: [e.battery_low(), e.tamper(), e.warning()],
     },
     {
         zigbeeModel: ['902010/23'],


### PR DESCRIPTION
Replace fz.ias_smoke_alarm_1 by fz.battery and remove e.smoke() as device is definitively an outdoor siren, not a smoke detector;-)