### PR TITLE
Added another manufacturerName for RTX ZB-RT1 radiator valve

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -15125,7 +15125,9 @@ const devices = [
             {modelID: '88teujp\u0000', manufacturerName: '_TYST11_c88teujp'},
             {modelID: 'w7cahqs\u0000', manufacturerName: '_TYST11_yw7cahqs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_c88teujp'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'}],
+            {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'},
+	    {modelId: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'}
+	],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',
         description: 'Thermostatic radiator valve',

--- a/devices.js
+++ b/devices.js
@@ -15127,7 +15127,7 @@ const devices = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_c88teujp'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'},
             {modelId: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
-	],
+        ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',
         description: 'Thermostatic radiator valve',

--- a/devices.js
+++ b/devices.js
@@ -15126,7 +15126,7 @@ const devices = [
             {modelID: 'w7cahqs\u0000', manufacturerName: '_TYST11_yw7cahqs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_c88teujp'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'},
-	    {modelId: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'}
+            {modelId: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
 	],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',


### PR DESCRIPTION
Hi,
I recently bought a ZB-RT1 by RTX radiator valve and it is recognized as `{modelId: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'}`. It is already supported, but not by this model/manufacturer, so in this PR I'm adding it.
