### PR TITLE
Add support for unbranded version of Orvibo RL804ZB

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -14404,7 +14404,7 @@ const devices = [
         extend: preset.light_onoff_brightness_colortemp_color(),
     },
     {
-        zigbeeModel: ['82c167c95ed746cdbd21d6817f72c593'],
+        zigbeeModel: ['82c167c95ed746cdbd21d6817f72c593', '8762413da99140cbb809195ff40f8c51'],
         model: 'RL804QZB',
         vendor: 'ORVIBO',
         description: 'Multi-functional 3 gang relay',


### PR DESCRIPTION
I've got an unbranded version of [Orvibo RL804ZB](https://www.zigbee2mqtt.io/devices/RL804QZB.html)
It's identical to the pictures I've see of the branded version.  The only differences are:
* They removed the word Orvibo from the case and the manual
* The model number in the case reads SH-222ZB
* The zigbeeModel is different.

I think there's no need to create a separate entry in `devices.js`, but please let me know if you prefer me to do it.