### PR TITLE
Add Hue Lily outdoor spot light base pack

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4426,7 +4426,7 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['1741530P7'],
+        zigbeeModel: ['1741530P7', '1741430P7'],
         model: '1741530P7',
         vendor: 'Philips',
         description: 'Hue Lily outdoor spot light',


### PR DESCRIPTION
I have four Hue Lily outdoor spot lights, one base pack consisting of three lights and a power supply, and an extension pack with one light.
Except for the ZigBee model numbers the lights are the same.
The extension pack was already supported, the lights in the base pack strangely weren't.
I have added the model number of the lights in the base pack.