### PR TITLE
YRD226/246 pin code management

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -11685,9 +11685,9 @@ const devices = [
         model: 'YRD226/246 TSDB',
         vendor: 'Yale',
         description: 'Assure lock',
-        fromZigbee: [fz.lock, fz.battery, fz.lock_operation_event],
-        toZigbee: [tz.lock],
-        meta: {configureKey: 2},
+        fromZigbee: [fz.lock, fz.battery, fz.lock_operation_event, fz.lock_programming_event, fz.lock_pin_code_response],
+        toZigbee: [tz.lock, tz.pincode_lock],
+        meta: {configureKey: 2, pinCodeCount: 250},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);


### PR DESCRIPTION
Added pin code message support for Yale YRD226/246. This is simply enabling the support which already exists in zigbee-herdsman-converters. I have tested this on my own lock (YRD246) and all works fine. It likely works with other Yale locks too, however I cannot test this so have not enabled it.