### PR TITLE
Remove output of enrolled due to missing zoneState

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -731,9 +731,7 @@ const converters = {
         type: 'commandStatusChangeNotification',
         convert: (model, msg, publish, options, meta) => {
             const zoneStatus = msg.data.zonestatus;
-            const zoneState = msg.data.zoneState;
             return {
-                enrolled: zoneState === 1,
                 smoke: (zoneStatus & 1) > 0,
                 tamper: (zoneStatus & 1<<2) > 0,
                 battery_low: (zoneStatus & 1<<3) > 0,


### PR DESCRIPTION
I propose to remove this attribute because it was highly confusing for me why the enrollment appears to be unsuccessful.

By looking at all the logs, it seems that this variable isn't even available, so this status can't be true at all.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/438434/115957272-01991e00-a50a-11eb-9085-e11c0a730cd1.png">

<img width="1487" alt="image" src="https://user-images.githubusercontent.com/438434/115957288-14135780-a50a-11eb-95db-d1b79a39f967.png">

Please let me know if I have misunderstood something.
