### PR TITLE
SMSZB-120: added test, removed tamper

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -741,6 +741,7 @@ const converters = {
                 restore_reports: (zoneStatus & 1<<5) > 0,
                 trouble: (zoneStatus & 1<<6) > 0,
                 ac_status: (zoneStatus & 1<<7) > 0,
+                test: (zoneStatus & 1<<8) > 0,
             };
         },
     },

--- a/devices.js
+++ b/devices.js
@@ -16210,7 +16210,7 @@ const devices = [
         endpoint: (device) => {
             return {default: 35};
         },
-        exposes: [e.temperature(), e.battery(), e.smoke(), e.battery_low(), e.tamper(), e.warning()],
+        exposes: [e.temperature(), e.battery(), e.smoke(), e.battery_low(), e.test(), e.warning()],
     },
     {
         zigbeeModel: ['HESZB-120'],

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -517,6 +517,7 @@ module.exports = {
         switch: () => new Switch().withState('state', true, 'On/off state of the switch'),
         tamper: () => new Binary('tamper', access.STATE, true, false).withDescription('Indicates whether the device is tampered'),
         temperature: () => new Numeric('temperature', access.STATE).withUnit('°C').withDescription('Measured temperature value'),
+        test: () => new Binary('test', access.STATE, true, false).withDescription('Indicates whether the device is being tested'),
         valve_detection: () => new Switch().withState('valve_detection', true).setAccess('state', access.STATE_SET),
         vibration: () => new Binary('vibration', access.STATE, true, false).withDescription('Indicates whether the device detected vibration'),
         voc: () => new Numeric('voc', access.STATE).withUnit('ppb').withDescription('Measured VOC value'),


### PR DESCRIPTION
The Develco smoke sensor implements the test flag, but it does not implement tamper detection.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/438434/115957781-0e6b4100-a50d-11eb-8243-ed030ff56297.png">

Similar conversion exists for `ias_carbon_monoxide_alarm_1_gas_alarm_2`

Unscrewing the alarm from the base yields no tamper event, so I would propose to remove this exposes part.

Log entry during test operation:

```
apr   24 14:24:42 raspberrypi-z2m npm[2107]: Zigbee2MQTT:debug 2021-04-24 14:24:42: Received Zigbee message from '0x0015bc00310095bd', type 'commandStatusChangeNotification', cluster 'ssIasZone', data '{"extendedstatus":0,"zonestatus":304}' from endpoint 35 with groupID 0
apr   24 14:24:42 raspberrypi-z2m npm[2107]: Zigbee2MQTT:info  2021-04-24 14:24:42: MQTT publish: topic 'zigbee2mqtt/0x0015bc00310095bd', payload '{"ac_status":false,"battery":100,"battery_low":false,"linkquality":30,"restore_reports":true,"smoke":false,"supervision_reports":true,"tamper":false,"temperature":24.06,"test":true,"trouble":false,"voltage":3100}'
```

Log entry immediately after test finish:
```
apr   24 14:24:43 raspberrypi-z2m npm[2107]: Zigbee2MQTT:debug 2021-04-24 14:24:43: Received Zigbee message from '0x0015bc00310095bd', type 'commandStatusChangeNotification', cluster 'ssIasZone', data '{"extendedstatus":0,"zonestatus":48}' from endpoint 35 with groupID 0
apr   24 14:24:43 raspberrypi-z2m npm[2107]: Zigbee2MQTT:info  2021-04-24 14:24:43: MQTT publish: topic 'zigbee2mqtt/0x0015bc00310095bd', payload '{"ac_status":false,"battery":100,"battery_low":false,"linkquality":24,"restore_reports":true,"smoke":false,"supervision_reports":true,"tamper":false,"temperature":24.06,"test":false,"trouble":false,"voltage":3100}'
```