### PR TITLE
added lock user status functions for YRD246 lock

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -225,27 +225,38 @@ const converters = {
         type: ['commandGetPinCodeRsp'],
         convert: (model, msg, publish, options, meta) => {
             const {data} = msg;
-            let status = '';
-            let pinCodeValue = null;
-            switch (data.userstatus) {
-            case 0:
-                status = 'available';
-                break;
-            case 1:
-                status = 'enabled';
-                pinCodeValue = data.pincodevalue;
-                break;
-            case 2:
-                status = 'disabled';
-                break;
-            default:
-                status = 'not_supported';
+            let status = constants.lockUserStatus[data.userstatus];
+
+            if (status === undefined) {
+                status = `not_supported (${data.userstatus})`;
             }
+
             const userId = data.userid.toString();
             const result = {users: {}};
             result.users[userId] = {status: status};
-            if (options && options.expose_pin && pinCodeValue) {
-                result.users[userId].pin_code = pinCodeValue;
+            if (options && options.expose_pin && data.pincodevalue) {
+                result.users[userId].pin_code = data.pincodevalue;
+            }
+            return result;
+        },
+    },
+    lock_user_status_response: {
+        cluster: 'closuresDoorLock',
+        type: ['commandGetUserStatusRsp'],
+        convert: (model, msg, publish, options, meta) => {
+            const {data} = msg;
+
+            let status = constants.lockUserStatus[data.userstatus];
+
+            if (status === undefined) {
+                status = `not_supported (${data.userstatus})`;
+            }
+
+            const userId = data.userid.toString();
+            const result = {users: {}};
+            result.users[userId] = {status: status};
+            if (options && options.expose_pin && data.pincodevalue) {
+                result.users[userId].pin_code = data.pincodevalue;
             }
             return result;
         },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -228,7 +228,7 @@ const converters = {
             let status = constants.lockUserStatus[data.userstatus];
 
             if (status === undefined) {
-                status = `not_supported (${data.userstatus})`;
+                status = `not_supported_${data.userstatus}`;
             }
 
             const userId = data.userid.toString();
@@ -249,7 +249,7 @@ const converters = {
             let status = constants.lockUserStatus[data.userstatus];
 
             if (status === undefined) {
-                status = `not_supported (${data.userstatus})`;
+                status = `not_supported_${data.userstatus}`;
             }
 
             const userId = data.userid.toString();

--- a/devices.js
+++ b/devices.js
@@ -11698,8 +11698,9 @@ const devices = [
         model: 'YRD226/246 TSDB',
         vendor: 'Yale',
         description: 'Assure lock',
-        fromZigbee: [fz.lock, fz.battery, fz.lock_operation_event, fz.lock_programming_event, fz.lock_pin_code_response],
-        toZigbee: [tz.lock, tz.pincode_lock],
+        fromZigbee: [fz.lock, fz.battery, fz.lock_operation_event, fz.lock_programming_event, fz.lock_pin_code_response,
+            fz.lock_user_status_response],
+        toZigbee: [tz.lock, tz.pincode_lock, tz.lock_userstatus],
         meta: {configureKey: 2, pinCodeCount: 250},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -122,6 +122,12 @@ const colorMode = {
 
 const lockSoundVolume = ['silent_mode', 'low_volume', 'high_volume'];
 
+const lockUserStatus = {
+    0: 'available',
+    1: 'enabled',
+    3: 'disabled',
+};
+
 module.exports = {
     OneJanuary2000,
     repInterval,
@@ -138,4 +144,5 @@ module.exports = {
     armMode,
     colorMode,
     lockSoundVolume,
+    lockUserStatus,
 };


### PR DESCRIPTION
This depends on https://github.com/Koenkk/zigbee-herdsman/pull/353

(Lock User Status allows switching user "slots" between available, enabled and disabled. This is part of the standard door lock zigbee cluster spec, but I have only enabled it for the lock mentioned in the title.)