### PR TITLE
Fixed battery voltage conversion for HMSZB-110

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -248,14 +248,14 @@ module.exports = [
         description: 'Temperature & humidity sensor',
         fromZigbee: [fz.battery, fz.temperature, fz.humidity],
         toZigbee: [],
-        exposes: [e.battery(), e.temperature(), e.humidity()],
-        meta: {configureKey: 2},
+        exposes: [e.battery(), e.battery_low(), e.temperature(), e.humidity()],
+        meta: {configureKey: 2, battery: {voltageToPercentage: '3V_2500_3200'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(38);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg']);
             await reporting.temperature(endpoint);
             await reporting.humidity(endpoint);
-            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.batteryVoltage(endpoint);
         },
     },
     {


### PR DESCRIPTION
* added `battery_low` to exposes to match other Develco devices
* added meta.battery.voltageToPercentage: '3V_2500_3200' to match 2x AA batteries installed in device
* changed reporting.batteryPercentageRemaining -> reporting.batteryVoltage to match other Develco devices

![image](https://user-images.githubusercontent.com/438434/116553992-5f12dd80-a903-11eb-872f-60a7be0a885d.png)

![image](https://user-images.githubusercontent.com/438434/116554029-676b1880-a903-11eb-956e-b844eb5de054.png)

```json
{
    "battery_low": false,
    "humidity": 36,
    "last_seen": "2021-04-29T12:55:35.325Z",
    "temperature": 22.8,
    "voltage": 3100,
    "battery": 86,
    "linkquality": 87
}
```