### PR TITLE
add support for another model number of the Econic light 1744030V7

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -521,7 +521,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['1743930P7', '1744030P7'],
+        zigbeeModel: ['1743930P7', '1744030P7', '1744030V7'],
         model: '1743930P7',
         vendor: 'Philips',
         description: 'Hue Outdoor Econic wall lantern',


### PR DESCRIPTION
This light appears to be the same as 1744030P7. I have them here and can confirm they are working with this.