### PR TITLE
added new device model ZTS-EU_2gang + control multiple states with 1 message

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2387,28 +2387,6 @@ const converters = {
             await tuya.sendDataPointValue(entity, dp, newValue, 'setData', 1);
         },
     },
-    tuya_switch_state_multi: {
-        key: ['state'],
-        convertSet: async (entity, key, value, meta) => {
-            const lookup = {l1: 1, l2: 2, l3: 3, l4: 4};
-            const multiEndpoint = utils.getMetaValue(entity, meta.mapped, 'multiEndpoint', 'allEqual', false);
-            const state = {
-                [`state_${meta.endpoint_name}`]: value
-            }
-            const keyid = multiEndpoint ? lookup[meta.endpoint_name] : 1;
-            await tuya.sendDataPointBool(entity, keyid, value === 'ON');
-
-            const message = meta.message
-            Object.entries(message).forEach(async messageEntry => {
-                if (messageEntry[0].includes('state_')) {
-                    const endpoint = messageEntry[0].split('_')[1]
-                    state[`state_${endpoint}`] = messageEntry[1]
-                    await tuya.sendDataPointBool(entity, lookup[endpoint], messageEntry[1] === 'ON');
-                }
-            });
-            return {state: state};
-        },
-    },
     tuya_switch_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2395,7 +2395,7 @@ const converters = {
             const state = {
                 [`state_${meta.endpoint_name}`]: value
             }
-            const keyid = multiEndpoint ? lookup[state[0]] : 1;
+            const keyid = multiEndpoint ? lookup[meta.endpoint_name] : 1;
             await tuya.sendDataPointBool(entity, keyid, value === 'ON');
 
             const message = meta.message

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2387,6 +2387,28 @@ const converters = {
             await tuya.sendDataPointValue(entity, dp, newValue, 'setData', 1);
         },
     },
+    tuya_switch_state_multi: {
+        key: ['state'],
+        convertSet: async (entity, key, value, meta) => {
+            const lookup = {l1: 1, l2: 2, l3: 3, l4: 4};
+            const multiEndpoint = utils.getMetaValue(entity, meta.mapped, 'multiEndpoint', 'allEqual', false);
+            const state = {
+                [`state_${meta.endpoint_name}`]: value
+            }
+            const keyid = multiEndpoint ? lookup[state[0]] : 1;
+            await tuya.sendDataPointBool(entity, keyid, value === 'ON');
+
+            const message = meta.message
+            Object.entries(message).forEach(async messageEntry => {
+                if (messageEntry[0].includes('state_')) {
+                    const endpoint = messageEntry[0].split('_')[1]
+                    state[`state_${endpoint}`] = messageEntry[1]
+                    await tuya.sendDataPointBool(entity, lookup[endpoint], messageEntry[1] === 'ON');
+                }
+            });
+            return {state: state};
+        },
+    },
     tuya_switch_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -117,7 +117,7 @@ module.exports = [
             // Reports itself as battery which is not correct: https://github.com/Koenkk/zigbee2mqtt/issues/6190
             device.powerSource = 'Mains (single phase)';
             device.save();
-        }
+        },
     },
     {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_tz32mtza'}],
@@ -140,7 +140,7 @@ module.exports = [
             // Reports itself as battery which is not correct: https://github.com/Koenkk/zigbee2mqtt/issues/6190
             device.powerSource = 'Mains (single phase)';
             device.save();
-        }
+        },
     },
     {
         fingerprint: [{modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'},

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -135,13 +135,13 @@ module.exports = [
         toZigbee: [tz.tuya_switch_state_multi],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(3)) await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
             // Endpoint selection is made in tuya_switch_state
             return {'l1': 1, 'l2': 1, 'l3': 1};
         },
         configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(3)) await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
             // Reports itself as battery which is not correct: https://github.com/Koenkk/zigbee2mqtt/issues/6190
             device.powerSource = 'Mains (single phase)';
             device.save();

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -85,7 +85,6 @@ module.exports = [
                 .withPreset(['hold', 'program']).withSensor(['IN', 'AL', 'OU'], ea.STATE_SET)],
         onEvent: tuya.onEventSetLocalTime,
     },
-    
     {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_amp6tsvy'}],
         model: 'ZTS-EU_1gang',
@@ -94,12 +93,8 @@ module.exports = [
         exposes: [e.switch().setAccess('state', ea.STATE_SET)],
         fromZigbee: [fz.tuya_switch],
         toZigbee: [tz.tuya_switch_state],
-        meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
-            // Reports itself as battery which is not correct: https://github.com/Koenkk/zigbee2mqtt/issues/6190
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            device.powerSource = 'Mains (single phase)';
-            device.save();
         },
     },
     {
@@ -110,8 +105,8 @@ module.exports = [
         exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
             e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET)],
         fromZigbee: [fz.ignore_basic_report, fz.tuya_switch],
-        toZigbee: [tz.tuya_switch_state_multi],
-        meta: {configureKey: 1, multiEndpoint: true},
+        toZigbee: [tz.tuya_switch_state],
+        meta: {multiEndpoint: true},
         endpoint: (device) => {
             // Endpoint selection is made in tuya_switch_state
             return {'l1': 1, 'l2': 1};
@@ -132,7 +127,7 @@ module.exports = [
         exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
             e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET), e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET)],
         fromZigbee: [fz.ignore_basic_report, fz.tuya_switch],
-        toZigbee: [tz.tuya_switch_state_multi],
+        toZigbee: [tz.tuya_switch_state],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
             // Endpoint selection is made in tuya_switch_state

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -211,7 +211,6 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_vhy3iakz'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_oisqyl4o'},
             {modelID: 'TS0601', manufacturerName: '_TZ3000_uim07oem'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_g1ib5ldv'},
         ],
         model: 'TS0601_switch',
         vendor: 'TuYa',


### PR DESCRIPTION
1. added new device model "ZTS-EU_2gang" it's a 2 gang touch wall switch by Moes

2. I had an issue to control multiple switches with 1 mqtt message, for example: {"state_l2":"ON","state_l1":"ON"}
This message was received from the homebridge-z2m plugin when using both switches in a HomeKit scene.

So I create a new converter named: "tuya_switch_state_multi", with that you can send a message to modify multiple datapoints of the same service.

 modified the other model of "Moes" multiswitch ("ZTS-EU_3gang") to use the same converter so it will work for that as well...