### PR TITLE
Added support for Philips Hue Iris (Generation 4) Gold

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1054,7 +1054,7 @@ module.exports = [
         zigbeeModel: ['929002376401'],
         model: '929002376401',
         vendor: 'Philips',
-        description: 'Hue Iris Gold Limited edition (generation 4) ',
+        description: 'Hue Iris gold limited edition (generation 4) ',
         meta: {turnsOffAtBrightness1: true},
         extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1051,6 +1051,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['929002376401'],
+        model: '929002376401',
+        vendor: 'Philips',
+        description: 'Hue Iris Gold Limited edition (generation 4) ',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['1742930P7'],
         model: '1742930P7',
         vendor: 'Philips',


### PR DESCRIPTION
I added support for Philips Hue Iris gen 4 Gold limited edition. The model number is 929002376401. I tried the extension with color temperature (light_onoff_brightness_colortemp_color) and it seems to work everything. 

See #1932 for reference.

My first pull request. Let me know if I can improve on this. 