### PR TITLE
Added support for Samotech SM323 retrofit dimmer

### DIFF
--- a/devices/samotech.js
+++ b/devices/samotech.js
@@ -37,6 +37,7 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
             await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
         },
     },
 ];

--- a/devices/samotech.js
+++ b/devices/samotech.js
@@ -27,7 +27,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['Dimmer-Switch-ZB3.0'],
+        fingerprint: [{modelID: 'Dimmer-Switch-ZB3.0', manufacturerName: 'Samotech'}],
         model: 'SM323',
         vendor: 'Samotech',
         description: 'ZigBee retrofit dimmer 250W',

--- a/devices/samotech.js
+++ b/devices/samotech.js
@@ -26,4 +26,17 @@ module.exports = [
             await reporting.onOff(endpoint);
         },
     },
+    {
+        zigbeeModel: ['Dimmer-Switch-ZB3.0'],
+        model: 'SM323',
+        vendor: 'Samotech',
+        description: 'ZigBee retrofit dimmer 250W',
+        extend: extend.light_onoff_brightness({noConfigure: true}),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.onOff(endpoint);
+        },
+    },
 ];


### PR DESCRIPTION
Adding SM323 listed here: https://www.samotech.co.uk/products/zigbee-dimmer-switch-hue-compatible/
This one is very similar to SM309 so pretty much copypasted the config and changed model name.

Tested on my setup that device is identified and can be controlled properly.