### PR TITLE
WIP: Add support for Moes Scene Switch whitelabel

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -411,7 +411,10 @@ module.exports = [
         toZigbee: [],
     },
     {
-        zigbeeModel: ['TS0044'],
+        fingerprint: [
+            {modelID: 'TS0044'},
+            {modelID: 'TS004F', manufacturerName: '_TZ3000_xabckq1v'},
+        ],
         model: 'TS0044',
         vendor: 'TuYa',
         description: 'Wireless switch with 4 buttons',


### PR DESCRIPTION
This draft is an attempt to add support for the [Moes Scene Switch](https://www.moeshouse.com/collections/zigbee-scene-switch/products/1-4-gang-tuya-zigbee-wireless-12-scene-switch-2mqtt-setup-smart-home-automation-scenario-switch-for-tuya-smart-devices-%E7%9A%84%E5%89%AF%E6%9C%AC-1) which are a Whitelabel of the [TuYa TS0044](https://www.zigbee2mqtt.io/devices/TS0044.html).

The respective log level entry is (adjusted for readabillity):

> `Zigbee2MQTT:warn` `2021-05-10 18:38:15`: Device '`0x60a423fffed5bf4c`' with Zigbee model '`TS004F`' and manufacturer name '`_TZ3000_xabckq1v`' is NOT supported, please follow https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html

I tried to deduce what I'd need further from the other examples for example by looking into [`devices/moes.js`](https://github.com/koenkk/zigbee-herdsman-converters/blob/2036f4bf5ce58fc4e3f13d5df0ed328bca7563c6/devices/moes.js) but with no success… what would I need to do further?