### PR TITLE
OSRAM CLA60 RGBW Z3 does not support startupColorTemp

### DIFF
--- a/devices/osram.js
+++ b/devices/osram.js
@@ -100,7 +100,7 @@ module.exports = [
         model: 'AC03647',
         vendor: 'OSRAM',
         description: 'SMART+ LED CLASSIC E27 RGBW',
-        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [153, 526]}),
+        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [153, 526], disableColorTempStartup: true}}),
         ota: ota.ledvance,
         exposes: [e.light_brightness_colortemp_colorhs([153, 526]), e.effect()],
     },

--- a/devices/osram.js
+++ b/devices/osram.js
@@ -100,7 +100,7 @@ module.exports = [
         model: 'AC03647',
         vendor: 'OSRAM',
         description: 'SMART+ LED CLASSIC E27 RGBW',
-        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [153, 526], disableColorTempStartup: true}}),
+        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [153, 526], disableColorTempStartup: true}),
         ota: ota.ledvance,
         exposes: [e.light_brightness_colortemp_colorhs([153, 526]), e.effect()],
     },

--- a/devices/osram.js
+++ b/devices/osram.js
@@ -102,7 +102,7 @@ module.exports = [
         description: 'SMART+ LED CLASSIC E27 RGBW',
         extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [153, 526], disableColorTempStartup: true}),
         ota: ota.ledvance,
-        exposes: [e.light_brightness_colortemp_colorhs([153, 526]), e.effect()],
+        exposes: [e.light_brightness_colortemp_colorhs([153, 526]).removeFeature('color_temp_startup'), e.effect()],
     },
     {
         zigbeeModel: ['CLA60 RGBW II Z3'],


### PR DESCRIPTION
```
Zigbee2MQTT:error 2021-05-12 20:55:15: Publish 'get' 'color_temp_startup' to '0xf0d1b8000010b893' failed: 'Error: Read 0xf0d1b8000010b893/1 lightingColorCtrl(["startUpColorTemperature"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'
```