### PR TITLE
The first version of GL-S-004P had GL-S-005P

### DIFF
--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -290,7 +290,7 @@ module.exports = [
         extend: gledoptoExtend.light_onoff_brightness_colortemp_color(),
     },
     {
-        zigbeeModel: ['GL-S-004P'],
+        zigbeeModel: ['GL-S-004P', 'GL-S-005P'],
         model: 'GL-S-004P',
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,


### PR DESCRIPTION
Simple change. The GL-S-005P has changed name to GL-S-004P - GL-S-004P was in the database. same light, same socket, same wattage, same model (pro) - just a different model id, same bulb