### PR TITLE
change(xiaomi): expose angle axis properties from DJT11LM

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -735,8 +735,9 @@ module.exports = [
         fromZigbee: [fz.xiaomi_battery, fz.DJT11LM_vibration],
         toZigbee: [tz.DJT11LM_vibration_sensitivity],
         exposes: [
-            e.battery(), e.action(['vibration', 'tilt', 'drop']), exposes.numeric('strength', ea.STATE),
-            exposes.enum('sensitivity', ea.STATE_SET, ['low', 'medium', 'high']), e.battery_voltage(),
+            e.battery(), e.action(['vibration', 'tilt', 'drop']),
+            exposes.numeric('strength', ea.STATE), exposes.enum('sensitivity', ea.STATE_SET, ['low', 'medium', 'high']),
+            e.angle_axis('angle_x'), e.angle_axis('angle_y'), e.angle_axis('angle_z'), e.battery_voltage(),
         ],
     },
     {

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -453,6 +453,7 @@ module.exports = {
     presets: {
         action: (values) => new Enum('action', access.STATE, values).withDescription('Triggered action (e.g. a button click)'),
         angle: (name) => new Numeric(name, access.STATE).withValueMin(-360).withValueMax(360),
+        angle_axis: (name) => new Numeric(name, access.STATE).withValueMin(-90).withValueMax(90),
         aqi: () => new Numeric('aqi', access.STATE).withDescription('Air quality index'),
         auto_lock: () => new Switch().withState('auto_lock', false, 'Enable/disable auto lock', access.STATE_SET, 'AUTO', 'MANUAL'),
         auto_relock_time: () => new Numeric('auto_relock_time', access.ALL).withValueMin(0).withUnit('s').withDescription('The number of seconds to wait after unlocking a lock before it automatically locks again. 0=disabled'),


### PR DESCRIPTION
As discussed here: https://github.com/Koenkk/zigbee2mqtt/discussions/7249#discussioncomment-676111 
we are on the way to expose device properties to sensor entities

Aqara vibration sensor has angle properties. Axis angles should be exposed so people eg can use it to detect if a window is open or tilted