### PR TITLE
Add fingerprint for Tuya Smart Zigbee Plug 16A EU

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -590,6 +590,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['TS0121'],
+        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_cphmq0q7'}],
         model: 'TS0121_plug',
         description: '10A UK or 16A EU smart plug',
         whiteLabel: [{vendor: 'BlitzWolf', model: 'BW-SHP13'}],


### PR DESCRIPTION
As far as I can see zigbeeModel and fingerprint are OR-ed, so this should not break other TS0121. I think there is no need to copy&paste the whole block. Switch / voltage / current / power are working.