### PR TITLE
Updated reporting defaults for Develco devices

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -148,7 +148,7 @@ module.exports = [
             await reporting.batteryVoltage(endpoint);
             const endpoint2 = device.getEndpoint(38);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint2);
+            await reporting.temperature(endpoint2, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
         },
         endpoint: (device) => {
             return {default: 35};
@@ -169,7 +169,7 @@ module.exports = [
             await reporting.batteryVoltage(endpoint);
             const endpoint2 = device.getEndpoint(38);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint2);
+            await reporting.temperature(endpoint2, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
         },
         endpoint: (device) => {
             return {default: 35};

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -246,8 +246,8 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(38);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg']);
-            await reporting.temperature(endpoint);
-            await reporting.humidity(endpoint);
+            await reporting.temperature(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
+            await reporting.humidity(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 300});
             await reporting.batteryVoltage(endpoint);
         },
     },


### PR DESCRIPTION
I've taken the default settings from Develco technical documentation and just specified them in the default reporting config here.

This helps device setup because I don't have to manually update all the values every time the device is rejoined.