### PR TITLE
v100_reporting_modify

### DIFF
--- a/devices/dawon_dns.js
+++ b/devices/dawon_dns.js
@@ -248,7 +248,6 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genPowerCfg']);
             await reporting.onOff(endpoint);
-            await reporting.batteryVoltage(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
         },
         exposes: [e.battery(), e.switch(), e.voltage()],


### PR DESCRIPTION
It only reported 6000mV when it used.
V100 is not support reporting battery voltage.
