### PR TITLE
Wiser Smart Europe Device Support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5560,6 +5560,135 @@ const converters = {
             return result;
         },
     },
+    wiser_smart_thermostat_client: {
+        cluster: 'hvacThermostat',
+        type: 'read',
+        convert: async (model, msg, publish, options, meta) => {
+            const response = {};
+            let setpoint = 20*100;
+            if (meta.state.hasOwnProperty('occupied_heating_setpoint')) {
+                setpoint = (Math.round((meta.state.occupied_heating_setpoint * 2).toFixed(1)) / 2).toFixed(1) * 100;
+            }
+
+            if (msg.data[0] == 'minHeatSetpointLimit') {
+                response['minHeatSetpointLimit'] = 7*100;
+            } else if (msg.data[0] == 'maxHeatSetpointLimit') {
+                response['maxHeatSetpointLimit'] = 30*100;
+            } else if (msg.data[0] == 'occupiedHeatingSetpoint') {
+                response['occupiedHeatingSetpoint'] = setpoint;
+            } else if (msg.data[0] == 'systemMode') {
+                response['systemMode'] = 4;
+            } else if (msg.data[0] == 'wiserSmartPriorityLevel') {
+                response['wiserSmartPriorityLevel'] = 0xff;
+            } else if (msg.data[0] == 'wiserSmartMasterShortAddress') {
+                response['wiserSmartMasterShortAddress'] = 0x0000;
+            } else if (msg.data[0] == 'wiserSmartZoneMode') {
+                const lookup = {'manual': 1, 'schedule': 2, 'energy_saver': 3, 'holiday': 6};
+                const zonemodeNum = lookup[meta.state.zone_mode];
+                response['wiserSmartZoneMode'] = zonemodeNum;
+            } else if (msg.data[0] == 'wiserSmartHactConfig') {
+                response['wiserSmartHactConfig'] = 0x80;
+            } else {
+                meta.logger.warn(`'${meta.device.ieeeAddr}' read req from unsupported attribute from hvacThermostat '${msg.data[0]}'`);
+            }
+
+            await msg.endpoint.readResponse(msg.cluster, msg.meta.zclTransactionSequenceNumber, response, {srcEndpoint: 11});
+
+            converters.wiser_smart_vact_update_params.convert(model, msg, publish, options, meta);
+        },
+    },
+    wiser_smart_thermostat: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse'],
+        convert: async (model, msg, publish, options, meta) => {
+            const result = converters.thermostat.convert(model, msg, publish, options, meta);
+
+            if (msg.data.hasOwnProperty('wiserSmartValveCalibrationStatus')) {
+                const lookup = {0: 'ongoing', 1: 'successful', 2: 'uncalibrated', 3: 'failed_e1', 4: 'failed_e2', 5: 'failed_e3'};
+                result['valve_calibration_status'] = lookup[msg.data['wiserSmartValveCalibrationStatus']];
+            }
+            if (msg.data.hasOwnProperty('wiserSmartZoneMode')) {
+                const lookup = {1: 'manual', 2: 'schedule', 3: 'energy_saver', 6: 'holiday'};
+                result['zone_mode'] = lookup[msg.data['wiserSmartZoneMode']];
+            }
+            if (msg.data.hasOwnProperty('wiserSmartValvePosition')) {
+                result['pi_heating_demand'] = msg.data['wiserSmartValvePosition'];
+            }
+            // Radiator thermostats command changes from UI, but report value periodically for sync,
+            // force an update of the value if it doesn't match the current existing value
+            if (meta.device.modelID === 'EH-ZB-VACT' &&
+            msg.data.hasOwnProperty('occupiedHeatingSetpoint') &&
+            meta.state.hasOwnProperty('occupied_heating_setpoint')) {
+                if (result.occupied_heating_setpoint != meta.state.occupied_heating_setpoint) {
+                    const lookup = {'manual': 1, 'schedule': 2, 'energy_saver': 3, 'holiday': 6};
+                    const zonemodeNum = lookup[meta.state.zone_mode];
+                    const setpoint = (Math.round((meta.state.occupied_heating_setpoint * 2).toFixed(1)) / 2).toFixed(1) * 100;
+                    const payload = {
+                        operatingmode: 0,
+                        zonemode: zonemodeNum,
+                        setpoint: setpoint,
+                        reserved: 0xff,
+                    };
+                    await msg.endpoint.command('hvacThermostat', 'wiserSmartSetSetpoint', payload,
+                        {srcEndpoint: 11, disableDefaultResponse: true});
+
+                    meta.logger.debug(`syncing vact setpoint was: '${result.occupied_heating_setpoint}'` +
+                    ` now: '${meta.state.occupied_heating_setpoint}'`);
+                }
+            } else {
+                publish(result);
+            }
+            converters.wiser_smart_vact_update_params.convert(model, msg, publish, options, meta);
+        },
+    },
+    wiser_smart_vact_update_params: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse', 'read'],
+        convert: async (model, msg, publish, options, meta) => {
+            const endpoint = msg.endpoint;
+
+            if (meta.state.hasOwnProperty('calibrate_valve')) {
+                if (meta.state.calibrate_valve == 'calibrate') {
+                    await endpoint.command('hvacThermostat', 'wiserSmartCalibrateValve', {srcEndpoint: 11, disableDefaultResponse: true});
+                    publish({calibrate_valve: 'idle'});
+                }
+            }
+            if (globalStore.hasValue(msg.endpoint, 'localTemperatureCalibrationUpdated')) {
+                if (globalStore.getValue(msg.endpoint, 'localTemperatureCalibrationUpdated')) {
+                    const localTemp = Math.round(meta.state.local_temperature_calibration * 10);
+                    await endpoint.write('hvacThermostat', {localTemperatureCalibration: localTemp},
+                        {srcEndpoint: 11, disableDefaultResponse: true});
+                    globalStore.putValue(msg.endpoint, 'localTemperatureCalibrationUpdated', false);
+                }
+            }
+            if (globalStore.hasValue(msg.endpoint, 'keypadLockoutUpdated')) {
+                if (globalStore.getValue(msg.endpoint, 'keypadLockoutUpdated')) {
+                    const keypadLockoutKey = getKey(constants.keypadLockoutMode,
+                        meta.state.keypad_lockout, meta.state.keypad_lockout, Number);
+                    await endpoint.write('hvacUserInterfaceCfg', {keypadLockout: keypadLockoutKey},
+                        {srcEndpoint: 11, disableDefaultResponse: true});
+                    globalStore.putValue(msg.endpoint, 'keypadLockoutUpdated', false);
+                }
+            }
+        },
+    },
+    wiser_smart_setpoint_command_client: {
+        cluster: 'hvacThermostat',
+        type: ['command', 'commandWiserSmartSetSetpoint'],
+        convert: (model, msg, publish, options, meta) => {
+            const attribute = {};
+            const result = {};
+
+            // the UI client on the thermostat also updates the server, so no need to readback/send again on next sync
+            attribute['occupiedHeatingSetpoint'] = msg.data['setpoint'];
+            msg.endpoint.saveClusterAttributeKeyValue('hvacThermostat', attribute);
+
+            result['occupied_heating_setpoint'] = parseFloat(msg.data['setpoint']) / 100.0;
+
+            meta.logger.debug(`received wiser setpoint command with value: '${msg.data['setpoint']}'`);
+            return result;
+        },
+    },
 
     // #endregion
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5572,7 +5572,6 @@ const converters = {
                 response[0xe010] = {value: zonemodeNum, type: 0x30};
                 await msg.endpoint.readResponse(msg.cluster, msg.meta.zclTransactionSequenceNumber, response, {srcEndpoint: 11});
             }
-            converters.wiser_smart_vact_update_params.convert(model, msg, publish, options, meta);
         },
     },
     wiser_smart_thermostat: {
@@ -5618,38 +5617,6 @@ const converters = {
                 }
             } else {
                 publish(result);
-            }
-            converters.wiser_smart_vact_update_params.convert(model, msg, publish, options, meta);
-        },
-    },
-    wiser_smart_vact_update_params: {
-        cluster: 'hvacThermostat',
-        type: ['attributeReport', 'readResponse', 'read'],
-        convert: async (model, msg, publish, options, meta) => {
-            const endpoint = msg.endpoint;
-
-            if (meta.state.hasOwnProperty('calibrate_valve')) {
-                if (meta.state.calibrate_valve == 'calibrate') {
-                    await endpoint.command('hvacThermostat', 'wiserSmartCalibrateValve', {srcEndpoint: 11, disableDefaultResponse: true});
-                    publish({calibrate_valve: 'idle'});
-                }
-            }
-            if (globalStore.hasValue(msg.endpoint, 'localTemperatureCalibrationUpdated')) {
-                if (globalStore.getValue(msg.endpoint, 'localTemperatureCalibrationUpdated')) {
-                    const localTemp = Math.round(meta.state.local_temperature_calibration * 10);
-                    await endpoint.write('hvacThermostat', {localTemperatureCalibration: localTemp},
-                        {srcEndpoint: 11, disableDefaultResponse: true});
-                    globalStore.putValue(msg.endpoint, 'localTemperatureCalibrationUpdated', false);
-                }
-            }
-            if (globalStore.hasValue(msg.endpoint, 'keypadLockoutUpdated')) {
-                if (globalStore.getValue(msg.endpoint, 'keypadLockoutUpdated')) {
-                    const keypadLockoutKey = getKey(constants.keypadLockoutMode,
-                        meta.state.keypad_lockout, meta.state.keypad_lockout, Number);
-                    await endpoint.write('hvacUserInterfaceCfg', {keypadLockout: keypadLockoutKey},
-                        {srcEndpoint: 11, disableDefaultResponse: true});
-                    globalStore.putValue(msg.endpoint, 'keypadLockoutUpdated', false);
-                }
             }
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4984,14 +4984,9 @@ const converters = {
             return {state: {'calibrate_valve': value}};
         },
     },
-    wiser_zone_mode: {
+    wiser_sed_zone_mode: {
         key: ['zone_mode'],
         convertSet: async (entity, key, value, meta) => {
-            const lookup = {'manual': 1, 'schedule': 2, 'energy_saver': 3, 'holiday': 6};
-            const zonemodeNum = lookup[value];
-            if (entity.getDevice().powerSource != 'Battery') {
-                await entity.write('hvacThermostat', {'wiserSmartZoneMode': zonemodeNum}, {disableDefaultResponse: true});
-            }
             return {state: {'zone_mode': value}};
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4978,6 +4978,43 @@ const converters = {
             }
         },
     },
+    wiser_vact_calibrate_valve: {
+        key: ['calibrate_valve'],
+        convertSet: async (entity, key, value, meta) => {
+            return {state: {'calibrate_valve': value}};
+        },
+    },
+    wiser_zone_mode: {
+        key: ['zone_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            const lookup = {'manual': 1, 'schedule': 2, 'energy_saver': 3, 'holiday': 6};
+            const zonemodeNum = lookup[value];
+            if (entity.getDevice().powerSource != 'Battery') {
+                await entity.write('hvacThermostat', {'wiserSmartZoneMode': zonemodeNum}, {disableDefaultResponse: true});
+            }
+            return {state: {'zone_mode': value}};
+        },
+    },
+    wiser_sed_occupied_heating_setpoint: {
+        key: ['occupied_heating_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            return {state: {'occupied_heating_setpoint': value}};
+        },
+    },
+    wiser_sed_thermostat_local_temperature_calibration: {
+        key: ['local_temperature_calibration'],
+        convertSet: async (entity, key, value, meta) => {
+            globalStore.putValue(entity, 'localTemperatureCalibrationUpdated', true);
+            return {state: {local_temperature_calibration: value}};
+        },
+    },
+    wiser_sed_thermostat_keypad_lockout: {
+        key: ['keypad_lockout'],
+        convertSet: async (entity, key, value, meta) => {
+            globalStore.putValue(entity, 'keypadLockoutUpdated', true);
+            return {state: {keypad_lockout: value}};
+        },
+    },
 
     // #endregion
 

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4981,6 +4981,8 @@ const converters = {
     wiser_vact_calibrate_valve: {
         key: ['calibrate_valve'],
         convertSet: async (entity, key, value, meta) => {
+            await entity.command('hvacThermostat', 'wiserSmartCalibrateValve',
+                {srcEndpoint: 11, disableDefaultResponse: true, sendWhenActive: true});
             return {state: {'calibrate_valve': value}};
         },
     },
@@ -5000,15 +5002,18 @@ const converters = {
     },
     wiser_sed_thermostat_local_temperature_calibration: {
         key: ['local_temperature_calibration'],
-        convertSet: async (entity, key, value, meta) => {
-            globalStore.putValue(entity, 'localTemperatureCalibrationUpdated', true);
+        convertSet: (entity, key, value, meta) => {
+            entity.write('hvacThermostat', {localTemperatureCalibration: Math.round(value * 10)},
+                {srcEndpoint: 11, disableDefaultResponse: true, sendWhenActive: true});
             return {state: {local_temperature_calibration: value}};
         },
     },
     wiser_sed_thermostat_keypad_lockout: {
         key: ['keypad_lockout'],
         convertSet: async (entity, key, value, meta) => {
-            globalStore.putValue(entity, 'keypadLockoutUpdated', true);
+            const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value, Number);
+            await entity.write('hvacUserInterfaceCfg', {keypadLockout},
+                {srcEndpoint: 11, disableDefaultResponse: true, sendWhenActive: true});
             return {state: {keypad_lockout: value}};
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4981,7 +4981,7 @@ const converters = {
     wiser_vact_calibrate_valve: {
         key: ['calibrate_valve'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.command('hvacThermostat', 'wiserSmartCalibrateValve',
+            await entity.command('hvacThermostat', 'wiserSmartCalibrateValve', {},
                 {srcEndpoint: 11, disableDefaultResponse: true, sendWhenActive: true});
             return {state: {'calibrate_valve': value}};
         },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4993,6 +4993,8 @@ const converters = {
     wiser_sed_occupied_heating_setpoint: {
         key: ['occupied_heating_setpoint'],
         convertSet: async (entity, key, value, meta) => {
+            const occupiedHeatingSetpoint = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
+            entity.saveClusterAttributeKeyValue('hvacThermostat', {occupiedHeatingSetpoint});
             return {state: {'occupied_heating_setpoint': value}};
         },
     },

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -257,7 +257,7 @@ module.exports = [
             fz.wiser_smart_thermostat, fz.wiser_smart_thermostat_client, fz.wiser_smart_setpoint_command_client],
         toZigbee: [tz.thermostat_local_temperature, tz.wiser_sed_thermostat_local_temperature_calibration,
             tz.wiser_sed_occupied_heating_setpoint, tz.wiser_sed_thermostat_keypad_lockout, tz.wiser_vact_calibrate_valve,
-            tz.wiser_zone_mode],
+            tz.wiser_sed_zone_mode],
         exposes: [e.battery(),
             exposes.binary('keypad_lockout', ea.STATE_SET, 'lock1', 'unlock')
                 .withDescription('Enables/disables physical input on the device'),
@@ -297,7 +297,7 @@ module.exports = [
         description: 'Wiser thermostat (RTS)',
         fromZigbee: [fz.ignore_basic_report, fz.ignore_genOta, fz.ignore_zclversion_read, fz.battery, fz.hvac_user_interface,
             fz.wiser_smart_thermostat_client, fz.wiser_smart_setpoint_command_client, fz.temperature],
-        toZigbee: [tz.wiser_zone_mode, tz.wiser_sed_occupied_heating_setpoint],
+        toZigbee: [tz.wiser_sed_zone_mode, tz.wiser_sed_occupied_heating_setpoint],
         exposes: [e.battery(), e.temperature(),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5, ea.STATE_SET),
             exposes.enum('zone_mode',

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -270,7 +270,7 @@ module.exports = [
                 .withDescription('Icon shown on device displays'),
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 7, 30, 0.5, ea.STATE_SET)
-                .withLocalTemperature(ea.STATE)
+                .withLocalTemperature(ea.STATE_GET)
                 .withLocalTemperatureCalibration(ea.STATE_SET)
                 .withPiHeatingDemand()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
@@ -335,7 +335,7 @@ module.exports = [
         vendor: 'Schneider Electric',
         description: 'Wiser H-Relay (HACT)',
         fromZigbee: [fz.ignore_basic_report, fz.ignore_genOta, fz.ignore_zclversion_read, fz.wiser_smart_thermostat],
-        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.wiser_zone_mode],
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.wiser_sed_zone_mode],
         exposes: [exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5)],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(11);

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -276,6 +276,11 @@ module.exports = [
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(11);
+            // Insert default values for client requested attributes
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {minHeatSetpointLimit: 7*100});
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {maxHeatSetpointLimit: 30*100});
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {occupiedHeatingSetpoint: 20*100});
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {systemMode: 4});
             // VACT needs binding to endpoint 11 due to some hardcoding in the device
             const coordinatorEndpointB = coordinatorEndpoint.getDevice().getEndpoint(11);
             const binds = ['genBasic', 'genPowerCfg', 'hvacThermostat'];
@@ -306,6 +311,11 @@ module.exports = [
         meta: {battery: {voltageToPercentage: '4LR6AA1_5v'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(11);
+            // Insert default values for client requested attributes
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {minHeatSetpointLimit: 7*100});
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {maxHeatSetpointLimit: 30*100});
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {occupiedHeatingSetpoint: 20*100});
+            endpoint.saveClusterAttributeKeyValue('hvacThermostat', {systemMode: 4});
             // RTS needs binding to endpoint 11 due to some hardcoding in the device
             const coordinatorEndpointB = coordinatorEndpoint.getDevice().getEndpoint(11);
             const binds = ['genBasic', 'genPowerCfg', 'genIdentify', 'genAlarms', 'genOta', 'hvacThermostat',

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -214,4 +214,124 @@ module.exports = [
             await reporting.currentSummDelivered(endpoint2, {min: 0, max: 60, change: 1});
         },
     },
+    {
+        zigbeeModel: ['EH-ZB-SPD-V2'],
+        model: 'EER40030',
+        vendor: 'Schneider Electric',
+        description: 'Zigbee smart plug with power meter',
+        fromZigbee: [fz.on_off, fz.metering],
+        toZigbee: [tz.on_off],
+        exposes: [e.switch(), e.power(), e.energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(11);
+            const options = {disableDefaultResponse: true};
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            await reporting.onOff(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.instantaneousDemand(endpoint);
+            await endpoint.write('genBasic', {0xe050: {value: 1, type: 0x10}}, options);
+        },
+    },
+    {
+        zigbeeModel: ['EH-ZB-LMACT'],
+        model: 'EER42000',
+        vendor: 'Schneider Electric',
+        description: 'Zigbee load actuator with power meter',
+        fromZigbee: [fz.on_off, fz.metering],
+        toZigbee: [tz.on_off],
+        exposes: [e.switch(), e.power(), e.energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(11);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            await reporting.onOff(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.instantaneousDemand(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['EH-ZB-VACT'],
+        model: 'EER53000',
+        vendor: 'Schneider Electric',
+        description: 'Wiser radiator thermostat (VACT)',
+        fromZigbee: [fz.ignore_basic_report, fz.ignore_genOta, fz.ignore_zclversion_read, fz.battery, fz.hvac_user_interface,
+            fz.wiser_smart_thermostat, fz.wiser_smart_thermostat_client, fz.wiser_smart_setpoint_command_client],
+        toZigbee: [tz.thermostat_local_temperature, tz.wiser_sed_thermostat_local_temperature_calibration,
+            tz.wiser_sed_occupied_heating_setpoint, tz.wiser_sed_thermostat_keypad_lockout, tz.wiser_vact_calibrate_valve,
+            tz.wiser_zone_mode],
+        exposes: [e.battery(),
+            exposes.binary('keypad_lockout', ea.STATE_SET, 'lock1', 'unlock')
+                .withDescription('Enables/disables physical input on the device'),
+            exposes.binary('calibrate_valve', ea.STATE_SET, 'calibrate', 'idle')
+                .withDescription('Calibrates valve on next wakeup'),
+            exposes.enum('valve_calibration_status',
+                ea.STATE, ['ongoing', 'successful', 'uncalibrated', 'failed_e1', 'failed_e2', 'failed_e3']),
+            exposes.enum('zone_mode',
+                ea.STATE_SET, ['manual', 'schedule', 'energy_saver', 'holiday'])
+                .withDescription('Icon shown on device displays'),
+            exposes.climate()
+                .withSetpoint('occupied_heating_setpoint', 7, 30, 0.5, ea.STATE_SET)
+                .withLocalTemperature(ea.STATE)
+                .withLocalTemperatureCalibration(ea.STATE_SET)
+                .withPiHeatingDemand()],
+        meta: {battery: {voltageToPercentage: '3V_2500'}},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(11);
+            // VACT needs binding to endpoint 11 due to some hardcoding in the device
+            const coordinatorEndpointB = coordinatorEndpoint.getDevice().getEndpoint(11);
+            const binds = ['genBasic', 'genPowerCfg', 'hvacThermostat'];
+            await reporting.bind(endpoint, coordinatorEndpointB, binds);
+            await reporting.batteryVoltage(endpoint);
+            await reporting.thermostatTemperature(endpoint, {min: constants.repInterval.MINUTE,
+                max: constants.repInterval.MINUTES_15, change: 50});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_15, change: 25});
+            await endpoint.configureReporting('hvacUserInterfaceCfg', [{attribute: 'keypadLockout',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1}]);
+        },
+    },
+    {
+        zigbeeModel: ['EH-ZB-RTS'],
+        model: 'EER51000',
+        vendor: 'Schneider Electric',
+        description: 'Wiser thermostat (RTS)',
+        fromZigbee: [fz.ignore_basic_report, fz.ignore_genOta, fz.ignore_zclversion_read, fz.battery, fz.hvac_user_interface,
+            fz.wiser_smart_thermostat_client, fz.wiser_smart_setpoint_command_client, fz.temperature],
+        toZigbee: [tz.wiser_zone_mode, tz.wiser_sed_occupied_heating_setpoint],
+        exposes: [e.battery(), e.temperature(),
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5, ea.STATE_SET),
+            exposes.enum('zone_mode',
+                ea.STATE_SET, ['manual', 'schedule', 'energy_saver', 'holiday'])
+                .withDescription('Icon shown on device displays')],
+        meta: {battery: {voltageToPercentage: '4LR6AA1_5v'}},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(11);
+            // RTS needs binding to endpoint 11 due to some hardcoding in the device
+            const coordinatorEndpointB = coordinatorEndpoint.getDevice().getEndpoint(11);
+            const binds = ['genBasic', 'genPowerCfg', 'genIdentify', 'genAlarms', 'genOta', 'hvacThermostat',
+                'hvacUserInterfaceCfg', 'msTemperatureMeasurement'];
+            await reporting.bind(endpoint, coordinatorEndpointB, binds);
+            // Battery reports without config once a day, do the first read manually
+            await endpoint.read('genPowerCfg', ['batteryVoltage']);
+            await endpoint.configureReporting('msTemperatureMeasurement', [{attribute: 'measuredValue',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.MINUTES_10,
+                reportableChange: 50}]);
+        },
+    },
+    {
+        zigbeeModel: ['EH-ZB-HACT'],
+        model: 'EER50000',
+        vendor: 'Schneider Electric',
+        description: 'Wiser H-Relay (HACT)',
+        fromZigbee: [fz.ignore_basic_report, fz.ignore_genOta, fz.ignore_zclversion_read, fz.wiser_smart_thermostat],
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.wiser_zone_mode],
+        exposes: [exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5)],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(11);
+            const binds = ['genBasic', 'genPowerCfg', 'hvacThermostat', 'msTemperatureMeasurement'];
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_15, change: 25});
+        },
+    },
 ];


### PR DESCRIPTION
- Added Room and Radiator Thermostats, Heating and Load Actuators and 2nd Gen Smartplug
- All devices excluding Smartplug require holding set button for 5 seconds to join
- Smartplug will join with short press, but only on channels 11,15,20,25
- Relies on commands added to PR Koenkk/zigbee-herdsman#363