### PR TITLE
Correct manufacturerName Saswell

### DIFF
--- a/devices/saswell.js
+++ b/devices/saswell.js
@@ -15,7 +15,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_c88teujp'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'},
             {modelId: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
-            {modelID: 'TS0601', manufacturerName: '_TYST11_zuhszj9s'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_zuhszj9s'},
         ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',


### PR DESCRIPTION
I believe that @drzony 's https://github.com/Koenkk/zigbee-herdsman-converters/pull/2594 was a good direction, but based on the logs I see in my installation, I think it should be `_TZE200_zuhszj9s` instead. 

But note that I have zero understanding of this whole project.