### PR TITLE
add Moes e-ink brightness thermometer

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -142,4 +142,13 @@ module.exports = [
             device.save();
         },
     },
+    {
+        fingerprint: [{modelID: 'TS0222', manufacturerName: '_TYZB01_kvwjujy9'}],
+        model: 'ZSS-ZK-THL',
+        vendor: 'Moes',
+        description: 'E-Ink Brightness Thermostat',
+        fromZigbee: [fz.battery, fz.illuminance, fz.temperature, fz.humidity],
+        toZigbee: [],
+        exposes: [e.battery(), e.illuminance(), e.illuminance_lux(), e.temperature(), e.humidity()],
+    },
 ];


### PR DESCRIPTION
Add Moes Brightness Thermometer (ZSS-ZK-THL). Variant of TS0222 illumination sensor with added temperature and humidity. 

Came in Moes branded packaging and branded manual. Model code from the device label.

manufacturerid: `_TYZB01_kvwjujy9`

Image:
![image](https://user-images.githubusercontent.com/5904370/119019790-dafdc400-b99d-11eb-975f-b172d52094c6.png)
