### PR TITLE
Add new manufacturer for a TS0505B RGB+CCT controller.

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -63,7 +63,7 @@ module.exports = [
         extend: extend.switch(),
     },
     {
-        fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3000_qqjaziws'}],
+        fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3000_qqjaziws'}, {modelID: 'TS0505B', manufacturerName: '_TZ3000_jtmhndw2'}],
         model: 'TS0505B',
         vendor: 'TuYa',
         description: 'Zigbee smart mini led strip controller 5V/12V/24V RGB+CCT',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -63,7 +63,8 @@ module.exports = [
         extend: extend.switch(),
     },
     {
-        fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3000_qqjaziws'}, {modelID: 'TS0505B', manufacturerName: '_TZ3000_jtmhndw2'}],
+        fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3000_qqjaziws'},
+            {modelID: 'TS0505B', manufacturerName: '_TZ3000_jtmhndw2'}],
         model: 'TS0505B',
         vendor: 'TuYa',
         description: 'Zigbee smart mini led strip controller 5V/12V/24V RGB+CCT',


### PR DESCRIPTION
I have a new tuya device, a LED RGB + CCT controller with model ID TS0505B but another manufacturer name. 
Creating a new external converter I found and tried the definition for TS0505B in tuya.js 
By adding an new manufacturerName it worked perfectly 
 
Log: "Device '0x.........' with Zigbee model 'TS0505B' and manufacturer name '_TZ3000_jtmhndw2' is NOT supported,"