### PR TITLE
Update ikea.js to support LED1935C3

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -557,4 +557,10 @@ module.exports = [
         description: 'TRADFRI LED bulb E14 470 lumen, opal, dimmable, white spectrum, color spectrum',
         extend: tradfriExtend.light_onoff_brightness_colortemp_color(),
     },
+		{		zigbeeModel: ['TRADFRIbulbE14WWclear250lm'],
+				model: 'LED1935C3',
+				vendor: 'IKEA',
+				description: 'TRADFRI LED bulb E14 WW clear 250 lumen, dimmable',
+				extend: tradfriExtend.light_onoff_brightness(),
+		},
 ];

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -557,10 +557,11 @@ module.exports = [
         description: 'TRADFRI LED bulb E14 470 lumen, opal, dimmable, white spectrum, color spectrum',
         extend: tradfriExtend.light_onoff_brightness_colortemp_color(),
     },
-		{		zigbeeModel: ['TRADFRIbulbE14WWclear250lm'],
-				model: 'LED1935C3',
-				vendor: 'IKEA',
-				description: 'TRADFRI LED bulb E14 WW clear 250 lumen, dimmable',
-				extend: tradfriExtend.light_onoff_brightness(),
-		},
+    {
+        zigbeeModel: ['TRADFRIbulbE14WWclear250lm'],
+        model: 'LED1935C3',
+        vendor: 'IKEA',
+        description: 'TRADFRI LED bulb E14 WW clear 250 lumen, dimmable',
+        extend: tradfriExtend.light_onoff_brightness(),
+    },
 ];


### PR DESCRIPTION
This weekend I bought a new bulb and only when I got home I discovered it wasn't supported yet and it's even not on the Ikea website. It very much looks like [this one which is claimed to be Hue](https://hueblog.com/2020/09/30/first-filament-lamp-with-e14-base-appeared-at-fcc/), black base and spiral filament.

Fitting: E14
Type: WW filament
Model: LED1935C3
Lumen: 250lm
Watt: 2,7W
Article: 304.413.80
Bought @ Ikea Netherlands

I wasn't able to fully test it with ``tradfriExtend`` because that was added after Zigbee2MQTT 1.18.3. So in my test I just used the default ``light_onoff_brightness()`` (see below) but I expect it to behave the same as other Tradfri. The zigbeeModel is weirdly space-free.

External converter I use at the moment:
```js
const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const reporting = require('zigbee-herdsman-converters/lib/reporting');
const extend = require('zigbee-herdsman-converters/lib/extend');
const e = exposes.presets;
const ea = exposes.access;

const bulbOnEvent = async (type, data, device) => {
    /**
     * IKEA bulbs lose their configured reportings when losing power.
     * A deviceAnnounce indicates they are powered on again.
     * Reconfigure the configured reoprting here.
     * NOTE: binds are not lost so rebinding is not needed!
     */
    if (type === 'deviceAnnounce') {
        for (const endpoint of device.endpoints) {
            for (const c of endpoint.configuredReportings) {
                await endpoint.configureReporting(c.cluster.name, [{
                    attribute: c.attribute.name, minimumReportInterval: c.minimumReportInterval,
                    maximumReportInterval: c.maximumReportInterval, reportableChange: c.reportableChange,
                }]);
            }
        }
    }
};

const definition = {
		zigbeeModel: ['TRADFRIbulbE14WWclear250lm'],
		model: 'LED1935C3',
		vendor: 'IKEA',
		description: 'TRADFRI LED bulb E14 WW clear 250 lumen, dimmable',
		extend: extend.light_onoff_brightness(),
		onEvent: bulbOnEvent,
};

module.exports = definition;
```