### PR TITLE
Please add the support for Phillips 1745530P7 to the converters

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -207,7 +207,8 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const isPosition = (key === 'position');
             const invert = !(meta.mapped.meta && meta.mapped.meta.coverInverted ? !meta.options.invert_cover : meta.options.invert_cover);
-            const position = invert ? 100 - value : value;
+            let position = invert ? 100 - value : value;
+            position = utils.minMaxPosition(position, meta.options);
 
             // Zigbee officially expects 'open' to be 0 and 'closed' to be 100 whereas
             // HomeAssistant etc. work the other way round.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -486,6 +486,21 @@ function validateValue(value, allowed) {
     }
 }
 
+function minMaxPosition(position, options) {
+    if (options.hasOwnProperty('position_min') || options.hasOwnProperty('position_max')) {
+        const min = options.hasOwnProperty('position_min') ? options.position_min : 0;
+        const max = options.hasOwnProperty('position_max') ? options.position_max : 100;
+        if (min >= max) {
+            throw new Error(`position_min is greater or equal to position_max (${min}/${max}`);
+        }
+
+        const range = max - min;
+        return (range * (position / 100)) + min;
+    } else {
+        return position;
+    }
+}
+
 module.exports = {
     correctHue,
     getOptions,
@@ -521,4 +536,5 @@ module.exports = {
     sleep,
     toSnakeCase,
     toCamelCase,
+    minMaxPosition,
 };


### PR DESCRIPTION
The Phillips 1745530P7 is the same as 1745630P7, only the hardware socket is longer than the socket of 1745630P7. The 1745530P7 is called as "Philips Lighting Hue LED-Außenstandleuchte 1745530P7 Nyro 13.5 W RGBW". Thank You for Your help.