### PR TITLE
Addded E26 variant to IKEA LED1924G9

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -158,10 +158,10 @@ module.exports = [
         onEvent: bulbOnEvent,
     },
     {
-        zigbeeModel: ['TRADFRI bulb E27 CWS 806lm'],
+        zigbeeModel: ['TRADFRI bulb E26 CWS 800lm', 'TRADFRI bulb E27 CWS 806lm'],
         model: 'LED1924G9',
         vendor: 'IKEA',
-        description: 'TRADFRI bulb E27 CWS 806 lumen, dimmable, color, opal white',
+        description: 'TRADFRI bulb E26/E27 CWS 800/806 lumen, dimmable, color, opal white',
         extend: tradfriExtend.light_onoff_brightness_colortemp_color(),
     },
     {


### PR DESCRIPTION
Tested with my E26 variant purchased at IKEA Canada on May 2021. Working fine with Zigbee2mqtt 1.18.3.

Please note it is 800lm and not 806lm but it matches the same model name.