### PR TITLE
Switch AXIS Gear to use closureWindowCovering

### DIFF
--- a/devices/axis.js
+++ b/devices/axis.js
@@ -3,8 +3,6 @@ const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/lega
 const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 const e = exposes.presets;
-const ea = exposes.access;
-
 module.exports = [
     {
         zigbeeModel: ['Gear'],

--- a/devices/axis.js
+++ b/devices/axis.js
@@ -11,15 +11,15 @@ module.exports = [
         model: 'GR-ZB01-W',
         vendor: 'AXIS',
         description: 'Gear window shade motor',
-        fromZigbee: [fz.cover_position_via_brightness, fz.battery],
-        toZigbee: [tz.cover_via_brightness],
+        fromZigbee: [fz.cover_position_tilt, fz.battery],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt],
         meta: {battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genLevelCtrl', 'genPowerCfg']);
-            await reporting.brightness(endpoint);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
             await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.currentPositionLiftPercentage(endpoint);
         },
-        exposes: [e.cover_position().setAccess('state', ea.ALL), e.battery()],
+        exposes: [e.cover_position(), e.battery()],
     },
 ];


### PR DESCRIPTION
After being stuck in transit for over 2 months, I finally got 2 of these last week.

However I was having some problems when trying to set a position other than 0 or 100.
Every so often (1/6 ish times) they would do nothing and flash leds RED on the unit, indicating an error, then I have to touch the power button on the unit to make it go again.

I didn't immediately see anything wrong from the z2m side of things, but I did notice the unit also supports closuresWindowCovering cluster. Out of ideas I tried using this instead of genLevelCtrl, so far I have not had any errors. (Granted I only played with it for about and hour raising and lowering it to different %'s or fully open and close.

We seem to lose the possibility to query state, but I'd say that's better than having to physically interact with the unit to get it going again. Also we gain 'stop' which is nice I guess.