### PR TITLE
Add support for Current Products Group Hybrid E-Wand Gen 2

### DIFF
--- a/devices/current_products_corp.js
+++ b/devices/current_products_corp.js
@@ -1,0 +1,26 @@
+const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
+const tz = require('zigbee-herdsman-converters/converters/toZigbee');
+const exposes = require('zigbee-herdsman-converters/lib/exposes');
+const reporting = require('zigbee-herdsman-converters/lib/reporting');
+const extend = require('zigbee-herdsman-converters/lib/extend');
+const e = exposes.presets;
+const ea = exposes.access;
+
+module.exports = [
+  {
+      zigbeeModel: ['E-Wand'],
+      model: 'CP180335E-01',
+      vendor: 'Current Products Corp',
+      description: 'Gen. 2 Hybrid E-Wand',
+      fromZigbee: [fz.cover_position_tilt, fz.battery],
+      toZigbee: [tz.cover_state, tz.cover_position_tilt],
+      meta: { configureKey: 1 },
+      configure: async (device, coordinatorEndpoint, logger) => {
+          const endpoint = device.getEndpoint(1);
+          await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
+          await reporting.batteryPercentageRemaining(endpoint);
+          await reporting.currentPositionTiltPercentage(endpoint);
+      },
+      exposes: [e.battery(), e.cover_tilt()],
+  },
+];

--- a/devices/current_products_corp.js
+++ b/devices/current_products_corp.js
@@ -9,7 +9,7 @@ module.exports = [
         zigbeeModel: ['E-Wand'],
         model: 'CP180335E-01',
         vendor: 'Current Products Corp',
-        description: 'Gen. 2 Hybrid E-Wand',
+        description: 'Gen. 2 hybrid E-Wand',
         fromZigbee: [fz.cover_position_tilt, fz.battery],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices/current_products_corp.js
+++ b/devices/current_products_corp.js
@@ -2,25 +2,22 @@ const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
 const tz = require('zigbee-herdsman-converters/converters/toZigbee');
 const exposes = require('zigbee-herdsman-converters/lib/exposes');
 const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
 const e = exposes.presets;
-const ea = exposes.access;
 
 module.exports = [
-  {
-      zigbeeModel: ['E-Wand'],
-      model: 'CP180335E-01',
-      vendor: 'Current Products Corp',
-      description: 'Gen. 2 Hybrid E-Wand',
-      fromZigbee: [fz.cover_position_tilt, fz.battery],
-      toZigbee: [tz.cover_state, tz.cover_position_tilt],
-      meta: { configureKey: 1 },
-      configure: async (device, coordinatorEndpoint, logger) => {
-          const endpoint = device.getEndpoint(1);
-          await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
-          await reporting.batteryPercentageRemaining(endpoint);
-          await reporting.currentPositionTiltPercentage(endpoint);
-      },
-      exposes: [e.battery(), e.cover_tilt()],
-  },
+    {
+        zigbeeModel: ['E-Wand'],
+        model: 'CP180335E-01',
+        vendor: 'Current Products Corp',
+        description: 'Gen. 2 Hybrid E-Wand',
+        fromZigbee: [fz.cover_position_tilt, fz.battery],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.currentPositionTiltPercentage(endpoint);
+        },
+        exposes: [e.battery(), e.cover_tilt()],
+    },
 ];

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -473,6 +473,7 @@ module.exports = {
         contact: () => new Binary('contact', access.STATE, false, true).withDescription('Indicates if the contact is closed (= true) or open (= false)'),
         cover_position: () => new Cover().withPosition(),
         cover_position_tilt: () => new Cover().withPosition().withTilt(),
+        cover_tilt: () => new Cover().withTilt(),
         cpu_temperature: () => new Numeric('cpu_temperature', access.STATE).withUnit('°C').withDescription('Temperature of the CPU'),
         cube_side: (name) => new Numeric(name, access.STATE).withDescription('Side of the cube').withValueMin(0).withValueMax(6).withValueStep(1),
         current: () => new Numeric('current', access.STATE).withUnit('A').withDescription('Instantaneous measured electrical current'),


### PR DESCRIPTION
This adds support for the Gen. 2 Hybrid E-Wand from Current Products Corp. More information about this device can be found here (https://www.myewand.com/product-page/gen-2-hybrid-e-wand-single-unit). 

I had to add an additional preset in exposes.js to have a tilt slider without a position slider. If there is a more ideal way to do this let me know. 

I am still seeing this in the logs: 
```
No converter available for 'CP180335E-01' with cluster '64528' and type 'raw' and data '{"data":[13,99,18,77,128,192,213,224,128,254,2,0,0,0,0,88,63,0,0,207,65,0,255,0,0,107,0],"type":"Buffer"}'
```

I'm not quite sure what to do with that though but everything is working as expected.

This resolves this issue: Koenkk/zigbee2mqtt#7648