### PR TITLE
Add support for Wiser 40/300-Series Module Dimmers

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -108,6 +108,25 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['CH/DIMMER/1'],
+        model: '41EPBDWCLMZ/354PBDMBTZ',
+        vendor: 'Schneider Electric',
+        description: 'Wiser 40/300-Series Module Dimmer',
+        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.lighting_ballast_configuration],
+        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config],
+        exposes: [e.light_brightness(),
+            exposes.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the minimum light output of the ballast'),
+            exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the maximum light output of the ballast')],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(3);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['U201DST600ZB'],
         model: 'U201DST600ZB',
         vendor: 'Schneider Electric',


### PR DESCRIPTION
This PR adds support for the [Wiser 40/300-Series Dimmers](https://zigbeealliance.org/zigbee_products/wiser-40-300-series-module-dimmer-2/) `CH/DIMMER/1` devices.

It transpires they are very similar to the `NHROTARY/DIMMER/1`, but its a push button dimmer not a rotary one which is why I duplicated it rather than adding an additional model fingerprint to that stanza.

These are sold in New Zealand and Australia under the PDL/Clipsal brand, compatible with the Iconic range of sockets. They have a bunch of other zigbee-compatible devices on sale (switches, sensors, etc) but these are the only ones I have installed at the moment.