### PR TITLE
Improve cover expose

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -301,7 +301,7 @@ class Cover extends Base {
         super();
         this.type = 'cover';
         this.features = [];
-        this.features.push(new Binary('state', access.STATE_SET, 'OPEN', 'CLOSE'));
+        this.features.push(new Enum('state', access.STATE_SET, ['OPEN', 'CLOSE', 'STOP']));
     }
 
     withPosition() {


### PR DESCRIPTION
<img width="691" alt="Screen Shot 2021-06-03 at 18 11 24" src="https://user-images.githubusercontent.com/379665/120677213-21bbe580-c497-11eb-8f32-ab3424db693b.png">

Currently it is expose as Binary and looks like this, given that it never actually ends up in the state for the device as it just sends a command, using an Enum of the available commands makes more sense.

https://github.com/Koenkk/zigbee-herdsman-converters/blob/c60f3df7e942d698ea378d7d1813dd5f488a6e41/converters/toZigbee.js#L337-L345

It now looks like

<img width="927" alt="image" src="https://user-images.githubusercontent.com/379665/120678105-0f8e7700-c498-11eb-8c43-745334dc4b18.png">

