### PR TITLE
Don't divide battery for Axis Gear

### DIFF
--- a/devices/axis.js
+++ b/devices/axis.js
@@ -11,7 +11,6 @@ module.exports = [
         description: 'Gear window shade motor',
         fromZigbee: [fz.cover_position_tilt, fz.battery],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        meta: {battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);


### PR DESCRIPTION
Part of #2664, now it shows ~30% as described in the issue when using AC power with the device in the wrong mode. (Not found a mode switch yet)