### PR TITLE
TuYa TS0505A_led RGB+CCT LED overhaul

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1642,31 +1642,36 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             const result = {};
-
+      
             if (msg.data.hasOwnProperty('colorTemperature')) {
                 const value = Number(msg.data['colorTemperature']);
-                // Mapping from
-                // Warmwhite 0 -> 255 Coldwhite
-                // to Homeassistant: Coldwhite 153 -> 500 Warmwight
                 result.color_temp = mapNumberRange(value, 0, 255, 500, 153);
             }
-
+      
             if (msg.data.hasOwnProperty('tuyaBrightness')) {
                 result.brightness = msg.data['tuyaBrightness'];
             }
-
+      
+            if (msg.data.hasOwnProperty('tuyaRgbMode')) {
+                if (msg.data['tuyaRgbMode'] === 1) {
+                    result.color_mode = constants.colorMode[0];
+                } else {
+                    result.color_mode = constants.colorMode[2];
+                }
+            }
+      
             result.color = {};
-
+      
             if (msg.data.hasOwnProperty('currentHue')) {
                 result.color.hue = mapNumberRange(msg.data['currentHue'], 0, 254, 0, 360);
-                result.color.h = result.color.hue; // deprecated
+                result.color.h = result.color.hue;
             }
-
+      
             if (msg.data.hasOwnProperty('currentSaturation')) {
                 result.color.saturation = mapNumberRange(msg.data['currentSaturation'], 0, 254, 0, 100);
-                result.color.s = result.color.saturation; // deprecated
+                result.color.s = result.color.saturation;
             }
-
+      
             return result;
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1642,16 +1642,16 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             const result = {};
-      
+
             if (msg.data.hasOwnProperty('colorTemperature')) {
                 const value = Number(msg.data['colorTemperature']);
                 result.color_temp = mapNumberRange(value, 0, 255, 500, 153);
             }
-      
+
             if (msg.data.hasOwnProperty('tuyaBrightness')) {
                 result.brightness = msg.data['tuyaBrightness'];
             }
-      
+
             if (msg.data.hasOwnProperty('tuyaRgbMode')) {
                 if (msg.data['tuyaRgbMode'] === 1) {
                     result.color_mode = constants.colorMode[0];
@@ -1659,19 +1659,19 @@ const converters = {
                     result.color_mode = constants.colorMode[2];
                 }
             }
-      
+
             result.color = {};
-      
+
             if (msg.data.hasOwnProperty('currentHue')) {
                 result.color.hue = mapNumberRange(msg.data['currentHue'], 0, 254, 0, 360);
                 result.color.h = result.color.hue;
             }
-      
+
             if (msg.data.hasOwnProperty('currentSaturation')) {
                 result.color.saturation = mapNumberRange(msg.data['currentSaturation'], 0, 254, 0, 100);
                 result.color.s = result.color.saturation;
             }
-      
+
             return result;
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1672,7 +1672,7 @@ const converters = {
                 result.color.s = result.color.saturation;
             }
 
-            return result;
+            return Object.assign(result, libColor.syncColorState(result, meta.state, options));
         },
     },
     tuya_cover: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2266,114 +2266,118 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             if (key === 'brightness' && meta.state.color_mode == constants.colorMode[2] &&
                 !meta.message.hasOwnProperty('color') && !meta.message.hasOwnProperty('color_temp')) {
-                const payload = {level: value, transtime: 0};
+                const zclData = {level: Number(value), transtime: 0};
 
-                await entity.command('genLevelCtrl', 'moveToLevel', payload, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', zclData, utils.getOptions(meta.mapped, entity));
 
-                globalStore.putValue(entity, 'brightness', payload.level);
+                globalStore.putValue(entity, 'brightness', zclData.level);
 
-                return {state: {brightness: payload.level}};
+                return {state: {brightness: zclData.level}};
             }
 
             if (key === 'brightness' && meta.message.hasOwnProperty('color_temp')) {
-                const payload = {colortemp: utils.mapNumberRange(meta.message.color_temp, 500, 154, 0, 254), transtime: 0};
-                const payloadBrightness = {level: value, transtime: 0};
+                const zclData = {colortemp: utils.mapNumberRange(meta.message.color_temp, 500, 154, 0, 254), transtime: 0};
+                const zclDataBrightness = {level: Number(value), transtime: 0};
 
                 await entity.command('lightingColorCtrl', 'tuyaRgbMode', {enable: 0}, {}, {disableDefaultResponse: true});
-                await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
-                await entity.command('genLevelCtrl', 'moveToLevel', payloadBrightness, utils.getOptions(meta.mapped, entity));
+                await entity.command('lightingColorCtrl', 'moveToColorTemp', zclData, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', zclDataBrightness, utils.getOptions(meta.mapped, entity));
 
-                globalStore.putValue(entity, 'brightness', value);
+                globalStore.putValue(entity, 'brightness', zclDataBrightness.level);
 
-                return {
-                    state: {
-                        brightness: payloadBrightness.level,
-                        color_mode: constants.colorMode[2],
-                        color_temp: meta.message.color_temp,
-                    },
+                const newState = {
+                    brightness: zclDataBrightness.level,
+                    color_mode: constants.colorMode[2],
+                    color_temp: meta.message.color_temp,
                 };
+
+                return {state: libColor.syncColorState(newState, meta.state, meta.options), readAfterWriteTime: zclData.transtime * 100};
             }
 
             if (key === 'color_temp') {
-                const payload = {colortemp: utils.mapNumberRange(value, 500, 154, 0, 254), transtime: 0};
-                const payloadBrightness = {level: globalStore.getValue(entity, 'brightness') || 100, transtime: 0};
+                const zclData = {colortemp: utils.mapNumberRange(value, 500, 154, 0, 254), transtime: 0};
+                const zclDataBrightness = {level: globalStore.getValue(entity, 'brightness') || 100, transtime: 0};
 
                 await entity.command('lightingColorCtrl', 'tuyaRgbMode', {enable: 0}, {}, {disableDefaultResponse: true});
-                await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
-                await entity.command('genLevelCtrl', 'moveToLevel', payloadBrightness, utils.getOptions(meta.mapped, entity));
+                await entity.command('lightingColorCtrl', 'moveToColorTemp', zclData, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', zclDataBrightness, utils.getOptions(meta.mapped, entity));
 
-                return {state: {brightness: payloadBrightness.level, color_mode: constants.colorMode[2], color_temp: value}};
+                const newState = {
+                    brightness: zclDataBrightness.level,
+                    color_mode: constants.colorMode[2],
+                    color_temp: value,
+                };
+
+                return {state: libColor.syncColorState(newState, meta.state, meta.options), readAfterWriteTime: zclData.transtime * 100};
             }
 
-            const payload = {
+            const zclData = {
                 brightness: globalStore.getValue(entity, 'brightness') || 100,
-                hue: utils.mapNumberRange(meta.state.color.h, 0, 360, 0, 254),
-                saturation: utils.mapNumberRange(meta.state.color.s, 0, 100, 0, 254),
+                hue: utils.mapNumberRange(meta.state.color.h, 0, 360, 0, 254) || 100,
+                saturation: utils.mapNumberRange(meta.state.color.s, 0, 100, 0, 254) || 100,
                 transtime: 0,
             };
 
             if (value.h) {
-                payload.hue = utils.mapNumberRange(value.h, 0, 360, 0, 254);
+                zclData.hue = utils.mapNumberRange(value.h, 0, 360, 0, 254);
             }
             if (value.hue) {
-                payload.hue = utils.mapNumberRange(value.hue, 0, 360, 0, 254);
+                zclData.hue = utils.mapNumberRange(value.hue, 0, 360, 0, 254);
             }
             if (value.s) {
-                payload.saturation = utils.mapNumberRange(value.s, 0, 100, 0, 254);
+                zclData.saturation = utils.mapNumberRange(value.s, 0, 100, 0, 254);
             }
             if (value.saturation) {
-                payload.saturation = utils.mapNumberRange(value.saturation, 0, 100, 0, 254);
+                zclData.saturation = utils.mapNumberRange(value.saturation, 0, 100, 0, 254);
             }
             if (value.b) {
-                payload.brightness = value.b;
+                zclData.brightness = Number(value.b);
             }
             if (value.brightness) {
-                payload.brightness = value.brightness;
+                zclData.brightness = Number(value.brightness);
             }
             if (typeof value === 'number') {
-                payload.brightness = value;
+                zclData.brightness = value;
             }
 
             if (meta.message.hasOwnProperty('color')) {
                 if (meta.message.color.h) {
-                    payload.hue = utils.mapNumberRange(meta.message.color.h, 0, 360, 0, 254);
+                    zclData.hue = utils.mapNumberRange(meta.message.color.h, 0, 360, 0, 254);
                 }
                 if (meta.message.color.s) {
-                    payload.saturation = utils.mapNumberRange(meta.message.color.s, 0, 100, 0, 254);
+                    zclData.saturation = utils.mapNumberRange(meta.message.color.s, 0, 100, 0, 254);
                 }
                 if (meta.message.color.b) {
-                    payload.brightness = meta.message.color.b;
+                    zclData.brightness = meta.message.color.b;
                 }
                 if (meta.message.color.brightness) {
-                    payload.brightness = meta.message.color.brightness;
+                    zclData.brightness = Number(meta.message.color.brightness);
                 }
             }
 
             await entity.command('lightingColorCtrl', 'tuyaRgbMode', {enable: 1}, {}, {disableDefaultResponse: true});
             await entity.command('lightingColorCtrl', 'tuyaMoveToHueAndSaturationBrightness',
-                payload, utils.getOptions(meta.mapped, entity));
+                zclData, utils.getOptions(meta.mapped, entity));
 
-            globalStore.putValue(entity, 'brightness', payload.brightness);
+            globalStore.putValue(entity, 'brightness', zclData.brightness);
 
-            return {
-                state: {
-                    brightness: payload.brightness,
-                    color: {
-                        h: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
-                        hue: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
-                        s: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100),
-                        saturation: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100),
-                    },
-                    color_mode: constants.colorMode[0],
+            const newState = {
+                brightness: zclData.brightness,
+                color: {
+                    h: utils.mapNumberRange(zclData.hue, 0, 254, 0, 360),
+                    hue: utils.mapNumberRange(zclData.hue, 0, 254, 0, 360),
+                    s: utils.mapNumberRange(zclData.saturation, 0, 254, 0, 100),
+                    saturation: utils.mapNumberRange(zclData.saturation, 0, 254, 0, 100),
                 },
+                color_mode: constants.colorMode[0],
             };
+
+            return {state: libColor.syncColorState(newState, meta.state, meta.options), readAfterWriteTime: zclData.transtime * 100};
         },
         convertGet: async (entity, key, meta) => {
-            if (key === 'color') {
-                await entity.read('lightingColorCtrl', [
-                    'currentHue', 'currentSaturation', 'tuyaBrightness', 'tuyaRgbMode', 'colorTemperature',
-                ]);
-            }
+            await entity.read('lightingColorCtrl', [
+                'currentHue', 'currentSaturation', 'tuyaBrightness', 'tuyaRgbMode', 'colorTemperature',
+            ]);
         },
     },
     tuya_led_controller: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2262,8 +2262,8 @@ const converters = {
         },
     },
     tuya_led_control: {
-      key: ['brightness', 'color', 'color_temp'],
-      convertSet: async (entity, key, value, meta) => {
+        key: ['brightness', 'color', 'color_temp'],
+        convertSet: async (entity, key, value, meta) => {
           if (key === 'brightness' && meta.state.color_mode == constants.colorMode[2] && !meta.message.hasOwnProperty('color') && !meta.message.hasOwnProperty('color_temp')) {
               const payload = { level: value, transtime: 0 };
 
@@ -2286,7 +2286,7 @@ const converters = {
 
               return { state: { brightness: payload_brightness.level, color_mode: constants.colorMode[2], color_temp: meta.message.color_temp } };
           }
-    
+
           if (key === 'color_temp') {
               const payload = { colortemp: utils.mapNumberRange(value, 500, 154, 0, 254), transtime: 0 };
               const payload_brightness = { level: globalStore.getValue(entity, 'brightness') || 100, transtime: 0 };
@@ -2341,7 +2341,7 @@ const converters = {
                   payload.brightness = meta.message.color.brightness;
               }
           }
-    
+
           await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 1 }, {}, { disableDefaultResponse: true });         
           await entity.command('lightingColorCtrl', 'tuyaMoveToHueAndSaturationBrightness', payload, utils.getOptions(meta.mapped, entity));
 
@@ -2359,14 +2359,14 @@ const converters = {
                   color_mode: constants.colorMode[0]
               }
           };
-      },
-      convertGet: async (entity, key, meta) => {
+        },
+        convertGet: async (entity, key, meta) => {
           if (key === 'color') {
               await entity.read('lightingColorCtrl', [
                   'currentHue', 'currentSaturation', 'tuyaBrightness', 'tuyaRgbMode', 'colorTemperature',
               ]);
           }
-      },
+        },
     },
     tuya_led_controller: {
         key: ['state', 'color'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2361,11 +2361,11 @@ const converters = {
             };
         },
         convertGet: async (entity, key, meta) => {
-          if (key === 'color') {
-              await entity.read('lightingColorCtrl', [
-                  'currentHue', 'currentSaturation', 'tuyaBrightness', 'tuyaRgbMode', 'colorTemperature',
-              ]);
-          }
+            if (key === 'color') {
+                await entity.read('lightingColorCtrl', [
+                    'currentHue', 'currentSaturation', 'tuyaBrightness', 'tuyaRgbMode', 'colorTemperature',
+                ]);
+            }
         },
     },
     tuya_led_controller: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2264,38 +2264,45 @@ const converters = {
     tuya_led_control: {
         key: ['brightness', 'color', 'color_temp'],
         convertSet: async (entity, key, value, meta) => {
-            if (key === 'brightness' && meta.state.color_mode == constants.colorMode[2] && !meta.message.hasOwnProperty('color') && !meta.message.hasOwnProperty('color_temp')) {
-                const payload = { level: value, transtime: 0 };
+            if (key === 'brightness' && meta.state.color_mode == constants.colorMode[2] &&
+                !meta.message.hasOwnProperty('color') && !meta.message.hasOwnProperty('color_temp')) {
+                const payload = {level: value, transtime: 0};
 
                 await entity.command('genLevelCtrl', 'moveToLevel', payload, utils.getOptions(meta.mapped, entity));
 
                 globalStore.putValue(entity, 'brightness', payload.level);
 
-                return { state: { brightness: payload.level } };
+                return {state: {brightness: payload.level}};
             }
 
             if (key === 'brightness' && meta.message.hasOwnProperty('color_temp')) {
-                const payload = { colortemp: utils.mapNumberRange(meta.message.color_temp, 500, 154, 0, 254), transtime: 0 };
-                const payload_brightness = { level: value, transtime: 0 };
+                const payload = {colortemp: utils.mapNumberRange(meta.message.color_temp, 500, 154, 0, 254), transtime: 0};
+                const payloadBrightness = {level: value, transtime: 0};
 
-                await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 0 }, {}, { disableDefaultResponse: true });
+                await entity.command('lightingColorCtrl', 'tuyaRgbMode', {enable: 0}, {}, {disableDefaultResponse: true});
                 await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
-                await entity.command('genLevelCtrl', 'moveToLevel', payload_brightness, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', payloadBrightness, utils.getOptions(meta.mapped, entity));
 
                 globalStore.putValue(entity, 'brightness', value);
 
-                return { state: { brightness: payload_brightness.level, color_mode: constants.colorMode[2], color_temp: meta.message.color_temp } };
+                return {
+                    state: {
+                        brightness: payloadBrightness.level,
+                        color_mode: constants.colorMode[2],
+                        color_temp: meta.message.color_temp,
+                    },
+                };
             }
 
             if (key === 'color_temp') {
-                const payload = { colortemp: utils.mapNumberRange(value, 500, 154, 0, 254), transtime: 0 };
-                const payload_brightness = { level: globalStore.getValue(entity, 'brightness') || 100, transtime: 0 };
+                const payload = {colortemp: utils.mapNumberRange(value, 500, 154, 0, 254), transtime: 0};
+                const payloadBrightness = {level: globalStore.getValue(entity, 'brightness') || 100, transtime: 0};
 
-                await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 0 }, {}, { disableDefaultResponse: true });
+                await entity.command('lightingColorCtrl', 'tuyaRgbMode', {enable: 0}, {}, {disableDefaultResponse: true});
                 await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
-                await entity.command('genLevelCtrl', 'moveToLevel', payload_brightness, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', payloadBrightness, utils.getOptions(meta.mapped, entity));
 
-                return { state: { brightness: payload_brightness.level, color_mode: constants.colorMode[2], color_temp: value } };
+                return {state: {brightness: payloadBrightness.level, color_mode: constants.colorMode[2], color_temp: value}};
             }
 
             const payload = {
@@ -2327,7 +2334,7 @@ const converters = {
                 payload.brightness = value;
             }
 
-            if(meta.message.hasOwnProperty('color')) {
+            if (meta.message.hasOwnProperty('color')) {
                 if (meta.message.color.h) {
                     payload.hue = utils.mapNumberRange(meta.message.color.h, 0, 360, 0, 254);
                 }
@@ -2342,22 +2349,23 @@ const converters = {
                 }
             }
 
-            await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 1 }, {}, { disableDefaultResponse: true });         
-            await entity.command('lightingColorCtrl', 'tuyaMoveToHueAndSaturationBrightness', payload, utils.getOptions(meta.mapped, entity));
+            await entity.command('lightingColorCtrl', 'tuyaRgbMode', {enable: 1}, {}, {disableDefaultResponse: true});
+            await entity.command('lightingColorCtrl', 'tuyaMoveToHueAndSaturationBrightness',
+                payload, utils.getOptions(meta.mapped, entity));
 
             globalStore.putValue(entity, 'brightness', payload.brightness);
 
             return {
                 state: {
                     brightness: payload.brightness,
-                    color: { 
+                    color: {
                         h: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
                         hue: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
-                        s: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100), 
-                        saturation: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100)
+                        s: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100),
+                        saturation: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100),
                     },
-                    color_mode: constants.colorMode[0]
-                }
+                    color_mode: constants.colorMode[0],
+                },
             };
         },
         convertGet: async (entity, key, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2264,101 +2264,101 @@ const converters = {
     tuya_led_control: {
         key: ['brightness', 'color', 'color_temp'],
         convertSet: async (entity, key, value, meta) => {
-          if (key === 'brightness' && meta.state.color_mode == constants.colorMode[2] && !meta.message.hasOwnProperty('color') && !meta.message.hasOwnProperty('color_temp')) {
-              const payload = { level: value, transtime: 0 };
+            if (key === 'brightness' && meta.state.color_mode == constants.colorMode[2] && !meta.message.hasOwnProperty('color') && !meta.message.hasOwnProperty('color_temp')) {
+                const payload = { level: value, transtime: 0 };
 
-              await entity.command('genLevelCtrl', 'moveToLevel', payload, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', payload, utils.getOptions(meta.mapped, entity));
 
-              globalStore.putValue(entity, 'brightness', payload.level);
+                globalStore.putValue(entity, 'brightness', payload.level);
 
-              return { state: { brightness: payload.level } };
-          }
+                return { state: { brightness: payload.level } };
+            }
 
-          if (key === 'brightness' && meta.message.hasOwnProperty('color_temp')) {
-              const payload = { colortemp: utils.mapNumberRange(meta.message.color_temp, 500, 154, 0, 254), transtime: 0 };
-              const payload_brightness = { level: value, transtime: 0 };
+            if (key === 'brightness' && meta.message.hasOwnProperty('color_temp')) {
+                const payload = { colortemp: utils.mapNumberRange(meta.message.color_temp, 500, 154, 0, 254), transtime: 0 };
+                const payload_brightness = { level: value, transtime: 0 };
 
-              await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 0 }, {}, { disableDefaultResponse: true });
-              await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
-              await entity.command('genLevelCtrl', 'moveToLevel', payload_brightness, utils.getOptions(meta.mapped, entity));
+                await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 0 }, {}, { disableDefaultResponse: true });
+                await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', payload_brightness, utils.getOptions(meta.mapped, entity));
 
-              globalStore.putValue(entity, 'brightness', value);
+                globalStore.putValue(entity, 'brightness', value);
 
-              return { state: { brightness: payload_brightness.level, color_mode: constants.colorMode[2], color_temp: meta.message.color_temp } };
-          }
+                return { state: { brightness: payload_brightness.level, color_mode: constants.colorMode[2], color_temp: meta.message.color_temp } };
+            }
 
-          if (key === 'color_temp') {
-              const payload = { colortemp: utils.mapNumberRange(value, 500, 154, 0, 254), transtime: 0 };
-              const payload_brightness = { level: globalStore.getValue(entity, 'brightness') || 100, transtime: 0 };
+            if (key === 'color_temp') {
+                const payload = { colortemp: utils.mapNumberRange(value, 500, 154, 0, 254), transtime: 0 };
+                const payload_brightness = { level: globalStore.getValue(entity, 'brightness') || 100, transtime: 0 };
 
-              await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 0 }, {}, { disableDefaultResponse: true });
-              await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
-              await entity.command('genLevelCtrl', 'moveToLevel', payload_brightness, utils.getOptions(meta.mapped, entity));
+                await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 0 }, {}, { disableDefaultResponse: true });
+                await entity.command('lightingColorCtrl', 'moveToColorTemp', payload, utils.getOptions(meta.mapped, entity));
+                await entity.command('genLevelCtrl', 'moveToLevel', payload_brightness, utils.getOptions(meta.mapped, entity));
 
-              return { state: { brightness: payload_brightness.level, color_mode: constants.colorMode[2], color_temp: value } };
-          }
+                return { state: { brightness: payload_brightness.level, color_mode: constants.colorMode[2], color_temp: value } };
+            }
 
-          const payload = {
-              brightness: globalStore.getValue(entity, 'brightness') || 100,
-              hue: utils.mapNumberRange(meta.state.color.h, 0, 360, 0, 254),
-              saturation: utils.mapNumberRange(meta.state.color.s, 0, 100, 0, 254),
-              transtime: 0,
-          };
+            const payload = {
+                brightness: globalStore.getValue(entity, 'brightness') || 100,
+                hue: utils.mapNumberRange(meta.state.color.h, 0, 360, 0, 254),
+                saturation: utils.mapNumberRange(meta.state.color.s, 0, 100, 0, 254),
+                transtime: 0,
+            };
 
-          if (value.h) {
-              payload.hue = utils.mapNumberRange(value.h, 0, 360, 0, 254);
-          }
-          if (value.hue) {
-              payload.hue = utils.mapNumberRange(value.hue, 0, 360, 0, 254);
-          }
-          if (value.s) {
-              payload.saturation = utils.mapNumberRange(value.s, 0, 100, 0, 254);
-          }
-          if (value.saturation) {
-              payload.saturation = utils.mapNumberRange(value.saturation, 0, 100, 0, 254);
-          }
-          if (value.b) {
-              payload.brightness = value.b;
-          }
-          if (value.brightness) {
-              payload.brightness = value.brightness;
-          }
-          if (typeof value === 'number') {
-              payload.brightness = value;
-          }
+            if (value.h) {
+                payload.hue = utils.mapNumberRange(value.h, 0, 360, 0, 254);
+            }
+            if (value.hue) {
+                payload.hue = utils.mapNumberRange(value.hue, 0, 360, 0, 254);
+            }
+            if (value.s) {
+                payload.saturation = utils.mapNumberRange(value.s, 0, 100, 0, 254);
+            }
+            if (value.saturation) {
+                payload.saturation = utils.mapNumberRange(value.saturation, 0, 100, 0, 254);
+            }
+            if (value.b) {
+                payload.brightness = value.b;
+            }
+            if (value.brightness) {
+                payload.brightness = value.brightness;
+            }
+            if (typeof value === 'number') {
+                payload.brightness = value;
+            }
 
-          if(meta.message.hasOwnProperty('color')) {
-              if (meta.message.color.h) {
-                  payload.hue = utils.mapNumberRange(meta.message.color.h, 0, 360, 0, 254);
-              }
-              if (meta.message.color.s) {
-                  payload.saturation = utils.mapNumberRange(meta.message.color.s, 0, 100, 0, 254);
-              }
-              if (meta.message.color.b) {
-                  payload.brightness = meta.message.color.b;
-              }
-              if (meta.message.color.brightness) {
-                  payload.brightness = meta.message.color.brightness;
-              }
-          }
+            if(meta.message.hasOwnProperty('color')) {
+                if (meta.message.color.h) {
+                    payload.hue = utils.mapNumberRange(meta.message.color.h, 0, 360, 0, 254);
+                }
+                if (meta.message.color.s) {
+                    payload.saturation = utils.mapNumberRange(meta.message.color.s, 0, 100, 0, 254);
+                }
+                if (meta.message.color.b) {
+                    payload.brightness = meta.message.color.b;
+                }
+                if (meta.message.color.brightness) {
+                    payload.brightness = meta.message.color.brightness;
+                }
+            }
 
-          await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 1 }, {}, { disableDefaultResponse: true });         
-          await entity.command('lightingColorCtrl', 'tuyaMoveToHueAndSaturationBrightness', payload, utils.getOptions(meta.mapped, entity));
+            await entity.command('lightingColorCtrl', 'tuyaRgbMode', { enable: 1 }, {}, { disableDefaultResponse: true });         
+            await entity.command('lightingColorCtrl', 'tuyaMoveToHueAndSaturationBrightness', payload, utils.getOptions(meta.mapped, entity));
 
-          globalStore.putValue(entity, 'brightness', payload.brightness);
+            globalStore.putValue(entity, 'brightness', payload.brightness);
 
-          return {
-              state: {
-                  brightness: payload.brightness,
-                  color: { 
-                      h: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
-                      hue: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
-                      s: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100), 
-                      saturation: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100)
-                  },
-                  color_mode: constants.colorMode[0]
-              }
-          };
+            return {
+                state: {
+                    brightness: payload.brightness,
+                    color: { 
+                        h: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
+                        hue: utils.mapNumberRange(payload.hue, 0, 254, 0, 360),
+                        s: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100), 
+                        saturation: utils.mapNumberRange(payload.saturation, 0, 254, 0, 100)
+                    },
+                    color_mode: constants.colorMode[0]
+                }
+            };
         },
         convertGet: async (entity, key, meta) => {
           if (key === 'color') {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2348,7 +2348,7 @@ const converters = {
                     zclData.saturation = utils.mapNumberRange(meta.message.color.s, 0, 100, 0, 254);
                 }
                 if (meta.message.color.b) {
-                    zclData.brightness = meta.message.color.b;
+                    zclData.brightness = Number(meta.message.color.b);
                 }
                 if (meta.message.color.brightness) {
                     zclData.brightness = Number(meta.message.color.brightness);

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -358,7 +358,7 @@ module.exports = [
         description: 'RGB+CCT LED',
         toZigbee: [tz.on_off, tz.tuya_led_control],
         fromZigbee: [fz.on_off, fz.tuya_led_controller, fz.brightness, fz.ignore_basic_report],
-        exposes: [e.light_brightness_colortemp_colorhs().removeFeature('color_temp_startup')],
+        exposes: [e.light_brightness_colortemp_colorhs([153, 500]).removeFeature('color_temp_startup')],
     },
     {
         zigbeeModel: ['TS0505A'],


### PR DESCRIPTION
This fixes some behavior of the bulb and supports the `color_mode` attribute used by HA.

Since this bulb behaves somewhat different than what we else have, the code looks a bit ugly in my opinion, but it works now in all modes and remembers even the brightness between `color_temp` and `color` mode correctly.

I'm open for corrections and enhancements before merging of course.