### PR TITLE
Add fingerprint for eWeLight ZB-CL02.

### DIFF
--- a/devices/lonsonho.js
+++ b/devices/lonsonho.js
@@ -141,7 +141,8 @@ module.exports = [
     },
     {
         zigbeeModel: ['ZB-RGBCW'],
-        fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'}, {modelID: 'ZB-CL02', manufacturerName: 'eWeLight'}],
+        fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'}, 
+            {modelID: 'ZB-CL02', manufacturerName: 'eWeLight'}],
         model: 'ZB-RGBCW',
         vendor: 'Lonsonho',
         description: 'Zigbee 3.0 LED-bulb, RGBW LED',

--- a/devices/lonsonho.js
+++ b/devices/lonsonho.js
@@ -141,7 +141,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['ZB-RGBCW'],
-        fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'}],
+        fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'}, {modelID: 'ZB-CL02', manufacturerName: 'eWeLight'}],
         model: 'ZB-RGBCW',
         vendor: 'Lonsonho',
         description: 'Zigbee 3.0 LED-bulb, RGBW LED',

--- a/devices/lonsonho.js
+++ b/devices/lonsonho.js
@@ -141,7 +141,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['ZB-RGBCW'],
-        fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'}, 
+        fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'},
             {modelID: 'ZB-CL02', manufacturerName: 'eWeLight'}],
         model: 'ZB-RGBCW',
         vendor: 'Lonsonho',


### PR DESCRIPTION
Add device fingerprint for ZB-CL02 GU10 bulb. Pretty much identical to ZB-CL01, with slightly different LED colours. Working perfectly with HASS via zigbee2mqtt with this definition.