### PR TITLE
Add support for toggle command on Legrand 067773

### DIFF
--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -106,7 +106,7 @@ module.exports = [
         // led blink RED when battery is low
         description: 'Wireless remote switch',
         fromZigbee: [fz.identify, fz.command_on, fz.command_off, fz.command_toggle, fz.legacy.cmd_move, fz.legacy.cmd_stop, fz.battery],
-        exposes: [e.battery(), e.action(['identify', 'on', 'off', 'toggle', 'brightness_move_up', 
+        exposes: [e.battery(), e.action(['identify', 'on', 'off', 'toggle', 'brightness_move_up',
             'brightness_move_down', 'brightness_stop'])],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2500'}},

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -106,7 +106,8 @@ module.exports = [
         // led blink RED when battery is low
         description: 'Wireless remote switch',
         fromZigbee: [fz.identify, fz.command_on, fz.command_off, fz.command_toggle, fz.legacy.cmd_move, fz.legacy.cmd_stop, fz.battery],
-        exposes: [e.battery(), e.action(['identify', 'on', 'off', 'toggle', 'brightness_move_up', 'brightness_move_down', 'brightness_stop'])],
+        exposes: [e.battery(), e.action(['identify', 'on', 'off', 'toggle', 'brightness_move_up', 
+            'brightness_move_down', 'brightness_stop'])],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -105,8 +105,8 @@ module.exports = [
         vendor: 'Legrand',
         // led blink RED when battery is low
         description: 'Wireless remote switch',
-        fromZigbee: [fz.identify, fz.command_on, fz.command_off, fz.legacy.cmd_move, fz.legacy.cmd_stop, fz.battery],
-        exposes: [e.battery(), e.action(['identify', 'on', 'off', 'brightness_move_up', 'brightness_move_down', 'brightness_stop'])],
+        fromZigbee: [fz.identify, fz.command_on, fz.command_off, fz.command_toggle, fz.legacy.cmd_move, fz.legacy.cmd_stop, fz.battery],
+        exposes: [e.battery(), e.action(['identify', 'on', 'off', 'toggle', 'brightness_move_up', 'brightness_move_down', 'brightness_stop'])],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
From my understanding, old firmwares supported actions `on` and `off`,
while new firmwares only support action `toggle`.
I suppose that adding action `toggle` would allow to support all
firmware versions.

More details here:
https://github.com/Koenkk/zigbee2mqtt/issues/2399#issuecomment-850793482
https://github.com/Koenkk/zigbee2mqtt/issues/2399#issuecomment-862707311