### PR TITLE
Add support for Sengled E11-N1G Vintage Bulb

### DIFF
--- a/devices/sengled.js
+++ b/devices/sengled.js
@@ -186,7 +186,7 @@ module.exports = [
         zigbeeModel: ['E11-N1G'],
         model: 'E11-N1G',
         vendor: 'Sengled',
-        description: 'Vintage LED Edison Bulb (ST19)',
+        description: 'Vintage LED edison bulb (ST19)',
         extend: extend.light_onoff_brightness(),
     },
 ];

--- a/devices/sengled.js
+++ b/devices/sengled.js
@@ -182,4 +182,11 @@ module.exports = [
         exposes: [e.action(['on', 'up', 'down', 'off', 'on_double', 'on_long', 'off_double', 'off_long'])],
         toZigbee: [],
     },
+    {
+        zigbeeModel: ['E11-N1G'],
+        model: 'E11-N1G',
+        vendor: 'Sengled',
+        description: 'Vintage LED Edison Bulb (ST19)',
+        extend: extend.light_onoff_brightness(),
+    },
 ];


### PR DESCRIPTION
Adds support for [Sengled E11-N1G vintage bulbs](https://www.amazon.com/gp/product/B08FL9CJDZ/ref=ppx_yo_dt_b_asin_title_o01_s00?ie=UTF8&th=1). 