### PR TITLE
Add support for Ledvance Outdoor Plug, compact version

### DIFF
--- a/devices/ledvance.js
+++ b/devices/ledvance.js
@@ -4,7 +4,7 @@ const extend = require('../lib/extend');
 module.exports = [
     {
         zigbeeModel: ['Outdoor Plug', 'Plug Value'],
-        model: 'AC26940',
+        model: 'AC26940/AC31266',
         vendor: 'LEDVANCE',
         description: 'Smart Zigbee outdoor plug',
         extend: extend.switch(),


### PR DESCRIPTION
In addition to the recently added [Ledvance Outdoor Plug](https://shop.ledvance.com/products/smart-outdoor-plug-eu) (white, with cord) there is a [new, compact version](https://www.ledvance.com/consumer/products/smart-home/smart-home-products-with-zigbee-technology/smart-home-components/smart-compact-outdoor-plug-c141283) (anthracite, only a plug without power cord) with type `AC31266`.