### PR TITLE
Add running_state reporting to Sinope thermostat

### DIFF
--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -34,6 +34,10 @@ module.exports = [
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
             await reporting.thermostatSystemMode(endpoint, {min: 1, max: 0});
 
+            try {
+                await reporting.thermostatRunningState(endpoint);
+            } catch (error) {/* Not all support this */}
+
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {min: 10, max: 303, change: [1, 1]});
             try {
@@ -80,6 +84,10 @@ module.exports = [
             await reporting.thermostatTemperature(endpoint, {min: 10, max: 300, change: 20});
             await reporting.thermostatPIHeatingDemand(endpoint, {min: 10, max: 301, change: 5});
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
+
+            try {
+                await reporting.thermostatRunningState(endpoint);
+            } catch (error) {/* Not all support this */}
 
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {min: 10, max: 303, change: [1, 1]});
@@ -137,6 +145,10 @@ module.exports = [
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
 
             try {
+                await reporting.thermostatRunningState(endpoint);
+            } catch (error) {/* Not all support this */}
+
+            try {
                 await reporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
             } catch (error) {
                 // Not all support this: https://github.com/Koenkk/zigbee2mqtt/issues/3760
@@ -169,6 +181,10 @@ module.exports = [
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
+
+            try {
+                await reporting.thermostatRunningState(endpoint);
+            } catch (error) {/* Do nothing*/}
         },
     },
     {
@@ -191,6 +207,10 @@ module.exports = [
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
+
+            try {
+                await reporting.thermostatRunningState(endpoint);
+            } catch (error) {/* Do nothing*/}
         },
     },
     {

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -1756,7 +1756,9 @@ const fromZigbee = {
             const result = {};
             const piHeatingDemand = msg.data['pIHeatingDemand'];
             if (typeof piHeatingDemand == 'number') {
+                // DEPRECATED: only return running_state here (change operation -> running_state)
                 result.operation = piHeatingDemand >= 10 ? 'heating' : 'idle';
+                result.running_state = piHeatingDemand >= 10 ? 'heat' : 'idle';
             }
             return result;
         },


### PR DESCRIPTION
HA MQTT generates  warnings for Sinope thermostat, "running_state" not defined. This issue affect all Sinope thermostats.

This commit solve this by:
1. adding reporting of thermostatRunningState.
2. setting running_state according to piHeathingDemand update in legacy.sinope_thermostat_state(). This is required for thermostat firmware version that don't support running_state reporting...
