### PR TITLE
SMSZB-120: Updated with OTA, added fw-attribute ++

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -805,6 +805,20 @@ const converters = {
             };
         },
     },
+    ias_smoke_alarm_1_develco: {
+        cluster: 'ssIasZone',
+        type: 'commandStatusChangeNotification',
+        convert: (model, msg, publish, options, meta) => {
+            const zoneStatus = msg.data.zonestatus;
+            return {
+                smoke: (zoneStatus & 1) > 0,
+                battery_low: (zoneStatus & 1<<3) > 0,
+                supervision_reports: (zoneStatus & 1<<4) > 0,
+                restore_reports: (zoneStatus & 1<<5) > 0,
+                test: (zoneStatus & 1<<8) > 0,
+            };
+        },
+    },
     ias_contact_alarm_1: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -6036,6 +6050,17 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const scenes = {2: '1', 52: '2', 102: '3', 153: '4', 194: '5', 254: '6'};
             return {action: `scene_${scenes[msg.data.level]}`};
+        },
+    },
+    smszb120_fw: {
+        cluster: 'genBasic',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result = {};
+            if (0x8000 in msg.data) {
+                result.current_firmware = msg.data[0x8000].join(".");
+            }
+            return result;
         },
     },
     // #endregion

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -6058,7 +6058,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const result = {};
             if (0x8000 in msg.data) {
-                result.current_firmware = msg.data[0x8000].join(".");
+                result.current_firmware = msg.data[0x8000].join('.');
             }
             return result;
         },

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -140,13 +140,17 @@ module.exports = [
         model: 'SMSZB-120',
         vendor: 'Develco',
         description: 'Smoke detector with siren',
-        fromZigbee: [fz.temperature, fz.battery, fz.ias_smoke_alarm_1, fz.ignore_basic_report, fz.ignore_genOta],
+        fromZigbee: [fz.temperature, fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report, fz.smszb120_fw],
         toZigbee: [tz.warning],
+        ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         configure: async (device, coordinatorEndpoint, logger) => {
+            const options = {manufacturerCode: 4117};
             const endpoint = device.getEndpoint(35);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'genBasic']);
             await reporting.batteryVoltage(endpoint);
+            await endpoint.read('genBasic', [0x8000], options);
+
             const endpoint2 = device.getEndpoint(38);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.temperature(endpoint2, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -3,6 +3,7 @@ const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/lega
 const tz = require('../converters/toZigbee');
 const constants = require('../lib/constants');
 const reporting = require('../lib/reporting');
+const ota = require('../lib/ota');
 const e = exposes.presets;
 const ea = exposes.access;
 

--- a/devices/heimgard.js
+++ b/devices/heimgard.js
@@ -1,0 +1,27 @@
+const exposes = require('../lib/exposes');
+const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const tz = require('../converters/toZigbee');
+const ota = require('../lib/ota');
+const reporting = require('../lib/reporting');
+const constants = require('../lib/constants');
+const {repInterval} = require('../lib/constants');
+const e = exposes.presets;
+const ea = exposes.access;
+
+module.exports = [
+    {
+        zigbeeModel: ['HC-SLM-1'],
+        model: 'HC-SLM-1',
+        vendor: 'Home Control AS',
+        description: 'Heimgard (Wattle) Door Lock Pro',
+        fromZigbee: [fz.lock, fz.battery],
+        toZigbee: [tz.lock],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await reporting.lockState(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+        exposes: [e.lock(), e.battery()],
+    };
+];


### PR DESCRIPTION
@Koenkk 

- Added support for OTA
- Added `current_firmware` attribute to `fromZigbee` and updated device
- Added `ias_smoke_alarm_1_develco` to `fromZigbee` and updated device

Reason for modified `ias_smoke_alarm_1_develco`:
SMSZB-120 do not support `tamper`, `trouble `and `ac_status `and will give wrong impression to users about supported features.

Please note the `common.js` and L129-issue regarding OTA with this merge. I still hope you will accept this PR for the July-release 👍 