### PR TITLE
Update nue_3a.js

### DIFF
--- a/devices/nue_3a.js
+++ b/devices/nue_3a.js
@@ -275,4 +275,11 @@ module.exports = [
         description: 'Smart Zigbee 3.0 strip light controller',
         extend: extend.light_onoff_brightness_colortemp_color(),
     },
+    {
+        zigbeeModel: ['LXN60-LS27-Z30'],
+        model: 'WL-SD001-9W',
+        vendor: 'Nue / 3A',
+        description: '9W RGB LED downlight',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
+    },
 ];


### PR DESCRIPTION
Add support for new Nue / 3A WL-SD001-9W RGB Downlight. It has less color_temp range than currently defined Nue / 3A lights.