### PR TITLE
Add support for zigbeeModel LWF001, which is also model 9290011370B

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1069,7 +1069,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LWF002', 'LWW001'],
+        zigbeeModel: ['LWF001', 'LWF002', 'LWW001'],
         model: '9290011370B',
         vendor: 'Philips',
         description: 'Hue white A60 bulb E27',


### PR DESCRIPTION
I have several Philips Hue A60 E27 light bulbs which have the model number 9290011370B. This model number is also printed directly onto the light bulbs. These light bulbs are connected with the zigbeeModel LWF001. I tried this zigbeeModel with an external converter and this works pretty well. I can control and handle all lights like my other HUE LWW001. So we have to add only the new zigbeeModel to the existing converter.