### PR TITLE
Added another model ID

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -77,7 +77,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['PUCK/SWITCH/1'],
-        model: 'CCT5011-0001/MEG5011-0001',
+        model: 'CCT5011-0001/CCT5011-0002/MEG5011-0001',
         vendor: 'Schneider Electric',
         description: 'Micro module switch',
         extend: extend.switch(),


### PR DESCRIPTION
Obviously the second generation Wiser light switch has the same zigbee model ID as the first generation. 
https://www.se.com/ww/en/product/CCT5011-0002/wiser-micro-module-light-switch/