### PR TITLE
sinope: add WL4200S sensor

### DIFF
--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -284,4 +284,13 @@ module.exports = [
         toZigbee: [],
         exposes: [e.water_leak(), e.battery_low(), e.tamper()],
     },
+    {
+        zigbeeModel: ['WL4200S'],
+        model: 'WL4200S',
+        vendor: 'Sinope',
+        description: 'Zigbee smart water leak detector',
+        fromZigbee: [fz.ias_water_leak_alarm_1],
+        toZigbee: [],
+        exposes: [e.water_leak(), e.battery_low(), e.tamper()],
+    },
 ];


### PR DESCRIPTION
This adds the WL4200S sensor, which is the same as the WL4200 but has a remote sensor (i.e. "extension cord") that you can put somewhere without putting the whole device there.

Product page:
https://www.sinopetech.com/en/product/smart-water-leak-detector-with-sensor-zigbee/

I've been running this as an external converter for the past few weeks and it seems to work fine.