### PR TITLE
Remove explicit post-fixing of return states with meta.endpoint_name in toZigbee converters.

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3980,7 +3980,7 @@ const converters = {
             };
             await entity.write('genOnOffSwitchCfg', payloads[key]);
 
-            return {state: {[`${key}_${meta.endpoint_name}`]: value}};
+            return {state: {[`${key}`]: value}};
         },
     },
     TYZB01_on_off: {


### PR DESCRIPTION
See https://github.com/Koenkk/zigbee2mqtt/commit/1985e2451797adbd91496012e869e151aa0fe7f6