### PR TITLE
Add battery voltage support for 3RSS009Z

### DIFF
--- a/devices/third_reality.js
+++ b/devices/third_reality.js
@@ -11,9 +11,9 @@ module.exports = [
         model: '3RSS009Z',
         vendor: 'Third Reality',
         description: 'Smart switch Gen3',
-        fromZigbee: [fz.on_off],
+        fromZigbee: [fz.on_off, fz.battery],
         toZigbee: [tz.on_off, tz.ignore_transition],
-        exposes: [e.switch()],
+        exposes: [e.switch(), e.battery_voltage()],
     },
     {
         zigbeeModel: ['3RSS008Z'],


### PR DESCRIPTION
This device reports the `genPowerCfg` cluster but I'm not sure if I've configured the device to expose it correctly.