### PR TITLE
Makes ID-EU20FW09 whiteLabel of ID-UK21FW09

### DIFF
--- a/devices/ecodim.js
+++ b/devices/ecodim.js
@@ -11,7 +11,6 @@ module.exports = [
         vendor: 'EcoDim',
         description: 'Zigbee & Z-wave dimmer ',
         extend: extend.light_onoff_brightness({noConfigure: true}),
-        whiteLabel: [{vendor: 'Iolloi', model: 'ID-EU20FW09'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);

--- a/devices/iolloi.js
+++ b/devices/iolloi.js
@@ -8,6 +8,7 @@ module.exports = [
         vendor: 'Iolloi',
         description: 'Zigbee LED smart dimmer switch',
         extend: extend.light_onoff_brightness({noConfigure: true}),
+        whiteLabel: [{vendor: 'Iolloi', model: 'ID-EU20FW09'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Following up on this: https://github.com/Koenkk/zigbee2mqtt.io/pull/716#issuecomment-875450341

As the manufacturer is HZC, that matches the Iolloi definition, so I'm moving the white-label association.