### PR TITLE
New zigbeeModel for Lily XL lights

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1664,7 +1664,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['1746230V7'],
+        zigbeeModel: ['1746230V7', '1746230P7'],
         model: '1746230V7',
         vendor: 'Philips',
         description: 'Hue Lily XL outdoor spot light',


### PR DESCRIPTION
It seems the new Lily XL spot lights have a slightly different zigbee model because... well .. philips hue :).
I've tested this change on my own hass installation and it seems to work.