### PR TITLE
Correct hue_move behaviour in from.Zigbee

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1262,8 +1262,8 @@ const converters = {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
         convert: (model, msg, publish, options, meta) => {
-            const moveStop = msg.data.movemode == 1 ? 'move' : 'stop';
-            const action = postfixWithEndpointName(`hue_${moveStop}`, msg, model); 
+            const movestop = msg.data.movemode == 1 ? 'move' : 'stop';
+            const action = postfixWithEndpointName(`hue_${movestop}`, msg, model); 
             const payload = {action, action_rate: msg.data.rate};
             addActionGroup(payload, msg, model);
             return payload;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1263,7 +1263,7 @@ const converters = {
         type: 'commandMoveHue',
         convert: (model, msg, publish, options, meta) => {
             const movestop = msg.data.movemode == 1 ? 'move' : 'stop';
-            const action = postfixWithEndpointName(`hue_${movestop}`, msg, model); 
+            const action = postfixWithEndpointName(`hue_${movestop}`, msg, model);
             const payload = {action, action_rate: msg.data.rate};
             addActionGroup(payload, msg, model);
             return payload;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1262,8 +1262,8 @@ const converters = {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
         convert: (model, msg, publish, options, meta) => {
-            const move_stop = msg.data.movemode == 1 ? 'move' : 'stop';
-            const action = postfixWithEndpointName(`hue_${move_stop}`, msg, model); 
+            const moveStop = msg.data.movemode == 1 ? 'move' : 'stop';
+            const action = postfixWithEndpointName(`hue_${moveStop}`, msg, model); 
             const payload = {action, action_rate: msg.data.rate};
             addActionGroup(payload, msg, model);
             return payload;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1262,7 +1262,9 @@ const converters = {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
         convert: (model, msg, publish, options, meta) => {
-            const payload = {action: postfixWithEndpointName('hue_move', msg, model)};
+            const move_stop = msg.data.movemode == 1 ? 'move' : 'stop';
+            const action = postfixWithEndpointName(`hue_${move_stop}`, msg, model); 
+            const payload = {action, action_rate: msg.data.rate};
             addActionGroup(payload, msg, model);
             return payload;
         },


### PR DESCRIPTION
Pass action_rate information and interpret movemode to be 'move' or 'stop' to mimic brightness_move / brightness_stop