### PR TITLE
Add the 1-spot version of the Philips Hue Adore spotlight

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -709,6 +709,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['3417831P6'],
+        model: '3417831P6',
+        vendor: 'Philips',
+        description: 'Hue white ambiance Adore spotlight with Bluetooth (1 spot)',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['3418131P6'],
         model: '3418131P6',
         vendor: 'Philips',


### PR DESCRIPTION
There's also a 1-spot version of the Adore spotlight (2-spot and 3-spot versions already supported), with model number 3417831P6. Works exactly as expected when adopted with an external converter.