### PR TITLE
Disable light effect on ID-UK21FW09

### DIFF
--- a/devices/iolloi.js
+++ b/devices/iolloi.js
@@ -7,7 +7,7 @@ module.exports = [
         model: 'ID-UK21FW09',
         vendor: 'Iolloi',
         description: 'Zigbee LED smart dimmer switch',
-        extend: extend.light_onoff_brightness({noConfigure: true}),
+        extend: extend.light_onoff_brightness({noConfigure: true, disableEffect: true}),
         whiteLabel: [{vendor: 'Iolloi', model: 'ID-EU20FW09'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);


### PR DESCRIPTION
The Iolloi ID-UK21FW09 does not support any light effects, so disabling this now.