### PR TITLE
Added support for LED1936G5

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -95,7 +95,7 @@ module.exports = [
         model: 'LED1936G5',
         vendor: 'IKEA',
         description: 'TRADFRI LED globe-bulb E27 470 lumen, dimmable, white spectrum, opal white',
-        extend: ttradfriExtend.light_onoff_brightness_colortemp(),
+        extend: tradfriExtend.light_onoff_brightness_colortemp(),
     },
     {
         zigbeeModel: ['TRADFRI bulb E27 opal 470lm', 'TRADFRI bulb E27 W opal 470lm', 'TRADFRIbulbT120E27WSopal470lm'],

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -91,6 +91,13 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
+        zigbeeModel: ['TRADFRIbulbG125E27WSopal470lm'],
+        model: 'LED1936G5',
+        vendor: 'IKEA',
+        description: 'TRADFRI LED globe-bulb E27 470 lumen, dimmable, white spectrum, opal white',
+        extend: ttradfriExtend.light_onoff_brightness_colortemp(),
+    },
+    {
         zigbeeModel: ['TRADFRI bulb E27 opal 470lm', 'TRADFRI bulb E27 W opal 470lm', 'TRADFRIbulbT120E27WSopal470lm'],
         model: 'LED1937T5',
         vendor: 'IKEA',


### PR DESCRIPTION
https://www.ikea.com/de/de/p/tradfri-led-leuchtmittel-e27-470-lm-kabellos-dimmbar-weissspektrum-rund-frostglas-weiss-20441333/
LED1936G5 is just the globe version to LED1937T5