### PR TITLE
Fix TS0601 (_TZE200_azqp6ssj)

### DIFF
--- a/devices/saswell.js
+++ b/devices/saswell.js
@@ -14,7 +14,7 @@ module.exports = [
             {modelID: 'w7cahqs\u0000', manufacturerName: '_TYST11_yw7cahqs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_c88teujp'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'},
-            {modelId: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuhszj9s'},
         ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',


### PR DESCRIPTION
The device is not supported correctly, it looks as though the issue is
an invalid key used when exporting the module (`Id` instead of `ID`)