### PR TITLE
Add support for Philips Hue Lucca Pedestal(1740293P0)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -324,6 +324,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['1740293P0'],
+        model: '1740293P0',
+        vendor: 'Philips',
+        description: 'Hue Lucca Pedestal',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LCC001'],
         model: '4090531P7',
         vendor: 'Philips',


### PR DESCRIPTION
- Support for Philips Hue Lucca Pedestal added.

Not sure what naming convention to use here.
The pedestal "just" contains a Philips Hue zigbee/bluetooth bulb (1740293P0)

Is is this correct convention ?

Sorry for the ignorance, I'm a first time contributor.  