### PR TITLE
Fix xiaomi_switch_operation_mode_basic converter

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1761,7 +1761,7 @@ const converters = {
             // 1/2 gang switches using genBasic on endpoint 1.
             let attrId;
             let attrValue;
-            if (meta.mapped.meta.multiEndpoint) {
+            if (meta.mapped.meta && meta.mapped.meta.multiEndpoint) {
                 attrId = {left: 0xFF22, right: 0xFF23}[meta.endpoint_name];
                 // Allow usage of control_relay for 2 gang switches by mapping it to the default side.
                 if (targetValue === 'control_relay') {
@@ -1790,7 +1790,7 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             let attrId;
-            if (meta.mapped.meta.multiEndpoint) {
+            if (meta.mapped.meta && meta.mapped.meta.multiEndpoint) {
                 attrId = {left: 0xFF22, right: 0xFF23}[meta.endpoint_name];
                 if (attrId == null) {
                     throw new Error(`Unsupported endpoint ${meta.endpoint_name} for getting operation_mode.`);


### PR DESCRIPTION
Fix empty meta

```
0|npm  | Zigbee2MQTT:error 2021-07-24 11:28:19: Publish 'get' 'operation_mode' to '0x00158d00044e3fae' failed: 'TypeError: Cannot read property 'multiEndpoint' of undefined'
0|npm  | Zigbee2MQTT:debug 2021-07-24 11:28:19: TypeError: Cannot read property 'multiEndpoint' of undefined
0|npm  |     at Object.convertGet (/home/nur/src/zigbee2mqtt/node_modules/zigbee-herdsman-converters/converters/toZigbee.js:1793:34)
```