### PR TITLE
Fix Yookee D10110 support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5035,12 +5035,12 @@ const converters = {
     D10110_cover_position_tilt: {
         cluster: 'closuresWindowCovering',
         type: ['attributeReport', 'readResponse'],
-        convert: async (model, msg, publish, options, meta) => {
+        convert: (model, msg, publish, options, meta) => {
             if (msg.data.hasOwnProperty('currentPositionLiftPercentage') && msg.data['currentPositionLiftPercentage'] <= 100) {
                 // The Yookee D10110 SENDs it's position reversed, relative to the spec.
-                msg.data['currentPositionLiftPercentage'] = 100 - (msg.data['currentPositionLiftPercentage'] + 1);
+                msg.data['currentPositionLiftPercentage'] = 100 - msg.data['currentPositionLiftPercentage'];
             }
-            return await converters.cover_position_tilt.convert(model, msg, publish, options, meta);
+            return converters.cover_position_tilt.convert(model, msg, publish, options, meta);
         },
     },
     PGC410EU_presence: {


### PR DESCRIPTION
Some recent commits broke the D10110 support I think. This fixes it up. Also fix the off-by-one, which no longer seems to exhibit since resetting/reprogramming my blinds fully. Will provide the reset/update procedure for zigbee2mqtt docs soon.