### PR TITLE
Fix `hue_power_on_color` action to use refactored color library

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1619,8 +1619,8 @@ const converters = {
                             await entity.write('lightingColorCtrl', {0x0004: {value: 0xFFFF, type: 0x21}}, manufacturerOptions.hue);
                         }
                     } else if (meta.message.hasOwnProperty('hue_power_on_color')) {
-                        const xy = utils.hexToXY(meta.message.hue_power_on_color);
-                        value = {x: utils.mapNumberRange(xy.x, 0, 1, 0, 65535), y: utils.mapNumberRange(xy.y, 0, 1, 0, 65535)};
+                        const colorXY = libColor.ColorRGB.fromHex(meta.message.hue_power_on_color).toXY();
+                        value = {x: utils.mapNumberRange(colorXY.x, 0, 1, 0, 65535), y: utils.mapNumberRange(colorXY.y, 0, 1, 0, 65535)};
 
                         // Set colortemp to default
                         if (supports.colorTemperature) {


### PR DESCRIPTION
This applies the lib changes from https://github.com/Koenkk/zigbee-herdsman-converters/pull/2453 to Hue power on hex color conversion.

Previously, trying to set the power on color resulted in an error since the function no longer exists:

    TypeError: utils.hexToXY is not a function