### PR TITLE
Add HLC610 converter for iLightsIn

### DIFF
--- a/devices/ilightsin.js
+++ b/devices/ilightsin.js
@@ -1,0 +1,11 @@
+const extend = require('../lib/extend');
+
+module.exports = [
+    {
+        zigbeeModel: ['053'],
+        model: 'HLC610',
+        vendor: 'iLightsIn',
+        description: '1-10V dimming LED controller',
+        extend: extend.light_onoff_brightness(),
+    },
+];


### PR DESCRIPTION
I just added this device to my home via zigbee2mqtt. It works well with this converter.

Product info: https://www.ilightsin.com/index.html#/product?fId=40003. Screenshot for historical reasons:

<img width="970" alt="image" src="https://user-images.githubusercontent.com/1079135/127784772-c32e738f-1ed7-43e8-a374-5b62fca58683.png">

Product image:

![image](https://user-images.githubusercontent.com/1079135/127784780-f46733a1-c091-42ef-b410-cb7ccea0b5fc.png)
