### PR TITLE
Added LTD012/5111531H5

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -96,7 +96,7 @@ module.exports = [
         vendor: 'Philips',
         description: 'Garnea downlight',
         meta: {turnsOffAtBrightness1: true},
-        extend: hueExtend.light_onoff_brightness_colortemp(),
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
     },
     {
@@ -149,7 +149,7 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue Aphelion downlight',
         meta: {turnsOffAtBrightness1: true},
-        extend: hueExtend.light_onoff_brightness_colortemp(),
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
     },
     {

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -91,6 +91,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LTD012'],
+        model: '5111531H5',
+        vendor: 'Philips',
+        description: 'Garnea downlight',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LWA010'],
         model: '929002335001',
         vendor: 'Philips',


### PR DESCRIPTION
Not sure if this should just be collapsed with the other Zigbee model for the Garnea range. Technically it has a different model number on the box so chose to create a new entry.

I have this running on my local instance using an external converter and all working nicely (I just duplicated the hueExtend section into my external converter).