### PR TITLE
Tint 404011 remote: Add direction of color temp changes

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2876,12 +2876,12 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'last_color_temp', msg.data.colortemp);
             }
 
-            const last_temp = globalStore.getValue(msg.endpoint, 'last_color_temp');
+            const lastTemp = globalStore.getValue(msg.endpoint, 'last_color_temp');
             globalStore.putValue(msg.endpoint, 'last_color_temp', msg.data.colortemp);
             let direction = 'down';
-            if (last_temp > msg.data.colortemp) {
+            if (lastTemp > msg.data.colortemp) {
                 direction = 'up';
-            } else if (last_temp < msg.data.colortemp) {
+            } else if (lastTemp < msg.data.colortemp) {
                 direction = 'down';
             } else if (msg.data.colortemp == 370 || msg.data.colortemp == 555) {
                 // The remote goes up to 370 in steps and emits 555 on down button hold.
@@ -2899,7 +2899,7 @@ const converters = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    },   
+    },
     ZNMS11LM_closuresDoorLock_report: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2866,6 +2866,40 @@ const converters = {
             return payload;
         },
     },
+    tint404011_move_to_color_temp: {
+        cluster: 'lightingColorCtrl',
+        type: 'commandMoveToColorTemp',
+        convert: (model, msg, publish, options, meta) => {
+            // The remote has an internal state so store the last action in order to
+            // determine the direction of the color temperature change.
+            if (!globalStore.hasValue(msg.endpoint, 'last_color_temp')) {
+                globalStore.putValue(msg.endpoint, 'last_color_temp', msg.data.colortemp);
+            }
+
+            const last_temp = globalStore.getValue(msg.endpoint, 'last_color_temp');
+            globalStore.putValue(msg.endpoint, 'last_color_temp', msg.data.colortemp);
+            let direction = 'down';
+            if (last_temp > msg.data.colortemp) {
+                direction = 'up';
+            } else if (last_temp < msg.data.colortemp) {
+                direction = 'down';
+            } else if (msg.data.colortemp == 370 || msg.data.colortemp == 555) {
+                // The remote goes up to 370 in steps and emits 555 on down button hold.
+                direction = 'down';
+            } else if (msg.data.colortemp == 153) {
+                direction = 'up';
+            }
+
+            const payload = {
+                action: postfixWithEndpointName(`color_temperature_move`, msg, model),
+                action_color_temperature: msg.data.colortemp,
+                action_transition_time: msg.data.transtime,
+                action_color_temperature_direction: direction,
+            };
+            addActionGroup(payload, msg, model);
+            return payload;
+        },
+    },   
     ZNMS11LM_closuresDoorLock_report: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -1394,7 +1394,7 @@ const fromZigbee = {
                 addActionGroup(payload, msg, model);
                 return payload;
             } else {
-                return fromZigbeeConverters.command_move_to_color_temp.convert(model, msg, publish, options, meta);
+                return fromZigbeeConverters.tint404011_move_to_color_temp.convert(model, msg, publish, options, meta);
             }
         },
     },


### PR DESCRIPTION
The tint remote MLI-404011 by Müller Licht has an internal state which is emitted through the color temperature change buttons. In order to get the actual button which has been pressed we need to mirror that state internally.