### PR TITLE
Add support for external temp sensor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2777,6 +2777,10 @@ const converters = {
                 result[postfixWithEndpointName('thermostat_vertical_orientation', msg, model)] =
                     (msg.data['danfossThermostatOrientation'] === 1);
             }
+            if (msg.data.hasOwnProperty('danfossExternalMeasuredRoomSensor')) {
+                result[postfixWithEndpointName('external_measured_room_sensor', msg, model)] =
+                    msg.data['danfossExternalMeasuredRoomSensor'];
+            }
             if (msg.data.hasOwnProperty('danfossViewingDirection')) {
                 result[postfixWithEndpointName('viewing_direction', msg, model)] = msg.data['danfossViewingDirection'];
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2148,6 +2148,16 @@ const converters = {
             await entity.read('hvacThermostat', ['danfossThermostatOrientation'], manufacturerOptions.danfoss);
         },
     },
+    danfoss_external_measured_room_sensor: {
+        key: ['external_measured_room_sensor'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'danfossExternalMeasuredRoomSensor': value}, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 200, state: {'external_measured_room_sensor': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossExternalMeasuredRoomSensor'], manufacturerOptions.danfoss);
+        },
+    },
     danfoss_viewing_direction: {
         key: ['viewing_direction'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -19,7 +19,8 @@ module.exports = [
             tz.danfoss_mounted_mode_control, tz.danfoss_thermostat_vertical_orientation, tz.danfoss_algorithm_scale_factor,
             tz.danfoss_heat_available, tz.danfoss_heat_required, tz.danfoss_day_of_week, tz.danfoss_trigger_time,
             tz.danfoss_window_open_internal, tz.danfoss_window_open_external, tz.danfoss_load_estimate,
-            tz.danfoss_viewing_direction, tz.thermostat_keypad_lockout, tz.thermostat_system_mode],
+            tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.thermostat_keypad_lockout,
+            tz.thermostat_system_mode],
         exposes: [e.battery(), e.keypad_lockout(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -39,6 +40,9 @@ module.exports = [
                 .withDescription('Values observed are `0` (set locally) or `2` (set via Zigbee)'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature().withPiHeatingDemand()
                 .withSystemMode(['heat']),
+            exposes.numeric('external_measured_room_sensor', ea.ALL)
+                .withDescription('Set at maximum 3 hours interval but not more often than every 30 minutes at every 100 ' +
+                    'value change. Resets every 3hours to standard (-8000=undefined).'),
             exposes.numeric('window_open_internal', ea.STATE_GET).withValueMin(0).withValueMax(4)
                 .withDescription('0=Quarantine, 1=Windows are closed, 2=Hold - Windows are maybe about to open, ' +
                     '3=Open window detected, 4=In window open state from external but detected closed locally'),

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -90,6 +90,12 @@ module.exports = [
                 maximumReportInterval: constants.repInterval.MINUTES_10,
                 reportableChange: 1,
             }], options);
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'danfossExternalMeasuredRoomSensor',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.MAX,
+                reportableChange: 1,
+            }], options);
 
             await endpoint.read('hvacThermostat', [
                 'danfossWindowOpenExternal',
@@ -99,6 +105,7 @@ module.exports = [
                 'danfossHeatAvailable',
                 'danfossMountedModeControl',
                 'danfossMountedModeActive',
+                'danfossExternalMeasuredRoomSensor',
             ], options);
             // read keypadLockout, we don't need reporting as it cannot be set physically on the device
             await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);

--- a/devices/hive.js
+++ b/devices/hive.js
@@ -194,6 +194,12 @@ module.exports = [
                 maximumReportInterval: constants.repInterval.MINUTES_10,
                 reportableChange: 1,
             }], options);
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'danfossExternalMeasuredRoomSensor',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.MAX,
+                reportableChange: 1,
+            }], options);
 
             await endpoint.read('hvacThermostat', [
                 'danfossWindowOpenExternal',
@@ -203,6 +209,7 @@ module.exports = [
                 'danfossHeatAvailable',
                 'danfossMountedModeControl',
                 'danfossMountedModeActive',
+                'danfossExternalMeasuredRoomSensor',
             ], options);
             // read keypadLockout, we don't need reporting as it cannot be set physically on the device
             await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);

--- a/devices/hive.js
+++ b/devices/hive.js
@@ -126,7 +126,8 @@ module.exports = [
             tz.danfoss_mounted_mode_control, tz.danfoss_thermostat_vertical_orientation, tz.danfoss_algorithm_scale_factor,
             tz.danfoss_heat_available, tz.danfoss_heat_required, tz.danfoss_day_of_week, tz.danfoss_trigger_time,
             tz.danfoss_window_open_internal, tz.danfoss_window_open_external, tz.danfoss_load_estimate,
-            tz.danfoss_viewing_direction, tz.thermostat_keypad_lockout, tz.thermostat_system_mode],
+            tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.thermostat_keypad_lockout,
+            tz.thermostat_system_mode],
         exposes: [e.battery(), e.keypad_lockout(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -144,6 +145,9 @@ module.exports = [
                 .withDescription('Whether or not the unit needs warm water. `false` No Heat Request or `true` Heat Request'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature().withPiHeatingDemand()
                 .withSystemMode(['heat']),
+            exposes.numeric('external_measured_room_sensor', ea.ALL)
+                .withDescription('Set at maximum 3 hours interval but not more often than every 30 minutes at every 100 ' +
+                    'value change. Resets every 3hours to standard (-8000=undefined).'),
             exposes.numeric('window_open_internal', ea.STATE_GET).withValueMin(0).withValueMax(4)
                 .withDescription('0=Quarantine, 1=Windows are closed, 2=Hold - Windows are maybe about to open, ' +
                     '3=Open window detected, 4=In window open state from external but detected closed locally'),


### PR DESCRIPTION
This adds support for External Temp Sensor for Danfoss Ally and Hive Trv. This code is based on the Danfoss Ally specs sheet and tested on the Hive Trv.

This was added at the request of a user here: https://github.com/Koenkk/zigbee2mqtt/issues/4504#issuecomment-895470566

The PR needs https://github.com/Koenkk/zigbee-herdsman/pull/404 to be merged first in zigbee-herdsman.