### PR TITLE
LDSENK02F: Fix energy stay null 

### DIFF
--- a/devices/adeo.js
+++ b/devices/adeo.js
@@ -65,6 +65,7 @@ module.exports = [
             await reporting.onOff(endpoint);
             await reporting.activePower(endpoint);
             await reporting.currentSummDelivered(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
         },
         exposes: [e.power(), e.switch(), e.energy()],
     },


### PR DESCRIPTION
As said in comment https://github.com/Koenkk/zigbee-herdsman-converters/pull/2877#issuecomment-896242126

It is missing `reporting.readMeteringMultiplierDivisor(endpoint)` for the smart plug.