### PR TITLE
Adding configuration to Sinope DM2500ZB

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2977,6 +2977,33 @@ const converters = {
             }
         },
     },
+    sinope_led_intensity_on: {
+        // DM2500ZB and SW2500ZB
+        key: ['led_intensity_on'],
+        convertSet: async (entity, key, value, meta) => {
+            if (value >= 0 && value <= 100) {
+                await entity.write('manuSpecificSinope', {ledIntensityOn: value});
+            }
+        },
+    },
+    sinope_led_intensity_off: {
+        // DM2500ZB and SW2500ZB
+        key: ['led_intensity_off'],
+        convertSet: async (entity, key, value, meta) => {
+            if (value >= 0 && value <= 100) {
+                await entity.write('manuSpecificSinope', {ledIntensityOff: value});
+            }
+        },
+    },
+    sinope_minimum_brightness: {
+        // DM2500ZB
+        key: ['minimum_brightness'],
+        convertSet: async (entity, key, value, meta) => {
+            if (value >= 0 && value <= 3000) {
+                await entity.write('manuSpecificSinope', {minimumBrightness: value});
+            }
+        },
+    },
     stelpro_thermostat_outdoor_temperature: {
         key: ['thermostat_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -241,7 +241,7 @@ module.exports = [
             .withDescription('Control status LED when load ON'), exposes.numeric('led_intensity_off', ea.SET).withValueMin(0)
             .withValueMax(100).withDescription('Control status LED when load OFF'), exposes.numeric('minimum_brightness', ea.SET)
             .withValueMin(0).withValueMax(3000).withDescription('Control minimum dimmer brightness')],
-        toZigbee: [tz.light_onoff_brightness, tz.sinope_led_intensity_on, tz.sinope_led_intensity_off,
+        toZigbee: [tz.light_onoff_brightness, tz.effect, tz.sinope_led_intensity_on, tz.sinope_led_intensity_off,
             tz.sinope_minimum_brightness],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -237,6 +237,12 @@ module.exports = [
         vendor: 'Sinope',
         description: 'Zigbee smart dimmer',
         extend: extend.light_onoff_brightness({noConfigure: true}),
+        exposes: [e.light_brightness(), e.effect(), exposes.numeric('led_intensity_on', ea.SET).withValueMin(0).withValueMax(100)
+            .withDescription('Control status LED when load ON'), exposes.numeric('led_intensity_off', ea.SET).withValueMin(0)
+            .withValueMax(100).withDescription('Control status LED when load OFF'), exposes.numeric('minimum_brightness', ea.SET)
+            .withValueMin(0).withValueMax(3000).withDescription('Control minimum dimmer brightness')],
+        toZigbee: [tz.light_onoff_brightness, tz.sinope_led_intensity_on, tz.sinope_led_intensity_off,
+            tz.sinope_minimum_brightness],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Adding some configuration options for the Sinope DM2500ZB dimmer

1. led_brightness_on (brightness of the status led when load is on)
2. led_brightness_off (brightness of the status led when load is off)
3. minimum_brightness (sets the minimum brightness of the dimmer to avoid flicker on some bulbs or make sure an inductive load has enough power to turn on at 1% brightness for example)

