### PR TITLE
Add support for Nedis ZBHTR10W

### DIFF
--- a/devices/siterwell.js
+++ b/devices/siterwell.js
@@ -8,7 +8,10 @@ const ea = exposes.access;
 module.exports = [
     {
         zigbeeModel: ['ivfvd7h', 'eaxp72v\u0000', 'kfvq6avy\u0000', 'fvq6avy\u0000', 'fvq6avy'],
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_zivfvd7h'}, {modelId: 'TS0601', manufacturerName: '_TZE200_kfvq6avy'}],
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_zivfvd7h'},
+            {modelId: 'TS0601', manufacturerName: '_TZE200_kfvq6avy'},
+            {modelId: 'TS0601', manufacturerName: '_TZE200_hhrtiq0x'}],
         model: 'GS361A-H04',
         vendor: 'Siterwell',
         description: 'Radiator valve with thermostat',


### PR DESCRIPTION
This is as a result of https://github.com/Koenkk/zigbee2mqtt/issues/8333

The user requesting support mentioned this being a different TRV behind the hood, also provided the reported model and manufacturer name. Also tested at their end and works fine.

I do not own the device not I was able to test this myself, just pushing the PR for OP