### PR TITLE
Update siterwell.js

### DIFF
--- a/devices/siterwell.js
+++ b/devices/siterwell.js
@@ -11,7 +11,8 @@ module.exports = [
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE200_zivfvd7h'},
             {modelId: 'TS0601', manufacturerName: '_TZE200_kfvq6avy'},
-            {modelId: 'TS0601', manufacturerName: '_TZE200_hhrtiq0x'}],
+            {modelId: 'TS0601', manufacturerName: '_TZE200_hhrtiq0x'},
+            {modelId: 'TS0601', manufacturerName: '_TZE200_ps5v5jor'}],
         model: 'GS361A-H04',
         vendor: 'Siterwell',
         description: 'Radiator valve with thermostat',
@@ -24,7 +25,8 @@ module.exports = [
             tz.tuya_thermostat_comfort_temp, tz.tuya_thermostat_eco_temp, tz.tuya_thermostat_force, tz.tuya_thermostat_preset],
         whiteLabel: [{vendor: 'Essentials', description: 'Smart home heizkörperthermostat premium', model: '120112'},
             {vendor: 'TuYa', description: 'Głowica termostatyczna', model: 'GTZ02'},
-            {vendor: 'Revolt', description: 'Thermostatic Radiator Valve Controller', model: 'NX-4911'}],
+            {vendor: 'Revolt', description: 'Thermostatic Radiator Valve Controller', model: 'NX-4911'},
+            {vendor: 'Unitec', description: 'Thermostatic Radiator Valve Controller', model: '30946'}],
         exposes: [e.child_lock(), e.window_detection(), e.battery(), e.valve_detection(), e.position(), exposes.climate()
             .withSetpoint('current_heating_setpoint', 5, 30, 0.5, ea.STATE_SET).withLocalTemperature(ea.STATE)
             .withSystemMode(['off', 'auto', 'heat'], ea.STATE_SET)


### PR DESCRIPTION
Adding fingerprint  _TZE200_ps5v5jor by [Unitec](https://www.amazon.de/UNITEC-Heizk%C3%B6rper-Thermostat-Erweiterung-Display-kompatibel/dp/B08TMY8S2D/ref=sr_1_2?__mk_de_DE=%C3%85M%C3%85%C5%BD%C3%95%C3%91&crid=1TZDM8RG2XYI3&dchild=1&keywords=unitec+thermostat&qid=1628801124&sprefix=unitec+ther%2Caps%2C185&sr=8-2), another whitelabel ID of the Essential/Siterwell thermostat. Tested and confirmed working in my home setup.