### PR TITLE
Add the `RGBW LED lamp GU10 6W dimbaar`

### DIFF
--- a/devices/prolight.js
+++ b/devices/prolight.js
@@ -15,4 +15,11 @@ module.exports = [
         description: 'E27 filament bulb dimmable',
         extend: extend.light_onoff_brightness(),
     },
+    {
+        zigbeeModel: ['PROLIGHT GU10 WHITE AND COLOUR'],
+        model: '5412748727401',
+        vendor: 'Prolight',
+        description: 'GU10 white and colour spot',
+        extend: extend.light_onoff_brightness_colortemp_color(),
+    },
 ];


### PR DESCRIPTION
Seems to be the same as the E27 version but a GU10 spot, sadly no access to the hardware myself but my uncle send me logs so I managed to extract the model.