### PR TITLE
Add support for Philips Bloom Gen4 - US Addition

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -8,20 +8,20 @@ const e = exposes.presets;
 const ea = exposes.access;
 
 const hueExtend = {
-    light_onoff_brightness: (options = {}) => ({
+    light_onoff_brightness: (options={}) => ({
         ...extend.light_onoff_brightness(options),
         toZigbee: extend.light_onoff_brightness(options).toZigbee.concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
     }),
-    light_onoff_brightness_colortemp: (options = {}) => ({
+    light_onoff_brightness_colortemp: (options={}) => ({
         ...extend.light_onoff_brightness_colortemp(options),
         toZigbee: extend.light_onoff_brightness_colortemp(options).toZigbee.concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
     }),
-    light_onoff_brightness_color: (options = {}) => ({
+    light_onoff_brightness_color: (options={}) => ({
         ...extend.light_onoff_brightness_color({supportsHS: true, ...options}),
         toZigbee: extend.light_onoff_brightness_color({supportsHS: true, ...options}).toZigbee
             .concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
     }),
-    light_onoff_brightness_colortemp_color: (options = {}) => ({
+    light_onoff_brightness_colortemp_color: (options={}) => ({
         ...extend.light_onoff_brightness_colortemp_color({supportsHS: true, ...options}),
         toZigbee: extend.light_onoff_brightness_colortemp_color({supportsHS: true, ...options})
             .toZigbee.concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -8,20 +8,20 @@ const e = exposes.presets;
 const ea = exposes.access;
 
 const hueExtend = {
-    light_onoff_brightness: (options={}) => ({
+    light_onoff_brightness: (options = {}) => ({
         ...extend.light_onoff_brightness(options),
         toZigbee: extend.light_onoff_brightness(options).toZigbee.concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
     }),
-    light_onoff_brightness_colortemp: (options={}) => ({
+    light_onoff_brightness_colortemp: (options = {}) => ({
         ...extend.light_onoff_brightness_colortemp(options),
         toZigbee: extend.light_onoff_brightness_colortemp(options).toZigbee.concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
     }),
-    light_onoff_brightness_color: (options={}) => ({
+    light_onoff_brightness_color: (options = {}) => ({
         ...extend.light_onoff_brightness_color({supportsHS: true, ...options}),
         toZigbee: extend.light_onoff_brightness_color({supportsHS: true, ...options}).toZigbee
             .concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
     }),
-    light_onoff_brightness_colortemp_color: (options={}) => ({
+    light_onoff_brightness_colortemp_color: (options = {}) => ({
         ...extend.light_onoff_brightness_colortemp_color({supportsHS: true, ...options}),
         toZigbee: extend.light_onoff_brightness_colortemp_color({supportsHS: true, ...options})
             .toZigbee.concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
@@ -192,9 +192,18 @@ module.exports = [
         zigbeeModel: ['929002375901'],
         model: '929002375901',
         vendor: 'Philips',
-        description: 'Hue Bloom with Bluetooth (White)',
+        description: 'Hue Bloom with Bluetooth (White) - EU/UK',
         meta: {turnsOffAtBrightness1: true},
         extend: hueExtend.light_onoff_brightness_colortemp_color(),
+        ota: ota.zigbeeOTA,
+    },
+    {
+        zigbeeModel: ['929002376501'],
+        model: '929002376501',
+        vendor: 'Philips',
+        description: 'Hue Bloom Gen4 with Bluetooth (White) - US',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,
     },
     {


### PR DESCRIPTION
Hopefully this was done properly - has been tested and linted. 

Added an additional descriptor text to the previous Bloom entry as that model is defined as an EU/UK model. My guess it is about the included plug adaptor but they have not only different Zigbee Models but different models from Philips as well.

Let me know if any changes are needed.