### PR TITLE
Updated tuya.js for support of ETOP HT-10 Radiator valve with new 'manufacturerName'

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -666,7 +666,7 @@ module.exports = [
             .withAwayMode()],
     },
     {
-        fingerprint: [{modelID: 'dpplnsn\u0000', manufacturerName: '_TYST11_2dpplnsn'}],
+        fingerprint: [{modelID: 'dpplnsn\u0000', manufacturerName: '_TYST11_2dpplnsn'}, {modelID: 'TS0601', manufacturerName: '_TZE200_2dpplnsn'}],
         model: 'HT-10',
         vendor: 'ETOP',
         description: 'Radiator valve',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -666,7 +666,8 @@ module.exports = [
             .withAwayMode()],
     },
     {
-        fingerprint: [{modelID: 'dpplnsn\u0000', manufacturerName: '_TYST11_2dpplnsn'}, {modelID: 'TS0601', manufacturerName: '_TZE200_2dpplnsn'}],
+        fingerprint: [{modelID: 'dpplnsn\u0000', manufacturerName: '_TYST11_2dpplnsn'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_2dpplnsn'}],
         model: 'HT-10',
         vendor: 'ETOP',
         description: 'Radiator valve',


### PR DESCRIPTION
ETOP HT-10 Radiator valve is trying to connect with modelID: 'TS0601' and manufacturerName: '_TZE200_2dpplnsn', but only {modelID: 'dpplnsn\u0000', manufacturerName: '_TYST11_2dpplnsn'} is supported.

I've added new modelID and manufacturerName