### PR TITLE
No converter available for 'AV2010/29A'

### DIFF
--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -79,7 +79,7 @@ module.exports = [
         model: 'AV2010/29A',
         vendor: 'Bitron',
         description: 'SMaBiT Zigbee outdoor siren',
-        fromZigbee: [fz.ias_no_alarm],
+        fromZigbee: [fz.ias_siren],
         toZigbee: [tz.warning],
         exposes: [e.warning(), e.battery_low(), e.tamper()],
     },


### PR DESCRIPTION
No converter available for 'AV2010/29A' with cluster 'ssIasZone' and type 'commandStatusChangeNotification' and data '{"extendedstatus":0,"zonestatus":20}'