### PR TITLE
Wait until LS21001 is active to change alert_behavior

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1729,7 +1729,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'siren_led': 3, 'siren': 2, 'led': 1, 'nothing': 0};
             await entity.write('genBasic', {0x400a: {value: lookup[value], type: 32}},
-                {manufacturerCode: 0x1168, disableDefaultResponse: true});
+                {manufacturerCode: 0x1168, disableDefaultResponse: true, sendWhenActive: true});
             return {state: {alert_behaviour: value}};
         },
     },

--- a/devices/echostar.js
+++ b/devices/echostar.js
@@ -1,6 +1,5 @@
 const exposes = require('../lib/exposes');
 const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
-const reporting = require('../lib/reporting');
 const e = exposes.presets;
 
 module.exports = [
@@ -19,13 +18,8 @@ module.exports = [
         model: 'SAGE206611',
         vendor: 'Echostar',
         description: 'SAGE by Hughes single gang light switch',
-        fromZigbee: [fz.command_on, fz.command_off, fz.battery],
-        exposes: [e.battery(), e.action(['on', 'off'])],
+        fromZigbee: [fz.command_on, fz.command_off],
+        exposes: [e.action(['on', 'off'])],
         toZigbee: [],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(18);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint);
-        },
     },
 ];


### PR DESCRIPTION
Need to wait to write the value until the sensor is active, otherwise the command times out.

Also remove battery reporting from the Echostar single gang switch. The device sends `batteryPercentageRemaining` messages, but the value is always 0 regardless of the batteries installed which makes the battery reporting useless. Confirmed by one other person and me during a discussion on Discord. It also doesn't support `batteryVoltage`, so that isn't an available workaround.