### PR TITLE
Adding working colour temp range for Osram AB32840

### DIFF
--- a/devices/osram.js
+++ b/devices/osram.js
@@ -142,7 +142,7 @@ module.exports = [
         model: 'AB32840',
         vendor: 'OSRAM',
         description: 'LIGHTIFY LED Classic B40 tunable white',
-        extend: extend.ledvance.light_onoff_brightness_colortemp(),
+        extend: extend.ledvance.light_onoff_brightness_colortemp({colorTempRange: [150, 370]}),
         ota: ota.ledvance,
     },
     {


### PR DESCRIPTION
The working maximum temperature for this bulb is 370. Anything from 370 to the (default) 500 makes no difference to the light output.