### PR TITLE
Add support for Mercator ikuü SMI7040 Ford Batten Light

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -395,10 +395,12 @@ module.exports = [
             {modelID: 'TS0502B', manufacturerName: '_TZ3210_s1x7gcq0'},
             {modelID: 'TS0502B', manufacturerName: '_TZ3210_hi1ym4bl'},
             {modelID: 'TS0502B', manufacturerName: '_TZ3210_psgq7ysz'},
+            {modelID: 'TS0502B', manufacturerName: '_TZ3000_zw7wr5uo'},
         ],
         model: 'TS0502B',
         vendor: 'TuYa',
         description: 'Light controller',
+        whiteLabel: [{vendor: 'Mercator ikuü', model: 'SMI7040', description: 'Ford Batten Light'}],
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500]}),
     },
     {


### PR DESCRIPTION
This PR adds support for https://www.ikuu.com.au/product/ford-40w-batten-light-2/, a white-labelled TuYa light controller.

Curiously, whilst the [data sheet](https://www.ikuu.com.au/downloadable-assets/product-specifications/MIDS000001Z%20Data%20Sheet.pdf) states the colour range is 3000K to 5700K, the light fixture visibly changes when set to warmer temperatures (500 mireds, 2000K) and whilst harder to discern on cooler temperatures, _seems_ to support change slightly when above 5700K (e.g. at 153 mireds / 6500K).