### PR TITLE
Add Ajax Online AJ_ZIGPROA60 12W A60 Bulb

### DIFF
--- a/devices/ajax_online.js
+++ b/devices/ajax_online.js
@@ -15,4 +15,12 @@ module.exports = [
         description: 'Smart Zigbee pro GU10 spotlight bulb',
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495], disableEffect: true}),
     },
+    {
+        zigbeeModel: ['AJ_ZBPROA60'],
+        model: 'AJ_ZIGPROA60',
+        vendor: 'Ajax Online',
+        description: 'Smart Zigbee Pro 12W A60 Bulb',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495]}),
+        meta: {turnsOffAtBrightness1: true},
+    },
 ];

--- a/devices/ajax_online.js
+++ b/devices/ajax_online.js
@@ -19,7 +19,7 @@ module.exports = [
         zigbeeModel: ['AJ_ZBPROA60'],
         model: 'AJ_ZIGPROA60',
         vendor: 'Ajax Online',
-        description: 'Smart Zigbee Pro 12W A60 Bulb',
+        description: 'Smart Zigbee pro 12W A60 bulb',
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495]}),
         meta: {turnsOffAtBrightness1: true},
     },


### PR DESCRIPTION
This bulb does seem almost identical to the Gledopto GL-B-008P (i.e photos and firmware versions seem identical) but as I don't have the Gledopto bulb to hand I can't be 100% sure. Therefore i've added this as a new device definition for now rather than as a whitelabel.

[Colour temperature range confirmed by following the instructions here](https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html#31-retrieving-color-temperature-range-only-required-for-lights-which-support-color-temperature). When setting the brightness to 1, the bulb does turn off so i've set the `turnsOffAtBrightness1` meta property to `true`.