### PR TITLE
[Bitron AV2010/29A] Revert warning converter + add squawk command

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -326,7 +326,7 @@ const converters = {
 
             let info;
             // https://github.com/Koenkk/zigbee2mqtt/issues/8310 some devices require the info to be reversed.
-            if (['SIRZB-110', 'SRAC-23B-ZBSR'].includes(meta.mapped.model)) {
+            if (['SIRZB-110', 'SRAC-23B-ZBSR', 'AV2010/29A'].includes(meta.mapped.model)) {
                 info = (mode[values.mode]) + ((values.strobe ? 1 : 0) << 4) + (level[values.level] << 6);
             } else {
                 info = (mode[values.mode] << 4) + ((values.strobe ? 1 : 0) << 2) + (level[values.level]);

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -80,8 +80,8 @@ module.exports = [
         vendor: 'Bitron',
         description: 'SMaBiT Zigbee outdoor siren',
         fromZigbee: [fz.ias_siren],
-        toZigbee: [tz.warning],
-        exposes: [e.warning(), e.battery_low(), e.tamper()],
+        toZigbee: [tz.warning, tz.squawk],
+        exposes: [e.warning(), e.squawk(), e.battery_low(), e.tamper()],
     },
     {
         zigbeeModel: ['902010/32'],


### PR DESCRIPTION
Bitron Smabit AV2010/29A seems to suffer the exact same mistake as https://github.com/Koenkk/zigbee2mqtt/issues/8310.
This could explain why we need this strange controlling chapter on the device description that makes absolutely no sense : https://www.zigbee2mqtt.io/devices/AV2010_29A.html#controlling
I'm quite confident this is the solution.

PS : honestly i haven't test this commit, i don't know how to override an existing device or an existing converter on my home assistant installation (normal plugin / not edge version). Is there a tuto ?