### PR TITLE
Add battery support for Linkind ZS1100400-IN-V1A02

### DIFF
--- a/devices/linkind.js
+++ b/devices/linkind.js
@@ -72,9 +72,14 @@ module.exports = [
         model: 'ZS1100400-IN-V1A02',
         vendor: 'Linkind',
         description: 'PIR motion sensor, wireless motion detector',
-        fromZigbee: [fz.ias_occupancy_alarm_1],
+        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery],
         toZigbee: [],
-        exposes: [e.occupancy(), e.battery_low(), e.tamper()],
+        exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
     },
     {
         zigbeeModel: ['ZB-DoorSensor-D0003'],


### PR DESCRIPTION
This motion sensor seems to support battery information. I haven't
directly tested this, but the code is just copied from the Door/Window
sensor.

debug Received Zigbee message from 'Montion Sensor', type 'attributeReport', cluster 'genPowerCfg', data '{"batteryPercentageRemaining":182}' from endpoint 1 with groupID 0
debug No converter available for 'ZS1100400-IN-V1A02' with cluster 'genPowerCfg' and type 'attributeReport' and data '{"batteryPercentageRemaining":182}'