### PR TITLE
Detect additional TS0601 Tuya air sensor

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -38,7 +38,7 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_8ygsuhe1'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_yvx5lh6k'}],
+            {modelID: 'TS0601', manufacturerName: '_TZE200_yvx5lh6k'}, {modelID: 'TS0601', manufacturerName: '_TZE200_ryfmq5rl'}],
         model: 'TS0601_air_quality_sensor',
         vendor: 'Tuya',
         description: 'Air quality sensor',


### PR DESCRIPTION
Ordered one of the Tuya indoor air quality sensors and it appears to be identical except it uses a new fingerprint. The model is often listed under AirBox02 on AliExpress.