### PR TITLE
Add TS0207_water_leak_detector

### DIFF
--- a/devices/cr_smart_home.js
+++ b/devices/cr_smart_home.js
@@ -40,15 +40,6 @@ module.exports = [
         extend: extend.switch(),
     },
     {
-        zigbeeModel: ['TS0207', 'FNB54-WTS08ML1.0'],
-        model: 'TS0207',
-        vendor: 'CR Smart Home',
-        description: 'Water leak detector',
-        fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
-        toZigbee: [],
-        exposes: [e.water_leak(), e.battery_low(), e.tamper(), e.battery()],
-    },
-    {
         zigbeeModel: ['TS0218'],
         model: 'TS0218',
         vendor: 'CR Smart Home',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -170,6 +170,11 @@ module.exports = [
         description: 'Water leak detector',
         fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
         toZigbee: [],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
         exposes: [e.water_leak(), e.battery_low(), e.battery()],
     },
     {

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -165,9 +165,9 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS0207', manufacturerName: '_TZ3000_upgcbody'}],
-        model: 'TS0207_water_leak_sensor',
+        model: 'TS0207_water_leak_detector',
         vendor: 'Tuya',
-        description: 'Water leak sensor',
+        description: 'Water leak detector',
         fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
         toZigbee: [],
         exposes: [e.water_leak(), e.battery_low(), e.battery()],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -170,6 +170,7 @@ module.exports = [
         vendor: 'TuYa',
         description: 'Water leak detector',
         fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
+        whiteLabel: [{vendor: 'CR Smart Home', model: 'TS0207'}],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -164,6 +164,15 @@ module.exports = [
         exposes: [],
     },
     {
+        fingerprint: [{modelID: 'TS0207', manufacturerName: '_TZ3000_upgcbody'}],
+        model: 'TS0207_water_leak_sensor',
+        vendor: 'Tuya',
+        description: 'Water leak sensor',
+        fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
+        toZigbee: [],
+        exposes: [e.water_leak(), e.battery_low(), e.battery()],
+    },
+    {
         fingerprint: [{modelID: 'TS0101', manufacturerName: '_TYZB01_ijihzffk'}],
         model: 'TS0101',
         vendor: 'TuYa',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -164,9 +164,10 @@ module.exports = [
         exposes: [],
     },
     {
+        zigbeeModel: ['TS0207', 'FNB54-WTS08ML1.0'],
         fingerprint: [{modelID: 'TS0207', manufacturerName: '_TZ3000_upgcbody'}],
         model: 'TS0207_water_leak_detector',
-        vendor: 'Tuya',
+        vendor: 'TuYa',
         description: 'Water leak detector',
         fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
         toZigbee: [],


### PR DESCRIPTION
This device was previously recognized as CR Smart Home TS0207, which is wrong.

The now integrated Tuya TS0207 Water Leak Sensor is this device ([AliExpress](https://www.aliexpress.com/item/1005002941769280.html)):
![TS0207 fw](https://user-images.githubusercontent.com/10342151/132507138-38ce3e55-7897-41e1-a466-f76254c991f0.png)

Three questions:

- Is it correct, that I have to put the image to Koenkk/zigbee2mqtt.io/blob/master/docs/images/devices/TS0207_water_leak_detector.jpg ? Currently when using my code in an external converter Zigbee2MQTT shows [this image](https://slsys.github.io/Gateway/devices/png/TS0207.png).
- Is there anything more to do, that this new device will not be mixed up with the CR Smart Home TS0207?
- ~~The battery level is not indicated correctly at first, but only appears when you shortly press the pairing button again after successfully pairing. Is it possible that the sensor only sends the value periodically or when there is a change? Is it possible to instruct Zigbee2MQTT to actively poll the value?~~