### PR TITLE
Add Lockwood T-Lock (rebranded Yale Assure SL)

### DIFF
--- a/devices/yale.js
+++ b/devices/yale.js
@@ -99,4 +99,14 @@ module.exports = [
         description: 'Assure lock SL',
         extend: lockExtend,
     },
+    {
+        // Appears to be a slightly rebranded Assure lock SL
+        // Just with Lockwood | Assa Abloy branding instead of Yale
+        // Appears to have been part of a deal with Telstra, hence the T-Lock name
+        zigbeeModel: ['YDD-D4F0 TSDB'],
+        model: 'YDD-D4F0-TSDB',
+        vendor: 'Yale',
+        description: 'Lockwood T-Lock',
+        extend: lockExtend,
+    },
 ];


### PR DESCRIPTION
The Lockwood T-Lock appears to be a Yale Assure SL with different stickers. It appears to work exactly the same, including the pin setting functionality.

Apparently the T-Lock was part of a deal with Telstra when they got into the smart home market about 5 years ago. They have since got out of that market and these locks are being sold off cheap as a result.

(Lockwood is an Australian subsidiary of Assa Abloy, which is also the parent company of Yale).

Thanks to http://leftfoot.com.au/blog/zigbee2mqtt-and-the-lockwood-t-lock for making it easy to find the external converter file to get this working in the first place.