### PR TITLE
Add support for E26 version of LED1937T5

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -105,6 +105,13 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
     },
     {
+        zigbeeModel: ['TRADFRIbulbT120E26WSopal450lm'],
+        model: 'LED1937T5',
+        vendor: 'IKEA',
+        description: 'LED bulb E26 450 lumen, wireless dimmable white spectrum/tube-shaped white frosted glass',
+        extend: tradfriExtend.light_onoff_brightness_colortemp(),
+    },
+    {
         zigbeeModel: ['TRADFRI bulb GU10 WS 400lm'],
         model: 'LED1537R6/LED1739R5',
         vendor: 'IKEA',

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -99,14 +99,14 @@ module.exports = [
     },
     {
         zigbeeModel: ['TRADFRI bulb E27 opal 470lm', 'TRADFRI bulb E27 W opal 470lm', 'TRADFRIbulbT120E27WSopal470lm'],
-        model: 'LED1937T5',
+        model: 'LED1937T5_E27',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E27 470 lumen, dimmable, opal white',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
     },
     {
         zigbeeModel: ['TRADFRIbulbT120E26WSopal450lm'],
-        model: 'LED1937T5',
+        model: 'LED1937T5_E26',
         vendor: 'IKEA',
         description: 'LED bulb E26 450 lumen, wireless dimmable white spectrum/tube-shaped white frosted glass',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),


### PR DESCRIPTION
E26 version is essentially the same as the E27 one, and tested to be fully functional. Just needed a slight change to zigbeeModel.