### PR TITLE
Fix recalling scenes before adding

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4606,7 +4606,7 @@ const converters = {
                 }
                 return {membersState};
             } else {
-                if (entity.meta.scenes.hasOwnProperty(metaKey)) {
+                if (entity.meta.hasOwnProperty('scenes') && entity.meta.scenes.hasOwnProperty(metaKey)) {
                     let recalledState = entity.meta.scenes[metaKey].state;
 
                     // add color_mode if saved state does not contain it


### PR DESCRIPTION
Fixes following
```
Zigbee2MQTT:debug 2021-09-11 15:17:37: Received MQTT message on 'zigbee2mqtt/LizaLight1/set' with data '{"scene_recall":0}'
Zigbee2MQTT:debug 2021-09-11 15:17:37: Publishing 'set' 'scene_recall' to 'LizaLight1'
Zigbee2MQTT:error 2021-09-11 15:17:37: Publish 'set' 'scene_recall' to 'LizaLight1' failed: 'TypeError: Cannot read property 'hasOwnProperty' of undefined'
Zigbee2MQTT:debug 2021-09-11 15:17:37: TypeError: Cannot read property 'hasOwnProperty' of undefined
    at Object.convertSet (/opt/zigbee2mqtt/node_modules/zigbee-herdsman-converters/converters/toZigbee.js:4609:40)
    at EntityPublish.onMQTTMessage (/opt/zigbee2mqtt/lib/extension/publish.js:230:36)
    at Controller.callExtensionMethod (/opt/zigbee2mqtt/lib/controller.js:419:58)
```