### PR TITLE
Add Paulmann RGBCW_LIGHT (4137)

### DIFF
--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -44,7 +44,7 @@ module.exports = [
         model: '4137',
         vendor: 'Paulmann',
         description: 'Smart Home Zigbee LED bulb 9,3W Matt E27 RGBW',
-        extend: extend.light_onoff_brightness_colortemp_color(),
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['CCT light'],

--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -43,7 +43,7 @@ module.exports = [
         zigbeeModel: ['RGBCW_LIGHT'],
         model: '4137',
         vendor: 'Paulmann',
-        description: 'Smart Home Zigbee LED Leuchtmittel 9,3W Matt E27 RGBW',
+        description: 'Smart Home Zigbee LED bulb 9,3W Matt E27 RGBW',
         extend: extend.light_onoff_brightness_colortemp_color(),
     },
     {

--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -44,7 +44,7 @@ module.exports = [
         model: '4137',
         vendor: 'Paulmann',
         description: 'Smart Home Zigbee LED bulb 9,3W Matt E27 RGBW',
-        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
     },
     {
         zigbeeModel: ['CCT light'],

--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -40,6 +40,13 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp_color(),
     },
     {
+        zigbeeModel: ['RGBCW_LIGHT'],
+        model: '4137',
+        vendor: 'Paulmann',
+        description: 'Smart Home Zigbee LED Leuchtmittel 9,3W Matt E27 RGBW',
+        extend: extend.light_onoff_brightness_colortemp_color(),
+    },
+    {
         zigbeeModel: ['CCT light'],
         model: '50064',
         vendor: 'Paulmann',


### PR DESCRIPTION
This Device https://www.elektro-wandelt.de/Paulmann-501-24-Smart-Home-Zigbee-LED-Leuchtmittel-9-3W-Matt-E27-RGBW.html