### PR TITLE
Add support for gledopto 7W garden lamp

### DIFF
--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -554,6 +554,14 @@ module.exports = [
         extend: gledoptoExtend.light_onoff_brightness_colortemp_color(),
     },
     {
+        zigbeeModel: ['GL-G-002P'],
+        model: 'GL-G-002P',
+        vendor: 'Gledopto',
+        ota: ota.zigbeeOTA,
+        description: 'Zigbee 7W Garden Lamp RGB+CCT (pro)',
+        extend: gledoptoExtend.light_onoff_brightness_colortemp_color(),
+    },
+    {
         zigbeeModel: ['GL-G-007Z'],
         model: 'GL-G-007Z',
         vendor: 'Gledopto',

--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -559,7 +559,7 @@ module.exports = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee 7W Garden Lamp RGB+CCT (pro)',
-        extend: gledoptoExtend.light_onoff_brightness_colortemp_color(),
+        extend: gledoptoExtend.light_onoff_brightness_colortemp_color({colorTempRange: [150, 500]}),
     },
     {
         zigbeeModel: ['GL-G-007Z'],

--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -558,7 +558,7 @@ module.exports = [
         model: 'GL-G-002P',
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
-        description: 'Zigbee 7W Garden Lamp RGB+CCT (pro)',
+        description: 'Zigbee 7W garden lamp RGB+CCT (pro)',
         extend: gledoptoExtend.light_onoff_brightness_colortemp_color({colorTempRange: [150, 500]}),
     },
     {


### PR DESCRIPTION
This PR adds support for the gledopto 7W garden lamp which is the same as the 12W lamp GL-G-001P.