### PR TITLE
Update Hue A19 1100 Lumen from extend to hueExtend

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1964,7 +1964,7 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue White and Color Ambiance A19 1100 lumen',
         meta: {turnsOffAtBrightness1: true},
-        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,
     },
     {


### PR DESCRIPTION
Changing Hue A19 1100 lumen from extend to hueExtend for additional control of power on behavior.