### PR TITLE
Philips LTC005

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1067,7 +1067,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp(),
     },
     {
-        zigbeeModel: ['3216131P6', 'LTC005],
+        zigbeeModel: ['3216131P6', 'LTC005'],
         model: '3216131P6',
         vendor: 'Philips',
         description: 'Hue white ambiance Aurelle square panel light',

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1046,7 +1046,7 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue ambiance ceiling',                
         meta: {turnsOffAtBrightness1: true},                    
-        extend: hueExtend.light_onoff_brightness_colortemp(),                       
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 454]}),
     },  
     {
         zigbeeModel: ['LTC011'],

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1040,6 +1040,14 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
     },
+    {                                           
+        zigbeeModel: ['LTC005'],                      
+        model: '3216131P6',                                                         
+        vendor: 'Philips',
+        description: 'Hue ambiance ceiling',                
+        meta: {turnsOffAtBrightness1: true},                    
+        extend: hueExtend.light_onoff_brightness_colortemp(),                       
+    },  
     {
         zigbeeModel: ['LTC011'],
         model: '4096730U7',
@@ -1065,7 +1073,6 @@ module.exports = [
         description: 'Hue white ambiance Aurelle square panel light',
         meta: {turnsOffAtBrightness1: true},
         extend: hueExtend.light_onoff_brightness_colortemp(),
-        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['3216131P6'],

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1040,14 +1040,6 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
     },
-    {                                           
-        zigbeeModel: ['LTC005'],                      
-        model: '3216131P6',                                                         
-        vendor: 'Philips',
-        description: 'Hue ambiance ceiling',                
-        meta: {turnsOffAtBrightness1: true},                    
-        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 454]}),
-    },  
     {
         zigbeeModel: ['LTC011'],
         model: '4096730U7',
@@ -1075,7 +1067,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp(),
     },
     {
-        zigbeeModel: ['3216131P6'],
+        zigbeeModel: ['3216131P6', 'LTC005],
         model: '3216131P6',
         vendor: 'Philips',
         description: 'Hue white ambiance Aurelle square panel light',


### PR DESCRIPTION
I noticed this Philips Hue is not recognized by the Zigbee2MQTT, so did some comparison, came up with this modification on the philips.js. Please take a look and merge it if there is no problem.

[Philips Hue Within Ceiling Lamp](https://www.philips-hue.com/ko-kr/p/hue-white-ambiance-within-ceiling-light/4505548C5)
<img width="671" alt="Screen Shot 2021-09-20 at 11 12 17 PM" src="https://user-images.githubusercontent.com/13171662/134017418-bdd9f685-b3ae-4ff2-a78a-d94c0647b86e.png">
