### PR TITLE
Apply red color fix to TS0503A

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -398,6 +398,7 @@ module.exports = [
         vendor: 'TuYa',
         description: 'Led strip controller',
         extend: extend.light_onoff_brightness_color(),
+        meta: {applyRedFix: true},
     },
     {
         zigbeeModel: ['TS0503A'],


### PR DESCRIPTION
When integrating this device it was impossible to set red color after a bit of research i've configured custom device with red color workaround present on other tuya devices which solved the issue.