### PR TITLE
Support for Paulmann 501.31 (Smart Plug)

### DIFF
--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -22,7 +22,7 @@ module.exports = [
         zigbeeModel: ['50131'],
         model: '501.31',
         vendor: 'Paulmann',
-        description: 'Paulmann Smart Plug for Euro- and Schuko-sockets',
+        description: 'Smart plug for Euro- and Schuko-sockets',
         extend: extend.switch(),
     },
     {

--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -19,6 +19,13 @@ module.exports = [
         extend: extend.switch(),
     },
     {
+        zigbeeModel: ['50131'],
+        model: '501.31',
+        vendor: 'Paulmann',
+        description: 'Paulmann Smart Plug for Euro- and Schuko-sockets',
+        extend: extend.switch(),
+    },
+    {
         zigbeeModel: ['Dimmablelight '],
         model: '50044/50045',
         vendor: 'Paulmann',


### PR DESCRIPTION
Support for a [Smart Plug from Paulmann](https://en.paulmann.com/p/plug-adapter-smart-home-zigbee-smart-plug-white/50131), which works fine with the `switch()` template.