### PR TITLE
Update neo.js - add battery_low to exposes for NAS-PD07

### DIFF
--- a/devices/neo.js
+++ b/devices/neo.js
@@ -36,7 +36,7 @@ module.exports = [
         fromZigbee: [fz.neo_nas_pd07],
         toZigbee: [],
         onEvent: tuya.setTime,
-        exposes: [e.occupancy(), e.humidity(), e.temperature(), e.tamper(),
+        exposes: [e.occupancy(), e.humidity(), e.temperature(), e.tamper(), e.battery_low(),
             exposes.enum('power_type', ea.STATE, ['battery_full', 'battery_high', 'battery_medium', 'battery_low', 'usb'])],
     },
 ];


### PR DESCRIPTION
Expose battery_low (reg. [#8996](https://github.com/Koenkk/zigbee2mqtt/issues/8996)).

As far I see - battery_low is calculated, published to MQTT, but not exposed as device property, thus not created in HA as entity.
If I understood correctly - e.battery_low() to be added to exposes array in same way as for NAS-AB02B0.