### PR TITLE
Added Philips hue E27 ST72 warm-to-white

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1820,7 +1820,7 @@ module.exports = [
         description: 'Hue white filament Edison ST72 E27 LED warm-to-cool',
         ota: ota.zigbeeOTA,
         meta: {turnsOffAtBrightness1: true},
-        extend: hueExtend.light_onoff_brightness_colortemp(),
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
     },
     {
         zigbeeModel: ['LWV002'],

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1814,6 +1814,15 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness(),
     },
     {
+        zigbeeModel: ['LTV002'],
+        model: '929002477901',
+        vendor: 'Philips',
+        description: 'Hue white filament Edison ST72 E27 LED warm-to-cool',
+        ota: ota.zigbeeOTA,
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp(),
+    },
+    {
         zigbeeModel: ['LWV002'],
         model: '046677551780',
         vendor: 'Philips',


### PR DESCRIPTION
This PR adds support for the new E27 Edison ST72 Philips Hue Bulb warm-to-cool. This bulb supports colour temperature unlike the previous bulbs.

Closes #3124 