### PR TITLE
Add support for `TS000x` Tuya switch modules

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3728,6 +3728,16 @@ const converters = {
             });
         },
     },
+    tuya_switch_type = {
+        cluster: 'manuSpecificTuya_3',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const lookup = {0: 'toggle', 1: 'state', 2: 'momentary'};
+            if (msg.data.hasOwnProperty('switchType')) {
+                return {switch_type: lookup[msg.data['switchType']]};
+            }
+        },
+    },
     restorable_brightness: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3728,7 +3728,7 @@ const converters = {
             });
         },
     },
-    tuya_switch_type = {
+    tuya_switch_type: {
         cluster: 'manuSpecificTuya_3',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2869,7 +2869,7 @@ const converters = {
             return {state: {state: value.toUpperCase()}};
         },
     },
-    tuya_switch_type = {
+    tuya_switch_type: {
         key: ['switch_type'],
         convertSet: async (entity, key, value, meta) => {
             value = value.toLowerCase();

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2869,6 +2869,19 @@ const converters = {
             return {state: {state: value.toUpperCase()}};
         },
     },
+    tuya_switch_type = {
+        key: ['switch_type'],
+        convertSet: async (entity, key, value, meta) => {
+            value = value.toLowerCase();
+            const lookup = {'toggle': 0, 'state': 1, 'momentary': 2};
+            utils.validateValue(value, Object.keys(lookup));
+            await entity.write('manuSpecificTuya_3', {'switchType': lookup[value]}, {disableDefaultResponse: true});
+            return {state: {switch_type: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificTuya_3', ['switchType']);
+        },
+    },
     frankever_threshold: {
         key: ['threshold'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -585,57 +585,30 @@ module.exports = [
         },
     },
     {
-        fingerprint: [
-            {modelID: 'TS0001', manufacturerName: '_TZ3000_tqlv4ug4'},
-        ],
+        fingerprint: [{modelID: 'TS0001', manufacturerName: '_TZ3000_tqlv4ug4'}],
         model: 'TS0001_switch_module',
         vendor: 'TuYa',
         description: '1 gang switch module',
-        whiteLabel: [
-            {vendor: 'OXT', model: 'SWTZ21'},
-        ],
-        toZigbee: extend.switch().toZigbee.concat([
-            tz.moes_power_on_behavior,
-            tz.tuya_switch_type,
-        ]),
-        fromZigbee: extend.switch().fromZigbee.concat([
-            fz.moes_power_on_behavior,
-            fz.tuya_switch_type,
-        ]),
-        exposes: extend.switch().exposes.concat([
-            exposes.presets.power_on_behavior(),
+        whiteLabel: [{vendor: 'OXT', model: 'SWTZ21'}],
+        toZigbee: extend.switch().toZigbee.concat([tz.moes_power_on_behavior, tz.tuya_switch_type]),
+        fromZigbee: extend.switch().fromZigbee.concat([fz.moes_power_on_behavior, fz.tuya_switch_type]),
+        exposes: extend.switch().exposes.concat([exposes.presets.power_on_behavior(),
             exposes.enum('switch_type', ea.ALL, ['toggle', 'state', 'momentary'])
-                .withDescription('Switch type settings'),
-        ]),
+                .withDescription('Switch type settings')]),
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
         },
     },
     {
-        fingerprint: [
-            {modelID: 'TS0002', manufacturerName: '_TZ3000_01gpyda5'},
-        ],
+        fingerprint: [{modelID: 'TS0002', manufacturerName: '_TZ3000_01gpyda5'}],
         model: 'TS0002_switch_module',
         vendor: 'TuYa',
         description: '2 gang switch module',
-        whiteLabel: [
-            {vendor: 'OXT', model: 'SWTZ22'},
-        ],
-        toZigbee: extend.switch().toZigbee.concat([
-            tz.moes_power_on_behavior,
-            tz.tuya_switch_type,
-        ]),
-        fromZigbee: extend.switch().fromZigbee.concat([
-            fz.moes_power_on_behavior,
-            fz.tuya_switch_type,
-        ]),
-        exposes: [
-            e.switch().withEndpoint('l1'),
-            e.switch().withEndpoint('l2'),
-            exposes.presets.power_on_behavior(),
-            exposes.enum('switch_type', ea.ALL, ['toggle', 'state', 'momentary'])
-                .withDescription('Switch type settings'),
-        ],
+        whiteLabel: [{vendor: 'OXT', model: 'SWTZ22'}],
+        toZigbee: extend.switch().toZigbee.concat([tz.moes_power_on_behavior, tz.tuya_switch_type]),
+        fromZigbee: extend.switch().fromZigbee.concat([fz.moes_power_on_behavior, fz.tuya_switch_type]),
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), exposes.presets.power_on_behavior(),
+            exposes.enum('switch_type', ea.ALL, ['toggle', 'state', 'momentary']).withDescription('Switch type settings')],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -588,7 +588,7 @@ module.exports = [
         fingerprint: [
             {modelID: 'TS0001', manufacturerName: '_TZ3000_tqlv4ug4'}
         ],
-        model: 'TS0001',
+        model: 'TS0001_switch_module',
         vendor: 'TuYa',
         description: '1 gang switch module',
         whiteLabel: [
@@ -615,7 +615,7 @@ module.exports = [
         fingerprint: [
             {modelID: 'TS0002', manufacturerName: '_TZ3000_01gpyda5'}
         ],
-        model: 'TS0002',
+        model: 'TS0002_switch_module',
         vendor: 'TuYa',
         description: '2 gang switch module',
         whiteLabel: [

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -585,6 +585,53 @@ module.exports = [
         },
     },
     {
+        fingerprint: [
+            {modelID: 'TS0001', manufacturerName: '_TZ3000_tqlv4ug4'}
+        ],
+        model: 'TS0001',
+        vendor: 'TuYa',
+        description: '1 gang switch module',
+        toZigbee: extend.switch().toZigbee.concat([
+            tz.moes_power_on_behavior
+        ]),
+        fromZigbee: extend.switch().fromZigbee.concat([
+            fz.moes_power_on_behavior
+        ]),
+        exposes: extend.switch().exposes.concat([
+            exposes.presets.power_on_behavior(),
+        ]),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+        },
+    },
+    {
+        fingerprint: [
+            {modelID: 'TS0002', manufacturerName: '_TZ3000_01gpyda5'}
+        ],
+        model: 'TS0002',
+        vendor: 'TuYa',
+        description: '2 gang switch module',
+        toZigbee: extend.switch().toZigbee.concat([
+            tz.moes_power_on_behavior
+        ]),
+        fromZigbee: extend.switch().fromZigbee.concat([
+            fz.moes_power_on_behavior
+        ]),
+        exposes: [
+            e.switch().withEndpoint('l1'),
+            e.switch().withEndpoint('l2'),
+            exposes.presets.power_on_behavior(),
+        ],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+        },
+    },
+    {
         zigbeeModel: [
             'owvfni3\u0000', 'owvfni3', 'u1rkty3', 'aabybja', // Curtain motors
             'mcdj3aq', 'mcdj3aq\u0000', // Tubular motors

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -586,7 +586,7 @@ module.exports = [
     },
     {
         fingerprint: [
-            {modelID: 'TS0001', manufacturerName: '_TZ3000_tqlv4ug4'}
+            {modelID: 'TS0001', manufacturerName: '_TZ3000_tqlv4ug4'},
         ],
         model: 'TS0001_switch_module',
         vendor: 'TuYa',
@@ -604,7 +604,7 @@ module.exports = [
         ]),
         exposes: extend.switch().exposes.concat([
             exposes.presets.power_on_behavior(),
-            exposes.enum('switch_type', ea.STATE_SET, ['toggle', 'state', 'momentary'])
+            exposes.enum('switch_type', ea.ALL, ['toggle', 'state', 'momentary'])
                 .withDescription('Switch type settings'),
         ]),
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -613,7 +613,7 @@ module.exports = [
     },
     {
         fingerprint: [
-            {modelID: 'TS0002', manufacturerName: '_TZ3000_01gpyda5'}
+            {modelID: 'TS0002', manufacturerName: '_TZ3000_01gpyda5'},
         ],
         model: 'TS0002_switch_module',
         vendor: 'TuYa',
@@ -633,7 +633,7 @@ module.exports = [
             e.switch().withEndpoint('l1'),
             e.switch().withEndpoint('l2'),
             exposes.presets.power_on_behavior(),
-            exposes.enum('switch_type', ea.STATE_SET, ['toggle', 'state', 'momentary'])
+            exposes.enum('switch_type', ea.ALL, ['toggle', 'state', 'momentary'])
                 .withDescription('Switch type settings'),
         ],
         endpoint: (device) => {

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -591,14 +591,21 @@ module.exports = [
         model: 'TS0001',
         vendor: 'TuYa',
         description: '1 gang switch module',
+        whiteLabel: [
+            {vendor: 'OXT', model: 'SWTZ21'},
+        ],
         toZigbee: extend.switch().toZigbee.concat([
-            tz.moes_power_on_behavior
+            tz.moes_power_on_behavior,
+            tz.tuya_switch_type,
         ]),
         fromZigbee: extend.switch().fromZigbee.concat([
-            fz.moes_power_on_behavior
+            fz.moes_power_on_behavior,
+            fz.tuya_switch_type,
         ]),
         exposes: extend.switch().exposes.concat([
             exposes.presets.power_on_behavior(),
+            exposes.enum('switch_type', ea.STATE_SET, ['toggle', 'state', 'momentary'])
+                .withDescription('Switch type settings'),
         ]),
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
@@ -611,16 +618,23 @@ module.exports = [
         model: 'TS0002',
         vendor: 'TuYa',
         description: '2 gang switch module',
+        whiteLabel: [
+            {vendor: 'OXT', model: 'SWTZ22'},
+        ],
         toZigbee: extend.switch().toZigbee.concat([
-            tz.moes_power_on_behavior
+            tz.moes_power_on_behavior,
+            tz.tuya_switch_type,
         ]),
         fromZigbee: extend.switch().fromZigbee.concat([
-            fz.moes_power_on_behavior
+            fz.moes_power_on_behavior,
+            fz.tuya_switch_type,
         ]),
         exposes: [
             e.switch().withEndpoint('l1'),
             e.switch().withEndpoint('l2'),
             exposes.presets.power_on_behavior(),
+            exposes.enum('switch_type', ea.STATE_SET, ['toggle', 'state', 'momentary'])
+                .withDescription('Switch type settings'),
         ],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};


### PR DESCRIPTION
This PR extends the functionality of the latest Tuya switch modules (1CH, 2CH). Currently, z2m detects them as wall switches with limited options.

This PR requires [0xe001](https://github.com/Koenkk/zigbee-herdsman/pull/430) cluster.

![2021-10-06 at 12 03](https://user-images.githubusercontent.com/1451824/136182544-94b959e1-9b16-40bc-a6a8-50626fad2d22.png)

This is how it looks like in the dashboard:

![2021-10-06 at 12 06](https://user-images.githubusercontent.com/1451824/136183132-44440c6f-b153-4860-aba1-194174d881ca.png)
![2021-10-06 at 15 11](https://user-images.githubusercontent.com/1451824/136209160-5634a789-6417-4e40-8e10-114813cb9b4f.png)

