### PR TITLE
Add Sanico TUYA TS0601 thermostat.

### DIFF
--- a/devices/saswell.js
+++ b/devices/saswell.js
@@ -17,6 +17,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_yw7cahqs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuhszj9s'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_9gvruqf5'},
         ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',


### PR DESCRIPTION
```
debug 2021-10-06 19:32:47: Received Zigbee message from '0x84fd27fffe31a6cb', type 'commandGetData', cluster 'manuSpecificTuya', data '{"data":{"data":[0,0,0,0,0,0,0,0,0,0,0,0],"type":"Buffer"},"datatype":0,"dp":122,"fn":0,"status":0,"transid":20}' from endpoint 1 with groupID 0
warn  2021-10-06 19:32:47: Received message from unsupported device with Zigbee model 'TS0601' and manufacturer name '_TZE200_9gvruqf5'
```

Same hardware as SEA801-Zigbee/SEA802-Zigbee but with different branding.