### PR TITLE
Add additional zigbeeModel for IKEA LED1936G5

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -91,10 +91,10 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
-        zigbeeModel: ['TRADFRIbulbG125E27WSopal470lm'],
+        zigbeeModel: ['TRADFRIbulbG125E27WSopal470lm', 'TRADFRIbulbG125E26WSopal450lm'],
         model: 'LED1936G5',
         vendor: 'IKEA',
-        description: 'TRADFRI LED globe-bulb E27 470 lumen, dimmable, white spectrum, opal white',
+        description: 'TRADFRI LED globe-bulb E26/E27 450/470 lumen, dimmable, white spectrum, opal white',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
     },
     {


### PR DESCRIPTION
Tested on my local hassio, bought this bulb from ikea in the US today, has a different zigbeeModel but confirmed the LED1936G5 model number on the box. Edited the description the same way that other E26/E27 bulbs in the file.