### PR TITLE
Add Schneider WDE002386 push button dimmer

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -108,6 +108,25 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['NHPB/DIMMER/1'],
+        model: 'WDE002386',
+        vendor: 'Schneider Electric',
+        description: 'Push button dimmer',
+        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.lighting_ballast_configuration],
+        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config],
+        exposes: [e.light_brightness().withLevelConfig(),
+            exposes.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the minimum light output of the ballast'),
+            exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the maximum light output of the ballast')],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(3);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['CH/DIMMER/1'],
         model: '41EPBDWCLMZ/354PBDMBTZ',
         vendor: 'Schneider Electric',


### PR DESCRIPTION
Adds support for the [Schneider Electric WDE002386 push button dimmer](https://www.se.com/ww/en/product/WDE002386/dimmer%2C-wiser%2C-exxact%2C-push-button%2C-universal%2C-led%2C-zigbee%2C-white/). This is essentially the same as the rotary dimmer introduced in #2544.

This is also sold in Norway under the name [Elko SmartDim Trykk Uni](https://elkosmart.elko.no/produkter/smartdim-trykk-uni-200w). I tested and verified this device integration using the Elko branded version, but as far as I can tell these should work identically.