### PR TITLE
Update YDD-D4F0 TSDB battery %

### DIFF
--- a/devices/yale.js
+++ b/devices/yale.js
@@ -108,6 +108,8 @@ module.exports = [
         vendor: 'Yale',
         description: 'Lockwood T-Lock',
         extend: lockExtend,
+        // Differs from Assure lock SL
+        meta: {battery: {dontDividePercentage: false}},
     },
     {
         zigbeeModel: ['c700000202'],


### PR DESCRIPTION
Added `dontDividePercentage` meta information for YDD-D4F0 TSDB  to prevent reporting double the battery remaining value.

Solves issue https://github.com/Koenkk/zigbee-herdsman-converters/issues/3133