### PR TITLE
Add a converter for the Alecto SMART-HEAT10 thermostatic radiator

### DIFF
--- a/devices/alecto.js
+++ b/devices/alecto.js
@@ -1,0 +1,26 @@
+const exposes = require('../lib/exposes');
+const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const tz = require('../converters/toZigbee');
+const tuya = require('../lib/tuya');
+const e = exposes.presets;
+const ea = exposes.access;
+
+module.exports = [
+    {
+        fingerprint: [
+            {modelID: 'daqwrsj\u0000', manufacturerName: '_TYST11_8daqwrsj'},
+        ],
+        model: 'SMART-HEAT10',
+        vendor: 'Alecto',
+        description: 'Radiator valve with thermostat',
+        fromZigbee: [fz.tuya_thermostat, fz.ignore_basic_report],
+        meta: {tuyaThermostatSystemMode: tuya.thermostatSystemModes4, tuyaThermostatPreset: tuya.thermostatPresets,
+            tuyaThermostatPresetToSystemMode: tuya.thermostatSystemModes4},
+        toZigbee: [tz.tuya_thermostat_child_lock, tz.siterwell_thermostat_window_detection,
+            tz.tuya_thermostat_current_heating_setpoint, tz.tuya_thermostat_system_mode,
+        ],
+        exposes: [e.child_lock(), e.window_detection(), e.battery(), exposes.climate()
+            .withSetpoint('current_heating_setpoint', 5, 30, 0.5, ea.STATE_SET).withLocalTemperature(ea.STATE)
+            .withSystemMode(['off', 'auto', 'heat'], ea.STATE_SET)],
+    },
+];


### PR DESCRIPTION
This device is sold as Tuya compatible, and after some probing it
appears to look quite similar to the device in siterwell.js but lacks
some features.

One dpid is still a mystery; this device sends out the following:

2021-10-12 22:52:04: Received Zigbee message from 'zolder_thermostaat', type 'commandGetData', cluster 'manuSpecificTuya', data '{"data":{"data":[0],"type":"Buffer"},"datatype":4,"dp":17,"fn":0,"status":0,"transid":166}' from endpoint 1 with groupID 0
zigbee-herdsman-converters:tuyaThermostat: Unrecognized DP #17 with data {"status":0,"transid":166,"dp":17,"datatype":4,"fn":0,"data":{"type":"Buffer","data":[0]}}

It always seems to be zero.

Unfortunately the vendor was unable to offer more details.