### PR TITLE
Add Hue Bluetooth white & color ambiance Surimu square panel

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2074,4 +2074,13 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
         ota: ota.zigbeeOTA,
     },
+    {
+        zigbeeModel: ['929002966401'],
+        model: '929002966401',
+        vendor: 'Philips',
+        description: 'Hue white & color ambiance Surimu square panel',
+        meta: {turnsOffAtBrightness1: true},
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        ota: ota.zigbeeOTA,
+    },
 ];


### PR DESCRIPTION
Unfortunately, I cannot [determine the color temp range](https://github.com/Koenkk/zigbee2mqtt.io/blob/develop/docs/how_tos/how_to_support_new_devices.md#31-retrieving-color-temperature-range-only-required-for-lights-which-support-color-temperature) because I use the light only with ioBroker, which does not expose the "sending commands" part. (In fact, ioBroker uses this library without requiring MQTT at all.)