### PR TITLE
add extra zigbeeModel 7602031P7 for Philips Hue Go

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -297,7 +297,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LCT026'],
+        zigbeeModel: ['LCT026', '7602031P7'],
         model: '7602031P7',
         vendor: 'Philips',
         description: 'Hue Go with Bluetooth',


### PR DESCRIPTION
After seeing:
> zigbee2mqtt@1.21.2 start
> node index.js
Zigbee2MQTT:warn  2021-10-14 12:56:23: Device '0x0017[REDACTED]' with Zigbee model '7602031P7' and manufacturer name 'Philips' is NOT supported, please follow https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html`

I would conclude that the actual Zigbee model should also support the string `7602031P7`