### PR TITLE
Correct Danfoss window closed constant

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -85,7 +85,7 @@ const temperatureDisplayMode = {
 
 const danfossWindowOpen = {
     0: 'quarantine',
-    1: 'closing',
+    1: 'closed',
     2: 'hold',
     3: 'open',
     4: 'external_open',


### PR DESCRIPTION
According to Danfoss [documentation](https://assets.danfoss.com/documents/176987/AM375549618098en-000101.pdf), the constant 0x01 means that windows are closed, not that they are closing.