### PR TITLE
Add Hue White & Color Ambiance Centris ceiling light (3 spots)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2092,4 +2092,13 @@ module.exports = [
         meta: {turnsOffAtBrightness1: true},
         ota: ota.zigbeeOTA,
     },
+    {
+        zigbeeModel: ['5060931P7_01', '5060931P7_02', '5060931P7_03', '5060931P7_04'],
+        model: '5060931P7',
+        vendor: 'Philips',
+        description: 'Hue White & Color Ambiance Centris ceiling light (3 spots)',
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        meta: {turnsOffAtBrightness1: true},
+        ota: ota.zigbeeOTA,
+    },
 ];


### PR DESCRIPTION
We already have a similar light, but in this configuration, the 3 spots are mounted linear. The other variant looks like a cross.