### PR TITLE
Added running_state to Eurotronic thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2205,6 +2205,9 @@ const converters = {
             if (typeof msg.data[0x4001] == 'number') {
                 result.valve_position = msg.data[0x4001];
             }
+            if (msg.data.hasOwnProperty('pIHeatingDemand')) {
+                result.running_state = msg.data['pIHeatingDemand'] >= 10 ? 'heat' : 'idle';
+            }
             return result;
         },
     },


### PR DESCRIPTION
Currently, the property `running_state` is reported as `N/A` and not fetched from Zigbee.

![Screenshot](https://user-images.githubusercontent.com/28873326/138408358-68fe09c8-206f-4736-bbb4-8c394d92adb6.png)

Reported status in Zigbee2MQTT:
```
{
    "battery": 100,
    "boost": false,
    "child_protection": false,
    "current_heating_setpoint": 19,
    "error_status": 0,
    "eurotronic_error_status": 0,
    "eurotronic_host_flags": {
        "boost": false,
        "child_protection": false,
        "mirror_display": false,
        "window_open": true
    },
    "eurotronic_system_mode": 17,
    "eurotronic_trv_mode": 2,
    "last_seen": "2021-10-22T08:58:27+02:00",
    "linkquality": 66,
    "local_temperature": 18.49,
    "local_temperature_calibration": 0,
    "mirror_display": false,
    "occupied_heating_setpoint": 19,
    "pi_heating_demand": 19,
    "system_mode": "auto",
    "trv_mode": 2,
    "unoccupied_heating_setpoint": 10,
    "update": {
        "state": "idle"
    },
    "update_available": false,
    "valve_position": 0,
    "window_open": false,
    "eurotronic_valve_position": null
}
```
The running_state isn't exposed as Zigbee Attribute (according to the [documentation](https://eurotronic.org/wp-content/uploads/2021/07/Spirit_ZigBee_BDA_web_EN_2021.pdf)). The proposed change is based on stelpro_thermostat, which should result in a correct reported running_state.
https://github.com/Koenkk/zigbee-herdsman-converters/blob/ca5a8e0f2c2a56005fe73a25a5725ba13d4009db/converters/fromZigbee.js#L2087-L2100
