### PR TITLE
White version of Hue White & Color ambience Centris ceiling light

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1355,6 +1355,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['5060731P7_01', '5060731P7_02', '5060731P7_03', '5060731P7_04', '5060731P7_05'],
+        model: '5060731P7',
+        vendor: 'Philips',
+        description: 'Hue White & Color ambience Centris ceiling light (4 spots)',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['5060830P7_01', '5060830P7_02', '5060830P7_03', '5060830P7_04'],
         model: '5060830P7',
         vendor: 'Philips',


### PR DESCRIPTION
Adding support for 5060731P7, the white version of Hue White & Color ambience Centris ceiling light (4 spots)