### PR TITLE
Add support for Haozee TS0601 TRV variant

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -687,7 +687,7 @@ module.exports = [
         zigbeeModel: ['kud7u2l'],
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l'}, {modelID: 'TS0601', manufacturerName: '_TZE200_ywdxldoj'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_cwnjrr72'}, {modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay'},
-                      {modelID: 'TS0601', manufacturerName: '_TZE200_a4bpgplm'}],
+            {modelID: 'TS0601', manufacturerName: '_TZE200_a4bpgplm'}],
         model: 'TS0601_thermostat',
         vendor: 'TuYa',
         description: 'Radiator valve with thermostat',


### PR DESCRIPTION
This PR adds support for the Haozee Zigbee thermostat sold on Aliex[ress. It's simply a variant of the Tuya TS0601 thermostat so it was sufficient to only add the different manufacurerName (_TZE200_a4bpgplm) to the tuya.js.
With this change the device gets detected and you can interact with it just like with any other TS0601 thermostat.