### PR TITLE
Add definition for LTV004 (Philips Hue White Ambience ST19/E26)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1878,6 +1878,15 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
     },
     {
+        zigbeeModel: ['LTV004'],
+        model: '929002478401',
+        vendor: 'Philips',
+        description: 'Hue white filament Edison ST19 E26 LED warm-to-cool',
+        ota: ota.zigbeeOTA,
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
+    },
+    {
         zigbeeModel: ['LWV002'],
         model: '046677551780',
         vendor: 'Philips',


### PR DESCRIPTION
Support for Philps Hue White Ambience ST19/E26 bulb. Seems to be identical in behavior to the LTV002 bulb. 

`Read result of 'lightingColorCtrl': {"colorTempPhysicalMin":222,"colorTempPhysicalMax":454}`

![1635003098](https://user-images.githubusercontent.com/494016/138562616-a8f5c267-a89a-4478-bd87-ce5df02159c9.png)
