### PR TITLE
Update LED1624G9 to support white spectrum

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -194,10 +194,8 @@ module.exports = [
         model: 'LED1624G9',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E14/E26/E27 600 lumen, dimmable, color, opal white',
-        extend: extend.light_onoff_brightness_color(),
-        ota: ota.tradfri,
+        extend: tradfriExtend.light_onoff_brightness_colortemp_color(),
         meta: {supportsHueAndSaturation: false},
-        onEvent: bulbOnEvent,
     },
     {
         zigbeeModel: ['TRADFRI bulb E26 CWS 800lm', 'TRADFRI bulb E27 CWS 806lm'],


### PR DESCRIPTION
Product should support both color and white spectrum controls.
Changed in ikea.js to reflect the change and remove code that became unnecessary, as it is included in tradfriExtend.
Unsure about if the meta -> supportsHueAndSaturation line 198 is still required, as it is not on any other lamp and I am unsure of its purpose.