### PR TITLE
Support newer Lupus 2 (fw or board revision?)

### DIFF
--- a/devices/lupus.js
+++ b/devices/lupus.js
@@ -54,7 +54,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['PRS3CH2_00.00.05.10TC', 'PRS3CH2_00.00.05.11TC'],
+        zigbeeModel: ['PRS3CH2_00.00.05.10TC', 'PRS3CH2_00.00.05.11TC', 'PRS3CH2_00.00.05.12TC'],
         model: '12127',
         vendor: 'Lupus',
         description: '2 chanel relay',


### PR DESCRIPTION
I've just added a new Lupus 2 to my zigbee network. It showed up as unsupported, which is due to the zigbeeModel being newer than what the converter supports.

My new device has zigbeeModel PRS3CH2_00.00.05.12TC as opposed to 10TC or 11TC.

This has been tested and works as expected.