### PR TITLE
Add danfoss thermostat load balancing support

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3024,6 +3024,12 @@ const converters = {
                     result[postfixWithEndpointName('running_state', msg, model)] = 'idle';
                 }
             }
+            if (msg.data.hasOwnProperty('danfossLoadBalancingEnable')) {
+                result[postfixWithEndpointName('load_balancing_enable', msg, model)] = (msg.data['danfossLoadBalancingEnable'] === 1);
+            }
+            if (msg.data.hasOwnProperty('danfossLoadRoomMean')) {
+                result[postfixWithEndpointName('load_room_mean', msg, model)] = msg.data['danfossLoadRoomMean'];
+            }
             if (msg.data.hasOwnProperty('danfossLoadEstimate')) {
                 result[postfixWithEndpointName('load_estimate', msg, model)] = msg.data['danfossLoadEstimate'];
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2510,6 +2510,26 @@ const converters = {
             await entity.read('hvacThermostat', ['danfossWindowOpenExternal'], manufacturerOptions.danfoss);
         },
     },
+    danfoss_load_balancing_enable: {
+        key: ['load_balancing_enable'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'danfossLoadBalancingEnable': value}, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 200, state: {'load_balancing_enable': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossLoadBalancingEnable'], manufacturerOptions.danfoss);
+        },
+    },
+    danfoss_load_room_mean: {
+        key: ['load_room_mean'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'danfossLoadRoomMean': value}, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 200, state: {'load_room_mean': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossLoadRoomMean'], manufacturerOptions.danfoss);
+        },
+    },
     danfoss_load_estimate: {
         key: ['load_estimate'],
         convertGet: async (entity, key, meta) => {

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -20,7 +20,7 @@ module.exports = [
             tz.danfoss_heat_available, tz.danfoss_heat_required, tz.danfoss_day_of_week, tz.danfoss_trigger_time,
             tz.danfoss_window_open_internal, tz.danfoss_window_open_external, tz.danfoss_load_estimate,
             tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.thermostat_keypad_lockout,
-            tz.thermostat_system_mode],
+            tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean],
         exposes: [e.battery(), e.keypad_lockout(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -57,6 +57,11 @@ module.exports = [
             exposes.numeric('algorithm_scale_factor', ea.ALL).withValueMin(1).withValueMax(10)
                 .withDescription('Scale factor of setpoint filter timeconstant ("aggressiveness" of control algorithm) '+
                     '1= Quick ...  5=Moderate ... 10=Slow'),
+            exposes.binary('load_balancing_enable', ea.ALL, true, false)
+                .withDescription('Whether or not the thermostat acts as standalone thermostat or shares load with other ' +
+                    'thermostats in the room. The gateway must update load_room_mean if enabled.'),
+            exposes.numeric('load_room_mean', ea.ALL)
+                .withDescription('Mean radiator load for room calculated by gateway for load balancing purposes'),
             exposes.numeric('load_estimate', ea.STATE_GET)
                 .withDescription('Load estimate on this radiator')],
         ota: ota.zigbeeOTA,
@@ -106,6 +111,8 @@ module.exports = [
                 'danfossMountedModeControl',
                 'danfossMountedModeActive',
                 'danfossExternalMeasuredRoomSensor',
+                'danfossLoadBalancingEnable',
+                'danfossLoadRoomMean',
             ], options);
 
             // read systemMode to have an initial value


### PR DESCRIPTION
Exposes the room-wide load balancing feature.

Depends on: https://github.com/Koenkk/zigbee-herdsman/pull/439