### PR TITLE
Danfoss thermostat is sleepy so use sendWhenActive

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3024,6 +3024,12 @@ const converters = {
                     result[postfixWithEndpointName('running_state', msg, model)] = 'idle';
                 }
             }
+            if (msg.data.hasOwnProperty('danfossLoadBalancingEnable')) {
+                result[postfixWithEndpointName('load_balancing_enable', msg, model)] = (msg.data['danfossLoadBalancingEnable'] === 1);
+            }
+            if (msg.data.hasOwnProperty('danfossLoadRoomMean')) {
+                result[postfixWithEndpointName('load_room_mean', msg, model)] = msg.data['danfossLoadRoomMean'];
+            }
             if (msg.data.hasOwnProperty('danfossLoadEstimate')) {
                 result[postfixWithEndpointName('load_estimate', msg, model)] = msg.data['danfossLoadEstimate'];
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2395,7 +2395,7 @@ const converters = {
                 setpointType: 1,
                 setpoint: (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100,
             };
-            await entity.command('hvacThermostat', 'danfossSetpointCommand', payload, manufacturerOptions.danfoss);
+            await entity.command('hvacThermostat', 'danfossSetpointCommand', payload, {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['occupiedHeatingSetpoint']);
@@ -2404,136 +2404,136 @@ const converters = {
     danfoss_mounted_mode_active: {
         key: ['mounted_mode_active'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossMountedModeActive'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossMountedModeActive'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_mounted_mode_control: {
         key: ['mounted_mode_control'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossMountedModeControl': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossMountedModeControl': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'mounted_mode_control': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossMountedModeControl'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossMountedModeControl'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_thermostat_vertical_orientation: {
         key: ['thermostat_vertical_orientation'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossThermostatOrientation': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossThermostatOrientation': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'thermostat_vertical_orientation': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossThermostatOrientation'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossThermostatOrientation'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_external_measured_room_sensor: {
         key: ['external_measured_room_sensor'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossExternalMeasuredRoomSensor': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossExternalMeasuredRoomSensor': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'external_measured_room_sensor': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossExternalMeasuredRoomSensor'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossExternalMeasuredRoomSensor'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_viewing_direction: {
         key: ['viewing_direction'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacUserInterfaceCfg', {'danfossViewingDirection': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacUserInterfaceCfg', {'danfossViewingDirection': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'viewing_direction': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacUserInterfaceCfg', ['danfossViewingDirection'], manufacturerOptions.danfoss);
+            await entity.read('hvacUserInterfaceCfg', ['danfossViewingDirection'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_algorithm_scale_factor: {
         key: ['algorithm_scale_factor'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossAlgorithmScaleFactor': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossAlgorithmScaleFactor': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'algorithm_scale_factor': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossAlgorithmScaleFactor'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossAlgorithmScaleFactor'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_heat_available: {
         key: ['heat_available'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossHeatAvailable': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossHeatAvailable': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'heat_available': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossHeatAvailable'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossHeatAvailable'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_heat_required: {
         key: ['heat_required'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossHeatRequired'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossHeatRequired'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_day_of_week: {
         key: ['day_of_week'],
         convertSet: async (entity, key, value, meta) => {
             const payload = {'danfossDayOfWeek': utils.getKey(constants.dayOfWeek, value, undefined, Number)};
-            await entity.write('hvacThermostat', payload, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', payload, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'day_of_week': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossDayOfWeek'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossDayOfWeek'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_trigger_time: {
         key: ['trigger_time'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossTriggerTime': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossTriggerTime': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'trigger_time': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossTriggerTime'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossTriggerTime'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_window_open_internal: {
         key: ['window_open_internal'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossWindowOpenInternal'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossWindowOpenInternal'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_window_open_external: {
         key: ['window_open_external'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossWindowOpenExternal': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossWindowOpenExternal': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'window_open_external': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossWindowOpenExternal'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossWindowOpenExternal'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_load_balancing_enable: {
         key: ['load_balancing_enable'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossLoadBalancingEnable': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossLoadBalancingEnable': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'load_balancing_enable': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossLoadBalancingEnable'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossLoadBalancingEnable'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_load_room_mean: {
         key: ['load_room_mean'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {'danfossLoadRoomMean': value}, manufacturerOptions.danfoss);
+            await entity.write('hvacThermostat', {'danfossLoadRoomMean': value}, {sendWhenActive: true, ...manufacturerOptions.danfoss});
             return {readAfterWriteTime: 200, state: {'load_room_mean': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossLoadRoomMean'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossLoadRoomMean'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_load_estimate: {
         key: ['load_estimate'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['danfossLoadEstimate'], manufacturerOptions.danfoss);
+            await entity.read('hvacThermostat', ['danfossLoadEstimate'], {sendWhenActive: true, ...manufacturerOptions.danfoss});
         },
     },
     danfoss_output_status: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2510,6 +2510,26 @@ const converters = {
             await entity.read('hvacThermostat', ['danfossWindowOpenExternal'], manufacturerOptions.danfoss);
         },
     },
+    danfoss_load_balancing_enable: {
+        key: ['load_balancing_enable'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'danfossLoadBalancingEnable': value}, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 200, state: {'load_balancing_enable': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossLoadBalancingEnable'], manufacturerOptions.danfoss);
+        },
+    },
+    danfoss_load_room_mean: {
+        key: ['load_room_mean'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'danfossLoadRoomMean': value}, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 200, state: {'load_room_mean': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossLoadRoomMean'], manufacturerOptions.danfoss);
+        },
+    },
     danfoss_load_estimate: {
         key: ['load_estimate'],
         convertGet: async (entity, key, meta) => {

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -20,7 +20,7 @@ module.exports = [
             tz.danfoss_heat_available, tz.danfoss_heat_required, tz.danfoss_day_of_week, tz.danfoss_trigger_time,
             tz.danfoss_window_open_internal, tz.danfoss_window_open_external, tz.danfoss_load_estimate,
             tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.thermostat_keypad_lockout,
-            tz.thermostat_system_mode],
+            tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean],
         exposes: [e.battery(), e.keypad_lockout(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -57,6 +57,11 @@ module.exports = [
             exposes.numeric('algorithm_scale_factor', ea.ALL).withValueMin(1).withValueMax(10)
                 .withDescription('Scale factor of setpoint filter timeconstant ("aggressiveness" of control algorithm) '+
                     '1= Quick ...  5=Moderate ... 10=Slow'),
+            exposes.binary('load_balancing_enable', ea.ALL, true, false)
+                .withDescription('Whether or not the thermostat acts as standalone thermostat or shares load with other ' +
+                    'thermostats in the room. The gateway must update load_room_mean if enabled.'),
+            exposes.numeric('load_room_mean', ea.ALL)
+                .withDescription('Mean radiator load for room calculated by gateway for load balancing purposes'),
             exposes.numeric('load_estimate', ea.STATE_GET)
                 .withDescription('Load estimate on this radiator')],
         ota: ota.zigbeeOTA,
@@ -106,6 +111,8 @@ module.exports = [
                 'danfossMountedModeControl',
                 'danfossMountedModeActive',
                 'danfossExternalMeasuredRoomSensor',
+                'danfossLoadBalancingEnable',
+                'danfossLoadRoomMean',
             ], options);
 
             // read systemMode to have an initial value


### PR DESCRIPTION
As a Sleepy End Device, we should use sendWhenActive for all requests to the device.

However, rather than manually setting this flag whenever someone discovers issues with sleeping devices like done here, maybe we should enable sendWhenActive by default for sleepy end-devices, possibly using "battery-powered end-device" as heuristic. Open to suggestions.

Note: Built upon https://github.com/Koenkk/zigbee-herdsman-converters/pull/3239