### PR TITLE
new white-label tuya curtain motor: Zemismart BCM500DS-TYZ-B

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -706,6 +706,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_nueqqe6k'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_xaabybja'},
             {modelID: 'zo2pocs\u0000', manufacturerName: '_TYST11_fzo2pocs'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_rmymn92d'},
             // Roller blinds:
             {modelID: 'TS0601', manufacturerName: '_TZE200_sbordckq'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_fctwhugx'},
@@ -734,6 +735,7 @@ module.exports = [
             {vendor: 'Zemismart', model: 'AM43', description: 'Roller blind motor'},
             {vendor: 'Zemismart', model: 'M2805EGBZTN', description: 'Tubular motor'},
             {vendor: 'Zemismart', model: 'BCM500DS-TYZ', description: 'Curtain motor'},
+            {vendor: 'Zemismart', model: 'BCM500DS-TYZ-B', description: 'Curtain motor'},
             {vendor: 'A-OK', model: 'AM25', description: 'Tubular motor'},
         ],
         fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],


### PR DESCRIPTION
Zemismart BCM500DS-TYZ-B has a new manufacturerName but otherwise seems to work OK a white-label of all the other TS0601 curtain motors.