### PR TITLE
Sync the code on Danfoss Ally, Popp and Hive TRV

### DIFF
--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -9,7 +9,8 @@ const ea = exposes.access;
 
 module.exports = [
     {
-        // eTRV0100 is the same as Hive TRV. If implementing anything, please consider changing Hive TRV001 too.
+        // eTRV0100 is the same as Hive TRV001 and Popp eT093WRO. If implementing anything, please consider
+        // changing those two too.
         zigbeeModel: ['eTRV0100'],
         model: '014G2461',
         vendor: 'Danfoss',
@@ -37,7 +38,7 @@ module.exports = [
             exposes.binary('heat_required', ea.STATE_GET, true, false)
                 .withDescription('Whether or not the unit needs warm water. `false` No Heat Request or `true` Heat Request'),
             exposes.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
-                .withDescription('Values observed are `0` (set locally) or `2` (set via Zigbee)'),
+                .withDescription('Values observed are `0` (manual), `1` (schedule) or `2` (externally)'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature().withPiHeatingDemand()
                 .withSystemMode(['heat']).withRunningState(['idle', 'heat'], ea.STATE),
             exposes.numeric('external_measured_room_sensor', ea.ALL)
@@ -71,10 +72,10 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
 
             // standard ZCL attributes
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 1});
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.MINUTES_10, change: 25});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 0, max: constants.repInterval.MINUTES_10, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_10, change: 25});
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
 
             // danfoss attributes
             await endpoint.configureReporting('hvacThermostat', [{

--- a/devices/hive.js
+++ b/devices/hive.js
@@ -150,6 +150,8 @@ module.exports = [
         },
     },
     {
+        // TRV001 is the same as Danfoss Ally (eTRV0100) and Popp eT093WRO. If implementing anything, please consider
+        // changing those two too.
         zigbeeModel: ['TRV001'],
         model: 'UK7004240',
         vendor: 'Hive',
@@ -160,7 +162,7 @@ module.exports = [
             tz.danfoss_heat_available, tz.danfoss_heat_required, tz.danfoss_day_of_week, tz.danfoss_trigger_time,
             tz.danfoss_window_open_internal, tz.danfoss_window_open_external, tz.danfoss_load_estimate,
             tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.thermostat_keypad_lockout,
-            tz.thermostat_system_mode],
+            tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean],
         exposes: [e.battery(), e.keypad_lockout(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -176,6 +178,8 @@ module.exports = [
                 .withDescription('Not clear how this affects operation. `false` No Heat Available or `true` Heat Available'),
             exposes.binary('heat_required', ea.STATE_GET, true, false)
                 .withDescription('Whether or not the unit needs warm water. `false` No Heat Request or `true` Heat Request'),
+            exposes.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
+                .withDescription('Values observed are `0` (manual), `1` (schedule) or `2` (externally)'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature().withPiHeatingDemand()
                 .withSystemMode(['heat']).withRunningState(['idle', 'heat'], ea.STATE),
             exposes.numeric('external_measured_room_sensor', ea.ALL)
@@ -195,6 +199,11 @@ module.exports = [
             exposes.numeric('algorithm_scale_factor', ea.ALL).withValueMin(1).withValueMax(10)
                 .withDescription('Scale factor of setpoint filter timeconstant ("aggressiveness" of control algorithm) '+
                     '1= Quick ...  5=Moderate ... 10=Slow'),
+            exposes.binary('load_balancing_enable', ea.ALL, true, false)
+                .withDescription('Whether or not the thermostat acts as standalone thermostat or shares load with other ' +
+                    'thermostats in the room. The gateway must update load_room_mean if enabled.'),
+            exposes.numeric('load_room_mean', ea.ALL)
+                .withDescription('Mean radiator load for room calculated by gateway for load balancing purposes'),
             exposes.numeric('load_estimate', ea.STATE_GET)
                 .withDescription('Load estimate on this radiator')],
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -243,6 +252,8 @@ module.exports = [
                 'danfossMountedModeControl',
                 'danfossMountedModeActive',
                 'danfossExternalMeasuredRoomSensor',
+                'danfossLoadBalancingEnable',
+                'danfossLoadRoomMean',
             ], options);
 
             // read systemMode to have an initial value


### PR DESCRIPTION
Brought these 3 devices in line.

Included:
Setpoint_change_source
https://github.com/Koenkk/zigbee-herdsman-converters/pull/3176

Load Balancing
https://github.com/Koenkk/zigbee-herdsman-converters/pull/3239

Better reporting on Danfoss and Popp thinking about device battery life

Comment to remind people to handle all devices when doing PRs to one

No new implementations on my side, just house keeping.