### PR TITLE
danfoss: Use normal reporting intervals

### DIFF
--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -1,7 +1,6 @@
 const exposes = require('../lib/exposes');
 const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
 const tz = require('../converters/toZigbee');
-const constants = require('../lib/constants');
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
 const e = exposes.presets;

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -199,7 +199,7 @@ module.exports = [
                 'genBasic', 'genPowerCfg', 'genIdentify', 'genPollCtrl', 'hvacThermostat', 'hvacUserInterfaceCfg',
             ];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(endpoint, {min: 900, max: constants.repInterval.HOUR, change: 1});
+            await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatTemperatureCalibration(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatRunningState(endpoint);

--- a/devices/candeo.js
+++ b/devices/candeo.js
@@ -13,7 +13,7 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
             await reporting.onOff(endpoint);
-            await reporting.brightness(endpoint, {min: 1});
+            await reporting.brightness(endpoint);
         },
     },
 ];

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -73,15 +73,15 @@ module.exports = [
 
             // standard ZCL attributes
             await reporting.batteryPercentageRemaining(endpoint);
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
+            await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             // danfoss attributes
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'danfossMountedModeActive',
                 minimumReportInterval: constants.repInterval.MINUTE,
-                maximumReportInterval: 43200,
+                maximumReportInterval: constants.repInterval.MAX,
                 reportableChange: 1,
             }], options);
             await endpoint.configureReporting('hvacThermostat', [{
@@ -93,7 +93,7 @@ module.exports = [
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'danfossHeatRequired',
                 minimumReportInterval: constants.repInterval.MINUTE,
-                maximumReportInterval: constants.repInterval.MINUTES_10,
+                maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: 1,
             }], options);
             await endpoint.configureReporting('hvacThermostat', [{

--- a/devices/eurotronic.js
+++ b/devices/eurotronic.js
@@ -34,12 +34,12 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             const options = {manufacturerCode: 4151};
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.MINUTES_10, change: 25});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 0, max: constants.repInterval.MINUTES_10, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_10, change: 25});
-            await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_10, change: 25});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
             await endpoint.configureReporting('hvacThermostat', [{attribute: {ID: 0x4003, type: 41}, minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.MINUTES_10, reportableChange: 25}], options);
+                maximumReportInterval: constants.repInterval.HOUR, reportableChange: 25}], options);
             await endpoint.configureReporting('hvacThermostat', [{attribute: {ID: 0x4008, type: 34}, minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.HOUR, reportableChange: 1}], options);
         },

--- a/devices/heiman.js
+++ b/devices/heiman.js
@@ -149,7 +149,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
         exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper()],
@@ -164,7 +164,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
@@ -188,7 +188,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
         exposes: [e.water_leak(), e.battery_low(), e.tamper(), e.battery()],
@@ -204,7 +204,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
     },
@@ -219,7 +219,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
         onEvent: async (type, data, device) => {
@@ -241,7 +241,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
     },
@@ -334,7 +334,7 @@ module.exports = [
             const endpoint1 = device.getEndpoint(1);
             await reporting.bind(endpoint1, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
             await reporting.temperature(endpoint1);
-            await reporting.batteryPercentageRemaining(endpoint1, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint1);
             await endpoint1.read('genPowerCfg', ['batteryPercentageRemaining']);
 
             const endpoint2 = device.getEndpoint(2);
@@ -405,7 +405,7 @@ module.exports = [
             const bindClusters = ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg'];
             await reporting.bind(endpoint, coordinatorEndpoint, bindClusters);
             await reporting.temperature(endpoint);
-            await reporting.humidity(endpoint, {min: 0, change: 25});
+            await reporting.humidity(endpoint);
             await reporting.batteryVoltage(endpoint);
         },
         exposes: [e.temperature(), e.humidity(), e.battery()],
@@ -421,7 +421,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
     },
@@ -436,7 +436,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'heimanSpecificScenes']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
         },
     },
     {
@@ -468,7 +468,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
         exposes: [e.vibration(), e.battery_low(), e.tamper(), e.battery()],
@@ -483,7 +483,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
         exposes: [e.vibration(), e.battery_low(), e.tamper(), e.battery()],
@@ -564,7 +564,7 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'heimanSpecificInfraRedRemote']);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint);
         },
     },
     {

--- a/devices/hive.js
+++ b/devices/hive.js
@@ -213,15 +213,15 @@ module.exports = [
 
             // standard ZCL attributes
             await reporting.batteryPercentageRemaining(endpoint);
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
+            await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             // danfoss attributes
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'danfossMountedModeActive',
                 minimumReportInterval: constants.repInterval.MINUTE,
-                maximumReportInterval: 43200,
+                maximumReportInterval: constants.repInterval.MAX,
                 reportableChange: 1,
             }], options);
             await endpoint.configureReporting('hvacThermostat', [{
@@ -233,7 +233,7 @@ module.exports = [
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'danfossHeatRequired',
                 minimumReportInterval: constants.repInterval.MINUTE,
-                maximumReportInterval: constants.repInterval.MINUTES_10,
+                maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: 1,
             }], options);
             await endpoint.configureReporting('hvacThermostat', [{
@@ -293,12 +293,12 @@ module.exports = [
             const endpoint = device.getEndpoint(5);
             const binds = ['genBasic', 'genIdentify', 'genAlarms', 'genTime', 'hvacThermostat'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatRunningState(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatSystemMode(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatTemperatureSetpointHold(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatTemperatureSetpointHoldDuration(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatRunningState(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatTemperatureSetpointHold(endpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(endpoint);
         },
     },
     {
@@ -324,12 +324,12 @@ module.exports = [
             const endpoint = device.getEndpoint(5);
             const binds = ['genBasic', 'genIdentify', 'genAlarms', 'genTime', 'hvacThermostat'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatRunningState(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatSystemMode(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatTemperatureSetpointHold(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatTemperatureSetpointHoldDuration(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatRunningState(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatTemperatureSetpointHold(endpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(endpoint);
         },
     },
     {
@@ -352,18 +352,18 @@ module.exports = [
                 'genBasic', 'genIdentify', 'genAlarms', 'genTime', 'hvacThermostat',
             ];
             await reporting.bind(heatEndpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatRunningState(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatSystemMode(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatTemperatureSetpointHold(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
+            await reporting.thermostatTemperature(heatEndpoint);
+            await reporting.thermostatRunningState(heatEndpoint);
+            await reporting.thermostatSystemMode(heatEndpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(heatEndpoint);
+            await reporting.thermostatTemperatureSetpointHold(heatEndpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint);
             await reporting.bind(waterEndpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatRunningState(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatSystemMode(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatTemperatureSetpointHold(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatTemperatureSetpointHoldDuration(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
+            await reporting.thermostatRunningState(waterEndpoint);
+            await reporting.thermostatSystemMode(waterEndpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint);
+            await reporting.thermostatTemperatureSetpointHold(waterEndpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(waterEndpoint);
         },
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()
@@ -403,18 +403,18 @@ module.exports = [
                 'genBasic', 'genIdentify', 'genAlarms', 'genTime', 'hvacThermostat',
             ];
             await reporting.bind(heatEndpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatRunningState(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatSystemMode(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatTemperatureSetpointHold(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
+            await reporting.thermostatTemperature(heatEndpoint);
+            await reporting.thermostatRunningState(heatEndpoint);
+            await reporting.thermostatSystemMode(heatEndpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(heatEndpoint);
+            await reporting.thermostatTemperatureSetpointHold(heatEndpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint);
             await reporting.bind(waterEndpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatRunningState(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatSystemMode(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
-            await reporting.thermostatTemperatureSetpointHold(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
-            await reporting.thermostatTemperatureSetpointHoldDuration(waterEndpoint, {min: 0, max: constants.repInterval.HOUR, change: 1});
+            await reporting.thermostatRunningState(waterEndpoint);
+            await reporting.thermostatSystemMode(waterEndpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint);
+            await reporting.thermostatTemperatureSetpointHold(waterEndpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(waterEndpoint);
         },
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()

--- a/devices/popp.js
+++ b/devices/popp.js
@@ -73,15 +73,15 @@ module.exports = [
 
             // standard ZCL attributes
             await reporting.batteryPercentageRemaining(endpoint);
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
+            await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.HOUR, change: 5});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             // danfoss attributes
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'danfossMountedModeActive',
                 minimumReportInterval: constants.repInterval.MINUTE,
-                maximumReportInterval: 43200,
+                maximumReportInterval: constants.repInterval.MAX,
                 reportableChange: 1,
             }], options);
             await endpoint.configureReporting('hvacThermostat', [{
@@ -93,7 +93,7 @@ module.exports = [
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'danfossHeatRequired',
                 minimumReportInterval: constants.repInterval.MINUTE,
-                maximumReportInterval: constants.repInterval.MINUTES_10,
+                maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: 1,
             }], options);
             await endpoint.configureReporting('hvacThermostat', [{

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -23,9 +23,9 @@ module.exports = [
             const binds = ['genBasic', 'genPowerCfg', 'hvacThermostat', 'haDiagnostic'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.batteryVoltage(endpoint);
-            await reporting.thermostatTemperature(endpoint, {min: 0, max: constants.repInterval.MINUTES_15, change: 25});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_15, change: 25});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 0, max: constants.repInterval.MINUTES_15, change: 1});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
             // bind of hvacUserInterfaceCfg fails with 'Table Full', does this have any effect?
             await endpoint.configureReporting('hvacUserInterfaceCfg', [{attribute: 'keypadLockout', reportableChange: 1,
                 minimumReportInterval: constants.repInterval.MINUTE, maximumReportInterval: constants.repInterval.HOUR}]);
@@ -354,8 +354,8 @@ module.exports = [
             const endpoint1 = device.getEndpoint(1);
             const endpoint2 = device.getEndpoint(2);
             await reporting.bind(endpoint1, coordinatorEndpoint, ['hvacThermostat']);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint1, {min: 0, max: 60, change: 1});
-            await reporting.thermostatPIHeatingDemand(endpoint1, {min: 0, max: 60, change: 1});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint1);
+            await reporting.thermostatPIHeatingDemand(endpoint1);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['seMetering']);
             await reporting.instantaneousDemand(endpoint2, {min: 0, max: 60, change: 1});
             await reporting.currentSummDelivered(endpoint2, {min: 0, max: 60, change: 1});
@@ -458,9 +458,8 @@ module.exports = [
             const binds = ['genBasic', 'genPowerCfg', 'hvacThermostat'];
             await reporting.bind(endpoint, coordinatorEndpointB, binds);
             await reporting.batteryVoltage(endpoint);
-            await reporting.thermostatTemperature(endpoint, {min: constants.repInterval.MINUTE,
-                max: constants.repInterval.MINUTES_15, change: 50});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_15, change: 25});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await endpoint.configureReporting('hvacUserInterfaceCfg', [{attribute: 'keypadLockout',
                 minimumReportInterval: constants.repInterval.MINUTE,
                 maximumReportInterval: constants.repInterval.HOUR,
@@ -514,7 +513,7 @@ module.exports = [
             const endpoint = device.getEndpoint(11);
             const binds = ['genBasic', 'genPowerCfg', 'hvacThermostat', 'msTemperatureMeasurement'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MINUTES_15, change: 25});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
         },
     },
     {

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -29,12 +29,12 @@ module.exports = [
                 'haElectricalMeasurement', 'seMetering', 'manuSpecificSinope'];
 
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(endpoint, {min: 10, max: 300, change: 20});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 10, max: 301, change: 5});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             try {
-                await reporting.thermostatSystemMode(endpoint, {min: 1, max: 0});
+                await reporting.thermostatSystemMode(endpoint);
                 await reporting.thermostatRunningState(endpoint);
                 await reporting.readMeteringMultiplierDivisor(endpoint);
                 await reporting.currentSummDelivered(endpoint, {min: 10, max: 303, change: [1, 1]});
@@ -71,9 +71,9 @@ module.exports = [
             const binds = ['genBasic', 'genIdentify', 'genGroups', 'hvacThermostat', 'hvacUserInterfaceCfg', 'msTemperatureMeasurement',
                 'haElectricalMeasurement', 'seMetering', 'manuSpecificSinope'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(endpoint, {min: 10, max: 300, change: 20});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 10, max: 301, change: 5});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             try {
                 await reporting.thermostatRunningState(endpoint);
@@ -97,7 +97,7 @@ module.exports = [
             } catch (error) {/* Do nothing*/}
 
             try {
-                await reporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+                await reporting.thermostatKeypadLockMode(endpoint);
             } catch (error) {
                 // Not all support this: https://github.com/Koenkk/zigbee2mqtt/issues/3760
             }
@@ -130,16 +130,16 @@ module.exports = [
             const binds = ['genBasic', 'genIdentify', 'genGroups', 'hvacThermostat', 'hvacUserInterfaceCfg',
                 'msTemperatureMeasurement', 'manuSpecificSinope'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatTemperature(endpoint, {min: 10, max: 300, change: 20});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 10, max: 301, change: 5});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 302, change: 50});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             try {
                 await reporting.thermostatRunningState(endpoint);
             } catch (error) {/* Not all support this */}
 
             try {
-                await reporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+                await reporting.thermostatKeypadLockMode(endpoint);
             } catch (error) {
                 // Not all support this: https://github.com/Koenkk/zigbee2mqtt/issues/3760
             }

--- a/devices/stelpro.js
+++ b/devices/stelpro.js
@@ -23,14 +23,18 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
 
             // Those exact parameters (min/max/change) are required for reporting to work with Stelpro Ki
-            await reporting.thermostatTemperature(endpoint, {min: 10, max: 60, change: 50});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 0, change: 50});
-            await reporting.thermostatSystemMode(endpoint, {min: 1, max: 0});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 1, max: 900, change: 5});
-            await reporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatKeypadLockMode(endpoint);
             // cluster 0x0201 attribute 0x401c
-            await endpoint.configureReporting('hvacThermostat', [{attribute: 'StelproSystemMode', minimumReportInterval: 1,
-                maximumReportInterval: 0}]);
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'StelproSystemMode',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1
+            }]);
         },
     },
     {
@@ -51,14 +55,18 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
 
             // Those exact parameters (min/max/change) are required for reporting to work with Stelpro Ki
-            await reporting.thermostatTemperature(endpoint, {min: 10, max: 60, change: 50});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 0, change: 50});
-            await reporting.thermostatSystemMode(endpoint, {min: 1, max: 0});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 1, max: 900, change: 5});
-            await reporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatKeypadLockMode(endpoint);
             // cluster 0x0201 attribute 0x401c
-            await endpoint.configureReporting('hvacThermostat', [{attribute: 'StelproSystemMode',
-                minimumReportInterval: 1, maximumReportInterval: 0}]);
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'StelproSystemMode',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1
+            }]);
         },
     },
     {
@@ -80,15 +88,18 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
 
             // Those exact parameters (min/max/change) are required for reporting to work with Stelpro Maestro
-            await reporting.thermostatTemperature(endpoint, {min: 10, max: 60, change: 50});
-            await reporting.humidity(endpoint, {min: 10, max: 300, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 0, change: 50});
-            await reporting.thermostatSystemMode(endpoint, {min: 1, max: 0});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 1, max: 900, change: 5});
-            await reporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.humidity(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatKeypadLockMode(endpoint);
             // cluster 0x0201 attribute 0x401c
             await endpoint.configureReporting('hvacThermostat', [{
-                attribute: 'StelproSystemMode', minimumReportInterval: 1, maximumReportInterval: 0}]);
+                attribute: 'StelproSystemMode',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1}]);
         },
     },
     {
@@ -110,15 +121,18 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
 
             // Those exact parameters (min/max/change) are required for reporting to work with Stelpro Maestro
-            await reporting.thermostatTemperature(endpoint, {min: 10, max: 60, change: 50});
-            await reporting.humidity(endpoint, {min: 10, max: 300, change: 1});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 1, max: 0, change: 50});
-            await reporting.thermostatSystemMode(endpoint, {min: 1, max: 0});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 1, max: 900, change: 5});
-            await reporting.thermostatKeypadLockMode(endpoint, {min: 1, max: 0});
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.humidity(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatKeypadLockMode(endpoint);
             // cluster 0x0201 attribute 0x401c
             await endpoint.configureReporting('hvacThermostat', [{
-                attribute: 'StelproSystemMode', minimumReportInterval: 1, maximumReportInterval: 0}]);
+                attribute: 'StelproSystemMode',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1}]);
         },
     },
 ];

--- a/devices/stelpro.js
+++ b/devices/stelpro.js
@@ -3,6 +3,7 @@ const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/lega
 const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 const e = exposes.presets;
+const constants = require('../lib/constants');
 
 module.exports = [
     {
@@ -33,7 +34,7 @@ module.exports = [
                 attribute: 'StelproSystemMode',
                 minimumReportInterval: constants.repInterval.MINUTE,
                 maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 1
+                reportableChange: 1,
             }]);
         },
     },
@@ -65,7 +66,7 @@ module.exports = [
                 attribute: 'StelproSystemMode',
                 minimumReportInterval: constants.repInterval.MINUTE,
                 maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 1
+                reportableChange: 1,
             }]);
         },
     },

--- a/devices/viessmann.js
+++ b/devices/viessmann.js
@@ -31,10 +31,10 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'hvacThermostat']);
 
             // standard ZCL attributes
-            await reporting.batteryPercentageRemaining(endpoint, {min: 60, max: 43200, change: 1});
-            await reporting.thermostatTemperature(endpoint, {min: 90, max: 900, change: 10});
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: 65534, change: 1});
-            await reporting.thermostatPIHeatingDemand(endpoint, {min: 60, max: 3600, change: 1});
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint);
 
             // manufacturer attributes
             await endpoint.configureReporting('hvacThermostat', [{attribute: 'viessmannWindowOpenInternal', minimumReportInterval: 60,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -449,7 +449,7 @@ describe('index.js', () => {
     });
 
     it('Calculate configure key legacy', () => {
-        const definition = index.findByZigbeeModel('WaterSensor-N');
+        const definition = index.findByZigbeeModel('MCT-340 SMA');
         expect(index.getConfigureKey(definition)).toBe(1);
     });
 });


### PR DESCRIPTION
The Danfoss Ally thermostat had some odd reporting intervals configured. Use the ones from the reporting library. If we want to change thermostat reporting intervals we should do it in the reporting library instead.