### PR TITLE
reporting: Increase interval for pIHeatingDemand

### DIFF
--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -148,7 +148,7 @@ module.exports = {
         await endpoint.configureReporting('hvacThermostat', p);
     },
     thermostatPIHeatingDemand: async (endpoint, overrides) => {
-        const p = payload('pIHeatingDemand', 0, repInterval.MINUTES_5, 10, overrides);
+        const p = payload('pIHeatingDemand', 0, repInterval.HOUR, 10, overrides);
         await endpoint.configureReporting('hvacThermostat', p);
     },
     thermostatRunningState: async (endpoint, overrides) => {


### PR DESCRIPTION
Reporting at least every 10 minutes is excessive for battery-powered
thermostats, and should never be necessary. Turn it back to at least
every hour like it used to be.

Note: The interval was previously lowered in https://github.com/Koenkk/zigbee-herdsman-converters/pull/755.