### PR TITLE
support Evolveo Heat M30

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -750,7 +750,8 @@ module.exports = [
     {
         zigbeeModel: ['kud7u2l'],
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l'}, {modelID: 'TS0601', manufacturerName: '_TZE200_ywdxldoj'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_cwnjrr72'}, {modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay'}],
+            {modelID: 'TS0601', manufacturerName: '_TZE200_cwnjrr72'}, {modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_pvvbommb'}],
         model: 'TS0601_thermostat',
         vendor: 'TuYa',
         description: 'Radiator valve with thermostat',


### PR DESCRIPTION
Hello, I have TRV from company Evolveo named Heat M30, in fact it seems be just TuYa TS0601_thermostat with another manufacturer name on the box. I tried this patch and it works like any other TuYa TRV.