### PR TITLE
Add Philips Hue white ambiance E27 800lm

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -565,6 +565,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LTA004'],
+        model: '9290024684',
+        vendor: 'Philips',
+        description: 'Hue white ambiance E27 800lm with Bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTA009'],
         model: '9290024684',
         vendor: 'Philips',

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -566,7 +566,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['LTA004'],
-        model: '9290024684',
+        model: '8719514328242',
         vendor: 'Philips',
         description: 'Hue white ambiance E27 800lm with Bluetooth',
         meta: {turnsOffAtBrightness1: true},


### PR DESCRIPTION
Based on info from https://github.com/Koenkk/zigbee2mqtt/issues/9527, this is the new 800lm version of the already supported 1100lm version.