### PR TITLE
Add support for Tuya TRV HY367 TS0601 _TZE200_2atgpdho

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -750,21 +750,21 @@ module.exports = [
     {
         zigbeeModel: ['kud7u2l'],
         fingerprint: [
-            { modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l' },
-            { modelID: 'TS0601', manufacturerName: '_TZE200_ywdxldoj' },
-            { modelID: 'TS0601', manufacturerName: '_TZE200_cwnjrr72' },
-            { modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay' },
-            { modelID: 'TS0601', manufacturerName: '_TZE200_pvvbommb' },
-            { modelID: 'TS0601', manufacturerName: '_TZE200_2atgpdho' }, // HY367
+            {modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_ywdxldoj'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_cwnjrr72'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_pvvbommb'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_2atgpdho'}, // HY367
         ],
         model: 'TS0601_thermostat',
         vendor: 'TuYa',
         description: 'Radiator valve with thermostat',
         whiteLabel: [
-            { vendor: 'Moes', model: 'HY368' },
-            { vendor: 'Moes', model: 'HY369RT' },
-            { vendor: 'SHOJZJ', model: '378RT' },
-            { vendor: 'Silvercrest', model: 'TVR01' },
+            {vendor: 'Moes', model: 'HY368'},
+            {vendor: 'Moes', model: 'HY369RT'},
+            {vendor: 'SHOJZJ', model: '378RT'},
+            {vendor: 'Silvercrest', model: 'TVR01'},
         ],
         meta: {tuyaThermostatPreset: tuya.thermostatPresets, tuyaThermostatSystemMode: tuya.thermostatSystemModes3},
         ota: ota.zigbeeOTA,

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -749,14 +749,23 @@ module.exports = [
     },
     {
         zigbeeModel: ['kud7u2l'],
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l'}, {modelID: 'TS0601', manufacturerName: '_TZE200_ywdxldoj'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_cwnjrr72'}, {modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_pvvbommb'}],
+        fingerprint: [
+            { modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l' },
+            { modelID: 'TS0601', manufacturerName: '_TZE200_ywdxldoj' },
+            { modelID: 'TS0601', manufacturerName: '_TZE200_cwnjrr72' },
+            { modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay' },
+            { modelID: 'TS0601', manufacturerName: '_TZE200_pvvbommb' },
+            { modelID: 'TS0601', manufacturerName: '_TZE200_2atgpdho' }, // HY367
+        ],
         model: 'TS0601_thermostat',
         vendor: 'TuYa',
         description: 'Radiator valve with thermostat',
-        whiteLabel: [{vendor: 'Moes', model: 'HY368'}, {vendor: 'Moes', model: 'HY369RT'}, {vendor: 'SHOJZJ', model: '378RT'},
-            {vendor: 'Silvercrest', model: 'TVR01'}],
+        whiteLabel: [
+            { vendor: 'Moes', model: 'HY368' },
+            { vendor: 'Moes', model: 'HY369RT' },
+            { vendor: 'SHOJZJ', model: '378RT' },
+            { vendor: 'Silvercrest', model: 'TVR01' },
+        ],
         meta: {tuyaThermostatPreset: tuya.thermostatPresets, tuyaThermostatSystemMode: tuya.thermostatSystemModes3},
         ota: ota.zigbeeOTA,
         onEvent: tuya.onEventSetLocalTime,


### PR DESCRIPTION
This PR adds support for Tuya Thermostatic Radiator Valve HY367 TS0601. 
Example: https://www.aliexpress.com/item/1005002668024526.html

It seems to be compatible with similar models, as it offers pretty much the same functionality.

There are some unrecognized DPs left, but overall the device works as expected.

```
zigbee-herdsman-converters:tuyaThermostat: Unrecognized DP #13 with data {"status":0,"transid":167,"dp":13,"datatype":5,"fn":0,"data":{"type":"Buffer","data":[0]}}
zigbee-herdsman-converters:tuyaThermostat: Unrecognized DP #115 with data {"status":0,"transid":180,"dp":115,"datatype":1,"fn":0,"data":{"type":"Buffer","data":[0]}}
zigbee-herdsman-converters:tuyaThermostat: Unrecognized DP #119 with data {"status":0,"transid":183,"dp":119,"datatype":0,"fn":0,"data":{"type":"Buffer","data":[1,0,1]}}
zigbee-herdsman-converters:tuyaThermostat: Unrecognized DP #119 with data {"status":0,"transid":187,"dp":119,"datatype":0,"fn":0,"data":{"type":"Buffer","data":[1,0,0]}}
zigbee-herdsman-converters:tuyaThermostat: Unrecognized DP #119 with data {"status":0,"transid":196,"dp":119,"datatype":0,"fn":0,"data":{"type":"Buffer","data":[1,0,0]}}
```