### PR TITLE
Added thermostat manufacturerName

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -756,6 +756,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_chyvmhay'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_pvvbommb'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_2atgpdho'}, // HY367
+            {modelID: 'TS0601', manufacturerName: '_TZE200_c88teujp'},
         ],
         model: 'TS0601_thermostat',
         vendor: 'TuYa',


### PR DESCRIPTION
The thermostat with the manufacturerName _TZE200_c88teujp shows up as supported by z2m and can be reached via HASS, but not all data points are exposed to HASS. Since it isn't listed here so far, I have added it.