### PR TITLE
fix tuya.dum.txt file location

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4002,7 +4002,7 @@ const converters = {
             });
             dataStr += '\n';
             const fs = require('fs');
-            fs.appendFile('data/tuya.dump.txt', dataStr, (err) => {
+            fs.appendFile('/share/zigbee2mqtt/tuya.dump.txt', dataStr, (err) => {
                 if (err) throw err;
             });
         },


### PR DESCRIPTION
prior the location was 'data/tuya.dump.txt' which caused the addon to crash on Home Assistant (https://github.com/Koenkk/zigbee2mqtt/issues/6292). Adding a slash '/data/tuya.dump.txt' fixes the issue. In addition, changing the path to '/share/zigbee2mqtt/tuya.dump.txt' should make the file accessible from the host via samba.

proposed changes https://github.com/Koenkk/zigbee-herdsman-converters/issues/3100