### PR TITLE
Expose DJT11LM vibration as binary sensor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -6213,9 +6213,9 @@ const converters = {
 
                     const timeout = options && options.hasOwnProperty('vibration_timeout') ? options.vibration_timeout : 90;
 
-                    // Stop any existing timers cause vibration detected
-                    globalStore.getValue(msg.endpoint, 'vibration_timers', []).forEach((t) => clearTimeout(t));
-                    globalStore.putValue(msg.endpoint, 'vibration_timers', []);
+                    // Stop any existing timer cause vibration detected
+                    clearTimeout(globalStore.getValue(msg.endpoint, 'vibration_timer', null));
+                    globalStore.putValue(msg.endpoint, 'vibration_timer', null);
 
                     // Set new timer to publish no_vibration message
                     if (timeout !== 0) {
@@ -6223,7 +6223,7 @@ const converters = {
                             publish({vibration: false});
                         }, timeout * 1000);
 
-                        globalStore.getValue(msg.endpoint, 'vibration_timers').push(timer);
+                        globalStore.putValue(msg.endpoint, 'vibration_timer', timer);
                     }
                 }
             }

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1127,7 +1127,7 @@ module.exports = [
         fromZigbee: [fz.xiaomi_battery, fz.DJT11LM_vibration],
         toZigbee: [tz.DJT11LM_vibration_sensitivity],
         exposes: [
-            e.battery(), e.action(['vibration', 'tilt', 'drop']),
+            e.battery(), e.vibration(), e.action(['vibration', 'tilt', 'drop']),
             exposes.numeric('strength', ea.STATE), exposes.enum('sensitivity', ea.STATE_SET, ['low', 'medium', 'high']),
             e.angle_axis('angle_x'), e.angle_axis('angle_y'), e.angle_axis('angle_z'), e.battery_voltage(),
         ],


### PR DESCRIPTION
Expose vibration DJT11LM as a binary sensor. This makes it easier to integrate it with e.g. [alarmo](https://github.com/nielsfaber/alarmo/).

As the sensor only sends an vibration message and not an no_vibration message, a no_vibration message is sent by ourself after a configured timeout. 