### PR TITLE
Restrict Candeo HK-DIM-A reporting interval to 1 second

### DIFF
--- a/devices/candeo.js
+++ b/devices/candeo.js
@@ -18,7 +18,7 @@ module.exports = [
             // to the extent that reported brighness values can arrive at the endpoint out of order
             // giving the appearance that the values are jumping around.
             // Limit the reporting to once a second to give a smoother reporting of brightness.
-            await reporting.brightness(endpoint, { min: 1 });
+            await reporting.brightness(endpoint, {min: 1});
         },
     },
 ];

--- a/devices/candeo.js
+++ b/devices/candeo.js
@@ -13,7 +13,12 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
             await reporting.onOff(endpoint);
-            await reporting.brightness(endpoint);
+
+            // The default reporting from the Candeo dimmer can result in a lot of Zigbee traffic
+            // to the extent that reported brighness values can arrive at the endpoint out of order
+            // giving the appearance that the values are jumping around.
+            // Limit the reporting to once a second to give a smoother reporting of brightness.
+            await reporting.brightness(endpoint, { min: 1 });
         },
     },
 ];


### PR DESCRIPTION
The original addition of this device had a minimum reporting interval of 1 second but no explaining comment so was cleaned up as part of #3268 

This has now been re-added with a suitable (hopefully?) comment.