### PR TITLE
haozee_thermostat_system_mode wrong lookup dictionary

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2807,7 +2807,7 @@ const converters = {
     haozee_thermostat_system_mode: {
         key: ['preset'],
         convertSet: async (entity, key, value, meta) => {
-            const lookup = {0: 'auto', 1: 'manual', 2: 'off', 3: 'on'};
+            const lookup = {'auto':0, 'manual':1, 'off':2,'on':3};
             await tuya.sendDataPointEnum(entity, tuya.dataPoints.haozeeSystemMode, lookup[value]);
         },
     },


### PR DESCRIPTION
Preset mode failed for the TS0601_thermostat_1.
Modified the lookup dictionary to const lookup = {'auto':0, 'manual':1, 'off':2,'on':3}