### PR TITLE
Add Hive SLR1c

### DIFF
--- a/devices/hive.js
+++ b/devices/hive.js
@@ -333,6 +333,37 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['SLR1c'],
+        model: 'SLR1c',
+        vendor: 'Hive',
+        description: 'Heating thermostat',
+        fromZigbee: [fz.thermostat, fz.thermostat_weekly_schedule],
+        toZigbee: [tz.thermostat_local_temperature, tz.thermostat_system_mode, tz.thermostat_running_state,
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation, tz.thermostat_weekly_schedule,
+            tz.thermostat_clear_weekly_schedule, tz.thermostat_temperature_setpoint_hold, tz.thermostat_temperature_setpoint_hold_duration],
+        exposes: [
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()
+                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']),
+            exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
+                .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
+                    ' Must be set to `false` when system_mode = off or `true` for heat'),
+            exposes.numeric('temperature_setpoint_hold_duration', ea.ALL).withValueMin(0).withValueMax(65535)
+                .withDescription('Period in minutes for which the setpoint hold will be active. 65535 = attribute not' +
+                    ' used. 0 to 360 to match the remote display')],
+        meta: {disableDefaultResponse: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(5);
+            const binds = ['genBasic', 'genIdentify', 'genAlarms', 'genTime', 'hvacThermostat'];
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatRunningState(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatTemperatureSetpointHold(endpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['SLR2'],
         model: 'SLR2',
         vendor: 'Hive',


### PR DESCRIPTION
It exactly the same as the SLR1b & the SLR1. Maybe we should just have 1 device with 3 entries in the zigbeeModel array?