### PR TITLE
add LTA011 to supported devices 

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -597,7 +597,7 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue white ambiance E27 1600lm with Bluetooth',
         meta: {turnsOffAtBrightness1: true},
-        extend: hueExtend.light_onoff_brightness_colortemp(),
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
     },
     {

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -592,6 +592,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LTA011'],
+        model: '929002471901',
+        vendor: 'Philips',
+        description: 'Hue white ambiance E27 1600lm with Bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTA008'],
         model: '9290022267A',
         vendor: 'Philips',


### PR DESCRIPTION
Add supports for Philips Hue white ambiance E27 1600lm with Bluetooth.

Link to product: https://www.philips-hue.com/en-gb/p/hue-white-ambiance-1-pack-e27/8719514288195