### PR TITLE
Add support for V3 of the Hive dual channel receiver

### DIFF
--- a/devices/hive.js
+++ b/devices/hive.js
@@ -466,6 +466,57 @@ module.exports = [
                     ' used. 0 to 360 to match the remote display').withEndpoint('water')],
     },
     {
+        zigbeeModel: ['SLR2c'],
+        model: 'SLR2c',
+        vendor: 'Hive',
+        description: 'Dual channel heating and hot water thermostat',
+        fromZigbee: [fz.thermostat, fz.thermostat_weekly_schedule],
+        toZigbee: [tz.thermostat_local_temperature, tz.thermostat_system_mode, tz.thermostat_running_state,
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation, tz.thermostat_weekly_schedule,
+            tz.thermostat_clear_weekly_schedule, tz.thermostat_temperature_setpoint_hold, tz.thermostat_temperature_setpoint_hold_duration],
+        endpoint: (device) => {
+            return {'heat': 5, 'water': 6};
+        },
+        meta: {disableDefaultResponse: true, multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const heatEndpoint = device.getEndpoint(5);
+            const waterEndpoint = device.getEndpoint(6);
+            const binds = [
+                'genBasic', 'genIdentify', 'genAlarms', 'genTime', 'hvacThermostat',
+            ];
+            await reporting.bind(heatEndpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatTemperature(heatEndpoint);
+            await reporting.thermostatRunningState(heatEndpoint);
+            await reporting.thermostatSystemMode(heatEndpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(heatEndpoint);
+            await reporting.thermostatTemperatureSetpointHold(heatEndpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint);
+            await reporting.bind(waterEndpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatRunningState(waterEndpoint);
+            await reporting.thermostatSystemMode(waterEndpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint);
+            await reporting.thermostatTemperatureSetpointHold(waterEndpoint);
+            await reporting.thermostatTemperatureSetpointHoldDuration(waterEndpoint);
+        },
+        exposes: [
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()
+                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withEndpoint('heat'),
+            exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
+                .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
+                    ' Must be set to `false` when system_mode = off or `true` for heat').withEndpoint('heat'),
+            exposes.numeric('temperature_setpoint_hold_duration', ea.ALL).withValueMin(0).withValueMax(65535)
+                .withDescription('Period in minutes for which the setpoint hold will be active. 65535 = attribute not' +
+                    ' used. 0 to 360 to match the remote display').withEndpoint('heat'),
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 22, 22, 1).withLocalTemperature()
+                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withEndpoint('water'),
+            exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
+                .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
+                    ' Must be set to `false` when system_mode = off or `true` for heat').withEndpoint('water'),
+            exposes.numeric('temperature_setpoint_hold_duration', ea.ALL).withValueMin(0).withValueMax(65535)
+                .withDescription('Period in minutes for which the setpoint hold will be active. 65535 = attribute not' +
+                    ' used. 0 to 360 to match the remote display').withEndpoint('water')],
+    },
+    {
         zigbeeModel: ['WPT1'],
         model: 'WPT1',
         vendor: 'Hive',


### PR DESCRIPTION
I have just noticed that Hive release a V3 of their thermostats (thanks to this recent PR https://github.com/Koenkk/zigbee-herdsman-converters/pull/3318)

I added support for the Dual Channel SLR2c (the PR above only did Single Channel SLR1c)

Thanks Koen

LE: this is under the assumption that the devices behave identical as the previous generations, which they did so far. The only thing Hive changes is the "looks". Should there be any issues I will gladly help people in need