### PR TITLE
Add pm25/air quality support to IKEA STARKVIND

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4245,6 +4245,32 @@ const converters = {
             }
         },
     },
+    ikea_pm25: {
+        cluster: 'manuSpecificIkeaPM25Measurement',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.data['measuredValue']) {
+                const pm25 = parseFloat(msg.data['measuredValue']) / 100.0;
+                const pm25Property = postfixWithEndpointName('pm25', msg, model);
+
+                // Air Quality Scale (ikea app):
+                // 0-35=Good, 35-80=OK, 80+=Not Good
+                let airQuality;
+                const airQualityProperty = postfixWithEndpointName('air_quality', msg, model);
+                if (pm25 <= 35) {
+                    airQuality = 'good';
+                } else if (pm25 <= 80) {
+                    airQuality = 'ok';
+                } else if (pm25 < 65535) {
+                    airQuality = 'not_good';
+                } else {
+                    airQuality = 'unknown';
+                }
+
+                return {[pm25Property]: calibrateAndPrecisionRoundOptions(pm25, options, 'pm25'), [airQualityProperty]: airQuality};
+            }
+        },
+    },
     E1524_E1810_levelctrl: {
         cluster: 'genLevelCtrl',
         type: [

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4248,6 +4248,7 @@ const converters = {
     ikea_pm25: {
         cluster: 'manuSpecificIkeaPM25Measurement',
         type: ['attributeReport', 'readResponse'],
+        options: [exposes.options.precision('pm25'), exposes.options.calibration('pm25')],
         convert: (model, msg, publish, options, meta) => {
             if (msg.data['measuredValue']) {
                 const pm25 = parseFloat(msg.data['measuredValue']) / 100.0;

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1910,6 +1910,12 @@ const converters = {
             await entity.read('genBasic', [0x0033], manufacturerOptions.hue);
         },
     },
+    ikea_pm25: {
+        key: ['pm25', 'air_quality'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificIkeaPM25Measurement', ['measuredValue']);
+        },
+    },
     RTCGQ13LM_motion_sensitivity: {
         key: ['motion_sensitivity'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -625,10 +625,16 @@ module.exports = [
         model: 'E2007',
         vendor: 'IKEA',
         description: 'STARKVIND air purifier',
-        exposes: [e.fan().withModes(['off', 'low', 'medium', 'high', 'auto'])],
+        exposes: [
+            e.fan().withModes(['off', 'low', 'medium', 'high', 'auto']),
+            e.pm25().withAccess(ea.STATE_GET),
+            exposes.enum('air_quality', ea.STATE_GET, [
+                'good', 'ok', 'not_good', 'unknown',
+            ]).withDescription('Measured air quality'),
+        ],
         meta: {fanStateOn: 'auto'},
-        fromZigbee: [fz.fan],
-        toZigbee: [tz.fan_mode],
+        fromZigbee: [fz.fan, fz.ikea_pm25],
+        toZigbee: [tz.fan_mode, tz.ikea_pm25],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['hvacFanCtrl']);


### PR DESCRIPTION
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/379665/141469881-326c18ef-6c20-441b-92f5-b4382bdffe2b.png">

Reporting for this cluster doesn't seem to work, it returns INVALID_DATA.

From what I gather from the various discussions over at the z2m repo is that the app will poll the value when viewing the device. The value also only updates when the fan is running, if the fan is off after a while the value will return 65535 indicating the current value is not known.

Edit: I assume we should update the notes for the device to indicate that the value needs to be manual refreshed and it's quirks?