### PR TITLE
Set default precision for pm25 to 2

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,7 +72,7 @@ function hasAlreadyProcessedMessage(msg, ID=null, key=null) {
     return false;
 }
 
-const defaultPrecision = {temperature: 2, humidity: 2, pressure: 1};
+const defaultPrecision = {temperature: 2, humidity: 2, pressure: 1, pm25: 2};
 function calibrateAndPrecisionRoundOptions(number, options, type) {
     // Calibrate
     const calibrateKey = `${type}_calibration`;


### PR DESCRIPTION
Might need some more discussion before merge, as from the other PR:

> That seems to work, that will effect other pm25 sensors like the heiman ones too right?
> Although those do not seem to get divided by 100.0, the ikea definitely needs that or otherwise I'd be living in a dusty saw mill.

https://github.com/Koenkk/zigbee-herdsman-converters/blob/1ad7e282849d804d2d3840c26ff7764e9be0c324/converters/fromZigbee.js#L5659-L5667

Looks like this is not even passing through `calibrateAndPrecisionRoundOptions` and just passing the raw value. So they would not be effected?