### PR TITLE
Revert "Add pm25/air quality support to IKEA STARKVIND E2007 (#3338)"

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4295,33 +4295,6 @@ const converters = {
             }
         },
     },
-    ikea_pm25: {
-        cluster: 'manuSpecificIkeaPM25Measurement',
-        type: ['attributeReport', 'readResponse'],
-        options: [exposes.options.precision('pm25'), exposes.options.calibration('pm25')],
-        convert: (model, msg, publish, options, meta) => {
-            if (msg.data['measuredValue']) {
-                const pm25 = parseFloat(msg.data['measuredValue']) / 100.0;
-                const pm25Property = postfixWithEndpointName('pm25', msg, model);
-
-                // Air Quality Scale (ikea app):
-                // 0-35=Good, 35-80=OK, 80+=Not Good
-                let airQuality;
-                const airQualityProperty = postfixWithEndpointName('air_quality', msg, model);
-                if (pm25 <= 35) {
-                    airQuality = 'good';
-                } else if (pm25 <= 80) {
-                    airQuality = 'ok';
-                } else if (pm25 < 65535) {
-                    airQuality = 'not_good';
-                } else {
-                    airQuality = 'unknown';
-                }
-
-                return {[pm25Property]: calibrateAndPrecisionRoundOptions(pm25, options, 'pm25'), [airQualityProperty]: airQuality};
-            }
-        },
-    },
     E1524_E1810_levelctrl: {
         cluster: 'genLevelCtrl',
         type: [

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1911,12 +1911,6 @@ const converters = {
             await entity.read('genBasic', [0x0033], manufacturerOptions.hue);
         },
     },
-    ikea_pm25: {
-        key: ['pm25', 'air_quality'],
-        convertGet: async (entity, key, meta) => {
-            await entity.read('manuSpecificIkeaPM25Measurement', ['measuredValue']);
-        },
-    },
     RTCGQ13LM_motion_sensitivity: {
         key: ['motion_sensitivity'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -625,16 +625,10 @@ module.exports = [
         model: 'E2007',
         vendor: 'IKEA',
         description: 'STARKVIND air purifier',
-        exposes: [
-            e.fan().withModes(['off', 'low', 'medium', 'high', 'auto']),
-            e.pm25().withAccess(ea.STATE_GET),
-            exposes.enum('air_quality', ea.STATE_GET, [
-                'good', 'ok', 'not_good', 'unknown',
-            ]).withDescription('Measured air quality'),
-        ],
+        exposes: [e.fan().withModes(['off', 'low', 'medium', 'high', 'auto'])],
         meta: {fanStateOn: 'auto'},
-        fromZigbee: [fz.fan, fz.ikea_pm25],
-        toZigbee: [tz.fan_mode, tz.ikea_pm25],
+        fromZigbee: [fz.fan],
+        toZigbee: [tz.fan_mode],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['hvacFanCtrl']);


### PR DESCRIPTION
This reverts commit 1ad7e282849d804d2d3840c26ff7764e9be0c324.

As per, https://github.com/Koenkk/zigbee2mqtt/discussions/8744#discussioncomment-1634437, Very likely this is reading junk that just happens to be within the range I was expecting.

Let's revert this for now while I try to map more of the attribute sniffed by hakaneriksson

Sorry about that, I guess I got a little to excited I was getting data seemed to match what I was expecting.