### PR TITLE
Update innr.js to support SP 234 Smart Plug 15A

### DIFF
--- a/devices/innr.js
+++ b/devices/innr.js
@@ -478,6 +478,30 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['SP 234'],
+        model: 'SP 234',
+        vendor: 'Innr',
+        description: 'Smart plug',
+        fromZigbee: [fz.electrical_measurement, fz.on_off, fz.ignore_genLevelCtrl_report, fz.metering],
+        toZigbee: [tz.on_off],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.onOff(endpoint);
+            // Gives UNSUPPORTED_ATTRIBUTE on reporting.readEletricalMeasurementMultiplierDivisors.
+            endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
+                acCurrentDivisor: 1000,
+                acCurrentMultiplier: 1,
+            });
+            await reporting.activePower(endpoint);
+            await reporting.rmsCurrent(endpoint);
+            await reporting.rmsVoltage(endpoint);
+            // Gives UNSUPPORTED_ATTRIBUTE on reporting.readMeteringMultiplierDivisor.
+            endpoint.saveClusterAttributeKeyValue('seMetering', {multiplier: 1, divisor: 100});
+        },
+        exposes: [e.power(), e.current(), e.voltage().withAccess(ea.STATE), e.switch(), e.energy()],
+    },
+    {
         zigbeeModel: ['OFL 120 C'],
         model: 'OFL 120 C',
         vendor: 'Innr',


### PR DESCRIPTION
My first attempt at such a thing (Git and the rest!) so hopefully I got this right.  I've updated the INNR.JS to reflect the necessary configuration for the Innr SP 234 smart plug 15A, which supports both the basic on/off function and also various metering abilities. As you might guess, most of the functionality I cloned from the SP 120 entry, minus the power summary method which the Sp 234 does not appear to support.

I was able to validate this configuration using the code inside an External Converter .JS file within my own Zigbee2MQTT + Home Assistant Core instances, hosted within a BSD jail, connected to a ConBee 2. I'm using my two new SP 234 devices to monitor my dishwasher and my washing machine. All features appear to be available and report sensible data.