### PR TITLE
Fix warning mode for Bitron AV2010/24A

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -330,7 +330,7 @@ const converters = {
 
             let info;
             // https://github.com/Koenkk/zigbee2mqtt/issues/8310 some devices require the info to be reversed.
-            if (['SIRZB-110', 'SRAC-23B-ZBSR', 'AV2010/29A'].includes(meta.mapped.model)) {
+            if (['SIRZB-110', 'SRAC-23B-ZBSR', 'AV2010/29A', 'AV2010/24A'].includes(meta.mapped.model)) {
                 info = (mode[values.mode]) + ((values.strobe ? 1 : 0) << 4) + (level[values.level] << 6);
             } else {
                 info = (mode[values.mode] << 4) + ((values.strobe ? 1 : 0) << 2) + (level[values.level]);


### PR DESCRIPTION
The Bitron AV2010/24A smoke detector behaves not as expected when mode,
level and strobe are set for the warning capability.
When the field order is flipped in the packet structure, the behaviour
is as expected (as far as the options are supported).

This patch has been tested with a Bitron AV2010/24A smoke detector.

Related to #2988 and Koenkk/zigbee2mqtt#8310