### PR TITLE
Adding 4256050-ZHAC support

### DIFF
--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -26,6 +26,27 @@ module.exports = [
             await reporting.activePower(endpoint);
         },
     },
+    {      
+        // Coppied from 4257050-ZHAC
+        zigbeeModel: ['4256050-ZHAC'],
+        model: '4256050-ZHAC',
+        vendor: 'Centralite',
+        description: '3-Series smart dimming outlet',
+        fromZigbee: [fz.restorable_brightness, fz.on_off, fz.electrical_measurement],
+        toZigbee: [tz.light_onoff_restorable_brightness],
+        exposes: [e.light_brightness(), e.power(), e.voltage(), e.current()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement']);
+            await reporting.onOff(endpoint);
+            // 4256050-ZHAC doesn't support reading 'acVoltageMultiplier' or 'acVoltageDivisor'
+            await endpoint.read('haElectricalMeasurement', ['acCurrentMultiplier', 'acCurrentDivisor']);
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
+            await reporting.rmsVoltage(endpoint, {change: 2}); // Voltage reports in V
+            await reporting.rmsCurrent(endpoint, {change: 10}); // Current reports in mA
+            await reporting.activePower(endpoint, {change: 2}); // Power reports in 0.1W
+        },
+    },    
     {
         zigbeeModel: ['4257050-ZHAC'],
         model: '4257050-ZHAC',

--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -26,8 +26,7 @@ module.exports = [
             await reporting.activePower(endpoint);
         },
     },
-    {      
-        // Coppied from 4257050-ZHAC
+    {
         zigbeeModel: ['4256050-ZHAC'],
         model: '4256050-ZHAC',
         vendor: 'Centralite',
@@ -46,7 +45,7 @@ module.exports = [
             await reporting.rmsCurrent(endpoint, {change: 10}); // Current reports in mA
             await reporting.activePower(endpoint, {change: 2}); // Power reports in 0.1W
         },
-    },    
+    },
     {
         zigbeeModel: ['4257050-ZHAC'],
         model: '4257050-ZHAC',


### PR DESCRIPTION
Adding 4256050-ZHAC based off of 4257050-ZHAC. 

Tested and dimming, on/off, and power monitoring are working as expected.