### PR TITLE
Added additional support for Philips Hue model 9290022268, Zigbee LWW002

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -441,7 +441,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LWA003'],
+        zigbeeModel: ['LWA003', 'LWW002'],
         model: '9290022268',
         vendor: 'Philips',
         description: 'Hue White A19 bulb with Bluetooth',


### PR DESCRIPTION
Initially the bulb joined as unsupported and came up with several options once the external converter file was configured. Also to note, the bulb came as part of the Philips Hue Inara Outdoor Lantern.