### PR TITLE
Improve the mean_power calculation for the Elko thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1574,6 +1574,10 @@ const converters = {
             const result = {};
             const data = msg.data;
 
+            if (data.hasOwnProperty(0x0401)) { // Load
+                result.load = data[0x0401];
+            }
+
             if (data.hasOwnProperty(0x0402)) { // Display text
                 result.display_text = data[0x0402];
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1379,6 +1379,16 @@ const converters = {
     // #endregion
 
     // #region Non-generic converters
+    elko_load: {
+        key: ['load'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'elkoLoad': value});
+            return {state: {load: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['elkoLoad']);
+        },
+    },
     elko_display_text: {
         key: ['display_text'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/elko.js
+++ b/devices/elko.js
@@ -32,8 +32,8 @@ module.exports = [
             tz.elko_relay_state, tz.elko_sensor_mode, tz.elko_local_temperature_calibration, tz.elko_max_floor_temp,
             tz.elko_regulator_mode, tz.elko_regulator_time, tz.elko_night_switching],
         exposes: [exposes.numeric('load', ea.ALL).withUnit('W')
-                .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the mean_power ' +
-                'calculation')
+                .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the ' +
+                'mean_power calculation')
                 .withValueMin(0).withValueMax(2000),
             exposes.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
             exposes.binary('regulator_mode', ea.ALL, 'regulator', 'thermostat')

--- a/devices/elko.js
+++ b/devices/elko.js
@@ -33,7 +33,7 @@ module.exports = [
             tz.elko_regulator_mode, tz.elko_regulator_time, tz.elko_night_switching],
         exposes: [exposes.numeric('load', ea.ALL).withUnit('W')
                 .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the ' +
-                'mean_power calculation')
+                'mean_power calculation.')
                 .withValueMin(0).withValueMax(2000),
             exposes.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
             exposes.binary('regulator_mode', ea.ALL, 'regulator', 'thermostat')

--- a/devices/elko.js
+++ b/devices/elko.js
@@ -32,7 +32,8 @@ module.exports = [
             tz.elko_relay_state, tz.elko_sensor_mode, tz.elko_local_temperature_calibration, tz.elko_max_floor_temp,
             tz.elko_regulator_mode, tz.elko_regulator_time, tz.elko_night_switching],
         exposes: [exposes.numeric('load', ea.ALL).withUnit('W')
-                .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the mean_power calculation')
+                .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the mean_power ' +
+                'calculation')
                 .withValueMin(0).withValueMax(2000),
             exposes.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
             exposes.binary('regulator_mode', ea.ALL, 'regulator', 'thermostat')

--- a/devices/elko.js
+++ b/devices/elko.js
@@ -27,11 +27,14 @@ module.exports = [
         vendor: 'ELKO',
         description: 'ESH Plus Super TR RF PH',
         fromZigbee: [fz.elko_thermostat, fz.thermostat],
-        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_heating_setpoint,
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_heating_setpoint, tz.elko_load,
             tz.elko_display_text, tz.elko_power_status, tz.elko_external_temp, tz.elko_mean_power, tz.elko_child_lock, tz.elko_frost_guard,
             tz.elko_relay_state, tz.elko_sensor_mode, tz.elko_local_temperature_calibration, tz.elko_max_floor_temp,
             tz.elko_regulator_mode, tz.elko_regulator_time, tz.elko_night_switching],
-        exposes: [exposes.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
+        exposes: [exposes.numeric('load', ea.ALL).withUnit('W')
+                .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the mean_power calculation')
+                .withValueMin(0).withValueMax(2000),
+            exposes.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
             exposes.binary('regulator_mode', ea.ALL, 'regulator', 'thermostat')
                 .withDescription('Device in regulator or thermostat mode.'),
             exposes.numeric('regulator_time', ea.ALL).withUnit('min')
@@ -69,6 +72,13 @@ module.exports = [
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             // ELKO attributes
+            // Load value
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'elkoLoad',
+                minimumReportInterval: 0,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: null,
+            }]);
             // Power status
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'elkoPowerStatus',

--- a/devices/elko.js
+++ b/devices/elko.js
@@ -31,11 +31,11 @@ module.exports = [
             tz.elko_display_text, tz.elko_power_status, tz.elko_external_temp, tz.elko_mean_power, tz.elko_child_lock, tz.elko_frost_guard,
             tz.elko_relay_state, tz.elko_sensor_mode, tz.elko_local_temperature_calibration, tz.elko_max_floor_temp,
             tz.elko_regulator_mode, tz.elko_regulator_time, tz.elko_night_switching],
-        exposes: [exposes.numeric('load', ea.ALL).withUnit('W')
+        exposes: [exposes.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
+            exposes.numeric('load', ea.ALL).withUnit('W')
                 .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the ' +
                 'mean_power calculation.')
                 .withValueMin(0).withValueMax(2000),
-            exposes.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
             exposes.binary('regulator_mode', ea.ALL, 'regulator', 'thermostat')
                 .withDescription('Device in regulator or thermostat mode.'),
             exposes.numeric('regulator_time', ea.ALL).withUnit('min')


### PR DESCRIPTION
Correct the mean_power calculation for the Elko thermostat by exposing "load". 
In order to get a correct mean_power value back from the thermostat the power (load) when heating has to be configured for the device. 