### PR TITLE
Add support for Philips 8719514392830 

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2345,7 +2345,7 @@ module.exports = [
         zigbeeModel: ['LTA005'],
         model: '8719514392830',
         vendor: 'Philips',
-        description: 'Hue White Ambiance E27 Filament Screw Globe',
+        description: 'Hue White Ambiance E27 filament screw globe',
         meta: {turnsOffAtBrightness1: true},
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
         ota: ota.zigbeeOTA,

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2341,4 +2341,13 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,
     },
+    {
+        zigbeeModel: ['LTA005'],
+        model: '8719514392830',
+        vendor: 'Philips',
+        description: 'Hue White Ambiance E27 Filament Screw Globe',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
+        ota: ota.zigbeeOTA,
+    },
 ];


### PR DESCRIPTION
This adds support for the Hue White Ambiance E27 Filament Screw Globe bulb (https://www.philips-hue.com/en-au/p/hue-white-ambiance-filament-1-pack-a60-e27-filament-standard/8719514392830)