### PR TITLE
Add support for Philips Aurelle 929003099101

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1247,6 +1247,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['929003099101'],
+        model: '929003099101',
+        vendor: 'Philips',
+        description: 'Hue white ambiance Aurelle rectangle panel light',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTC016'],
         model: '3216431P5',
         vendor: 'Philips',


### PR DESCRIPTION
I added support for a new model of the Philips Aurelle 120x30cm lamp.

For all I know it is feature identical with this one:
https://www.zigbee2mqtt.io/devices/3216331P6.html