### PR TITLE
Add 8719514302235

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2446,7 +2446,7 @@ module.exports = [
         zigbeeModel: ['LWE004'],
         model: '8719514302235',
         vendor: 'Philips',
-        description: 'Hue White Filament Bulb e14',
+        description: 'Hue White Filament Bulb E14',
         extend: hueExtend.light_onoff_brightness(),
         ota: ota.zigbeeOTA,
     },

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2442,4 +2442,12 @@ module.exports = [
         meta: {turnsOffAtBrightness1: true},
         ota: ota.zigbeeOTA,
     },
+    {
+        zigbeeModel: ['LWE004'],
+        model: '8719514302235',
+        vendor: 'Philips',
+        description: 'Hue White Filament Bulb e14',
+        extend: hueExtend.light_onoff_brightness(),
+        ota: ota.zigbeeOTA,
+    },
 ];


### PR DESCRIPTION
This change adds the device with EAN 8719514302235, a philips hue filament bulb for e14 sockets, which is seemlingy only available in european markets. See also the pull request for the zigbee2mqtt.io device list [TODO, still have to do that].
