### PR TITLE
Valve position over reporting

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3841,7 +3841,7 @@ const converters = {
                 return {'local_temperature_calibration': ( value/10 ).toFixed(1)};
             case tuya.dataPoints.haozeeValvePosition:
                 // valve position
-                return {'position': value};
+                return {'position': ( value/10 ).toFixed(1)};
             case tuya.dataPoints.haozeeMinTemp:
                 // lower limit temperature
                 return {'min_temperature': ( value/10 ).toFixed(1)};


### PR DESCRIPTION
For all Haozee Thermostats the valve position is over reporting by a factor of 10, making 100% -> 1000%