### PR TITLE
Update Lidl HG06463B description

### DIFF
--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -624,7 +624,7 @@ module.exports = [
         fingerprint: [{modelID: 'TS0501A', manufacturerName: '_TZ3000_nosnx7im'}],
         model: 'HG06463B',
         vendor: 'Lidl',
-        description: 'Livarno Lux E27 G30 filament bulb',
+        description: 'Livarno Lux E27 G95 filament bulb',
         extend: extend.light_onoff_brightness({disableEffect: true}),
         meta: {turnsOffAtBrightness1: false},
     },


### PR DESCRIPTION
This is a G95 globe bulb, not G30. Ref https://www.lidl.de/p/livarno-lux-leuchtmittel-spiralfilament-dimmbar-zigbee-smart-home/p100311870