### PR TITLE
Develco ZHEMI101 - add  low battery & check_meter

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -670,6 +670,7 @@ const converters = {
             }
             if (msg.data.hasOwnProperty('status')) {
                 result['battery_low'] = (msg.data.status & 2) > 0;
+                result['check_meter'] = (msg.data.status & 1) > 0;
             }
 
             return result;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -668,6 +668,9 @@ const converters = {
                         constants.develcoInterfaceMode[msg.data['develcoInterfaceMode']] :
                         msg.data['develcoInterfaceMode'];
             }
+            if (msg.data.hasOwnProperty('status')) {
+                result['battery_low'] = (msg.data.status & 2) > 0;
+            }
 
             return result;
         },

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -319,6 +319,8 @@ module.exports = [
                 .withDescription('Operating mode/probe'),
             exposes.numeric('current_summation', ea.SET)
                 .withDescription('Current summation value sent to the display. e.g. 570 = 0,570 kWh'),
+            exposes.binary('check_meter', ea.STATE, true, false)
+                .withDescription('Is true if communication problem with meter is experienced'),
         ],
     },
     {

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -311,6 +311,7 @@ module.exports = [
         exposes: [
             e.power(),
             e.energy(),
+            e.battery_low(),
             exposes.numeric('pulse_configuration', ea.ALL).withValueMin(0).withValueMax(65535)
                 .withDescription('Pulses per kwh. Default 1000 imp/kWh. Range 0 to 65535'),
             exposes.enum('interface_mode', ea.ALL,


### PR DESCRIPTION
This PR adds two indicators that are reported by Develco ZHEMI101:
- low battery
- communication error

I was not able to simulate low batteries in any way (the ones that failed without alert are completely discharged), so I wrote this based on the [Technical Manual for ZHEMI101](https://github.com/Koenkk/zigbee-herdsman-converters/files/7612260/Technical.Manual.for.ZHEMI101.-.ZigBee.External.Meter.Interface.HA.pdf), chapter 3.3.3.3.

