### PR TITLE
Support Moes BHT with manufacturerName _TZE200_u9bfwha0

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -76,7 +76,8 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_aoclfnxz'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_ztvwu4nk'}],
+            {modelID: 'TS0601', manufacturerName: '_TZE200_ztvwu4nk'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_u9bfwha0'}],
         model: 'BHT-002-GCLZB',
         vendor: 'Moes',
         description: 'Moes BHT series Thermostat',


### PR DESCRIPTION
I've recently bought a thermostat branded by Tuya that looks exactly like https://www.zigbee2mqtt.io/devices/BHT-002-GCLZB.html

After pairing the device I was getting `Received message from unsupported device with Zigbee model 'TS0601' and manufacturer name '_TZE200_u9bfwha0'`
After adding this manufacturer name to `BHT-002-GCLZB` `fingerprint` list it seems to work correctly in zigbee2mqtt and home assistant.
I didn't test the temperature deadzone and and max temperature properly, but everything else seemed to work correctly.

I've tested the converter by creating a new external converter and copy pasting the device definition from moes.js with updated fingerprint list.