### PR TITLE
Added OWON THS317 temperature & humidity sensor

### DIFF
--- a/devices/owon.js
+++ b/devices/owon.js
@@ -83,4 +83,23 @@ module.exports = [
             await reporting.thermostatAcLouverPosition(endpoint);
         },
     },
+    {
+        zigbeeModel: ['THS317'],
+        model: 'THS317',
+        vendor: 'OWON',
+        description: 'OWON temperature and humidity sensor',
+        fromZigbee: [fz.temperature, fz.humidity, fz.battery],
+        toZigbee: [],
+        exposes: [e.battery(), e.temperature(), e.humidity()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(2);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg']);
+            await reporting.temperature(endpoint);
+            await reporting.humidity(endpoint);
+            await reporting.batteryVoltage(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
+            device.powerSource = 'Battery';
+            device.save();
+        },
+    },
 ];

--- a/devices/owon.js
+++ b/devices/owon.js
@@ -87,7 +87,7 @@ module.exports = [
         zigbeeModel: ['THS317'],
         model: 'THS317',
         vendor: 'OWON',
-        description: 'OWON temperature and humidity sensor',
+        description: 'Temperature and humidity sensor',
         fromZigbee: [fz.temperature, fz.humidity, fz.battery],
         toZigbee: [],
         exposes: [e.battery(), e.temperature(), e.humidity()],


### PR DESCRIPTION
Configuration fails after inclusion, but if the unit's battery is removed and inserted back after inclusion the configuration succeeds and the unit works and reports normally.