### PR TITLE
Added manufacturer name for 'TuYa TS0601_cover'

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -726,6 +726,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_nueqqe6k'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_xaabybja'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_rmymn92d'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_3i3exuay'},
             {modelID: 'zo2pocs\u0000', manufacturerName: '_TYST11_fzo2pocs'},
             // Roller blinds:
             {modelID: 'TS0601', manufacturerName: '_TZE200_sbordckq'},


### PR DESCRIPTION
I bought a Zemismart curtain motor model ZM79EDT which is supported according to the 'TuYa TS0601_cover' page.
![image](https://user-images.githubusercontent.com/6565963/144588318-b663f152-ffa5-489d-9814-4a7bf3918701.png)

However, it had a different manufacturer name than what is listed in the vendor file. So from my understanding, this should make it supported.
![image](https://user-images.githubusercontent.com/6565963/144588649-2d7b34f0-1036-477a-9dda-4bb580fc9e77.png)
 