### PR TITLE
Fix hy_set_time_request converter getting endpoint

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2735,7 +2735,7 @@ const converters = {
             const currentTime = new Date().getTime();
             const utcTime = Math.round((currentTime - OneJanuary2000) / 1000);
             const localTime = Math.round(currentTime / 1000) - (new Date()).getTimezoneOffset() * 60;
-            const endpoint = msg.device.getEndpoint(1);
+            const endpoint = msg.endpoint;
             const payload = {
                 payloadSize: 8,
                 payload: [


### PR DESCRIPTION
I've got an issue with my Tuya TS0601 (_TZE200_znzs7yaw) thermostat and described here https://github.com/Koenkk/zigbee-herdsman-converters/issues/3264, so here the time of getting time from device