### PR TITLE
Add support for NUE-AUWZO2

### DIFF
--- a/devices/nue_3a.js
+++ b/devices/nue_3a.js
@@ -286,7 +286,7 @@ module.exports = [
         zigbeeModel: ['LXN-2S27LX1.0'],
         model: 'NUE-AUWZO2',
         vendor: 'Nue / 3A',
-        description: 'Smart Zigbee Double Power Point',
+        description: 'Smart Zigbee double power point',
         extend: extend.switch(),
         exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right')],
         meta: {multiEndpoint: true},

--- a/devices/nue_3a.js
+++ b/devices/nue_3a.js
@@ -291,7 +291,7 @@ module.exports = [
         exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right')],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
-            return {left: 01, right: 02};
+            return {left: 1, right: 2};
         },
     },
 ];

--- a/devices/nue_3a.js
+++ b/devices/nue_3a.js
@@ -157,7 +157,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['FNB56-ZSW02LX2.0', 'LXN-2S27LX1.0'],
+        zigbeeModel: ['FNB56-ZSW02LX2.0'],
         model: 'HGZB-42',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 2 gang v2.0',
@@ -281,5 +281,17 @@ module.exports = [
         vendor: 'Nue / 3A',
         description: '9W RGB LED downlight',
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
+    },
+    {
+        zigbeeModel: ['LXN-2S27LX1.0'],
+        model: 'NUE-AUWZO2',
+        vendor: 'Nue / 3A',
+        description: 'Smart Zigbee Double Power Point',
+        extend: extend.switch(),
+        exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right')],
+        meta: {multiEndpoint: true},
+        endpoint: (device) => {
+            return {left: 01, right: 02};
+        },
     },
 ];


### PR DESCRIPTION
Adding support for NUE-AUWZO2 which is a new Double Power Point from Nue / 3A Smarthome.

These have a zigbeeModel of 'LXN-2S27LX1.0' which was detected as "Smart light switch - 2 gang v2.0" which is not correct.

I have removed that zigbeeModel from the Smart light switch, and created new entry for NUE-AUWZO2 as "Smart Zigbee Double Power Point" which is the name and model on the box and back of the device. Have confirmed that these settings work correctly for the 2x devices I just bought.

Cannot confirm that LXN-2S27LX1.0 is not also the zigbeeModel of a light switch, because I don't have any of these.