### PR TITLE
Added new zigbee id for Philips Play Lightbar

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -834,7 +834,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LCT024', '440400982841'],
+        zigbeeModel: ['LCT024', '440400982841', '440400982842'],
         model: '915005733701',
         vendor: 'Philips',
         description: 'Hue White and color ambiance Play Lightbar',


### PR DESCRIPTION
I found a new zigbee model id for the [Philips Play Lightbar](https://www.zigbee2mqtt.io/devices/915005733701.html) after a recent purchase.
I have tested and confirmed that other than the different ID, it's completely the same.