### PR TITLE
Decrease minimum temperature change for SONOFF SNZB-02

### DIFF
--- a/devices/sonoff.js
+++ b/devices/sonoff.js
@@ -104,7 +104,7 @@ module.exports = [
                 const endpoint = device.getEndpoint(1);
                 const bindClusters = ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg'];
                 await reporting.bind(endpoint, coordinatorEndpoint, bindClusters);
-                await reporting.temperature(endpoint, {min: 5, max: constants.repInterval.MINUTES_30, change: 50});
+                await reporting.temperature(endpoint, {min: 5, max: constants.repInterval.MINUTES_30, change: 20});
                 await reporting.humidity(endpoint);
                 await reporting.batteryVoltage(endpoint);
                 await reporting.batteryPercentageRemaining(endpoint);


### PR DESCRIPTION
Decrease the minimum temperature change the is reported, so the SONOFF SNZB-02 reports the temperature sooner.
This would fix the issue described at https://www.zigbee2mqtt.io/devices/SNZB-02.html.

Already tested this with my SNZB-02 sensor.