### PR TITLE
Add default attribute for visibility

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -6,6 +6,14 @@ const assert = require('assert');
 const constants = require('./constants');
 
 class Base {
+    constructor() {
+        this.visible = true;
+    }
+
+    isVisible(visibility) {
+        this.visible = visibility;
+    }
+
     withEndpoint(endpointName) {
         this.endpoint = endpointName;
 

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -7,11 +7,11 @@ const constants = require('./constants');
 
 class Base {
     constructor() {
-        this.visible = true;
+        this.enabled = true;
     }
 
     isVisible(visibility) {
-        this.visible = visibility;
+        this.enabled = visibility;
     }
 
     withEndpoint(endpointName) {


### PR DESCRIPTION
This attribute (activated by default) permits a dynamic exposition of entitities.

Coming from the issue https://github.com/Koenkk/zigbee2mqtt/issues/9929