### PR TITLE
Osram AB3284 - add another manufacturer

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -136,7 +136,8 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS0503B', manufacturerName: '_TZ3000_i8l0nqdu'},
-            {modelID: 'TS0503B', manufacturerName: '_TZ3210_a5fxguxr'}],
+            {modelID: 'TS0503B', manufacturerName: '_TZ3210_a5fxguxr'},
+            {modelID: 'TS0503B', manufacturerName: '_TZ3000_g5xawfcq'}],
         model: 'TS0503B',
         vendor: 'TuYa',
         description: 'Zigbee RGB light',


### PR DESCRIPTION
second batch of Osram AB32840 (Classic B40 TW - Lightify) and yet another manufacturer name.