### PR TITLE
Add NOUS E6

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1779,7 +1779,7 @@ const converters = {
             case tuya.dataPoints.nousMinTemp:
                 return {min_temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             case tuya.dataPoints.nousTempAlarm:
-                return {temperature_alarm: {0x00: 'canceled', 0x01: 'loweralarm', 0x02: 'upperalarm'}[value]};
+                return {temperature_alarm: {0x00: 'canceled', 0x01: 'lower_alarm', 0x02: 'upper_alarm'}[value]};
             case tuya.dataPoints.nousTempSensitivity:
                 return {temperature_sensitivity: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             default:

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1757,6 +1757,37 @@ const converters = {
             }
         },
     },
+    nous_lcd_temperature_humidity_sensor: {
+        cluster: 'manuSpecificTuya',
+        type: ['commandGetData'],
+        options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
+            exposes.options.precision('humidity'), exposes.options.calibration('humidity')],
+        convert: (model, msg, publish, options, meta) => {
+            const dp = msg.data.dp;
+            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            switch (dp) {
+            case tuya.dataPoints.nousTemperature:
+                return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+            case tuya.dataPoints.nousHumidity:
+                return {humidity: calibrateAndPrecisionRoundOptions(value, options, 'humidity')};
+            case tuya.dataPoints.nousBattery:
+                return {battery: value};
+            case tuya.dataPoints.nousTempUnitConvert:
+                return {temp_unit_convert: {0x00: '°C', 0x01: '°F'}[value]};
+            case tuya.dataPoints.nousMaxTemp:
+                return {maxtemp: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+            case tuya.dataPoints.nousMinTemp:
+                return {mintemp: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+            case tuya.dataPoints.nousTempAlarm:
+                return {temp_alarm: {0x00: 'canceled', 0x01: 'loweralarm', 0x02: 'upperalarm'}[value]};
+            case tuya.dataPoints.nousTempSensitivity:
+                return {temp_sensitivity: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+            default:
+                meta.logger.warn(`zigbee-herdsman-converters:nous_lcd_temperature_humidity_sensor: NOT RECOGNIZED ` +
+                    `DP #${dp} with data ${JSON.stringify(msg.data)}`);
+            }
+        },
+    },
     tuya_illuminance_temperature_humidity_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1773,15 +1773,15 @@ const converters = {
             case tuya.dataPoints.nousBattery:
                 return {battery: value};
             case tuya.dataPoints.nousTempUnitConvert:
-                return {temp_unit_convert: {0x00: '°C', 0x01: '°F'}[value]};
+                return {temperature_unit_convert: {0x00: '°C', 0x01: '°F'}[value]};
             case tuya.dataPoints.nousMaxTemp:
-                return {maxtemp: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+                return {max_temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             case tuya.dataPoints.nousMinTemp:
-                return {mintemp: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+                return {min_temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             case tuya.dataPoints.nousTempAlarm:
-                return {temp_alarm: {0x00: 'canceled', 0x01: 'loweralarm', 0x02: 'upperalarm'}[value]};
+                return {temperature_alarm: {0x00: 'canceled', 0x01: 'loweralarm', 0x02: 'upperalarm'}[value]};
             case tuya.dataPoints.nousTempSensitivity:
-                return {temp_sensitivity: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+                return {temperature_sensitivity: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:nous_lcd_temperature_humidity_sensor: NOT RECOGNIZED ` +
                     `DP #${dp} with data ${JSON.stringify(msg.data)}`);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4973,6 +4973,27 @@ const converters = {
             }
         },
     },
+    nous_lcd_temperature_humidity_sensor: {
+        key: ['mintemp', 'maxtemp', 'temp_sensitivity', 'temp_unit_convert'],
+        convertSet: async (entity, key, value, meta) => {
+            switch (key) {
+            case 'temp_unit_convert':
+                await tuya.sendDataPointEnum(entity, tuya.dataPoints.nousTempUnitConvert, ['°C', '°F'].indexOf(value));
+                break;
+            case 'mintemp':
+                await tuya.sendDataPointValue(entity, tuya.dataPoints.nousMinTemp, Math.round(value * 10));
+                break;
+            case 'maxtemp':
+                await tuya.sendDataPointValue(entity, tuya.dataPoints.nousMaxTemp, Math.round(value * 10));
+                break;
+            case 'temp_sensitivity':
+                await tuya.sendDataPointValue(entity, tuya.dataPoints.nousTempSensitivity, Math.round(value * 10));
+                break;
+            default: // Unknown key
+                meta.logger.warn(`Unhandled key ${key}`);
+            }
+        },
+    },
     heiman_ir_remote: {
         key: ['send_key', 'create', 'learn', 'delete', 'get_list'],
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4974,19 +4974,19 @@ const converters = {
         },
     },
     nous_lcd_temperature_humidity_sensor: {
-        key: ['mintemp', 'maxtemp', 'temp_sensitivity', 'temp_unit_convert'],
+        key: ['min_temperature', 'max_temperature', 'temperature_sensitivity', 'temperature_unit_convert'],
         convertSet: async (entity, key, value, meta) => {
             switch (key) {
-            case 'temp_unit_convert':
+            case 'temperature_unit_convert':
                 await tuya.sendDataPointEnum(entity, tuya.dataPoints.nousTempUnitConvert, ['°C', '°F'].indexOf(value));
                 break;
-            case 'mintemp':
+            case 'min_temperature':
                 await tuya.sendDataPointValue(entity, tuya.dataPoints.nousMinTemp, Math.round(value * 10));
                 break;
-            case 'maxtemp':
+            case 'max_temperature':
                 await tuya.sendDataPointValue(entity, tuya.dataPoints.nousMaxTemp, Math.round(value * 10));
                 break;
-            case 'temp_sensitivity':
+            case 'temperature_sensitivity':
                 await tuya.sendDataPointValue(entity, tuya.dataPoints.nousTempSensitivity, Math.round(value * 10));
                 break;
             default: // Unknown key

--- a/devices/nous.js
+++ b/devices/nous.js
@@ -1,0 +1,40 @@
+const exposes = require('../lib/exposes');
+const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const tz = require('../converters/toZigbee');
+const tuya = require('../lib/tuya');
+const reporting = require('../lib/reporting');
+const e = exposes.presets;
+const ea = exposes.access;
+
+module.exports = [
+    {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_nnrfa68v'}],
+        model: 'E6',
+        vendor: 'Nous',
+        description: 'Temperature & humidity LCD sensor',
+        fromZigbee: [fz.nous_lcd_temperature_humidity_sensor, fz.ignore_tuya_set_time],
+        toZigbee: [tz.nous_lcd_temperature_humidity_sensor],
+        onEvent: tuya.onEventSetLocalTime,
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
+        },
+        exposes: [
+            e.temperature(),
+            e.humidity(),
+            e.battery(),
+            exposes.enum('temperature_unit_convert', ea.STATE_SET, ['°C', '°F']).withDescription('Current display unit'),
+            exposes.enum('temperature_alarm', ea.STATE, ['canceled', 'loweralarm', 'upperalarm'])
+                .withDescription('Temperature alarm status'),
+            exposes.numeric('max_temperature', ea.STATE_SET)
+                .withUnit('°C').withValueMin(-20).withValueMax(60)
+                .withDescription('Alarm temperature max'),
+            exposes.numeric('min_temperature', ea.STATE_SET).withUnit('°C')
+                .withValueMin(-20).withValueMax(60)
+                .withDescription('Alarm temperature min'),
+            exposes.numeric('temperature_sensitivity', ea.STATE_SET)
+                .withUnit('°C').withValueMin(0.1).withValueMax(50).withValueStep(0.1)
+                .withDescription('Temperature sensitivity'),
+        ],
+    },
+];

--- a/devices/nous.js
+++ b/devices/nous.js
@@ -23,8 +23,8 @@ module.exports = [
             e.temperature(),
             e.humidity(),
             e.battery(),
-            exposes.enum('temperature_unit_convert', ea.STATE_SET, ['°C', '°F']).withDescription('Current display unit'),
-            exposes.enum('temperature_alarm', ea.STATE, ['canceled', 'loweralarm', 'upperalarm'])
+            exposes.enum('temperature_unit_convert', ea.STATE_SET, ['celsius', 'fahrenheit']).withDescription('Current display unit'),
+            exposes.enum('temperature_alarm', ea.STATE, ['canceled', 'lower_alarm', 'upper_alarm'])
                 .withDescription('Temperature alarm status'),
             exposes.numeric('max_temperature', ea.STATE_SET)
                 .withUnit('°C').withValueMin(-20).withValueMax(60)

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1626,35 +1626,6 @@ module.exports = [
         ],
     },
     {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_nnrfa68v'}],
-        model: 'E6',
-        vendor: 'Nous',
-        description: 'Temperature & humidity LCD sensor',
-        fromZigbee: [fz.nous_lcd_temperature_humidity_sensor, fz.ignore_tuya_set_time],
-        toZigbee: [tz.nous_lcd_temperature_humidity_sensor],
-        onEvent: tuya.onEventSetLocalTime,
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
-        },
-        exposes: [
-            e.temperature(),
-            e.humidity(),
-            e.battery(),
-            exposes.enum('temp_unit_convert', ea.STATE_SET, ['°C', '°F']).withDescription('Current display unit'),
-            exposes.enum('temp_alarm', ea.STATE, ['canceled', 'loweralarm', 'upperalarm']).withDescription('Temperature alarm status'),
-            exposes.numeric('maxtemp', ea.STATE_SET)
-                .withUnit('°C').withValueMin(-20).withValueMax(60)
-                .withDescription('Alarm temperature max'),
-            exposes.numeric('mintemp', ea.STATE_SET).withUnit('°C')
-                .withValueMin(-20).withValueMax(60)
-                .withDescription('Alarm temperature min'),
-            exposes.numeric('temp_sensitivity', ea.STATE_SET)
-                .withUnit('°C').withValueMin(0.1).withValueMax(50).withValueStep(0.1)
-                .withDescription('Temperature sensitivity'),
-        ],
-    },
-    {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_auin8mzr'}],
         model: 'TS0601_motion_sensor',
         vendor: 'TuYa',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1626,6 +1626,35 @@ module.exports = [
         ],
     },
     {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_nnrfa68v'}],
+        model: 'E6',
+        vendor: 'Nous',
+        description: 'Temperature & humidity LCD sensor',
+        fromZigbee: [fz.nous_lcd_temperature_humidity_sensor, fz.ignore_tuya_set_time],
+        toZigbee: [tz.nous_lcd_temperature_humidity_sensor],
+        onEvent: tuya.onEventSetLocalTime,
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
+        },
+        exposes: [
+            e.temperature(),
+            e.humidity(),
+            e.battery(),
+            exposes.enum('temp_unit_convert', ea.STATE_SET, ['°C', '°F']).withDescription('Current display unit'),
+            exposes.enum('temp_alarm', ea.STATE, ['canceled', 'loweralarm', 'upperalarm']).withDescription('Temperature alarm status'),
+            exposes.numeric('maxtemp', ea.STATE_SET)
+                .withUnit('°C').withValueMin(-20).withValueMax(60)
+                .withDescription('Alarm temperature max'),
+            exposes.numeric('mintemp', ea.STATE_SET).withUnit('°C')
+                .withValueMin(-20).withValueMax(60)
+                .withDescription('Alarm temperature min'),
+            exposes.numeric('temp_sensitivity', ea.STATE_SET)
+                .withUnit('°C').withValueMin(0.1).withValueMax(50).withValueStep(0.1)
+                .withDescription('Temperature sensitivity'),
+        ],
+    },
+    {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_auin8mzr'}],
         model: 'TS0601_motion_sensor',
         vendor: 'TuYa',

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -475,6 +475,15 @@ const dataPoints = {
     hochTotalReverseActivePower: 117,
     hochHistoricalVoltage: 118,
     hochHistoricalCurrent: 119,
+    // NOUS SMart LCD Temperature and Humidity Sensor E6
+    nousTemperature: 1,
+    nousHumidity: 2,
+    nousBattery: 4,
+    nousTempUnitConvert: 9,
+    nousMaxTemp: 10,
+    nousMinTemp: 11,
+    nousTempAlarm: 14,
+    nousTempSensitivity: 19,
 
     // TUYA / HUMIDITY/ILLUMINANCE/TEMPERATURE SENSOR
     thitBatteryPercentage: 3,


### PR DESCRIPTION
Add support for Smart ZigBee LCD Temperature and Humidity Sensor Nous E6
[https://nous.technology/product/e6.html](url)
Tested with Zigbee2mqtt HA add-on with attached file in `external_converters`
[nous_e6.js.txt](https://github.com/Koenkk/zigbee-herdsman-converters/files/7699326/nous_e6.js.txt)

