### PR TITLE
OSRAM: Add Support for Lightify bulb AC03641-DIM

### DIFF
--- a/devices/osram.js
+++ b/devices/osram.js
@@ -170,6 +170,14 @@ module.exports = [
         ota: ota.ledvance,
     },
     {
+        zigbeeModel: ['Classic A60 W clear - LIGHTIFY'],
+        model: 'AC03641-DIM',
+        vendor: 'OSRAM',
+        description: 'LIGHTIFY LED Classic A60 clear',
+        extend: extend.ledvance.light_onoff_brightness(),
+        ota: ota.ledvance,
+    },
+    {
         zigbeeModel: ['Surface Light W �C LIGHTIFY'],
         model: '4052899926158',
         vendor: 'OSRAM',


### PR DESCRIPTION
This PR adds Support for the DIM variant of osram smart+ AC03641, which was bought by amazon (labeled as AC03641).
Im owning one of this bulb variant (basicaly a non-dim) and worked after adding this entry.