### PR TITLE
Add Elko/Schneider EKO09738 and EKO09716

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -652,6 +652,46 @@ const converters = {
             return payload;
         },
     },
+    EKO09738_metering: {
+        /**
+         * When using this converter also add the following to the configure method of the device:
+         * await readMeteringPowerConverterAttributes(endpoint);
+         */
+        cluster: 'seMetering',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const payload = {};
+            const multiplier = msg.endpoint.getClusterAttributeValue('seMetering', 'multiplier');
+            const divisor = msg.endpoint.getClusterAttributeValue('seMetering', 'divisor');
+            const factor = multiplier && divisor ? multiplier / divisor : null;
+
+            if (msg.data.hasOwnProperty('instantaneousDemand')) {
+                let power = msg.data['instantaneousDemand'];
+                if (factor != null) {
+                    power = (power * factor); // Unit reports in mW
+                }
+                payload.power = precisionRound(power, 2);
+            }
+
+            if (factor != null && (msg.data.hasOwnProperty('currentSummDelivered') ||
+                msg.data.hasOwnProperty('currentSummReceived'))) {
+                let energy = 0;
+                if (msg.data.hasOwnProperty('currentSummDelivered')) {
+                    const data = msg.data['currentSummDelivered'];
+                    const value = (parseInt(data[0]) << 32) + parseInt(data[1]);
+                    energy += value * factor;
+                }
+                if (msg.data.hasOwnProperty('currentSummReceived')) {
+                    const data = msg.data['currentSummReceived'];
+                    const value = (parseInt(data[0]) << 32) + parseInt(data[1]);
+                    energy -= value * factor;
+                }
+                payload.energy = precisionRound(energy, 2);
+            }
+
+            return payload;
+        },
+    },
     develco_metering: {
         cluster: 'seMetering',
         type: ['attributeReport', 'readResponse'],

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -533,4 +533,40 @@ module.exports = [
             await reporting.batteryPercentageRemaining(endpoint);
         },
     },
+    {
+        zigbeeModel: ['SOCKET/OUTLET/2'],
+        model: 'EKO09738',
+        vendor: 'Schneider Electric',
+        description: 'Zigbee smart socket with power meter',
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.EKO09738_metering, fz.power_on_behavior],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
+        exposes: [e.switch(), e.power(), e.energy(), exposes.enum('power_on_behavior', ea.ALL, ['off', 'previous', 'on'])
+            .withDescription('Controls the behaviour when the device is powered on'), e.current(), e.voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(6);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.onOff(endpoint);
+            // Unit supports acVoltage and acCurrent, but only acCurrent divisor/multiplier can be read
+            await endpoint.read('haElectricalMeasurement', ['acCurrentDivisor', 'acCurrentMultiplier']);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['SOCKET/OUTLET/1'],
+        model: 'EKO09716',
+        vendor: 'Schneider Electric',
+        description: 'Zigbee smart socket with power meter',
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.EKO09738_metering, fz.power_on_behavior],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
+        exposes: [e.switch(), e.power(), e.energy(), exposes.enum('power_on_behavior', ea.ALL, ['off', 'previous', 'on'])
+            .withDescription('Controls the behaviour when the device is powered on'), e.current(), e.voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(6);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.onOff(endpoint);
+            // Unit supports acVoltage and acCurrent, but only acCurrent divisor/multiplier can be read
+            await endpoint.read('haElectricalMeasurement', ['acCurrentDivisor', 'acCurrentMultiplier']);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+        },
+    },
 ];


### PR DESCRIPTION
Add support for Elko/Schneider Electric EKO09738/EKO09716

[Elko Website EKO09716](https://elkosmart.elko.no/produkter/stikkontakt-enkel)
[Elko Website EKO09738](https://elkosmart.elko.no/produkter/stikkontakt-dobbel)

[Compliance Documentation EKO09716](https://zigbeealliance.org/zigbee_products/elko-smartsocket-single-16a/)
[Compliance Documentation EKO09738](https://zigbeealliance.org/no/zigbee_Produkter/elko-smartsocket-dobbel-16a/)

I have only tested EKO09738, but the only difference is that EKO09738 has an extra not-controlled/metered outlet. Looking at  Koenkk/zigbee2mqtt#7781 this should work.

The devices reports instantaneousDemand in mW, hence the new converter. I dont know if there is another way of doing it.
