### PR TITLE
Add Schwaiger HAL500

### DIFF
--- a/devices/schwaiger.js
+++ b/devices/schwaiger.js
@@ -45,5 +45,4 @@ module.exports = [
         description: 'LED bulb GU10 350 lumen, dimmable, color, white 2700-6500K',
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
     },
-    
 ];

--- a/devices/schwaiger.js
+++ b/devices/schwaiger.js
@@ -38,4 +38,12 @@ module.exports = [
         description: 'LED candle bulb E14 470 lumen, dimmable, color, white 2700K',
         extend: extend.light_onoff_brightness(),
     },
+    {
+        fingerprint: [{modelID: 'ZBT-CCTLight-GU100904', manufacturerName: 'LDS'}],
+        model: 'HAL500',
+        vendor: 'Schwaiger',
+        description: 'LED bulb GU10 350 lumen, dimmable, color, white 2700-6500K',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
+    },
+    
 ];


### PR DESCRIPTION
Add support for Schwaiger HAL500, device reports manufacturer as LDS but I wasnt able to find any information about that brand name.

https://zigbee.blakadder.com/Schwaiger_HAL500.html shows this bulb as already supported by Z2M, zigbeeModel and supported features however don't match.