### PR TITLE
Add branding to TuYa TS0201

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -490,6 +490,7 @@ module.exports = [
         model: 'TS0201',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor with display',
+        whiteLabel: [{vendor: 'BlitzWolf', model: 'BW-IS4'}],
         fromZigbee: [fz.battery, fz.temperature, fz.humidity],
         toZigbee: [],
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],


### PR DESCRIPTION
TuYa TS0201 is also sold under the brand  BlitzWolf with model BW-IS4