### PR TITLE
Unconditionally add all generic toZigbee converters

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,9 +75,7 @@ function addDefinition(definition) {
         };
     }
 
-    if (definition.toZigbee.length > 0) {
-        definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.read, tz.write);
-    }
+    definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.read, tz.write);
 
     if (definition.exposes) {
         definition.exposes = definition.exposes.concat([exposes.presets.linkquality()]);


### PR DESCRIPTION
Generic toZigbee converters are only added if a device has at least one converter defined. They're useful for most devices, especially for using the dev console to probe which attributes are supported. Fixes #3261.