### PR TITLE
Adapt TuYa converters to multiple data point change

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4280,18 +4280,22 @@ const converters = {
                 }
                 return hex;
             };
-            let dataStr =
-                Date.now().toString() + ' ' +
-                meta.device.ieeeAddr + ' ' +
-                getHex(msg.data.seq) + ' ' +
-                getHex(msg.data.dp) + ' ' +
-                getHex(msg.data.datatype) + ' ' +
-                getHex(msg.data.fn);
+            const now = Date.now().toString();
+            let dataStr = '';
+            for (const [i, dpValue] of msg.data.dpValues.entries()) {
+                dataStr +=
+                    now + ' ' +
+                    meta.device.ieeeAddr + ' ' +
+                    getHex(msg.data.seq) + ' ' +
+                    getHex(i) + ' ' +
+                    getHex(dpValue.dp) + ' ' +
+                    getHex(dpValue.datatype);
 
-            msg.data.data.forEach((elem) => {
-                dataStr += ' ' + getHex(elem);
-            });
-            dataStr += '\n';
+                dpValue.data.forEach((elem) => {
+                    dataStr += ' ' + getHex(elem);
+                });
+                dataStr += '\n';
+            }
             const fs = require('fs');
             fs.appendFile('data/tuya.dump.txt', dataStr, (err) => {
                 if (err) throw err;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1690,10 +1690,11 @@ const converters = {
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
             const multiEndpoint = model.meta && model.meta.multiEndpoint;
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'moes_105_dimmer');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
-            meta.logger.debug(`from moes_105_dimmer, msg.data.dp=[${dp}], msg.data.datatype=[${msg.data.datatype}], value=[${value}]`);
+            meta.logger.debug(`from moes_105_dimmer, dp=[${dp}], datatype=[${dpValue.datatype}], value=[${value}]`);
 
             const state = value ? 'ON': 'OFF';
             const brightness = mapNumberRange(value, 0, 1000, 0, 254);
@@ -1709,7 +1710,7 @@ const converters = {
                 return {brightness_l2: brightness};
             default:
                 meta.logger.debug(`zigbee-herdsman-converters:moes_105_dimmer:` +
-                    `NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                    `NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -1785,8 +1786,9 @@ const converters = {
         options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
             exposes.options.precision('humidity'), exposes.options.calibration('humidity')],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_temperature_humidity_sensor');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case 1:
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
@@ -1796,7 +1798,7 @@ const converters = {
                 return {battery: value};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:maa_tuya_temp_sensor: NOT RECOGNIZED ` +
-                    `DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                    `DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -1806,8 +1808,9 @@ const converters = {
         options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
             exposes.options.precision('humidity'), exposes.options.calibration('humidity')],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'nous_lcd_temperature_humidity_sensor');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case tuya.dataPoints.nousTemperature:
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
@@ -1827,7 +1830,7 @@ const converters = {
                 return {temperature_sensitivity: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:nous_lcd_temperature_humidity_sensor: NOT RECOGNIZED ` +
-                    `DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                    `DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -1837,8 +1840,9 @@ const converters = {
         options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
             exposes.options.precision('humidity'), exposes.options.calibration('humidity')],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_illuminance_temperature_humidity_sensor');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case tuya.dataPoints.thitTemperature:
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
@@ -1850,7 +1854,7 @@ const converters = {
                 return {illuminance_lux: value};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:tuya_illuminance_temperature_humidity_sensor: NOT RECOGNIZED ` +
-                    `DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                    `DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -1887,8 +1891,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_thermostat_weekly_schedule');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             const thermostatMeta = getMetaValue(msg.endpoint, model, 'thermostat');
             const firstDayDpId = thermostatMeta.weeklyScheduleFirstDayDpId;
@@ -1936,8 +1941,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'hy_thermostat');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.hyWorkdaySchedule1: // schedule for workdays [5,9,12,8,0,15,10,0,15]
@@ -2010,7 +2016,7 @@ const converters = {
                 return {alarm: (value > 0) ? true : false};
             default: // The purpose of the codes 17 & 19 are still unknown
                 meta.logger.warn(`zigbee-herdsman-converters:hy_thermostat: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -2070,8 +2076,9 @@ const converters = {
             // Protocol description
             // https://github.com/Koenkk/zigbee-herdsman-converters/issues/1159#issuecomment-614659802
 
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_cover');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.coverPosition: // Started moving to position (triggered from Zigbee)
@@ -2097,7 +2104,7 @@ const converters = {
                 break;
             default: // Unknown code
                 meta.logger.warn(`TuYa_cover_control: Unhandled DP #${dp} for ${meta.device.manufacturerName}:
-                ${JSON.stringify(msg.data)}`);
+                ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -2391,8 +2398,9 @@ const converters = {
         options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
             exposes.options.precision('humidity'), exposes.options.calibration('humidity')],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'neo_nas_pd07');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             if (dp === 101) return {occupancy: value > 0 ? true : false};
             else if (dp === 102) {
@@ -2407,7 +2415,7 @@ const converters = {
             } else if (dp === 105) {
                 return {humidity: calibrateAndPrecisionRoundOptions(value, options, 'humidity')};
             } else {
-                meta.logger.warn(`zigbee-herdsman-converters:NEO-PD07: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`zigbee-herdsman-converters:NEO-PD07: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -2415,8 +2423,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'neo_t_h_alarm');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.neoAlarm:
@@ -2453,7 +2462,7 @@ const converters = {
             case tuya.dataPoints.neoVolume: // 0x0474 [0]/[1]/[2] Volume 0-max, 2-low
                 return {volume: {2: 'low', 1: 'medium', 0: 'high'}[value]};
             default: // Unknown code
-                meta.logger.warn(`Unhandled DP #${dp}: ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`Unhandled DP #${dp}: ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -2560,8 +2569,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: 'commandDataReport',
         convert: (model, msg, publish, options, meta) => {
-            if (msg.data.dp === tuya.dataPoints.waterLeak) {
-                return {water_leak: tuya.getDataValue(msg.data.datatype, msg.data.data)};
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_water_leak');
+            if (dpValue.dp === tuya.dataPoints.waterLeak) {
+                return {water_leak: tuya.getDataValue(dpValue)};
             }
         },
     },
@@ -2924,8 +2934,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'silvercrest_smart_led_string');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             const result = {};
 
             if (dp === tuya.dataPoints.silvercrestChangeMode) {
@@ -3547,8 +3558,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'moes_thermostat');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             let temperature;
             /* See tuyaThermostat above for message structure comment */
             switch (dp) {
@@ -3612,7 +3624,7 @@ const converters = {
                 }
             default: // DataPoint 17 is unknown
                 meta.logger.warn(`zigbee-herdsman-converters:Moes BHT-002: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -3620,8 +3632,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp; // First we get the data point ID
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'moesS_thermostat');
+            const dp = dpValue.dp; // First we get the data point ID
+            const value = tuya.getDataValue(dpValue);
             const presetLookup = {0: 'programming', 1: 'manual', 2: 'temporary_manual', 3: 'holiday'};
             switch (dp) {
             case tuya.dataPoints.moesSsystemMode:
@@ -3672,7 +3685,7 @@ const converters = {
             }
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:moesS_thermostat: NOT RECOGNIZED DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -3680,8 +3693,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tvtwo_thermostat');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             const presetLookup = {0: 'auto', 1: 'manual', 2: 'holiday'};
             switch (dp) {
             case tuya.dataPoints.tvMode:
@@ -3823,7 +3837,7 @@ const converters = {
 
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:tvtwo_thermostat: NOT RECOGNIZED DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -3831,8 +3845,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp; // First we get the data point ID
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'haozee_thermostat');
+            const dp = dpValue.dp; // First we get the data point ID
+            const value = tuya.getDataValue(dpValue);
             const presetLookup = {0: 'auto', 1: 'manual', 2: 'off', 3: 'on'};
             switch (dp) {
             case tuya.dataPoints.haozeeSystemMode:
@@ -3938,7 +3953,7 @@ const converters = {
                 break;
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:haozee: NOT RECOGNIZED DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -3951,8 +3966,9 @@ const converters = {
             exposes.options.precision('voc'), exposes.options.calibration('voc'),
             exposes.options.precision('formaldehyd'), exposes.options.calibration('formaldehyd')],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_air_quality');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case tuya.dataPoints.tuyaSabTemp:
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
@@ -3967,7 +3983,7 @@ const converters = {
                 return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:TuyaSmartAirBox: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -3975,8 +3991,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'saswell_thermostat');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.saswellHeating:
@@ -4091,7 +4108,7 @@ const converters = {
                 return {anti_scaling: value ? 'ON' : 'OFF'};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:SaswellThermostat: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -4099,8 +4116,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'etop_thermostat');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             if (dp >= 101 && dp <=107) return; // handled by tuya_thermostat_weekly_schedule
 
@@ -4140,7 +4158,7 @@ const converters = {
                 return {running_state: value ? 'heat' : 'idle'};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:eTopThermostat: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -4148,8 +4166,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_thermostat');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.windowDetection:
@@ -4246,7 +4265,7 @@ const converters = {
                 return {week: tuya.thermostatWeekFormat[value]};
             default: // The purpose of the dps 17 & 19 is still unknown
                 console.log(`zigbee-herdsman-converters:tuyaThermostat: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -4254,12 +4273,13 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
-            if (msg.data.dp === tuya.dataPoints.state) {
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_dimmer');
+            const value = tuya.getDataValue(dpValue);
+            if (dpValue.dp === tuya.dataPoints.state) {
                 return {state: value ? 'ON': 'OFF'};
             } else if (meta.device.manufacturerName === '_TZE200_swaamsoy') {
                 // https://github.com/Koenkk/zigbee-herdsman-converters/pull/3004
-                if (msg.data.dp === 2) {
+                if (dpValue.dp === 2) {
                     return {brightness: mapNumberRange(value, 10, 1000, 0, 254)};
                 }
             } else { // TODO: Unknown dp, assumed value type
@@ -4340,7 +4360,8 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: 'commandDataResponse',
         convert: (model, msg, publish, options, meta) => {
-            msg.data.occupancy = msg.data.dp === tuya.dataPoints.occupancy ? 1 : 0;
+            const dpValue = tuya.firstDpValue(msg, meta, 'blitzwolf_occupancy_with_timeout');
+            msg.data.occupancy = dpValue.dp === tuya.dataPoints.occupancy ? 1 : 0;
             return converters.occupancy_with_timeout.convert(model, msg, publish, options, meta);
         },
     },
@@ -4637,8 +4658,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'commandActiveStatusReport'],
         convert: (model, msg, publish, options, meta) => {
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
-            const dp = msg.data.dp;
+            const dpValue = tuya.firstDpValue(msg, meta, 'frankever_valve');
+            const value = tuya.getDataValue(dpValue);
+            const dp = dpValue.dp;
             switch (dp) {
             case tuya.dataPoints.state: {
                 return {state: value ? 'ON': 'OFF'};
@@ -4651,7 +4673,7 @@ const converters = {
             }
             default: {
                 meta.logger.warn(`zigbee-herdsman-converters:FrankeverValve: NOT RECOGNIZED DP ` +
-                    `#${dp} with data ${JSON.stringify(msg.data)}`);
+                    `#${dp} with data ${JSON.stringify(dpValue)}`);
             }
             }
         },
@@ -4660,13 +4682,14 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_smoke');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case tuya.dataPoints.state:
                 return {smoke: value === 0};
             default:
-                meta.logger.warn(`zigbee-herdsman-converters:tuya_smoke: Unrecognized DP #${ dp} with data ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`zigbee-herdsman-converters:tuya_smoke: Unrecognized DP #${ dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -4674,8 +4697,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_woox_smoke');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case tuya.dataPoints.wooxBattery:
                 return {battery_low: value === 0};
@@ -4684,7 +4708,7 @@ const converters = {
             case tuya.dataPoints.wooxSmokeTest:
                 return {smoke: value};
             default:
-                meta.logger.warn(`zigbee-herdsman-converters:tuya_smoke: Unrecognized DP #${ dp} with data ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`zigbee-herdsman-converters:tuya_smoke: Unrecognized DP #${ dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -4693,8 +4717,9 @@ const converters = {
         type: ['commandDataReport', 'commandDataResponse', 'commandActiveStatusReport'],
         convert: (model, msg, publish, options, meta) => {
             const multiEndpoint = model.meta && model.meta.multiEndpoint;
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_switch');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             const state = value ? 'ON' : 'OFF';
             if (multiEndpoint) {
                 const lookup = {1: 'l1', 2: 'l2', 3: 'l3', 4: 'l4'};
@@ -4712,8 +4737,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse', 'commandActiveStatusReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_dinrail_switch');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             const state = value ? 'ON' : 'OFF';
 
             switch (dp) {
@@ -4729,7 +4755,7 @@ const converters = {
                 return {voltage: value/10};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:TuyaDinRailSwitch: NOT RECOGNIZED DP ` +
-                    `#${dp} with data ${JSON.stringify(msg.data)}`);
+                    `#${dp} with data ${JSON.stringify(dpValue)}`);
             }
 
             return null;
@@ -6111,8 +6137,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'javis_microwave_sensor');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             const lookup = {
                 0: 'no_motion',
                 1: 'big_motion',
@@ -6174,7 +6201,7 @@ const converters = {
                 }
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:javis_microwave_sensor: NOT RECOGNIZED ` +
-                    `DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                    `DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -6318,8 +6345,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: 'commandDataResponse',
         convert: (model, msg, publish, options, meta) => {
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
-            const dp = msg.data.dp;
+            const dpValue = tuya.firstDpValue(msg, meta, 'ZVG1');
+            const value = tuya.getDataValue(dpValue);
+            const dp = dpValue.dp;
             switch (dp) {
             case tuya.dataPoints.state: {
                 return {state: value ? 'ON': 'OFF'};
@@ -6346,7 +6374,7 @@ const converters = {
             }
             default: {
                 meta.logger.warn(`zigbee-herdsman-converters:RTXZVG1Valve: NOT RECOGNIZED DP ` +
-                    `#${dp} with data ${JSON.stringify(msg.data)}`);
+                    `#${dp} with data ${JSON.stringify(dpValue)}`);
             }
             }
         },
@@ -6882,8 +6910,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'SLUXZB');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case 2:
                 return {illuminance_lux: value.toFixed(0)};
@@ -6892,7 +6921,7 @@ const converters = {
             case 1:
                 return {battery_low: value.toFixed(1)};
             default:
-                meta.logger.warn(`s_lux_zb_illuminance: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`s_lux_zb_illuminance: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -6902,8 +6931,9 @@ const converters = {
         options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
             exposes.options.precision('humidity'), exposes.options.calibration('humidity')],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'ZB003X');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.fantemTemp:
@@ -6932,7 +6962,7 @@ const converters = {
                 return {reporting_enable: value};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:FantemZB003X: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -6965,15 +6995,16 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_gas');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.state:
                 return {gas: value === 0 ? true : false};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:tuya_gas: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -6981,15 +7012,16 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandActiveStatusReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'woox_R7060');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
 
             switch (dp) {
             case tuya.dataPoints.wooxSwitch:
                 return {state: value === 2 ? 'OFF' : 'ON'};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:WooxR7060: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(msg.data)}`);
+                    dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },
@@ -7335,8 +7367,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_motion_sensor');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             let result = null;
             switch (dp) {
             case tuya.dataPoints.state:
@@ -7373,7 +7406,7 @@ const converters = {
                 result = {luminance_level: value};
                 break;
             default:
-                meta.logger.warn(`fromZigbee.tuya_motion_sensor: NOT RECOGNIZED DP ${dp} with data ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`fromZigbee.tuya_motion_sensor: NOT RECOGNIZED DP ${dp} with data ${JSON.stringify(dpValue)}`);
             }
 
             return result;
@@ -7383,8 +7416,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_radar_sensor');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case tuya.dataPoints.trsPresenceState:
                 return {presence: {0: false, 1: true}[value]};
@@ -7407,8 +7441,9 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'raw'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            let value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'moes_thermostat_tv');
+            const dp = dpValue.dp;
+            let value = tuya.getDataValue(dpValue);
             let result = null;
             switch (dp) {
             case tuya.dataPoints.tvMode:
@@ -7482,7 +7517,7 @@ const converters = {
                 }
                 break;
             default:
-                meta.logger.warn(`fromZigbee.moes_thermostat_tv: NOT RECOGNIZED DP ${dp} with data ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`fromZigbee.moes_thermostat_tv: NOT RECOGNIZED DP ${dp} with data ${JSON.stringify(dpValue)}`);
             }
 
             return result;
@@ -7516,10 +7551,11 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'hoch_din');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             const result = {};
-            meta.logger.debug(`from hoch_din, msg.data.dp=[${dp}], msg.data.datatype=[${msg.data.datatype}], value=[${value}]`);
+            meta.logger.debug(`from hoch_din, dp=[${dp}], datatype=[${dpValue.datatype}], value=[${value}]`);
 
             if (dp === tuya.dataPoints.state) {
                 result.state = value ? 'ON' : 'OFF';

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -5462,7 +5462,7 @@ const converters = {
                     }
                 }
 
-                await tuya.sendDataPoint(entity, tuya.dataTypes.string, tuya.dataPoints.silvercrestSetEffect, data);
+                await tuya.sendDataPointStringBuffer(entity, tuya.dataPoints.silvercrestSetEffect, data);
             } else if (key === 'brightness') {
                 await tuya.sendDataPointEnum(entity, tuya.dataPoints.silvercrestChangeMode, tuya.silvercrestModes.white);
                 // It expects 2 leading zero's.
@@ -5472,7 +5472,10 @@ const converters = {
                 const scaled = utils.mapNumberRange(value, 0, 255, 0, 1000);
                 data = data.concat(tuya.convertDecimalValueTo2ByteHexArray(scaled));
 
-                await tuya.sendDataPoint(entity, tuya.dataTypes.value, tuya.dataPoints.silvercrestSetBrightness, data);
+                await tuya.sendDataPoint(
+                    entity,
+                    {dp: tuya.dataPoints.silvercrestSetBrightness, datatype: tuya.dataTypes.value, data: data},
+                );
             } else if (key === 'color') {
                 await tuya.sendDataPointEnum(entity, tuya.dataPoints.silvercrestChangeMode, tuya.silvercrestModes.color);
 
@@ -5544,7 +5547,7 @@ const converters = {
                 data = data.concat(tuya.convertStringToHexArray(hsb.s));
                 data = data.concat(tuya.convertStringToHexArray(hsb.b));
 
-                await tuya.sendDataPoint(entity, tuya.dataTypes.string, tuya.dataPoints.silvercrestSetColor, data);
+                await tuya.sendDataPointStringBuffer(entity, tuya.dataPoints.silvercrestSetColor, data);
             }
         },
     },

--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -40,8 +40,9 @@ const fzLocal = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'zs_thermostat');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
             const ret = {};
             const daysMap = {1: 'monday', 2: 'tuesday', 3: 'wednesday', 4: 'thursday', 5: 'friday', 6: 'saturday', 7: 'sunday'};
             const day = daysMap[value[0]];
@@ -135,7 +136,7 @@ const fzLocal = {
                 ret.away_preset_days = (value[6]<<8)+value[7];
                 return ret;
             default:
-                meta.logger.warn(`zigbee-herdsman-converters:zsThermostat: Unrecognized DP #${dp} with data ${JSON.stringify(msg.data)}`);
+                meta.logger.warn(`zigbee-herdsman-converters:zsThermostat: Unrecognized DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
     },

--- a/devices/zemismart.js
+++ b/devices/zemismart.js
@@ -11,8 +11,9 @@ const fzLocal = {
         cluster: 'manuSpecificTuya',
         type: ['commandGetData', 'commandSetDataResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const button = msg.data.dp;
-            const actionValue = tuya.getDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'ZMRM02');
+            const button = dpValue.dp;
+            const actionValue = tuya.getDataValue(dpValue);
             const lookup = {0: 'single', 1: 'double', 2: 'hold'};
             const action = lookup[actionValue];
             return {action: `button_${button}_${action}`};

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -2052,8 +2052,9 @@ const fromZigbee = {
                 return fromZigbeeConverters.tuya_thermostat_weekly_schedule.convert(model, msg, publish, options, meta);
             }
 
-            const dp = msg.data.dp;
-            const value = tuyaGetDataValue(msg.data.datatype, msg.data.data);
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_thermostat_weekly_schedule');
+            const dp = dpValue.dp;
+            const value = tuyaGetDataValue(dpValue.datatype, dpValue.data);
 
             const thermostatMeta = getMetaValue(msg.endpoint, model, 'thermostat');
             const firstDayDpId = thermostatMeta.weeklyScheduleFirstDayDpId;

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -618,15 +618,15 @@ const tvThermostatPreset = {
 };
 
 // Return `seq` - transaction ID for handling concrete response
-async function sendDataPoint(entity, datatype, dp, data, cmd, seq=undefined) {
+async function sendDataPoints(entity, dpValues, cmd, seq=undefined) {
     if (seq === undefined) {
-        if (sendDataPoint.seq === undefined) {
-            sendDataPoint.seq = 0;
+        if (sendDataPoints.seq === undefined) {
+            sendDataPoints.seq = 0;
         } else {
-            sendDataPoint.seq++;
-            sendDataPoint.seq %= 0xFFFF;
+            sendDataPoints.seq++;
+            sendDataPoints.seq %= 0xFFFF;
         }
-        seq = sendDataPoint.seq;
+        seq = sendDataPoints.seq;
     }
 
     await entity.command(
@@ -634,67 +634,91 @@ async function sendDataPoint(entity, datatype, dp, data, cmd, seq=undefined) {
         cmd || 'dataRequest',
         {
             seq,
-            dp: dp,
-            datatype: datatype,
-            length_hi: (data.length >> 8) & 0xFF,
-            length_lo: data.length & 0xFF,
-            data: data,
+            dpValues,
         },
         {disableDefaultResponse: true},
     );
     return seq;
 }
 
+function dpValueFromIntValue(dp, value) {
+    return {dp, datatype: dataTypes.value, data: convertDecimalValueTo4ByteHexArray(value)};
+}
+
+function dpValueFromBool(dp, value) {
+    return {dp, datatype: dataTypes.bool, data: [value ? 1 : 0]};
+}
+
+function dpValueFromEnum(dp, value) {
+    return {dp, datatype: dataTypes.enum, data: [value]};
+}
+
+function dpValueFromStringBuffer(dp, stringBuffer) {
+    return {dp, datatype: dataTypes.string, data: stringBuffer};
+}
+
+function dpValueFromRaw(dp, rawBuffer) {
+    return {dp, datatype: dataTypes.raw, data: rawBuffer};
+}
+
+function dpValueFromBitmap(dp, bitmapBuffer) {
+    return {dp, datatype: dataTypes.bitmap, data: bitmapBuffer};
+}
+
+// Return `seq` - transaction ID for handling concrete response
+async function sendDataPoint(entity, dpValue, cmd, seq=undefined) {
+    return await sendDataPoints(entity, [dpValue], cmd, seq);
+}
+
 async function sendDataPointValue(entity, dp, value, cmd, seq=undefined) {
-    return await sendDataPoint(
+    return await sendDataPoints(
         entity,
-        dataTypes.value,
-        dp,
-        convertDecimalValueTo4ByteHexArray(value),
+        [dpValueFromIntValue(dp, value)],
         cmd,
         seq,
     );
 }
 
 async function sendDataPointBool(entity, dp, value, cmd, seq=undefined) {
-    return await sendDataPoint(
+    return await sendDataPoints(
         entity,
-        dataTypes.bool,
-        dp,
-        [value ? 1 : 0],
+        [dpValueFromBool(dp, value)],
         cmd,
         seq,
     );
 }
 
 async function sendDataPointEnum(entity, dp, value, cmd, seq=undefined) {
-    return await sendDataPoint(
+    return await sendDataPoints(
         entity,
-        dataTypes.enum,
-        dp,
-        [value],
+        [dpValueFromEnum(dp, value)],
         cmd,
         seq,
     );
 }
 
 async function sendDataPointRaw(entity, dp, value, cmd, seq=undefined) {
-    return await sendDataPoint(
+    return await sendDataPoints(
         entity,
-        dataTypes.raw,
-        dp,
-        value,
+        [dpValueFromRaw(dp, value)],
         cmd,
         seq,
     );
 }
 
 async function sendDataPointBitmap(entity, dp, value, cmd, seq=undefined) {
-    return await sendDataPoint(
+    return await sendDataPoints(
         entity,
-        dataTypes.bitmap,
-        dp,
-        value,
+        [dpValueFromBitmap(dp, value)],
+        cmd,
+        seq,
+    );
+}
+
+async function sendDataPointStringBuffer(entity, dp, value, cmd, seq=undefined) {
+    return await sendDataPoints(
+        entity,
+        [dpValueFromStringBuffer(dp, value)],
         cmd,
         seq,
     );
@@ -702,15 +726,23 @@ async function sendDataPointBitmap(entity, dp, value, cmd, seq=undefined) {
 
 module.exports = {
     sendDataPoint,
+    sendDataPoints,
     sendDataPointValue,
     sendDataPointBool,
     sendDataPointEnum,
     sendDataPointBitmap,
     sendDataPointRaw,
+    sendDataPointStringBuffer,
     firstDpValue,
     getDataValue,
     dataTypes,
     dataPoints,
+    dpValueFromIntValue,
+    dpValueFromBool,
+    dpValueFromEnum,
+    dpValueFromStringBuffer,
+    dpValueFromRaw,
+    dpValueFromBitmap,
     convertDecimalValueTo4ByteHexArray,
     convertDecimalValueTo2ByteHexArray,
     onEventSetTime,

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -23,26 +23,38 @@ const convertMultiByteNumberPayloadToSingleDecimalNumber = (chunks) => {
     return value;
 };
 
-function getDataValue(dataType, data) {
-    switch (dataType) {
+function firstDpValue(msg, meta, converterName) {
+    const dpValues = msg.data.dpValues;
+    for (let index = 1; index < dpValues.length; index++) {
+        meta.logger.warn(`zigbee-herdsman-converters:${converterName}: Additional DP #${
+            dpValues[index].dp} with data ${JSON.stringify(dpValues[index])} will be ignored! ` +
+            'Use a for loop in the fromZigbee converter (see ' +
+            'https://www.zigbee2mqtt.io/advanced/support-new-devices/02_support_new_tuya_devices.html)');
+    }
+    return dpValues[0];
+}
+
+
+function getDataValue(dpValue) {
+    switch (dpValue.datatype) {
     case dataTypes.raw:
-        return data;
+        return dpValue.data;
     case dataTypes.bool:
-        return data[0] === 1;
+        return dpValue.data[0] === 1;
     case dataTypes.value:
-        return convertMultiByteNumberPayloadToSingleDecimalNumber(data);
+        return convertMultiByteNumberPayloadToSingleDecimalNumber(dpValue.data);
     case dataTypes.string:
         // eslint-disable-next-line
         let dataString = '';
         // Don't use .map here, doesn't work: https://github.com/Koenkk/zigbee-herdsman-converters/pull/1799/files#r530377091
-        for (let i = 0; i < data.length; ++i) {
-            dataString += String.fromCharCode(data[i]);
+        for (let i = 0; i < dpValue.data.length; ++i) {
+            dataString += String.fromCharCode(dpValue.data[i]);
         }
         return dataString;
     case dataTypes.enum:
-        return data[0];
+        return dpValue.data[0];
     case dataTypes.bitmap:
-        return convertMultiByteNumberPayloadToSingleDecimalNumber(data);
+        return convertMultiByteNumberPayloadToSingleDecimalNumber(dpValue.data);
     }
 }
 
@@ -695,6 +707,7 @@ module.exports = {
     sendDataPointEnum,
     sendDataPointBitmap,
     sendDataPointRaw,
+    firstDpValue,
     getDataValue,
     dataTypes,
     dataPoints,

--- a/scripts/read_tuya_dump.py
+++ b/scripts/read_tuya_dump.py
@@ -122,28 +122,25 @@ PROGRAM_MODES = {
 
 DATA_POINT_NAMES = SASWELL_DATA_POINT_NAMES
 DATA_TYPE_PARSERS = [parse_raw, parse_bool, parse_value, parse_string, parse_enum, parse_bitmap]
+DATA_TYPE_NAME = ["raw", "bool", "int", "string", "enum", "bitmap"]
 EXTRA_PARSERS = SASWELL_PARSERS
 
 
 def get_values(numbers):
-    data = bytearray()
     dp = int(numbers[0], 16)
     dtype = int(numbers[1], 16)
-    fn = int(numbers[2], 16)
-    for number in numbers[3:]:
-        data += bytes([int(number, 16)])
-
+    data = bytes.fromhex("".join(numbers[2:]))
+    name = "DP {:3d} ".format(dp)
     if dp in DATA_POINT_NAMES.keys():
-        name = DATA_POINT_NAMES[dp]
+        name += DATA_POINT_NAMES[dp]
     else:
-        name = "unknown     "
+        name += "unknown     "
     length = len(data)
 
-    value = "{:d} ".format(fn)
     if dp in EXTRA_PARSERS.keys():
-        value += EXTRA_PARSERS[dp](length, data)
+        value = EXTRA_PARSERS[dp](length, data)
     else:
-        value += DATA_TYPE_PARSERS[dtype](length, data)
+        value = DATA_TYPE_NAME[dtype] + ": " + DATA_TYPE_PARSERS[dtype](length, data)
     return (name, value)
 
 
@@ -155,16 +152,17 @@ def main():
         line = line[:-1]
         if len(line) == 0:
             continue
-        tokens = line.split(" ")
+        tokens = line.split()
         time = datetime.datetime.fromtimestamp(int(int(tokens[0]) / 1000))
         address = tokens[1]
 
         seq = int(tokens[2], 16)
+        seq_dp = int(tokens[3], 16)
 
-        (name, value) = get_values(tokens[3:])
+        (name, value) = get_values(tokens[4:])
         print(
-            "{} {} (seq: {:4d}) [{}] => {}".format(
-                time.isoformat(), address, seq, name, value
+            "{} {} (seq: {:4d}, value: #{}) [{}] => {}".format(
+                time.isoformat(), address, seq, seq_dp, name, value
             )
         )
 


### PR DESCRIPTION
Receiving side:

Types `commandDataReport`, `commandDataResponse`, and
`commandActiveStatusReport` receive an array of DP values now (instead of a
single value).  Adapt existing converters to use the first entry of this
array.
    
To avoid breakage, additional DP values that may be present in a payload are
ignored (as before).

Additionally, extend `tuya_data_point_dump` to support multiple DP values per payload
    
Adapt `scripts/read_tuya_dump.py` accordingly and make its output more
helpful (print the numerical DP value and remove the `fn` field).  Its
output for a packet with two DP values now looks like this:
    
```
2021-12-22T20:50:13 0x867829fffe2de210 (seq:    0, value: #0) [DP   1 unknown     ] => enum: 1
2021-12-22T20:50:13 0x867829fffe2de210 (seq:    0, value: #1) [DP   4 unknown     ] => int: 92
```

Sending side:

The existing helper functions can still be used to send a single DP value. Add a new function `sendDataPoints` that
is able to send multiple DP values and helpers `dpValueFrom*` to construct DP values. 