### PR TITLE
fix MCCGQ12LM

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1724,7 +1724,7 @@ module.exports = [
         model: 'MCCGQ12LM',
         vendor: 'Xiaomi',
         description: 'Aqara T1 door & window contact sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
+        fromZigbee: [fz.xiaomi_contact, fz.battery],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         exposes: [e.contact(), e.battery(), e.battery_voltage()],


### PR DESCRIPTION
debug log:
No converter available for 'MCCGQ12LM' with cluster 'genOnOff' and type 'attributeReport' and data '{"onOff":1}'
No converter available for 'MCCGQ12LM' with cluster 'genOnOff' and type 'attributeReport' and data '{"onOff":0}'

Input claster show 'ssIasZone' not 'genonoff'
but real data is coming from 'genonoff'.