### PR TITLE
Expose additional features for Aqara Magic Cube

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5760,13 +5760,30 @@ const converters = {
             if (value === 0) result = {action: 'shake'};
             else if (value === 2) result = {action: 'wakeup'};
             else if (value === 3) result = {action: 'fall'};
-            else if (value >= 512) result = {action: 'tap', side: value-512};
-            else if (value >= 256) result = {action: 'slide', side: value-256};
-            else if (value >= 128) result = {action: 'flip180', side: value-128};
+            else if (value >= 512) result = {
+                action: 'tap',
+                action_side: value-512,
+                side: value-512
+            };
+            else if (value >= 256) result = {
+                action: 'slide',
+                action_side: value-256,
+                side: value-256
+            };
+            else if (value >= 128) result = {
+                action: 'flip180',
+                action_side: value-128,
+                side: value-128,
+            };
             else if (value >= 64) {
                 result = {
-                    action: 'flip90', action_from_side: Math.floor((value-64) / 8), action_to_side: value % 8, action_side: value % 8,
-                    from_side: Math.floor((value-64) / 8), to_side: value % 8, side: value % 8,
+                    action: 'flip90',
+                    action_from_side: Math.floor((value-64) / 8),
+                    from_side: Math.floor((value-64) / 8),
+                    action_to_side: value % 8,
+                    to_side: value % 8,
+                    action_side: value % 8,
+                    side: value % 8,
                 };
             }
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5760,30 +5760,13 @@ const converters = {
             if (value === 0) result = {action: 'shake'};
             else if (value === 2) result = {action: 'wakeup'};
             else if (value === 3) result = {action: 'fall'};
-            else if (value >= 512) result = {
-                action: 'tap',
-                action_side: value-512,
-                side: value-512
-            };
-            else if (value >= 256) result = {
-                action: 'slide',
-                action_side: value-256,
-                side: value-256
-            };
-            else if (value >= 128) result = {
-                action: 'flip180',
-                action_side: value-128,
-                side: value-128,
-            };
+            else if (value >= 512) result = {action: 'tap', action_side: value-512, side: value-512};
+            else if (value >= 256) result = {action: 'slide', action_side: value-256, side: value-256};
+            else if (value >= 128) result = {action: 'flip180', action_side: value-128, side: value-128};
             else if (value >= 64) {
                 result = {
-                    action: 'flip90',
-                    action_from_side: Math.floor((value-64) / 8),
-                    from_side: Math.floor((value-64) / 8),
-                    action_to_side: value % 8,
-                    to_side: value % 8,
-                    action_side: value % 8,
-                    side: value % 8,
+                    action: 'flip90', action_from_side: Math.floor((value-64) / 8), action_to_side: value % 8, action_side: value % 8,
+                    from_side: Math.floor((value-64) / 8), to_side: value % 8, side: value % 8,
                 };
             }
 

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -937,7 +937,7 @@ module.exports = [
         fromZigbee: [fz.xiaomi_battery, fz.MFKZQ01LM_action_multistate, fz.MFKZQ01LM_action_analog],
         exposes: [e.battery(), e.battery_voltage(), e.angle('action_angle'),
             e.cube_side('action_from_side'), e.cube_side('action_side'), e.cube_side('action_to_side'),
-            e.cube_side('from_side'), e.cube_side('side'), e.cube_side('to_side'),
+            e.cube_side('side'),
             e.action(['shake', 'wakeup', 'fall', 'tap', 'slide', 'flip180', 'flip90', 'rotate_left', 'rotate_right'])],
         toZigbee: [],
     },

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -937,6 +937,7 @@ module.exports = [
         fromZigbee: [fz.xiaomi_battery, fz.MFKZQ01LM_action_multistate, fz.MFKZQ01LM_action_analog],
         exposes: [e.battery(), e.battery_voltage(), e.angle('action_angle'),
             e.cube_side('action_from_side'), e.cube_side('action_side'), e.cube_side('action_to_side'),
+            e.cube_side('from_side'), e.cube_side('side'), e.cube_side('to_side'),
             e.action(['shake', 'wakeup', 'fall', 'tap', 'slide', 'flip180', 'flip90', 'rotate_left', 'rotate_right'])],
         toZigbee: [],
     },


### PR DESCRIPTION
* Exposes `side` to enable retrieval of the current side facing up
  * `side` remains set persistently, whereas `action_side` is blanked after the action is published
* Sets `action_side` in events where previously only `side` was being set