### PR TITLE
TuYa - Zigbee Radiator Valve - TZE200_zr9c0day

### DIFF
--- a/devices/saswell.js
+++ b/devices/saswell.js
@@ -18,7 +18,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuhszj9s'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_9gvruqf5'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_zr9c0day'},                      
+            {modelID: 'TS0601', manufacturerName: '_TZE200_zr9c0day'},      
         ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',

--- a/devices/saswell.js
+++ b/devices/saswell.js
@@ -18,7 +18,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuhszj9s'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_9gvruqf5'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_zr9c0day'},      
+            {modelID: 'TS0601', manufacturerName: '_TZE200_zr9c0day'},
         ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',

--- a/devices/saswell.js
+++ b/devices/saswell.js
@@ -18,6 +18,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_azqp6ssj'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuhszj9s'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_9gvruqf5'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_zr9c0day'},                      
         ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',


### PR DESCRIPTION
It seems that recent version of RTX/ZB-RT1 are has new `manufacturerName` - `_TZE200_zr9c0day`. At this moment function seems to work correctly, except that data point #3 is reported as not supported. I have no clue what is the purpose of it.
```
warn  2021-12-31 17:07:18: zigbee-herdsman-converters:SaswellThermostat: Unrecognized DP #3 with data {"status":0,"transid":27,"dp":3,"datatype":4,"fn":0,"data":{"type":"Buffer","data":[0]}}
warn  2021-12-31 17:08:55: zigbee-herdsman-converters:SaswellThermostat: Unrecognized DP #3 with data {"status":0,"transid":27,"dp":3,"datatype":4,"fn":0,"data":{"type":"Buffer","data":[1]}}
warn  2021-12-31 17:14:38: zigbee-herdsman-converters:SaswellThermostat: Unrecognized DP #3 with data {"status":0,"transid":27,"dp":3,"datatype":4,"fn":0,"data":{"type":"Buffer","data":[0]}}
warn  2021-12-31 17:27:11: zigbee-herdsman-converters:SaswellThermostat: Unrecognized DP #3 with data {"status":0,"transid":27,"dp":3,"datatype":4,"fn":0,"data":{"type":"Buffer","data":[1]}}
warn  2021-12-31 18:01:23: zigbee-herdsman-converters:SaswellThermostat: Unrecognized DP #3 with data {"status":0,"transid":27,"dp":3,"datatype":4,"fn":0,"data":{"type":"Buffer","data":[0]}}
```