### PR TITLE
Use postfixWithEndpointName() for simluated_brightness

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1164,7 +1164,8 @@ const converters = {
 
             if (options.simulated_brightness) {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', msg.data.level);
-                payload.brightness = msg.data.level;
+                const property = postfixWithEndpointName('brightness', msg, model);
+                payload[property] = msg.data.level;
             }
 
             return payload;
@@ -1195,7 +1196,8 @@ const converters = {
                         brightness += delta;
                         brightness = numberWithinRange(brightness, 0, 255);
                         globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
-                        publish({brightness});
+                        const property = postfixWithEndpointName('brightness', msg, model);
+                        publish({[property]: brightness});
                     }, intervalOpts);
 
                     globalStore.putValue(msg.endpoint, 'simulated_brightness_timer', timer);
@@ -1225,7 +1227,8 @@ const converters = {
                 brightness += delta;
                 brightness = numberWithinRange(brightness, 0, 255);
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
-                payload.brightness = brightness;
+                const property = postfixWithEndpointName('brightness', msg, model);
+                payload[property] = brightness;
             }
 
             return payload;


### PR DESCRIPTION
Add endpoint name for simulated brightness. Useful for multichannel switches like https://www.zigbee2mqtt.io/devices/4512703.html#namron-4512703

Values was already stored for each endpoint, so edits are only for payload / publish. Tested this with the Namron 4512703. 

Code is basically the same as the one used for the "normal" brightness control, so I think it should behave well with other multichannel or single channel switches, but I don't have any switches on hand for testing. 