### PR TITLE
Add support for iris 3450-L2

### DIFF
--- a/devices/iris.js
+++ b/devices/iris.js
@@ -74,7 +74,7 @@ module.exports = [
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },
     {
-        zigbeeModel: ['3450-L'],
+        zigbeeModel: ['3450-L', '3450-L2'],
         model: '3450-L',
         vendor: 'Iris',
         description: 'Smart fob',


### PR DESCRIPTION
Tested with a copy of 3450-L and it looks to work for all buttons and presence detection.