### PR TITLE
tuya_smoke: Accept commandDataReport in addition to commandDataResponse

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4682,17 +4682,21 @@ const converters = {
     },
     tuya_smoke: {
         cluster: 'manuSpecificTuya',
-        type: ['commandDataResponse'],
+        type: ['commandDataResponse', 'commandDataReport'],
         convert: (model, msg, publish, options, meta) => {
-            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_smoke');
-            const dp = dpValue.dp;
-            const value = tuya.getDataValue(dpValue);
-            switch (dp) {
-            case tuya.dataPoints.state:
-                return {smoke: value === 0};
-            default:
-                meta.logger.warn(`zigbee-herdsman-converters:tuya_smoke: Unrecognized DP #${ dp} with data ${JSON.stringify(dpValue)}`);
+            const result = {};
+            for (const dpValue of msg.data.dpValues) {
+                const dp = dpValue.dp;
+                const value = tuya.getDataValue(dpValue);
+                switch (dp) {
+                case tuya.dataPoints.state:
+                    result.smoke = value === 0;
+                    break;
+                default:
+                    meta.logger.warn(`zigbee-herdsman-converters:tuya_smoke: Unrecognized DP #${ dp} with data ${JSON.stringify(dpValue)}`);
+                }
             }
+            return result;
         },
     },
     tuya_woox_smoke: {


### PR DESCRIPTION
Newer(?) versions of the TS0601 (_TZE200_uebojraa) smoke detector seem to use
commandDataReport instead of/in addition to commandDataResponse payloads.

Add commandDataReport to the accepted types.  While at it, change the
converter to use the new "multi-dp for loop" approach.  (A new DP 14 shows
up when doing this, but we currently don't know what it is)

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/10464