### PR TITLE
Update centralite.js

### DIFF
--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -196,12 +196,15 @@ module.exports = [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_cooling_setpoint,
             tz.thermostat_setpoint_raise_lower, tz.thermostat_remote_sensing,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
-            tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state],
-        exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 10, 30, 1).withLocalTemperature()
-            .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
-            .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
-            .withSetpoint('occupied_cooling_setpoint', 10, 30, 1)
-            .withLocalTemperatureCalibration(-30, 30, 0.1)],
+            tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state, tz.thermostat_temperature_setpoint_hold],
+        exposes: [e.battery(),
+            exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
+                .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.'),
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 10, 30, 1).withLocalTemperature()
+                .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
+                .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
+                .withSetpoint('occupied_cooling_setpoint', 10, 30, 1)
+                .withLocalTemperatureCalibration(-30, 30, 0.1)],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -210,6 +213,7 @@ module.exports = [
             await reporting.thermostatRunningState(endpoint);
             await reporting.thermostatTemperature(endpoint);
             await reporting.fanMode(endpoint);
+            await reporting.thermostatTemperatureSetpointHold(endpoint);
         },
     },
     {


### PR DESCRIPTION
I'm submitting this PR to update the Centralite  3157100-E Thermostat to report the status of and control the temperature hold function.  I tested this on the thermostat I have and it works - it exposes a binary to control the value similar to other thermostats that support this function.