### PR TITLE
Changed RTCGQ12LM and RTCGQ13LM for correct operation on coordinator firmware with support for native Aqara logic (T1/E1/etc series devices)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5336,7 +5336,7 @@ const converters = {
                 }
 
                 const illuminance = msg.data['illuminance'] - 65536;
-                return {occupancy: true, illuminance: calibrateAndPrecisionRoundOptions(illuminance, options, 'illuminance')}
+                return {occupancy: true, illuminance: calibrateAndPrecisionRoundOptions(illuminance, options, 'illuminance')};
             }
         },
     },
@@ -5369,7 +5369,7 @@ const converters = {
                 globalStore.getValue(msg.endpoint, 'timers').push(timer);
             }
 
-            return {occupancy: true}
+            return {occupancy: true};
         },
     },
     xiaomi_WXKG01LM_action: {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2076,12 +2076,12 @@ const converters = {
             await entity.read('aqaraOpple', [0x0000], manufacturerOptions.xiaomi);
         },
     },
-    RTCGQ13LM_detection_interval: {
-        key: ['detection_interval'],
+    aqara_occupancy_timeout: {
+        key: ['occupancy_timeout'],
         convertSet: async (entity, key, value, meta) => {
             value *= 1;
             await entity.write('aqaraOpple', {0x0102: {value: [value], type: 0x20}}, manufacturerOptions.xiaomi);
-            return {state: {detection_interval: value}};
+            return {state: {occupancy_timeout: value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0102], manufacturerOptions.xiaomi);

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -868,19 +868,17 @@ module.exports = [
         zigbeeModel: ['lumi.motion.agl02'],
         model: 'RTCGQ12LM',
         vendor: 'Xiaomi',
-        description: 'Aqara T1 human body movement and illuminance sensor (illuminance not supported for now)',
-        fromZigbee: [fz.occupancy, fz.occupancy_timeout, fz.battery],
-        toZigbee: [tz.occupancy_timeout],
-        exposes: [e.occupancy(), e.battery(),
-            exposes.numeric('occupancy_timeout', exposes.access.ALL).withValueMin(0).withValueMax(65535).withUnit('s')
-                .withDescription('Time in seconds till occupancy goes to false')],
+        description: 'Aqara T1 human body movement and illuminance sensor',
+        fromZigbee: [fz.RTCGQ12LM_occupancy_illuminance, fz.aqara_opple, fz.battery],
+        toZigbee: [tz.aqara_occupancy_timeout],
+        exposes: [e.occupancy(), e.illuminance().withUnit('lx').withDescription('Measured illuminance in lux'),
+            exposes.numeric('occupancy_timeout', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
+                .withDescription('Time in seconds till occupancy goes to false'), e.battery()],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msOccupancySensing']);
-            await reporting.occupancy(endpoint);
-            await reporting.batteryVoltage(endpoint);
-            await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
+            await endpoint.read('genPowerCfg', ['batteryVoltage']);
+            await endpoint.read('aqaraOpple', [0x0102], {manufacturerCode: 0x115f});
         },
     },
     {
@@ -888,15 +886,15 @@ module.exports = [
         model: 'RTCGQ13LM',
         vendor: 'Xiaomi',
         description: 'Aqara high precision motion sensor',
-        fromZigbee: [fz.occupancy_with_timeout, fz.aqara_opple, fz.battery],
-        toZigbee: [tz.RTCGQ13LM_detection_interval, tz.RTCGQ13LM_motion_sensitivity],
-        exposes: [e.occupancy(), e.battery(),
-            exposes.enum('motion_sensitivity', exposes.access.ALL, ['low', 'medium', 'high']),
-            exposes.numeric('detection_interval', exposes.access.ALL).withValueMin(2).withValueMax(180).withUnit('s')
-                .withDescription('Time interval for detecting actions')],
+        fromZigbee: [fz.RTCGQ13LM_occupancy, fz.aqara_opple, fz.battery],
+        toZigbee: [tz.aqara_occupancy_timeout, tz.RTCGQ13LM_motion_sensitivity],
+        exposes: [e.occupancy(), exposes.enum('motion_sensitivity', ea.ALL, ['low', 'medium', 'high']),
+            exposes.numeric('occupancy_timeout', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
+                .withDescription('Time in seconds till occupancy goes to false'), e.battery()],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
+            await endpoint.read('genPowerCfg', ['batteryVoltage']);
             await endpoint.read('aqaraOpple', [0x0102], {manufacturerCode: 0x115f});
             await endpoint.read('aqaraOpple', [0x010c], {manufacturerCode: 0x115f});
         },


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#10471
Fixes Koenkk/zigbee2mqtt#5706
Fixes Koenkk/zigbee2mqtt#5203

On the coordinator's firmware without support for the native Aqara logic, as a workaround, it is proposed to use the previous version of the converter added in the configuration settings via the [`external_converters`](https://www.zigbee2mqtt.io/guide/configuration/more-config-options.html#external-converters) option:

- RTCGQ12LM_basic_mode.js

```javascript
const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const reporting = require('zigbee-herdsman-converters/lib/reporting');
const e = exposes.presets;
const ea = exposes.access;

const definition = {
    zigbeeModel: ['lumi.motion.agl02'],
    model: 'RTCGQ12LM',
    vendor: 'Xiaomi',
    description: 'Aqara T1 human body movement and illuminance sensor (illuminance not supported for now)',
    fromZigbee: [fz.occupancy, fz.occupancy_timeout, fz.battery],
    toZigbee: [tz.occupancy_timeout],
    exposes: [e.occupancy(), exposes.numeric('occupancy_timeout', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
        .withDescription('Time in seconds till occupancy goes to false'), e.battery()],
    meta: {battery: {voltageToPercentage: '3V_2100'}},
    configure: async (device, coordinatorEndpoint, logger) => {
        const endpoint = device.getEndpoint(1);
        await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msOccupancySensing']);
        await reporting.occupancy(endpoint);
        await reporting.batteryVoltage(endpoint);
        await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
    },
};

module.exports = definition;
```

- RTCGQ13LM_basic_mode.js

```javascript
const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const reporting = require('zigbee-herdsman-converters/lib/reporting');
const e = exposes.presets;
const ea = exposes.access;

const definition = {
    zigbeeModel: ['lumi.motion.agl04'],
    model: 'RTCGQ13LM',
    vendor: 'Xiaomi',
    description: 'Aqara high precision motion sensor',
    fromZigbee: [fz.occupancy, fz.occupancy_timeout, fz.aqara_opple, fz.battery],
    toZigbee: [tz.occupancy_timeout, tz.RTCGQ13LM_motion_sensitivity],
    exposes: [e.occupancy(), exposes.enum('motion_sensitivity', ea.ALL, ['low', 'medium', 'high']),
        exposes.numeric('occupancy_timeout', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
            .withDescription('Time in seconds till occupancy goes to false'), e.battery()],
    meta: {battery: {voltageToPercentage: '3V_2100'}},
    configure: async (device, coordinatorEndpoint, logger) => {
        const endpoint = device.getEndpoint(1);
        await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msOccupancySensing']);
        await reporting.occupancy(endpoint);
        await reporting.batteryVoltage(endpoint);
        await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
        await endpoint.read('aqaraOpple', [0x010c], {manufacturerCode: 0x115f});
    },
};

module.exports = definition;
```