### PR TITLE
Fix IL06_1 battery

### DIFF
--- a/devices/iris.js
+++ b/devices/iris.js
@@ -19,6 +19,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
             await reporting.temperature(endpoint);
             await reporting.batteryVoltage(endpoint);
+            device.powerSource = 'Battery';
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },

--- a/devices/iris.js
+++ b/devices/iris.js
@@ -20,6 +20,7 @@ module.exports = [
             await reporting.temperature(endpoint);
             await reporting.batteryVoltage(endpoint);
             device.powerSource = 'Battery';
+            device.save();
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },


### PR DESCRIPTION
The Iris IL06_1 contact sensor wasn't being detected as battery mode for either me or my friend. Tested locally and it now shows both the % and `Battery OK` in the dashboard.