### PR TITLE
Fix `tuya_smart_vibration_sensor` converter to use new tuya DP interface

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -7538,19 +7538,25 @@ const converters = {
         cluster: 'manuSpecificTuya',
         type: ['commandGetData', 'commandDataResponse', 'raw'],
         convert: (model, msg, publish, options, meta) => {
-            const dp = msg.data.dp;
-            const value = tuya.getDataValue(msg.data.datatype, msg.data.data);
-            switch (dp) {
-            case tuya.dataPoints.state:
-                return {contact: Boolean(value)};
-            case tuya.dataPoints.thitBatteryPercentage:
-                return {battery: value};
-            case tuya.dataPoints.tuyaVibration:
-                return {vibration: Boolean(value)};
-            default:
-                meta.logger.warn(`zigbee-herdsman-converters:tuya_smart_vibration_sensor: NOT RECOGNIZED ` +
-                    `DP #${dp} with data ${JSON.stringify(msg.data)}`);
+            const result = {};
+            for (const dpValue of msg.data.dpValues) {
+                const value = tuya.getDataValue(dpValue);
+                switch (dpValue.dp) {
+                case tuya.dataPoints.state:
+                    result.contact = Boolean(value);
+                    break;
+                case tuya.dataPoints.thitBatteryPercentage:
+                    result.battery = value;
+                    break;
+                case tuya.dataPoints.tuyaVibration:
+                    result.vibration = Boolean(value);
+                    break;
+                default:
+                    meta.logger.warn(`zigbee-herdsman-converters:tuya_smart_vibration_sensor: NOT RECOGNIZED ` +
+                        `DP #${dpValue.dp} with data ${JSON.stringify(dpValue)}`);
+                }
             }
+            return result;
         },
     },
     moes_thermostat_tv: {

--- a/test/fromZigbee.test.js
+++ b/test/fromZigbee.test.js
@@ -3,10 +3,8 @@ const tuya = require('../lib/tuya');
 
 describe('converters/fromZigbee', () => {
     describe('tuya', () => {
+        const meta = { logger: { warn: jest.fn()}}
         describe('wls100z_water_leak', () => {
-            const cut = fz.wls100z_water_leak;
-            const meta = { logger: { warn: jest.fn()}}
-
             it.each([
                 [
                     'water_leak',
@@ -36,7 +34,33 @@ describe('converters/fromZigbee', () => {
                 ],
             ])
             ("Receives '%s' indication", (_name, dpValues, result) => {
-                expect(cut.convert(null, { data: {dpValues}}, null, null, meta)).toEqual(result);
+                expect(fz.wls100z_water_leak.convert(null, { data: {dpValues}}, null, null, meta)).toEqual(result);
+            });
+        });
+        describe('tuya_smart_vibration_sensor', () => {
+            it.each([
+                [
+                    'no contact',
+                    [tuya.dpValueFromBool(tuya.dataPoints.state, false)],
+                    {contact: false},
+                ],
+                [
+                    'no vibration',
+                    [tuya.dpValueFromEnum(tuya.dataPoints.tuyaVibration, 0)],
+                    {vibration: false},
+                ],
+                [
+                    'contact & vibration & battery',
+                    [
+                        tuya.dpValueFromBool(tuya.dataPoints.state, true),
+                        tuya.dpValueFromEnum(tuya.dataPoints.tuyaVibration, 1),
+                        tuya.dpValueFromIntValue(tuya.dataPoints.thitBatteryPercentage, 97),
+                    ],
+                    {contact: true, battery: 97, vibration: true},
+                ],
+            ])
+            ("Receives '%s' indication", (_name, dpValues, result) => {
+                expect(fz.tuya_smart_vibration_sensor.convert(null, { data: {dpValues}}, null, null, meta)).toEqual(result);
             });
         });
     });


### PR DESCRIPTION
Commit 38cae96c76d95a0d974815878a4a4a7b0c601251 (Add TS0601_vibration_sensor
(#3619)) added the "from Zigbee" converter `tuya_smart_vibration_sensor`.
However, it uses the old lib/tuya.js interface which does not work anymore.

Adapt it to use the new interface (including a for loop) and add a couple of
tests (using the DP values in the logs from
https://github.com/Koenkk/zigbee2mqtt/issues/10534 as input).