### PR TITLE
Replacing occupancy_timeout with detection_interval for RTCGQ12LM and RTCGQ13LM

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5160,7 +5160,7 @@ const converters = {
             if (msg.data.hasOwnProperty('0')) payload.detection_period = msg.data['0'];
             if (msg.data.hasOwnProperty('4')) payload.mode_switch = {4: 'anti_flicker_mode', 1: 'quick_mode'}[msg.data['4']];
             if (msg.data.hasOwnProperty('10')) payload.switch_type = {1: 'toggle', 2: 'momentary'}[msg.data['10']];
-            if (msg.data.hasOwnProperty('258')) payload.occupancy_timeout = msg.data['258'];
+            if (msg.data.hasOwnProperty('258')) payload.detection_interval = msg.data['258'];
             if (msg.data.hasOwnProperty('268')) payload.motion_sensitivity = {1: 'low', 2: 'medium', 3: 'high'}[msg.data['268']];
             if (msg.data.hasOwnProperty('512')) {
                 if (['ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM'].includes(model.model)) {
@@ -5321,7 +5321,7 @@ const converters = {
             if (msg.data.hasOwnProperty('illuminance')) {
                 // The occupancy sensor only sends a message when motion detected.
                 // Therefore we need to publish the no_motion detected by ourselves.
-                const timeout = meta && meta.state && meta.state.hasOwnProperty('occupancy_timeout') ? meta.state.occupancy_timeout : 60;
+                const timeout = meta && meta.state && meta.state.hasOwnProperty('detection_interval') ? meta.state.detection_interval : 60;
 
                 // Stop existing timers because motion is detected and set a new one.
                 globalStore.getValue(msg.endpoint, 'timers', []).forEach((t) => clearTimeout(t));
@@ -5355,7 +5355,7 @@ const converters = {
 
             // The occupancy sensor only sends a message when motion detected.
             // Therefore we need to publish the no_motion detected by ourselves.
-            const timeout = meta && meta.state && meta.state.hasOwnProperty('occupancy_timeout') ? meta.state.occupancy_timeout : 60;
+            const timeout = meta && meta.state && meta.state.hasOwnProperty('detection_interval') ? meta.state.detection_interval : 60;
 
             // Stop existing timers because motion is detected and set a new one.
             globalStore.getValue(msg.endpoint, 'timers', []).forEach((t) => clearTimeout(t));

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2078,12 +2078,12 @@ const converters = {
             await entity.read('aqaraOpple', [0x0000], manufacturerOptions.xiaomi);
         },
     },
-    aqara_occupancy_timeout: {
-        key: ['occupancy_timeout'],
+    aqara_detection_interval: {
+        key: ['detection_interval'],
         convertSet: async (entity, key, value, meta) => {
             value *= 1;
             await entity.write('aqaraOpple', {0x0102: {value: [value], type: 0x20}}, manufacturerOptions.xiaomi);
-            return {state: {occupancy_timeout: value}};
+            return {state: {detection_interval: value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0102], manufacturerOptions.xiaomi);

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -875,10 +875,10 @@ module.exports = [
         vendor: 'Xiaomi',
         description: 'Aqara T1 human body movement and illuminance sensor',
         fromZigbee: [fz.RTCGQ12LM_occupancy_illuminance, fz.aqara_opple, fz.battery],
-        toZigbee: [tz.aqara_occupancy_timeout],
+        toZigbee: [tz.aqara_detection_interval],
         exposes: [e.occupancy(), e.illuminance().withUnit('lx').withDescription('Measured illuminance in lux'),
-            exposes.numeric('occupancy_timeout', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
-                .withDescription('Time in seconds till occupancy goes to false'), e.battery()],
+            exposes.numeric('detection_interval', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
+                .withDescription('Time interval for detecting actions'), e.battery()],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -892,10 +892,10 @@ module.exports = [
         vendor: 'Xiaomi',
         description: 'Aqara high precision motion sensor',
         fromZigbee: [fz.RTCGQ13LM_occupancy, fz.aqara_opple, fz.battery],
-        toZigbee: [tz.aqara_occupancy_timeout, tz.RTCGQ13LM_motion_sensitivity],
+        toZigbee: [tz.aqara_detection_interval, tz.RTCGQ13LM_motion_sensitivity],
         exposes: [e.occupancy(), exposes.enum('motion_sensitivity', ea.ALL, ['low', 'medium', 'high']),
-            exposes.numeric('occupancy_timeout', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
-                .withDescription('Time in seconds till occupancy goes to false'), e.battery()],
+            exposes.numeric('detection_interval', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
+                .withDescription('Time interval for detecting actions'), e.battery()],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
After discussion in #3631, it was decided to replace `occupancy_timeout` with `detection_interval` for _RTCGQ12LM_ and _RTCGQ13LM_.