### PR TITLE
Extended support for BTicino L441C/N4411C/NT4411C and Legrand 067797

### DIFF
--- a/devices/bticino.js
+++ b/devices/bticino.js
@@ -30,19 +30,22 @@ module.exports = [
         vendor: 'BTicino',
         description: 'Dimmer switch with neutral',
         extend: extend.light_onoff_brightness({noConfigure: true}),
-        exposes: [
-            e.light_brightness(),
+        fromZigbee: [fz.brightness, fz.identify, fz.on_off, fz.lighting_ballast_configuration],
+        toZigbee: [tz.light_onoff_brightness, tz.legrand_settingAlwaysEnableLed, tz.legrand_settingEnableLedIfOn,
+            tz.legrand_settingEnableDimmer, tz.legrand_identify, tz.ballast_config],
+        exposes: [e.light_brightness(),
+            exposes.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the minimum brightness value'),
+            exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the maximum brightness value'),
             exposes.binary('dimmer_enabled', ea.STATE_SET, 'ON', 'OFF').withDescription('Allow the device to change brightness'),
             exposes.binary('permanent_led', ea.STATE_SET, 'ON', 'OFF').withDescription('Enable or disable the permanent blue LED'),
-            exposes.binary('led_when_on', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables the LED when the light is on'),
-        ],
-        fromZigbee: [fz.brightness, fz.identify, fz.on_off],
-        toZigbee: [tz.light_onoff_brightness, tz.legrand_settingAlwaysEnableLed, tz.legrand_settingEnableLedIfOn,
-            tz.legrand_settingEnableDimmer, tz.legrand_identify],
+            exposes.binary('led_when_on', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables the LED when the light is on')],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genLevelCtrl', 'genBinaryInput']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genLevelCtrl',
+                'genBinaryInput', 'lightingBallastCfg']);
             await reporting.onOff(endpoint);
             await reporting.brightness(endpoint);
         },


### PR DESCRIPTION
Basically a copy/paste of https://github.com/Koenkk/zigbee-herdsman-converters/pull/3021

I think the following issue is also related: https://github.com/Koenkk/zigbee2mqtt/issues/10580

It seems that BTicino L441C/N4411C/NT4411C and Legrand 067797 use the exact same firmware or at least the same Zigbee API (and I suspect Legrand 067771 also, as I also have it at home and I use the same converter without any issue)

PS: a side note to future readers of this PR, you **must** update your switch's firmware using the Home+Control app and the Legrand gateway before associating it to your own Zigbee network (this can take a day or two, you cannot trigger the upgrade manually, and OTA update through zigbee2mqtt is not supported for the moment)