### PR TITLE
Enable reporting of measurements of LCZ030

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1660,7 +1660,10 @@ module.exports = [
         toZigbee: [],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg']);
+            // Enables reporting of measurement state changes
+            await endpoint.read('genBasic', ['manufacturerName', 'zclVersion', 'appVersion', 'modelId', 'powerSource', 0xfffe]);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg',
+                'msTemperatureMeasurement', 'msIlluminanceMeasurement', 'msRelativeHumidity', 'manuSpecificTuya_2']);
         },
         exposes: [e.temperature(), e.humidity(), e.battery(), e.illuminance(), e.illuminance_lux(),
             exposes.numeric('alarm_temperature_max', ea.STATE).withUnit('°C').withDescription('Alarm temperature max'),


### PR DESCRIPTION
Fixes [#9054](https://github.com/Koenkk/zigbee2mqtt/issues/9054)

Enables the reporting of the measurements on the LCZ030. Equal to the implementation [here](https://github.com/Koenkk/zigbee-herdsman-converters/commit/ab434284e8073bdb8a0e47ecc6b7b4288dff8207)