### PR TITLE
Expose setting alarm values on LCZ030/TS0201

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -5029,6 +5029,27 @@ const converters = {
             }
         },
     },
+    ts0201_temperature_humidity_alarm = {
+        key: ['alarm_humidity_max', 'alarm_humidity_min', 'alarm_temperature_max', 'alarm_temperature_min'],
+        convertSet: async (entity, key, value, meta) => {
+            switch (key) {
+            case 'alarm_temperature_max':
+            case 'alarm_temperature_min':
+            case 'alarm_humidity_max':
+            case 'alarm_humidity_min':
+                //await entity.write('manuSpecificTuya_2', {[key]: value});
+                //instead write as custom attribute to override incorrect herdsman dataType from uint16 to int16
+                //https://github.com/Koenkk/zigbee-herdsman/blob/v0.13.191/src/zcl/definition/cluster.ts#L4235
+                const keyToAttributeLookup = {'alarm_temperature_max': 0xD00A, 'alarm_temperature_min': 0xD00B, 
+                    'alarm_humidity_max': 0xD00D, 'alarm_humidity_min': 0xD00E };
+                const payload = {[keyToAttributeLookup[key]]: {value: value, type: 0x29} };
+                await entity.write('manuSpecificTuya_2', payload);
+                break;
+            default: // Unknown key
+                meta.logger.warn(`Unhandled key ${key}`);
+            }
+        },
+    },
     heiman_ir_remote: {
         key: ['send_key', 'create', 'learn', 'delete', 'get_list'],
         convertSet: async (entity, key, value, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -5036,15 +5036,16 @@ const converters = {
             case 'alarm_temperature_max':
             case 'alarm_temperature_min':
             case 'alarm_humidity_max':
-            case 'alarm_humidity_min':
-                //await entity.write('manuSpecificTuya_2', {[key]: value});
-                //instead write as custom attribute to override incorrect herdsman dataType from uint16 to int16
-                //https://github.com/Koenkk/zigbee-herdsman/blob/v0.13.191/src/zcl/definition/cluster.ts#L4235
-                const keyToAttributeLookup = {'alarm_temperature_max': 0xD00A, 'alarm_temperature_min': 0xD00B, 
-                    'alarm_humidity_max': 0xD00D, 'alarm_humidity_min': 0xD00E };
-                const payload = {[keyToAttributeLookup[key]]: {value: value, type: 0x29} };
+            case 'alarm_humidity_min': {
+                // await entity.write('manuSpecificTuya_2', {[key]: value});
+                // instead write as custom attribute to override incorrect herdsman dataType from uint16 to int16
+                // https://github.com/Koenkk/zigbee-herdsman/blob/v0.13.191/src/zcl/definition/cluster.ts#L4235
+                const keyToAttributeLookup = {'alarm_temperature_max': 0xD00A, 'alarm_temperature_min': 0xD00B,
+                    'alarm_humidity_max': 0xD00D, 'alarm_humidity_min': 0xD00E};
+                const payload = {[keyToAttributeLookup[key]]: {value: value, type: 0x29}};
                 await entity.write('manuSpecificTuya_2', payload);
                 break;
+            }
             default: // Unknown key
                 meta.logger.warn(`Unhandled key ${key}`);
             }

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -5029,7 +5029,7 @@ const converters = {
             }
         },
     },
-    ts0201_temperature_humidity_alarm = {
+    ts0201_temperature_humidity_alarm: {
         key: ['alarm_humidity_max', 'alarm_humidity_min', 'alarm_temperature_max', 'alarm_temperature_min'],
         convertSet: async (entity, key, value, meta) => {
             switch (key) {

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1658,7 +1658,7 @@ module.exports = [
         vendor: 'TuYa',
         description: 'Temperature & humidity & illuminance sensor with display',
         fromZigbee: [fz.battery, fz.illuminance, fz.temperature, fz.humidity, fz.ts0201_temperature_humidity_alarm],
-        toZigbee: [],
+        toZigbee: [tz.ts0201_temperature_humidity_alarm],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             // Enables reporting of measurement state changes
@@ -1667,10 +1667,10 @@ module.exports = [
                 'msTemperatureMeasurement', 'msIlluminanceMeasurement', 'msRelativeHumidity', 'manuSpecificTuya_2']);
         },
         exposes: [e.temperature(), e.humidity(), e.battery(), e.illuminance(), e.illuminance_lux(),
-            exposes.numeric('alarm_temperature_max', ea.STATE).withUnit('°C').withDescription('Alarm temperature max'),
-            exposes.numeric('alarm_temperature_min', ea.STATE).withUnit('°C').withDescription('Alarm temperature min'),
-            exposes.numeric('alarm_humidity_max', ea.STATE).withUnit('%').withDescription('Alarm humidity max'),
-            exposes.numeric('alarm_humidity_min', ea.STATE).withUnit('%').withDescription('Alarm humidity min'),
+            exposes.numeric('alarm_temperature_max', ea.STATE_SET).withUnit('°C').withDescription('Alarm temperature max').withValueMin(-20).withValueMax(80),
+            exposes.numeric('alarm_temperature_min', ea.STATE_SET).withUnit('°C').withDescription('Alarm temperature min').withValueMin(-20).withValueMax(80),
+            exposes.numeric('alarm_humidity_max', ea.STATE_SET).withUnit('%').withDescription('Alarm humidity max').withValueMin(0).withValueMax(100),
+            exposes.numeric('alarm_humidity_min', ea.STATE_SET).withUnit('%').withDescription('Alarm humidity min').withValueMin(0).withValueMax(100),
             exposes.enum('alarm_humidity', ea.STATE, ['below_min_humdity', 'over_humidity', 'off'])
                 .withDescription('Alarm humidity status'),
             exposes.enum('alarm_temperature', ea.STATE, ['below_min_temperature', 'over_temperature', 'off'])

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1667,10 +1667,14 @@ module.exports = [
                 'msTemperatureMeasurement', 'msIlluminanceMeasurement', 'msRelativeHumidity', 'manuSpecificTuya_2']);
         },
         exposes: [e.temperature(), e.humidity(), e.battery(), e.illuminance(), e.illuminance_lux(),
-            exposes.numeric('alarm_temperature_max', ea.STATE_SET).withUnit('°C').withDescription('Alarm temperature max').withValueMin(-20).withValueMax(80),
-            exposes.numeric('alarm_temperature_min', ea.STATE_SET).withUnit('°C').withDescription('Alarm temperature min').withValueMin(-20).withValueMax(80),
-            exposes.numeric('alarm_humidity_max', ea.STATE_SET).withUnit('%').withDescription('Alarm humidity max').withValueMin(0).withValueMax(100),
-            exposes.numeric('alarm_humidity_min', ea.STATE_SET).withUnit('%').withDescription('Alarm humidity min').withValueMin(0).withValueMax(100),
+            exposes.numeric('alarm_temperature_max', ea.STATE_SET).withUnit('°C').withDescription('Alarm temperature max')
+                .withValueMin(-20).withValueMax(80),
+            exposes.numeric('alarm_temperature_min', ea.STATE_SET).withUnit('°C').withDescription('Alarm temperature min')
+                .withValueMin(-20).withValueMax(80),
+            exposes.numeric('alarm_humidity_max', ea.STATE_SET).withUnit('%').withDescription('Alarm humidity max')
+                .withValueMin(0).withValueMax(100),
+            exposes.numeric('alarm_humidity_min', ea.STATE_SET).withUnit('%').withDescription('Alarm humidity min')
+                .withValueMin(0).withValueMax(100),
             exposes.enum('alarm_humidity', ea.STATE, ['below_min_humdity', 'over_humidity', 'off'])
                 .withDescription('Alarm humidity status'),
             exposes.enum('alarm_temperature', ea.STATE, ['below_min_temperature', 'over_temperature', 'off'])


### PR DESCRIPTION
Allows the user to set the min/max alarm values for the humidity and temperature.
![image](https://user-images.githubusercontent.com/56737876/148663746-a7e1ab74-8217-4f29-8244-62d2d918e480.png)

Includes a workaround for what I presume will be fixed after [PR 489](https://github.com/Koenkk/zigbee-herdsman/pull/489)