### PR TITLE
Add support for local firmware files

### DIFF
--- a/lib/ota/zigbeeOTA.js
+++ b/lib/ota/zigbeeOTA.js
@@ -4,8 +4,10 @@ const common = require('./common');
 const axios = common.getAxios();
 const fs = require('fs');
 const URI = require('uri-js');
+const path = require('path');
 
-let overrideFileName = null;
+let overrideIndexFileName = null;
+let dataDir = null;
 
 /**
  * Helper functions
@@ -22,7 +24,7 @@ function isValidUrl(url) {
     return parsed.scheme === 'http' || parsed.scheme === 'https';
 }
 
-async function getFile(urlOrName) {
+async function getIndexFile(urlOrName) {
     if (isValidUrl(urlOrName)) {
         return (await axios.get(urlOrName)).data;
     }
@@ -30,14 +32,33 @@ async function getFile(urlOrName) {
     return JSON.parse(fs.readFileSync(urlOrName));
 }
 
+async function getFirmwareFile(image, logger) {
+    let urlOrName = image.url;
+
+    // First try to download firmware file with the URL provided
+    if (isValidUrl(urlOrName)) {
+        logger.debug(`ZigbeeOTA: downloading firmware image from ${urlOrName}`);
+        return await axios.get(urlOrName, {responseType: 'arraybuffer'});
+    }
+
+    // If the file name is not a full path, then treat it as a relative to the data directory
+    if (!path.isAbsolute(urlOrName) && dataDir) {
+        urlOrName = path.join(dataDir, urlOrName);
+    }
+
+    logger.debug(`ZigbeeOTA: getting local firmware file ${urlOrName}`);
+    return {data: fs.readFileSync(urlOrName)};
+}
+
+
 async function getIndex(logger) {
     const index = (await axios.get(url)).data;
 
     logger.debug(`ZigbeeOTA: downloaded main index`);
 
-    if (overrideFileName) {
-        logger.debug(`ZigbeeOTA: Loading override index ${overrideFileName}`);
-        const localIndex = await getFile(overrideFileName);
+    if (overrideIndexFileName) {
+        logger.debug(`ZigbeeOTA: Loading override index ${overrideIndexFileName}`);
+        const localIndex = await getIndexFile(overrideIndexFileName);
 
         // Resulting index will have overriden items first
         return localIndex.concat(index);
@@ -78,7 +99,7 @@ async function isUpdateAvailable(device, logger, requestPayload=null) {
 }
 
 async function updateToLatest(device, logger, onProgress) {
-    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta);
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta, getFirmwareFile);
 }
 
 module.exports = {
@@ -86,6 +107,9 @@ module.exports = {
     isUpdateAvailable,
     updateToLatest,
     useIndexOverride: (indexFileName) => {
-        overrideFileName = indexFileName;
+        overrideIndexFileName = indexFileName;
+    },
+    setDataDir: (dir) => {
+        dataDir = dir;
     },
 };


### PR DESCRIPTION
[Previous change](https://github.com/Koenkk/zigbee-herdsman-converters/pull/3495) added possibility to have local OTA index file. This change adds possibility to use local firmware files. Having a web server is no longer a requirement for OTA update of DIY devices.

Firmware URL can have one of these options:
- an URL of the image stored on a web server (keep existing behavior)
- absolute path to an image file
- path relative to a data directory

For enabling the latter option, a new setDataDir() interface function is introduced. In case of Zigbee2MQTT, the data directory is the configuration directory. Zigbee2MQTT calls setDataDir() during startup. Other clients (non-Z2M) will have to call setDataDir() as well to enable non-absolute paths.


Example of a local index file:
```
[
    {
        "fileVersion": 2,
        "manufacturerCode": 4151,
        "imageType": 1,
        "url": "HelloZigbee.ota"
    }
]
```
Note that `hash` field (`sha256` or `sha512`), `fileSize` and `path` fields are not mandatory, and can be omitted in case of local firmware files.  Other fields still required, and have to correspond to the image file contents - `imageType` and `manufacturerCode` participate in searching available images for the particular device, while `fileVerision` is involved in decision making process whether the image is newer than flashed in the device.