### PR TITLE
Expose color, hue, and color temperature actions for RGBgenie ZB-5028

### DIFF
--- a/devices/rgb_genie.js
+++ b/devices/rgb_genie.js
@@ -71,8 +71,8 @@ module.exports = [
         fromZigbee: [fz.battery, fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.command_recall,
             fz.command_move_hue, fz.command_move_to_color, fz.command_move_to_color_temp],
         exposes: [e.battery(), e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up',
-            'brightness_move_down', 'brightness_stop', 'recall_1', 'recall_2', 'recall_3', 'hue_move', 'color_temperature_move', 'color_move',
-            'hue_stop'])],
+            'brightness_move_down', 'brightness_stop', 'recall_1', 'recall_2', 'recall_3', 'hue_move', 'color_temperature_move',
+            'color_move', 'hue_stop'])],
         toZigbee: [],
         meta: {multiEndpoint: true, battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint) => {

--- a/devices/rgb_genie.js
+++ b/devices/rgb_genie.js
@@ -71,7 +71,8 @@ module.exports = [
         fromZigbee: [fz.battery, fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.command_recall,
             fz.command_move_hue, fz.command_move_to_color, fz.command_move_to_color_temp],
         exposes: [e.battery(), e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up',
-            'brightness_move_down', 'brightness_stop', 'recall_1', 'recall_2', 'recall_3'])],
+            'brightness_move_down', 'brightness_stop', 'recall_1', 'recall_2', 'recall_3', 'hue_move', 'color_temperature_move', 'color_move',
+            'hue_stop'])],
         toZigbee: [],
         meta: {multiEndpoint: true, battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Looks like the proper commands are defined in the `fromZigbee`, but those actions are not exposed in MQTT.