### PR TITLE
Minor fix to color XY calculation

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1380,8 +1380,8 @@ const converters = {
             const payload = {
                 action: postfixWithEndpointName(`color_move`, msg, model),
                 action_color: {
-                    x: precisionRound(msg.data.colorx / 65535, 3),
-                    y: precisionRound(msg.data.colory / 65535, 3),
+                    x: precisionRound(msg.data.colorx / 65536, 3),
+                    y: precisionRound(msg.data.colory / 65536, 3),
                 },
                 action_transition_time: msg.data.transtime,
             };


### PR DESCRIPTION
The color XY uint16 representation in zigbee spec is in `s15Fixed16Number` format per ICC spec (https://www.color.org/specification/ICC1v43_2010-12.pdf). It is actually a 16-bit fixed-point number. If we don't consider negative numbers, it is exactly the integer divide by 65536 instead of 65535. Minor, but better to get it according to spec.