### PR TITLE
Update TS0601_thermostat calibration according to documentation

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -904,7 +904,7 @@ module.exports = [
                     'Mode of this device, in the `heat` mode the TS0601 will remain continuously heating, i.e. it does not regulate ' +
                     'to the desired temperature. If you want TRV to properly regulate the temperature you need to use mode `auto` ' +
                     'instead setting the desired temperature.')
-                .withLocalTemperatureCalibration(-30, 30, 0.1, ea.STATE_SET)
+                .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
                 .withAwayMode().withPreset(['schedule', 'manual', 'boost', 'complex', 'comfort', 'eco']),
             e.auto_lock(), e.away_mode(), e.away_preset_days(), e.boost_time(), e.comfort_temperature(), e.eco_temperature(), e.force(),
             e.max_temperature(), e.min_temperature(), e.away_preset_temperature(),


### PR DESCRIPTION
Having tried to make use of @KartoffelToby changes at https://github.com/Koenkk/zigbee-herdsman-converters/pull/3491 , I never managed to get a 0.1 step to work.

The documentation indicates +/- 9 degrees with a 1°C step only.

I'm not sure this is valid for all clones so I updated only for those I have
![IMG_20220110_121057](https://user-images.githubusercontent.com/2236444/148758372-d731baa0-6185-4d4a-8e70-56fca799af67.jpg)
.