### PR TITLE
Add 'force' key to the OTA index files to force selection of a firmware image

### DIFF
--- a/lib/ota/common.js
+++ b/lib/ota/common.js
@@ -265,6 +265,11 @@ async function isNewImageAvailable(current, logger, device, getImageMeta) {
     const meta = await getImageMeta(current, logger, device);
     const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
     logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
+
+    if(meta.force) {
+        return -1; // Negative number means the new firmware is 'newer' than current one
+    }
+
     return Math.sign(current.fileVersion - meta.fileVersion);
 }
 
@@ -411,7 +416,7 @@ async function updateToLatest(device, logger, onProgress, getNewImage, getImageM
 async function getNewImage(current, logger, device, getImageMeta, downloadImage) {
     const meta = await getImageMeta(current, logger, device);
     logger.debug(`getNewImage for '${device.ieeeAddr}', meta ${JSON.stringify(meta)}`);
-    assert(meta.fileVersion > current.fileVersion, 'No new image available');
+    assert(meta.fileVersion > current.fileVersion || meta.force, 'No new image available');
 
     const download = downloadImage ? await downloadImage(meta, logger) :
         await getAxios().get(meta.url, {responseType: 'arraybuffer'});

--- a/lib/ota/common.js
+++ b/lib/ota/common.js
@@ -266,7 +266,7 @@ async function isNewImageAvailable(current, logger, device, getImageMeta) {
     const [currentS, metaS] = [JSON.stringify(current), JSON.stringify(meta)];
     logger.debug(`Is new image available for '${device.ieeeAddr}', current '${currentS}', latest meta '${metaS}'`);
 
-    if(meta.force) {
+    if (meta.force) {
         return -1; // Negative number means the new firmware is 'newer' than current one
     }
 

--- a/lib/ota/zigbeeOTA.js
+++ b/lib/ota/zigbeeOTA.js
@@ -88,6 +88,7 @@ async function getImageMeta(current, logger, device) {
         fileSize: image.fileSize,
         url: image.url,
         sha512: image.sha512,
+        force: image.force
     };
 }
 

--- a/lib/ota/zigbeeOTA.js
+++ b/lib/ota/zigbeeOTA.js
@@ -88,7 +88,7 @@ async function getImageMeta(current, logger, device) {
         fileSize: image.fileSize,
         url: image.url,
         sha512: image.sha512,
-        force: image.force
+        force: image.force,
     };
 }
 


### PR DESCRIPTION
One of highly desired features is to force Zigbee2MQTT to use a specific version of a firmware, instead of one on the main OTA index. Unfortunately there is no way to downgrade the firmware, even with hacking the index or overriding information there. There is a special code in that does not allow flashing a firmware with a version lower than current.

With this change a new `force` key is added to work this around. If a firmware marked with `force` key it is considered as newer, regardless to the version burned in the file.