### PR TITLE
Add colour temp range to Philips Hue white ambiance E14 (with Bluetooth) [9290022944]

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -920,7 +920,7 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue white ambiance E14 (with Bluetooth)',
         meta: {turnsOffAtBrightness1: true},
-        extend: hueExtend.light_onoff_brightness_colortemp(),
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
     },
     {


### PR DESCRIPTION
`Read result of 'lightingColorCtrl': {"colorTempPhysicalMin":153,"colorTempPhysicalMax":454}`