### PR TITLE
Add support for Aurora AU-A1GSZ9RGBWE light bulbs with model code RGBBulb51AU

### DIFF
--- a/devices/aurora_lighting.js
+++ b/devices/aurora_lighting.js
@@ -68,15 +68,8 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp_color(),
     },
     {
-        zigbeeModel: ['RGBBulb01UK', 'RGBBulb02UK'],
+        zigbeeModel: ['RGBBulb01UK', 'RGBBulb02UK', 'RGBBulb51AU'],
         model: 'AU-A1GSZ9RGBW_HV-GSCXZB269K',
-        vendor: 'Aurora Lighting',
-        description: 'AOne 9.5W smart RGBW GLS E27/B22',
-        extend: extend.light_onoff_brightness_colortemp_color(),
-    },
-    {
-        zigbeeModel: ['RGBBulb51AU'],
-        model: 'AU-A1GSZ9RGBWE',
         vendor: 'Aurora Lighting',
         description: 'AOne 9.5W smart RGBW GLS E27/B22',
         extend: extend.light_onoff_brightness_colortemp_color(),

--- a/devices/aurora_lighting.js
+++ b/devices/aurora_lighting.js
@@ -75,6 +75,13 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp_color(),
     },
     {
+        zigbeeModel: ['RGBBulb51AU'],
+        model: 'AU-A1GSZ9RGBWE',
+        vendor: 'Aurora Lighting',
+        description: 'AOne 9.5W smart RGBW GLS E27/B22',
+        extend: extend.light_onoff_brightness_colortemp_color(),
+    },
+    {
         zigbeeModel: ['Remote50AU'],
         model: 'AU-A1ZBRC',
         vendor: 'Aurora Lighting',


### PR DESCRIPTION
I just received a bulb that lists RGBBulb51AU as the zigbee model number but says AU-A1GSZ9RGBWE on the box (last char E == E27 fitting, there's a B model too). It supports all the same features as the existing models that are supported, so this PR just adds the new model code to the existing definition.