### PR TITLE
Do not require fileVersion, manufacturerID, and imageType fields for local OTA images

### DIFF
--- a/lib/ota/zigbeeOTA.js
+++ b/lib/ota/zigbeeOTA.js
@@ -43,7 +43,7 @@ function readLocalFile(fileName, logger) {
 }
 
 async function getFirmwareFile(image, logger) {
-    let urlOrName = image.url;
+    const urlOrName = image.url;
 
     // First try to download firmware file with the URL provided
     if (isValidUrl(urlOrName)) {
@@ -89,7 +89,7 @@ async function getIndex(logger) {
         const localIndex = await getIndexFile(overrideIndexFileName);
 
         // Resulting index will have overriden items first
-        return localIndex.concat(index).map(item => isValidUrl(item.url) ? item : fillImageInfo(item, logger));
+        return localIndex.concat(index).map((item) => isValidUrl(item.url) ? item : fillImageInfo(item, logger));
     }
 
     return index;

--- a/lib/ota/zigbeeOTA.js
+++ b/lib/ota/zigbeeOTA.js
@@ -32,6 +32,16 @@ async function getIndexFile(urlOrName) {
     return JSON.parse(fs.readFileSync(urlOrName));
 }
 
+function readLocalFile(fileName, logger) {
+    // If the file name is not a full path, then treat it as a relative to the data directory
+    if (!path.isAbsolute(fileName) && dataDir) {
+        fileName = path.join(dataDir, fileName);
+    }
+
+    logger.debug(`ZigbeeOTA: getting local firmware file ${fileName}`);
+    return fs.readFileSync(fileName);
+}
+
 async function getFirmwareFile(image, logger) {
     let urlOrName = image.url;
 
@@ -41,15 +51,33 @@ async function getFirmwareFile(image, logger) {
         return await axios.get(urlOrName, {responseType: 'arraybuffer'});
     }
 
-    // If the file name is not a full path, then treat it as a relative to the data directory
-    if (!path.isAbsolute(urlOrName) && dataDir) {
-        urlOrName = path.join(dataDir, urlOrName);
-    }
-
-    logger.debug(`ZigbeeOTA: getting local firmware file ${urlOrName}`);
-    return {data: fs.readFileSync(urlOrName)};
+    return {data: readLocalFile(urlOrName, logger)};
 }
 
+function fillImageInfo(meta, logger) {
+    // Web-hosted images must come with all fields filled already
+    if (isValidUrl(meta.url)) {
+        return meta;
+    }
+
+    // Nothing to do if needed fields were filled already
+    if (meta.hasOwnProperty('imageType') &&
+        meta.hasOwnProperty('manufacturerCode') &&
+        meta.hasOwnProperty('fileVersion')) {
+        return meta;
+    }
+
+    // If no fields provided - get them from the image file
+    const buffer = readLocalFile(meta.url, logger);
+    const start = buffer.indexOf(common.upgradeFileIdentifier);
+    const image = common.parseImage(buffer.slice(start));
+
+    // Will fill only those fields that were absent
+    if (!meta.hasOwnProperty('imageType')) meta.imageType = image.header.imageType;
+    if (!meta.hasOwnProperty('manufacturerCode')) meta.manufacturerCode = image.header.manufacturerCode;
+    if (!meta.hasOwnProperty('fileVersion')) meta.fileVersion = image.header.fileVersion;
+    return meta;
+}
 
 async function getIndex(logger) {
     const index = (await axios.get(url)).data;
@@ -61,7 +89,7 @@ async function getIndex(logger) {
         const localIndex = await getIndexFile(overrideIndexFileName);
 
         // Resulting index will have overriden items first
-        return localIndex.concat(index);
+        return localIndex.concat(index).map(item => isValidUrl(item.url) ? item : fillImageInfo(item, logger));
     }
 
     return index;


### PR DESCRIPTION
The only necessary field for local OTA images is a file name - everything else can be easily retrieved from the firmware image. No need to obligate users to fill these fields in the local OTA index. This change removes requirement for filling `fileVersion`, `manufacturerID`, and `imageType` fields.