### PR TITLE
Add support for Hue Struana 27W

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -35,7 +35,6 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue Struana 27W',
         meta: {turnsOffAtBrightness1: true},
-        // This color temp range is just a guess.
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
     },

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -30,6 +30,16 @@ const hueExtend = {
 
 module.exports = [
     {
+        zigbeeModel: ['929003056901'],
+        model: '929003056901',
+        vendor: 'Philips',
+        description: 'Hue Struana 27W',
+        meta: {turnsOffAtBrightness1: true},
+        // This color temp range is just a guess.
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LWA018'],
         model: '9290024693',
         vendor: 'Philips',


### PR DESCRIPTION
I copied what looked like a common color range because I didn't manage to get the range by following the instructions here: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_3-adding-converter-s-for-your-device