### PR TITLE
Add 4080248P7

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1526,11 +1526,11 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: [ 'LCF003', '4080248P7' ],
+        zigbeeModel: ['LCF003', '4080248P7'],
         model: '4080248P7',
         vendor: 'Philips',
         description: 'Hue Signe floor light',
-        meta: { turnsOffAtBrightness1: true },
+        meta: {turnsOffAtBrightness1: true},
         extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,
     },

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1526,6 +1526,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: [ 'LCF003', '4080248P7' ],
+        model: '4080248P7',
+        vendor: 'Philips',
+        description: 'Hue Signe floor light',
+        meta: { turnsOffAtBrightness1: true },
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['4080248U9'],
         model: '4080248U9',
         vendor: 'Philips',


### PR DESCRIPTION
Tested with my 4080248P7 light (Philips LCF003) using this script:

```javascript
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const extend = require('zigbee-herdsman-converters/lib/extend');
const ota = require('zigbee-herdsman-converters/lib/ota');

const hueExtend = {
    light_onoff_brightness_colortemp_color: (options={}) => ({
        ...extend.light_onoff_brightness_colortemp_color({supportsHS: true, ...options}),
        toZigbee: extend.light_onoff_brightness_colortemp_color({supportsHS: true, ...options})
            .toZigbee.concat([tz.hue_power_on_behavior, tz.hue_power_on_error]),
    }),
};

module.exports = {
    zigbeeModel: [ 'LCF003', '4080248P7' ],
    model: '4080248P7',
    vendor: 'Philips',
    description: 'Hue Signe floor light',
    meta: { turnsOffAtBrightness1: true },
    extend: hueExtend.light_onoff_brightness_colortemp_color(),
    ota: ota.zigbeeOTA,
};
```

Relates to https://github.com/Koenkk/zigbee-herdsman-converters/issues/3380