### PR TITLE
Update toZigbee.js

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1270,7 +1270,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             let result;
             if (meta.options.thermostat_unit === 'fahrenheit') {
-                result = utils.normalizeCelsiusVersionOfFahrenheit(value) * 100;
+                result = Math.round(utils.normalizeCelsiusVersionOfFahrenheit(value) * 100);
             } else {
                 result = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
             }
@@ -1287,7 +1287,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             let result;
             if (meta.options.thermostat_unit === 'fahrenheit') {
-                result = utils.normalizeCelsiusVersionOfFahrenheit(value) * 100;
+                result = Math.round(utils.normalizeCelsiusVersionOfFahrenheit(value) * 100);
             } else {
                 result = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
             }
@@ -1304,7 +1304,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             let result;
             if (meta.options.thermostat_unit === 'fahrenheit') {
-                result = utils.normalizeCelsiusVersionOfFahrenheit(value) * 100;
+                result = Math.round(utils.normalizeCelsiusVersionOfFahrenheit(value) * 100);
             } else {
                 result = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
             }
@@ -1321,7 +1321,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             let result;
             if (meta.options.thermostat_unit === 'fahrenheit') {
-                result = utils.normalizeCelsiusVersionOfFahrenheit(value) * 100;
+                result = Math.round(utils.normalizeCelsiusVersionOfFahrenheit(value) * 100);
             } else {
                 result = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
             }
@@ -1356,7 +1356,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             let result;
             if (meta.options.thermostat_unit === 'fahrenheit') {
-                result = utils.normalizeCelsiusVersionOfFahrenheit(value) * 100;
+                result = Math.round(utils.normalizeCelsiusVersionOfFahrenheit(value) * 100);
             } else {
                 result = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
             }
@@ -1372,7 +1372,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             let result;
             if (meta.options.thermostat_unit === 'fahrenheit') {
-                result = utils.normalizeCelsiusVersionOfFahrenheit(value) * 100;
+                result = Math.round(utils.normalizeCelsiusVersionOfFahrenheit(value) * 100);
             } else {
                 result = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
             }


### PR DESCRIPTION
Update to make sure temperature settings to thermostats are a whole round number by adding math.round calculation

I discussed this problem on this issue - https://github.com/Koenkk/zigbee2mqtt/issues/10619https://github.com/Koenkk/zigbee2mqtt/issues/10619

The temperature being published to the thermostat needs to be a 4 digit whole number.  The temperature is in celcius, and the decimal point is moved over two places to determine the whole number that is published to the thermostat.  The prior calculation took the celcius temperature and just multiplied it by 100, but this was not always producing a whole number, resulting in log errors like in the log below where a value like 1944.0000000000002 was trying to be published and failed.  This resulted in the thermostat's temperature not updating:

```
debug 2022-01-14 06:15:56: Received MQTT message on 'zigbee2mqtt/Upper Floor Heat/set' with data '{"occupied_heating_setpoint":19.44}'
debug 2022-01-14 06:15:56: Publishing 'set' 'occupied_heating_setpoint' to 'Upper Floor Heat'
error 2022-01-14 06:15:59: Publish 'set' 'occupied_heating_setpoint' to 'Upper Floor Heat' failed: 'Error: Write 0x000d6f000304c118/1 hvacThermostat({"occupiedHeatingSetpoint":1944.0000000000002}, {"sendWhenActive":true,"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'HARDWARE_FAILURE')'
debug 2022-01-14 06:15:59: Error: Write 0x000d6f000304c118/1 hvacThermostat({"occupiedHeatingSetpoint":1944.0000000000002}, {"sendWhenActive":true,"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'HARDWARE_FAILURE')
    at Endpoint.checkStatus (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:310:23)
    at Endpoint.write (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:392:22)
    at Object.convertSet (/app/node_modules/zigbee-herdsman-converters/converters/toZigbee.js:1278:13)
    at Publish.onMQTTMessage (/app/lib/extension/publish.ts:246:36)
info  2022-01-14 06:15:59: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"message":"Publish 'set' 'occupied_heating_setpoint' to 'Upper Floor Heat' failed: 'Error: Write 0x000d6f000304c118/1 hvacThermostat({\"occupiedHeatingSetpoint\":1944.0000000000002}, {\"sendWhenActive\":true,\"timeout\":10000,\"disableResponse\":false,\"disableRecovery\":false,\"disableDefaultResponse\":true,\"direction\":0,\"srcEndpoint\":null,\"reservedBits\":0,\"manufacturerCode\":null,\"transactionSequenceNumber\":null,\"writeUndiv\":false}) failed (Status 'HARDWARE_FAILURE')'","meta":{"friendly_name":"Upper Floor Heat"},"type":"zigbee_publish_error"}'
```

Adding the additional Math.round makes sure that a whole number is published to the set point to eliminate this error.