### PR TITLE
for MIR-HE200-TY_fall  refinement expose  "fall_down_status"

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -7694,7 +7694,7 @@ const converters = {
                 result = {tumble_switch: {false: 'OFF', true: 'ON'}[value]};
                 break;
             case tuya.dataPoints.trsfFallDownStatus:
-                result = {fall_down_status: {0: false, 1: true}[value]};
+                result = {fall_down_status: tuya.tuyaRadar.fallDown[value]};
                 break;
             case tuya.dataPoints.trsfStaticDwellAlarm:
                 result = {static_dwell_alarm: value};

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1755,7 +1755,8 @@ module.exports = [
                 .withDescription('fall sensitivity of the radar'),
             exposes.numeric('tumble_alarm_time', ea.STATE_SET).withValueMin(1).withValueMax(5).withValueStep(1)
                 .withUnit('min').withDescription('tumble alarm time'),
-            exposes.binary('fall_down_status', ea.STATE).withDescription('fall down status'),
+            exposes.enum('fall_down_status', ea.STATE, Object.values(tuya.tuyaRadar.fallDown))
+                .withDescription('fall down status'),
             exposes.text('static_dwell_alarm', ea.STATE).withDescription('static dwell alarm'),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -648,7 +648,7 @@ const tuyaRadar = {
         0: 'none',
         1: 'maybe_fall',
         2: 'fall',
-   },    
+    },    
 };
 
 // Motion sensor lookups

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -648,7 +648,7 @@ const tuyaRadar = {
         0: 'none',
         1: 'maybe_fall',
         2: 'fall',
-    },    
+    },
 };
 
 // Motion sensor lookups

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -644,6 +644,11 @@ const tuyaRadar = {
         1: 'moving_forward',
         2: 'moving_backward',
     },
+    fallDown: {
+        0: 'none',
+        1: 'maybe_fall',
+        2: 'fall',
+   },    
 };
 
 // Motion sensor lookups


### PR DESCRIPTION
### **Was:**
binary expose "fall_down_status"

### **Now**
enum expose "fall_down_status"
with value ['none', 'maybe_fall', 'fall']

### **none**
<img width="647" alt="Снимок экрана 2022-01-19 в 03 03 54" src="https://user-images.githubusercontent.com/81035252/150038747-3097d854-a2fb-4509-b850-fc2237f41feb.png">

### **maybe_fall**
<img width="647" alt="Снимок экрана 2022-01-19 в 03 04 36" src="https://user-images.githubusercontent.com/81035252/150038754-53344afd-a435-4625-8aad-2f16ff488182.png">

### **fall**
<img width="647" alt="Снимок экрана 2022-01-19 в 03 05 52" src="https://user-images.githubusercontent.com/81035252/150038765-509aea58-9f62-4328-bcde-fe84161d07fc.png">

