### PR TITLE
Support 1746630V7

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -495,6 +495,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['1746630V7'],
+        model: '1746630V7',
+        vendor: 'Philips',
+        description: 'Amarant linear outdoor light',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        ota: ota.zigbeeOTA,
+    },    
+    {
         zigbeeModel: ['LCC001'],
         model: '4090531P7',
         vendor: 'Philips',


### PR DESCRIPTION
Added support for Philips Amarant linear outdoor light (1746630V7), see [its product page](https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-amarant-linear-outdoor-light/1746630V7)
Verified `colorTempRange` by reading attributes through the Dev console
Finally, tested that the device responds properly to all commands.