### PR TITLE
add colorhs to gardenpole definition

### DIFF
--- a/devices/ledvance.js
+++ b/devices/ledvance.js
@@ -1,6 +1,8 @@
 const ota = require('../lib/ota');
 const extend = require('../lib/extend');
+const exposes = require('../lib/exposes');
 const reporting = require('../lib/reporting');
+const e = exposes.presets;
 
 module.exports = [
     {
@@ -109,6 +111,7 @@ module.exports = [
         vendor: 'LEDVANCE',
         description: 'SMART+ gardenpole multicolour',
         extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [153, 526]}),
+        exposes: [e.light_brightness_colortemp_colorhs([153, 526]), e.effect()],
         ota: ota.ledvance,
     },
     {


### PR DESCRIPTION
The OSRAM Gardenpole Mini RGBW OSRAM (model AC0363900NJ) is visually identical to the 4058075208353, but only the OSRAM definition includes HSV color mode.

This commit brings them both to the same feature set. Without it, it's not possible to create all colors from Home Assistant, for example, a pure blue is not possible, it's always tinted purple.

I have both devices next to each other and the difference is very visible.