### PR TITLE
Configure Xiaomi SSM-U01 as router

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1448,6 +1448,7 @@ module.exports = [
             await reporting.onOff(endpoint);
             await reporting.deviceTemperature(endpoint);
             device.powerSource = 'Mains (single phase)';
+            device.type = 'Router';
             device.save();
         },
     },


### PR DESCRIPTION
It appears as EndDevice. With this change it appears as Router, as expected.

The device seems to work as router without problem:
![image](https://user-images.githubusercontent.com/2673520/150558125-febcfcdb-ff8c-4630-bcfd-7ffe6dc3a1a1.png)
