### PR TITLE
Added support for Philips-branded Disney StoryLight (LLC013) - a re-badged LivingColors light

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -268,7 +268,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LLC012', 'LLC011'],
+        zigbeeModel: ['LLC012', 'LLC011', 'LLC013'],
         model: '7299760PH',
         vendor: 'Philips',
         description: 'Hue Bloom',


### PR DESCRIPTION
Added LLC013 to philips.js - this is a variant of the LivingColors lights already supported but sold branded as the Disney StoryLight.