### PR TITLE
Adds support for TuYa clone TS0502B with manufacturer _TZ3210_rm0hthdo

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -510,6 +510,7 @@ module.exports = [
             {modelID: 'TS0502B', manufacturerName: '_TZ3000_zw7wr5uo'},
             {modelID: 'TS0502B', manufacturerName: '_TZ3210_pz9zmxjj'},
             {modelID: 'TS0502B', manufacturerName: '_TZ3000_fzwhym79'},
+	    {modelID: 'TS0502B', manufacturerName: '_TZ3210_rm0hthdo'},
         ],
         model: 'TS0502B',
         vendor: 'TuYa',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -510,7 +510,7 @@ module.exports = [
             {modelID: 'TS0502B', manufacturerName: '_TZ3000_zw7wr5uo'},
             {modelID: 'TS0502B', manufacturerName: '_TZ3210_pz9zmxjj'},
             {modelID: 'TS0502B', manufacturerName: '_TZ3000_fzwhym79'},
-	    {modelID: 'TS0502B', manufacturerName: '_TZ3210_rm0hthdo'},
+            {modelID: 'TS0502B', manufacturerName: '_TZ3210_rm0hthdo'},
         ],
         model: 'TS0502B',
         vendor: 'TuYa',


### PR DESCRIPTION
Bought 2 sets of lights from AliExpress, none of them are branded as TuYa but they work perfectly with the TuYa configuration as is; except for the manufacturer code.

This PR adds the manufacturer code to the list.