### PR TITLE
add OTA capability to lumi.airmonitor.acn01

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1655,6 +1655,7 @@ module.exports = [
             const payload = reporting.payload('presentValue', 10, constants.repInterval.HOUR, 5);
             await endpoint.configureReporting('genAnalogInput', payload);
         },
+        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['lumi.switch.b2nc01'],


### PR DESCRIPTION
here is an update for the Aqara TVOC sensor (VOCKQJK11LM), in view of https://github.com/Koenkk/zigbee-OTA/pull/86 and https://github.com/Koenkk/zigbee2mqtt/issues/9454#issuecomment-1017909049