### PR TITLE
Add new model to 'Philips Hue white ambiance Adore 2 spots'

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1021,7 +1021,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['3417931P6'],
+        zigbeeModel: ['3417931P6', '929003056201'],
         model: '3417931P6',
         vendor: 'Philips',
         description: 'Hue white ambiance Adore GU10 with Bluetooth (2 spots)',


### PR DESCRIPTION
Model number tested and also checked that the color temprange is still the same.