### PR TITLE
Fixed formerly renamed datapoint for the Matsee garage door trigger

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2336,7 +2336,7 @@ const converters = {
     matsee_garage_door_opener: {
         key: ['trigger'],
         convertSet: (entity, key, value, meta) => {
-            tuya.sendDataPointBool(entity, tuya.dataPoints.action, true);
+            tuya.sendDataPointBool(entity, tuya.dataPoints.garageDoorTrigger, true);
         },
     },
     SPZ01_power_outage_memory: {


### PR DESCRIPTION
I am very sorry for another PR, but I need to fix formerly renamed datapoint for the Matsee garage door trigger
Now it is working fine.

Signed-off-by: Ondrej Pecta <opecta@gmail.com>