### PR TITLE
Add model 929003055101 to Philips Hue Being white

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1210,7 +1210,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['3261031P6', '929003055001'],
+        zigbeeModel: ['3261031P6', '929003055001', '929003055101'],
         model: '3261031P6',
         vendor: 'Philips',
         description: 'Hue Being white',


### PR DESCRIPTION
This adds a new zigbee model to the Philips Hue Being white.

<img width="647" alt="Bildschirmfoto 2022-01-22 um 18 06 14" src="https://user-images.githubusercontent.com/418970/150648446-e5028e74-327a-44d7-8332-f0dd213133bf.png">
