### PR TITLE
Add Schneider Electric 41E2PBSWMZ/356PB2MBTZ support

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -187,6 +187,18 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['CH2AX/SWITCH/1'],
+        model: '41E2PBSWMZ/356PB2MBTZ',
+        vendor: 'Schneider Electric',
+        description: 'Wiser 40/300-Series Module Switch 2A',
+        extend: extend.switch(),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        }
+    },
+    {
         zigbeeModel: ['SMARTPLUG/1'],
         model: 'CCT711119',
         vendor: 'Schneider Electric',


### PR DESCRIPTION
Added support for [Wiser 40/300-Series Module Switch 2A](https://csa-iot.org/csa_product/wiser-40-300-series-module-switch-2a-2/) `CH2AX/SWITCH/1` device.

These are sold in Australia and New Zealand under the Clipsal/PDL brand, compatible with the Iconic range of sockets.

Support document pull request here waiting to be merged -> https://github.com/Koenkk/zigbee2mqtt.io/pull/1169