### PR TITLE
Fix UNSUPPORTED_ATTRIBUTE error message

### DIFF
--- a/devices/edp.js
+++ b/devices/edp.js
@@ -16,8 +16,10 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(85);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            // await reporting.readMeteringMultiplierDivisor(endpoint);
+            // Fix for UNSUPPORTED_ATTRIBUTE
+            endpoint.saveClusterAttributeKeyValue('seMetering', {divisor: 1000, multiplier: 1});
             await reporting.onOff(endpoint);
-            await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.instantaneousDemand(endpoint);
         },
         exposes: [e.switch(), e.power(), e.energy()],


### PR DESCRIPTION
Since the multiplier and dividor atributes are optional, this SmartPlugs don't use them and we need to not rely on them.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/9561