### PR TITLE
 Add support for TS011F (_TZ3000_gjnozsaz) smart plug

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -12,7 +12,7 @@ const utils = require('../lib/utils');
 
 const TS011Fplugs = ['_TZ3000_5f43h46b', '_TZ3000_cphmq0q7', '_TZ3000_dpo1ysak', '_TZ3000_ew3ldmgx', '_TZ3000_gjnozsaz',
     '_TZ3000_jvzvulen', '_TZ3000_mraovvmm', '_TZ3000_nfnmi125', '_TZ3000_ps3dmato', '_TZ3000_w0qqde0g', '_TZ3000_u5u4cakc',
-    '_TZ3000_rdtixbnu', '_TZ3000_typdpbpg', '_TZ3000_v1pdxuqq'];
+    '_TZ3000_rdtixbnu', '_TZ3000_typdpbpg', '_TZ3000_v1pdxuqq', '_TZ3000_gjnozsaz'];
 
 const tzLocal = {
     TS0504B_color: {


### PR DESCRIPTION
Add _TZ3000_gjnozsaz to TS011F plugs.
It works with polling workaround (TS011F_plug_3).