### PR TITLE
Patch 4

### DIFF
--- a/devices/konke.js
+++ b/devices/konke.js
@@ -73,4 +73,15 @@ module.exports = [
         toZigbee: [],
         exposes: [e.water_leak(), e.battery_low(), e.tamper()],
     },
+    {
+
+        zigbeeModel: ['TS0222'],
+        model: 'KK-ES-J01W',
+        vendor: 'Konke',
+        description: 'Room temperature, relative humidity and illuminance sensor',
+        fromZigbee: [fz.battery, fz.illuminance, fz.humidity, fz.temperature],
+        toZigbee: [],
+        exposes: [e.battery(), e.illuminance(), e.illuminance_lux().withUnit('lx'), e.humidity(), e.temperature()],
+};
+
 ];

--- a/devices/konke.js
+++ b/devices/konke.js
@@ -74,7 +74,7 @@ module.exports = [
         exposes: [e.water_leak(), e.battery_low(), e.tamper()],
     },
     {
-        zigbeeModel: ['TS0222'],
+        fingerprint: [{modelID: 'TS0222', manufacturerName: '_TYZB01_fi5yftwv'}],
         model: 'KK-ES-J01W',
         vendor: 'Konke',
         description: 'Room temperature, relative humidity and illuminance sensor',
@@ -82,5 +82,4 @@ module.exports = [
         toZigbee: [],
         exposes: [e.battery(), e.illuminance(), e.illuminance_lux().withUnit('lx'), e.humidity(), e.temperature()],
     },
-
 ];

--- a/devices/konke.js
+++ b/devices/konke.js
@@ -74,7 +74,6 @@ module.exports = [
         exposes: [e.water_leak(), e.battery_low(), e.tamper()],
     },
     {
-
         zigbeeModel: ['TS0222'],
         model: 'KK-ES-J01W',
         vendor: 'Konke',
@@ -82,6 +81,6 @@ module.exports = [
         fromZigbee: [fz.battery, fz.illuminance, fz.humidity, fz.temperature],
         toZigbee: [],
         exposes: [e.battery(), e.illuminance(), e.illuminance_lux().withUnit('lx'), e.humidity(), e.temperature()],
-};
+    },
 
 ];


### PR DESCRIPTION
For over half a year now the Xiaomi aqara smartplug mmeu01 is whining about the overload treshold being 2200 w because in the converter someone put this value in. 

```
    {
        zigbeeModel: ['lumi.plug.mmeu01'],
        model: 'ZNCZ04LM',
        description: 'Mi power plug ZigBee EU',
        vendor: 'Xiaomi',
        fromZigbee: [fz.on_off, fz.xiaomi_power, fz.aqara_opple, fz.ignore_occupancy_report, fz.ignore_illuminance_report,
            fz.ignore_time_read],
        toZigbee: [tz.on_off, tz.xiaomi_power, tz.xiaomi_switch_power_outage_memory, tz.xiaomi_auto_off, tz.xiaomi_led_disabled_night,
            tz.xiaomi_overload_protection],
        exposes: [
            e.switch(), e.power().withAccess(ea.STATE_GET), e.energy(), e.temperature().withAccess(ea.STATE),
            e.voltage().withAccess(ea.STATE), e.current(), e.consumer_connected(), e.led_disabled_night(),
            e.power_outage_memory(), exposes.binary('auto_off', ea.STATE_SET, true, false)
                .withDescription('Turn the device automatically off when attached device consumes less than 2W for 20 minutes'),
            exposes.numeric('overload_protection', exposes.access.ALL).withValueMin(100).withValueMax(2200).withUnit('W')
                .withDescription('Maximum allowed load, turns off if exceeded')],
        ota: ota.zigbeeOTA,
    },
```

When looking on the actual device you can see it supports up to 2300 w. please change this in the next release... its no more then changing 1 digit in the converter....

Here some proof if you dont believe me....
![20220126_085628](https://user-images.githubusercontent.com/73538763/151124523-8c92590b-21d3-452c-ad48-79ff4037b51f.jpg)

I could make my own external converter but it seems nicer if this is just fixed in the code.