### PR TITLE
feat(devices): add Namron ZigBee dimmer 2-pol 400w

### DIFF
--- a/devices/namron.js
+++ b/devices/namron.js
@@ -26,6 +26,19 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['4512733'],
+        model: '4512733',
+        vendor: 'Namron',
+        description: 'ZigBee dimmer 2-pol 400W',
+        extend: extend.light_onoff_brightness({noConfigure: true}),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.onOff(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['4512704'],
         model: '4512704',
         vendor: 'Namron',


### PR DESCRIPTION
Zigbee model 4512733 = Namron ZigBee dimmer 2-pol 400w
More or less the exact same as 4512700 - Namron ZigBee dimmer 400W, but is dual pole.