### PR TITLE
Add support for Jasco 43132 smart outlet.

### DIFF
--- a/devices/jasco.js
+++ b/devices/jasco.js
@@ -1,5 +1,7 @@
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
+const exposes = require('../lib/exposes');
+const e = exposes.presets;
 
 module.exports = [
     {
@@ -13,6 +15,21 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['43132'],
+        model: '43132',
+        vendor: 'Jasco',
+        description: 'Zigbee smart outlet',
+        extend: extend.switch(),
+        exposes: [e.switch(), e.power(), e.energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            await reporting.onOff(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.instantaneousDemand(endpoint);
         },
     },
 ];


### PR DESCRIPTION
Adds support for Jasco smart outlet with power reporting.

Documentation via: https://github.com/Koenkk/zigbee2mqtt.io/pull/1183

Product: https://www.amazon.com/Jasco-Receptacle-Monitoring-Tamper-Resistant-43132/dp/B08G58HVL5