### PR TITLE
Fix for Miboxer FUT036Z LED controller

### DIFF
--- a/devices/miboxer.js
+++ b/devices/miboxer.js
@@ -22,8 +22,13 @@ module.exports = [
         ],
     },
     {
-        fingerprint: [{modelID: 'TS0501B', manufacturerName: '_TZ3210_dxroobu3'},
-            {modelID: 'TS0501B', manufacturerName: '_TZ3210_dbilpfqk'}],
+        zigbeeModel: [
+            'TS0501B',
+        ],
+        fingerprint: [
+            {modelID: 'TS0501B', manufacturerName: '_TZ3210_dxroobu3'},
+            {modelID: 'TS0501B', manufacturerName: '_TZ3210_dbilpfqk'},
+        ],
         model: 'FUT036Z',
         description: 'Single color LED controller',
         vendor: 'Miboxer',


### PR DESCRIPTION
Trying to fix the issue with Miboxer FUT036Z. 

Can't pair it. The device is marked as unsupported.

I am receiving the following errors:
```
Device '0x84fd27fffe635a6d' with Zigbee model 'TS0501B' and manufacturer name '_TZ3210_dxroobu3' is NOT supported
Received message from unsupported device with Zigbee model 'TS0501B' and manufacturer name '_TZ3210_dxroobu3'
Device '0x84fd27fffe635a6d' with Zigbee model 'undefined' and manufacturer name '_TZ3210_dxroobu3' is NOT supported
```

While in the device description we have everything  needed in place:
```
fingerprint: [{modelID: 'TS0501B', manufacturerName: '_TZ3210_dxroobu3'}],
```

Not sure if it helps. 