### PR TITLE
add generic 'command' to all devices

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -57,7 +57,8 @@ const converters = {
     command: {
         key: ['command'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.command(value.cluster, value.command, (value.hasOwnProperty('payload') ? value.payload : {}), utils.getOptions(meta.mapped, entity));
+            const options = utils.getOptions(meta.mapped, entity);
+            await entity.command(value.cluster, value.command, (value.hasOwnProperty('payload') ? value.payload : {}), options);
             meta.logger.info(`Invoked '${value.cluster}.${value.command}' with payload '${JSON.stringify(value.payload)}'`);
         },
     },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -54,6 +54,13 @@ const converters = {
             meta.logger.info(`Wrote '${JSON.stringify(value.payload)}' to '${value.cluster}'`);
         },
     },
+    command: {
+        key: ['command'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.command(value.cluster, value.command, (value.hasOwnProperty('payload') ? value.payload : {}), utils.getOptions(meta.mapped, entity));
+            meta.logger.info(`Invoked '${value.cluster}.${value.command}' with payload '${JSON.stringify(value.payload)}'`);
+        },
+    },
     factory_reset: {
         key: ['reset'],
         convertSet: async (entity, key, value, meta) => {

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function addDefinition(definition) {
         };
     }
 
-    definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.read, tz.write);
+    definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.read, tz.write, tz.command);
 
     if (definition.exposes && Array.isArray(definition.exposes) && !definition.exposes.find((e) => e.name === 'linkquality')) {
         definition.exposes = definition.exposes.concat([exposes.presets.linkquality()]);

--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ function addDefinition(definition) {
         };
     }
 
-    definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.read, tz.write, tz.command);
+    definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.read, tz.write,
+        tz.command);
 
     if (definition.exposes && Array.isArray(definition.exposes) && !definition.exposes.find((e) => e.name === 'linkquality')) {
         definition.exposes = definition.exposes.concat([exposes.presets.linkquality()]);


### PR DESCRIPTION
This is similar to the generic `read` and `write` and allows to execute arbitrary commands for debugging purposes.