### PR TITLE
Update Sinopé WL4200 and WL4200S devices

### DIFF
--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -304,17 +304,32 @@ module.exports = [
         model: 'WL4200',
         vendor: 'Sinopé',
         description: 'Zigbee smart water leak detector',
-        fromZigbee: [fz.ias_water_leak_alarm_1],
+        fromZigbee: [fz.ias_water_leak_alarm_1, fz.temperature, fz.battery],
         toZigbee: [],
-        exposes: [e.water_leak(), e.battery_low(), e.tamper()],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msTemperatureMeasurement']);
+            await reporting.temperature(endpoint, {min: 600, max: constants.repInterval.MAX, change: 100});
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.batteryAlarmState(endpoint);
+        },
+        exposes: [e.water_leak(), e.battery_low(), e.temperature(), e.battery()],
     },
     {
         zigbeeModel: ['WL4200S'],
         model: 'WL4200S',
         vendor: 'Sinopé',
-        description: 'Zigbee smart water leak detector',
-        fromZigbee: [fz.ias_water_leak_alarm_1],
+        description: 'Zigbee smart water leak detector with external sensor',
+        fromZigbee: [fz.ias_water_leak_alarm_1, fz.temperature, fz.battery],
         toZigbee: [],
-        exposes: [e.water_leak(), e.battery_low(), e.tamper()],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msTemperatureMeasurement']);
+            await reporting.temperature(endpoint, {min: 600, max: constants.repInterval.MAX, change: 100});
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.batteryAlarmState(endpoint);
+        },
+
+        exposes: [e.water_leak(), e.battery_low(), e.temperature(), e.battery()],
     },
 ];

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -329,7 +329,6 @@ module.exports = [
             await reporting.batteryPercentageRemaining(endpoint);
             await reporting.batteryAlarmState(endpoint);
         },
-
         exposes: [e.water_leak(), e.battery_low(), e.temperature(), e.battery()],
     },
 ];


### PR DESCRIPTION
The current water sensors definitions don't currently show battery information. I tried to validate if the low battery warning would work, and it didn't seem to be the case, so I changed the device definition. It now pulls the proper battery status and exposes them.

While checking the product page, I saw a reference that said that the devices could report "freeze risks", so I checked the available clusters and it does report temperatures, so that has been added too.

Also, I removed the useless Temper attribute that doesn't seem to do anything.

Lastly, I edited the WL4200S definition to properly differentiate it from the WL4200 model.