### PR TITLE
add support for Legrand Cable outlet 064882

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5029,10 +5029,33 @@ const converters = {
             // dimmer
             else if (option0 === 0x0101) payload.device_mode = 'dimmer_on';
             else if (option0 === 0x0100) payload.device_mode = 'dimmer_off';
+            // pilot wire
+            else if (option0 === 0x0002) payload.device_mode = 'pilot_on';
+            else if (option0 === 0x0001) payload.device_mode = 'pilot_off';
             // unknown case
             else {
                 meta.logger.warn(`device_mode ${option0} not recognized, please fix me`);
                 payload.device_mode = 'unknown';
+            }
+            return payload;
+        },
+    },
+    legrand_cable_outlet_mode: {
+        cluster: '64576',
+        type: ['readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const payload = {};
+            const mode = msg.data['0'];
+
+            if (mode === 0x00) payload.cable_outlet_mode = 'comfort';
+            else if (mode === 0x01) payload.cable_outlet_mode = 'comfort-1';
+            else if (mode === 0x02) payload.cable_outlet_mode = 'comfort-2';
+            else if (mode === 0x03) payload.cable_outlet_mode = 'eco';
+            else if (mode === 0x04) payload.cable_outlet_mode = 'frost_protection';
+            else if (mode === 0x05) payload.cable_outlet_mode = 'off';
+            else {
+                meta.logger.warn(`Bad mode : ${mode}`);
+                payload.cable_outlet_mode = 'unknown';
             }
             return payload;
         },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4490,6 +4490,9 @@ const converters = {
                 // contactor
                 'switch': 0x0003,
                 'auto': 0x0004,
+                // pilot wire
+                'pilot_on': 0x0002,
+                'pilot_off': 0x0001,
             };
 
             value = value.toLowerCase();
@@ -4500,6 +4503,15 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificLegrandDevices', [0x0000, 0x0001, 0x0002], manufacturerOptions.legrand);
+        },
+    },
+    legrand_cableOutletMode: {
+        key: ['cable_outlet_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            meta.logger.warn('Feature is being implemented');
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read(64576, [0x0000], manufacturerOptions.legrand);
         },
     },
     legrand_powerAlarm: {

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -297,4 +297,16 @@ module.exports = [
         toZigbee: [],
         exposes: [e.action(['press_once', 'press_twice'])],
     },
+    {
+        zigbeeModel: [' Cable outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
+        model: '064882',
+        vendor: 'Legrand',
+        description: 'Cable outlet with pilot wire and consumption measurement',
+        fromZigbee: [fz.legrand_device_mode, fz.legrand_cable_outlet_mode, fz.on_off, fz.electrical_measurement],
+        toZigbee: [tz.legrand_deviceMode, tz.legrand_cableOutletMode, tz.on_off, tz.electrical_measurement_power],
+        exposes: [exposes.enum('device_mode', ea.ALL, ['pilot_off', 'pilot_on']),
+            exposes.enum('cable_outlet_mode', ea.ALL, ['comfort', 'comfort-1', 'comfort-2', 'eco', 'frost_protection', 'off']),
+            exposes.switch().withState('state', true, 'Works only when the pilot wire is deactivated'),
+            e.power().withAccess(ea.STATE_GET)],
+    },
 ];

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -298,7 +298,8 @@ module.exports = [
         exposes: [e.action(['press_once', 'press_twice'])],
     },
     {
-        zigbeeModel: [' Cable outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
+        zigbeeModel: [' Cable outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000' + 
+            '\u0000\u0000'],
         model: '064882',
         vendor: 'Legrand',
         description: 'Cable outlet with pilot wire and consumption measurement',

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -298,7 +298,7 @@ module.exports = [
         exposes: [e.action(['press_once', 'press_twice'])],
     },
     {
-        zigbeeModel: [' Cable outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000' + 
+        zigbeeModel: [' Cable outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000' +
             '\u0000\u0000'],
         model: '064882',
         vendor: 'Legrand',


### PR DESCRIPTION
Support for [Legrand Cable outlet](https://www.legrand.fr/pro/catalogue/43076-sortie-de-cable/sortie-de-cable-connectee-pour-installation-with-netatmo-compatible-fil-pilote-3000w-on-off-et-mesure-conso-titane)

The command to send the selected mode to the device is not yet functional. This part is very complicated because we can't write directly the command on the 64576 cluster because this one is read-only.

Here is also the current database of this device :
``` json
{
  "id": 2,
  "type": "Router",
  "ieeeAddr": "0x000474000011041c",
  "nwkAddr": 60419,
  "manufId": 4129,
  "manufName": " Legrand\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
  "powerSource": "Mains (single phase)",
  "modelId": " Cable outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
  "epList": [
    1,
    242
  ],
  "endpoints": {
    "1": {
      "profId": 260,
      "epId": 1,
      "devId": 1,
      "inClusterList": [
        0,
        3,
        4,
        6,
        5,
        64513,
        2820,
        64576
      ],
      "outClusterList": [
        0,
        64513,
        25
      ],
      "clusters": {
        "64576": {
          "attributes": {
            "0": 0
          }
        },
        "genBasic": {
          "attributes": {
            "modelId": " Cable outlet\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
            "manufacturerName": " Legrand\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
            "powerSource": 1,
            "zclVersion": 2,
            "appVersion": 0,
            "stackVersion": 66,
            "hwVersion": 1,
            "dateCode": " \u000020210429\u0000\u0000\u0000\u0000\u0000",
            "swBuildId": "0008"
          }
        },
        "genOnOff": {
          "attributes": {
            "onOff": 1
          }
        },
        "haElectricalMeasurement": {
          "attributes": {
            "activePower": 0
          }
        },
        "manuSpecificUbisysDimmerSetup": {
          "attributes": {
            "0": 1,
            "1": 0,
            "2": 0
          }
        }
      },
      "binds": [],
      "configuredReportings": [],
      "meta": {}
    },
    "242": {
      "profId": 41440,
      "epId": 242,
      "devId": 97,
      "inClusterList": [],
      "outClusterList": [
        33
      ],
      "clusters": {},
      "binds": [],
      "configuredReportings": [],
      "meta": {}
    }
  },
  "appVersion": 0,
  "stackVersion": 66,
  "hwVersion": 1,
  "dateCode": " \u000020210429\u0000\u0000\u0000\u0000\u0000",
  "swBuildId": "0008",
  "zclVersion": 2,
  "interviewCompleted": true,
  "meta": {},
  "lastSeen": 1643606218010,
  "useImplicitCheckin": true
}
```