### PR TITLE
fix(tuya): extended TS1101_dimmer_module_1ch fingerprints

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1235,7 +1235,8 @@ module.exports = [
         exposes: [e.switch().setAccess('state', ea.STATE_SET), e.voltage(), e.power(), e.current(), e.energy()],
     },
     {
-        fingerprint: [{modelID: 'TS1101', manufacturerName: '_TZ3000_xfs39dbf'}],
+        fingerprint: [{modelID: 'TS1101', manufacturerName: '_TZ3000_xfs39dbf'}, 
+            {modelID: 'TS110E', manufacturerName: '_TZ3210_zxbtub8r'}],
         model: 'TS1101_dimmer_module_1ch',
         vendor: 'TuYa',
         description: 'Zigbee dimmer module 1 channel',


### PR DESCRIPTION
As discussed in: https://github.com/Koenkk/zigbee2mqtt/issues/11081
I bought the Tuya 1 on [AliExpress](https://nl.aliexpress.com/item/1005003012298844.html?gatewayAdapt=glo2nld&spm=a2g0o.9042311.0.0.dbe84c4dNKaMnY) but the zigbee2mqtt service didn't recognize it as supported. This should be the fix :) 