### PR TITLE
Added support to Alcantara 2 (Acova) heater

### DIFF
--- a/devices/acova.js
+++ b/devices/acova.js
@@ -3,33 +3,64 @@ const fz = require('../converters/fromZigbee');
 const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 
-module.exports = [{
-    zigbeeModel: ['PERCALE2 D1.00P1.01Z1.00'],
-    model: 'PERCALE2',
-    vendor: 'Acova',
-    description: 'Percale 2 heater',
-    fromZigbee: [fz.thermostat, fz.hvac_user_interface],
-    toZigbee: [
-        tz.thermostat_local_temperature,
-        tz.thermostat_system_mode,
-        tz.thermostat_occupied_heating_setpoint,
-        tz.thermostat_unoccupied_heating_setpoint,
-        tz.thermostat_occupied_cooling_setpoint,
-        tz.thermostat_running_state,
-    ],
-    exposes: [
-        exposes.climate()
-            .withSetpoint('occupied_heating_setpoint', 7, 28, 0.5)
-            .withLocalTemperature()
-            .withSystemMode(['off', 'heat', 'auto'])
-            .withRunningState(['idle', 'heat']),
-    ],
-    configure: async (device, coordinatorEndpoint, logger) => {
-        const endpoint = device.getEndpoint(1);
-        await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
-        await reporting.thermostatTemperature(endpoint);
-        await reporting.thermostatRunningState(endpoint);
-        await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
-        await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
+module.exports = [
+    {
+        zigbeeModel: ['PERCALE2 D1.00P1.01Z1.00'],
+        model: 'PERCALE2',
+        vendor: 'Acova',
+        description: 'Percale 2 heater',
+        fromZigbee: [fz.thermostat, fz.hvac_user_interface],
+        toZigbee: [
+            tz.thermostat_local_temperature,
+            tz.thermostat_system_mode,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_occupied_cooling_setpoint,
+            tz.thermostat_running_state,
+        ],
+        exposes: [
+            exposes.climate()
+                .withSetpoint('occupied_heating_setpoint', 7, 28, 0.5)
+                .withLocalTemperature()
+                .withSystemMode(['off', 'heat', 'auto'])
+                .withRunningState(['idle', 'heat']),
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatRunningState(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
+        },
     },
-}];
+    {
+        zigbeeModel: ['ALCANTARA2 D1.00P1.02Z1.00\u0000\u0000\u0000\u0000\u0000\u0000'],
+        model: 'ALCANTARA2',
+        vendor: 'Acova',
+        description: 'Alcantara 2 heater',
+        fromZigbee: [fz.thermostat, fz.hvac_user_interface],
+        toZigbee: [
+            tz.thermostat_local_temperature,
+            tz.thermostat_system_mode,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_running_state,
+        ],
+        exposes: [
+            exposes.climate()
+                .withSetpoint('occupied_heating_setpoint', 7, 28, 0.5)
+                .withLocalTemperature()
+                .withSystemMode(['off', 'heat', 'auto'])
+                .withRunningState(['idle', 'heat']),
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatRunningState(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
+        },
+    },
+];


### PR DESCRIPTION
This PR adds support for the Alcantara 2 heater (Acova).

I've duplicated the original configuration entry made for the Percale 2 heater because they are not completly the same. The Percale 2 model has presence detection while the Alcantara model does not (even if it is not implemented).

Also, I removed `thermostat_occupied_cooling_setpoint` attribute from `toZigbee` since it does not make sense to me. This might also be removed for the Percale 2 model but I don't have it at home to test it before, and I'd prefer not to introduce a bug for existing users.

Side note: the `local_temperature` is actually (at least on the Alcantara model) the temperature setpoint that can be set on the device itself, and is not the temperature measured by the device, so I'm not sure if it should be reported as the `local_temperature` either...