### PR TITLE
Add new Zigbee Model for Kwikset SmartCode Deadbolt

### DIFF
--- a/devices/kwikset.js
+++ b/devices/kwikset.js
@@ -36,7 +36,7 @@ module.exports = [
         exposes: [e.lock(), e.battery()],
     },
     {
-        zigbeeModel: ['SMARTCODE_DEADBOLT_10_W3'],
+        zigbeeModel: ['SMARTCODE_DEADBOLT_10_W3', 'SMARTCODE_DEADBOLT_10T_W3'],
         model: '99140-031',
         vendor: 'Kwikset',
         description: 'SmartCode traditional electronic deadbolt',


### PR DESCRIPTION
Installed a new SmarCode Deadbolt on my Zigbee network and saw that the model had changed. Added the model to the same object on herdsman and everything works as expected