### PR TITLE
Add support for window feature - Danfoss Ally

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3212,7 +3212,7 @@ const converters = {
                     precisionRound(msg.data['pIHeatingDemand'], 0);
             }
             if (msg.data.hasOwnProperty('danfossWindowOpenFeatureEnable')) {
-                result[postfixWithEndpointName('window_open_feature_enable', msg, model)] =
+                result[postfixWithEndpointName('window_open_feature_enabled', msg, model)] =
                     (msg.data['danfossWindowOpenFeatureEnable'] === 1);
             }
             if (msg.data.hasOwnProperty('danfossWindowOpenInternal')) {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3212,7 +3212,7 @@ const converters = {
                     precisionRound(msg.data['pIHeatingDemand'], 0);
             }
             if (msg.data.hasOwnProperty('danfossWindowOpenFeatureEnable')) {
-                result[postfixWithEndpointName('window_open_feature_enabled', msg, model)] =
+                result[postfixWithEndpointName('window_open_feature', msg, model)] =
                     (msg.data['danfossWindowOpenFeatureEnable'] === 1);
             }
             if (msg.data.hasOwnProperty('danfossWindowOpenInternal')) {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3211,6 +3211,10 @@ const converters = {
                 result[postfixWithEndpointName('pi_heating_demand', msg, model)] =
                     precisionRound(msg.data['pIHeatingDemand'], 0);
             }
+            if (msg.data.hasOwnProperty('danfossWindowOpenFeatureEnable')) {
+                result[postfixWithEndpointName('window_open_feature_enable', msg, model)] =
+                    (msg.data['danfossWindowOpenFeatureEnable'] === 1);
+            }
             if (msg.data.hasOwnProperty('danfossWindowOpenInternal')) {
                 result[postfixWithEndpointName('window_open_internal', msg, model)] =
                     constants.danfossWindowOpen.hasOwnProperty(msg.data['danfossWindowOpenInternal']) ?

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2752,11 +2752,11 @@ const converters = {
             await entity.read('hvacThermostat', ['danfossTriggerTime'], manufacturerOptions.danfoss);
         },
     },
-    danfoss_window_open_feature_enable: {
-        key: ['window_open_feature_enable'],
+    danfoss_window_open_feature_enabled: {
+        key: ['window_open_feature_enabled'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('hvacThermostat', {'danfossWindowOpenFeatureEnable': value}, manufacturerOptions.danfoss);
-            return {readAfterWriteTime: 200, state: {'window_open_feature_enable': value}};
+            return {readAfterWriteTime: 200, state: {'window_open_feature_enabled': value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossWindowOpenFeatureEnable'], manufacturerOptions.danfoss);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2752,11 +2752,11 @@ const converters = {
             await entity.read('hvacThermostat', ['danfossTriggerTime'], manufacturerOptions.danfoss);
         },
     },
-    danfoss_window_open_feature_enabled: {
-        key: ['window_open_feature_enabled'],
+    danfoss_window_open_feature: {
+        key: ['window_open_feature'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('hvacThermostat', {'danfossWindowOpenFeatureEnable': value}, manufacturerOptions.danfoss);
-            return {readAfterWriteTime: 200, state: {'window_open_feature_enabled': value}};
+            return {readAfterWriteTime: 200, state: {'window_open_feature': value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossWindowOpenFeatureEnable'], manufacturerOptions.danfoss);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2752,6 +2752,16 @@ const converters = {
             await entity.read('hvacThermostat', ['danfossTriggerTime'], manufacturerOptions.danfoss);
         },
     },
+    danfoss_window_open_feature_enable: {
+        key: ['window_open_feature_enable'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'danfossWindowOpenFeatureEnable': value}, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 200, state: {'window_open_feature_enable': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossWindowOpenFeatureEnable'], manufacturerOptions.danfoss);
+        },
+    },
     danfoss_window_open_internal: {
         key: ['window_open_internal'],
         convertGet: async (entity, key, meta) => {

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -22,7 +22,8 @@ module.exports = [
             tz.danfoss_window_open_internal, tz.danfoss_window_open_external, tz.danfoss_load_estimate,
             tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.danfoss_radiator_covered,
             tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean,
-            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_programming_operation_mode],
+            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_programming_operation_mode,
+            tz.danfoss_window_open_feature_enable],
         exposes: [e.battery(), e.keypad_lockout(), e.programming_operation_mode(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -53,6 +54,8 @@ module.exports = [
             exposes.binary('radiator_covered', ea.ALL, true, false)
                 .withDescription('Set if the TRV should solely rely on external_measured_room_sensor or operate in offset mode. ' +
                     '`false` = Auto Offset Mode or `true` = Room Sensor Mode'),
+            exposes.binary('window_open_feature_enable', ea.ALL, true, false)
+                .withDescription('Whether or not the window open feature is enabled'),
             exposes.numeric('window_open_internal', ea.STATE_GET).withValueMin(0).withValueMax(4)
                 .withDescription('0=Quarantine, 1=Windows are closed, 2=Hold - Windows are maybe about to open, ' +
                     '3=Open window detected, 4=In window open state from external but detected closed locally'),

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -23,7 +23,7 @@ module.exports = [
             tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.danfoss_radiator_covered,
             tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean,
             tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_programming_operation_mode,
-            tz.danfoss_window_open_feature_enable],
+            tz.danfoss_window_open_feature_enabled],
         exposes: [e.battery(), e.keypad_lockout(), e.programming_operation_mode(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -54,7 +54,7 @@ module.exports = [
             exposes.binary('radiator_covered', ea.ALL, true, false)
                 .withDescription('Set if the TRV should solely rely on external_measured_room_sensor or operate in offset mode. ' +
                     '`false` = Auto Offset Mode or `true` = Room Sensor Mode'),
-            exposes.binary('window_open_feature_enable', ea.ALL, true, false)
+            exposes.binary('window_open_feature_enabled', ea.ALL, true, false)
                 .withDescription('Whether or not the window open feature is enabled'),
             exposes.numeric('window_open_internal', ea.STATE_GET).withValueMin(0).withValueMax(4)
                 .withDescription('0=Quarantine, 1=Windows are closed, 2=Hold - Windows are maybe about to open, ' +

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -117,6 +117,7 @@ module.exports = [
             }], options);
 
             await endpoint.read('hvacThermostat', [
+                'danfossWindowOpenFeatureEnable',
                 'danfossWindowOpenExternal',
                 'danfossDayOfWeek',
                 'danfossTriggerTime',

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -23,7 +23,7 @@ module.exports = [
             tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.danfoss_radiator_covered,
             tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean,
             tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_programming_operation_mode,
-            tz.danfoss_window_open_feature_enabled],
+            tz.danfoss_window_open_feature],
         exposes: [e.battery(), e.keypad_lockout(), e.programming_operation_mode(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -54,7 +54,7 @@ module.exports = [
             exposes.binary('radiator_covered', ea.ALL, true, false)
                 .withDescription('Set if the TRV should solely rely on external_measured_room_sensor or operate in offset mode. ' +
                     '`false` = Auto Offset Mode or `true` = Room Sensor Mode'),
-            exposes.binary('window_open_feature_enabled', ea.ALL, true, false)
+            exposes.binary('window_open_feature', ea.ALL, true, false)
                 .withDescription('Whether or not the window open feature is enabled'),
             exposes.numeric('window_open_internal', ea.STATE_GET).withValueMin(0).withValueMax(4)
                 .withDescription('0=Quarantine, 1=Windows are closed, 2=Hold - Windows are maybe about to open, ' +


### PR DESCRIPTION
This adds support for the new feature included with firmware 1.18 which allows turning the window feature on and off.

Not supported by Hive TRV - or at least the version of firmware I have - don't even know if there is a newer one as I have not connected them to Hive in a looong time.

Not sure about Popp TRV, hence me not adding it. I am sure someone will try it on the Popp and do a PR if they find it works.

Confirmed working on Danfoss Ally 1.18 in this post https://github.com/Koenkk/zigbee2mqtt/issues/4504#issuecomment-1028116201