### PR TITLE
Add support for Yale YMF40A RL

### DIFF
--- a/devices/yale.js
+++ b/devices/yale.js
@@ -129,6 +129,6 @@ module.exports = [
         model: 'YMF40A RL',
         vendor: 'Yale',
         description: 'Real living lock / Intelligent biometric digital lock',
-        extend: lockExtend(),
+        extend: lockExtend({battery: {dontDividePercentage: true}}),
     },
 ];


### PR DESCRIPTION
Added the code for support to Yale YMF40A RL - https://github.com/Koenkk/zigbee2mqtt/issues/11199

Note: the batteries are at 100% but they appear at 50%, could you correct the code at this point?