### PR TITLE
ZNJLBL01LM Getting the motor state result in wrong data.

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2417,12 +2417,6 @@ const converters = {
             await entity.read('genAnalogOutput', [0x0055]);
         },
     },
-    xiaomi_curtain_acn002_status: {
-        key: ['motor_state'],
-        convertGet: async (entity, key, meta) => {
-            await entity.read('genMultistateOutput', [0x0055]);
-        },
-    },
     ledvance_commands: {
         /* deprectated osram_*/
         key: ['set_transition', 'remember_state', 'osram_set_transition', 'osram_remember_state'],

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1272,9 +1272,9 @@ module.exports = [
         vendor: 'Xiaomi',
         fromZigbee: [fz.xiaomi_curtain_acn002_position, fz.xiaomi_curtain_acn002_status, fz.cover_position_tilt, fz.ignore_basic_report,
             fz.aqara_opple],
-        toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_acn002_status],
+        toZigbee: [tz.xiaomi_curtain_position_state],
         exposes: [e.cover_position().setAccess('state', ea.ALL), e.battery(),
-            exposes.enum('motor_state', ea.STATE_GET, ['declining', 'rising', 'pause', 'blocked'])
+            exposes.enum('motor_state', ea.STATE, ['declining', 'rising', 'pause', 'blocked'])
                 .withDescription('The current state of the motor.'),
             exposes.binary('running', ea.STATE, true, false)
                 .withDescription('Whether the motor is moving or not.')],


### PR DESCRIPTION
Getting the motor state while running, the device will report the motor state as pause, dispite that the motor is actually running. So GET access should be removed. The device will publish the state attribute on state change, so it is not useful anyway.