### PR TITLE
Add support for energy metering on sengled e11-g13 bulbs

### DIFF
--- a/devices/sengled.js
+++ b/devices/sengled.js
@@ -60,13 +60,20 @@ module.exports = [
         model: 'E11-G13',
         vendor: 'Sengled',
         description: 'Element classic (A19)',
-        extend: extend.light_onoff_brightness({noConfigure: true}),
-        ota: ota.zigbeeOTA,
+        fromZigbee: extend.light_onoff_brightness().fromZigbee.concat([fz.metering]),
+        toZigbee: extend.light_onoff_brightness().toZigbee,
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             device.powerSource = 'Mains (single phase)';
             device.save();
+
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint);
+            await reporting.instantaneousDemand(endpoint);
         },
+        exposes: [e.power(), e.energy(), e.light_brightness()],
     },
     {
         zigbeeModel: ['E11-G23', 'E11-G33'],


### PR DESCRIPTION
I noticed my zigbee sengled e11-g13 bulbs were reporting power and energy usage values in zha.  So I added it for zigbee2mqtt ;-).  Tested using an external converter in zigbee2mqtt.

`npm run lint` and `npm test` both pass 100%

<img width="783" alt="Screen Shot 2022-02-03 at 3 11 14 PM" src="https://user-images.githubusercontent.com/19671779/152429532-79a08ba1-d981-48ca-b3ce-28a10b1cd134.png">

