### PR TITLE
added support for Schwaiger HAL400 to schwaiger.js

### DIFF
--- a/devices/schwaiger.js
+++ b/devices/schwaiger.js
@@ -45,4 +45,11 @@ module.exports = [
         description: 'LED bulb GU10 350 lumen, dimmable, color, white 2700-6500K',
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
     },
+    {
+        zigbeeModel: ['ZBT-DIMLight-GU100800'],
+        model: 'HAL400',
+        vendor: 'Schwaiger (LDS)',
+        description: 'LED Schwaiger HAL400 GU10 dimmable, warm white',
+        extend: extend.light_onoff_brightness(),
+    },
 ];

--- a/devices/schwaiger.js
+++ b/devices/schwaiger.js
@@ -48,7 +48,7 @@ module.exports = [
     {
         zigbeeModel: ['ZBT-DIMLight-GU100800'],
         model: 'HAL400',
-        vendor: 'Schwaiger (LDS)',
+        vendor: 'Schwaiger',
         description: 'LED Schwaiger HAL400 GU10 dimmable, warm white',
         extend: extend.light_onoff_brightness(),
     },


### PR DESCRIPTION
added support for missing LED light bulb 
details at https://www.conrad.com/p/schwaiger-hal400-led-light-bulb-eec-a-a-e-1521155

Dimmable Light, Light color: warm-white, 2,700 Kelvin