### PR TITLE
Expose recall_0 and recall_1 for philips 929002398602 (RWL022)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1904,10 +1904,10 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue dimmer switch',
         fromZigbee: [fz.ignore_command_on, fz.ignore_command_off, fz.ignore_command_step, fz.ignore_command_stop,
-            fz.hue_dimmer_switch, fz.battery],
+            fz.hue_dimmer_switch, fz.battery, fz.command_recall],
         exposes: [e.battery(), e.action(['on_press', 'on_hold', 'on_press_release', 'on_hold_release',
             'off_press', 'off_hold', 'off_press_release', 'off_hold_release', 'up_press', 'up_hold', 'up_press_release', 'up_hold_release',
-            'down_press', 'down_hold', 'down_press_release', 'down_hold_release'])],
+            'down_press', 'down_hold', 'down_press_release', 'down_hold_release', 'recall_0', 'recall_1'])],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
This allows me to switch between two scenes when using the RWL022 button on the bottom labeled as "hue".

The only thing i dont understand is, that the **groupid** sent by the device is some seemingly random number.
Is there any way to assign a **groupid** to this device? 

Output from a working recall, i manually added a group with the ID **49875**, not sure where this magic number is coming from though. I have a second remote and im gonna test if it has the same number.
```
Debug Received Zigbee message from 'FBMartin', type 'commandRecall', cluster 'genScenes', data '{"groupid":49875,"sceneid":1}' from endpoint 1 with groupID 0
Info MQTT publish: topic 'zigbee2mqtt/FBMartin', payload '{"action":"recall_1","battery":85.5,"brightness":0,"last_seen":"2022-02-04T01:55:32.234Z","linkquality":109,"update":{"state":"idle"},"update_available":false}'
Info MQTT publish: topic 'zigbee2mqtt/FBMartin', payload '{"action":"","battery":85.5,"brightness":0,"last_seen":"2022-02-04T01:55:32.234Z","linkquality":109,"update":{"state":"idle"},"update_available":false}'
Info MQTT publish: topic 'zigbee2mqtt/FBMartin/action', payload 'recall_1'
```