### PR TITLE
Add support for new Zemismart tubular motor _TZE200_68nvbio9

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -882,6 +882,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_5sbebbzs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuz7f94z'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zyrdrmno'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_68nvbio9'},
         ],
         model: 'TS0601_cover',
         vendor: 'TuYa',


### PR DESCRIPTION
Add support for additional Zemismart tubular motors from Aliexpress

I have tested with with 2 of the same motors. All working.

testing device file ......

const exposes = require('zigbee-herdsman-converters/lib/exposes');
const fz = {...require('zigbee-herdsman-converters/converters/fromZigbee'), legacy: require('zigbee-herdsman-converters/lib/legacy').fromZigbee};
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const ota = require('zigbee-herdsman-converters/lib/ota');
const tuya = require('zigbee-herdsman-converters/lib/tuya');
const reporting = require('zigbee-herdsman-converters/lib/reporting');
const extend = require('zigbee-herdsman-converters/lib/extend');
const e = exposes.presets;
const ea = exposes.access;
const libColor = require('zigbee-herdsman-converters/lib/color');
const utils = require('zigbee-herdsman-converters/lib/utils');

const definition = {

      fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_68nvbio9'}],
        model: 'TS0601',
        vendor: 'Zemismart',
        description: 'Zigbee/RF curtain motor',
         fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
        toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options],
        exposes: [
            e.cover_position().setAccess('position', ea.STATE_SET),
            exposes.composite('options', 'options')
                .withFeature(exposes.numeric('motor_speed', ea.STATE_SET)
                    .withValueMin(0)
                    .withValueMax(255)
                    .withDescription('Motor speed'))],
};

module.exports = definition;

Seems to work fine.