### PR TITLE
Remove stray space from TuYa vendor name

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -250,7 +250,7 @@ module.exports = [
         model: 'TS0202',
         vendor: 'TuYa',
         description: 'Motion sensor',
-        whiteLabel: [{vendor: 'Mercator Ikuü', model: 'SMA02P'}, {vendor: 'TuYa ', model: 'TY-ZPR06'}],
+        whiteLabel: [{vendor: 'Mercator Ikuü', model: 'SMA02P'}, {vendor: 'TuYa', model: 'TY-ZPR06'}],
         fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, fz.ignore_basic_report, fz.ias_occupancy_alarm_1_report],
         toZigbee: [],
         exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],


### PR DESCRIPTION
The removed space caused a duplicate TuYa entry to show up in the list
and lead to links like
https://www.zigbee2mqtt.io/supported-devices/#e=temperature&v=TuYa,TuYa%20