### PR TITLE
feat: Add Hue white ambiance ceiling black Enrave M with Bluetooth

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -91,6 +91,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['915005996701'],
+        model: '915005996701',
+        vendor: 'Philips',
+        description: 'Hue white ambiance ceiling black Enrave M with Bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['929003054001'],
         model: '929003054001',
         vendor: 'Philips',


### PR DESCRIPTION
Untested locally, but used config from small version of this light.

Database record:
{"id":3,"type":"Router","ieeeAddr":"0x0017880109c55ed4","nwkAddr":48128,"manufId":4107,"manufName":"Philips","powerSource":"Mains (single phase)","modelId":"915005996701","epList":[11,242],"endpoints":{"11":{"profId":260,"epId":11,"devId":268,"inClusterList":[0,3,4,5,6,8,4096,768],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"915005996701","manufacturerName":"Philips","powerSource":1,"zclVersion":2,"appVersion":2,"stac
kVersion":1,"hwVersion":0,"dateCode":"20210305","swBuildId":"1.82.10"}}},"binds":[],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":2,"stackVersion":1,"hwVersion":0,"dateCode":"20210305","swBuildId":"1.82.10","zclVersion":2,"interviewCompleted":true,"meta":{},"lastSeen":1644092611237,"defaultSend
RequestWhen":"immediate"}

color range:
![image](https://user-images.githubusercontent.com/4787591/152659157-b3d51b7b-2723-4542-a825-8f431e28f3a6.png)
