### PR TITLE
Adds Jasco 43095

### DIFF
--- a/devices/jasco.js
+++ b/devices/jasco.js
@@ -1,3 +1,6 @@
+const fz = require('../converters/fromZigbee');
+const tz = require('../converters/toZigbee');
+const ea = exposes.access;
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
 const exposes = require('../lib/exposes');

--- a/devices/jasco.js
+++ b/devices/jasco.js
@@ -32,4 +32,19 @@ module.exports = [
             await reporting.instantaneousDemand(endpoint);
         },
     },
+    {
+        zigbeeModel: ['43095'],
+        model: '43095', 
+        vendor: 'Jasco Products', 
+        description: 'Zigbee Smart Plug-In Switch with Energy Metering',
+        fromZigbee:[fz.command_on_state, fz.command_off_state, fz.metering], 
+        extend: extend.switch(),
+        exposes: [e.switch(), e.power(), e.energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint1 = device.getEndpoint(1);
+            await reporting.bind(endpoint1, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            await reporting.onOff(endpoint1);
+            await reporting.instantaneousDemand(endpoint1);
+            await reporting.readMeteringMultiplierDivisor(endpoint1);
+        }
 ];

--- a/devices/jasco.js
+++ b/devices/jasco.js
@@ -38,7 +38,7 @@ module.exports = [
         zigbeeModel: ['43095'],
         model: '43095',
         vendor: 'Jasco Products',
-        description: 'Zigbee Smart Plug-In Switch with Energy Metering',
+        description: 'Zigbee smart plug-in switch with energy metering',
         fromZigbee: [fz.command_on_state, fz.command_off_state, fz.metering],
         extend: extend.switch(),
         exposes: [e.switch(), e.power(), e.energy()],

--- a/devices/jasco.js
+++ b/devices/jasco.js
@@ -1,10 +1,11 @@
 const fz = require('../converters/fromZigbee');
 const tz = require('../converters/toZigbee');
-const ea = exposes.access;
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
 const exposes = require('../lib/exposes');
 const e = exposes.presets;
+const ea = exposes.access;
+
 
 module.exports = [
     {

--- a/devices/jasco.js
+++ b/devices/jasco.js
@@ -1,10 +1,8 @@
 const fz = require('../converters/fromZigbee');
-const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
 const exposes = require('../lib/exposes');
 const e = exposes.presets;
-const ea = exposes.access;
 
 
 module.exports = [
@@ -38,10 +36,10 @@ module.exports = [
     },
     {
         zigbeeModel: ['43095'],
-        model: '43095', 
-        vendor: 'Jasco Products', 
+        model: '43095',
+        vendor: 'Jasco Products',
         description: 'Zigbee Smart Plug-In Switch with Energy Metering',
-        fromZigbee:[fz.command_on_state, fz.command_off_state, fz.metering], 
+        fromZigbee: [fz.command_on_state, fz.command_off_state, fz.metering],
         extend: extend.switch(),
         exposes: [e.switch(), e.power(), e.energy()],
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -50,6 +48,6 @@ module.exports = [
             await reporting.onOff(endpoint1);
             await reporting.instantaneousDemand(endpoint1);
             await reporting.readMeteringMultiplierDivisor(endpoint1);
-        }
+        },
     },
 ];

--- a/devices/jasco.js
+++ b/devices/jasco.js
@@ -47,4 +47,5 @@ module.exports = [
             await reporting.instantaneousDemand(endpoint1);
             await reporting.readMeteringMultiplierDivisor(endpoint1);
         }
+    },
 ];


### PR DESCRIPTION
Adds Jasco 43095, aka Enbrighten Zigbee Switch, Dual Outlet Control Plug-In. Note this treats both outlets as one, but per docs they should be independently controllable.

Tested with the exact device and everything appears to function correctly (apart from the whole only being able to control both outlets together thing)