### PR TITLE
add Legrand 067772

### DIFF
--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -320,4 +320,26 @@ module.exports = [
             await reporting.activePower(endpoint);
         },
     },
+    {
+        zigbeeModel: [' NLIS - Double light switch\u0000\u0000\u0000\u0000'],
+        model: '067772',
+        vendor: 'Legrand',
+        description: 'Double wired switch with neutral',
+        fromZigbee: [fz.on_off],
+        toZigbee: [tz.on_off, tz.legrand_settingAlwaysEnableLed, tz.legrand_settingEnableLedIfOn],
+        exposes: [e.switch().withEndpoint('left'),
+            e.switch().withEndpoint('right'),
+            exposes.binary('permanent_led', ea.STATE_SET, 'ON', 'OFF').withDescription('Enable or disable the permanent blue LED'),
+            exposes.binary('led_when_on', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables the LED when the light is on')],
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpointLeft = device.getEndpoint(1);
+            await reporting.bind(endpointLeft, coordinatorEndpoint, ['genOnOff']);
+            const endpointRight = device.getEndpoint(2);
+            await reporting.bind(endpointRight, coordinatorEndpoint, ['genOnOff']);
+        },
+        endpoint: (device) => {
+            return {left: 1, right: 2};
+        },
+    },
 ];


### PR DESCRIPTION
* Add support for Legrand [067772](https://www.legrand.fr/catalogue/interrupteur/interrupteur-double-a-cabler-2-circuits-250w-pour-installation-connectee-celiane-with-netatmo-avec-plaque-metal-titane).

**Current device database**
``` json
{
  "id": 4,
  "type": "Router",
  "ieeeAddr": "0x0004740000132502",
  "nwkAddr": 4728,
  "manufId": 4129,
  "manufName": " Legrand\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
  "powerSource": "Mains (single phase)",
  "modelId": " NLIS - Double light switch\u0000\u0000\u0000\u0000",
  "epList": [
    1,
    2,
    242
  ],
  "endpoints": {
    "1": {
      "profId": 260,
      "epId": 1,
      "devId": 256,
      "inClusterList": [
        3,
        4,
        5,
        15,
        6,
        0,
        64513
      ],
      "outClusterList": [
        5,
        0,
        64513,
        25
      ],
      "clusters": {
        "genBasic": {
          "attributes": {
            "modelId": " NLIS - Double light switch\u0000\u0000\u0000\u0000",
            "manufacturerName": " Legrand\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
            "powerSource": 1,
            "zclVersion": 2,
            "appVersion": 0,
            "stackVersion": 66,
            "hwVersion": 1,
            "dateCode": " \u000020210927\u0000\u0000\u0000\u0000\u0000",
            "swBuildId": "000d"
          }
        },
        "genOnOff": {
          "attributes": {
            "onOff": 0
          }
        }
      },
      "binds": [
        {
          "cluster": 6,
          "type": "endpoint",
          "deviceIeeeAddress": "0x00212effff07d6c3",
          "endpointID": 1
        }
      ],
      "configuredReportings": [],
      "meta": {}
    },
    "2": {
      "profId": 260,
      "epId": 2,
      "devId": 256,
      "inClusterList": [
        3,
        4,
        5,
        15,
        6
      ],
      "outClusterList": [
        5
      ],
      "clusters": {
        "genOnOff": {
          "attributes": {
            "onOff": 0
          }
        }
      },
      "binds": [
        {
          "cluster": 6,
          "type": "endpoint",
          "deviceIeeeAddress": "0x00212effff07d6c3",
          "endpointID": 1
        }
      ],
      "configuredReportings": [],
      "meta": {}
    },
    "242": {
      "profId": 41440,
      "epId": 242,
      "devId": 102,
      "inClusterList": [
        33
      ],
      "outClusterList": [
        33
      ],
      "clusters": {},
      "binds": [],
      "configuredReportings": [],
      "meta": {}
    }
  },
  "appVersion": 0,
  "stackVersion": 66,
  "hwVersion": 1,
  "dateCode": " \u000020210927\u0000\u0000\u0000\u0000\u0000",
  "swBuildId": "000d",
  "zclVersion": 2,
  "interviewCompleted": true,
  "meta": {
    "configured": 2052383256
  },
  "lastSeen": 1644136005471,
  "defaultSendRequestWhen": "immediate"
}
```