### PR TITLE
Added support for acFrequency for Develco SPLZB-132

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -39,7 +39,8 @@ module.exports = [
         description: 'Power plug',
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.device_temperature],
         toZigbee: [tz.on_off],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature()],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
+        options: [exposes.options.precision(`ac_frequency`)],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -52,6 +53,7 @@ module.exports = [
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {change: [0, 20]}); // Limit reports to once every 5m, or 0.02kWh
             await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
+            await reporting.acFrequency(endpoint);
         },
         endpoint: (device) => {
             return {default: 2};

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -501,6 +501,7 @@ module.exports = {
         illuminance_below_threshold_check: () => new Binary(`illuminance_below_threshold_check`, access.SET, true, false).withDescription(`Set to false to also send messages when illuminance is above threshold in night mode (default true).`),
     },
     presets: {
+        ac_frequency: () => new Numeric('ac_frequency', access.STATE).withUnit('Hz').withDescription('Measured electrical AC frequency'),
         action: (values) => new Enum('action', access.STATE, values).withDescription('Triggered action (e.g. a button click)'),
         angle: (name) => new Numeric(name, access.STATE).withValueMin(-360).withValueMax(360),
         angle_axis: (name) => new Numeric(name, access.STATE).withValueMin(-90).withValueMax(90),

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -19,9 +19,10 @@ function payload(attribute, min, max, change, overrides) {
 }
 
 async function readEletricalMeasurementMultiplierDivisors(endpoint) {
-    // Split into two chunks, some devices fail to respond when reading too much attributes at once.
+    // Split into three chunks, some devices fail to respond when reading too much attributes at once.
     await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
     await endpoint.read('haElectricalMeasurement', ['acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor']);
+    await endpoint.read('haElectricalMeasurement', ['acFrequencyDivisor', 'acFrequencyMultiplier']);
 }
 
 async function readMeteringMultiplierDivisor(endpoint) {
@@ -198,5 +199,9 @@ module.exports = {
     soil_moisture: async (endpoint, overrides) => {
         const p = payload('measuredValue', 10, repInterval.HOUR, 100, overrides);
         await endpoint.configureReporting('msSoilMoisture', p);
+    },
+    acFrequency: async (endpoint, overrides) => {
+        const p = payload('acFrequency', 5, repInterval.MINUTES_5, 10, overrides);
+        await endpoint.configureReporting('haElectricalMeasurement', p);
     },
 };


### PR DESCRIPTION
Hello, my first PR!

This closes: https://github.com/Koenkk/zigbee2mqtt/issues/11213

- Added support for acFrequency for Develco SPLZB-132
- Add missing `acFrequencyDivisor` and `acFrequencyMultiplier` to `readEletricalMeasurementMultiplierDivisors()`
- Add expose new preset `ac_frequency`

Please note this is based on a custom external converter that I made based on the original one inside this repo. This PR is an updated "good way" version. I don't have access to a full working dev environment so please test before 🤣 .

The custom external converter is attached to the PR for comparison. 

```js
const definition = {
    zigbeeModel: ['SPLZB-132'],
    model: 'SPLZB-132',
    vendor: 'Develco',
    description: 'Power plug',
    fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.device_temperature],
    toZigbee: [tz.on_off],
    exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature(), exposes.numeric('ac_frequency', ea.STATE).withUnit('Hz').withDescription('Measured electrical AC frequency')],
    options: [
        exposes.options.precision(`ac_frequency`)
    ],
    configure: async (device, coordinatorEndpoint, logger) => {
        const endpoint = device.getEndpoint(2);
        await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
        await reporting.onOff(endpoint);
        await reporting.deviceTemperature(endpoint);
        await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
        await reporting.activePower(endpoint, { change: 10 }); // Power reports with every 10W change
        await reporting.rmsCurrent(endpoint, { change: 20 }); // Current reports with every 20mA change
        await reporting.rmsVoltage(endpoint, { min: constants.repInterval.MINUTES_5, change: 400 }); // Limit reports to every 5m, or 4V
        await reporting.readMeteringMultiplierDivisor(endpoint);
        await reporting.currentSummDelivered(endpoint, { change: [0, 20] }); // Limit reports to once every 5m, or 0.02kWh
        await reporting.instantaneousDemand(endpoint, { min: constants.repInterval.MINUTES_5, change: 10 });

        await endpoint.read('haElectricalMeasurement', ['acFrequencyDivisor', 'acFrequencyMultiplier']);
        const p = reporting.payload('acFrequency', 5, repInterval.MINUTES_5, 10);
        await endpoint.configureReporting('haElectricalMeasurement', p);
    },
    endpoint: (device) => {
        return { default: 2 };
    },
}
```