### PR TITLE
Add Nedis ZBSM10WT

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1306,7 +1306,7 @@ module.exports = [
         description: 'PIR sensor',
         fromZigbee: [fz.battery, fz.ignore_basic_report, fz.ias_occupancy_alarm_1],
         toZigbee: [],
-        whiteLabel: [{vendor: 'Samotech', model: 'SM301Z'}],
+        whiteLabel: [{vendor: 'Samotech', model: 'SM301Z'}, {vendor: 'Nedis', model: 'ZBSM10WT'}],
         exposes: [e.battery(), e.occupancy(), e.battery_low(), e.tamper()],
     },
     {


### PR DESCRIPTION
I bought a Nedis ZBSM10WT assuming that it was not supported, yet when i tried to join it, it was detected as a TuYa RH3040 and seems to be working fine. It does have a different case though, so the image is not correct.