### PR TITLE
add new hue zigbeemodel for 9290018216

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -661,7 +661,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LWW003'],
+        zigbeeModel: ['LWW003', 'LWF003'],
         model: '9290018216',
         vendor: 'Philips',
         description: 'Hue white A60 bulb E27 bluetooth',


### PR DESCRIPTION
I have 4 outdoor lights. One at my main door, four at the way to this door. I recently switched from homeassistants zha to zigbee2mqtt and run into issues pairing my hue lights. So connected to the light and my main door via bluetooth, reset it and connected it flawlesley to zigbee2mqtt. Since the lights on the way are powered all the time, i later did this with its fuse. But the i also updated the four lights firmware via the hue bluetooth app. All the updated lights appear with zigbeemodel LWF003, only the light at the main door, which is not updated currently appears as LWW003.
Way lights (Hue A60 9W 60mA 2700K, Model: 9290018216):
![image](https://user-images.githubusercontent.com/4090694/153506807-ee489644-29ea-4a2f-aa95-aaa00b1f3678.png)
Door Light:
![image](https://user-images.githubusercontent.com/4090694/153506985-a2eacb01-4fba-4774-8abd-c0bdaf15872b.png)
Watch out for the firmware versions.

So i digged in my zigbee2mqtt docker container, changed the phillips.js file there and restarted everything. It works (for me).

Be gentle, its my first PR here ;-)