### PR TITLE
Support running_state for TS0601_thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4453,7 +4453,7 @@ const converters = {
             case tuya.dataPoints.ecoTemp:
                 return {eco_temperature: value};
             case tuya.dataPoints.valvePos:
-                return {position: value};
+                return {position: value, running_state: value ? 'heat' : 'idle'};
             case tuya.dataPoints.awayTemp:
                 return {away_preset_temperature: value};
             case tuya.dataPoints.awayDays:

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -971,7 +971,8 @@ module.exports = [
                     'to the desired temperature. If you want TRV to properly regulate the temperature you need to use mode `auto` ' +
                     'instead setting the desired temperature.')
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
-                .withAwayMode().withPreset(['schedule', 'manual', 'boost', 'complex', 'comfort', 'eco']),
+                .withAwayMode().withPreset(['schedule', 'manual', 'boost', 'complex', 'comfort', 'eco'])
+                .withRunningState(['idle', 'heat'], ea.STATE),
             e.auto_lock(), e.away_mode(), e.away_preset_days(), e.boost_time(), e.comfort_temperature(), e.eco_temperature(), e.force(),
             e.max_temperature(), e.min_temperature(), e.away_preset_temperature(),
             exposes.composite('programming_mode').withDescription('Schedule MODE ⏱ - In this mode, ' +


### PR DESCRIPTION
Device: https://www.zigbee2mqtt.io/devices/TS0601_thermostat.html

It supports `position` (also known as `valvePos`) of valve being open in %, so if it's non-zero it would now report running_state as `heat`, which is quite useful in HA interface.

This will likely bring support to `GS361A-H04` as well since it exposes position:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/5e61dd36b5fbfe60dc1d52386efe70cfca102d23/devices/siterwell.js#L34

As well as running state:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/5e61dd36b5fbfe60dc1d52386efe70cfca102d23/devices/siterwell.js#L37
