### PR TITLE
Add battery_voltage expose to TS0202

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -265,7 +265,7 @@ module.exports = [
         whiteLabel: [{vendor: 'Mercator Ikuü', model: 'SMA02P'}, {vendor: 'TuYa', model: 'TY-ZPR06'}],
         fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, fz.ignore_basic_report, fz.ias_occupancy_alarm_1_report],
         toZigbee: [],
-        exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],
+        exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery(), e.battery_voltage()],
     },
     {
         fingerprint: [{modelID: 'TS0202', manufacturerName: '_TZ3000_mcxw5ehu'},


### PR DESCRIPTION
I only have TS0202 _TZ3000_ykwcwxmz and it reports battery voltage. Not sure about others.
<details><summary>Wireshark screenshot</summary>
<img src="https://user-images.githubusercontent.com/16994749/154377998-93230b68-00ea-40e1-b931-b729265fdd77.png" /></details>
