### PR TITLE
Expose humidity for Stelpro SMT402 series thermostats

### DIFF
--- a/devices/stelpro.js
+++ b/devices/stelpro.js
@@ -47,7 +47,7 @@ module.exports = [
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupancy, tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode,
             tz.thermostat_running_state, tz.stelpro_thermostat_outdoor_temperature],
-        exposes: [e.local_temperature(), e.keypad_lockout(),
+        exposes: [e.local_temperature(), e.keypad_lockout(), e.humidity(),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
                 .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat'])],
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -79,7 +79,7 @@ module.exports = [
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupancy, tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.thermostat_running_state,
             tz.stelpro_thermostat_outdoor_temperature],
-        exposes: [e.local_temperature(), e.keypad_lockout(),
+        exposes: [e.local_temperature(), e.keypad_lockout(), e.humidity(),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
                 .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat'])],
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -142,7 +142,7 @@ module.exports = [
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupancy, tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.thermostat_running_state,
             tz.stelpro_thermostat_outdoor_temperature],
-        exposes: [e.local_temperature(), e.keypad_lockout(),
+        exposes: [e.local_temperature(), e.keypad_lockout(), e.humidity(),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
                 .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat'])],
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
### Description
Stelpro SMT402 thermostats provides humidity value. We can just expose its value so it can be easily used in home automation. ie turn on/off vent in bathroom, control humidifiers in another rooms etc without additional devices.

### Screenshot
Home assistant sensors
![image](https://user-images.githubusercontent.com/2119471/154981481-a6072389-6c6d-47fa-980b-abe42d558457.png)

