### PR TITLE
Add unit to angle and angle_axis

### DIFF
--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -503,8 +503,8 @@ module.exports = {
     presets: {
         ac_frequency: () => new Numeric('ac_frequency', access.STATE).withUnit('Hz').withDescription('Measured electrical AC frequency'),
         action: (values) => new Enum('action', access.STATE, values).withDescription('Triggered action (e.g. a button click)'),
-        angle: (name) => new Numeric(name, access.STATE).withValueMin(-360).withValueMax(360),
-        angle_axis: (name) => new Numeric(name, access.STATE).withValueMin(-90).withValueMax(90),
+        angle: (name) => new Numeric(name, access.STATE).withValueMin(-360).withValueMax(360).withUnit('°'),
+        angle_axis: (name) => new Numeric(name, access.STATE).withValueMin(-90).withValueMax(90).withUnit('°'),
         aqi: () => new Numeric('aqi', access.STATE).withDescription('Air quality index'),
         auto_lock: () => new Switch().withState('auto_lock', false, 'Enable/disable auto lock', access.STATE_SET, 'AUTO', 'MANUAL'),
         auto_relock_time: () => new Numeric('auto_relock_time', access.ALL).withValueMin(0).withUnit('s').withDescription('The number of seconds to wait after unlocking a lock before it automatically locks again. 0=disabled'),


### PR DESCRIPTION
I'm using homeassistant and have a sensor that exposes an angle measurement but without any unit of measurement. This should fix that.