### PR TITLE
Fix `warning_simple`

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -378,6 +378,7 @@ const converters = {
                 {startwarninginfo: info, warningduration: 300, strobedutycycle: 0, strobelevel: 0},
                 utils.getOptions(meta.mapped, entity),
             );
+            return {state: {'alarm': value}};
         },
     },
     squawk: {


### PR DESCRIPTION
Added the return of the `alarm` state so that it can be stopped in the case of a test run.
Which is the case for this [device](https://www.zigbee2mqtt.io/devices/SMSZB-120.html#develco-smszb-120).

