### PR TITLE
Updating xiaomi batteries calculation to logarithmic percentage from 2850 to 3200

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -56,7 +56,7 @@ module.exports = [
         description: 'Aqara P1 door & window contact sensor',
         fromZigbee: [fz. xiaomi_contact, fz.ias_contact_alarm_1, fz.aqara_opple, fz.battery],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.contact(), e.battery(), e.battery_voltage()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -158,7 +158,7 @@ module.exports = [
         model: 'WXKG01LM',
         vendor: 'Xiaomi',
         description: 'MiJia wireless switch',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.xiaomi_WXKG01LM_action, fz.legacy.WXKG01LM_click],
         exposes: [e.battery(), e.action(['single', 'double', 'triple', 'quadruple', 'hold', 'release', 'many']), e.battery_voltage()],
         toZigbee: [],
@@ -168,7 +168,7 @@ module.exports = [
         model: 'WXKG11LM',
         vendor: 'Xiaomi',
         description: 'Aqara wireless switch',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.battery_voltage(), e.action(['single', 'double', 'triple', 'quadruple', 'hold', 'release'])],
         fromZigbee: [fz.xiaomi_multistate_action, fz.xiaomi_WXKG11LM_action, fz.xiaomi_battery,
             fz.legacy.WXKG11LM_click, fz.legacy.xiaomi_action_click_multistate],
@@ -179,7 +179,7 @@ module.exports = [
         model: 'WXKG12LM',
         vendor: 'Xiaomi',
         description: 'Aqara wireless switch (with gyroscope)',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.action(['single', 'double', 'hold', 'release', 'shake']), e.battery_voltage()],
         fromZigbee: [fz.xiaomi_battery, fz.xiaomi_multistate_action, fz.legacy.WXKG12LM_action_click_multistate],
         toZigbee: [],
@@ -189,7 +189,7 @@ module.exports = [
         model: 'WXKG03LM_rev1',
         vendor: 'Xiaomi',
         description: 'Aqara single key wireless wall switch (2016 model)',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.action(['single']), e.battery_voltage()],
         fromZigbee: [fz.xiaomi_on_off_action, fz.xiaomi_battery, fz.legacy.WXKG03LM_click],
         toZigbee: [],
@@ -200,7 +200,7 @@ module.exports = [
         model: 'WXKG03LM_rev2',
         vendor: 'Xiaomi',
         description: 'Aqara single key wireless wall switch (2018 model)',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.action(['single', 'double', 'hold']), e.battery_voltage()],
         fromZigbee: [fz.xiaomi_on_off_action, fz.xiaomi_multistate_action, fz.xiaomi_battery,
             fz.legacy.WXKG03LM_click, fz.legacy.xiaomi_action_click_multistate],
@@ -218,7 +218,7 @@ module.exports = [
             e.action(['single', 'double', 'hold']),
             e.battery_voltage()],
         onEvent: preventReset,
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             try {
                 const endpoint = device.endpoints[1];
@@ -233,7 +233,7 @@ module.exports = [
         model: 'WXKG02LM_rev1',
         vendor: 'Xiaomi',
         description: 'Aqara double key wireless wall switch (2016 model)',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.action(['single_left', 'single_right', 'single_both']), e.battery_voltage()],
         fromZigbee: [fz.xiaomi_on_off_action, fz.xiaomi_battery, fz.legacy.WXKG02LM_click],
         toZigbee: [],
@@ -244,7 +244,7 @@ module.exports = [
         model: 'WXKG02LM_rev2',
         vendor: 'Xiaomi',
         description: 'Aqara double key wireless wall switch (2018 model)',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.action(['single_left', 'single_right', 'single_both', 'double_left', 'double_right', 'double_both',
             'hold_left', 'hold_right', 'hold_both']), e.battery_voltage()],
         fromZigbee: [fz.xiaomi_on_off_action, fz.xiaomi_multistate_action, fz.xiaomi_battery,
@@ -537,7 +537,7 @@ module.exports = [
         model: 'WXKG07LM',
         vendor: 'Xiaomi',
         description: 'Aqara D1 double key wireless wall switch',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.legacy.xiaomi_on_off_action, fz.legacy.xiaomi_multistate_action],
         toZigbee: [],
         endpoint: (device) => {
@@ -814,7 +814,7 @@ module.exports = [
         model: 'WSDCGQ01LM',
         vendor: 'Xiaomi',
         description: 'MiJia temperature & humidity sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.WSDCGQ01LM_WSDCGQ11LM_interval, fz.xiaomi_temperature, fz.humidity],
         toZigbee: [],
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
@@ -824,7 +824,7 @@ module.exports = [
         model: 'WSDCGQ11LM',
         vendor: 'Xiaomi',
         description: 'Aqara temperature, humidity and pressure sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.xiaomi_temperature, fz.humidity, fz.pressure, fz.WSDCGQ01LM_WSDCGQ11LM_interval],
         toZigbee: [],
         exposes: [e.battery(), e.temperature(), e.humidity(), e.pressure(), e.battery_voltage()],
@@ -840,7 +840,7 @@ module.exports = [
         description: 'Aqara T1 temperature, humidity and pressure sensor',
         fromZigbee: [fz.xiaomi_battery, fz.temperature, fz.humidity, fz.pressure],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const binds = ['msTemperatureMeasurement', 'msRelativeHumidity', 'msPressureMeasurement'];
@@ -853,7 +853,7 @@ module.exports = [
         model: 'RTCGQ01LM',
         vendor: 'Xiaomi',
         description: 'MiJia human body movement sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.occupancy_with_timeout],
         toZigbee: [],
         exposes: [e.battery(), e.occupancy(), e.battery_voltage()],
@@ -863,7 +863,7 @@ module.exports = [
         model: 'RTCGQ11LM',
         vendor: 'Xiaomi',
         description: 'Aqara human body movement and illuminance sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.occupancy_with_timeout, fz.RTCGQ11LM_illuminance, fz.RTCGQ11LM_interval],
         toZigbee: [],
         exposes: [e.battery(), e.occupancy(), e.temperature(), e.battery_voltage(), e.illuminance_lux().withProperty('illuminance'),
@@ -879,7 +879,7 @@ module.exports = [
         exposes: [e.occupancy(), e.illuminance().withUnit('lx').withDescription('Measured illuminance in lux'),
             exposes.numeric('detection_interval', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
                 .withDescription('Time interval for detecting actions'), e.battery()],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read('genPowerCfg', ['batteryVoltage']);
@@ -897,7 +897,7 @@ module.exports = [
         exposes: [e.occupancy(), exposes.enum('motion_sensitivity', ea.ALL, ['low', 'medium', 'high']),
             exposes.numeric('detection_interval', ea.ALL).withValueMin(2).withValueMax(65535).withUnit('s')
                 .withDescription('Time interval for detecting actions'), e.battery()],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read('genPowerCfg', ['batteryVoltage']);
@@ -935,7 +935,7 @@ module.exports = [
         model: 'MCCGQ01LM',
         vendor: 'Xiaomi',
         description: 'MiJia door & window contact sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.xiaomi_contact],
         toZigbee: [],
         exposes: [e.battery(), e.contact(), e.battery_voltage()],
@@ -945,7 +945,7 @@ module.exports = [
         model: 'MCCGQ11LM',
         vendor: 'Xiaomi',
         description: 'Aqara door & window contact sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.xiaomi_contact, fz.xiaomi_contact_interval],
         toZigbee: [],
         exposes: [e.battery(), e.contact(), e.temperature(), e.battery_voltage()],
@@ -959,7 +959,7 @@ module.exports = [
         model: 'SJCGQ11LM',
         vendor: 'Xiaomi',
         description: 'Aqara water leak sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.ias_water_leak_alarm_1, fz.SJCGQ11LM_temperature],
         toZigbee: [],
         exposes: [e.battery(), e.water_leak(), e.battery_low(), e.battery_voltage(), e.temperature()],
@@ -969,7 +969,7 @@ module.exports = [
         model: 'SJCGQ12LM',
         vendor: 'Xiaomi',
         description: 'Aqara T1 water leak sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.ias_water_leak_alarm_1],
         toZigbee: [],
         exposes: [e.battery(), e.water_leak(), e.battery_low(), e.tamper(), e.battery_voltage()],
@@ -980,7 +980,7 @@ module.exports = [
         model: 'MFKZQ01LM',
         vendor: 'Xiaomi',
         description: 'Mi/Aqara smart home cube',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.MFKZQ01LM_action_multistate, fz.MFKZQ01LM_action_analog],
         exposes: [e.battery(), e.battery_voltage(), e.angle('action_angle'),
             e.cube_side('action_from_side'), e.cube_side('action_side'), e.cube_side('action_to_side'),
@@ -1138,7 +1138,7 @@ module.exports = [
         model: 'JTYJ-GD-01LM/BW',
         description: 'MiJia Honeywell smoke detector',
         vendor: 'Xiaomi',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.JTYJGD01LMBW_smoke, fz.JTYJGD01LMBW_smoke_density],
         toZigbee: [tz.JTQJBF01LMBW_JTYJGD01LMBW_sensitivity, tz.JTQJBF01LMBW_JTYJGD01LMBW_selfest],
         exposes: [
@@ -1208,7 +1208,7 @@ module.exports = [
         model: 'DJT11LM',
         vendor: 'Xiaomi',
         description: 'Aqara vibration sensor',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_battery, fz.DJT11LM_vibration],
         toZigbee: [tz.DJT11LM_vibration_sensitivity],
         exposes: [
@@ -1380,7 +1380,7 @@ module.exports = [
         ]), exposes.enum('operation_mode', ea.ALL, ['command', 'event'])
             .withDescription('Operation mode, select "command" to enable bindings (wake up the device before changing modes!)')],
         toZigbee: [tz.aqara_opple_operation_mode],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.write('aqaraOpple', {'mode': 1}, {manufacturerCode: 0x115f});
@@ -1402,7 +1402,7 @@ module.exports = [
         ]), exposes.enum('operation_mode', ea.ALL, ['command', 'event'])
             .withDescription('Operation mode, select "command" to enable bindings (wake up the device before changing modes!)')],
         toZigbee: [tz.aqara_opple_operation_mode],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.write('aqaraOpple', {'mode': 1}, {manufacturerCode: 0x115f});
@@ -1428,7 +1428,7 @@ module.exports = [
         ]), exposes.enum('operation_mode', ea.ALL, ['command', 'event'])
             .withDescription('Operation mode, select "command" to enable bindings (wake up the device before changing modes!)')],
         toZigbee: [tz.aqara_opple_operation_mode],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.write('aqaraOpple', {'mode': 1}, {manufacturerCode: 0x115f});
@@ -1444,7 +1444,7 @@ module.exports = [
         description: 'MiJia light intensity sensor',
         fromZigbee: [fz.battery, fz.illuminance],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'msIlluminanceMeasurement']);
@@ -1596,7 +1596,7 @@ module.exports = [
         description: 'Aqara wireless remote switch H1 (double rocker)',
         fromZigbee: [fz.battery, fz.xiaomi_multistate_action, fz.aqara_opple, fz.command_toggle],
         toZigbee: [tz.xiaomi_switch_click_mode, tz.aqara_opple_operation_mode],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}, multiEndpoint: true},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}, multiEndpoint: true},
         exposes: [
             e.battery(), e.battery_voltage(), e.action([
                 'single_left', 'single_right', 'single_both',
@@ -1683,7 +1683,7 @@ module.exports = [
         description: 'Aqara TVOC air quality monitor',
         fromZigbee: [fz.xiaomi_tvoc, fz.battery, fz.temperature, fz.humidity],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.temperature(), e.humidity(), e.voc()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -1762,7 +1762,7 @@ module.exports = [
         model: 'WXKG13LM',
         vendor: 'Xiaomi',
         description: 'Aqara T1 wireless mini switch',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.battery, fz.aqara_opple_multistate, fz.aqara_opple],
         toZigbee: [],
         exposes: [e.battery(), e.battery_voltage(), e.action(['single', 'double', 'triple', 'quintuple', 'hold', 'release', 'many'])],
@@ -1778,7 +1778,7 @@ module.exports = [
         description: 'Aqara T1 light intensity sensor',
         fromZigbee: [fz.battery, fz.illuminance, fz.aqara_opple],
         toZigbee: [tz.GZCGQ11LM_detection_period],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.battery_voltage(), e.illuminance(), e.illuminance_lux(),
             exposes.numeric('detection_period', exposes.access.ALL).withValueMin(1).withValueMax(59).withUnit('s')
                 .withDescription('Time interval in seconds to report after light changes')],
@@ -1817,7 +1817,7 @@ module.exports = [
         description: 'Aqara T1 door & window contact sensor',
         fromZigbee: [fz.xiaomi_contact, fz.battery],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.contact(), e.battery(), e.battery_voltage()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -1846,7 +1846,7 @@ module.exports = [
         model: 'ZNXNKG02LM',
         vendor: 'Xiaomi',
         description: 'Aqara knob H1 (wireless)',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.battery_voltage(),
             e.action(['single', 'double', 'hold', 'release', 'start_rotating', 'rotation', 'stop_rotating']),
             exposes.enum('operation_mode', ea.ALL, ['event', 'command']).withDescription('Button mode'),
@@ -1884,7 +1884,7 @@ module.exports = [
         model: 'WXKG17LM',
         vendor: 'Xiaomi',
         description: 'Aqara E1 double key wireless switch',
-        meta: {battery: {voltageToPercentage: '3V_2850_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.battery(), e.battery_voltage(),
             e.action(['single_left', 'single_right', 'single_both', 'double_left', 'double_right', 'hold_left', 'hold_right']),
             // eslint-disable-next-line max-len

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,7 +94,7 @@ function calibrateAndPrecisionRoundOptions(number, options, type) {
     return precisionRound(number, precision);
 }
 
-function toPercentage(value, min, max) {
+function toPercentage(value, min, max, log=false) {
     if (value > max) {
         value = max;
     } else if (value < min) {
@@ -102,7 +102,12 @@ function toPercentage(value, min, max) {
     }
 
     const normalised = (value - min) / (max - min);
-    return Math.round(normalised * 100);
+    if (log == true) {
+        percentage = normalised * (1 - Math.log( normalised ));
+    } else {
+        percentage = normalised ;
+    }
+    return Math.round(percentage * 100);
 }
 
 function addActionGroup(payload, msg, definition) {
@@ -163,6 +168,8 @@ function batteryVoltageToPercentage(voltage, option) {
         percentage = Math.round(percentage);
     } else if (option === '3V_2850_3200') {
         percentage = toPercentage(voltage, 2850, 3200);
+    } else if (option === '3V_2850_3000_log') {
+        percentage = toPercentage(voltage, 2850, 3000, true);
     } else if (option === '4LR6AA1_5v') {
         percentage = toPercentage(voltage, 3000, 4200);
     } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,10 +102,11 @@ function toPercentage(value, min, max, log=false) {
     }
 
     const normalised = (value - min) / (max - min);
+    let percentage;
     if (log == true) {
-        percentage = normalised * (1 - Math.log( normalised ));
+        percentage = normalised === 0 ? 0 : normalised * (1 - Math.log( normalised ));
     } else {
-        percentage = normalised ;
+        percentage = normalised;
     }
     return Math.round(percentage * 100);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 const index = require('../index');
 const exposes = require('../lib/exposes');
+const utils = require('../lib/utils');
 const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
 const equals = require('fast-deep-equal/es6');
 const fs = require('fs');
@@ -491,5 +492,14 @@ describe('index.js', () => {
             const content = fs.readFileSync(`devices/${file}`, {encoding: 'utf-8'});
             expect(content).not.toContain(`require('zigbee-herdsman-converters`);
         }
+    });
+
+    it('Test to percentage', () => {
+        expect(utils.toPercentage(3000, 2850, 3200, true)).toBe(79);
+        expect(utils.toPercentage(3200, 2850, 3200, true)).toBe(100);
+        expect(utils.toPercentage(4000, 2850, 3200, true)).toBe(100);
+        expect(utils.toPercentage(2000, 2850, 3200, true)).toBe(0);
+        expect(utils.toPercentage(2850, 2850, 3200, true)).toBe(0);
+        expect(utils.toPercentage(2851, 2850, 3200, true)).toBe(2);
     });
 });


### PR DESCRIPTION
for Issue #8499

- add a log boolean parameter to function toPercentage to select a logarithm or linear percentage result (default)
- create a new option type 3V_2850_3000_log
- use this option type for xiaomi batteries end devices
