### PR TITLE
added Gledopto G95

### DIFF
--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -672,4 +672,11 @@ module.exports = [
         description: 'Zigbee 3.0 smart home switch',
         extend: gledoptoExtend.switch(),
     },
+    {
+        zigbeeModel: ['GL-B-004P'], 
+        model: 'GL-B-004P',
+        vendor: 'Gledopto',
+        description: 'Gledopto Filament LED Light Bulb E27 G95 7W Pro',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495]}),
+    },
 ];

--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -676,7 +676,7 @@ module.exports = [
         zigbeeModel: ['GL-B-004P'],
         model: 'GL-B-004P',
         vendor: 'Gledopto',
-        description: 'Gledopto Filament LED Light Bulb E27 G95 7W Pro',
+        description: 'Filament LED light bulb E27 G95 7W pro',
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495]}),
     },
 ];

--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -673,7 +673,7 @@ module.exports = [
         extend: gledoptoExtend.switch(),
     },
     {
-        zigbeeModel: ['GL-B-004P'], 
+        zigbeeModel: ['GL-B-004P'],
         model: 'GL-B-004P',
         vendor: 'Gledopto',
         description: 'Gledopto Filament LED Light Bulb E27 G95 7W Pro',


### PR DESCRIPTION
Hi,

I added this bulb to the vendor file.

https://www.auto-homes.com/spd/GL-B-004P/Gledopto-Filament-LED-Light-Bulb-E27-G95-7W-Pro-Zi

I am not sure how to add the documentation file: Can I just copy the file of a similar bulb and change the model and picture? I don't know all the settings/options of this bulb so I don't know how to get this right.