### PR TITLE
Add support for action group for trust remote

### DIFF
--- a/devices/trust.js
+++ b/devices/trust.js
@@ -26,7 +26,7 @@ module.exports = [
         vendor: 'Trust',
         description: 'Remote control',
         fromZigbee: [fz.command_on, fz.command_off_with_effect, fz.legacy.ZYCT202_stop, fz.legacy.ZYCT202_up_down],
-        exposes: [e.action(['on', 'off', 'stop', 'brightness_stop', 'brightness_move_up', 'brightness_move_down'])],
+        exposes: [e.action(['on', 'off', 'stop', 'brightness_stop', 'brightness_move_up', 'brightness_move_down']), e.action_group()],
         toZigbee: [],
         // Device does not support battery: https://github.com/Koenkk/zigbee2mqtt/issues/5928
     },

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -503,6 +503,7 @@ module.exports = {
     presets: {
         ac_frequency: () => new Numeric('ac_frequency', access.STATE).withUnit('Hz').withDescription('Measured electrical AC frequency'),
         action: (values) => new Enum('action', access.STATE, values).withDescription('Triggered action (e.g. a button click)'),
+        action_group: (values) => new Numeric('action_group', access.STATE).withDescription('Group where the action was triggered on'),
         angle: (name) => new Numeric(name, access.STATE).withValueMin(-360).withValueMax(360).withUnit('°'),
         angle_axis: (name) => new Numeric(name, access.STATE).withValueMin(-90).withValueMax(90).withUnit('°'),
         aqi: () => new Numeric('aqi', access.STATE).withDescription('Air quality index'),


### PR DESCRIPTION
I would like to add support for the action group property of the full state of the device:
{
    "linkquality": 33,
    "action": "",
    "action_group": 150,
    "action_rate": 30
}
This value will change depending on the current selected group on the remote and will allow controlling individual lights as well as all lights. Contains value 145 .... 150, where 150 is all groups