### PR TITLE
Add Waxman 8850100/leakSMART Valve 2.0

### DIFF
--- a/devices/waxman.js
+++ b/devices/waxman.js
@@ -30,7 +30,7 @@ module.exports = [
         // 8850310 2"
         model: '8850100',
         vendor: 'Waxman',
-        description: 'leakSMART Automatic Water Shut-off Valve 2.0',
+        description: 'leakSMART automatic water shut-off valve 2.0',
         fromZigbee: [fz.battery, fz.on_off],
         toZigbee: [tz.on_off],
         exposes: [e.battery(), e.switch()],

--- a/devices/waxman.js
+++ b/devices/waxman.js
@@ -1,5 +1,6 @@
 const exposes = require('../lib/exposes');
 const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 const e = exposes.presets;
 
@@ -17,6 +18,28 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'haApplianceEventsAlerts', 'msTemperatureMeasurement']);
             await reporting.batteryPercentageRemaining(endpoint);
             await reporting.temperature(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['House Water Valve - MDL-TBD'],
+        // Should work with all manufacturer model numbers for the 2.0 series:
+        // 8850000 3/4"
+        // 8850100 1"
+        // 8850200 1-1/4"
+        // 8850300 1-1/2"
+        // 8850310 2"
+        model: '8850100',
+        vendor: 'Waxman',
+        description: 'leakSMART Automatic Water Shut-off Valve 2.0',
+        fromZigbee: [fz.battery, fz.on_off],
+        toZigbee: [tz.on_off],
+        exposes: [e.battery(), e.switch()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'haApplianceEventsAlerts', 'genOnOff']);
+            await reporting.onOff(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.batteryVoltage(endpoint);
         },
     },
 ];


### PR DESCRIPTION
Docs are here: https://github.com/Koenkk/zigbee2mqtt.io/pull/1269

I tested this locally with the 8850100 I have, but in theory it should work for all other models as well and I doubt they identify themselves differently.