### PR TITLE
invert door status for _TZE200_nklqjk62

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1819,7 +1819,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
         },
         exposes: [exposes.binary('trigger', ea.STATE_SET, true, false).withDescription('Trigger the door movement'),
-            exposes.binary('garage_door_contact', ea.STATE, true, false)],
+            exposes.binary('garage_door_contact', ea.STATE, false, true)],
     },
     {
         fingerprint: [{modelID: 'TS0201', manufacturerName: '_TZ3000_qaaysllp'}],


### PR DESCRIPTION
inverted status reported - becouse garage_door: on means open, off means closed (ie door_contact = TRUE should be "closed")

still we needs to customize home assistant device class for this device - this should be done somehow in homeassistant.ts