### PR TITLE
Add HCHP Rate

### DIFF
--- a/devices/lixee.js
+++ b/devices/lixee.js
@@ -504,7 +504,7 @@ function getCurrentConfig(device, options, logger=console) {
         break;
     case linkyMode == linkyModeDef.standard && tarifsDef.stand_HPHC.currentTarf:
         myExpose = myExpose.filter((a) => !tarifsDef.stand_HPHC.excluded.includes(a.exposes.name));
-        break;            
+        break;
     default:
         break;
     }

--- a/devices/lixee.js
+++ b/devices/lixee.js
@@ -271,6 +271,33 @@ const tarifsDef = {
             'PJOURF+1',
             'PPOINTE1',
         ]},
+    stand_HPHC: {fname: 'Standard - Heure Pleine Heure Creuse',
+        currentTarf: 'H PLEINE/CREUSE', excluded: [
+            'EASF03',
+            'EASF04',
+            'EASF05',
+            'EASF06',
+            'EASF07',
+            'EASF08',
+            'EASF09',
+            'EASF10',
+            'EASD02',
+            'EASD03',
+            'EASD04',
+            'DPM1',
+            'DPM2',
+            'DPM3',
+            'FPM1',
+            'FPM2',
+            'FPM3',
+            'NJOURF',
+            'NJOURF+1',
+            'PJOURF+1',
+            'PPOINTE1',
+
+        ]},
+
+
 };
 
 const linkyModeDef = {
@@ -478,6 +505,9 @@ function getCurrentConfig(device, options, logger=console) {
     case linkyMode == linkyModeDef.standard && tarifsDef.stand_SEM_WE_MERCR.currentTarf:
         myExpose = myExpose.filter((a) => !tarifsDef.stand_SEM_WE_MERCR.excluded.includes(a.exposes.name));
         break;
+    case linkyMode == linkyModeDef.standard && tarifsDef.stand_HPHC.currentTarf:
+        myExpose = myExpose.filter((a) => !tarifsDef.stand_HPHC.excluded.includes(a.exposes.name));
+        break;            
     default:
         break;
     }

--- a/devices/lixee.js
+++ b/devices/lixee.js
@@ -294,10 +294,7 @@ const tarifsDef = {
             'NJOURF+1',
             'PJOURF+1',
             'PPOINTE1',
-
         ]},
-
-
 };
 
 const linkyModeDef = {


### PR DESCRIPTION
Add HCHP Rate

```
{
    "active_enerfy_out_d01": 7327.651,
    "active_enerfy_out_d02": 6184,
    "active_power": 310,
    "active_power_max": 974,
    "active_power_max_ph_b": 1100,
    "active_power_max_ph_c": 986,
    "active_power_ph_b": 390,
    "apparent_power": 235,
    "apparent_power_ph_b": 95,
    "apparent_power_ph_c": 98,
    "available_power": 9,
    "average_rms_voltage_meas_period": 237,
    "average_rms_voltage_meas_period_ph_c": 235,
    "average_rms_voltage_measure_period_ph_b": 230,
    "current_date": "H220302075330",
    "current_index_tarif": 2,
    "current_price": "HEURE PLEINE",
    "current_summ_delivered": 13511.803,
    "current_tarif": "H PLEINE/CREUSE",
    "current_tier10_summ_delivered": 0,
    "current_tier1_summ_delivered": 6246.159,
    "current_tier2_summ_delivered": 7265.644,
    "current_tier3_summ_delivered": 0,
    "current_tier4_summ_delivered": 0,
    "current_tier5_summ_delivered": 0,
    "current_tier6_summ_delivered": 0,
    "current_tier7_summ_delivered": 0,
    "current_tier8_summ_delivered": 0,
    "current_tier9_summ_delivered": 0,
    "drawn_v_a_max_n1": 1064,
    "drawn_v_a_max_n1_p2": 3115,
    "drawn_v_a_max_n1_p3": 2451,
    "last_seen": "2022-03-03T10:07:18+01:00",
    "linkquality": 114,
    "message1": "PAS DE MESSAGE",
    "message2": "",
    "meter_serial_number": "HIDE",
    "power_threshold": 9,
    "rms_current": 1,
    "rms_current_max": 65535,
    "rms_current_max_ph_b": 65535,
    "rms_current_max_ph_c": 65535,
    "rms_current_ph_b": 1,
    "rms_current_ph_c": 1,
    "rms_voltage": 240,
    "rms_voltage_ph_b": 235,
    "rms_voltage_ph_c": 235,
    "site_id": "HIDE",
    "software_revision": 2,
    "status_register": "HIDE",
    "tomorrow_color": "",
    "update": {
        "state": "idle"
    },
    "update_available": false
}
```

I don't know if I have filled everything in correctly.

@vk496 if you can check the code