### PR TITLE
Adapt LLKZMK11LM to new firmware and refactor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -20,6 +20,7 @@ const constants = require('../lib/constants');
 const libColor = require('../lib/color');
 const utils = require('../lib/utils');
 const exposes = require('../lib/exposes');
+const xiaomi = require('../lib/xiaomi');
 
 const converters = {
     // #region Generic/recommended converters
@@ -5266,6 +5267,25 @@ const converters = {
             }
         },
     },
+    xiaomi_basic_raw: {
+        cluster: 'genBasic',
+        type: ['raw'],
+        options: (definition) => {
+            const result = [];
+            if (definition.exposes.find((e) => e.name === 'temperature')) {
+                result.push(exposes.options.precision('temperature'), exposes.options.calibration('temperature'));
+            }
+            return result;
+        },
+        convert: (model, msg, publish, options, meta) => {
+            let payload = {};
+            if (Buffer.isBuffer(msg.data)) {
+                const dataObject = xiaomi.buffer2DataObject(meta, model, msg.data);
+                payload = xiaomi.numericAttributes2Payload(msg, meta, model, options, dataObject);
+            }
+            return payload;
+        },
+    },
     aqara_opple: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -5280,226 +5300,7 @@ const converters = {
             return result;
         },
         convert: (model, msg, publish, options, meta) => {
-            const payload = {};
-            if (msg.data.hasOwnProperty('247')) {
-                const data = msg.data['247'];
-                // Xiaomi struct parsing
-                const length = data.length;
-                for (let i=0; i < length; i++) {
-                    const index = data[i];
-                    let value = null;
-                    switch (data[i+1]) {
-                    case 16:
-                        // 0x10 ZclBoolean
-                        value = data.readUInt8(i+2);
-                        i += 2;
-                        break;
-                    case 32:
-                        // 0x20 Zcl8BitUint
-                        value = data.readUInt8(i+2);
-                        i += 2;
-                        break;
-                    case 33:
-                        // 0x21 Zcl16BitUint
-                        value = data.readUInt16LE(i+2);
-                        i += 3;
-                        break;
-                    case 34:
-                        // 0x22 Zcl24BitUint
-                        value = data.readUIntLE(i+2, 3);
-                        i += 4;
-                        break;
-                    case 35:
-                        // 0x23 Zcl32BitUint
-                        value = data.readUInt32LE(i+2);
-                        i += 5;
-                        break;
-                    case 36:
-                        // 0x24 Zcl40BitUint
-                        value = data.readUIntLE(i+2, 5);
-                        i += 6;
-                        break;
-                    case 37:
-                        // 0x25 Zcl48BitUint
-                        value = data.readUIntLE(i+2, 6);
-                        i += 7;
-                        break;
-                    case 38:
-                        // 0x26 Zcl56BitUint
-                        value = data.readUIntLE(i+2, 7);
-                        i += 8;
-                        break;
-                    case 39:
-                        // 0x27 Zcl64BitUint
-                        value = data.readBigUInt64BE(i+2);
-                        i += 9;
-                        break;
-                    case 40:
-                        // 0x28 Zcl8BitInt
-                        value = data.readInt8(i+2);
-                        i += 2;
-                        break;
-                    case 41:
-                        // 0x29 Zcl16BitInt
-                        value = data.readInt16LE(i+2);
-                        i += 3;
-                        break;
-                    case 42:
-                        // 0x2A Zcl24BitInt
-                        value = data.readIntLE(i+2, 3);
-                        i += 4;
-                        break;
-                    case 43:
-                        // 0x2B Zcl32BitInt
-                        value = data.readInt32LE(i+2);
-                        i += 5;
-                        break;
-                    case 44:
-                        // 0x2C Zcl40BitInt
-                        value = data.readIntLE(i+2, 5);
-                        i += 6;
-                        break;
-                    case 45:
-                        // 0x2D Zcl48BitInt
-                        value = data.readIntLE(i+2, 6);
-                        i += 7;
-                        break;
-                    case 46:
-                        // 0x2E Zcl56BitInt
-                        value = data.readIntLE(i+2, 7);
-                        i += 8;
-                        break;
-                    case 47:
-                        // 0x2F Zcl64BitInt
-                        value = data.readBigInt64BE(i+2);
-                        i += 9;
-                        break;
-                    case 57:
-                        // 0x39 ZclSingleFloat
-                        value = data.readFloatLE(i+2);
-                        i += 5;
-                        break;
-                    case 58:
-                        // 0x3a ZclDoubleFloat
-                        value = data.readDoubleLE(i+2);
-                        i += 5;
-                        break;
-                    default:
-                        if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: unknown vtype=${data[i+1]}, pos=${i+1}`);
-                    }
-
-                    if (index == 1) {
-                        payload.voltage = value;
-                        payload.battery = batteryVoltageToPercentage(value, '3V_2100');
-                    } else if (index === 3) {
-                        if (!['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
-                            payload.temperature = calibrateAndPrecisionRoundOptions(value, options, 'temperature'); // 0x03
-                        }
-                    } else if (index === 5) {
-                        if (['JT-BZ-01AQ/A', 'RTCZCGQ11LM'].includes(model.model)) payload.power_outage_count = value;
-                    } else if (index === 100) {
-                        if (['QBKG20LM', 'QBKG31LM', 'QBKG39LM', 'QBKG41LM', 'QBCZ15LM'].includes(model.model)) {
-                            const mapping = model.model === 'QBCZ15LM' ? 'relay' : 'left';
-                            payload[`state_${mapping}`] = value === 1 ? 'ON' : 'OFF';
-                        } else if (['WXKG14LM', 'WXKG16LM', 'WXKG17LM'].includes(model.model)) {
-                            payload.click_mode = {1: 'fast', 2: 'multi'}[value];
-                        } else if (['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
-                            // We don't know what the value means for these devices.
-                            // https://github.com/Koenkk/zigbee2mqtt/issues/11126
-                        } else {
-                            payload.state = value === 1 ? 'ON' : 'OFF';
-                        }
-                    } else if (index === 101) {
-                        if (['QBKG20LM', 'QBKG31LM', 'QBKG39LM', 'QBKG41LM', 'QBCZ15LM'].includes(model.model)) {
-                            const mapping = model.model === 'QBCZ15LM' ? 'usb' : 'right';
-                            payload[`state_${mapping}`] = value === 1 ? 'ON' : 'OFF';
-                        } else if (['QBKG25LM', 'QBKG34LM'].includes(model.model)) {
-                            payload.state_center = value === 1 ? 'ON' : 'OFF';
-                        } else if (['RTCGQ12LM'].includes(model.model)) {
-                            payload.illuminance = calibrateAndPrecisionRoundOptions(value, options, 'illuminance');
-                        } else if (['ZNJLBL01LM'].includes(model.model)) {
-                            payload.battery = value;
-                        }
-                    } else if (index ===102 ) {
-                        if (['QBKG25LM', 'QBKG34LM'].includes(model.model)) {
-                            payload.state_right = value === 1 ? 'ON' : 'OFF';
-                        } else if (['RTCZCGQ11LM'].includes(model.model)) {
-                            payload.presence_event = {0: 'enter', 1: 'leave', 2: 'left_enter', 3: 'right_leave', 4: 'right_enter',
-                                5: 'left_leave', 6: 'approach', 7: 'away', 255: null}[value];
-                        }
-                    } else if (index === 103) {
-                        if (['RTCZCGQ11LM'].includes(model.model)) payload.monitoring_mode = value === 1 ? 'left_right' : 'undirected';
-                    } else if (index === 105) {
-                        if (['RTCGQ13LM'].includes(model.model)) {
-                            payload.motion_sensitivity = {1: 'low', 2: 'medium', 3: 'high'}[value];
-                        } else if (['RTCZCGQ11LM'].includes(model.model)) {
-                            payload.approach_distance = {0: 'far', 1: 'medium', 2: 'near'}[value];
-                        }
-                    } else if (index === 149) {
-                        payload.energy = precisionRound(value, 2); // 0x95
-                        // Consumption is deprecated
-                        payload.consumption = payload.energy;
-                    } else if (index === 150) payload.voltage = precisionRound(value * 0.1, 1); // 0x96
-                    else if (index === 151) payload.current = precisionRound(value * 0.001, 4); // 0x97
-                    else if (index === 152) payload.power = precisionRound(value, 2); // 0x98
-                    else if (index === 159) payload.gas_sensitivity = {1: '15%LEL', 2: '10%LEL'}[value]; // JT-BZ-01AQ/A
-                    else if (index === 160) payload.gas = value === 1; // JT-BZ-01AQ/A
-                    else if (index === 161) payload.gas_density = value; // JT-BZ-01AQ/A
-                    else if (index === 162) payload.test = value === 1; // JT-BZ-01AQ/A
-                    else if (index === 163) payload.mute = value === 1; // JT-BZ-01AQ/A
-                    else if (index === 164) payload.state = value === 1 ? 'preparation' : 'work'; // JT-BZ-01AQ/A
-                    else if (index === 166) payload.linkage_alarm = value === 1; // JT-BZ-01AQ/A
-                    else if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: unknown index ${index} with value ${value}`);
-                }
-            }
-
-            if (msg.data.hasOwnProperty('0')) payload.detection_period = msg.data['0'];
-            if (msg.data.hasOwnProperty('2')) {
-                if (['JT-BZ-01AQ/A'].includes(model.model)) payload.power_outage_count = msg.data['2'];
-            }
-            if (msg.data.hasOwnProperty('4')) payload.mode_switch = {4: 'anti_flicker_mode', 1: 'quick_mode'}[msg.data['4']];
-            if (msg.data.hasOwnProperty('10')) payload.switch_type = {1: 'toggle', 2: 'momentary'}[msg.data['10']];
-            if (msg.data.hasOwnProperty('240')) payload.flip_indicator_light = msg.data['240'] === 1 ? 'ON' : 'OFF';
-            if (msg.data.hasOwnProperty('258')) payload.detection_interval = msg.data['258'];
-            if (msg.data.hasOwnProperty('268')) {
-                if (['RTCGQ13LM'].includes(model.model)) {
-                    payload.motion_sensitivity = {1: 'low', 2: 'medium', 3: 'high'}[msg.data['268']];
-                } else if (['JT-BZ-01AQ/A'].includes(model.model)) {
-                    payload.gas_sensitivity = {1: '15%LEL', 2: '10%LEL'}[msg.data['268']];
-                }
-            }
-            if (msg.data.hasOwnProperty('293')) payload.click_mode = {1: 'fast', 2: 'multi'}[msg.data['293']];
-            if (msg.data.hasOwnProperty('294')) payload.mute = msg.data['294'] === 1; // JT-BZ-01AQ/A
-            if (msg.data.hasOwnProperty('295')) payload.test = msg.data['295'] === 1; // JT-BZ-01AQ/A
-            if (msg.data.hasOwnProperty('313')) payload.state = msg.data['313'] === 1 ? 'preparation' : 'work'; // JT-BZ-01AQ/A
-            if (msg.data.hasOwnProperty('314')) payload.gas = msg.data['314'] === 1; // JT-BZ-01AQ/A
-            if (msg.data.hasOwnProperty('315')) payload.gas_density = msg.data['315']; // JT-BZ-01AQ/A
-            if (msg.data.hasOwnProperty('322')) payload.presence = msg.data['322'] === 1; // RTCZCGQ11LM
-            if (msg.data.hasOwnProperty('323')) {
-                payload.presence_event = {0: 'enter', 1: 'leave', 2: 'left_enter', 3: 'right_leave', 4: 'right_enter',
-                    5: 'left_leave', 6: 'approach', 7: 'away'}[msg.data['323']]; // RTCZCGQ11LM
-            }
-            // RTCZCGQ11LM
-            if (msg.data.hasOwnProperty('324')) payload.monitoring_mode = msg.data['324'] === 1 ? 'left_right' : 'undirected';
-            // RTCZCGQ11LM
-            if (msg.data.hasOwnProperty('326')) payload.approach_distance = {0: 'far', 1: 'medium', 2: 'near'}[msg.data['326']];
-            if (msg.data.hasOwnProperty('331')) payload.linkage_alarm = msg.data['331'] === 1; // JT-BZ-01AQ/A
-            if (msg.data.hasOwnProperty('512')) {
-                if (['ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM'].includes(model.model)) {
-                    payload.button_lock = msg.data['512'] === 1 ? 'OFF' : 'ON';
-                } else {
-                    const mode = {0x01: 'control_relay', 0x00: 'decoupled'}[msg.data['512']];
-                    payload[postfixWithEndpointName('operation_mode', msg, model)] = mode;
-                }
-            }
-            if (msg.data.hasOwnProperty('513')) payload.power_outage_memory = msg.data['513'] === 1;
-            if (msg.data.hasOwnProperty('514')) payload.auto_off = msg.data['514'] === 1;
-            if (msg.data.hasOwnProperty('515')) payload.led_disabled_night = msg.data['515'] === 1;
-            if (msg.data.hasOwnProperty('519')) payload.consumer_connected = msg.data['519'] === 1;
-            if (msg.data.hasOwnProperty('523')) payload.overload_protection = precisionRound(msg.data['523'], 2);
-            if (msg.data.hasOwnProperty('550')) payload.button_switch_mode = msg.data['550'] === 1 ? 'relay_and_usb' : 'relay';
-            if (msg.data['mode'] !== undefined) payload.operation_mode = ['command', 'event'][msg.data['mode']];
-            if (msg.data.hasOwnProperty('1289')) payload.dimmer_mode = {3: 'rgbw', 1: 'dual_ct'}[msg.data['1289']];
+            const payload = xiaomi.numericAttributes2Payload(msg, meta, model, options, msg.data);
             return payload;
         },
     },

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1292,7 +1292,7 @@ module.exports = [
         model: 'LLKZMK11LM',
         vendor: 'Xiaomi',
         description: 'Aqara wireless relay controller',
-        fromZigbee: [fz.xiaomi_switch_basic, fz.xiaomi_power, fz.ignore_multistate_report, fz.on_off, fz.aqara_opple],
+        fromZigbee: [fz.xiaomi_switch_basic, fz.xiaomi_power, fz.ignore_multistate_report, fz.on_off, fz.xiaomi_basic_raw],
         meta: {multiEndpoint: true},
         toZigbee: [tz.on_off, tz.LLKZMK11LM_interlock, tz.xiaomi_power],
         endpoint: (device) => {

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -1,0 +1,374 @@
+'use strict';
+
+const {
+    batteryVoltageToPercentage,
+    calibrateAndPrecisionRoundOptions,
+    postfixWithEndpointName,
+    precisionRound,
+} = require('./utils');
+
+const buffer2DataObject = (meta, model, buffer) => {
+    const dataObject = {};
+
+    if (buffer !== null && Buffer.isBuffer(buffer)) {
+        // Xiaomi struct parsing
+        for (let i = 0; i < buffer.length - 1; i++) {
+            const index = buffer[i];
+            let value = null;
+
+            switch (buffer[i + 1]) {
+            case 16:
+            case 32:
+                // 0x10 ZclBoolean
+                // 0x20 Zcl8BitUint
+                value = buffer.readUInt8(i + 2);
+                i += 2;
+                break;
+            case 33:
+                // 0x21 Zcl16BitUint
+                value = buffer.readUInt16LE(i + 2);
+                i += 3;
+                break;
+            case 34:
+                // 0x22 Zcl24BitUint
+                value = buffer.readUIntLE(i + 2, 3);
+                i += 4;
+                break;
+            case 35:
+                // 0x23 Zcl32BitUint
+                value = buffer.readUInt32LE(i + 2);
+                i += 5;
+                break;
+            case 36:
+                // 0x24 Zcl40BitUint
+                value = buffer.readUIntLE(i + 2, 5);
+                i += 6;
+                break;
+            case 37:
+                // 0x25 Zcl48BitUint
+                value = buffer.readUIntLE(i + 2, 6);
+                i += 7;
+                break;
+            case 38:
+                // 0x26 Zcl56BitUint
+                value = buffer.readUIntLE(i + 2, 7);
+                i += 8;
+                break;
+            case 39:
+                // 0x27 Zcl64BitUint
+                value = buffer.readBigUInt64BE(i + 2);
+                i += 9;
+                break;
+            case 40:
+                // 0x28 Zcl8BitInt
+                value = buffer.readInt8(i + 2);
+                i += 2;
+                break;
+            case 41:
+                // 0x29 Zcl16BitInt
+                value = buffer.readInt16LE(i + 2);
+                i += 3;
+                break;
+            case 42:
+                // 0x2A Zcl24BitInt
+                value = buffer.readIntLE(i + 2, 3);
+                i += 4;
+                break;
+            case 43:
+                // 0x2B Zcl32BitInt
+                value = buffer.readInt32LE(i+2);
+                i += 5;
+                break;
+            case 44:
+                // 0x2C Zcl40BitInt
+                value = buffer.readIntLE(i + 2, 5);
+                i += 6;
+                break;
+            case 45:
+                // 0x2D Zcl48BitInt
+                value = buffer.readIntLE(i + 2, 6);
+                i += 7;
+                break;
+            case 46:
+                // 0x2E Zcl56BitInt
+                value = buffer.readIntLE(i + 2, 7);
+                i += 8;
+                break;
+            case 47:
+                // 0x2F Zcl64BitInt
+                value = buffer.readBigInt64BE(i + 2);
+                i += 9;
+                break;
+            case 57:
+                // 0x39 ZclSingleFloat
+                value = buffer.readFloatLE(i + 2);
+                i += 5;
+                break;
+            case 58:
+                // 0x3a ZclDoubleFloat
+                value = buffer.readDoubleLE(i + 2);
+                i += 5;
+                break;
+            case 66:
+                // 0x42 unknown, length taken from what seems correct in the logs, maybe is wrong
+                if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: unknown vtype=${buffer[i+1]}, pos=${i+1}, moving length 1`);
+                i += 2;
+                break;
+            case 95:
+                // 0x5f unknown, length taken from what seems correct in the logs, maybe is wrong
+                if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: unknown vtype=${buffer[i+1]}, pos=${i+1}, moving length 4`);
+                i += 5;
+                break;
+            default:
+                if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: unknown vtype=${buffer[i + 1]}, pos=${i + 1}`);
+            }
+
+            if (value != null) {
+                dataObject[index] = value;
+            }
+        }
+    }
+
+    if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: Processed buffer into data ${JSON.stringify(dataObject)}`);
+
+    return dataObject;
+};
+
+const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
+    let payload = {};
+
+    Object.entries(dataObject).forEach(([key, value]) => {
+        switch (key) {
+        case '0':
+            payload.detection_period = value;
+            break;
+        case '1':
+            payload.voltage = value;
+            payload.battery = batteryVoltageToPercentage(value, '3V_2100');
+            break;
+        case '2':
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.power_outage_count = value;
+            }
+            break;
+        case '3':
+            if (!['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
+                payload.temperature = calibrateAndPrecisionRoundOptions(value, options, 'temperature'); // 0x03
+            }
+            break;
+        case '4':
+            payload.mode_switch = {4: 'anti_flicker_mode', 1: 'quick_mode'}[value];
+            break;
+        case '5':
+            if (['JT-BZ-01AQ/A', 'RTCZCGQ11LM'].includes(model.model)) {
+                payload.power_outage_count = value;
+            }
+            break;
+        case '10':
+            payload.switch_type = {1: 'toggle', 2: 'momentary'}[value];
+            break;
+        case '100':
+            if (['QBKG20LM', 'QBKG31LM', 'QBKG39LM', 'QBKG41LM', 'QBCZ15LM', 'LLKZMK11LM'].includes(model.model)) {
+                let mapping;
+                switch (model.model) {
+                case 'QBCZ15LM':
+                    mapping = 'relay';
+                    break;
+                case 'LLKZMK11LM':
+                    mapping = 'l1';
+                    break;
+                default:
+                    mapping = 'left';
+                }
+                payload[`state_${mapping}`] = value === 1 ? 'ON' : 'OFF';
+            } else if (['WXKG14LM', 'WXKG16LM', 'WXKG17LM'].includes(model.model)) {
+                payload.click_mode = {1: 'fast', 2: 'multi'}[value];
+            } else if (['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
+                // We don't know what the value means for these devices.
+                // https://github.com/Koenkk/zigbee2mqtt/issues/11126
+            } else {
+                payload.state = value === 1 ? 'ON' : 'OFF';
+            }
+            break;
+        case '101':
+            if (['QBKG20LM', 'QBKG31LM', 'QBKG39LM', 'QBKG41LM', 'QBCZ15LM', 'QBKG25LM', 'QBKG34LM', 'LLKZMK11LM']
+                .includes(model.model)) {
+                let mapping;
+                switch (model.model) {
+                case 'QBCZ15LM':
+                    mapping = 'usb';
+                    break;
+                case 'QBKG25LM':
+                case 'QBKG34LM':
+                    mapping = 'center';
+                    break;
+                case 'LLKZMK11LM':
+                    mapping = 'l2';
+                    break;
+                default:
+                    mapping = 'right';
+                }
+                payload[`state_${mapping}`] = value === 1 ? 'ON' : 'OFF';
+            } else if (['RTCGQ12LM'].includes(model.model)) {
+                payload.illuminance = calibrateAndPrecisionRoundOptions(value, options, 'illuminance');
+            } else if (['ZNJLBL01LM'].includes(model.model)) {
+                payload.battery = value;
+            }
+            break;
+        case '102':
+            if (['QBKG25LM', 'QBKG34LM'].includes(model.model)) {
+                payload.state_right = value === 1 ? 'ON' : 'OFF';
+            } else if (['RTCZCGQ11LM'].includes(model.model)) {
+                payload.presence_event = {0: 'enter', 1: 'leave', 2: 'left_enter', 3: 'right_leave', 4: 'right_enter',
+                    5: 'left_leave', 6: 'approach', 7: 'away', 255: null}[value];
+            }
+            break;
+        case '103':
+            if (['RTCZCGQ11LM'].includes(model.model)) {
+                payload.monitoring_mode = value === 1 ? 'left_right' : 'undirected';
+            }
+            break;
+        case '105':
+            if (['RTCGQ13LM'].includes(model.model)) {
+                payload.motion_sensitivity = {1: 'low', 2: 'medium', 3: 'high'}[value];
+            } else if (['RTCZCGQ11LM'].includes(model.model)) {
+                payload.approach_distance = {0: 'far', 1: 'medium', 2: 'near'}[value];
+            }
+            break;
+        case '149':
+            payload.energy = precisionRound(value, 2); // 0x95
+            // Consumption is deprecated
+            payload.consumption = payload.energy;
+            break;
+        case '150':
+            payload.voltage = precisionRound(value * 0.1, 1); // 0x96
+            break;
+        case '151':
+            payload.current = precisionRound(value * 0.001, 4); // 0x97
+            break;
+        case '152':
+            payload.power = precisionRound(value, 2); // 0x98
+            break;
+        case '159':
+            payload.gas_sensitivity = {1: '15%LEL', 2: '10%LEL'}[value]; // JT-BZ-01AQ/A
+            break;
+        case '160':
+            payload.gas = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '161':
+            payload.gas_density = value; // JT-BZ-01AQ/A
+            break;
+        case '162':
+            payload.test = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '163':
+            payload.mute = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '164':
+            payload.state = value === 1 ? 'preparation' : 'work'; // JT-BZ-01AQ/A
+            break;
+        case '166':
+            payload.linkage_alarm = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '240':
+            payload.flip_indicator_light = value === 1 ? 'ON' : 'OFF';
+            break;
+        case '247':
+            {
+                const dataObject247 = buffer2DataObject(meta, model, value);
+                const payload247 = numericAttributes2Payload(msg, meta, model, options, dataObject247);
+                payload = {...payload, ...payload247};
+            }
+            break;
+        case '258':
+            payload.detection_interval = value;
+            break;
+        case '268':
+            if (['RTCGQ13LM'].includes(model.model)) {
+                payload.motion_sensitivity = {1: 'low', 2: 'medium', 3: 'high'}[value];
+            } else if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.gas_sensitivity = {1: '15%LEL', 2: '10%LEL'}[value];
+            }
+            break;
+        case '293':
+            payload.click_mode = {1: 'fast', 2: 'multi'}[value];
+            break;
+        case '294':
+            payload.mute = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '295':
+            payload.test = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '313':
+            payload.state = value === 1 ? 'preparation' : 'work'; // JT-BZ-01AQ/A
+            break;
+        case '314':
+            payload.gas = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '315':
+            payload.gas_density = value; // JT-BZ-01AQ/A
+            break;
+        case '322':
+            payload.presence = value === 1; // RTCZCGQ11LM
+            break;
+        case '323':
+            payload.presence_event = {0: 'enter', 1: 'leave', 2: 'left_enter', 3: 'right_leave', 4: 'right_enter',
+                5: 'left_leave', 6: 'approach', 7: 'away'}[value]; // RTCZCGQ11LM
+            break;
+        case '324':
+            // RTCZCGQ11LM
+            payload.monitoring_mode = value === 1 ? 'left_right' : 'undirected';
+            break;
+        case '326':
+            // RTCZCGQ11LM
+            payload.approach_distance = {0: 'far', 1: 'medium', 2: 'near'}[value];
+            break;
+        case '331':
+            payload.linkage_alarm = value === 1; // JT-BZ-01AQ/A
+            break;
+        case '512':
+            if (['ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM'].includes(model.model)) {
+                payload.button_lock = value === 1 ? 'OFF' : 'ON';
+            } else {
+                const mode = {0x01: 'control_relay', 0x00: 'decoupled'}[value];
+                payload[postfixWithEndpointName('operation_mode', msg, model)] = mode;
+            }
+            break;
+        case '513':
+            payload.power_outage_memory = value === 1;
+            break;
+        case '514':
+            payload.auto_off = value === 1;
+            break;
+        case '515':
+            payload.led_disabled_night = value === 1;
+            break;
+        case '519':
+            payload.consumer_connected = value === 1;
+            break;
+        case '523':
+            payload.overload_protection = precisionRound(value, 2);
+            break;
+        case '550':
+            payload.button_switch_mode = value === 1 ? 'relay_and_usb' : 'relay';
+            break;
+        case '1289':
+            payload.dimmer_mode = {3: 'rgbw', 1: 'dual_ct'}[value];
+            break;
+        case 'mode':
+            payload.operation_mode = ['command', 'event'][value];
+            break;
+        default:
+            if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: unknown key ${key} with value ${value}`);
+        }
+    });
+
+    if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: Processed data into payload ${JSON.stringify(payload)}`);
+
+    return payload;
+};
+
+module.exports = {
+    buffer2DataObject,
+    numericAttributes2Payload,
+};


### PR DESCRIPTION
This fixes https://github.com/Koenkk/zigbee2mqtt/issues/7112 but I have some doubts and problems before merging it or before working more on it:

- The new "message" with the new firmware, is from a different cluster, so I added a new converter for it `xiaomi_basic_raw`.
- The converter needs a code very similar to the one of `aqara_opple`.
- The code of this converters is big, so I decided to refactor it moving to a "utility" library. I've seen there is one for Tuya so I added one for Xiaomi in the `lib/xiaomi.js` folder. I don't know if this is acceptable or not.
- This library has two methods: one to process the "raw buffer" into a more common object with attribute-value elements, and other to process this attribute numeric objects into a payload. I'm sure the refactor can be done deeply but it's a first step and I don't want this PR to be too big.

~~Here is my problem: I've tested the code with `external_converters`, and then moved into the code structure, but I'm not able to test it. I can open a bash into the docker, and replace files there, but it does not seem to work. What is the correct way to test this?~~
I think I've found a way to test it, I will report soon...