### PR TITLE
add TS0601 temperature and humidity sensor

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -108,7 +108,8 @@ module.exports = [
         },
     },
     {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_bq5c8xfe'}],
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_bq5c8xfe'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_bjawzodf'}],
         model: 'TS0601_temperature_humidity_sensor',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor',


### PR DESCRIPTION
Ref https://github.com/Koenkk/zigbee2mqtt/issues/11432, device is already in [docs](https://www.zigbee2mqtt.io/devices/TS0601_temperature_humidity_sensor.html#tuya-ts0601-temperature-humidity-sensor) with correct pic but manufacturerName is different

_TZE200_bq5c8xfe is self-standing mount
_TZE200_bjawzodf is wall-mount (duct tape)