### PR TITLE
Update hive.js

### DIFF
--- a/devices/hive.js
+++ b/devices/hive.js
@@ -291,7 +291,7 @@ module.exports = [
                 .withDescription('Period in minutes for which the setpoint hold will be active. 65535 = attribute not' +
                     ' used. 0 to 360 to match the remote display').withEndpoint('heat'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 22, 22, 1).withLocalTemperature()
-                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withEndpoint('water'),
+                .withSystemMode(['off', 'auto', 'heat', 'emergency_heating']).withRunningState(['idle', 'heat']).withEndpoint('water'),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
                     ' Must be set to `false` when system_mode = off or `true` for heat').withEndpoint('water'),
@@ -342,7 +342,7 @@ module.exports = [
                 .withDescription('Period in minutes for which the setpoint hold will be active. 65535 = attribute not' +
                     ' used. 0 to 360 to match the remote display').withEndpoint('heat'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 22, 22, 1).withLocalTemperature()
-                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withEndpoint('water'),
+                .withSystemMode(['off', 'auto', 'heat', 'emergency_heating']).withRunningState(['idle', 'heat']).withEndpoint('water'),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
                     ' Must be set to `false` when system_mode = off or `true` for heat').withEndpoint('water'),
@@ -393,7 +393,7 @@ module.exports = [
                 .withDescription('Period in minutes for which the setpoint hold will be active. 65535 = attribute not' +
                     ' used. 0 to 360 to match the remote display').withEndpoint('heat'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 22, 22, 1).withLocalTemperature()
-                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withEndpoint('water'),
+                .withSystemMode(['off', 'auto', 'heat', 'emergency_heating']).withRunningState(['idle', 'heat']).withEndpoint('water'),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
                     ' Must be set to `false` when system_mode = off or `true` for heat').withEndpoint('water'),


### PR DESCRIPTION
Added in `emergency_heating` to system mode water for SLR2/b/c devices to fix the following error which shows in Domoticz when using native MQTT device:

```
Error: Zigbee2MQTT: Climate device invalid/unknown mode received! (0x001e5e00000cd00_climate_water_zigbee2mqtt: emergency_heating)
```

system mode `emergency_heating` is shown in the MQTT message, but not currently handled:

```
MQTT publish: topic 'zigbee2mqtt/Hive Controller', payload '{"linkquality":15,"local_temperature_heat":21.38,"occupied_heating_setpoint_heat":21,"occupied_heating_setpoint_water":22,"running_state_heat":"idle","running_state_water":"idle","system_mode":"emergency_heating","system_mode_heat":"heat","system_mode_water":"off","temperature_setpoint_hold_duration_heat":65535,"temperature_setpoint_hold_duration_water":0,"temperature_setpoint_hold_heat":true,"temperature_setpoint_hold_water":false}}'
```

I think this is also a valid state for Endpoint heat too, when selecting 'Boost' of the heating from the SLT controller, but I only use this on water so have only tested on water at present