### PR TITLE
Livolo implementation of new firmware, all switches with up to 4 gangs

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2976,8 +2976,8 @@ const converters = {
                     meta.device.modelID = 'TI0001-socket';
                     meta.device.save();
                 }
-// No need to detect this switches, will be done by universal procedure
-/*                if (msg.data.includes(Buffer.from([19, 1, 0]), 13)) {
+                // No need to detect this switches, will be done by universal procedure
+                /* if (msg.data.includes(Buffer.from([19, 1, 0]), 13)) {
                     // new switch, hack
                     meta.device.modelID = 'TI0001-switch';
                     meta.device.save();

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2790,6 +2790,33 @@ const converters = {
             }
         },
     },
+    livolo_new_switch_state_4gang: {
+        cluster: 'genPowerCfg',
+        type: ['raw'],
+        convert: (model, msg, publish, options, meta) => {
+            const stateHeader = Buffer.from([122, 209]);
+            if (msg.data.indexOf(stateHeader) === 0) {
+                if (msg.data[10] === 7) {
+                    const status = msg.data[14];
+                    return {
+                        state_left: status & 1 ? 'ON' : 'OFF',
+                        state_right: status & 2 ? 'ON' : 'OFF',
+                        state_bottom_left: status & 4 ? 'ON' : 'OFF',
+                        state_bottom_right: status & 8 ? 'ON' : 'OFF',
+                    };
+                }
+                if (msg.data[10] === 13) {
+                    const status = msg.data[13];
+                    return {
+                        state_left: status & 1 ? 'ON' : 'OFF',
+                        state_right: status & 2 ? 'ON' : 'OFF',
+                        state_bottom_left: status & 4 ? 'ON' : 'OFF',
+                        state_bottom_right: status & 8 ? 'ON' : 'OFF',
+                    };
+                }
+            }
+        },
+    },
     livolo_curtain_switch_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2949,7 +2976,8 @@ const converters = {
                     meta.device.modelID = 'TI0001-socket';
                     meta.device.save();
                 }
-                if (msg.data.includes(Buffer.from([19, 1, 0]), 13)) {
+// No need to detect this switches, will be done by universal procedure
+/*                if (msg.data.includes(Buffer.from([19, 1, 0]), 13)) {
                     // new switch, hack
                     meta.device.modelID = 'TI0001-switch';
                     meta.device.save();
@@ -2958,7 +2986,7 @@ const converters = {
                     // new switch, hack
                     meta.device.modelID = 'TI0001-switch-2gang';
                     meta.device.save();
-                }
+                }*/
                 if (msg.data.includes(Buffer.from([19, 5, 0]), 13)) {
                     if (meta.logger) meta.logger.debug('Detected Livolo Curtain Switch');
                     // curtain switch, hack

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1614,7 +1614,7 @@ const converters = {
             const payloadOffBottomLeft = {0x0001: {value: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), type: 4}};
             const payloadOnBottomRight = {0x0001: {value: Buffer.from([8, 0, 0, 0, 0, 0, 0, 0]), type: 136}};
             const payloadOffBottomRight = {0x0001: {value: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), type: 136}};
-        if (postfix === 'left') {
+            if (postfix === 'left') {
                 await entity.command('genLevelCtrl', 'moveToLevelWithOnOff', {level: oldstate, transtime: channel});
                 await entity.write('genPowerCfg', (state === 'on') ? payloadOn : payloadOff,
                     {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1599,13 +1599,23 @@ const converters = {
             }
 
             const state = value.toLowerCase();
+            let oldstate = 1;
+            if (state === 'on') {
+                oldstate = 108;
+            }
+            let channel = 1.0;
             const postfix = meta.endpoint_name || 'left';
             await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
             const payloadOn = {0x0001: {value: Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]), type: 1}};
             const payloadOff = {0x0001: {value: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), type: 1}};
             const payloadOnRight = {0x0001: {value: Buffer.from([2, 0, 0, 0, 0, 0, 0, 0]), type: 2}};
             const payloadOffRight = {0x0001: {value: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), type: 2}};
-            if (postfix === 'left') {
+            const payloadOnBottomLeft = {0x0001: {value: Buffer.from([4, 0, 0, 0, 0, 0, 0, 0]), type: 4}};
+            const payloadOffBottomLeft = {0x0001: {value: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), type: 4}};
+            const payloadOnBottomRight = {0x0001: {value: Buffer.from([8, 0, 0, 0, 0, 0, 0, 0]), type: 136}};
+            const payloadOffBottomRight = {0x0001: {value: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), type: 136}};
+        if (postfix === 'left') {
+                await entity.command('genLevelCtrl', 'moveToLevelWithOnOff', {level: oldstate, transtime: channel});
                 await entity.write('genPowerCfg', (state === 'on') ? payloadOn : payloadOff,
                     {
                         manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
@@ -1613,12 +1623,28 @@ const converters = {
                     });
                 return {state: {state_left: value.toUpperCase()}, readAfterWriteTime: 250};
             } else if (postfix === 'right') {
+                channel = 2.0;
+                await entity.command('genLevelCtrl', 'moveToLevelWithOnOff', {level: oldstate, transtime: channel});
                 await entity.write('genPowerCfg', (state === 'on') ? payloadOnRight : payloadOffRight,
                     {
                         manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
                         reservedBits: 3, direction: 1, transactionSequenceNumber: 0xe9,
                     });
                 return {state: {state_right: value.toUpperCase()}, readAfterWriteTime: 250};
+            } else if (postfix === 'bottom_right') {
+                await entity.write('genPowerCfg', (state === 'on') ? payloadOnBottomRight : payloadOffBottomRight,
+                    {
+                        manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
+                        reservedBits: 3, direction: 1, transactionSequenceNumber: 0xe9,
+                    });
+                return {state: {state_bottom_right: value.toUpperCase()}, readAfterWriteTime: 250};
+            } else if (postfix === 'bottom_left') {
+                await entity.write('genPowerCfg', (state === 'on') ? payloadOnBottomLeft : payloadOffBottomLeft,
+                    {
+                        manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
+                        reservedBits: 3, direction: 1, transactionSequenceNumber: 0xe9,
+                    });
+                return {state: {state_bottom_left: value.toUpperCase()}, readAfterWriteTime: 250};
             }
             return {state: {state: value.toUpperCase()}, readAfterWriteTime: 250};
         },

--- a/devices/livolo.js
+++ b/devices/livolo.js
@@ -20,13 +20,13 @@ module.exports = [
     {
         zigbeeModel: ['TI0001          '],
         model: 'TI0001',
-        description: 'Zigbee switch (1 and 2 gang)',
+        description: 'Zigbee switch (1, 2, 3, 4 gang)',
         vendor: 'Livolo',
-        exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right')],
-        fromZigbee: [fz.livolo_switch_state, fz.livolo_switch_state_raw],
-        toZigbee: [tz.livolo_switch_on_off],
+        exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right'),e.switch().withEndpoint('bottom_left'), e.switch().withEndpoint('bottom_right')],
+        fromZigbee: [fz.livolo_switch_state, fz.livolo_switch_state_raw, fz.livolo_new_switch_state_4gang],
+        toZigbee: [tz.livolo_socket_switch_on_off],
         endpoint: (device) => {
-            return {'left': 6, 'right': 6};
+            return {'left': 6, 'right': 6, 'bottom_left':6, 'bottom_right': 6};
         },
         configure: poll,
         onEvent: async (type, data, device) => {
@@ -41,6 +41,19 @@ module.exports = [
                     globalStore.putValue(device, 'interval', interval);
                 }
             }
+            if (data.cluster === 'genPowerCfg' && data.type === 'raw') {
+                const dp = data.data[10];
+                if (data.data[0] === 0x7a && data.data[1] === 0xd1) {
+                    const endpoint = device.getEndpoint(6);
+                    if (dp === 0x01) {
+                        const options = {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
+                            reservedBits: 3, direction: 1, writeUndiv: true};
+                        const payload = {0x2002: {value: [0, 0, 0, 0, 0, 0, 0], type: 0x0e}};
+                        await endpoint.readResponse('genPowerCfg', 0xe9, payload, options);
+                    }
+                }
+            }
+
         },
     },
     {

--- a/devices/livolo.js
+++ b/devices/livolo.js
@@ -22,11 +22,16 @@ module.exports = [
         model: 'TI0001',
         description: 'Zigbee switch (1, 2, 3, 4 gang)',
         vendor: 'Livolo',
-        exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right'),e.switch().withEndpoint('bottom_left'), e.switch().withEndpoint('bottom_right')],
+        exposes: [
+            e.switch().withEndpoint('left'),
+            e.switch().withEndpoint('right'),
+            e.switch().withEndpoint('bottom_left'),
+            e.switch().withEndpoint('bottom_right'),
+        ],
         fromZigbee: [fz.livolo_switch_state, fz.livolo_switch_state_raw, fz.livolo_new_switch_state_4gang],
         toZigbee: [tz.livolo_socket_switch_on_off],
         endpoint: (device) => {
-            return {'left': 6, 'right': 6, 'bottom_left':6, 'bottom_right': 6};
+            return {'left': 6, 'right': 6, 'bottom_left': 6, 'bottom_right': 6};
         },
         configure: poll,
         onEvent: async (type, data, device) => {
@@ -53,7 +58,6 @@ module.exports = [
                     }
                 }
             }
-
         },
     },
     {


### PR DESCRIPTION
Implementation discussed and tested in Koenkk/zigbee2mqtt#8075
Also implements chages requested in Koenkk/zigbee2mqtt#11330, Koenkk/zigbee2mqtt#10568 and may help fixing https://github.com/ioBroker/ioBroker.zigbee/issues/1368

Added 2 additional gangs to TI0001 (bottom_left and bottom_right).
Added fz.livolo_new_switch_state_4gang that supports status for devices that has up to 4 gangs with firmware v2 (2020-2021) and v3 (2021-...)
Updated tz.livolo_socket_switch_on_off so it will support sending on/off commands to all livolo switches with fw v1 (EU 1 and 2 gang, vl-c70*z), v2 (insert module with up to gangs VL-FC*Z-*WP) and v3 (new modules vl-fc*z-2g, VL-C90*Z-3WG, up to 4 gangs)
Updated TI0001 onEvent trigger implementation command to finish join request on all devices with v2 and v3 firmware.