### PR TITLE
Updated fingerprint for awox remote

### DIFF
--- a/devices/awox.js
+++ b/devices/awox.js
@@ -70,11 +70,19 @@ module.exports = [
     },
     {
         fingerprint: [
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 2028, inputClusters: [0, 3, 4, 4096], outputClusters: [0, 3, 4, 5, 6, 8, 768, 4096]},
-                {ID: 3, profileID: 4751, deviceID: 2048, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-            ]},
+            {
+                type: 'EndDevice',
+                manufacturerName: 'AwoX',
+                modelID: 'TLSR82xx',
+                endpoints: [
+                    {
+                        ID: 1,
+                        groupID: 32776,
+                    },
+                ],
+            },
         ],
+        zigbeeModel: ['TLSR82xx'],
         model: '33952',
         vendor: 'AwoX',
         description: 'Remote controller',
@@ -87,24 +95,80 @@ module.exports = [
     },
     {
         fingerprint: [
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 269, inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599, 10], outputClusters: [6]},
-                {ID: 3, profileID: 4751, deviceID: 269, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-                {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
-            ]},
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 258, inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096], outputClusters: [6, 25]},
-                {ID: 3, profileID: 49152, deviceID: 258, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-            ]},
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 269, inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599], outputClusters: [6]},
-                {ID: 3, profileID: 4751, deviceID: 269, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-                {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
-            ]},
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 269, inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599], outputClusters: [6]},
-                {ID: 3, profileID: 4751, deviceID: 269, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-            ]},
+            {
+                type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
+                    {
+                        ID: 1,
+                        profileID: 260,
+                        deviceID: 269,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599, 10],
+                        outputClusters: [6],
+                    },
+                    {
+                        ID: 3,
+                        profileID: 4751,
+                        deviceID: 269,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
+                    },
+                    {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
+                ],
+            },
+            {
+                type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
+                    {
+                        ID: 1,
+                        profileID: 260,
+                        deviceID: 258,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096],
+                        outputClusters: [6, 25],
+                    },
+                    {
+                        ID: 3,
+                        profileID: 49152,
+                        deviceID: 258,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
+                    },
+                ],
+            },
+            {
+                type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
+                    {
+                        ID: 1,
+                        profileID: 260,
+                        deviceID: 269,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599],
+                        outputClusters: [6],
+                    },
+                    {
+                        ID: 3,
+                        profileID: 4751,
+                        deviceID: 269,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
+                    },
+                    {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
+                ],
+            },
+            {
+                type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
+                    {
+                        ID: 1,
+                        profileID: 260,
+                        deviceID: 269,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599],
+                        outputClusters: [6],
+                    },
+                    {
+                        ID: 3,
+                        profileID: 4751,
+                        deviceID: 269,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
+                    },
+                ],
+            },
         ],
         model: '33943/33944/33946',
         vendor: 'AwoX',
@@ -113,15 +177,43 @@ module.exports = [
     },
     {
         fingerprint: [
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 268, inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599], outputClusters: [6]},
-                {ID: 3, profileID: 4751, deviceID: 268, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-            ]},
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 268, inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599], outputClusters: [6]},
-                {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
-                {ID: 3, profileID: 4751, deviceID: 268, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-            ]},
+            {
+                type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
+                    {
+                        ID: 1,
+                        profileID: 260,
+                        deviceID: 268,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599],
+                        outputClusters: [6],
+                    },
+                    {
+                        ID: 3,
+                        profileID: 4751,
+                        deviceID: 268,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
+                    },
+                ],
+            },
+            {
+                type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
+                    {
+                        ID: 1,
+                        profileID: 260,
+                        deviceID: 268,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096, 64599],
+                        outputClusters: [6],
+                    },
+                    {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
+                    {
+                        ID: 3,
+                        profileID: 4751,
+                        deviceID: 268,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
+                    },
+                ],
+            },
         ],
         model: '33957',
         vendor: 'AwoX',
@@ -130,10 +222,24 @@ module.exports = [
     },
     {
         fingerprint: [
-            {type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
-                {ID: 1, profileID: 260, deviceID: 268, inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096], outputClusters: [6, 25]},
-                {ID: 3, profileID: 49152, deviceID: 268, inputClusters: [65360, 65361], outputClusters: [65360, 65361]},
-            ]},
+            {
+                type: 'Router', manufacturerName: 'AwoX', modelID: 'TLSR82xx', endpoints: [
+                    {
+                        ID: 1,
+                        profileID: 260,
+                        deviceID: 268,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 768, 4096],
+                        outputClusters: [6, 25],
+                    },
+                    {
+                        ID: 3,
+                        profileID: 49152,
+                        deviceID: 268,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
+                    },
+                ],
+            },
         ],
         model: '33955',
         vendor: 'Eglo',

--- a/devices/awox.js
+++ b/devices/awox.js
@@ -74,10 +74,21 @@ module.exports = [
                 type: 'EndDevice',
                 manufacturerName: 'AwoX',
                 modelID: 'TLSR82xx',
+                powerSource: 'Battery',
                 endpoints: [
                     {
                         ID: 1,
-                        groupID: 32776,
+                        profileID: 260,
+                        deviceID: 2048,
+                        inputClusters: [0, 3, 4, 4096],
+                        outputClusters: [0, 3, 4, 5, 6, 8, 768, 4096],
+                    },
+                    {
+                        ID: 3,
+                        profileID: 4751,
+                        deviceID: 2048,
+                        inputClusters: [65360, 65361],
+                        outputClusters: [65360, 65361],
                     },
                 ],
             },

--- a/devices/awox.js
+++ b/devices/awox.js
@@ -82,7 +82,6 @@ module.exports = [
                 ],
             },
         ],
-        zigbeeModel: ['TLSR82xx'],
         model: '33952',
         vendor: 'AwoX',
         description: 'Remote controller',


### PR DESCRIPTION
The recently uploaded fingerprint was based on an issue on github. I didn't look, my bad (someone pasted from a light bulb in place of the remote...). I corrected it to code that works after testing it a few times. 

Unfortunately the custom endpoint broadcast frames have a minimum of one byte different at each broadcast. I don't know how to prepare an input claster to handle this kind of data.  