### PR TITLE
Expose battery & position for Qmotion blinds (HDM40PV620)

### DIFF
--- a/devices/qmotion.js
+++ b/devices/qmotion.js
@@ -3,6 +3,7 @@ const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/lega
 const tz = require('../converters/toZigbee');
 const e = exposes.presets;
 const ea = exposes.access;
+const reporting = require('../lib/reporting');
 
 module.exports = [
     {
@@ -19,8 +20,14 @@ module.exports = [
         model: 'HDM40PV620',
         vendor: 'Qmotion',
         description: 'Motorized roller blind',
-        fromZigbee: [fz.identify],
+        fromZigbee: [fz.identify, fz.cover_position_tilt, fz.battery],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        exposes: [e.cover_position()],
+        exposes: [e.cover_position(), e.battery()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.currentPositionLiftPercentage(endpoint);
+        },
     },
 ];


### PR DESCRIPTION
Exposes shade position and battery percentage as well as reporting for Qmotion HDM40PV620 shades. This change is based exactly on the contribution made in (PR/issue #2643)

I made one small addition by including the following line at the top:

`const reporting = require('../lib/reporting');`

Everything else is the same (kudos to @pabergman). With this change I can now observe battery and position values in the zigbee2mqtt UI and mqtt gateway.