### PR TITLE
Expose cover running state

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -998,7 +998,7 @@ module.exports = [
         fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
         toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options],
         exposes: [
-            e.cover_position().setAccess('position', ea.STATE_SET),
+            e.cover_position().withRunning().setAccess('position', ea.STATE_SET),
             exposes.composite('options', 'options')
                 .withFeature(exposes.numeric('motor_speed', ea.STATE_SET)
                     .withValueMin(0)

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1239,7 +1239,7 @@ module.exports = [
         vendor: 'Xiaomi',
         fromZigbee: [fz.xiaomi_curtain_position, fz.cover_position_tilt, fz.xiaomi_curtain_options],
         toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_options],
-        exposes: [e.cover_position().setAccess('state', ea.ALL)],
+        exposes: [e.cover_position().withRunning().setAccess('state', ea.ALL)],
         ota: ota.zigbeeOTA,
     },
     {
@@ -1249,7 +1249,7 @@ module.exports = [
         vendor: 'Xiaomi',
         fromZigbee: [fz.xiaomi_curtain_position, fz.cover_position_tilt, fz.xiaomi_curtain_options],
         toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_options],
-        exposes: [e.cover_position().setAccess('state', ea.ALL)],
+        exposes: [e.cover_position().withRunning().setAccess('state', ea.ALL)],
         ota: ota.zigbeeOTA,
     },
     {
@@ -1266,7 +1266,7 @@ module.exports = [
                 await device.endpoints[0].read('genAnalogOutput', ['presentValue']);
             }
         },
-        exposes: [e.cover_position().setAccess('state', ea.ALL), e.battery()],
+        exposes: [e.cover_position().withRunning().setAccess('state', ea.ALL), e.battery()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.endpoints[0];
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
@@ -1282,11 +1282,9 @@ module.exports = [
         fromZigbee: [fz.xiaomi_curtain_acn002_position, fz.xiaomi_curtain_acn002_status, fz.cover_position_tilt, fz.ignore_basic_report,
             fz.aqara_opple],
         toZigbee: [tz.xiaomi_curtain_position_state],
-        exposes: [e.cover_position().setAccess('state', ea.ALL), e.battery(),
+        exposes: [e.cover_position().withRunning().setAccess('state', ea.ALL), e.battery(),
             exposes.enum('motor_state', ea.STATE, ['declining', 'rising', 'pause', 'blocked'])
-                .withDescription('The current state of the motor.'),
-            exposes.binary('running', ea.STATE, true, false)
-                .withDescription('Whether the motor is moving or not.')],
+                .withDescription('The current state of the motor.')],
         configure: async (device, coordinatorEndpoint, logger) => {
             device.powerSource = 'Battery';
             device.save();

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -335,6 +335,12 @@ class Cover extends Base {
         this.features.push(new Numeric('tilt', access.ALL).withValueMin(0).withValueMax(100).withDescription('Tilt of this cover'));
         return this;
     }
+
+    withRunning() {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        this.features.push(new Binary('running', access.STATE, true, false).withDescription('Whether the motor is moving or not'));
+        return this;
+    }
 }
 
 class Fan extends Base {


### PR DESCRIPTION
Related PR: Koenkk/zigbee2mqtt/pull/11789

The expose added for all devices where the `running` can be present.