### PR TITLE
Fix Orvibo AM25 power source

### DIFF
--- a/devices/orvibo.js
+++ b/devices/orvibo.js
@@ -289,6 +289,8 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
             await reporting.batteryPercentageRemaining(endpoint);
             await reporting.currentPositionLiftPercentage(endpoint);
+            device.powerSource = 'Battery';
+            device.save();
         },
         exposes: [e.cover_position(), e.battery()],
     },


### PR DESCRIPTION
The battery is showing the correct value but is not recognized as a battery device.