### PR TITLE
Update hive.js

### DIFF
--- a/devices/hive.js
+++ b/devices/hive.js
@@ -275,6 +275,7 @@ module.exports = [
             await reporting.thermostatTemperatureSetpointHold(heatEndpoint);
             await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint);
             await reporting.bind(waterEndpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatTemperature(waterEndpoint);
             await reporting.thermostatRunningState(waterEndpoint);
             await reporting.thermostatSystemMode(waterEndpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint);
@@ -326,6 +327,7 @@ module.exports = [
             await reporting.thermostatTemperatureSetpointHold(heatEndpoint);
             await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint);
             await reporting.bind(waterEndpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatTemperature(waterEndpoint);
             await reporting.thermostatRunningState(waterEndpoint);
             await reporting.thermostatSystemMode(waterEndpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint);
@@ -377,6 +379,7 @@ module.exports = [
             await reporting.thermostatTemperatureSetpointHold(heatEndpoint);
             await reporting.thermostatTemperatureSetpointHoldDuration(heatEndpoint);
             await reporting.bind(waterEndpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatTemperature(waterEndpoint);
             await reporting.thermostatRunningState(waterEndpoint);
             await reporting.thermostatSystemMode(waterEndpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(waterEndpoint);


### PR DESCRIPTION
Add missing local_temperature_water value from water endpoint which generates 'climate device unhandled current_temperature_template' errors via homeassistant messages