### PR TITLE
Update tuya air housekeeper, different DP to smart air box

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4177,14 +4177,14 @@ const converters = {
             case tuya.dataPoints.tuyaSabHumidity:
                 return {humidity: calibrateAndPrecisionRoundOptions(value / 10, options, 'humidity')};
             // DP22: Smart Air Box: Formaldehyd, Smart Air Housekeeper: co2
-            case 22:
+            case tuya.dataPoints.tuyaSabFormaldehyd:
                 if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
                     return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}
                 } else {
                     return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')}
                 };
             // DP2: Smart Air Box: co2, Smart Air Housekeeper: MP25
-            case 2:
+            case tuya.dataPoints.tuyaSabCO2:
                 if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
                     return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')}
                 } else {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4171,7 +4171,7 @@ const converters = {
             const dpValue = tuya.firstDpValue(msg, meta, 'tuya_air_quality');
             const dp = dpValue.dp;
             const value = tuya.getDataValue(dpValue);
-            switch (dp)
+            switch (dp) {
             case tuya.dataPoints.tuyaSabTemp:
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             case tuya.dataPoints.tuyaSabHumidity:

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4171,8 +4171,7 @@ const converters = {
             const dpValue = tuya.firstDpValue(msg, meta, 'tuya_air_quality');
             const dp = dpValue.dp;
             const value = tuya.getDataValue(dpValue);
-            switch (dp) {
-            switch (dp) {
+            switch (dp)
             case tuya.dataPoints.tuyaSabTemp:
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             case tuya.dataPoints.tuyaSabHumidity:

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4191,6 +4191,39 @@ const converters = {
             }
         },
     },
+    tuya_air_housekeeper: {
+        cluster: 'manuSpecificTuya',
+        type: ['commandDataReport', 'commandDataResponse'],
+        options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
+            exposes.options.precision('humidity'), exposes.options.calibration('humidity'),
+            exposes.options.precision('co2'), exposes.options.calibration('co2'),
+            exposes.options.precision('voc'), exposes.options.calibration('voc'),
+            exposes.options.precision('formaldehyd'), exposes.options.calibration('formaldehyd'),
+            exposes.options.precision('pm25'), exposes.options.calibration('pm25')],
+        convert: (model, msg, publish, options, meta) => {
+            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_air_quality');
+            const dp = dpValue.dp;
+            const value = tuya.getDataValue(dpValue);
+            switch (dp) {
+            case tuya.dataPoints.tuyaSabTemp:
+                return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
+            case tuya.dataPoints.tuyaSabHumidity:
+                return {humidity: calibrateAndPrecisionRoundOptions(value / 10, options, 'humidity')};
+            case tuya.dataPoints.tuyaSahkCO2:
+                return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')};
+            case tuya.dataPoints.tuyaSabVOC:
+                return {voc: calibrateAndPrecisionRoundOptions(value, options, 'voc')};
+            case tuya.dataPoints.tuyaSahkFormaldehyd:
+                // Not sure which unit this is, supposedly mg/m³, but the value seems way too high.
+                return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')};
+            case tuya.dataPoints.tuyaSahkMP25:
+                return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')};
+            default:
+                meta.logger.warn(`zigbee-herdsman-converters:TuyaSmartAirBox: Unrecognized DP #${
+                    dp} with data ${JSON.stringify(dpValue)}`);
+            }
+        },
+    },
     tuya_CO: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4179,17 +4179,17 @@ const converters = {
             // DP22: Smart Air Box: Formaldehyd, Smart Air Housekeeper: co2
             case 22:
                 if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
-                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}}
-                else {
+                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}
+                } else {
                     return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')}
-                }
+                };
             // DP2: Smart Air Box: co2, Smart Air Housekeeper: MP25
             case 2:
                 if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
                     return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')}
                 } else {
                     return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}
-                }
+                };
             case tuya.dataPoints.tuyaSabVOC:
                 return {voc: calibrateAndPrecisionRoundOptions(value, options, 'voc')};
             case tuya.dataPoints.tuyaSahkCH2O:

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4172,52 +4172,29 @@ const converters = {
             const dp = dpValue.dp;
             const value = tuya.getDataValue(dpValue);
             switch (dp) {
-            case tuya.dataPoints.tuyaSabTemp:
-                return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
-            case tuya.dataPoints.tuyaSabHumidity:
-                return {humidity: calibrateAndPrecisionRoundOptions(value / 10, options, 'humidity')};
-            case tuya.dataPoints.tuyaSabCO2:
-                return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')};
-            case tuya.dataPoints.tuyaSabVOC:
-                return {voc: calibrateAndPrecisionRoundOptions(value, options, 'voc')};
-            case tuya.dataPoints.tuyaSabFormaldehyd:
-                // Not sure which unit this is, supposedly mg/m³, but the value seems way too high.
-                return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')};
-            case tuya.dataPoints.tuyaSahkMP25:
-                return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')};
-            default:
-                meta.logger.warn(`zigbee-herdsman-converters:TuyaSmartAirBox: Unrecognized DP #${
-                    dp} with data ${JSON.stringify(dpValue)}`);
-            }
-        },
-    },
-    tuya_air_housekeeper: {
-        cluster: 'manuSpecificTuya',
-        type: ['commandDataReport', 'commandDataResponse'],
-        options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature'),
-            exposes.options.precision('humidity'), exposes.options.calibration('humidity'),
-            exposes.options.precision('co2'), exposes.options.calibration('co2'),
-            exposes.options.precision('voc'), exposes.options.calibration('voc'),
-            exposes.options.precision('formaldehyd'), exposes.options.calibration('formaldehyd'),
-            exposes.options.precision('pm25'), exposes.options.calibration('pm25')],
-        convert: (model, msg, publish, options, meta) => {
-            const dpValue = tuya.firstDpValue(msg, meta, 'tuya_air_quality');
-            const dp = dpValue.dp;
-            const value = tuya.getDataValue(dpValue);
             switch (dp) {
             case tuya.dataPoints.tuyaSabTemp:
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             case tuya.dataPoints.tuyaSabHumidity:
                 return {humidity: calibrateAndPrecisionRoundOptions(value / 10, options, 'humidity')};
-            case tuya.dataPoints.tuyaSahkCO2:
-                return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')};
+            // DP22: Smart Air Box: Formaldehyd, Smart Air Housekeeper: co2
+            case 22:
+                if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
+                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}}
+                else {
+                    return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')}
+                }
+            // DP2: Smart Air Box: co2, Smart Air Housekeeper: MP25
+            case 2:
+                if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
+                    return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')}
+                } else {
+                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}
+                }
             case tuya.dataPoints.tuyaSabVOC:
                 return {voc: calibrateAndPrecisionRoundOptions(value, options, 'voc')};
-            case tuya.dataPoints.tuyaSahkFormaldehyd:
-                // Not sure which unit this is, supposedly mg/m³, but the value seems way too high.
+            case tuya.dataPoints.tuyaSahkCH2O:
                 return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')};
-            case tuya.dataPoints.tuyaSahkMP25:
-                return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')};
             default:
                 meta.logger.warn(`zigbee-herdsman-converters:TuyaSmartAirBox: Unrecognized DP #${
                     dp} with data ${JSON.stringify(dpValue)}`);

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4176,20 +4176,20 @@ const converters = {
                 return {temperature: calibrateAndPrecisionRoundOptions(value / 10, options, 'temperature')};
             case tuya.dataPoints.tuyaSabHumidity:
                 return {humidity: calibrateAndPrecisionRoundOptions(value / 10, options, 'humidity')};
-            // DP22: Smart Air Box: Formaldehyd, Smart Air Housekeeper: co2
+                // DP22: Smart Air Box: Formaldehyd, Smart Air Housekeeper: co2
             case tuya.dataPoints.tuyaSabFormaldehyd:
-                if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
-                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}
+                if (meta.device.manufacturerName === '_TZE200_dwcarsat') {
+                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')};
                 } else {
-                    return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')}
-                };
-            // DP2: Smart Air Box: co2, Smart Air Housekeeper: MP25
+                    return {formaldehyd: calibrateAndPrecisionRoundOptions(value, options, 'formaldehyd')};
+                }
+                // DP2: Smart Air Box: co2, Smart Air Housekeeper: MP25
             case tuya.dataPoints.tuyaSabCO2:
-                if (meta.device.manufacturerName === '_TZE200_dwcarsat'){
-                    return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')}
+                if (meta.device.manufacturerName === '_TZE200_dwcarsat') {
+                    return {pm25: calibrateAndPrecisionRoundOptions(value, options, 'pm25')};
                 } else {
-                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')}
-                };
+                    return {co2: calibrateAndPrecisionRoundOptions(value, options, 'co2')};
+                }
             case tuya.dataPoints.tuyaSabVOC:
                 return {voc: calibrateAndPrecisionRoundOptions(value, options, 'voc')};
             case tuya.dataPoints.tuyaSahkCH2O:

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -143,7 +143,7 @@ module.exports = [
         description: 'Smart air house keeper',
         fromZigbee: [fz.tuya_air_housekeeper],
         toZigbee: [],
-        exposes: [e.temperature(), e.humidity(), e.co2(), e.voc(), e.formaldehyd(), e.pm25()],
+        exposes: [e.temperature(), e.humidity(), e.co2(), e.voc(), e.formaldehyd().withUnit('ppm'), e.pm25()],
     },
     {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_7bztmfm1'}],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -141,7 +141,7 @@ module.exports = [
         model: 'TS0601_smart_air_house_keeper',
         vendor: 'TuYa',
         description: 'Smart air house keeper',
-        fromZigbee: [fz.tuya_air_quality],
+        fromZigbee: [fz.tuya_air_housekeeper],
         toZigbee: [],
         exposes: [e.temperature(), e.humidity(), e.co2(), e.voc(), e.formaldehyd(), e.pm25()],
     },

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -141,7 +141,7 @@ module.exports = [
         model: 'TS0601_smart_air_house_keeper',
         vendor: 'TuYa',
         description: 'Smart air house keeper',
-        fromZigbee: [fz.tuya_air_housekeeper],
+        fromZigbee: [fz.tuya_air_quality],
         toZigbee: [],
         exposes: [e.temperature(), e.humidity(), e.co2(), e.voc(), e.formaldehyd().withUnit('ppm'), e.pm25()],
     },

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -420,7 +420,9 @@ const dataPoints = {
     tuyaSabFormaldehyd: 22,
     // tuya Smart Air House Keeper, Multifunctionale air quality detector.
     // CO2, Temp, Humidity, VOC and Formaldehyd same as Smart Air Box
-    tuyaSahkMP25: 20,
+    tuyaSahkMP25: 2,
+    tuyaSahkCO2: 22,
+    tuyaSahkFormaldehyd: 20,
     // Tuya CO (carbon monoxide) smart air box
     tuyaSabCOalarm: 1,
     tuyaSabCO: 2,


### PR DESCRIPTION
Formaldehyd (ch2o): DP20 instead of DP22
CO2: DP22 instead of DP2
PM2.5: DP2 instead of DP20

Added unit ppm to formaldehyd (ch2o) as called in original definition from tuya:

```json
{
  "result": {
    "category": "pm2.5",
    "functions": [],
    "status": [
      {
        "code": "pm25_value",
        "dp_id": 2,
        "type": "Integer",
        "values": "{\"unit\":\"ug/m3\",\"min\":0,\"max\":999,\"scale\":0,\"step\":1}"
      },
      {
        "code": "temp_current",
        "dp_id": 18,
        "type": "Integer",
        "values": "{\"unit\":\"℃\",\"min\":0,\"max\":850,\"scale\":1,\"step\":1}"
      },
      {
        "code": "humidity_value",
        "dp_id": 19,
        "type": "Integer",
        "values": "{\"unit\":\"%\",\"min\":0,\"max\":1000,\"scale\":1,\"step\":1}"
      },
      {
        "code": "ch2o_value",
        "dp_id": 20,
        "type": "Integer",
        "values": "{\"unit\":\"ppm\",\"min\":0,\"max\":1000,\"scale\":3,\"step\":1}"
      },
      {
        "code": "voc_value",
        "dp_id": 21,
        "type": "Integer",
        "values": "{\"unit\":\"ppm\",\"min\":0,\"max\":2000,\"scale\":3,\"step\":1}"
      },
      {
        "code": "co2_value",
        "dp_id": 22,
        "type": "Integer",
        "values": "{\"unit\":\"ppm\",\"min\":350,\"max\":2000,\"scale\":0,\"step\":1}"
      }
    ]
  },
```