### PR TITLE
Exposes `battery` and `battery_voltage` for 3RSS008Z

### DIFF
--- a/devices/third_reality.js
+++ b/devices/third_reality.js
@@ -20,9 +20,10 @@ module.exports = [
         model: '3RSS008Z',
         vendor: 'Third Reality',
         description: 'RealitySwitch Plus',
-        fromZigbee: [fz.on_off],
+        fromZigbee: [fz.on_off, fz.battery],
         toZigbee: [tz.on_off, tz.ignore_transition],
-        exposes: [e.switch()],
+        meta: {battery: {voltageToPercentage: '3V_2100'}},
+        exposes: [e.switch(), e.battery(), e.battery_voltage()],
     },
     {
         zigbeeModel: ['3RSS007Z'],


### PR DESCRIPTION
The Third Reality switch 3RSS008Z was missing battery information. Confirmed the `3V_2100` voltage setting [from the ZHA quirks for this switch](https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/thirdreality/switch.py#L27).