### PR TITLE
ZLinky_TIC: add setting to allow user to filter exposed values

### DIFF
--- a/devices/lixee.js
+++ b/devices/lixee.js
@@ -509,6 +509,14 @@ function getCurrentConfig(device, options, logger=console) {
         break;
     }
 
+    // Filter exposed attributes with user whitelist
+    if (options && options.hasOwnProperty('tic_command_whitelist')) {
+        const tic_commands_str = options['tic_command_whitelist'].toUpperCase();
+        if (tic_commands_str !== 'ALL') {
+            const tic_commands = tic_commands_str.split(',').map((a) => a.trim());
+            myExpose = myExpose.filter((a) => tic_commands.includes(a.exposes.name));
+        }
+    }
 
     return myExpose;
 }
@@ -547,6 +555,7 @@ const definition = {
             .withDescription(`Overrides the automatic current tarif. This option will exclude unnecesary attributes. Open a issue to support more of them. Default: auto`),
         exposes.options.precision(`kWh`),
         exposes.numeric(`measurement_poll_chunk`, ea.SET).withValueMin(1).withDescription(`During the poll, request multiple exposes to the Zlinky at once for reducing Zigbee network overload. Too much request at once could exceed device limit. Requieres Z2M restart. Default: 1`),
+        exposes.text(`tic_command_whitelist`, ea.SET).withDescription(`List of TIC commands to be exposed (separated by comma). Reconfigure device after change. Default: all`),
     ],
     configure: async (device, coordinatorEndpoint, logger, options) => {
         const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Hello,

Device `ZLinky_TIC` can expose a lot of attributes in certain conditions (mostly users with STANDARD mode for theirs Linky energy meter). This PR adds a new setting (specific) `tic_command_whitelist` to allow user to chose the attributes (s)he wants to expose. The values are the TIC command available [here](https://github.com/fairecasoimeme/Zlinky_TIC#mode-historique). Values should be separated by comma.

@vk496, what do you think? My personal use case is that I only need 5 attributes of ~20 .


![image](https://user-images.githubusercontent.com/10107072/158067560-45ea2434-d917-4aa6-ac09-ec00b1948fad.png)
![image](https://user-images.githubusercontent.com/10107072/158067566-446c2166-d399-4063-9ba0-ed3e52558650.png)
