### PR TITLE
Add LEDVANCE AC33906

### DIFF
--- a/devices/ledvance.js
+++ b/devices/ledvance.js
@@ -60,7 +60,7 @@ module.exports = [
         model: 'AC33906',
         vendor: 'LEDVANCE',
         description: 'SMART+ spot GU10 multicolor RGBW',
-        extend: extend.ledvance.light_onoff_brightness_colortemp_color(),
+        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
         ota: ota.ledvance,
     },
     {

--- a/devices/ledvance.js
+++ b/devices/ledvance.js
@@ -56,6 +56,14 @@ module.exports = [
         ota: ota.ledvance,
     },
     {
+        zigbeeModel: ['PAR16S RGBW'],
+        model: 'AC33906',
+        vendor: 'LEDVANCE',
+        description: 'SMART+ spot GU10 multicolor RGBW',
+        extend: extend.ledvance.light_onoff_brightness_colortemp_color(),
+        ota: ota.ledvance,
+    },
+    {
         zigbeeModel: ['B40 TW Z3'],
         model: '4058075208414',
         vendor: 'LEDVANCE',


### PR DESCRIPTION
This PR adds support for the LEDVANCE AC33906 GU10 RGBW spots.

I added the product image in Koenkk/zigbee2mqtt.io#1285