### PR TITLE
Remove expose `running` for TuYa TS0601_cover

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1000,8 +1000,6 @@ module.exports = [
         toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options],
         exposes: [
             e.cover_position().setAccess('position', ea.STATE_SET),
-            exposes.binary('running', ea.STATE, true, false)
-                .withDescription('Whether the motor is moving or not'),
             exposes.composite('options', 'options')
                 .withFeature(exposes.numeric('motor_speed', ea.STATE_SET)
                     .withValueMin(0)


### PR DESCRIPTION
The `running` value on some tuya-like devices is broken and always returns `true`. Staring at Koenkk/zigbee2mqtt/pull/11789 this bug can break the curtain control interface in HA.

Based on reports: 
https://github.com/Koenkk/zigbee-herdsman-converters/pull/3975#issuecomment-1067149210
https://github.com/Koenkk/zigbee2mqtt/commit/8f1787ed4a32912ca5f5a0e2b9cc5ff8b6064fb8#commitcomment-68595849

P.S. Please take a look at #2298, may it can be fixed. I think mismatch occurred in this place:

```js
const running = dp === tuya.dataPoints.coverArrived ? false : true;
```