### PR TITLE
Fix issue with Elko power metering added in #3511

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -674,7 +674,9 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             const result = converters.metering.convert(model, msg, publish, options, meta);
-            result.power /= 1000;
+            if (result.hasOwnProperty('power')) {
+                result.power /= 1000;
+            }
             return result;
         },
     },


### PR DESCRIPTION
Fix an issue where 0W would be reported any time a device report without power reading was received

Previous pull request: https://github.com/Koenkk/zigbee-herdsman-converters/pull/3511
Issue mentioned: https://github.com/Koenkk/zigbee2mqtt/issues/7781#issuecomment-1061890264
