### PR TITLE
Add support for Philips GU10 Milliskin 929003047101

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2436,6 +2436,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['929003047101'],
+        model: '929003047101',
+        vendor: 'Philips',
+        description: 'Hue White ambiance Milliskin (round)',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['5047131P9', '5047131P6'],
         model: '5047131P9',
         vendor: 'Philips',


### PR DESCRIPTION
This MR adds support for the (new) Philips Milliskin GU10 spots with model number 929003047101.

You can see the number (929003047101) mentioned on the following page too:

https://www.philips-hue.com/nl-nl/p/hue-white-ambiance-milliskin--extra-inbouwspot/8719514338562

After adding this as an external converter it's working fine :)

See also: https://github.com/Koenkk/zigbee2mqtt.io/pull/1288

![Screenshot 2022-03-15 at 11 42 06](https://user-images.githubusercontent.com/711208/158360707-e9456676-9f7c-4b2e-b215-e50344bb4358.png)

