### PR TITLE
Create the new definition for the RB 266

### DIFF
--- a/devices/innr.js
+++ b/devices/innr.js
@@ -96,6 +96,14 @@ module.exports = [
         meta: {turnsOffAtBrightness1: true},
     },
     {
+        zigbeeModel: ['RB 266'],
+        model: 'RB 266',
+        vendor: 'Innr',
+        description: 'E27 bulb',
+        extend: extend.light_onoff_brightness(),
+        meta: {turnsOffAtBrightness1: true},
+    },
+    {
         zigbeeModel: ['RF 265'],
         model: 'RF 265',
         vendor: 'Innr',


### PR DESCRIPTION
Hello

I got today a new version of the RB 265 and I tested this definition in my local home assistant lab, got it working.
The functions are the same as the RB 265 but the model is the RB 266.