### PR TITLE
Read MCCGQ01LM contact from genBasic

### DIFF
--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -428,9 +428,12 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             }
             break;
         case '65282':
-            // This is a a complete structure with attributes, at this moment we only extract voltage
-            // Other elements like value[0].elmVal contain the "state" (for example contact for door sensor)
-            // but it seems to be always 1 for a occupancy sensor, so we ignore them at this moment
+            // This is a a complete structure with attributes, like element 0 for state, element 1 for voltage...
+            // At this moment we only extract what we are sure, for example, position 0 seems to be always 1 for a
+            // occupancy sensor, so we ignore it at this moment
+            if (['MCCGQ01LM'].includes(model.model)) {
+                payload.contact = value[0].elmVal === 0;
+            }
             payload.voltage = value[1].elmVal;
             if (model.meta && model.meta.battery && model.meta.battery.voltageToPercentage) {
                 payload.battery = batteryVoltageToPercentage(payload.voltage, model.meta.battery.voltageToPercentage);


### PR DESCRIPTION
From time to time, when I open and close my dorr, my Xiaomi door sensor detected the open but it does not detect the close action.
I suspected simply the close message was lost. But today I've captured one log in debug mode and I can see the open door, with the `genOnOff` cluster, as expected, and then, instead of another `genOnOff` with the close action, as usually, I receive the `genBasic` one with the close state.
So I added the option to detect the open/close using the `genBasic` cluster.