### PR TITLE
fixes Koenkk/zigbee2mqtt#6071

### DIFF
--- a/devices/adurosmart.js
+++ b/devices/adurosmart.js
@@ -34,7 +34,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['ZLL-ExtendedColo', 'ZLL-ExtendedColor', 'AD-RGBW3001'],
+        zigbeeModel: ['ZLL-ExtendedColo', 'ZLL-ExtendedColor'],
         model: '81809/81813',
         vendor: 'AduroSmart',
         description: 'ERIA colors and white shades smart light bulb A19/BR30',
@@ -43,6 +43,14 @@ module.exports = [
         endpoint: (device) => {
             return {'default': 2};
         },
+    },
+    {
+        zigbeeModel: ['AD-RGBW3001'],
+        model: '81809FBA',
+        vendor: 'AduroSmart',
+        description: 'ERIA colors and white shades smart light bulb A19/BR30',
+        extend: extend.light_onoff_brightness_colortemp_color({supportsHS: true, colorTempRange: [153, 500]}),
+        meta: {applyRedFix: true},
     },
     {
         zigbeeModel: ['AD-E14RGBW3001'],


### PR DESCRIPTION
Newer ERIA lights from Amazon with the zigbeeModel AD-RGBW3001 need `colorTempRange` set and support HS.