### PR TITLE
TS011F Smart Plug

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -12,7 +12,7 @@ const utils = require('../lib/utils');
 
 const TS011Fplugs = ['_TZ3000_5f43h46b', '_TZ3000_cphmq0q7', '_TZ3000_dpo1ysak', '_TZ3000_ew3ldmgx', '_TZ3000_gjnozsaz',
     '_TZ3000_jvzvulen', '_TZ3000_mraovvmm', '_TZ3000_nfnmi125', '_TZ3000_ps3dmato', '_TZ3000_w0qqde0g', '_TZ3000_u5u4cakc',
-    '_TZ3000_rdtixbnu', '_TZ3000_typdpbpg', '_TZ3000_kx0pris5', '_TZ3000_amdymr7l'];
+    '_TZ3000_rdtixbnu', '_TZ3000_typdpbpg', '_TZ3000_kx0pris5', '_TZ3000_amdymr7l', '_TZ3000_z1pnpsdo'];
 
 const tzLocal = {
     TS0504B_color: {


### PR DESCRIPTION
Hello.
Just received a zigbee 3.0 smart plug from aliexpress model TS011F with manufacturer name as '_TZ3000_z1pnpsdo'.
Created a js file to test with your TS011F_plug_3 settings, and it worked!

Smart Plug from aliexpress:
https://pt.aliexpress.com/item/1005002960622930.html?gatewayAdapt=glo2bra&spm=a2g0o.order_list.0.0.21efcaa4rcOUn4