### PR TITLE
Danfoss Ally: Add support for preheat_status, adaptation variables, regulation setpoint offset

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3392,6 +3392,23 @@ const converters = {
             if (msg.data.hasOwnProperty('danfossLoadEstimate')) {
                 result[postfixWithEndpointName('load_estimate', msg, model)] = msg.data['danfossLoadEstimate'];
             }
+            if (msg.data.hasOwnProperty('danfossPreheatStatus')) {
+                result[postfixWithEndpointName('preheat_status', msg, model)] = (msg.data['danfossPreheatStatus'] === 1);
+            }
+            if (msg.data.hasOwnProperty('danfossAdaptionRunStatus')) {
+                result[postfixWithEndpointName('adaptation_run_status', msg, model)] =
+                    constants.danfossAdaptionRunStatus[msg.data['danfossAdaptionRunStatus']];
+            }
+            if (msg.data.hasOwnProperty('danfossAdaptionRunSettings')) {
+                result[postfixWithEndpointName('adaptation_run_settings', msg, model)] = (msg.data['danfossAdaptionRunSettings'] === 1);
+            }
+            if (msg.data.hasOwnProperty('danfossAdaptionRunControl')) {
+                result[postfixWithEndpointName('adaptation_run_control', msg, model)] =
+                    constants.danfossAdaptionRunControl[msg.data['danfossAdaptionRunControl']];
+            }
+            if (msg.data.hasOwnProperty('danfossRegulationSetpointOffset')) {
+                result[postfixWithEndpointName('regulation_setpoint_offset', msg, model)] = msg.data['danfossRegulationSetpointOffset'];
+            }
             // Danfoss Icon Converters
             if (msg.data.hasOwnProperty('danfossRoomStatusCode')) {
                 result[postfixWithEndpointName('room_status_code', msg, model)] =

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2854,6 +2854,53 @@ const converters = {
             await entity.read('hvacThermostat', ['danfossLoadEstimate'], manufacturerOptions.danfoss);
         },
     },
+    danfoss_preheat_status: {
+        key: ['preheat_status'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossPreheatStatus'], manufacturerOptions.danfoss);
+        },
+    },
+    danfoss_adaptation_status: {
+        key: ['adaptation_run_status'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossAdaptionRunStatus'], manufacturerOptions.danfoss);
+        },
+    },
+    danfoss_adaptation_settings: {
+        key: ['adaptation_run_settings'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('hvacThermostat', {'danfossAdaptionRunSettings': value}, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 200, state: {'adaptation_run_settings': value}};
+        },
+
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossAdaptionRunSettings'], manufacturerOptions.danfoss);
+        },
+    },
+    danfoss_adaptation_control: {
+        key: ['adaptation_run_control'],
+        convertSet: async (entity, key, value, meta) => {
+            const payload = {'danfossAdaptionRunControl': utils.getKey(constants.danfossAdaptionRunControl, value, value, Number)};
+            await entity.write('hvacThermostat', payload, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 250, state: {'adaptation_run_control': value}};
+        },
+
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossAdaptionRunControl'], manufacturerOptions.danfoss);
+        },
+    },
+    danfoss_regulation_setpoint_offset: {
+        key: ['regulation_setpoint_offset'],
+        convertSet: async (entity, key, value, meta) => {
+            const payload = {'danfossRegulationSetpointOffset': value};
+            await entity.write('hvacThermostat', payload, manufacturerOptions.danfoss);
+            return {readAfterWriteTime: 250, state: {'regulation_setpoint_offset': value}};
+        },
+
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossRegulationSetpointOffset'], manufacturerOptions.danfoss);
+        },
+    },
     danfoss_output_status: {
         key: ['output_status'],
         convertGet: async (entity, key, meta) => {

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -82,12 +82,13 @@ module.exports = [
                 .withDescription('Load estimate on this radiator'),
             exposes.binary('preheat_status', ea.STATE_GET, true, false)
                 .withDescription('Specific for pre-heat running in Zigbee Weekly Schedule mode'),
-            exposes.enum('adaptation_run_status', ea.STATE_GET, ['None', 'In progress', 'Found', 'Lost'])
-                .withDescription('bit0=Adaptation run in progress, bit1=Valve Characteristic found, bit2=Valve Characteristic lost'),
+            exposes.enum('adaptation_run_status', ea.STATE_GET, ['none', 'in_progress', 'found', 'lost'])
+                .withDescription('Status of adaptation run: None (before first run), In Progress, Valve Characteristic Found, ' +
+                    'Valve Characteristic Lost'),
             exposes.binary('adaptation_run_settings', ea.ALL, true, false)
                 .withDescription('Automatic adaptation run enabled (the one during the night)'),
-            exposes.enum('adaptation_run_control', ea.ALL, ['None', 'Initate Adaption', 'Cancel Adaption'])
-                .withDescription('Adaptation control 1=Initiate Adaptation run 2=cancel Adaptation run'),
+            exposes.enum('adaptation_run_control', ea.ALL, ['initate_adaptation', 'cancel_adaptation'])
+                .withDescription('Adaptation run control: Initiate Adaptation Run or Cancel Adaptation Run'),
             exposes.numeric('regulation_setpoint_offset', ea.ALL)
                 .withDescription('Regulation SetPoint Offset in range -2.5°C to 2.5°C in steps of 0.1°C. Value 2.5°C = 25.')
                 .withValueMin(-25).withValueMax(25)],
@@ -129,6 +130,20 @@ module.exports = [
                 reportableChange: 1,
             }], options);
 
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'danfossPreheatStatus',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.MAX,
+                reportableChange: 1,
+            }], options);
+
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: 'danfossAdaptionRunStatus',
+                minimumReportInterval: constants.repInterval.MINUTE,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1,
+            }], options);
+
             try {
                 await endpoint.read('hvacThermostat', [
                     'danfossWindowOpenFeatureEnable',
@@ -143,6 +158,9 @@ module.exports = [
                     'danfossRadiatorCovered',
                     'danfossLoadBalancingEnable',
                     'danfossLoadRoomMean',
+                    'danfossAdaptionRunControl',
+                    'danfossAdaptionRunSettings',
+                    'danfossRegulationSetpointOffset',
                 ], options);
             } catch (e) {
                 /* not supported by all https://github.com/Koenkk/zigbee2mqtt/issues/11872 */

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -24,7 +24,8 @@ module.exports = [
             tz.danfoss_viewing_direction, tz.danfoss_external_measured_room_sensor, tz.danfoss_radiator_covered,
             tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean,
             tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_programming_operation_mode,
-            tz.danfoss_window_open_feature],
+            tz.danfoss_window_open_feature, tz.danfoss_preheat_status, tz.danfoss_adaptation_status, tz.danfoss_adaptation_settings,
+            tz.danfoss_adaptation_control, tz.danfoss_regulation_setpoint_offset],
         exposes: [e.battery(), e.keypad_lockout(), e.programming_operation_mode(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -78,7 +79,18 @@ module.exports = [
                 .withDescription('Mean radiator load for room calculated by gateway for load balancing purposes (-8000=undefined)')
                 .withValueMin(-8000).withValueMax(2000),
             exposes.numeric('load_estimate', ea.STATE_GET)
-                .withDescription('Load estimate on this radiator')],
+                .withDescription('Load estimate on this radiator'),
+            exposes.binary('preheat_status', ea.STATE_GET, true, false)
+                .withDescription('Specific for pre-heat running in Zigbee Weekly Schedule mode'),
+            exposes.enum('adaptation_run_status', ea.STATE_GET, ['None', 'In progress', 'Found', 'Lost'])
+                .withDescription('bit0=Adaptation run in progress, bit1=Valve Characteristic found, bit2=Valve Characteristic lost'),
+            exposes.binary('adaptation_run_settings', ea.ALL, true, false)
+                .withDescription('Automatic adaptation run enabled (the one during the night)'),
+            exposes.enum('adaptation_run_control', ea.ALL, ['None', 'Initate Adaption', 'Cancel Adaption'])
+                .withDescription('Adaptation control 1=Initiate Adaptation run 2=cancel Adaptation run'),
+            exposes.numeric('regulation_setpoint_offset', ea.ALL)
+                .withDescription('Regulation SetPoint Offset in range -2.5°C to 2.5°C in steps of 0.1°C. Value 2.5°C = 25.')
+                .withValueMin(-25).withValueMax(25)],
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -97,6 +97,18 @@ const temperatureDisplayMode = {
     1: 'fahrenheit',
 };
 
+const danfossAdaptationRunStatus= {
+    0: 'none',
+    1: 'in_progress',
+    2: 'found',
+    4: 'lost',
+};
+
+const danfossAdaptationRunControl = {
+    1: 'initate_adaptation',
+    2: 'cancel_adaptation',
+};
+
 const danfossWindowOpen = {
     0: 'quarantine',
     1: 'closed',
@@ -267,6 +279,8 @@ module.exports = {
     dayOfWeek,
     fanMode,
     temperatureDisplayMode,
+    danfossAdaptationRunControl,
+    danfossAdaptationRunStatus,
     danfossWindowOpen,
     danfossRoomStatusCode,
     danfossOutputStatus,


### PR DESCRIPTION
Added support for:
* regulation setpoint offset
* adaptation run control
* adaptation run status
* adaptation run settings
* preheat status

![obraz](https://user-images.githubusercontent.com/18015241/159137219-b613bc9b-a220-4e28-bd53-b2c5c9a21ccb.png)

This will allow observation of the valve behaviour and reduce the problem of "random heating" at night.
https://github.com/Koenkk/zigbee2mqtt/issues/7107#issuecomment-924796226

In case of overheating it also allows a simple change of regulation setpoint offset.