### PR TITLE
Add support for 4023331P6

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1514,6 +1514,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['4023331P6'],
+        model: '4023331P6',
+        vendor: 'Philips',
+        description: 'Hue white ambiance Amaze',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 500]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['929003054801'],
         model: '929003054801',
         vendor: 'Philips',


### PR DESCRIPTION
Hi,

I added support for my lamp (4023331P6) and this seems to work perfectly since it matches some already supported lamps.
How to proceed with getting it to the supported list and how to retrieve a 150x150 pixel image for it?

Kind regards,