### PR TITLE
Fix inverted Xiaomi Covers controls

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2446,10 +2446,7 @@ const converters = {
 
                 value = typeof value === 'string' ? value.toLowerCase() : value;
                 value = lookup.hasOwnProperty(value) ? lookup[value] : value;
-
-                if (key === 'position') {
-                    value = meta.options.invert_cover ? 100 - value : value;
-                }
+                value = meta.options.invert_cover ? 100 - value : value;
 
                 const payload = {0x0055: {value, type: 0x39}};
                 await entity.write('genAnalogOutput', payload);

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -416,7 +416,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '1028':
             payload = {...payload,
-                motor_state: (options.invert_cover ? {0: 'stopped', 1: 'closing', 2: 'opening'} : 
+                motor_state: (options.invert_cover ? {0: 'stopped', 1: 'closing', 2: 'opening'} :
                     {0: 'stopped', 1: 'opening', 2: 'closing'})[value],
                 running: !!value,
             };

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -416,7 +416,8 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '1028':
             payload = {...payload,
-                motor_state: {0: 'stopped', 1: 'opening', 2: 'closing'}[value],
+                motor_state: (options.invert_cover ? {0: 'stopped', 1: 'closing', 2: 'opening'} : 
+                    {0: 'stopped', 1: 'opening', 2: 'closing'})[value],
                 running: !!value,
             };
             break;


### PR DESCRIPTION
Xiaomi curtains are fully controlled through position and when inversion is enabled, we also need to invert the position when we send open or close. this is a bug in the current implementation, that breaks the control of curtains with buttons in HA when inverse is enabled. I don't know how people used it before :)

I also added reverse detection to `motor_state`.