### PR TITLE
Fix Xiaomi Covers position jumping on stop

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5690,6 +5690,24 @@ const converters = {
             return {position};
         },
     },
+    xiaomi_curtain_position_tilt: {
+        cluster: 'closuresWindowCovering',
+        type: ['attributeReport', 'readResponse'],
+        options: [exposes.options.invert_cover()],
+        convert: (model, msg, publish, options, meta) => {
+            const result = {};
+            const invert = model.meta && model.meta.coverInverted ? !options.invert_cover : options.invert_cover;
+            if (msg.data.hasOwnProperty('currentPositionLiftPercentage') && msg.data['currentPositionLiftPercentage'] <= 100) {
+                const value = msg.data['currentPositionLiftPercentage'];
+                result[postfixWithEndpointName('position', msg, model)] = invert ? 100 - value : value;
+            }
+            if (msg.data.hasOwnProperty('currentPositionTiltPercentage') && msg.data['currentPositionTiltPercentage'] <= 100) {
+                const value = msg.data['currentPositionTiltPercentage'];
+                result[postfixWithEndpointName('tilt', msg, model)] = invert ? 100 - value : value;
+            }
+            return result;
+        },
+    },
     xiaomi_curtain_acn002_position: {
         cluster: 'genAnalogOutput',
         type: ['attributeReport', 'readResponse'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2438,9 +2438,6 @@ const converters = {
                 } else {
                     await entity.command('closuresWindowCovering', 'stop', {}, utils.getOptions(meta.mapped, entity));
                 }
-
-                // Xiaomi curtain does not send position update on stop, request this.
-                await entity.read('genAnalogOutput', [0x0055]);
             } else {
                 const lookup = {'open': 100, 'close': 0, 'on': 100, 'off': 0};
 

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1236,7 +1236,7 @@ module.exports = [
         model: 'ZNCLDJ11LM',
         description: 'Aqara curtain motor',
         vendor: 'Xiaomi',
-        fromZigbee: [fz.xiaomi_basic, fz.xiaomi_curtain_position, fz.cover_position_tilt],
+        fromZigbee: [fz.xiaomi_basic, fz.xiaomi_curtain_position, fz.xiaomi_curtain_position_tilt],
         toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_options],
         exposes: [e.cover_position().setAccess('state', ea.ALL),
             exposes.binary('running', ea.STATE, true, false)
@@ -1250,7 +1250,7 @@ module.exports = [
         model: 'SRSC-M01',
         description: 'Aqara roller shade motor',
         vendor: 'Xiaomi',
-        fromZigbee: [fz.xiaomi_basic, fz.xiaomi_curtain_position, fz.cover_position_tilt],
+        fromZigbee: [fz.xiaomi_basic, fz.xiaomi_curtain_position, fz.xiaomi_curtain_position_tilt],
         toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_options],
         exposes: [e.cover_position().setAccess('state', ea.ALL),
             exposes.binary('running', ea.STATE, true, false)
@@ -1262,7 +1262,7 @@ module.exports = [
         model: 'ZNCLDJ12LM',
         vendor: 'Xiaomi',
         description: 'Aqara B1 curtain motor',
-        fromZigbee: [fz.xiaomi_basic, fz.xiaomi_curtain_position, fz.battery, fz.cover_position_tilt],
+        fromZigbee: [fz.xiaomi_basic, fz.xiaomi_curtain_position, fz.battery, fz.xiaomi_curtain_position_tilt],
         toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_options],
         onEvent: async (type, data, device) => {
             // The position (genAnalogOutput.presentValue) reported via an attribute contains an invaid value
@@ -1286,8 +1286,8 @@ module.exports = [
         model: 'ZNJLBL01LM',
         description: 'Aqara roller shade companion E1',
         vendor: 'Xiaomi',
-        fromZigbee: [fz.xiaomi_curtain_acn002_position, fz.xiaomi_curtain_acn002_status, fz.cover_position_tilt, fz.ignore_basic_report,
-            fz.aqara_opple],
+        fromZigbee: [fz.xiaomi_curtain_acn002_position, fz.xiaomi_curtain_acn002_status, fz.xiaomi_curtain_position_tilt,
+            fz.ignore_basic_report, fz.aqara_opple],
         toZigbee: [tz.xiaomi_curtain_position_state, tz.xiaomi_curtain_acn002_battery, tz.xiaomi_curtain_acn002_charging_status],
         exposes: [e.cover_position().setAccess('state', ea.ALL), e.battery().withAccess(ea.STATE_GET),
             exposes.binary('charging_status', ea.STATE_GET, true, false)


### PR DESCRIPTION
When the stop command is sent, the `currentPositionLiftPercentage` of the `closuresWindowCovering` cluster sending the current position of the curtains. 

The problem is that the default converter `fz.cover_position_tilt` inverses the value and sets incorrect position (xiaomi expect 'open' to be 100, 'closed' to be 0, instead Zigbee specs).

<details>
<summary>Before</summary>

![1](https://user-images.githubusercontent.com/11841379/159996079-3b224e98-b675-43b7-814f-4af03b03ea6d.gif)
</details>

<details>
<summary>After</summary>

![2](https://user-images.githubusercontent.com/11841379/159996088-0e08e739-cdec-406a-b197-f2ab7c7808dd.gif)
</details>
