### PR TITLE
 add ADEO zigbeeModel: ZBEK-13 - IG-CDZFB2AG010RA-MNZ

### DIFF
--- a/devices/adeo.js
+++ b/devices/adeo.js
@@ -14,6 +14,13 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
     {
+        zigbeeModel: ['ZBEK-13'],
+        model: 'IG-CDZFB2AG010RA-MNZ',
+        vendor: 'ADEO',
+        description: 'ENKI LEXMAN E27 LED white',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+    },
+    {
         zigbeeModel: ['ZBEK-3'],
         model: 'IP-CDZOTAAP005JA-MAN',
         vendor: 'ADEO',


### PR DESCRIPTION
Hi,
please  add the E27 75w W bulb form lexman, Enki, IG-CDZFB2AG010RA-MNZ.
https://www.leroymerlin.fr/produits/decoration-eclairage/ampoule-et-led/ampoule-led/ampoule-e27/ampoule-connectee-led-globe-95mm-e27-1055lm-75w-variation-de-blancs-lexman-84372284.html

Regards.

