### PR TITLE
Add Niko Double connectable switch

### DIFF
--- a/devices/niko.js
+++ b/devices/niko.js
@@ -77,7 +77,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['Single connectable switch,10A'],
-        model: '552-72101',
+        model: '552-721X1',
         vendor: 'Niko',
         description: 'Single connectable switch',
         fromZigbee: [fz.on_off],
@@ -89,6 +89,29 @@ module.exports = [
         },
         exposes: [
             e.switch(),
+        ],
+    },
+    {
+        zigbeeModel: ['Double connectable switch,10A'],
+        model: '552-721X2',
+        vendor: 'Niko',
+        description: 'Double connectable switch',
+        fromZigbee: [fz.on_off],
+        toZigbee: [tz.on_off],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const ep1 = device.getEndpoint(1);
+            const ep2 = device.getEndpoint(2);
+            await reporting.bind(ep1, coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(ep2, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(ep1);
+            await reporting.onOff(ep2);
+        },
+        exposes: [
+            e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
         ],
     },
 ];


### PR DESCRIPTION
Also brought the model naming in line with the manual for the single connectable switch, they use X in the 2nd to last model number spot as that one changes depending on if it has clamped or screw mount.

Unfortunately, I was also able to verify that both are rather spares in features. You can't even rebind them switch to toggle a group/device like with the Ubisys S1/S2 and some Aqara devices.

I'll try to figure out a docs PR for this later and mention the fact that they can't be rebound which is probably a deal breaker for some people.