### PR TITLE
Add E17 variant of LED1925G6

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -746,7 +746,7 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness_colortemp_color({colorTempRange: [250, 454]}),
     },
     {
-        zigbeeModel: ['TRADFRI bulb E14 CWS 470lm', 'TRADFRI bulb E12 CWS 450lm'],
+        zigbeeModel: ['TRADFRI bulb E14 CWS 470lm', 'TRADFRI bulb E12 CWS 450lm', 'TRADFRI bulb E17 CWS 440lm'],
         model: 'LED1925G6',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E14 470 lumen, opal, dimmable, white spectrum, color spectrum',


### PR DESCRIPTION
I recently bought an E17 variant of LED1925G6.
The pre-exist converter for the other variants also works for the E17.

https://www.ikea.com/jp/en/p/tradfri-led-bulb-e17-440-lumen-wireless-dimmable-colour-and-white-spectrum-globe-opal-white-10439203/
https://www.ikea.com/jp/en/manuals/tradfri-led-bulb-e17-440-lumen-wireless-dimmable-colour-and-white-spectrum-globe-opal-white__AA-2302838-2-100.pdf