### PR TITLE
Add support for `JY-GZ-01AQ` and improve `JT-BZ-01AQ/A`

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2584,14 +2584,14 @@ const converters = {
             await entity.write('ssIasZone', {0xFFF1: {value: 0x03010000, type: 0x23}}, options);
         },
     },
-    JTBZ01AQA_gas: {
-        key: ['gas'],
+    aqara_alarm: {
+        key: ['gas', 'smoke'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x013a], manufacturerOptions.xiaomi);
         },
     },
-    JTBZ01AQA_gas_density: {
-        key: ['gas_density'],
+    aqara_density: {
+        key: ['gas_density', 'smoke_density'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x013b], manufacturerOptions.xiaomi);
         },
@@ -2608,26 +2608,39 @@ const converters = {
             await entity.read('aqaraOpple', [0x010c], manufacturerOptions.xiaomi);
         },
     },
-    JTBZ01AQA_selftest: {
+    aqara_selftest: {
         key: ['selftest'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('aqaraOpple', {0x0127: {value: true, type: 0x10}}, manufacturerOptions.xiaomi);
         },
     },
-    JTBZ01AQA_mute_buzzer: {
+    aqara_mute_buzzer: {
         key: ['mute_buzzer'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('aqaraOpple', {0x013f: {value: 15360, type: 0x23}}, manufacturerOptions.xiaomi);
+            let attribute = 0x013f;
+            if (['JY-GZ-01AQ'].includes(meta.mapped.model)) attribute = 0x013e;
+            await entity.write('aqaraOpple', {[`${attribute}`]: {value: 15360, type: 0x23}}, manufacturerOptions.xiaomi);
             await entity.write('aqaraOpple', {0x0126: {value: 1, type: 0x20}}, manufacturerOptions.xiaomi);
         },
     },
-    JTBZ01AQA_mute: {
+    aqara_mute: {
         key: ['mute'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0126], manufacturerOptions.xiaomi);
         },
     },
-    JTBZ01AQA_linkage_alarm: {
+    JYGZ01AQ_heartbeat_indicator: {
+        key: ['heartbeat_indicator'],
+        convertSet: async (entity, key, value, meta) => {
+            const lookup = {true: 1, false: 0};
+            await entity.write('aqaraOpple', {0x013c: {value: lookup[value], type: 0x20}}, manufacturerOptions.xiaomi);
+            return {state: {heartbeat_indicator: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('aqaraOpple', [0x013c], manufacturerOptions.xiaomi);
+        },
+    },
+    aqara_linkage_alarm: {
         key: ['linkage_alarm'],
         convertSet: async (entity, key, value, meta) => {
             const lookup = {true: 1, false: 0};

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1170,9 +1170,9 @@ module.exports = [
         vendor: 'Xiaomi',
         description: 'Aqara smart natural gas detector',
         fromZigbee: [fz.aqara_opple],
-        toZigbee: [tz.JTBZ01AQA_gas, tz.JTBZ01AQA_gas_density, tz.JTBZ01AQA_gas_sensitivity, tz.JTBZ01AQA_selftest,
-            tz.JTBZ01AQA_mute_buzzer, tz.JTBZ01AQA_mute, tz.JTBZ01AQA_linkage_alarm, tz.JTBZ01AQA_state, tz.aqara_power_outage_count],
-        exposes: [e.gas().withAccess(ea.STATE_GET), e.power_outage_count().withAccess(ea.STATE_GET),
+        toZigbee: [tz.aqara_alarm, tz.aqara_density, tz.JTBZ01AQA_gas_sensitivity, tz.aqara_selftest, tz.aqara_mute_buzzer,
+            tz.aqara_mute, tz.aqara_linkage_alarm, tz.JTBZ01AQA_state, tz.aqara_power_outage_count],
+        exposes: [e.gas().withAccess(ea.STATE_GET),
             exposes.numeric('gas_density', ea.STATE_GET).withUnit('%LEL').withDescription('Value of gas concentration'),
             exposes.enum('gas_sensitivity', ea.ALL, ['10%LEL', '15%LEL']).withDescription('Gas concentration value at which ' +
                 'an alarm is triggered ("10%LEL" is more sensitive than "15%LEL")'),
@@ -1186,7 +1186,7 @@ module.exports = [
                 'is detected, other detectors with this option enabled will also sound the alarm buzzer'),
             exposes.binary('state', ea.STATE_GET, 'preparation', 'work').withDescription('"Preparation" or "work" ' +
                 '(measurement of the gas concentration value and triggering of an alarm are only performed in the "work" state)'),
-        ],
+            e.power_outage_count().withAccess(ea.STATE_GET)],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read('aqaraOpple', [0x013a], {manufacturerCode: 0x115f});
@@ -1196,6 +1196,40 @@ module.exports = [
             await endpoint.read('aqaraOpple', [0x010c], {manufacturerCode: 0x115f});
             await endpoint.read('aqaraOpple', [0x014b], {manufacturerCode: 0x115f});
             await endpoint.read('aqaraOpple', [0x0002], {manufacturerCode: 0x115f});
+        },
+        ota: ota.zigbeeOTA,
+    },
+    {
+        zigbeeModel: ['lumi.sensor_smoke.acn03'],
+        model: 'JY-GZ-01AQ',
+        vendor: 'Xiaomi',
+        description: 'Aqara smart smoke detector',
+        fromZigbee: [fz.aqara_opple, fz.battery],
+        toZigbee: [tz.aqara_alarm, tz.aqara_density, tz.aqara_selftest, tz.aqara_mute_buzzer, tz.aqara_mute,
+            tz.JYGZ01AQ_heartbeat_indicator, tz.aqara_linkage_alarm],
+        exposes: [e.smoke().withAccess(ea.STATE_GET),
+            exposes.numeric('smoke_density', ea.STATE_GET).withDescription('Value of smoke concentration'),
+            exposes.numeric('smoke_density_dbm', ea.STATE).withUnit('dB/m').withDescription('Value of smoke concentration in dB/m'),
+            exposes.enum('selftest', ea.SET, ['Test']).withDescription('Starts the self-test process (checking the indicator ' +
+                'light and buzzer work properly)'),
+            exposes.binary('test', ea.STATE, true, false).withDescription('Self-test in progress'),
+            exposes.enum('mute_buzzer', ea.SET, ['Mute']).withDescription('Mute the buzzer for 80 seconds (buzzer cannot be ' +
+                'pre-muted, because this function only works when the alarm is triggered)'),
+            exposes.binary('mute', ea.STATE_GET, true, false).withDescription('Buzzer muted'),
+            exposes.binary('heartbeat_indicator', ea.ALL, true, false).withDescription('When this option is enabled then in ' +
+                'the normal monitoring state, the green indicator light flashes every 60 seconds'),
+            exposes.binary('linkage_alarm', ea.ALL, true, false).withDescription('When this option is enabled and a smoke ' +
+                'is detected, other detectors with this option enabled will also sound the alarm buzzer'),
+            e.temperature(), e.battery()],
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('genPowerCfg', ['batteryVoltage']);
+            await endpoint.read('aqaraOpple', [0x013a], {manufacturerCode: 0x115f});
+            await endpoint.read('aqaraOpple', [0x013b], {manufacturerCode: 0x115f});
+            await endpoint.read('aqaraOpple', [0x013c], {manufacturerCode: 0x115f});
+            await endpoint.read('aqaraOpple', [0x0126], {manufacturerCode: 0x115f});
+            await endpoint.read('aqaraOpple', [0x014b], {manufacturerCode: 0x115f});
         },
         ota: ota.zigbeeOTA,
     },

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -308,9 +308,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '160':
             if (['JT-BZ-01AQ/A'].includes(model.model)) {
-                 payload.gas = value === 1;
+                payload.gas = value === 1;
             } else if (['JY-GZ-01AQ'].includes(model.model)) {
-                 payload.smoke = value === 1;
+                payload.smoke = value === 1;
             }
             break;
         case '161':
@@ -389,9 +389,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '314':
             if (['JT-BZ-01AQ/A'].includes(model.model)) {
-                 payload.gas = value === 1;
+                payload.gas = value === 1;
             } else if (['JY-GZ-01AQ'].includes(model.model)) {
-                 payload.smoke = value === 1;
+                payload.smoke = value === 1;
             }
             break;
         case '315':

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -174,9 +174,11 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             payload.switch_type = {1: 'toggle', 2: 'momentary'}[value];
             break;
         case '11':
-            payload.illuminance = calibrateAndPrecisionRoundOptions(value, options, 'illuminance');
-            // DEPRECATED: remove illuminance_lux here.
-            payload.illuminance_lux = calibrateAndPrecisionRoundOptions(value, options, 'illuminance_lux');
+            if (!['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.illuminance = calibrateAndPrecisionRoundOptions(value, options, 'illuminance');
+                // DEPRECATED: remove illuminance_lux here.
+                payload.illuminance_lux = calibrateAndPrecisionRoundOptions(value, options, 'illuminance_lux');
+            }
             break;
         case '100':
             if (['QBKG20LM', 'QBKG31LM', 'QBKG39LM', 'QBKG41LM', 'QBCZ15LM', 'LLKZMK11LM', 'QBKG12LM', 'QBKG03LM'].includes(model.model)) {
@@ -300,25 +302,52 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             }
             break;
         case '159':
-            payload.gas_sensitivity = {1: '15%LEL', 2: '10%LEL'}[value]; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.gas_sensitivity = {1: '15%LEL', 2: '10%LEL'}[value];
+            }
             break;
         case '160':
-            payload.gas = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                 payload.gas = value === 1;
+            } else if (['JY-GZ-01AQ'].includes(model.model)) {
+                 payload.smoke = value === 1;
+            }
             break;
         case '161':
-            payload.gas_density = value; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.gas_density = value;
+            } else if (['JY-GZ-01AQ'].includes(model.model)) {
+                payload.smoke_density = value;
+                payload.smoke_density_dbm = {0: 0, 1: 0.085, 2: 0.088, 3: 0.093, 4: 0.095, 5: 0.100, 6: 0.105, 7: 0.110,
+                    8: 0.115, 9: 0.120, 10: 0.125}[value];
+            }
             break;
         case '162':
-            payload.test = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A', 'JY-GZ-01AQ'].includes(model.model)) {
+                payload.test = value === 1;
+            }
             break;
         case '163':
-            payload.mute = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A', 'JY-GZ-01AQ'].includes(model.model)) {
+                payload.mute = value === 1;
+            }
             break;
         case '164':
-            payload.state = value === 1 ? 'preparation' : 'work'; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.state = {0: 'work', 1: 'preparation'}[value];
+            } else if (['JY-GZ-01AQ'].includes(model.model)) {
+                payload.heartbeat_indicator = value === 1;
+            }
+            break;
+        case '165':
+            if (['JY-GZ-01AQ'].includes(model.model)) {
+                payload.linkage_alarm = value === 1;
+            }
             break;
         case '166':
-            payload.linkage_alarm = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.linkage_alarm = value === 1;
+            }
             break;
         case '240':
             payload.flip_indicator_light = value === 1 ? 'ON' : 'OFF';
@@ -344,19 +373,40 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             payload.click_mode = {1: 'fast', 2: 'multi'}[value];
             break;
         case '294':
-            payload.mute = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A', 'JY-GZ-01AQ'].includes(model.model)) {
+                payload.mute = value === 1;
+            }
             break;
         case '295':
-            payload.test = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A', 'JY-GZ-01AQ'].includes(model.model)) {
+                payload.test = value === 1;
+            }
             break;
         case '313':
-            payload.state = value === 1 ? 'preparation' : 'work'; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.state = {0: 'work', 1: 'preparation'}[value];
+            }
             break;
         case '314':
-            payload.gas = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                 payload.gas = value === 1;
+            } else if (['JY-GZ-01AQ'].includes(model.model)) {
+                 payload.smoke = value === 1;
+            }
             break;
         case '315':
-            payload.gas_density = value; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.gas_density = value;
+            } else if (['JY-GZ-01AQ'].includes(model.model)) {
+                payload.smoke_density = value;
+                payload.smoke_density_dbm = {0: 0, 1: 0.085, 2: 0.088, 3: 0.093, 4: 0.095, 5: 0.100, 6: 0.105, 7: 0.110,
+                    8: 0.115, 9: 0.120, 10: 0.125}[value];
+            }
+            break;
+        case '316':
+            if (['JY-GZ-01AQ'].includes(model.model)) {
+                payload.heartbeat_indicator = value === 1;
+            }
             break;
         case '322':
             if (['RTCZCGQ11LM'].includes(model.model)) {
@@ -380,7 +430,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             }
             break;
         case '331':
-            payload.linkage_alarm = value === 1; // JT-BZ-01AQ/A
+            if (['JT-BZ-01AQ/A', 'JY-GZ-01AQ'].includes(model.model)) {
+                payload.linkage_alarm = value === 1;
+            }
             break;
         case '512':
             if (['ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM'].includes(model.model)) {


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#11986

This converter is designed to work on coordinator firmware with support for native Aqara logic.

OTA file for `JY-GZ-01AQ` added with Koenkk/zigbee-OTA#101