### PR TITLE
First stage of additional changes to Centralite pearl thermostat.

### DIFF
--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -170,12 +170,14 @@ module.exports = [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_cooling_setpoint,
             tz.thermostat_setpoint_raise_lower, tz.thermostat_remote_sensing,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
-            tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state],
+            tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state, tz.thermostat_running_mode],
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 10, 30, 1).withLocalTemperature()
             .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
             .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
             .withSetpoint('occupied_cooling_setpoint', 10, 30, 1)
-            .withLocalTemperatureCalibration(-30, 30, 0.1)],
+            .withLocalTemperatureCalibration(-30, 30, 0.1)
+            .withControlSequenceOfOperation(['cooling_only', 'heating_only', 'cooling_and_heating_4-pipes'])
+            .withRunningMode(['off', 'heat', 'cool'])],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -402,11 +402,27 @@ class Climate extends Base {
         return this;
     }
 
+    withRunningMode(modes, access=a.STATE_GET) {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        const allowed = ['off', 'cool', 'heat'];
+        modes.forEach((m) => assert(allowed.includes(m)));
+        this.features.push(new Enum('running_mode', access, modes).withDescription('The current running mode'));
+        return this;
+    }
+
     withFanMode(modes) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         const allowed = ['off', 'low', 'medium', 'high', 'on', 'auto', 'smart'];
         modes.forEach((m) => assert(allowed.includes(m)));
         this.features.push(new Enum('fan_mode', access.ALL, modes).withDescription('Mode of the fan'));
+        return this;
+    }
+
+    withControlSequenceOfOperation(modes) {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        const allowed = ['cooling_only', 'cooling_with_reheat', 'heating_only', 'heating_with_reheat', 'cooling_and_heating_4-pipes', 'cooling_and_heating_4-pipes_with_reheat'];
+        modes.forEach((m) => assert(allowed.includes(m)));
+        this.features.push(new Enum('control_sequence_of_operation', access.ALL, modes).withDescription('Control sequence of operation'));
         return this;
     }
 

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -160,6 +160,10 @@ module.exports = {
         const p = payload('runningState', 0, repInterval.HOUR, 0, overrides);
         await endpoint.configureReporting('hvacThermostat', p);
     },
+    thermostatRunningMode: async (endpoint, overrides) => {
+        const p = payload('runningMode', 0, repInterval.HOUR, 0, overrides);
+        await endpoint.configureReporting('hvacThermostat', p);
+    },
     thermostatTemperatureSetpointHold: async (endpoint, overrides) => {
         const p = payload('tempSetpointHold', 0, repInterval.HOUR, 0, overrides);
         await endpoint.configureReporting('hvacThermostat', p);


### PR DESCRIPTION
1) Add a new exposed value "thermostat_running_mode" which is different from both thermostat_system_mode
and thermostat_running_state in that it expresses whether the thermostat is currently cooling, heating, or off (e.g. system mode could be cooling, but if the system is not actually cooling - due to setpoints - running mode would be off), since this value is exposed by this thermostate, and is useful for reporting purposes.

2) Expose the value of thermostat_control_sequence_of_operation and make it changeable.

@alexisiglesias1 
@Koenkk 

I noticed that a new/almost identical configuration was added recently for a centralite 3157100-E and I'm curious what the difference between that thermostat and the 3157100 that I have is, as well as what the difference between fz.legacy.thermostat_att_report and fz.thermostat is.  The new config also supports thermostat_temperature_setpoint_hold which I know the 3157100 also support (I just hadn't bothered to add that setting).  I guess I'm wondering if it might be possible to merge these two configurations, and/or if it would make sense to copy over the various changes I have been making, to the new configuration.  