### PR TITLE
Second stage of additional changes to centralite pearl thermostat

### DIFF
--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -173,7 +173,7 @@ module.exports = [
             tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state],
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 10, 30, 1).withLocalTemperature()
             .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
-            .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
+            .withRunningState(['idle', 'heat', 'cool', 'fan_only', 'aux_heat', 'heat_no_fan']).withFanMode(['auto', 'on'])
             .withSetpoint('occupied_cooling_setpoint', 10, 30, 1)
             .withLocalTemperatureCalibration(-30, 30, 0.1)],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -57,8 +57,8 @@ const dayOfWeek = {
 
 const thermostatRunningStates = {
     0: 'idle',
-    1: 'heat',
-    2: 'cool',
+    1: 'heat_no_fan',
+    2: 'cool_no_fan',
     4: 'fan_only',
     5: 'heat',
     6: 'cool',
@@ -68,6 +68,7 @@ const thermostatRunningStates = {
     D: 'heat',
     10: 'cool',
     12: 'cool',
+    13: 'aux_heat',
     14: 'cool',
     15: 'cool',
     22: 'cool',

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -396,7 +396,7 @@ class Climate extends Base {
 
     withRunningState(modes, access=a.STATE_GET) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
-        const allowed = ['idle', 'heat', 'cool', 'fan_only'];
+        const allowed = ['idle', 'heat', 'cool', 'fan_only', 'aux_heat', 'heat_no_fan'];
         modes.forEach((m) => assert(allowed.includes(m)));
         this.features.push(new Enum('running_state', access, modes).withDescription('The current running state'));
         return this;


### PR DESCRIPTION
While debugging the activity of this thermostat, I noticed that the configuration
didn't handle the "aux" use case, in that first, there was no "aux" running state declared, and
second, I noticed that different numerical values produced by the thermostat for 
running state were being overloaded onto the value 'heat' - namely
the case where the system is in heating mode, and is about to go into                 
emergency heat mode.  At that point, the system reports heating being on, but the fan is off (briefly).
As a result I chose to call this state "heat_no_fan" but I'm open to other suggestions.

Note that this thermostat doesn't technically support aux mode, though the company
has provided tech support indications that it's OK to tie the emergency heat
and aux wires together, in which case selecting "emergency heat" mode will 
effectively the system into aux mode, and the system can also enter emergency heat mode automatically.  
What I observed was the reported value of running state was different in both of these cases, and different 
from the normal heating case.

As I mentioned in my other centralite PR (https://github.com/Koenkk/zigbee-herdsman-converters/pull/4081) 
I see that there is another almost identical thermostat recently added and the same questions apply - namely 
Whether the configs can be merged and/or whether I should apply my changes, to the newer config.

