### PR TITLE
WIP: fix configure problem with haElectricalMeasurement MicroMatic zb250

### DIFF
--- a/devices/micromatic.js
+++ b/devices/micromatic.js
@@ -19,10 +19,6 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering']);
             await reporting.brightness(endpoint);
-            // Unit missing acFrequencyDivisor and acFrequencyMultiplier, so we need to target specific units in haElectricalMeasurement
-            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor']);
-            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
-            // end
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.rmsVoltage(endpoint, {min: 10, change: 20}); // Voltage - Min change of 2V
             await reporting.rmsCurrent(endpoint, {min: 10, change: 10}); // A - z2m displays only the first decimals, change of 10 / 0,01A

--- a/devices/micromatic.js
+++ b/devices/micromatic.js
@@ -19,7 +19,6 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering']);
             await reporting.brightness(endpoint);
-            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.rmsVoltage(endpoint, {min: 10, change: 20}); // Voltage - Min change of 2V
             await reporting.rmsCurrent(endpoint, {min: 10, change: 10}); // A - z2m displays only the first decimals, change of 10 / 0,01A
             await reporting.activePower(endpoint, {min: 10, change: 15}); // W - Min change of 1,5W

--- a/devices/micromatic.js
+++ b/devices/micromatic.js
@@ -20,8 +20,8 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering']);
             await reporting.brightness(endpoint);
             // Unit missing acFrequencyDivisor and acFrequencyMultiplier, so we need to target specific units in haElectricalMeasurement
-            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor' ]);
-            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier' ]);
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor']);
+            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
             // end
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.rmsVoltage(endpoint, {min: 10, change: 20}); // Voltage - Min change of 2V

--- a/devices/micromatic.js
+++ b/devices/micromatic.js
@@ -19,8 +19,10 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering']);
             await reporting.brightness(endpoint);
-            // Unit doesn´t expose acFrequencyDivisor and acFrequencyMultiplier, so we need to target specific units in haElectricalMeasurement
-            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor', 'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
+            // Unit missing acFrequencyDivisor and acFrequencyMultiplier, so we need to target specific units in haElectricalMeasurement
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor' ]);
+            await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier' ]);
+            // end
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.rmsVoltage(endpoint, {min: 10, change: 20}); // Voltage - Min change of 2V
             await reporting.rmsCurrent(endpoint, {min: 10, change: 10}); // A - z2m displays only the first decimals, change of 10 / 0,01A
@@ -31,3 +33,4 @@ module.exports = [
     },
 ];
 
+await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor', 'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);

--- a/devices/micromatic.js
+++ b/devices/micromatic.js
@@ -19,6 +19,9 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering']);
             await reporting.brightness(endpoint);
+            // Unit doesn´t expose acFrequencyDivisor and acFrequencyMultiplier, so we need to target specific units in haElectricalMeasurement
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor', 'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.rmsVoltage(endpoint, {min: 10, change: 20}); // Voltage - Min change of 2V
             await reporting.rmsCurrent(endpoint, {min: 10, change: 10}); // A - z2m displays only the first decimals, change of 10 / 0,01A
             await reporting.activePower(endpoint, {min: 10, change: 15}); // W - Min change of 1,5W

--- a/devices/micromatic.js
+++ b/devices/micromatic.js
@@ -32,5 +32,3 @@ module.exports = [
         exposes: [e.light_brightness(), e.power(), e.current(), e.voltage().withAccess(ea.STATE), e.energy()],
     },
 ];
-
-await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor', 'acCurrentDivisor', 'acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);


### PR DESCRIPTION
A user reported that a new device will throw an error, tested this and it seems to be correct.

``` log
error 2022-03-31 15:38:59: Failed to configure '0x04cd15fffeb16a98', attempt 3 (Error: Read 0x04cd15fffeb16a98/1 haElectricalMeasurement(["acFrequencyDivisor","acFrequencyMultiplier"], {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')
    at Endpoint.checkStatus (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:317:28)
    at Endpoint.read (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:480:22)
    at Object.readEletricalMeasurementMultiplierDivisors (/app/node_modules/zigbee-herdsman-converters/lib/reporting.js:25:5)
    at Object.configure (/app/node_modules/zigbee-herdsman-converters/devices/micromatic.js:22:13)
    at Configure.configure (/app/lib/extension/configure.ts:115:13))
```
    
By adding a new device i also discovered another potential problem, that I need input on.

The device has energy consumption measurement, but this is not updated in z2m even tough the device sends a report.
Based on my test device this seems to only be updated once it reached 1kwh.
But in this case the device is still at 0,21kwh so z2m is not updated, is this correct behaviour ?

```
Received Zigbee message from 'Sofa', type 'attributeReport', cluster 'seMetering', data '{"currentSummDelivered":[0,2103939]}' from endpoint 1 with groupID 0
```
