### PR TITLE
Fix for commit #3839

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -46,14 +46,14 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
             await reporting.onOff(endpoint);
             await reporting.deviceTemperature(endpoint);
-            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint, true); // Set to true, to access the acFrequencyDivisor and acFrequencyMultiplier attribute. Not all devices support this.
             await reporting.activePower(endpoint, {change: 10}); // Power reports with every 10W change
             await reporting.rmsCurrent(endpoint, {change: 20}); // Current reports with every 20mA change
             await reporting.rmsVoltage(endpoint, {min: constants.repInterval.MINUTES_5, change: 400}); // Limit reports to every 5m, or 4V
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {change: [0, 20]}); // Limit reports to once every 5m, or 0.02kWh
             await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
-            await reporting.acFrequency(endpoint);
+            //await reporting.acFrequency(endpoint); // dont use this, because it breaks all devices that dont support it. Look above for correct usage.
         },
         endpoint: (device) => {
             return {default: 2};

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -18,11 +18,17 @@ function payload(attribute, min, max, change, overrides) {
     return [payload];
 }
 
-async function readEletricalMeasurementMultiplierDivisors(endpoint) {
+// Fix the problem that commit #3839 introduced.
+// You can set readFrequencyAttrs = true if the device support acFrequencyDivisor and acFrequencyMultiplier
+// See Develco.js SPLZB-132 for example
+async function readEletricalMeasurementMultiplierDivisors(endpoint, readFrequencyAttrs = false) {
     // Split into three chunks, some devices fail to respond when reading too much attributes at once.
     await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
     await endpoint.read('haElectricalMeasurement', ['acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor']);
-    await endpoint.read('haElectricalMeasurement', ['acFrequencyDivisor', 'acFrequencyMultiplier']);
+    // Only read frequency multiplier/devisor when enabled as not all devices support this.
+    if (readFrequencyAttrs) {
+        await endpoint.read('haElectricalMeasurement', ['acFrequencyDivisor', 'acFrequencyMultiplier']);
+    }
 }
 
 async function readMeteringMultiplierDivisor(endpoint) {


### PR DESCRIPTION
This PR fix, what problems commit #3839 introduced.

Not all devices support acFrequencyDivisor and acFrequencyMultiplier.

With the original PR, this would introduce an UNSUPPORTED_ATTRIBUTE error on for example Heiman HS2SK, and no readings could be fetched from the device.

To access the acFrequencyDivisor and acFrequencyMultiplier, the following line should be used in the device:

await reporting.readEletricalMeasurementMultiplierDivisors(endpoint, true);

Do NOT use the following line, because it will break it again:

await reporting.acFrequency(endpoint);

Co-Authored-By: corneyl <5320363+corneyl@users.noreply.github.com>