### PR TITLE
Add _TZ3000_zwaadvus to TS011F_2_gang_wall

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -215,7 +215,7 @@ module.exports = [
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_mvn6jl7x'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_raviyuvk'}, {modelID: 'TS011F', manufacturerName: '_TYZB01_hlla45kx'},
-            {modelID: 'TS011F', manufacturerName: '_TZ3000_92qd4sqa'}],
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_92qd4sqa'}, {modelID: 'TS011F', manufacturerName: '_TZ3000_zwaadvus'}],
         model: 'TS011F_2_gang_wall',
         vendor: 'TuYa',
         description: '2 gang wall outlet',


### PR DESCRIPTION
This adds support  for _TZ3000_zwaadvus, which appears to be a variant of TS011F_2_gang_wall.

The hardware has a different model number printed on its back: SM-PW801-VZ. I wanted to add an entry for it in `whiteLabel`, but I'm not sure what to put in the `vendor` field since it doesn't have any branding.