### PR TITLE
Add Wiser water leakage detector CCT592011

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -777,6 +777,15 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['CCT592011_AS'],
+        model: 'CCT592011',
+        vendor: 'Schneider Electric',
+        description: 'Wiser water leakage sensor',
+        fromZigbee: [fz.ias_water_leak_alarm_1],
+        toZigbee: [],
+        exposes: [e.battery_low(), e.water_leak(), e.tamper()],
+    },
+    {
         fingerprint: [{modelID: 'GreenPower_254', ieeeAddr: /^0x00000000e.......$/}],
         model: 'A9MEM1570',
         vendor: 'Schneider Electric',


### PR DESCRIPTION
I don't really know what I'm doing, but by following https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html and doing as best I could I got the CCT592011 to work with zigbee2mqtt.