### PR TITLE
Add support for Innr BY 286 C

### DIFF
--- a/devices/innr.js
+++ b/devices/innr.js
@@ -160,6 +160,14 @@ module.exports = [
         meta: {applyRedFix: true, turnsOffAtBrightness1: true},
     },
     {
+        zigbeeModel: ['BY 286 C'],
+        model: 'BY 286 C',
+        vendor: 'Innr',
+        description: 'B22 bulb RGBW',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 555], supportsHS: true}),
+        meta: {applyRedFix: true, turnsOffAtBrightness1: true},
+    },
+    {
         zigbeeModel: ['RB 165'],
         model: 'RB 165',
         vendor: 'Innr',


### PR DESCRIPTION
BY 285 C:
`Read result of 'genBasic': {"manufacturerName":"innr","modelId":"BY 285 C","hwVersion":1,"dateCode":"20190114-27","swBuildId":"2.1","zclVersion":2,"stackVersion":21}`

BY 286 C:
`Read result of 'genBasic': {"manufacturerName":"innr","modelId":"BY 286 C","hwVersion":2,"dateCode":"20211013","swBuildId":"2.03.00","zclVersion":3,"stackVersion":21}`

```
{
    "brightness": 254,
    "color": {
        "h": 40,
        "hue": 40,
        "s": 49,
        "saturation": 49,
        "x": 0.3804,
        "y": 0.3767
    },
    "color_mode": "color_temp",
    "color_temp": 250,
    "color_temp_startup": 153,
    "linkquality": 116,
    "state": "ON"
}
```

`Read result of 'lightingColorCtrl': {"colorTempPhysicalMax":555,"colorTempPhysicalMin":153}`

---

Not sure on documentation + image PR in zigbee2mqtt.io repo. As this will be an exact copy of BY 285 C. Is there a better way to handle that, maybe combine?
