### PR TITLE
Ignore leak in genBasic Xiaomi SJCGQ11LM

### DIFF
--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -212,7 +212,8 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             } else if (['MCCGQ11LM'].includes(model.model)) {
                 payload.contact = value === 0;
             } else if (['SJCGQ11LM'].includes(model.model)) {
-                payload.water_leak = value === 1;
+                // Ignore the message. It seems not reliable. See discussion here https://github.com/Koenkk/zigbee2mqtt/issues/12018
+                // payload.water_leak = value === 1;
             } else if (['JTYJ-GD-01LM/BW'].includes(model.model)) {
                 payload.smoke_density = value;
             } else {
@@ -513,6 +514,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case 'mode':
             payload.operation_mode = ['command', 'event'][value];
+            break;
+        case 'modelId':
+            // We ignore it, but we add it here to not shown an unknown key in the log
             break;
         default:
             if (meta.logger) meta.logger.debug(`${model.zigbeeModel}: unknown key ${key} with value ${value}`);


### PR DESCRIPTION
This fixes https://github.com/Koenkk/zigbee2mqtt/issues/12018 in some way...

The PR does two things:
- Ignore the `genBasic` water leak report. We don't know why it does not send the "correct" value, but until we find another fix I suppose is better to ignore it.
- Adds the `modelId` attribute to the library. We ignore it, but is a way to not shown a log message with unknown field for it. I discovered that this field is sent only when we press the button of the device, here an example of the message received alone and with the press of the button:
```
debug 2022-04-09 09:57:14: Received Zigbee message from 'fuga_agua_ac', type 'attributeReport', cluster 'genBasic', data '{"65281":{"1":3115,"10":41058,"100":0,"3":25,"4":13224,"5":44,"6":[0,1],"8":516}}' from endpoint 1 with groupID 0
debug 2022-04-09 10:38:25: Received Zigbee message from 'fuga_agua_ac', type 'attributeReport', cluster 'genBasic', data '{"65281":{"1":3115,"10":41058,"100":0,"3":25,"4":13224,"5":44,"6":[0,0],"8":516},"modelId":"lumi.sensor_wleak.aq1"}' from endpoint 1 with groupID 0
```
maybe is the way the real gateway detects the button press to send a sound to verify the connection is working?