### PR TITLE
Adding new naming for TRADFRI bulb E27 C/WS opal 600

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -378,7 +378,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['TRADFRI bulb E27 CWS opal 600lm', 'TRADFRI bulb E26 CWS opal 600lm', 'TRADFRI bulb E14 CWS opal 600lm',
-            'TRADFRI bulb E12 CWS opal 600lm'],
+            'TRADFRI bulb E12 CWS opal 600lm', 'TRADFRI bulb E27 C/WS opal 600'],
         model: 'LED1624G9',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E14/E26/E27 600 lumen, dimmable, color, opal white',


### PR DESCRIPTION
When trying to add my Ikea bulb I realised, that it has a different model name.

![image](https://user-images.githubusercontent.com/35373554/162592586-c20a580e-8908-4923-818d-8ee5572ef1dd.png)

I tried the provided change locally and it works as expected.