### PR TITLE
ZM25TQ add data_point_test and remove speed ctrl

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1084,7 +1084,6 @@ module.exports = [
             // Window pushers:
             {modelID: 'TS0601', manufacturerName: '_TZE200_g5wdnuow'},
             // Tubular motors:
-            {modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_5sbebbzs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuz7f94z'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zyrdrmno'},
@@ -1105,7 +1104,6 @@ module.exports = [
             {vendor: 'Moes', model: 'AM43-0.45/40-ES-EB'},
             {vendor: 'Larkkey', model: 'ZSTY-SM-1SRZG-EU'},
             {vendor: 'Zemismart', model: 'ZM85EL-2Z', description: 'Roman Rod I type curtains track'},
-            {vendor: 'Zemismart', model: 'ZM25TQ', description: 'Tubular motor'},
             {vendor: 'Zemismart', model: 'AM43', description: 'Roller blind motor'},
             {vendor: 'Zemismart', model: 'M2805EGBZTN', description: 'Tubular motor'},
             {vendor: 'Zemismart', model: 'BCM500DS-TYZ', description: 'Curtain motor'},
@@ -1121,6 +1119,21 @@ module.exports = [
                     .withValueMin(0)
                     .withValueMax(255)
                     .withDescription('Motor speed'))],
+    },
+    {
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'},
+        ],
+        model: 'TS0601_cover',
+        vendor: 'TuYa',
+        description: 'Tubular motor',
+        whiteLabel: [
+            {vendor: 'Zemismart', model: 'ZM25TQ', description: 'Tubular motor'},
+        ],
+        fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
+        toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options, tz.tuya_data_point_test],
+        exposes: [
+            e.cover_position().setAccess('position', ea.STATE_SET),
     },
     {
         zigbeeModel: ['kud7u2l'],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1133,7 +1133,7 @@ module.exports = [
         fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
         toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options, tz.tuya_data_point_test],
         exposes: [
-            e.cover_position().setAccess('position', ea.STATE_SET),
+            e.cover_position().setAccess('position', ea.STATE_SET)],
     },
     {
         zigbeeModel: ['kud7u2l'],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1124,7 +1124,7 @@ module.exports = [
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'},
         ],
-        model: 'TS0601_cover',
+        model: 'ZM25TQ_cover',
         vendor: 'TuYa',
         description: 'Tubular motor',
         whiteLabel: [

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1121,21 +1121,6 @@ module.exports = [
                     .withDescription('Motor speed'))],
     },
     {
-        fingerprint: [
-            {modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'},
-        ],
-        model: 'ZM25TQ_cover',
-        vendor: 'TuYa',
-        description: 'Tubular motor',
-        whiteLabel: [
-            {vendor: 'Zemismart', model: 'ZM25TQ', description: 'Tubular motor'},
-        ],
-        fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
-        toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options, tz.tuya_data_point_test],
-        exposes: [
-            e.cover_position().setAccess('position', ea.STATE_SET)],
-    },
-    {
         zigbeeModel: ['kud7u2l'],
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l'},

--- a/devices/zemismart.js
+++ b/devices/zemismart.js
@@ -154,4 +154,19 @@ module.exports = [
         // exposes.enum('situation_set', ea.STATE, Object.values(tuya.ZMAM02.AM02Situation)),
         ],
     },
+    {
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'},
+        ],
+        model: 'ZM25TQ_cover',
+        vendor: 'Zemismart',
+        description: 'Tubular motor',
+        whiteLabel: [
+            {vendor: 'Zemismart', model: 'ZM25TQ', description: 'Tubular motor'},
+        ],
+        fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
+        toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options, tz.tuya_data_point_test],
+        exposes: [
+            e.cover_position().setAccess('position', ea.STATE_SET)],
+    },
 ];

--- a/devices/zemismart.js
+++ b/devices/zemismart.js
@@ -155,18 +155,12 @@ module.exports = [
         ],
     },
     {
-        fingerprint: [
-            {modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'},
-        ],
-        model: 'ZM25TQ_cover',
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'}],
+        model: 'ZM25TQ',
         vendor: 'Zemismart',
         description: 'Tubular motor',
-        whiteLabel: [
-            {vendor: 'Zemismart', model: 'ZM25TQ', description: 'Tubular motor'},
-        ],
         fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
         toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options, tz.tuya_data_point_test],
-        exposes: [
-            e.cover_position().setAccess('position', ea.STATE_SET)],
+        exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],
     },
 ];


### PR DESCRIPTION
Following to issue  "TS0601 _TZE200_fzo2pocs (Zemismart ZM25TQ) - position and motor speed issue" #11164
Separated definition of Zemismart ZM25TQ from big Tuya section with added tz.tuya_data_point_test capability and removal of speed control not supported by this device.