### PR TITLE
Fix duplication of `voltage` value for `JTYJ-GD-01LM/BW`

### DIFF
--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -293,7 +293,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             payload.consumption = payload.energy;
             break;
         case '150':
-            payload.voltage = precisionRound(value * 0.1, 1); // 0x96
+            if (!['JTYJ-GD-01LM/BW'].includes(model.model)) {
+                payload.voltage = precisionRound(value * 0.1, 1); // 0x96
+            }
             break;
         case '151':
             if (['LLKZMK11LM'].includes(model.model)) {


### PR DESCRIPTION
This PR fixes _duplicate value problem_ that [I warned about earlier](https://github.com/Koenkk/zigbee-herdsman-converters/pull/4058#discussion_r838483169).

This is what report from the sensor looks like:

```json
{"65281":{"1":3025,"10":0,"100":0,"150":0,"3":28,"4":5032,"5":466,"6":[0,4],"8":4100}}

{"65281":{"1":3025,"10":0,"100":255,"150":50331648,"3":28,"4":5032,"5":466,"6":[0,2],"8":4100}}
```

The problem is that `voltage` value is not correct, because _key 1_ is overwritten by _key 150_ due to absence of a condition in it:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/1cf1c4385839d686f77590f1dbcd8cc4bf9f4168/lib/xiaomi.js#L149-L154

https://github.com/Koenkk/zigbee-herdsman-converters/blob/1cf1c4385839d686f77590f1dbcd8cc4bf9f4168/lib/xiaomi.js#L295-L297