### PR TITLE
Add support for the 7602031U7 variation Philips Hue Go with BT

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -447,7 +447,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LCT026', '7602031P7'],
+        zigbeeModel: ['LCT026', '7602031P7', '7602031U7'],
         model: '7602031P7',
         vendor: 'Philips',
         description: 'Hue Go with Bluetooth',


### PR DESCRIPTION
There is a variation of the Philips Hue Go with Bluetooth with the model number 7602031U7 (previous model was 7602031P7). This PR simply adds a Zigbee Model for the U7.