### PR TITLE
Add support for Ajax Online TS011F

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -13,7 +13,7 @@ const utils = require('../lib/utils');
 const TS011Fplugs = ['_TZ3000_5f43h46b', '_TZ3000_cphmq0q7', '_TZ3000_dpo1ysak', '_TZ3000_ew3ldmgx', '_TZ3000_gjnozsaz',
     '_TZ3000_jvzvulen', '_TZ3000_mraovvmm', '_TZ3000_nfnmi125', '_TZ3000_ps3dmato', '_TZ3000_w0qqde0g', '_TZ3000_u5u4cakc',
     '_TZ3000_rdtixbnu', '_TZ3000_typdpbpg', '_TZ3000_kx0pris5', '_TZ3000_amdymr7l', '_TZ3000_z1pnpsdo', '_TZ3000_ksw8qtmt',
-    '_TZ3000_nzkqcvvs'];
+    '_TZ3000_nzkqcvvs', '_TZ3000_1h2x4akh'];
 
 const tzLocal = {
     TS0504B_color: {


### PR DESCRIPTION
I have just received an Ajax Online badged Tuya TS011F smart plug (https://smile.amazon.co.uk/gp/product/B09N43BBC1/)
Added new manufacturer name to list of TS011F plugs and it seems to be working now.