### PR TITLE
Add support for MiBoxer FUT089Z

### DIFF
--- a/devices/miboxer.js
+++ b/devices/miboxer.js
@@ -1,5 +1,5 @@
 const exposes = require('../lib/exposes');
-const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const fz = require('../converters/fromZigbee');
 const tz = require('../converters/toZigbee');
 const e = exposes.presets;
 const ea = exposes.access;

--- a/devices/miboxer.js
+++ b/devices/miboxer.js
@@ -1,4 +1,5 @@
 const exposes = require('../lib/exposes');
+const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
 const tz = require('../converters/toZigbee');
 const e = exposes.presets;
 const ea = exposes.access;
@@ -47,4 +48,29 @@ module.exports = [
         vendor: 'Miboxer',
         extend: extend.light_onoff_brightness_colortemp_color({disableColorTempStartup: true, colorTempRange: [153, 500]}),
     },
+    {
+        fingerprint: [{manufacturerName: '_TZ3000_xwh1e22x'}],
+        zigbeeModel: ['TS1002'],
+        model: 'FUT089Z',
+        vendor: 'MiBoxer',
+        description: 'RGB+CCT Remote',
+        fromZigbee: [fz.battery],
+        toZigbee: [],
+        exposes: [e.battery(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('genBasic', ['manufacturerName', 'zclVersion', 'appVersion', 'modelId', 'powerSource', 0xfffe]);
+            await endpoint.command('genGroups', 'miboxerSetZones', { zones: [
+                { zoneNum: 1, groupId: 101 },
+                { zoneNum: 2, groupId: 102 },
+                { zoneNum: 3, groupId: 103 },
+                { zoneNum: 4, groupId: 104 },
+                { zoneNum: 5, groupId: 105 },
+                { zoneNum: 6, groupId: 106 },
+                { zoneNum: 7, groupId: 107 },
+                { zoneNum: 8, groupId: 108 },
+            ]});
+            await endpoint.command('genBasic', 'tuyaSetup', {}, {disableDefaultResponse: true});
+        },
+    }
 ];

--- a/devices/miboxer.js
+++ b/devices/miboxer.js
@@ -60,17 +60,17 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read('genBasic', ['manufacturerName', 'zclVersion', 'appVersion', 'modelId', 'powerSource', 0xfffe]);
-            await endpoint.command('genGroups', 'miboxerSetZones', { zones: [
-                { zoneNum: 1, groupId: 101 },
-                { zoneNum: 2, groupId: 102 },
-                { zoneNum: 3, groupId: 103 },
-                { zoneNum: 4, groupId: 104 },
-                { zoneNum: 5, groupId: 105 },
-                { zoneNum: 6, groupId: 106 },
-                { zoneNum: 7, groupId: 107 },
-                { zoneNum: 8, groupId: 108 },
+            await endpoint.command('genGroups', 'miboxerSetZones', {zones: [
+                {zoneNum: 1, groupId: 101},
+                {zoneNum: 2, groupId: 102},
+                {zoneNum: 3, groupId: 103},
+                {zoneNum: 4, groupId: 104},
+                {zoneNum: 5, groupId: 105},
+                {zoneNum: 6, groupId: 106},
+                {zoneNum: 7, groupId: 107},
+                {zoneNum: 8, groupId: 108},
             ]});
             await endpoint.command('genBasic', 'tuyaSetup', {}, {disableDefaultResponse: true});
         },
-    }
+    },
 ];

--- a/devices/miboxer.js
+++ b/devices/miboxer.js
@@ -50,7 +50,6 @@ module.exports = [
     },
     {
         fingerprint: [{manufacturerName: '_TZ3000_xwh1e22x'}],
-        zigbeeModel: ['TS1002'],
         model: 'FUT089Z',
         vendor: 'MiBoxer',
         description: 'RGB+CCT Remote',


### PR DESCRIPTION
This adds support for [MiBoxer's FUT089Z 8-zone remote](https://miboxer.com/light/products/zigbee_remote.html). This is kind of a quirky device which can only output to groups and none of the standard group assignment procedures work. It's required to use a custom command ([zigbee-herdsman PR](https://github.com/Koenkk/zigbee-herdsman/pull/529)) to assign group IDs for all 8 zones during the initial configuration since remote does not seem to respond to any commands sent after initial setup.

This poses some issues for working with Zigbee2MQTT because technically we'd need to create 8 new groups for each remote when configuring it initially. For testing this I just hardcoded them currently, but that is very unintuitive, can potentially step on other groups and only allows a maximum of one remote of this type in a network. This is definitely something that needs to be solved before merging this.

Closes https://github.com/Koenkk/zigbee2mqtt/issues/10708