### PR TITLE
Change max temp from 32 to 35 for Danfoss Ally

### DIFF
--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -45,7 +45,7 @@ module.exports = [
                 .withDescription('Whether or not the unit needs warm water. `false` No Heat Request or `true` Heat Request'),
             exposes.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
                 .withDescription('Values observed are `0` (manual), `1` (schedule) or `2` (externally)'),
-            exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature().withPiHeatingDemand()
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5).withLocalTemperature().withPiHeatingDemand()
                 .withSystemMode(['heat']).withRunningState(['idle', 'heat'], ea.STATE),
             exposes.numeric('external_measured_room_sensor', ea.ALL)
                 .withDescription('If `radiator_covered` is `true`: Set at maximum 30 minutes interval but not more often than every ' +


### PR DESCRIPTION
The technical specification lists a temperature range from 5 to 35 deg celsius. See here (MaxHeatSetpointLimit): https://assets.danfoss.com/documents/193613/AM375549618098en-000102.pdf
Also the user guide says the same and my personal device with the latest firmware goes up to 35.