### PR TITLE
Add  915005996901 (Enrave L with Bluetooth)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -109,6 +109,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['915005996801', '915005996901'],
+        model: '915005996901',
+        vendor: 'Philips',
+        description: 'Hue white ambiance ceiling light Enrave L with Bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['915005997001', '915005997101'],
         model: '915005997001',
         vendor: 'Philips',


### PR DESCRIPTION
Add support for Philips [915005996901](https://www.philips-hue.com/en-gb/p/hue-white-ambiance-enrave-large-ceiling-lamp/4116030P6).
I also included the variant with the white housing ([915005996801](https://www.philips-hue.com/en-gb/p/hue-white-ambiance-enrave-large-ceiling-lamp/4116031P6)), although I don't have that lamp and could not test it.