### PR TITLE
Ignore Xiami Basic state for ZNMS12LM

### DIFF
--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -196,9 +196,10 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
                 payload[`state_${mapping}`] = value === 1 ? 'ON' : 'OFF';
             } else if (['WXKG14LM', 'WXKG16LM', 'WXKG17LM'].includes(model.model)) {
                 payload.click_mode = {1: 'fast', 2: 'multi'}[value];
-            } else if (['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
+            } else if (['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM', 'ZNMS12LM'].includes(model.model)) {
                 // We don't know what the value means for these devices.
                 // https://github.com/Koenkk/zigbee2mqtt/issues/11126
+                // https://github.com/Koenkk/zigbee2mqtt/issues/12279
             } else if (['WSDCGQ01LM', 'WSDCGQ11LM'].includes(model.model)) {
                 // https://github.com/Koenkk/zigbee2mqtt/issues/798
                 // Sometimes the sensor publishes non-realistic vales, filter these


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/12279

The sensor publishes `"100": 44,` that is being mapped to `STATE: OFF` by default, that is not correct. We ignore it until we know what this `44` implies.