### PR TITLE
AVATTO Smart Plug support

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -13,7 +13,7 @@ const utils = require('../lib/utils');
 const TS011Fplugs = ['_TZ3000_5f43h46b', '_TZ3000_cphmq0q7', '_TZ3000_dpo1ysak', '_TZ3000_ew3ldmgx', '_TZ3000_gjnozsaz',
     '_TZ3000_jvzvulen', '_TZ3000_mraovvmm', '_TZ3000_nfnmi125', '_TZ3000_ps3dmato', '_TZ3000_w0qqde0g', '_TZ3000_u5u4cakc',
     '_TZ3000_rdtixbnu', '_TZ3000_typdpbpg', '_TZ3000_kx0pris5', '_TZ3000_amdymr7l', '_TZ3000_z1pnpsdo', '_TZ3000_ksw8qtmt',
-    '_TZ3000_nzkqcvvs', '_TZ3000_1h2x4akh'];
+    '_TZ3000_nzkqcvvs', '_TZ3000_1h2x4akh', '_TZ3000_9vo5icau'];
 
 const tzLocal = {
     TS0504B_color: {
@@ -1413,7 +1413,8 @@ module.exports = [
         model: 'TS011F_plug_3',
         description: 'Smart plug (with power monitoring by polling)',
         vendor: 'TuYa',
-        whiteLabel: [{vendor: 'VIKEFON', model: 'TS011F'}, {vendor: 'BlitzWolf', model: 'BW-SHP15'}],
+        whiteLabel: [{vendor: 'VIKEFON', model: 'TS011F'}, {vendor: 'BlitzWolf', model: 'BW-SHP15'},
+            {vendor: 'Avatto', model: 'MIUCOT10Z'}],
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.ignore_basic_report, fz.tuya_switch_power_outage_memory,
             fz.ts011f_plug_indicator_mode, fz.ts011f_plug_child_mode],


### PR DESCRIPTION
Good day,

I bought a Smart Plug: AVATTO Tuya Zigbee Brazil Smart Plug with Power Monitor - https://www.aliexpress.com/item/1005003059126398.html?spm=a2g0o.order_list.0.0.2a0c1802ReGDKw

But according to the scan, he has a different model. It seems that just adding a model to TS011F_plug_3 (polling) is enough and everything will work.