### PR TITLE
Add OTA support, fix `battery` and other improvements for `WSDCGQ12LM`

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -844,15 +844,17 @@ module.exports = [
         model: 'WSDCGQ12LM',
         vendor: 'Xiaomi',
         description: 'Aqara T1 temperature, humidity and pressure sensor',
-        fromZigbee: [fz.xiaomi_basic, fz.temperature, fz.humidity, fz.pressure],
+        fromZigbee: [fz.aqara_opple, fz.temperature, fz.humidity, fz.pressure, fz.battery],
         toZigbee: [],
+        exposes: [e.temperature(), e.humidity(), e.pressure(), e.battery(), e.battery_voltage()],
         meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const binds = ['msTemperatureMeasurement', 'msRelativeHumidity', 'msPressureMeasurement'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await endpoint.read('genPowerCfg', ['batteryVoltage']);
         },
-        exposes: [e.battery(), e.temperature(), e.humidity(), e.pressure(), e.battery_voltage()],
+        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['lumi.sensor_motion'],

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -158,7 +158,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             }
             break;
         case '3':
-            if (!['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
+            if (['WSDCGQ12LM'].includes(model.model)) {
+                // This temperature value is ignored because with greater accuracy it is reported in key №100
+            } else if (!['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
                 payload.temperature = calibrateAndPrecisionRoundOptions(value, options, 'temperature'); // 0x03
             }
             break;
@@ -200,7 +202,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
                 // We don't know what the value means for these devices.
                 // https://github.com/Koenkk/zigbee2mqtt/issues/11126
                 // https://github.com/Koenkk/zigbee2mqtt/issues/12279
-            } else if (['WSDCGQ01LM', 'WSDCGQ11LM'].includes(model.model)) {
+            } else if (['WSDCGQ01LM', 'WSDCGQ11LM', 'WSDCGQ12LM'].includes(model.model)) {
                 // https://github.com/Koenkk/zigbee2mqtt/issues/798
                 // Sometimes the sensor publishes non-realistic vales, filter these
                 const temperature = parseFloat(value) / 100.0;
@@ -242,7 +244,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
                 payload[`state_${mapping}`] = value === 1 ? 'ON' : 'OFF';
             } else if (['RTCGQ12LM', 'RTCGQ14LM'].includes(model.model)) {
                 payload.illuminance = calibrateAndPrecisionRoundOptions(value, options, 'illuminance');
-            } else if (['WSDCGQ01LM', 'WSDCGQ11LM'].includes(model.model)) {
+            } else if (['WSDCGQ01LM', 'WSDCGQ11LM', 'WSDCGQ12LM'].includes(model.model)) {
                 // https://github.com/Koenkk/zigbee2mqtt/issues/798
                 // Sometimes the sensor publishes non-realistic vales, filter these
                 const humidity = parseFloat(value) / 100.0;
@@ -260,6 +262,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
                 payload.state_right = value === 1 ? 'ON' : 'OFF';
             } else if (['WSDCGQ01LM', 'WSDCGQ11LM'].includes(model.model)) {
                 payload.pressure = calibrateAndPrecisionRoundOptions(value/100.0, options, 'pressure');
+            } else if (['WSDCGQ12LM'].includes(model.model)) {
+                // This pressure value is ignored because it is less accurate than reported in the 'scaledValue' attribute
+                // of the 'msPressureMeasurement' cluster
             } else if (['RTCZCGQ11LM'].includes(model.model)) {
                 if (meta.device.applicationVersion < 50) {
                     payload.presence_event = {0: 'enter', 1: 'leave', 2: 'left_enter', 3: 'right_leave', 4: 'right_enter',


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#9952

Sensor sends heartbeat reports through the _aqaraOpple_ cluster, not _genBasic_:

```javascript
cluster 'aqaraOpple', data '{"247":{"data":[1,33,238,11,3,40,24,4,33,168,19,5,33,43,0,6,36,2,0,0,0,0,8,33,28,1,10,33,0,0,12,32,1,100,41,183,9,101,41,149,18,102,41,224,3],"type":"Buffer"}}'
Processed buffer into data {"1":3054,"3":24,"4":5032,"5":43,"6":2,"8":284,"10":0,"12":1,"100":2487,"101":4757,"102":992}
```