### PR TITLE
Add Philips Hue Runner triple model 929003046201

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2580,6 +2580,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['929003046201_01', '929003046201_02', '929003046201_03'],
+        model: '929003046201',
+        vendor: 'Philips',
+        description: 'Hue White Ambiance Runner triple spotlight',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    };
+    {
         zigbeeModel: ['5309331P6', '5309330P6', '929003046301_03', '929003046301_02'],
         model: '5309331P6',
         vendor: 'Philips',

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2587,7 +2587,7 @@ module.exports = [
         meta: {turnsOffAtBrightness1: true},
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
-    };
+    },
     {
         zigbeeModel: ['5309331P6', '5309330P6', '929003046301_03', '929003046301_02'],
         model: '5309331P6',


### PR DESCRIPTION
This model was missing. I'm not sure if adding the ZigBee models to the existing Philips Hue White Ambiance Runner triple spotlight entry is better or keeping it separate like this since it has a different model number.

https://www.philips-hue.com/en-gb/p/hue-white-ambiance-runner-triple-spotlight/8719514338388