### PR TITLE
Add support for L1(WZ) 0/1-10V Dimmer

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -476,6 +476,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_swaamsoy'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_3p5ydos3'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_1agwnems'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_6qoazbre'},
         ],
         model: 'TS0601_dimmer',
         vendor: 'TuYa',
@@ -495,6 +496,7 @@ module.exports = [
             {vendor: 'Earda', model: 'EDM-1ZAB-EU'},
             {vendor: 'Earda', model: 'EDM-1ZBA-EU'},
             {vendor: 'Mercator Ikuü', model: 'SSWD01'},
+            {vendor: 'Unknown', model: 'L1(WZ)'},
         ],
     },
     {


### PR DESCRIPTION
Add support for L1(WZ) 0/1-10V Dimmer, sold on Aliexpress with no vendor name

Aliexpress link:
https://www.aliexpress.com/item/1005003956909568.html

Aliexpress screenshots:
![image](https://user-images.githubusercontent.com/14281572/167111608-547514d6-e671-486f-90d2-68211980523f.png)
![image](https://user-images.githubusercontent.com/14281572/167111656-e776d457-6205-4d6d-b2f3-d04253dab9c3.png)
