### PR TITLE
Add on_level and execute_if_off to level_config

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -532,6 +532,24 @@ const converters = {
                 }
             }
 
+            // onLevel - range 0x00 to 0xff - optional
+            //           Any value outside of MinLevel to MaxLevel, including 0xff and 0x00, is interpreted as "previous".
+            if (msg.data.hasOwnProperty('onLevel') && (msg.data['onLevel'] !== undefined)) {
+                result.level_config.on_level = Number(msg.data['onLevel']);
+                if (result.level_config.on_level === 255) {
+                    result.level_config.on_level = 'previous';
+                }
+            }
+
+            // options - 8-bit map
+            //   bit 0: ExecuteIfOff - when 0, Move commands are ignored if the device is off;
+            //          when 1, CurrentLevel can be changed while the device is off.
+            //   bit 1: CoupleColorTempToLevel - when 1, changes to level also change color temperature.
+            //          (What this means is not defined, but it's most likely to be "dim to warm".)
+            if (msg.data.hasOwnProperty('options') && msg.data['options'] !== undefined) {
+                result.level_config.execute_if_off = !!(Number(msg.data['options']) & 1);
+            }
+
             if (Object.keys(result.level_config).length > 0) {
                 return result;
             }

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -36,8 +36,11 @@ const bulbOnEvent = async (type, data, device, options, state) => {
 
         // NOTE: execute_if_off default is false
         //       we only restore if true, to save unneeded network writes
-        if (state.color_options.execute_if_off === true) {
+        if (state.color_options !== undefined && state.color_options.execute_if_off === true) {
             device.endpoints[0].write('lightingColorCtrl', {'options': 1});
+        }
+        if (state.level_config !== undefined && state.level_config.execute_if_off === true) {
+            device.endpoints[0].write('genLevelCtrl', {'options': 1});
         }
     }
 };


### PR DESCRIPTION
on_level: the brightness at which the light turns on. Differs from current_level_startup in that the latter is specifically for when the device is connected to power. Values: "previous", 1..254.

execute_if_off: whether setting `{brightness: VALUE, state: null}` should have an effect even while current state is off. If so and on_level is "previous", the next time the light is turned on it will use the new brightness; otherwise it keeps the brightness set the last time it was on. Values: true, false.