### PR TITLE
Add information to the description about the temporarily unsupported `trigger indicator` option for `RTCGQ14LM`

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -919,7 +919,7 @@ module.exports = [
         model: 'RTCGQ14LM',
         vendor: 'Xiaomi',
         whiteLabel: [{vendor: 'Xiaomi', model: 'MS-S02'}],
-        description: 'Aqara P1 human body movement and illuminance sensor',
+        description: 'Aqara P1 human body movement and illuminance sensor (trigger indicator not supported for now)',
         fromZigbee: [fz.aqara_occupancy_illuminance, fz.aqara_opple, fz.battery],
         toZigbee: [tz.aqara_detection_interval, tz.aqara_motion_sensitivity],
         exposes: [e.occupancy(), e.illuminance_lux().withProperty('illuminance'),


### PR DESCRIPTION
Judging by the screenshot of the sensor settings from the _Aqara Home_ app, there is also the `trigger indicator` option, the support of which has not yet been implemented, so we make an appropriate note in the description.

![Motion-Sensor P1](https://user-images.githubusercontent.com/38351800/167274092-7d688a91-ae59-475f-85e5-b81cb849a6e7.jpg)

