### PR TITLE
Add battery / color / temperature to remote control

### DIFF
--- a/devices/prolight.js
+++ b/devices/prolight.js
@@ -45,7 +45,7 @@ module.exports = [
         vendor: 'Prolight',
         description: 'Remote control',
         toZigbee: [],
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level],
-        exposes: [e.action(['on', 'off', 'brightness_move_up', 'brightness_move_down'])],
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move, fz.command_stop, fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_move_color_temperature, fz.battery],
+        exposes: [e.battery(), e.action(['on', 'off', 'color_temperature_move', 'color_temperature_move_up', 'color_temperature_move_down', 'color_move', 'brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_move_to_level'])]
     },
 ];

--- a/devices/prolight.js
+++ b/devices/prolight.js
@@ -45,10 +45,10 @@ module.exports = [
         vendor: 'Prolight',
         description: 'Remote control',
         toZigbee: [],
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move, fz.command_stop, 
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move, fz.command_stop,
             fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_move_color_temperature, fz.battery],
         exposes: [e.battery(), e.action(['on', 'off', 'color_temperature_move', 'color_temperature_move_up',
-            'color_temperature_move_down', 'color_move', 'brightness_move_up', 'brightness_move_down', 
+            'color_temperature_move_down', 'color_move', 'brightness_move_up', 'brightness_move_down',
             'brightness_stop', 'brightness_move_to_level'])],
     },
 ];

--- a/devices/prolight.js
+++ b/devices/prolight.js
@@ -45,7 +45,9 @@ module.exports = [
         vendor: 'Prolight',
         description: 'Remote control',
         toZigbee: [],
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move, fz.command_stop, fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_move_color_temperature, fz.battery],
-        exposes: [e.battery(), e.action(['on', 'off', 'color_temperature_move', 'color_temperature_move_up', 'color_temperature_move_down', 'color_move', 'brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_move_to_level'])]
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move, fz.command_stop, 
+                     fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_move_color_temperature, fz.battery],
+        exposes: [e.battery(), e.action(['on', 'off', 'color_temperature_move', 'color_temperature_move_up', 'color_temperature_move_down', 
+                                         'color_move', 'brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_move_to_level'])],
     },
 ];

--- a/devices/prolight.js
+++ b/devices/prolight.js
@@ -46,8 +46,9 @@ module.exports = [
         description: 'Remote control',
         toZigbee: [],
         fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move, fz.command_stop, 
-                     fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_move_color_temperature, fz.battery],
-        exposes: [e.battery(), e.action(['on', 'off', 'color_temperature_move', 'color_temperature_move_up', 'color_temperature_move_down', 
-                                         'color_move', 'brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_move_to_level'])],
+            fz.command_move_to_color_temp, fz.command_move_to_color, fz.command_move_color_temperature, fz.battery],
+        exposes: [e.battery(), e.action(['on', 'off', 'color_temperature_move', 'color_temperature_move_up',
+            'color_temperature_move_down', 'color_move', 'brightness_move_up', 'brightness_move_down', 
+            'brightness_stop', 'brightness_move_to_level'])],
     },
 ];


### PR DESCRIPTION
Added
- Battery
- Color / scenes
- Color temperature

To the Prolight Remote Control.

Compare it to the Ynoa LA-5KEY-RGBW or Linkind ZS230002!