### PR TITLE
xiaomi: MCCGQ14LM: fix battery and expose tamper

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -45,9 +45,10 @@ module.exports = [
         model: 'MCCGQ14LM',
         vendor: 'Xiaomi',
         description: 'Aqara E1 door & window contact sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.aqara_opple],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.aqara_opple, fz.battery],
         toZigbee: [],
-        exposes: [e.contact(), e.battery_low(), e.battery_voltage(), e.tamper()],
+        meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
+        exposes: [e.contact(), e.battery(), e.battery_low(), e.battery_voltage(), e.tamper()],
     },
     {
         zigbeeModel: ['lumi.magnet.ac01'],

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -47,7 +47,7 @@ module.exports = [
         description: 'Aqara E1 door & window contact sensor',
         fromZigbee: [fz.ias_contact_alarm_1, fz.aqara_opple],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_voltage()],
+        exposes: [e.contact(), e.battery_low(), e.battery_voltage(), e.tamper()],
     },
     {
         zigbeeModel: ['lumi.magnet.ac01'],


### PR DESCRIPTION
This is what my Aqara E1 shows in Zigbee2MQTT status:
```
{
    "battery_low": false,
    "contact": true,
    "linkquality": 87,
    "state": "OFF",
    "tamper": false,
    "temperature": 25,
    "voltage": 3019
}
```

There's no `battery` percent value and there's a tamper value.
`temperature` value is always 25ºC, as reported here: https://github.com/Koenkk/zigbee-herdsman-converters/pull/3585