### PR TITLE
Update xiaomi.js

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -55,15 +55,10 @@ module.exports = [
         model: 'MCCGQ13LM',
         vendor: 'Xiaomi',
         description: 'Aqara P1 door & window contact sensor',
-        fromZigbee: [fz. xiaomi_contact, fz.ias_contact_alarm_1, fz.aqara_opple, fz.battery],
+        fromZigbee: [fz. xiaomi_contact, fz.ias_contact_alarm_1, fz.aqara_opple],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         exposes: [e.contact(), e.battery(), e.battery_voltage()],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint);
-        },
     },
     {
         zigbeeModel: ['lumi.dimmer.rcbac1'],


### PR DESCRIPTION
Voltage comes from fz.aqara_opple.
No need fz.battery and reporting.
Before, not showing battery, cause meta is missing