### PR TITLE
Add OTA support, `battery` initialization and other improvements for `Xiaomi MCCGQ14LM`

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -48,7 +48,13 @@ module.exports = [
         fromZigbee: [fz.ias_contact_alarm_1, fz.aqara_opple, fz.battery],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
-        exposes: [e.contact(), e.battery(), e.battery_low(), e.battery_voltage(), e.tamper()],
+        exposes: [e.contact(), e.battery(), e.battery_low(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('genPowerCfg', ['batteryVoltage']);
+        },
+        // OTA request: "fieldControl":0, "manufacturerCode":4447, "imageType":10635
+        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['lumi.magnet.ac01'],

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -212,7 +212,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             } else if (['RTCGQ11LM'].includes(model.model)) {
                 // It contains the occupancy, but in z2m we use a custom timer to do it, so we ignore it
                 // payload.occupancy = value === 1;
-            } else if (['MCCGQ11LM'].includes(model.model)) {
+            } else if (['MCCGQ11LM', 'MCCGQ14LM'].includes(model.model)) {
                 payload.contact = value === 0;
             } else if (['SJCGQ11LM'].includes(model.model)) {
                 // Ignore the message. It seems not reliable. See discussion here https://github.com/Koenkk/zigbee2mqtt/issues/12018


### PR DESCRIPTION
Changes based on [log](https://github.com/Koenkk/zigbee2mqtt/issues/12372#issuecomment-1124179229) analysis provided by @Noltari

`e.tamper()` has been removed because the sensor does not physically have a tamper.