### PR TITLE
Expose `power_outage_count` and remove erroneous `state` and `illuminance` properties for `Xiaomi QBKG25LM`

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -636,6 +636,7 @@ module.exports = [
                 'left_single', 'left_double', 'center_single', 'center_double', 'right_single', 'right_double',
                 'single_left_center', 'double_left_center', 'single_left_right', 'double_left_right',
                 'single_center_right', 'double_center_right', 'single_all', 'double_all']),
+            e.power_outage_count(),
         ],
         onEvent: preventReset,
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -176,14 +176,18 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             payload.switch_type = {1: 'toggle', 2: 'momentary'}[value];
             break;
         case '11':
-            if (!['JT-BZ-01AQ/A'].includes(model.model)) {
+            if (['JT-BZ-01AQ/A', 'QBKG25LM'].includes(model.model)) {
+                // We don't know what the value means for these devices.
+                // https://github.com/Koenkk/zigbee2mqtt/issues/12451
+            } else {
                 payload.illuminance = calibrateAndPrecisionRoundOptions(value, options, 'illuminance');
                 // DEPRECATED: remove illuminance_lux here.
                 payload.illuminance_lux = calibrateAndPrecisionRoundOptions(value, options, 'illuminance_lux');
             }
             break;
         case '100':
-            if (['QBKG20LM', 'QBKG31LM', 'QBKG39LM', 'QBKG41LM', 'QBCZ15LM', 'LLKZMK11LM', 'QBKG12LM', 'QBKG03LM'].includes(model.model)) {
+            if (['QBKG20LM', 'QBKG31LM', 'QBKG39LM', 'QBKG41LM', 'QBCZ15LM', 'LLKZMK11LM', 'QBKG12LM', 'QBKG03LM', 'QBKG25LM']
+                .includes(model.model)) {
                 let mapping;
                 switch (model.model) {
                 case 'QBCZ15LM':


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#12451