### PR TITLE
Add 7602031N6 model for Hue Go with Bluetooth

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -465,7 +465,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LCT026', '7602031P7', '7602031U7'],
+        zigbeeModel: ['LCT026', '7602031P7', '7602031U7', '7602031N6'],
         model: '7602031P7',
         vendor: 'Philips',
         description: 'Hue Go with Bluetooth',


### PR DESCRIPTION
Adding 7602031N6 as a model for Hue with Bluetooth as it seems the Australian market has the same device/product specs but under a different model number.