### PR TITLE
Power outage count start from 0

### DIFF
--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -154,7 +154,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '2':
             if (['JT-BZ-01AQ/A'].includes(model.model)) {
-                payload.power_outage_count = value;
+                payload.power_outage_count = value - 1;
             }
             break;
         case '3':
@@ -169,7 +169,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '5':
             if (['Mains (single phase)', 'DC Source'].includes(meta.device.powerSource)) {
-                payload.power_outage_count = value;
+                payload.power_outage_count = value - 1;
             }
             break;
         case '10':

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -154,7 +154,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '2':
             if (['JT-BZ-01AQ/A'].includes(model.model)) {
-                payload.power_outage_count = value - 1;
+                payload.power_outage_count = value;
             }
             break;
         case '3':
@@ -169,7 +169,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             break;
         case '5':
             if (['Mains (single phase)', 'DC Source'].includes(meta.device.powerSource)) {
-                payload.power_outage_count = value - 1;
+                payload.power_outage_count = value;
             }
             break;
         case '10':


### PR DESCRIPTION
power_outage_count is always 1 initially, and should be subtracted from 1 to make it 0 to show the number of times the device's power has actually been interrupted

<pre>
info  2022-05-14 08:43:31: Successfully interviewed '0x04cf8cdf3c8e8762', device has successfully been paired
info  2022-05-14 08:43:31: Device '0x04cf8cdf3c8e8762' is supported, identified as: Xiaomi Aqara single switch module T1 (with neutral) (SSM-U01)
info  2022-05-14 08:43:31: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"definition":{"description":"Aqara single switch module T1 (with neutral)","exposes":[{"features":[{"access":7,"description":"On/off state of the switch","name":"state","property":"state","type":"binary","value_off":"OFF","value_on":"ON","value_toggle":"TOGGLE"}],"type":"switch"},{"access":1,"description":"Sum of consumed energy","nam
info  2022-05-14 08:43:31: Configuring '0x04cf8cdf3c8e8762'
info  2022-05-14 08:43:31: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"message":"interview_successful","meta":{"description":"Aqara single switch module T1 (with neutral)","friendly_name":"0x04cf8cdf3c8e8762","model":"SSM-U01","supported":true,"vendor":"Xiaomi"},"type":"pairing"}'
info  2022-05-14 08:43:31: Successfully configured '0x04cf8cdf3c8e8762'
debug 2022-05-14 08:43:32: Received Zigbee message from '0x04cf8cdf3c8e8762', type 'attributeReport', cluster 'genBasic', data '{"appVersion":23}' from endpoint 1 with groupID null
debug 2022-05-14 08:43:33: Received Zigbee message from '0x04cf8cdf3c8e8762', type 'attributeReport', cluster 'aqaraOpple', data '{"247":{"data":[100,16,0,3,40,22,152,57,0,0,0,0,149,57,0,0,0,0,150,57,13,111,18,69,151,57,0,0,0,0,5,33,1,0,154,32,0,11,32,0,8,33,23,1,9,33,0,1],"type":"Buffer"}}' from endpoint 1 with groupID null
debug 2022-05-14 08:43:33: lumi.switch.n0agl1: Processed buffer into data {"3":22,"5":1,"8":279,"9":256,"11":0,"100":0,"149":0,"150":2342.940673828125,"151":0,"152":0,"154":0}
debug 2022-05-14 08:43:33: lumi.switch.n0agl1: unknown key 8 with value 279
debug 2022-05-14 08:43:33: lumi.switch.n0agl1: unknown key 9 with value 256
debug 2022-05-14 08:43:33: lumi.switch.n0agl1: unknown key 154 with value 0
debug 2022-05-14 08:43:33: lumi.switch.n0agl1: Processed data into payload {"temperature":22,"power_outage_count":1,"illuminance":0,"illuminance_lux":0,"state":"OFF","energy":0,"consumption":0,"voltage":234.3,"current":0,"power":0}
debug 2022-05-14 08:43:33: lumi.switch.n0agl1: Processed data into payload {"temperature":22,"power_outage_count":1,"illuminance":0,"illuminance_lux":0,"state":"OFF","energy":0,"consumption":0,"voltage":234.3,"current":0,"power":0}
</pre>