### PR TITLE
Added duration support to the Merten Roller Shutter drive

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -441,9 +441,9 @@ module.exports = [
         vendor: 'Schneider Electric',
         description: 'Merten MEG5165 PlusLink Shutter insert with Merten Wiser System M Push Button (1fold)',
         fromZigbee: [fz.cover_position_tilt, fz.command_cover_close, fz.command_cover_open, fz.command_cover_stop],
-        toZigbee: [tz.cover_position_tilt, tz.cover_state, tzLocal.lift_duration, tzLocal.led_setting],
+        toZigbee: [tz.cover_position_tilt, tz.cover_state, tzLocal.lift_duration],
         exposes: [e.cover_position(), 
-                    exposes.numeric('lift_duration', ea.STATE_SET).withUnit('seconds').withValueMin(0).withValueMax(300).withDescription('Duration of lift')
+                exposes.numeric('lift_duration', ea.STATE_SET).withUnit('seconds').withValueMin(0).withValueMax(300).withDescription('Duration of lift')
                 ],
         meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -442,9 +442,10 @@ module.exports = [
         description: 'Merten MEG5165 PlusLink Shutter insert with Merten Wiser System M Push Button (1fold)',
         fromZigbee: [fz.cover_position_tilt, fz.command_cover_close, fz.command_cover_open, fz.command_cover_stop],
         toZigbee: [tz.cover_position_tilt, tz.cover_state, tzLocal.lift_duration],
-        exposes: [e.cover_position(), 
-                exposes.numeric('lift_duration', ea.STATE_SET).withUnit('seconds').withValueMin(0).withValueMax(300).withDescription('Duration of lift')
-                ],
+        exposes: [e.cover_position(),
+            exposes.numeric('lift_duration', ea.STATE_SET).withUnit('seconds').withValueMin(0)
+            .withValueMax(300).withDescription('Duration of lift')
+        ],
         meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(5);

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -439,13 +439,15 @@ module.exports = [
         zigbeeModel: ['1GANG/SHUTTER/1'],
         model: 'MEG5113-0300/MEG5165-0000',
         vendor: 'Schneider Electric',
-        description: 'Merten PlusLink Shutter insert with Merten Wiser System M Push Button',
+        description: 'Merten MEG5165 PlusLink Shutter insert with Merten Wiser System M Push Button (1fold)',
         fromZigbee: [fz.cover_position_tilt, fz.command_cover_close, fz.command_cover_open, fz.command_cover_stop],
-        toZigbee: [tz.cover_position_tilt, tz.cover_state],
-        exposes: [e.cover_position()],
+        toZigbee: [tz.cover_position_tilt, tz.cover_state, tzLocal.lift_duration, tzLocal.led_setting],
+        exposes: [e.cover_position(), 
+                    exposes.numeric('lift_duration', ea.STATE_SET).withUnit('seconds').withValueMin(0).withValueMax(300).withDescription('Duration of lift')
+                ],
         meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1) || device.getEndpoint(5);
+            const endpoint = device.getEndpoint(5);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
             await reporting.currentPositionLiftPercentage(endpoint);
         },

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -442,10 +442,8 @@ module.exports = [
         description: 'Merten MEG5165 PlusLink Shutter insert with Merten Wiser System M Push Button (1fold)',
         fromZigbee: [fz.cover_position_tilt, fz.command_cover_close, fz.command_cover_open, fz.command_cover_stop],
         toZigbee: [tz.cover_position_tilt, tz.cover_state, tzLocal.lift_duration],
-        exposes: [e.cover_position(),
-            exposes.numeric('lift_duration', ea.STATE_SET).withUnit('seconds').withValueMin(0)
-            .withValueMax(300).withDescription('Duration of lift')
-        ],
+        exposes: [e.cover_position(), exposes.numeric('lift_duration', ea.STATE_SET).withUnit('seconds')
+            .withValueMin(0).withValueMax(300).withDescription('Duration of lift')],
         meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(5);

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -446,7 +446,7 @@ module.exports = [
             .withValueMin(0).withValueMax(300).withDescription('Duration of lift')],
         meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(5);
+            const endpoint = device.getEndpoint(1) || device.getEndpoint(5);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
             await reporting.currentPositionLiftPercentage(endpoint);
         },


### PR DESCRIPTION
I added the function to support setting the duration of the Merten Roller Shutter driver following the request [on this post](https://community.home-assistant.io/t/hab-mal-ne-frage-bzgl-deiner-merten-rolladen-mqtt-losung/363990/3?u=7h0mas-r)
Tested it and it is working for me (function was also already implemented for the `PUCK/SHUTTER/1`device.