### PR TITLE
Move Somgoms cover switch definition

### DIFF
--- a/devices/somgoms.js
+++ b/devices/somgoms.js
@@ -26,6 +26,15 @@ module.exports = [
         exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],
     },
     {
+        zigbeeModel: ['sbordckq'],
+        model: 'TS0601_switch_cover',
+        vendor: 'Somgoms',
+        description: 'Curtain switch',
+        fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],
+        toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options],
+        exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],
+    },
+    {
         zigbeeModel: ['hpb9yts'],
         model: 'ZSTY-SM-1DMZG-US-W',
         vendor: 'Somgoms',

--- a/devices/somgoms.js
+++ b/devices/somgoms.js
@@ -27,7 +27,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['sbordckq'],
-        model: 'TS0601_switch_cover',
+        model: 'SM-1CTW-EU',
         vendor: 'Somgoms',
         description: 'Curtain switch',
         fromZigbee: [fz.tuya_cover, fz.ignore_basic_report],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1099,7 +1099,6 @@ module.exports = [
             {modelID: 'zo2pocs\u0000', manufacturerName: '_TYST11_fzo2pocs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_cf1sl3tj'},
             // Roller blinds:
-            {modelID: 'TS0601', manufacturerName: '_TZE200_sbordckq'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_fctwhugx'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zah67ekd'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_hsgrhjpf'},


### PR DESCRIPTION
The Somgoms 'sbordckq' incorrectly identified as a cover motor controller.
This moves the definition into the Somgoms vendor file and specifies it as a cover switch.

closes #4254 

- [x] run lint
- [x] run test
- [x] create pr for documentation