### PR TITLE
Add support for Legrand Binary Input On Off (NLIS)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5379,6 +5379,15 @@ const converters = {
             return {action: msg.data.presentValue ? 'moving' : 'stopped'};
         },
     },
+    legrand_binary_input_on_off: {
+        cluster: 'genBinaryInput',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const multiEndpoint = model.meta && model.meta.multiEndpoint;
+            const property = multiEndpoint ? postfixWithEndpointName('state', msg, model) : 'state';
+            return {[property]: msg.data.presentValue ? 'ON' : 'OFF'};
+        },
+    },
     bticino_4027C_binary_input_moving: {
         cluster: 'genBinaryInput',
         type: ['attributeReport', 'readResponse'],

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -324,7 +324,7 @@ module.exports = [
         model: '067772',
         vendor: 'Legrand',
         description: 'Double wired switch with neutral',
-        fromZigbee: [fz.on_off, fz.legrand_cluster_fc01],
+        fromZigbee: [fz.on_off, fz.legrand_binary_input_on_off, fz.legrand_cluster_fc01],
         toZigbee: [tz.on_off, tz.legrand_settingAlwaysEnableLed, tz.legrand_settingEnableLedIfOn],
         exposes: [e.switch().withEndpoint('left'),
             e.switch().withEndpoint('right'),
@@ -333,9 +333,9 @@ module.exports = [
         meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpointLeft = device.getEndpoint(2);
-            await reporting.bind(endpointLeft, coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(endpointLeft, coordinatorEndpoint, ['genOnOff', 'genBinaryInput']);
             const endpointRight = device.getEndpoint(1);
-            await reporting.bind(endpointRight, coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(endpointRight, coordinatorEndpoint, ['genOnOff', 'genBinaryInput']);
         },
         endpoint: (device) => {
             return {left: 2, right: 1};


### PR DESCRIPTION
When pressing on a button of the NLIS switch, the switch immediately sends a genOnOff attributeReport, then a second one around 5 seconds later.
Between these two messages, every time one of the two buttons is pressed, genBinaryInput messages are sent to report the new state rather than genOnOff.

Adding this allows the two endpoints states to be updated instantly without having to wait for the next (and delayed) genOnOff message.