### PR TITLE
Include support for temperature and power outage count in SSM-U02

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1601,7 +1601,7 @@ module.exports = [
         model: 'SSM-U02',
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (without neutral). Doesn\'t work as a router and doesn\'t support power meter',
-        fromZigbee: [fz.on_off, fz.aqara_opple, fz.temperature],
+        fromZigbee: [fz.on_off, fz.aqara_opple],
         exposes: [e.switch(), e.power_outage_memory(), e.switch_type(), e.power_outage_count(), e.device_temperature()],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1601,8 +1601,8 @@ module.exports = [
         model: 'SSM-U02',
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (without neutral). Doesn\'t work as a router and doesn\'t support power meter',
-        fromZigbee: [fz.on_off, fz.aqara_opple],
-        exposes: [e.switch(), e.power_outage_memory(), e.switch_type()],
+        fromZigbee: [fz.on_off, fz.aqara_opple, fz.temperature],
+        exposes: [e.switch(), e.power_outage_memory(), e.switch_type(), e.power_outage_count(), e.device_temperature()],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1601,8 +1601,8 @@ module.exports = [
         model: 'SSM-U02',
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (without neutral). Doesn\'t work as a router and doesn\'t support power meter',
-        fromZigbee: [fz.on_off, fz.aqara_opple, fz.temperature],
-        exposes: [e.switch(), e.power_outage_memory(), e.switch_type(), e.power_outage_count(), e.device_temperature()],
+        fromZigbee: [fz.on_off, fz.aqara_opple],
+        exposes: [e.switch(), e.power_outage_memory(), e.switch_type()],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Log 

<pre>
Zigbee2MQTT:debug 2022-05-18 22:43:51: Received MQTT message on 'zigbee2mqtt/bridge/request/device/configure' with data '{"id":"0x54ef4410000760b6","transaction":"8yro5-1"}'
Zigbee2MQTT:info  2022-05-18 22:43:51: Configuring '0x54ef4410000760b6'
Zigbee2MQTT:info  2022-05-18 22:43:52: Successfully configured '0x54ef4410000760b6'
Zigbee2MQTT:info  2022-05-18 22:43:52: MQTT publish: topic 'zigbee2mqtt/bridge/response/device/configure', payload '{"data":{"id":"0x54ef4410000760b6"},"status":"ok","transaction":"8yro5-1"}'
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'zigbee2mqtt/bridge/request/device/remove' with data '{"block":false,"force":true,"id":"0x54ef4410000760b6","transaction":"8yro5-2"}'
Zigbee2MQTT:info  2022-05-18 22:44:20: Removing device '0x54ef4410000760b6' (block: false, force: true)
Zigbee2MQTT:debug 2022-05-18 22:44:20: Clearing Home Assistant discovery topic for '0x54ef4410000760b6'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'homeassistant/switch/0x54ef4410000760b6/switch/config', payload 'null'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'homeassistant/switch/0x54ef4410000760b6/switch_power_outage_memory/config', payload 'null'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/switch_type/config', payload 'null'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'homeassistant/select/0x54ef4410000760b6/switch_type/config', payload 'null'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/power_outage_count/config', payload 'null'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/temperature/config', payload 'null'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/linkquality/config', payload 'null'
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'zigbee2mqtt/0x54ef4410000760b6', payload ''
Zigbee2MQTT:info  2022-05-18 22:44:20: Successfully removed device '0x54ef4410000760b6' (block: false, force: true)
Zigbee2MQTT:info  2022-05-18 22:44:20: MQTT publish: topic 'zigbee2mqtt/bridge/response/device/remove', payload '{"data":{"block":false,"force":true,"id":"0x54ef4410000760b6"},"status":"ok","transaction":"8yro5-2"}'
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'homeassistant/switch/0x54ef4410000760b6/switch/config' with data ''
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'homeassistant/switch/0x54ef4410000760b6/switch_power_outage_memory/config' with data ''
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/switch_type/config' with data ''
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'homeassistant/select/0x54ef4410000760b6/switch_type/config' with data ''
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/power_outage_count/config' with data ''
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/temperature/config' with data ''
Zigbee2MQTT:debug 2022-05-18 22:44:20: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/linkquality/config' with data ''
Zigbee2MQTT:info  2022-05-18 22:44:42: Device '0x54ef4410000760b6' joined
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x54ef4410000760b6","ieee_address":"0x54ef4410000760b6"},"type":"device_joined"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'homeassistant/switch/0x54ef4410000760b6/switch/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"command_topic":"zigbee2mqtt/0x54ef4410000760b6/set","device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"name":"0x54ef4410000760b6","payload_off":"OFF","payload_on":"ON","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_zigbee2mqtt","value_template":"{{ value_json.state }}"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'homeassistant/switch/0x54ef4410000760b6/switch_power_outage_memory/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"command_topic":"zigbee2mqtt/0x54ef4410000760b6/set/power_outage_memory","device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"entity_category":"config","icon":"mdi:memory","name":"0x54ef4410000760b6 power_outage_memory","payload_off":"false","payload_on":"true","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_power_outage_memory_zigbee2mqtt","value_template":"{% if value_json.power_outage_memory %} true {% else %} false {% endif %}"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/switch_type/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"enabled_by_default":false,"entity_category":"config","icon":"mdi:tune","name":"0x54ef4410000760b6 switch type","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_type_zigbee2mqtt","value_template":"{{ value_json.switch_type }}"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'homeassistant/select/0x54ef4410000760b6/switch_type/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"command_topic":"zigbee2mqtt/0x54ef4410000760b6/set/switch_type","device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"entity_category":"config","icon":"mdi:tune","name":"0x54ef4410000760b6 switch type","options":["toggle","momentary","off"],"state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_type_zigbee2mqtt","value_template":"{{ value_json.switch_type }}"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/power_outage_count/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"enabled_by_default":true,"name":"0x54ef4410000760b6 power outage count","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_power_outage_count_zigbee2mqtt","value_template":"{{ value_json.power_outage_count }}"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/temperature/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"device_class":"temperature","enabled_by_default":true,"name":"0x54ef4410000760b6 temperature","state_class":"measurement","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_temperature_zigbee2mqtt","unit_of_measurement":"°C","value_template":"{{ value_json.temperature }}"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'homeassistant/sensor/0x54ef4410000760b6/linkquality/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"enabled_by_default":false,"entity_category":"diagnostic","icon":"mdi:signal","name":"0x54ef4410000760b6 linkquality","state_class":"measurement","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_linkquality_zigbee2mqtt","unit_of_measurement":"lqi","value_template":"{{ value_json.linkquality }}"}'
Zigbee2MQTT:info  2022-05-18 22:44:42: Starting interview of '0x54ef4410000760b6'
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x54ef4410000760b6","ieee_address":"0x54ef4410000760b6","status":"started"},"type":"device_interview"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Received MQTT message on 'homeassistant/switch/0x54ef4410000760b6/switch/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"command_topic":"zigbee2mqtt/0x54ef4410000760b6/set","device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"name":"0x54ef4410000760b6","payload_off":"OFF","payload_on":"ON","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_zigbee2mqtt","value_template":"{{ value_json.state }}"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Received MQTT message on 'homeassistant/switch/0x54ef4410000760b6/switch_power_outage_memory/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"command_topic":"zigbee2mqtt/0x54ef4410000760b6/set/power_outage_memory","device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"entity_category":"config","icon":"mdi:memory","name":"0x54ef4410000760b6 power_outage_memory","payload_off":"false","payload_on":"true","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_power_outage_memory_zigbee2mqtt","value_template":"{% if value_json.power_outage_memory %} true {% else %} false {% endif %}"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/switch_type/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"enabled_by_default":false,"entity_category":"config","icon":"mdi:tune","name":"0x54ef4410000760b6 switch type","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_type_zigbee2mqtt","value_template":"{{ value_json.switch_type }}"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Received MQTT message on 'homeassistant/select/0x54ef4410000760b6/switch_type/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"command_topic":"zigbee2mqtt/0x54ef4410000760b6/set/switch_type","device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"entity_category":"config","icon":"mdi:tune","name":"0x54ef4410000760b6 switch type","options":["toggle","momentary","off"],"state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_switch_type_zigbee2mqtt","value_template":"{{ value_json.switch_type }}"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/power_outage_count/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"enabled_by_default":true,"name":"0x54ef4410000760b6 power outage count","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_power_outage_count_zigbee2mqtt","value_template":"{{ value_json.power_outage_count }}"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/temperature/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"device_class":"temperature","enabled_by_default":true,"name":"0x54ef4410000760b6 temperature","state_class":"measurement","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_temperature_zigbee2mqtt","unit_of_measurement":"°C","value_template":"{{ value_json.temperature }}"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Received MQTT message on 'homeassistant/sensor/0x54ef4410000760b6/linkquality/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x54ef4410000760b6"],"manufacturer":"Xiaomi","model":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)","name":"0x54ef4410000760b6"},"enabled_by_default":false,"entity_category":"diagnostic","icon":"mdi:signal","name":"0x54ef4410000760b6 linkquality","state_class":"measurement","state_topic":"zigbee2mqtt/0x54ef4410000760b6","unique_id":"0x54ef4410000760b6_linkquality_zigbee2mqtt","unit_of_measurement":"lqi","value_template":"{{ value_json.linkquality }}"}'
Zigbee2MQTT:debug 2022-05-18 22:44:42: Device '0x54ef4410000760b6' announced itself
Zigbee2MQTT:info  2022-05-18 22:44:42: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x54ef4410000760b6","ieee_address":"0x54ef4410000760b6"},"type":"device_announce"}'
Zigbee2MQTT:debug 2022-05-18 22:44:44: Received Zigbee message from '0x54ef4410000760b6', type 'attributeReport', cluster 'aqaraOpple', data '{"247":{"data":[100,16,0,3,40,24,5,33,1,0,154,32,16,8,33,22,1,10,33,51,252,11,32,0],"type":"Buffer"}}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 22:44:44: lumi.switch.l0agl1: Processed buffer into data {"3":24,"5":1,"8":278,"10":64563,"11":0,"100":0,"154":16}
Zigbee2MQTT:debug 2022-05-18 22:44:44: lumi.switch.l0agl1: Processed data into payload {"temperature":24,"power_outage_count":0,"unknown8":278,"illuminance":0,"illuminance_lux":0,"state":"OFF","unknown154":16}
Zigbee2MQTT:debug 2022-05-18 22:44:44: lumi.switch.l0agl1: Processed data into payload {"temperature":24,"power_outage_count":0,"unknown8":278,"illuminance":0,"illuminance_lux":0,"state":"OFF","unknown154":16}
Zigbee2MQTT:info  2022-05-18 22:44:44: MQTT publish: topic 'zigbee2mqtt/0x54ef4410000760b6', payload '{"illuminance":0,"illuminance_lux":0,"linkquality":87,"power_outage_count":0,"power_outage_memory":null,"state":"OFF","temperature":24,"unknown154":16,"unknown8":278}'
Zigbee2MQTT:debug 2022-05-18 22:44:45: Received Zigbee message from '0x54ef4410000760b6', type 'attributeReport', cluster 'genBasic', data '{"appVersion":22,"modelId":"lumi.switch.l0agl1"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 22:44:45: Received Zigbee message from '0x54ef4410000760b6', type 'read', cluster 'genTime', data '["time","timeZone"]' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 22:44:46: Received Zigbee message from '0x54ef4410000760b6', type 'attributeReport', cluster 'genBasic', data '{"appVersion":22}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 22:44:47: Received Zigbee message from '0x54ef4410000760b6', type 'attributeReport', cluster 'aqaraOpple', data '{"247":{"data":[100,16,0,3,40,24,5,33,1,0,154,32,16,8,33,22,1,10,33,51,252,11,32,0],"type":"Buffer"}}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 22:44:47: lumi.switch.l0agl1: Processed buffer into data {"3":24,"5":1,"8":278,"10":64563,"11":0,"100":0,"154":16}
Zigbee2MQTT:debug 2022-05-18 22:44:47: lumi.switch.l0agl1: Processed data into payload {"temperature":24,"	power_outage_count":0,"unknown8":278,"illuminance":0,"illuminance_lux":0,"state":"OFF","unknown154":16}
Zigbee2MQTT:debug 2022-05-18 22:44:47: lumi.switch.l0agl1: Processed data into payload {"temperature":24,"power_outage_count":0,"unknown8":278,"illuminance":0,"illuminance_lux":0,"state":"OFF","unknown154":16}
Zigbee2MQTT:info  2022-05-18 22:44:47: MQTT publish: topic 'zigbee2mqtt/0x54ef4410000760b6', payload '{"illuminance":0,"illuminance_lux":0,"linkquality":76,"power_outage_count":0,"power_outage_memory":null,"state":"OFF","temperature":24,"unknown154":16,"unknown8":278}'
Zigbee2MQTT:debug 2022-05-18 22:44:48: Received Zigbee message from '0x54ef4410000760b6', type 'attributeReport', cluster 'genOnOff', data '{"245":50331392,"onOff":0}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2022-05-18 22:44:48: MQTT publish: topic 'zigbee2mqtt/0x54ef4410000760b6', payload '{"illuminance":0,"illuminance_lux":0,"linkquality":83,"power_outage_count":0,"power_outage_memory":null,"state":"OFF","temperature":24,"unknown154":16,"unknown8":278}'
Zigbee2MQTT:debug 2022-05-18 22:44:52: Received Zigbee message from '0x54ef4410000760b6', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2022-05-18 22:44:53: Successfully interviewed '0x54ef4410000760b6', device has successfully been paired
Zigbee2MQTT:info  2022-05-18 22:44:53: Device '0x54ef4410000760b6' is supported, identified as: Xiaomi Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter (SSM-U02)
Zigbee2MQTT:info  2022-05-18 22:44:53: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"definition":{"description":"Aqara single switch module T1 (without neutral). Doesn't work as a router and doesn't support power meter","exposes":[{"features":[{"access":7,"description":"On/off state of the switch","name":"state","property":"state","type":"binary","value_off":"OFF","value_on":"ON","value_toggle":"TOGGLE"}],"type":"switch"},{"access":7,"description":"Enable/disable the power outage memory, this recovers the on/off mode after power failure","name":"power_outage_memory","property":"power_outage_memory","type":"binary","value_off":false,"value_on":true},{"access":7,"description":"Wall switch type","name":"switch_type","property":"switch_type","type":"enum","values":["toggle","momentary","off"]},{"access":1,"description":"Number of power outages (since last pairing)","name":"power_outage_count","property":"power_outage_count","type":"numeric"},{"access":1,"description":"Measured temperature value","name":"temperature","property":"temperature","type":"numeric","unit":"°C"},{"access":1,"description":"Link quality (signal strength)","name":"linkquality","property":"linkquality","type":"numeric","unit":"lqi","value_max":255,"value_min":0}],"model":"SSM-U02","options":[{"access":2,"description":"Number of digits after decimal point for temperature, takes into effect on next report of device.","name":"temperature_precision","property":"temperature_precision","type":"numeric","value_max":3,"value_min":0},{"access":2,"description":"Calibrates the temperature value (absolute offset), takes into effect on next report of device.","name":"temperature_calibration","property":"temperature_calibration","type":"numeric"}],"supports_ota":false,"vendor":"Xiaomi"},"friendly_name":"0x54ef4410000760b6","ieee_address":"0x54ef4410000760b6","status":"successful","supported":true},"type":"device_interview"}'
Zigbee2MQTT:info  2022-05-18 22:44:53: Configuring '0x54ef4410000760b6'
Zigbee2MQTT:info  2022-05-18 22:44:53: Successfully configured '0x54ef4410000760b6'
Zigbee2MQTT:debug 2022-05-18 22:45:58: Saving state to file /var/lib/zigbee2mqtt/state.json
</pre>