### PR TITLE
Include support for power outage count in MCCGQ01LM

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1001,7 +1001,7 @@ module.exports = [
         meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_basic, fz.ias_water_leak_alarm_1],
         toZigbee: [],
-        exposes: [e.battery(), e.water_leak(), e.battery_low(), e.battery_voltage(), e.temperature()],
+        exposes: [e.battery(), e.water_leak(), e.battery_low(), e.battery_voltage(), e.temperature(), e.power_outage_count()],
     },
     {
         zigbeeModel: ['lumi.flood.agl02'],

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1601,8 +1601,8 @@ module.exports = [
         model: 'SSM-U02',
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (without neutral). Doesn\'t work as a router and doesn\'t support power meter',
-        fromZigbee: [fz.on_off, fz.aqara_opple],
-        exposes: [e.switch(), e.power_outage_memory(), e.switch_type()],
+        fromZigbee: [fz.on_off, fz.aqara_opple, fz.temperature],
+        exposes: [e.switch(), e.power_outage_memory(), e.switch_type(), e.power_outage_count(), e.device_temperature()],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1601,8 +1601,8 @@ module.exports = [
         model: 'SSM-U02',
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (without neutral). Doesn\'t work as a router and doesn\'t support power meter',
-        fromZigbee: [fz.on_off, fz.aqara_opple, fz.temperature],
-        exposes: [e.switch(), e.power_outage_memory(), e.switch_type(), e.power_outage_count(), e.device_temperature()],
+        fromZigbee: [fz.on_off, fz.aqara_opple],
+        exposes: [e.switch(), e.power_outage_memory(), e.switch_type()],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Shows the number of times the battery has been changed
attached log

<pre>
Zigbee2MQTT:warn  2022-05-18 23:12:38: Device '0x00158d0006c4b533' left the network
Zigbee2MQTT:info  2022-05-18 23:12:38: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d0006c4b533","ieee_address":"0x00158d0006c4b533"},"type":"device_leave"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: Device '0x00158d0006c4b533' joined
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d0006c4b533","ieee_address":"0x00158d0006c4b533"},"type":"device_joined"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'homeassistant/sensor/0x00158d0006c4b533/battery/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"battery","enabled_by_default":true,"entity_category":"diagnostic","name":"0x00158d0006c4b533 battery","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_battery_zigbee2mqtt","unit_of_measurement":"%","value_template":"{{ value_json.battery }}"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'homeassistant/binary_sensor/0x00158d0006c4b533/water_leak/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"moisture","name":"0x00158d0006c4b533 water leak","payload_off":false,"payload_on":true,"state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_water_leak_zigbee2mqtt","value_template":"{{ value_json.water_leak }}"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'homeassistant/binary_sensor/0x00158d0006c4b533/battery_low/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"battery","entity_category":"diagnostic","name":"0x00158d0006c4b533 battery low","payload_off":false,"payload_on":true,"state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_battery_low_zigbee2mqtt","value_template":"{{ value_json.battery_low }}"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'homeassistant/sensor/0x00158d0006c4b533/voltage/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"voltage","enabled_by_default":false,"entity_category":"diagnostic","name":"0x00158d0006c4b533 voltage","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_voltage_zigbee2mqtt","unit_of_measurement":"mV","value_template":"{{ value_json.voltage }}"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'homeassistant/sensor/0x00158d0006c4b533/temperature/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"temperature","enabled_by_default":true,"name":"0x00158d0006c4b533 temperature","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_temperature_zigbee2mqtt","unit_of_measurement":"°C","value_template":"{{ value_json.temperature }}"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'homeassistant/sensor/0x00158d0006c4b533/linkquality/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"enabled_by_default":false,"entity_category":"diagnostic","icon":"mdi:signal","name":"0x00158d0006c4b533 linkquality","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_linkquality_zigbee2mqtt","unit_of_measurement":"lqi","value_template":"{{ value_json.linkquality }}"}'
Zigbee2MQTT:info  2022-05-18 23:12:39: Starting interview of '0x00158d0006c4b533'
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d0006c4b533","ieee_address":"0x00158d0006c4b533","status":"started"},"type":"device_interview"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Received MQTT message on 'homeassistant/sensor/0x00158d0006c4b533/battery/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"battery","enabled_by_default":true,"entity_category":"diagnostic","name":"0x00158d0006c4b533 battery","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_battery_zigbee2mqtt","unit_of_measurement":"%","value_template":"{{ value_json.battery }}"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Received MQTT message on 'homeassistant/binary_sensor/0x00158d0006c4b533/water_leak/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"moisture","name":"0x00158d0006c4b533 water leak","payload_off":false,"payload_on":true,"state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_water_leak_zigbee2mqtt","value_template":"{{ value_json.water_leak }}"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Received MQTT message on 'homeassistant/binary_sensor/0x00158d0006c4b533/battery_low/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"battery","entity_category":"diagnostic","name":"0x00158d0006c4b533 battery low","payload_off":false,"payload_on":true,"state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_battery_low_zigbee2mqtt","value_template":"{{ value_json.battery_low }}"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Received MQTT message on 'homeassistant/sensor/0x00158d0006c4b533/voltage/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"voltage","enabled_by_default":false,"entity_category":"diagnostic","name":"0x00158d0006c4b533 voltage","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_voltage_zigbee2mqtt","unit_of_measurement":"mV","value_template":"{{ value_json.voltage }}"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Received MQTT message on 'homeassistant/sensor/0x00158d0006c4b533/temperature/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"device_class":"temperature","enabled_by_default":true,"name":"0x00158d0006c4b533 temperature","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_temperature_zigbee2mqtt","unit_of_measurement":"°C","value_template":"{{ value_json.temperature }}"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Received MQTT message on 'homeassistant/sensor/0x00158d0006c4b533/linkquality/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d0006c4b533"],"manufacturer":"Xiaomi","model":"Aqara water leak sensor (SJCGQ11LM)","name":"0x00158d0006c4b533","sw_version":"3000-0001"},"enabled_by_default":false,"entity_category":"diagnostic","icon":"mdi:signal","name":"0x00158d0006c4b533 linkquality","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d0006c4b533","unique_id":"0x00158d0006c4b533_linkquality_zigbee2mqtt","unit_of_measurement":"lqi","value_template":"{{ value_json.linkquality }}"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Device '0x00158d0006c4b533' announced itself
Zigbee2MQTT:info  2022-05-18 23:12:39: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d0006c4b533","ieee_address":"0x00158d0006c4b533"},"type":"device_announce"}'
Zigbee2MQTT:debug 2022-05-18 23:12:39: Received Zigbee message from '0x00158d0006c4b533', type 'attributeReport', cluster 'genBasic', data '{"appVersion":6,"modelId":"lumi.sensor_wleak.aq1"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 23:12:39: lumi.sensor_wleak.aq1: unknown key appVersion with value 6
Zigbee2MQTT:debug 2022-05-18 23:12:39: lumi.sensor_wleak.aq1: Processed data into payload {}
Zigbee2MQTT:debug 2022-05-18 23:12:40: Received Zigbee message from '0x00158d0006c4b533', type 'attributeReport', cluster 'genBasic', data '{"65281":{"1":3045,"10":0,"100":0,"3":33,"4":424,"5":7,"6":[0,1],"8":518}}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 23:12:40: lumi.sensor_wleak.aq1: unknown key 6 with value 0,1
Zigbee2MQTT:debug 2022-05-18 23:12:40: lumi.sensor_wleak.aq1: Processed data into payload {"voltage":3045,"battery":100,"temperature":33,"power_outage_count":6,"unknown8":518}
Zigbee2MQTT:debug 2022-05-18 23:12:40: lumi.sensor_wleak.aq1: Processed data into payload {"voltage":3045,"battery":100,"temperature":33,"power_outage_count":6,"unknown8":518}
Zigbee2MQTT:info  2022-05-18 23:12:40: MQTT publish: topic 'zigbee2mqtt/0x00158d0006c4b533', payload '{"battery":100,"battery_low":null,"linkquality":167,"power_outage_count":6,"temperature":33,"unknown8":518,"voltage":3045,"water_leak":null}'
Zigbee2MQTT:info  2022-05-18 23:12:44: Successfully interviewed '0x00158d0006c4b533', device has successfully been paired
Zigbee2MQTT:info  2022-05-18 23:12:44: Device '0x00158d0006c4b533' is supported, identified as: Xiaomi Aqara water leak sensor (SJCGQ11LM)
Zigbee2MQTT:info  2022-05-18 23:12:44: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"definition":{"description":"Aqara water leak sensor","exposes":[{"access":1,"description":"Remaining battery in %","name":"battery","property":"battery","type":"numeric","unit":"%","value_max":100,"value_min":0},{"access":1,"description":"Indicates whether the device detected a water leak","name":"water_leak","property":"water_leak","type":"binary","value_off":false,"value_on":true},{"access":1,"description":"Indicates if the battery of this device is almost empty","name":"battery_low","property":"battery_low","type":"binary","value_off":false,"value_on":true},{"access":1,"description":"Voltage of the battery in millivolts","name":"voltage","property":"voltage","type":"numeric","unit":"mV"},{"access":1,"description":"Measured temperature value","name":"temperature","property":"temperature","type":"numeric","unit":"°C"},{"access":1,"description":"Link quality (signal strength)","name":"linkquality","property":"linkquality","type":"numeric","unit":"lqi","value_max":255,"value_min":0}],"model":"SJCGQ11LM","options":[{"access":2,"description":"Number of digits after decimal point for temperature, takes into effect on next report of device.","name":"temperature_precision","property":"temperature_precision","type":"numeric","value_max":3,"value_min":0},{"access":2,"description":"Calibrates the temperature value (absolute offset), takes into effect on next report of device.","name":"temperature_calibration","property":"temperature_calibration","type":"numeric"}],"supports_ota":false,"vendor":"Xiaomi"},"friendly_name":"0x00158d0006c4b533","ieee_address":"0x00158d0006c4b533","status":"successful","supported":true},"type":"device_interview"}'
Zigbee2MQTT:debug 2022-05-18 23:13:40: Received Zigbee message from '0x00158d0006c4b533', type 'attributeReport', cluster 'genBasic', data '{"65281":{"1":3045,"10":0,"100":0,"3":34,"4":424,"5":7,"6":[0,0],"8":518},"modelId":"lumi.sensor_wleak.aq1"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 23:13:40: lumi.sensor_wleak.aq1: unknown key 6 with value 0,0
Zigbee2MQTT:debug 2022-05-18 23:13:40: lumi.sensor_wleak.aq1: Processed data into payload {"voltage":3045,"battery":100,"temperature":34,"power_outage_count":6,"unknown8":518}
Zigbee2MQTT:debug 2022-05-18 23:13:40: lumi.sensor_wleak.aq1: Processed data into payload {"voltage":3045,"battery":100,"temperature":34,"power_outage_count":6,"unknown8":518}
Zigbee2MQTT:info  2022-05-18 23:13:40: MQTT publish: topic 'zigbee2mqtt/0x00158d0006c4b533', payload '{"battery":100,"battery_low":null,"linkquality":149,"power_outage_count":6,"temperature":34,"unknown8":518,"voltage":3045,"water_leak":null}'
Zigbee2MQTT:debug 2022-05-18 23:14:58: Received MQTT message on 'zigbee2mqtt/bridge/request/device/configure' with data '{"id":"0x00158d0006c4b533","transaction":"v5mnw-1"}'
Zigbee2MQTT:info  2022-05-18 23:14:58: MQTT publish: topic 'zigbee2mqtt/bridge/response/device/configure', payload '{"data":{"id":"0x00158d0006c4b533"},"error":"Device '0x00158d0006c4b533' cannot be configured","status":"error","transaction":"v5mnw-1"}'
Zigbee2MQTT:debug 2022-05-18 23:15:58: Saving state to file /var/lib/zigbee2mqtt/state.json
Zigbee2MQTT:debug 2022-05-18 23:17:41: Received Zigbee message from '0x00158d0006c4b533', type 'attributeReport', cluster 'genBasic', data '{"65281":{"1":3045,"10":0,"100":0,"3":38,"4":5032,"5":8,"6":[0,0],"8":518},"modelId":"lumi.sensor_wleak.aq1"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 23:17:41: lumi.sensor_wleak.aq1: unknown key 6 with value 0,0
Zigbee2MQTT:debug 2022-05-18 23:17:41: lumi.sensor_wleak.aq1: Processed data into payload {"voltage":3045,"battery":100,"temperature":38,"power_outage_count":7,"unknown8":518}
Zigbee2MQTT:debug 2022-05-18 23:17:41: lumi.sensor_wleak.aq1: Processed data into payload {"voltage":3045,"battery":100,"temperature":38,"power_outage_count":7,"unknown8":518}
Zigbee2MQTT:info  2022-05-18 23:17:41: MQTT publish: topic 'zigbee2mqtt/0x00158d0006c4b533', payload '{"battery":100,"battery_low":null,"linkquality":178,"power_outage_count":7,"temperature":38,"unknown8":518,"voltage":3045,"water_leak":null}'
</pre>