### PR TITLE
Include support for temperature and power outage count in MFKZQ01LM

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1021,7 +1021,7 @@ module.exports = [
         description: 'Mi/Aqara smart home cube',
         meta: {battery: {voltageToPercentage: '3V_2850_3000_log'}},
         fromZigbee: [fz.xiaomi_basic, fz.MFKZQ01LM_action_multistate, fz.MFKZQ01LM_action_analog],
-        exposes: [e.battery(), e.battery_voltage(), e.angle('action_angle'),
+        exposes: [e.battery(), e.battery_voltage(), e.angle('action_angle'), e.temperature(), e.power_outage_count(),
             e.cube_side('action_from_side'), e.cube_side('action_side'), e.cube_side('action_to_side'),
             e.action(['shake', 'wakeup', 'fall', 'tap', 'slide', 'flip180', 'flip90', 'rotate_left', 'rotate_right'])],
         toZigbee: [],

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1601,8 +1601,8 @@ module.exports = [
         model: 'SSM-U02',
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (without neutral). Doesn\'t work as a router and doesn\'t support power meter',
-        fromZigbee: [fz.on_off, fz.aqara_opple],
-        exposes: [e.switch(), e.power_outage_memory(), e.switch_type()],
+        fromZigbee: [fz.on_off, fz.aqara_opple, fz.temperature],
+        exposes: [e.switch(), e.power_outage_memory(), e.switch_type(), e.power_outage_count(), e.device_temperature()],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1601,8 +1601,8 @@ module.exports = [
         model: 'SSM-U02',
         vendor: 'Xiaomi',
         description: 'Aqara single switch module T1 (without neutral). Doesn\'t work as a router and doesn\'t support power meter',
-        fromZigbee: [fz.on_off, fz.aqara_opple, fz.temperature],
-        exposes: [e.switch(), e.power_outage_memory(), e.switch_type(), e.power_outage_count(), e.device_temperature()],
+        fromZigbee: [fz.on_off, fz.aqara_opple],
+        exposes: [e.switch(), e.power_outage_memory(), e.switch_type()],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
<pre>
Zigbee2MQTT:info  2022-05-18 23:43:37: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d00051e15c2","ieee_address":"0x00158d00051e15c2"},"type":"device_leave"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: Device '0x00158d00051e15c2' joined
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d00051e15c2","ieee_address":"0x00158d00051e15c2"},"type":"device_joined"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/battery/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"device_class":"battery","enabled_by_default":true,"entity_category":"diagnostic","name":"0x00158d00051e15c2 battery","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_battery_zigbee2mqtt","unit_of_measurement":"%","value_template":"{{ value_json.battery }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/voltage/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"device_class":"voltage","enabled_by_default":false,"entity_category":"diagnostic","name":"0x00158d00051e15c2 voltage","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_voltage_zigbee2mqtt","unit_of_measurement":"mV","value_template":"{{ value_json.voltage }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/action_angle/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action angle","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_angle_zigbee2mqtt","unit_of_measurement":"°","value_template":"{{ value_json.action_angle }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/action_from_side/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action from side","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_from_side_zigbee2mqtt","value_template":"{{ value_json.action_from_side }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/action_side/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action side","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_side_zigbee2mqtt","value_template":"{{ value_json.action_side }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/action_to_side/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action to side","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_to_side_zigbee2mqtt","value_template":"{{ value_json.action_to_side }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/action/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"icon":"mdi:gesture-double-tap","name":"0x00158d00051e15c2 action","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_zigbee2mqtt","value_template":"{{ value_json.action }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'homeassistant/sensor/0x00158d00051e15c2/linkquality/config', payload '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":false,"entity_category":"diagnostic","icon":"mdi:signal","name":"0x00158d00051e15c2 linkquality","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_linkquality_zigbee2mqtt","unit_of_measurement":"lqi","value_template":"{{ value_json.linkquality }}"}'
Zigbee2MQTT:info  2022-05-18 23:43:39: Starting interview of '0x00158d00051e15c2'
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d00051e15c2","ieee_address":"0x00158d00051e15c2","status":"started"},"type":"device_interview"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/battery/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"device_class":"battery","enabled_by_default":true,"entity_category":"diagnostic","name":"0x00158d00051e15c2 battery","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_battery_zigbee2mqtt","unit_of_measurement":"%","value_template":"{{ value_json.battery }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/voltage/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"device_class":"voltage","enabled_by_default":false,"entity_category":"diagnostic","name":"0x00158d00051e15c2 voltage","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_voltage_zigbee2mqtt","unit_of_measurement":"mV","value_template":"{{ value_json.voltage }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/action_angle/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action angle","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_angle_zigbee2mqtt","unit_of_measurement":"°","value_template":"{{ value_json.action_angle }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/action_from_side/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action from side","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_from_side_zigbee2mqtt","value_template":"{{ value_json.action_from_side }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/action_side/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action side","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_side_zigbee2mqtt","value_template":"{{ value_json.action_side }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/action_to_side/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"name":"0x00158d00051e15c2 action to side","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_to_side_zigbee2mqtt","value_template":"{{ value_json.action_to_side }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/action/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":true,"icon":"mdi:gesture-double-tap","name":"0x00158d00051e15c2 action","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_action_zigbee2mqtt","value_template":"{{ value_json.action }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received MQTT message on 'homeassistant/sensor/0x00158d00051e15c2/linkquality/config' with data '{"availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":"{{ value_json.state }}"}],"device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"enabled_by_default":false,"entity_category":"diagnostic","icon":"mdi:signal","name":"0x00158d00051e15c2 linkquality","state_class":"measurement","state_topic":"zigbee2mqtt/0x00158d00051e15c2","unique_id":"0x00158d00051e15c2_linkquality_zigbee2mqtt","unit_of_measurement":"lqi","value_template":"{{ value_json.linkquality }}"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Device '0x00158d00051e15c2' announced itself
Zigbee2MQTT:info  2022-05-18 23:43:39: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x00158d00051e15c2","ieee_address":"0x00158d00051e15c2"},"type":"device_announce"}'
Zigbee2MQTT:debug 2022-05-18 23:43:39: Received Zigbee message from '0x00158d00051e15c2', type 'attributeReport', cluster 'genBasic', data '{"appVersion":5,"modelId":"lumi.sensor_cube.aqgl01"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 23:43:39: lumi.sensor_cube,lumi.sensor_cube.aqgl01: unknown key appVersion with value 5
Zigbee2MQTT:debug 2022-05-18 23:43:39: lumi.sensor_cube,lumi.sensor_cube.aqgl01: Processed data into payload {}
Zigbee2MQTT:debug 2022-05-18 23:43:40: Received Zigbee message from '0x00158d00051e15c2', type 'attributeReport', cluster 'genBasic', data '{"65281":{"1":2865,"10":0,"151":3,"152":3,"153":0,"154":4,"3":27,"4":424,"5":89,"6":[0,1]}}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2022-05-18 23:43:40: lumi.sensor_cube,lumi.sensor_cube.aqgl01: unknown key 6 with value 0,1
Zigbee2MQTT:debug 2022-05-18 23:43:40: lumi.sensor_cube,lumi.sensor_cube.aqgl01: unknown key 153 with value 0
Zigbee2MQTT:debug 2022-05-18 23:43:40: lumi.sensor_cube,lumi.sensor_cube.aqgl01: Processed data into payload {"voltage":2865,"battery":33,"temperature":27,"power_outage_count":88,"current":0.003,"power":3,"unknown154":4}
Zigbee2MQTT:debug 2022-05-18 23:43:40: lumi.sensor_cube,lumi.sensor_cube.aqgl01: Processed data into payload {"voltage":2865,"battery":33,"temperature":27,"power_outage_count":88,"current":0.003,"power":3,"unknown154":4}
Zigbee2MQTT:info  2022-05-18 23:43:40: MQTT publish: topic 'zigbee2mqtt/0x00158d00051e15c2', payload '{"action":null,"action_angle":null,"action_from_side":null,"action_side":null,"action_to_side":null,"battery":33,"current":0.003,"linkquality":174,"power":3,"power_outage_count":88,"temperature":27,"unknown154":4,"voltage":2865}'
Zigbee2MQTT:info  2022-05-18 23:43:50: Successfully interviewed '0x00158d00051e15c2', device has successfully been paired
Zigbee2MQTT:info  2022-05-18 23:43:50: Device '0x00158d00051e15c2' is supported, identified as: Xiaomi Mi/Aqara smart home cube (MFKZQ01LM)
Zigbee2MQTT:info  2022-05-18 23:43:50: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"definition":{"description":"Mi/Aqara smart home cube","exposes":[{"access":1,"description":"Remaining battery in %","name":"battery","property":"battery","type":"numeric","unit":"%","value_max":100,"value_min":0},{"access":1,"description":"Voltage of the battery in millivolts","name":"voltage","property":"voltage","type":"numeric","unit":"mV"},{"access":1,"name":"action_angle","property":"action_angle","type":"numeric","unit":"°","value_max":360,"value_min":-360},{"access":1,"description":"Side of the cube","name":"action_from_side","property":"action_from_side","type":"numeric","value_max":6,"value_min":0,"value_step":1},{"access":1,"description":"Side of the cube","name":"action_side","property":"action_side","type":"numeric","value_max":6,"value_min":0,"value_step":1},{"access":1,"description":"Side of the cube","name":"action_to_side","property":"action_to_side","type":"numeric","value_max":6,"value_min":0,"value_step":1},{"access":1,"description":"Triggered action (e.g. a button click)","name":"action","property":"action","type":"enum","values":["shake","wakeup","fall","tap","slide","flip180","flip90","rotate_left","rotate_right"]},{"access":1,"description":"Link quality (signal strength)","name":"linkquality","property":"linkquality","type":"numeric","unit":"lqi","value_max":255,"value_min":0}],"model":"MFKZQ01LM","options":[{"access":2,"description":"Set to false to disable the legacy integration (highly recommended), will change structure of the published payload (default true).","name":"legacy","property":"legacy","type":"binary","value_off":false,"value_on":true}],"supports_ota":false,"vendor":"Xiaomi"},"friendly_name":"0x00158d00051e15c2","ieee_address":"0x00158d00051e15c2","status":"successful","supported":true},"type":"device_interview"}'
Zigbee2MQTT:debug 2022-05-18 23:44:56: Received Zigbee message from '0x00158d00051e15c2', type 'attributeReport', cluster 'genMultistateInput', data '{"presentValue":92}' from endpoint 2 with groupID 0
Zigbee2MQTT:info  2022-05-18 23:44:56: MQTT publish: topic 'zigbee2mqtt/0x00158d00051e15c2', payload '{"action":"flip90","action_angle":null,"action_from_side":3,"action_side":4,"action_to_side":4,"battery":33,"current":0.003,"linkquality":189,"power":3,"power_outage_count":88,"side":4,"temperature":27,"unknown154":4,"voltage":2865}'
Zigbee2MQTT:info  2022-05-18 23:44:56: MQTT publish: topic 'zigbee2mqtt/0x00158d00051e15c2', payload '{"action":"","action_angle":null,"action_from_side":null,"action_side":null,"action_to_side":null,"battery":33,"current":0.003,"linkquality":189,"power":3,"power_outage_count":88,"side":4,"temperature":27,"unknown154":4,"voltage":2865}'
Zigbee2MQTT:info  2022-05-18 23:44:56: MQTT publish: topic 'homeassistant/device_automation/0x00158d00051e15c2/action_flip90/config', payload '{"automation_type":"trigger","device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"payload":"flip90","subtype":"flip90","topic":"zigbee2mqtt/0x00158d00051e15c2/action","type":"action"}'
Zigbee2MQTT:info  2022-05-18 23:44:56: MQTT publish: topic 'zigbee2mqtt/0x00158d00051e15c2/action', payload 'flip90'
Zigbee2MQTT:debug 2022-05-18 23:44:56: Received MQTT message on 'homeassistant/device_automation/0x00158d00051e15c2/action_flip90/config' with data '{"automation_type":"trigger","device":{"identifiers":["zigbee2mqtt_0x00158d00051e15c2"],"manufacturer":"Xiaomi","model":"Mi/Aqara smart home cube (MFKZQ01LM)","name":"0x00158d00051e15c2","sw_version":"3000-0001"},"payload":"flip90","subtype":"flip90","topic":"zigbee2mqtt/0x00158d00051e15c2/action","type":"action"}'
Zigbee2MQTT:debug 2022-05-18 23:45:01: Received Zigbee message from '0x00158d00051e15c2', type 'attributeReport', cluster 'genMultistateInput', data '{"presentValue":99}' from endpoint 2 with groupID 0
Zigbee2MQTT:info  2022-05-18 23:45:01: MQTT publish: topic 'zigbee2mqtt/0x00158d00051e15c2', payload '{"action":"flip90","action_angle":null,"action_from_side":4,"action_side":3,"action_to_side":3,"battery":33,"current":0.003,"linkquality":178,"power":3,"power_outage_count":88,"side":3,"temperature":27,"unknown154":4,"voltage":2865}'
Zigbee2MQTT:info  2022-05-18 23:45:01: MQTT publish: topic 'zigbee2mqtt/0x00158d00051e15c2', payload '{"action":"","action_angle":null,"action_from_side":null,"action_side":null,"action_to_side":null,"battery":33,"current":0.003,"linkquality":178,"power":3,"power_outage_count":88,"side":3,"temperature":27,"unknown154":4,"voltage":2865}'
Zigbee2MQTT:info  2022-05-18 23:45:01: MQTT publish: topic 'zigbee2mqtt/0x00158d00051e15c2/action', payload 'flip90'
Zigbee2MQTT:debug 2022-05-18 23:46:02: Saving state to file /var/lib/zigbee2mqtt/state.json
</pre>