### PR TITLE
Fix duplication temperature/device_temperature SSM-U01

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1568,7 +1568,7 @@ module.exports = [
         fromZigbee: [fz.on_off, fz.device_temperature, fz.aqara_opple, fz.ignore_metering, fz.ignore_electrical_measurement,
             fz.xiaomi_power],
         exposes: [e.switch(), e.energy(), e.power(), e.device_temperature(), e.power_outage_memory(), e.power_outage_count(),
-            e.switch_type(), e.voltage(), e.temperature(), e.current(),
+            e.switch_type(), e.voltage(), e.current(),
         ],
         toZigbee: [tz.xiaomi_switch_type, tz.on_off, tz.xiaomi_switch_power_outage_memory, tz.xiaomi_led_disabled_night],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -160,6 +160,8 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
         case '3':
             if (['WSDCGQ12LM'].includes(model.model)) {
                 // This temperature value is ignored because with greater accuracy it is reported in key №100
+            } else if (['SSM-U01'].includes(model.model)) {
+                payload.device_temperature = value;
             } else if (!['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM'].includes(model.model)) {
                 payload.temperature = calibrateAndPrecisionRoundOptions(value, options, 'temperature'); // 0x03
             }


### PR DESCRIPTION
The SSM-U01 now is publishing two sensors (`temperature` and `device_temperature`) that get the data from the same "physical" sensor. So it has a duplication in the sensors published.

![image](https://user-images.githubusercontent.com/2673520/169510467-73f57480-a7c9-4682-87ae-034cff0d0843.png)

The SSM-U01 does not publish the `temperature` (cluster `msTemperatureMeasurement`), in place it publishes the `device_temperature` (cluster `genDeviceTempCfg`). It publishes the same value too in the `aqaraOpple` cluster, attribute `3`.

This PR removes the `temperature` converter from the device, letting only the `device_temperature` one, and modifies the `aqara_opple` converter to publish the value as `device_temperature` in place of `temperature`.

I'm pretty sure some people will complain about this, because the `device_temperature` has no options to "calibrate" it. But we need to unify both sensors, in one sense or in the other.