### PR TITLE
Add temperature expose to DJT11LM

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1286,7 +1286,7 @@ module.exports = [
         fromZigbee: [fz.xiaomi_basic, fz.DJT11LM_vibration],
         toZigbee: [tz.DJT11LM_vibration_sensitivity],
         exposes: [
-            e.battery(), e.vibration(), e.action(['vibration', 'tilt', 'drop']),
+            e.battery(), e.temperature(), e.vibration(), e.action(['vibration', 'tilt', 'drop']),
             exposes.numeric('strength', ea.STATE), exposes.enum('sensitivity', ea.STATE_SET, ['low', 'medium', 'high']),
             e.angle_axis('angle_x'), e.angle_axis('angle_y'), e.angle_axis('angle_z'), e.battery_voltage(),
         ],


### PR DESCRIPTION
The DJT11LM publishes temperature as attribute 3 in the genBasic cluster.

This PR adds the expose needed to publish the attribute as sensor.

```
Received Zigbee message from 'vibracion_silla_miguel', type 'attributeReport', cluster 'genBasic', data '{"65281":{"1":2985,"10":45452,"152":45,"153":2524,"154":[64880,7340108],"3":32,"4":17320,"5":1062,"6":[0,8],"8":776}}' from endpoint 1 with groupID 0
```