### PR TITLE
Update Centralite Thermostats

### DIFF
--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -222,7 +222,7 @@ module.exports = [
         vendor: 'Centralite',
         description: 'HA thermostat',
         fromZigbee: [fz.battery, fz.thermostat, fz.fan, fz.ignore_time_read],
-        toZigbee: [tz.factory_reset, tz.thermostat_local_temperature, tz.thermostat_local_temperature_calibration,
+        toZigbee: [tz.factory_reset, tz.thermostat_local_temperature,
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_cooling_setpoint,
             tz.thermostat_setpoint_raise_lower, tz.thermostat_remote_sensing,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
@@ -233,8 +233,7 @@ module.exports = [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
                 .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
-                .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)
-                .withLocalTemperatureCalibration(-30, 30, 0.1)],
+                .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -170,12 +170,15 @@ module.exports = [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_cooling_setpoint,
             tz.thermostat_setpoint_raise_lower, tz.thermostat_remote_sensing,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
-            tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state],
-        exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
-            .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
-            .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
-            .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)
-            .withLocalTemperatureCalibration(-2.5, 2.5, 0.1)],
+            tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state, tz.thermostat_temperature_setpoint_hold],
+        exposes: [e.battery(),
+            exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
+                .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.'),
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
+                .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
+                .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
+                .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)
+                .withLocalTemperatureCalibration(-2.5, 2.5, 0.1)],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -184,6 +187,7 @@ module.exports = [
             await reporting.thermostatRunningState(endpoint);
             await reporting.thermostatTemperature(endpoint);
             await reporting.fanMode(endpoint);
+            await reporting.thermostatTemperatureSetpointHold(endpoint);
         },
     },
     {

--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -171,11 +171,11 @@ module.exports = [
             tz.thermostat_setpoint_raise_lower, tz.thermostat_remote_sensing,
             tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
             tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state],
-        exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 10, 30, 1).withLocalTemperature()
+        exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
             .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
             .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
-            .withSetpoint('occupied_cooling_setpoint', 10, 30, 1)
-            .withLocalTemperatureCalibration(-30, 30, 0.1)],
+            .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)
+            .withLocalTemperatureCalibration(-2.5, 2.5, 0.1)],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -200,11 +200,11 @@ module.exports = [
         exposes: [e.battery(),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.'),
-            exposes.climate().withSetpoint('occupied_heating_setpoint', 10, 30, 1).withLocalTemperature()
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
                 .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
-                .withSetpoint('occupied_cooling_setpoint', 10, 30, 1)
-                .withLocalTemperatureCalibration(-30, 30, 0.1)],
+                .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)
+                .withLocalTemperatureCalibration(-2.5, 2.5, 0.1)],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -230,10 +230,10 @@ module.exports = [
         exposes: [e.battery(),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.'),
-            exposes.climate().withSetpoint('occupied_heating_setpoint', 6.66, 30, 1).withLocalTemperature()
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
                 .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
-                .withSetpoint('occupied_cooling_setpoint', 6.66, 30, 1)
+                .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)
                 .withLocalTemperatureCalibration(-30, 30, 0.1)],
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices/centralite.js
+++ b/devices/centralite.js
@@ -161,38 +161,8 @@ module.exports = [
         extend: extend.light_onoff_brightness(),
     },
     {
-        zigbeeModel: ['3157100'],
+        fingerprint: [{modelID: '3157100', manufacturerName: 'Centralite'}, {modelID: '3157100-E', manufacturerName: 'Centralite'}],
         model: '3157100',
-        vendor: 'Centralite',
-        description: '3-Series pearl touch thermostat,',
-        fromZigbee: [fz.battery, fz.legacy.thermostat_att_report, fz.fan, fz.ignore_time_read],
-        toZigbee: [tz.factory_reset, tz.thermostat_local_temperature, tz.thermostat_local_temperature_calibration,
-            tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_cooling_setpoint,
-            tz.thermostat_setpoint_raise_lower, tz.thermostat_remote_sensing,
-            tz.thermostat_control_sequence_of_operation, tz.thermostat_system_mode,
-            tz.thermostat_relay_status_log, tz.fan_mode, tz.thermostat_running_state, tz.thermostat_temperature_setpoint_hold],
-        exposes: [e.battery(),
-            exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
-                .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.'),
-            exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature()
-                .withSystemMode(['off', 'heat', 'cool', 'emergency_heating'])
-                .withRunningState(['idle', 'heat', 'cool', 'fan_only']).withFanMode(['auto', 'on'])
-                .withSetpoint('occupied_cooling_setpoint', 7, 30, 1)
-                .withLocalTemperatureCalibration(-2.5, 2.5, 0.1)],
-        meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat', 'hvacFanCtrl']);
-            await reporting.batteryVoltage(endpoint);
-            await reporting.thermostatRunningState(endpoint);
-            await reporting.thermostatTemperature(endpoint);
-            await reporting.fanMode(endpoint);
-            await reporting.thermostatTemperatureSetpointHold(endpoint);
-        },
-    },
-    {
-        zigbeeModel: ['3157100-E'],
-        model: '3157100-E',
         vendor: 'Centralite',
         description: '3-Series pearl touch thermostat,',
         fromZigbee: [fz.battery, fz.thermostat, fz.fan, fz.ignore_time_read],


### PR DESCRIPTION
After owning all of the 3 different Centralite thermostats, I noticed some things that should be changed. After which, the 3157100 and 3157100-E configs were identical, so I combined them.