### PR TITLE
Add additional Zigbee model name for Insta 57008000

### DIFF
--- a/devices/insta.js
+++ b/devices/insta.js
@@ -21,7 +21,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['Generic UP Device'],
+        zigbeeModel: ['NEXENTRO Blinds Actuator', 'Generic UP Device'],
         model: '57008000',
         vendor: 'Insta',
         description: 'Blinds actor with lift/tilt calibration & with with inputs for wall switches',


### PR DESCRIPTION
The Zigbee model name for Insta 57008000 seems to have changed (probably with a recent firmware update). This PR adds the new name (keeping the old one for backwards compatibility).

Apart from the model name the existing device definition still seems to work fine with the latest firmware.

"Nexentro" seems to be the brand name under which Insta GmbH sells its own Zigbee devices (see https://www.nexentro.com/legal-notice/).