### PR TITLE
Add white version of Philips Enrave M

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -109,10 +109,10 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['915005996701'],
+        zigbeeModel: ['915005996701', '915005996601'],
         model: '915005996701',
         vendor: 'Philips',
-        description: 'Hue white ambiance ceiling black Enrave M with Bluetooth',
+        description: 'Hue white ambiance ceiling light Enrave M with Bluetooth',
         meta: {turnsOffAtBrightness1: true},
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,


### PR DESCRIPTION
This adds the white version of the Philips Hue Enrave M, similar to the other Enrave models.