### PR TITLE
Add support for Müller Licht Model 404038

### DIFF
--- a/devices/müller_licht.js
+++ b/devices/müller_licht.js
@@ -169,8 +169,8 @@ module.exports = [
         model: '404038',
         vendor: 'Müller Licht',
         description: 'Tint retro filament LED-bulb E27, Globe bulb gold, white+ambiance (1800-6500K), dimmable, 5,5W',
-        extend: extend.light_onoff_brightness_colortemp(),
-        toZigbee: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 555]}).toZigbee.concat([tz.tint_scene]),
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 555]}),
+        toZigbee: extend.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
     },
     {
         fingerprint: [{

--- a/devices/müller_licht.js
+++ b/devices/müller_licht.js
@@ -165,6 +165,14 @@ module.exports = [
         toZigbee: extend.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
     },
     {
+        zigbeeModel: ['tint-ColorTemperature'],
+        model: '404038',
+        vendor: 'Müller Licht',
+        description: 'Tint retro filament LED-bulb E27, Globe bulb gold, white+ambiance (1800-6500K), dimmable, 5,5W',
+        extend: extend.light_onoff_brightness_colortemp(),
+        toZigbee: extend.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
+    },
+    {
         fingerprint: [{
             // Identify through fingerprint as modelID is the same as Sunricher ZG192910-4
             type: 'Router', manufacturerID: 4635, manufacturerName: 'MLI', modelID: 'CCT Lighting',

--- a/devices/müller_licht.js
+++ b/devices/müller_licht.js
@@ -170,7 +170,7 @@ module.exports = [
         vendor: 'Müller Licht',
         description: 'Tint retro filament LED-bulb E27, Globe bulb gold, white+ambiance (1800-6500K), dimmable, 5,5W',
         extend: extend.light_onoff_brightness_colortemp(),
-        toZigbee: extend.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
+        toZigbee: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 555]}).toZigbee.concat([tz.tint_scene]),
     },
     {
         fingerprint: [{

--- a/devices/müller_licht.js
+++ b/devices/müller_licht.js
@@ -165,7 +165,7 @@ module.exports = [
         toZigbee: extend.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
     },
     {
-        zigbeeModel: ['tint-ColorTemperature'],
+        zigbeeModel: ['tint-ColorTemperature2'],
         model: '404038',
         vendor: 'Müller Licht',
         description: 'Tint retro filament LED-bulb E27, Globe bulb gold, white+ambiance (1800-6500K), dimmable, 5,5W',


### PR DESCRIPTION
Add support for Müller Licht Model 404038, Tint retro filament LED-bulb E27, Globe bulb gold, white+ambiance (1800-6500K), dimmable, 5,5W.

Link to product page: https://www.mueller-licht.de/produktinformationen/artikel/?q=404038

This light bulb is technically similar to the model 404037, the only difference is the shape of the bulb.