### PR TITLE
Try catch around unsupported attribute

### DIFF
--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -130,20 +130,23 @@ module.exports = [
                 maximumReportInterval: constants.repInterval.MAX,
                 reportableChange: 1,
             }], options);
-
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: 'danfossPreheatStatus',
-                minimumReportInterval: constants.repInterval.MINUTE,
-                maximumReportInterval: constants.repInterval.MAX,
-                reportableChange: 1,
-            }], options);
-
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: 'danfossAdaptionRunStatus',
                 minimumReportInterval: constants.repInterval.MINUTE,
                 maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: 1,
             }], options);
+
+            try {
+                await endpoint.configureReporting('hvacThermostat', [{
+                    attribute: 'danfossPreheatStatus',
+                    minimumReportInterval: constants.repInterval.MINUTE,
+                    maximumReportInterval: constants.repInterval.MAX,
+                    reportableChange: 1,
+                }], options);
+            } catch (e) {
+                /* not supported by all */
+            }
 
             try {
                 await endpoint.read('hvacThermostat', [


### PR DESCRIPTION
Hi Koen,

You have already patched the majority of them as part of this issue:
https://github.com/Koenkk/zigbee2mqtt/issues/11872

There was however 1 more that is having the same behaviour. The attribute is not available on the Hive TRV, only on the official Danfoss firmware.