### PR TITLE
Add support for Philips Hue Model 4503748C6

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1248,6 +1248,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['4503748C6'],
+        model: '4503748C6',
+        vendor: 'Philips',
+        description: 'Hue white ambiance Muscari ceiling light',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTD003'],
         model: '4503848C5',
         vendor: 'Philips',


### PR DESCRIPTION
Add support for Philips Hue white ambiance Muscari ceiling light (model 4503748C6). White ambiance (2200K-6500K), dimmable, 40W.

Link to product page: [https://www.philips-hue.com/en-au/p/hue-white-ambiance-muscari-ceiling-light/4503748C6](https://www.philips-hue.com/en-au/p/hue-white-ambiance-muscari-ceiling-light/4503748C6)

Technically the same as pendant equivalent (Muscari pendant light, LTD003, model 4503848C5), already in device list.