### PR TITLE
Set power source to battery for two Third Reality devices

### DIFF
--- a/devices/third_reality.js
+++ b/devices/third_reality.js
@@ -75,6 +75,10 @@ module.exports = [
         toZigbee: [],
         meta: {battery: {dontDividePercentage: true}},
         exposes: [e.occupancy(), e.battery_low(), e.battery(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            device.powerSource = 'Battery';
+            device.save();
+        },
     },
     {
         zigbeeModel: ['3RDS17BZ'],
@@ -85,6 +89,10 @@ module.exports = [
         toZigbee: [],
         meta: {battery: {dontDividePercentage: true}},
         exposes: [e.contact(), e.battery_low(), e.battery(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            device.powerSource = 'Battery';
+            device.save();
+        },
     },
     {
         zigbeeModel: ['3RSP019BZ'],


### PR DESCRIPTION
Both of these devices have batteries and are not connected to mains. Hopefully this will fix the issue where these devices appear plugged in in the zigbee2mqtt GUI.