### PR TITLE
Danfoss Ally - adaptation run control - Add default state and fix typo

### DIFF
--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -88,7 +88,7 @@ module.exports = [
                     'Valve Characteristic Lost'),
             exposes.binary('adaptation_run_settings', ea.ALL, true, false)
                 .withDescription('Automatic adaptation run enabled (the one during the night)'),
-            exposes.enum('adaptation_run_control', ea.ALL, ['initate_adaptation', 'cancel_adaptation'])
+            exposes.enum('adaptation_run_control', ea.ALL, ['none', 'initiate_adaptation', 'cancel_adaptation'])
                 .withDescription('Adaptation run control: Initiate Adaptation Run or Cancel Adaptation Run'),
             exposes.numeric('regulation_setpoint_offset', ea.ALL)
                 .withDescription('Regulation SetPoint Offset in range -2.5°C to 2.5°C in steps of 0.1°C. Value 2.5°C = 25.')

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -105,7 +105,8 @@ const danfossAdaptionRunStatus= {
 };
 
 const danfossAdaptionRunControl = {
-    1: 'initate_adaptation',
+    0: 'none',
+    1: 'initiate_adaptation',
     2: 'cancel_adaptation',
 };
 


### PR DESCRIPTION
Hi Koen,

Just doing some maintenance on my HA and have discovered the following:

![image](https://user-images.githubusercontent.com/9019306/171485613-e9aa4630-acef-483f-ab8e-f0348c2a9e92.png)

The device when not doing neither of these 2 actions reports that attribute with a value of `0` which was not defined in the constants definition. (There was also a type in the word `initiate` which was fixed)

As per the documentation:
![image](https://user-images.githubusercontent.com/9019306/171485769-68a938e9-29e1-4899-acac-9414fb4a2018.png)

The documentation fails to make note of the `0`value which is however supported and default as seen in the last column `0x00` but also in range.

This PR adds the default value to the constants and the device converter and will fix the error in HA

Thanks