### PR TITLE
Add support for Zemismart 6-Gang Smart Wall Switch

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5267,7 +5267,7 @@ const converters = {
             const value = tuya.getDataValue(dpValue);
             const state = value ? 'ON' : 'OFF';
             if (multiEndpoint) {
-                const lookup = {1: 'l1', 2: 'l2', 3: 'l3', 4: 'l4'};
+                const lookup = {1: 'l1', 2: 'l2', 3: 'l3', 4: 'l4', 5: 'l5', 6: 'l6'};
                 const endpoint = lookup[dp];
                 if (endpoint in model.endpoint(msg.device)) {
                     return {[`state_${endpoint}`]: state};

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3842,7 +3842,7 @@ const converters = {
     tuya_switch_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
-            const lookup = {l1: 1, l2: 2, l3: 3, l4: 4};
+            const lookup = {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5, l6: 6};
             const multiEndpoint = utils.getMetaValue(entity, meta.mapped, 'multiEndpoint', 'allEqual', false);
             const keyid = multiEndpoint ? lookup[meta.endpoint_name] : 1;
             await tuya.sendDataPointBool(entity, keyid, value === 'ON');

--- a/devices/zemismart.js
+++ b/devices/zemismart.js
@@ -189,21 +189,21 @@ module.exports = [
         toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options, tz.tuya_data_point_test],
         exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],
     },
-    {        
+    {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_9mahtqtg'}],
         model: 'TB26-6',
         vendor: 'Zemismart',
         description: '6-Gang Smart Wall Switch',
         exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
-                e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
-                e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),
-                e.switch().withEndpoint('l4').setAccess('state', ea.STATE_SET),
-                e.switch().withEndpoint('l5').setAccess('state', ea.STATE_SET),
-                e.switch().withEndpoint('l6').setAccess('state', ea.STATE_SET)],
+            e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l4').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l5').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l6').setAccess('state', ea.STATE_SET)],
         fromZigbee: [fz.ignore_basic_report, fz.tuya_switch],
         toZigbee: [tz.tuya_switch_state],
         meta: {multiEndpoint: true},
-        endpoint: (device) => {                
+        endpoint: (device) => {
             return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1};
         },
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -217,5 +217,5 @@ module.exports = [
             device.powerSource = 'Mains (single phase)';
             device.save();
         },
-    },    
+    },
 ];

--- a/devices/zemismart.js
+++ b/devices/zemismart.js
@@ -193,7 +193,7 @@ module.exports = [
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_9mahtqtg'}],
         model: 'TB26-6',
         vendor: 'Zemismart',
-        description: '6-Gang Smart Wall Switch',
+        description: '6-gang smart wall switch',
         exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
             e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
             e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),

--- a/devices/zemismart.js
+++ b/devices/zemismart.js
@@ -189,4 +189,33 @@ module.exports = [
         toZigbee: [tz.tuya_cover_control, tz.tuya_cover_options, tz.tuya_data_point_test],
         exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],
     },
+    {        
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_9mahtqtg'}],
+        model: 'TB26-6',
+        vendor: 'Zemismart',
+        description: '6-Gang Smart Wall Switch',
+        exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
+                e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
+                e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),
+                e.switch().withEndpoint('l4').setAccess('state', ea.STATE_SET),
+                e.switch().withEndpoint('l5').setAccess('state', ea.STATE_SET),
+                e.switch().withEndpoint('l6').setAccess('state', ea.STATE_SET)],
+        fromZigbee: [fz.ignore_basic_report, fz.tuya_switch],
+        toZigbee: [tz.tuya_switch_state],
+        meta: {multiEndpoint: true},
+        endpoint: (device) => {                
+            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1};
+        },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(3)) await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(4)) await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(5)) await reporting.bind(device.getEndpoint(5), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(6)) await reporting.bind(device.getEndpoint(6), coordinatorEndpoint, ['genOnOff']);
+            // Reports itself as battery which is not correct: https://github.com/Koenkk/zigbee2mqtt/issues/6190
+            device.powerSource = 'Mains (single phase)';
+            device.save();
+        },
+    },    
 ];


### PR DESCRIPTION
Add support for Zemismart 6-Gang Smart Wall Switch

I also needed to edit FZ and TZ converters to allow 6 states on tuya_switch and tuya_switch_state, respectively.