### PR TITLE
Add GL-C-002P mini5in1 as whitelabel of GL-C-008P

### DIFF
--- a/devices/gledopto.js
+++ b/devices/gledopto.js
@@ -267,7 +267,7 @@ module.exports = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee LED Controller RGB+CCT (pro)',
-        whiteLabel: [{vendor: 'Gledopto', model: 'GL-C-001P'}],
+        whiteLabel: [{vendor: 'Gledopto', model: 'GL-C-001P'}, {vendor: 'Gledopto', model: 'GL-C-002P'}],
         extend: gledoptoExtend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495], noConfigure: true}),
         meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
I think its safe to include this device as whitelabel now.
See: https://github.com/Koenkk/zigbee2mqtt/issues/11202