### PR TITLE
Change in Inovelli firmware numbering

### DIFF
--- a/lib/ota/inovelli.js
+++ b/lib/ota/inovelli.js
@@ -18,8 +18,8 @@ async function getImageMeta(current, logger, device) {
         .sort((a, b) => {
             const aRadix = a.version.match(/[A-F]/) ? 16 : 10;
             const bRadix = b.version.match(/[A-F]/) ? 16 : 10;
-            const aVersion = parseInt(a.version.replace(/\./g, ''), aRadix);
-            const bVersion = parseInt(b.version.replace(/\./g, ''), bRadix);
+            const aVersion = parseFloat(a.version, aRadix);
+            const bVersion = parseFloat(b.version, bRadix);
             // doesn't matter which order they are in
             if (aVersion < bVersion) {
                 return -1;
@@ -37,7 +37,7 @@ async function getImageMeta(current, logger, device) {
     }
     // version in the firmare removes the zero padding and support hex versioning
     return {
-        fileVersion: parseInt(image.version, image.version.match(/[A-F]/) ? 16 : 10),
+        fileVersion: parseFloat(image.version, image.version.match(/[A-F]/) ? 16 : 10),
         url: image.firmware,
     };
 }


### PR DESCRIPTION
This is a fix for a recent change in Inovelli's versioning to decimal type numbers.