### PR TITLE
Add support for battery from batteryVoltage for Develco WISZB-120

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -234,13 +234,17 @@ module.exports = [
         model: 'WISZB-120',
         vendor: 'Develco',
         description: 'Window sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.temperature],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.battery, fz.temperature],
         toZigbee: [],
-        exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature()],
+        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature()],
+        meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(38);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint);
+            const endpoint35 = device.getEndpoint(35);
+            const endpoint38 = device.getEndpoint(38);
+            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
+            await reporting.batteryVoltage(endpoint35);
+            await reporting.temperature(endpoint38);
         },
     },
     {


### PR DESCRIPTION
Just got one of these and the manual says it supports battery readout, after poking the device it seems only batteryVoltage can be read. A fresh set of batteries reports 30 (2xAAA). I put in an older set that read ~50% on my Hue Motion sensor and with 3V_2500 they read around 40% so seems to be the correct one.

The WISZB-121 should be similar but without the tamper and temperature but I do not have one so I cannot verify the genPowerCfg also lives on endpoint 35.