### PR TITLE
Expose colortemp capability of Hue Iris gen2 white

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1655,7 +1655,7 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue Iris (generation 2, white)',
         meta: {turnsOffAtBrightness1: true},
-        extend: hueExtend.light_onoff_brightness_color(),
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
         ota: ota.zigbeeOTA,
     },
     {


### PR DESCRIPTION
Make sure Hue Iris gen2 white has colortemp exposed, just like black edition.