### PR TITLE
Set turnsOffAtBrightness1 to true on some of the IKEA lights

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -374,6 +374,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E27 WW clear 250 lumen, dimmable',
         extend: tradfriExtend.light_onoff_brightness(),
+        meta: {turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['TRADFRIbulbE26WWclear250lm'],
@@ -411,6 +412,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'TRADFRI bulb E26/E27 CWS 800/806 lumen, dimmable, color, opal white',
         extend: tradfriExtend.light_onoff_brightness_colortemp_color(),
+        meta: {turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['TRADFRI bulb E14 W op/ch 400lm', 'TRADFRI bulb E12 W op/ch 400lm', 'TRADFRI bulb E17 W op/ch 400lm'],
@@ -432,6 +434,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E26/E27 806 lumen, dimmable, warm white',
         extend: tradfriExtend.light_onoff_brightness(),
+        meta: {turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['TRADFRI bulb E27 WS clear 806lm', 'TRADFRI bulb E26 WS clear 806lm'],
@@ -498,6 +501,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'FLOALT LED light panel, dimmable, white spectrum (30x30 cm)',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
+        meta: {turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['FLOALT panel WS 60x60'],
@@ -505,6 +509,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'FLOALT LED light panel, dimmable, white spectrum (60x60 cm)',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
+        meta: {turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['JORMLIEN door WS 40x80'],
@@ -519,6 +524,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'FLOALT LED light panel, dimmable, white spectrum (30x90 cm)',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
+        meta: {turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['SURTE door WS 38x64'],


### PR DESCRIPTION
This is the default behavior on the latest IKEA firmware.
Without turnsOffAtBrightness1, setting the brightness to 1 turns off the light (while still showing the state as ON).

Due to this, I had to use workarounds in my home assistant automations that would limit the min brightness to 2, which was not ideal.

I only updated the bulbs and LED panels that I personally own and have tested with the latest OTA update (updated via zigbee2mqtt).
