### PR TITLE
Fix xiaomi sensors show null in power_outage_count 

### DIFF
--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -153,9 +153,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             }
             break;
         case '2':
-            if (['JT-BZ-01AQ/A'].includes(model.model)) {
-                payload.power_outage_count = value - 1;
-            }
+            payload.power_outage_count = value - 1;
             break;
         case '3':
             if (['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM', 'MCCGQ14LM', 'GZCGQ01LM'].includes(model.model)) {
@@ -170,9 +168,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             payload.mode_switch = {4: 'anti_flicker_mode', 1: 'quick_mode'}[value];
             break;
         case '5':
-            if (['Mains (single phase)', 'DC Source'].includes(meta.device.powerSource) || ['ZNCLDJ12LM'].includes(model.model)) {
-                payload.power_outage_count = value - 1;
-            }
+            payload.power_outage_count = value - 1;
             break;
         case '10':
             payload.switch_type = {1: 'toggle', 2: 'momentary'}[value];

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -170,10 +170,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             payload.mode_switch = {4: 'anti_flicker_mode', 1: 'quick_mode'}[value];
             break;
         case '5':
-            if (['Mains (single phase)', 'DC Source'].includes(meta.device.powerSource) ||
-                ['ZNCLDJ12LM', 'SJCGQ11LM', 'MFKZQ01LM'].includes(model.model)) {
-                payload.power_outage_count = value - 1;
-            }
+            payload.power_outage_count = value - 1;
             break;
         case '10':
             payload.switch_type = {1: 'toggle', 2: 'momentary'}[value];

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -153,7 +153,9 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             }
             break;
         case '2':
-            payload.power_outage_count = value - 1;
+            if (['JT-BZ-01AQ/A'].includes(model.model)) {
+                payload.power_outage_count = value - 1;
+            }
             break;
         case '3':
             if (['WXCJKG11LM', 'WXCJKG12LM', 'WXCJKG13LM', 'MCCGQ14LM', 'GZCGQ01LM'].includes(model.model)) {
@@ -168,7 +170,10 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             payload.mode_switch = {4: 'anti_flicker_mode', 1: 'quick_mode'}[value];
             break;
         case '5':
-            payload.power_outage_count = value - 1;
+            if (['Mains (single phase)', 'DC Source'].includes(meta.device.powerSource) ||
+                ['ZNCLDJ12LM', 'SJCGQ11LM', 'MFKZQ01LM'].includes(model.model)) {
+                payload.power_outage_count = value - 1;
+            }
             break;
         case '10':
             payload.switch_type = {1: 'toggle', 2: 'momentary'}[value];


### PR DESCRIPTION
Remove double check and fix the issue with sensors not displaying power_outage_count value

If sensors expose power_outage_count doesn't recheck which sensor can update payload.power_outage_count , it's assumed that you need it because it uses it.

Signed-off-by: Fco Javier Felix <ffelix@inode64.com>