### PR TITLE
Add Lidl Livarno Home LED-Flooder

### DIFF
--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -487,6 +487,14 @@ module.exports = [
         },
     },
     {
+        fingerprint: [{modelID: 'TS0505B', manufactureName: '_TZ3210_umi6vbsz'}],
+        model: '100341862',
+        vendor: 'Lidl',
+        description: 'Livarno Home LED-Flooder',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500], disableColorTempStartup: true}),
+        meta: {applyRedFix: true, enhancedHue: false},
+    },
+    {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_s8gkrkxk'}],
         model: 'HG06467',
         vendor: 'Lidl',


### PR DESCRIPTION
added Lidl Livarno Home LED-Flooder, Sales started today in Germany.
https://www.lidl.de/p/livarno-home-aussenstrahler-mit-lichtfarbensteuerung-und-rgb-zigbee-smart-home/p100341862