### PR TITLE
re-added support for PIR Neo Tuya PST-ZMIR01

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -553,6 +553,7 @@ module.exports = [
             {modelID: 'TS0202', manufacturerName: '_TZ3000_tiwq83wk'},
             {modelID: 'TS0202', manufacturerName: '_TZ3000_ykwcwxmz'},
             {modelID: 'TS0202', manufacturerName: '_TZ3000_hgu1dlak'},
+            {modelID: 'TS0202', manufacturerName: '_TZ3000_kmh5qpmb'},
             {modelID: 'WHD02', manufacturerName: '_TZ3000_hktqahrq'}],
         model: 'TS0202',
         vendor: 'TuYa',


### PR DESCRIPTION
after the latest build 1.25.2, the support of the device 'PIR Neo Tuya PST-ZMIR01' was broken.
See [#12925](https://github.com/Koenkk/zigbee2mqtt/issues/12925)