### PR TITLE
Fix battery TS0201 _TZ3000_*

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -961,9 +961,13 @@ module.exports = [
         model: 'WSD500A',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor',
-        fromZigbee: [fz.battery, fz.temperature, fz.humidity],
+        fromZigbee: [fzLocal.TS0201_battery, fz.temperature, fz.humidity],
         toZigbee: [],
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('genBasic', ['manufacturerName', 'zclVersion', 'appVersion', 'modelId', 'powerSource', 0xfffe]);
+        },
     },
     {
         fingerprint: [{modelID: 'SM0201', manufacturerName: '_TYZB01_cbiezpds'}],


### PR DESCRIPTION
The temperature sensor report battery usage as `null` (see #3914). So I did some tests with `_TZ3000_fllyghyj` and `_TZ3000_dowj6gyi`. I was able to get battery reporting working.