### PR TITLE
Update schneider_electric.js

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -358,6 +358,18 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['CH10AX/SWITCH/1'],
+        model: '41E10PBSWMZ-VW',
+        vendor: 'Schneider Electric',
+        description: 'Wiser 40/300-Series module switch with ControlLink 10A',
+        extend: extend.switch(),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        },
+    },    
+    {
         zigbeeModel: ['SMARTPLUG/1'],
         model: 'CCT711119',
         vendor: 'Schneider Electric',


### PR DESCRIPTION
Added new device 41E10PBSWMZ-VW. Wiser 40/300-Series module switch with ControlLink 10A
https://eref.se.com/au/en/clipsal/product-pdf/41E10PBSWMZ-VW