### PR TITLE
Fix typo for BTicino L4411C

### DIFF
--- a/devices/bticino.js
+++ b/devices/bticino.js
@@ -26,7 +26,7 @@ module.exports = [
     },
     {
         zigbeeModel: [' Dimmer switch with neutral\u0000\u0000\u0000\u0000'],
-        model: 'L441C/N4411C/NT4411C',
+        model: 'L4411C/N4411C/NT4411C',
         vendor: 'BTicino',
         description: 'Dimmer switch with neutral',
         extend: extend.light_onoff_brightness({noConfigure: true}),


### PR DESCRIPTION
This device is called L4411C, as mentioned in the official BTicino
catalogue https://catalogue.bticino.com/BTI-L4411C-EN