### PR TITLE
S-LUX-ZB doesn't support battery_low

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -7345,7 +7345,7 @@ const converters = {
             case 4:
                 return {battery: value};
             case 1:
-                return {brightness_state: brightnesStateLookup[value]};
+                return {brightness_level: brightnesStateLookup[value]};
             default:
                 meta.logger.warn(`s_lux_zb_illuminance: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -7338,13 +7338,14 @@ const converters = {
             const dpValue = tuya.firstDpValue(msg, meta, 'SLUXZB');
             const dp = dpValue.dp;
             const value = tuya.getDataValue(dpValue);
+            const brightnesStateLookup = {'0': 'LOW', '1': 'MEDIUM', '2': 'HIGH'};
             switch (dp) {
             case 2:
                 return {illuminance_lux: value};
             case 4:
                 return {battery: value};
             case 1:
-                return {battery_low: value === 1};
+                return {brightness_state: brightnesStateLookup[value]};
             default:
                 meta.logger.warn(`s_lux_zb_illuminance: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -752,7 +752,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
         },
         exposes: [e.battery(), e.illuminance_lux(), e.linkquality(),
-            exposes.enum('brightness_state', ea.STATE, ['LOW', 'MEDIUM', 'HIGH'])],
+            exposes.enum('brightness_level', ea.STATE, ['LOW', 'MEDIUM', 'HIGH'])],
     },
     {
         zigbeeModel: ['TS130F'],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -752,7 +752,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
         },
         exposes: [e.battery(), e.illuminance_lux(), e.linkquality(),
-            exposes.enum('brightness_state', ea.STATE, ['LOW', 'Medium', 'HIGH'],
+            exposes.enum('brightness_state', ea.STATE, ['LOW', 'Medium', 'HIGH']),
     },
     {
         zigbeeModel: ['TS130F'],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -751,7 +751,8 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
         },
-        exposes: [e.battery(), e.illuminance_lux(), e.battery_low(), e.linkquality()],
+        exposes: [e.battery(), e.illuminance_lux(), e.linkquality(),
+            exposes.enum('brightness_state', ea.STATE, ['LOW', 'Medium', 'HIGH'],
     },
     {
         zigbeeModel: ['TS130F'],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -752,7 +752,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
         },
         exposes: [e.battery(), e.illuminance_lux(), e.linkquality(),
-            exposes.enum('brightness_state', ea.STATE, ['LOW', 'Medium', 'HIGH']),
+            exposes.enum('brightness_state', ea.STATE, ['LOW', 'MEDIUM', 'HIGH'])],
     },
     {
         zigbeeModel: ['TS130F'],


### PR DESCRIPTION
Changed "battery_low" to "brightness_state". As "battery_low" isn't supported by device.

```json
{
  "result": {
    "category": "ldcg",
    "functions": [],
    "status": [
      {
        "code": "bright_state",
        "dp_id": 1,
        "type": "Enum",
        "values": "{\"range\":[\"low\",\"middle\",\"high\"]}"
      },
      {
        "code": "bright_value",
        "dp_id": 2,
        "type": "Integer",
        "values": "{\"unit\":\"\",\"min\":0,\"max\":1000,\"scale\":0,\"step\":1}"
      },
      {
        "code": "battery_percentage",
        "dp_id": 4,
        "type": "Integer",
        "values": "{\"unit\":\"%\",\"min\":0,\"max\":100,\"scale\":0,\"step\":1}"
      }
    ]
  },
  "success": true,
  "t": 1657358245906,
  "tid": "f29868adff6711ec8204daf929f70cab"
}
```
