### PR TITLE
Properly support _TZ3000_r6buo8ba and others with appVersion 160

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1660,7 +1660,7 @@ module.exports = [
     },
     {
         fingerprint: [].concat(...TS011Fplugs.map((manufacturerName) => {
-            return [69, 68, 65, 64].map((applicationVersion) => {
+            return [160, 69, 68, 65, 64].map((applicationVersion) => {
                 return {modelID: 'TS011F', manufacturerName, applicationVersion};
             });
         })),
@@ -1677,7 +1677,11 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             // Enables reporting of physical state changes
             // https://github.com/Koenkk/zigbee2mqtt/issues/9057#issuecomment-1007742130
-            await endpoint.read('genBasic', ['manufacturerName', 'zclVersion', 'appVersion', 'modelId', 'powerSource', 0xfffe]);
+            try {
+                await endpoint.read('genBasic', ['manufacturerName', 'zclVersion', 'appVersion', 'modelId', 'powerSource', 0xfffe]);
+            } catch (e) {
+                // Sometimes can fail: https://github.com/Koenkk/zigbee2mqtt/issues/12760#issuecomment-1165435220
+            }
             endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {acCurrentDivisor: 1000, acCurrentMultiplier: 1});
             endpoint.saveClusterAttributeKeyValue('seMetering', {divisor: 100, multiplier: 1});
             device.save();


### PR DESCRIPTION
Turns out that devices with applicationVersion 160 (fw 2.2.0) also require
polling for electrical measurements. Even though currentSummDelivered,
complains that it's unreportable attribute, it still reports the energy
when the value changes (depending on the load - very infrequently).

These are round plugs with Model: BSD48 marking.

Fixing issue https://github.com/Koenkk/zigbee2mqtt/issues/12760