### PR TITLE
Fixing Maximum temperature bug. Adding running state based on output_status

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3603,12 +3603,12 @@ const converters = {
             //             msg.data['danfossOutputStatus'];
             // }
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
-                if (msg.data['danfossOutputStatus'] === 1) {
+                if (msg.data['danfossOutputStatus'] === true) {
                     result[postfixWithEndpointName('output_status', msg, model)] = true;
-                    result[postfixWithEndpointName('system_off', msg, model)] = 'heat';
+                    result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
                 } else {
                     result[postfixWithEndpointName('output_status', msg, model)] = false;
-                    result[postfixWithEndpointName('system_off', msg, model)] = 'off';
+                    result[postfixWithEndpointName('running_state', msg, model)] = 'idle';
                 }
             }
             return result;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3603,11 +3603,11 @@ const converters = {
             //             msg.data['danfossOutputStatus'];
             // }
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
-                if (msg.data['danfossOutputStatus'] === active) {
-                    // result[postfixWithEndpointName('output_status', msg, model)] = true;
+                if (msg.data['danfossOutputStatus'] === "active") {
+                    result[postfixWithEndpointName('output_status', msg, model)] = "active";
                     result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
                 } else {
-                    // result[postfixWithEndpointName('output_status', msg, model)] = false;
+                    result[postfixWithEndpointName('output_status', msg, model)] = "inactive";
                     result[postfixWithEndpointName('running_state', msg, model)] = 'idle';
                 }
             }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3596,14 +3596,8 @@ const converters = {
                         constants.danfossRoomStatusCode[msg.data['danfossRoomStatusCode']] :
                         msg.data['danfossRoomStatusCode'];
             }
-            // if (msg.data.hasOwnProperty('danfossOutputStatus')) {
-            //     result[postfixWithEndpointName('output_status', msg, model)] =
-            //         constants.danfossOutputStatus.hasOwnProperty(msg.data['danfossOutputStatus']) ?
-            //             constants.danfossOutputStatus[msg.data['danfossOutputStatus']] :
-            //             msg.data['danfossOutputStatus'];
-            // }
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
-                if (msg.data['danfossOutputStatus'] === "active") {
+                if (msg.data['danfossOutputStatus'] === 1) {
                     result[postfixWithEndpointName('output_status', msg, model)] = "active";
                     result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
                 } else {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3605,10 +3605,10 @@ const converters = {
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
                 if (msg.data['danfossOutputStatus'] === 1) {
                     result[postfixWithEndpointName('output_status', msg, model)] = true;
-                    result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
+                    result[postfixWithEndpointName('system_off', msg, model)] = 'heat';
                 } else {
                     result[postfixWithEndpointName('output_status', msg, model)] = false;
-                    result[postfixWithEndpointName('running_state', msg, model)] = 'off';
+                    result[postfixWithEndpointName('system_off', msg, model)] = 'off';
                 }
             }
             return result;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3602,6 +3602,15 @@ const converters = {
                         constants.danfossOutputStatus[msg.data['danfossOutputStatus']] :
                         msg.data['danfossOutputStatus'];
             }
+            if (msg.data.hasOwnProperty('danfossHeatRequired')) {
+                if (msg.data['danfossOutputStatus'] === 1) {
+                    result[postfixWithEndpointName('danfossOutputStatus', msg, model)] = true;
+                    result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
+                } else {
+                    result[postfixWithEndpointName('danfossOutputStatus', msg, model)] = false;
+                    result[postfixWithEndpointName('running_state', msg, model)] = 'off';
+                }
+            }
             return result;
         },
     },

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3603,11 +3603,11 @@ const converters = {
             //             msg.data['danfossOutputStatus'];
             // }
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
-                if (msg.data['danfossOutputStatus'] === true) {
-                    result[postfixWithEndpointName('output_status', msg, model)] = true;
+                if (msg.data['danfossOutputStatus'] === active) {
+                    // result[postfixWithEndpointName('output_status', msg, model)] = true;
                     result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
                 } else {
-                    result[postfixWithEndpointName('output_status', msg, model)] = false;
+                    // result[postfixWithEndpointName('output_status', msg, model)] = false;
                     result[postfixWithEndpointName('running_state', msg, model)] = 'idle';
                 }
             }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3602,7 +3602,7 @@ const converters = {
                         constants.danfossOutputStatus[msg.data['danfossOutputStatus']] :
                         msg.data['danfossOutputStatus'];
             }
-            if (msg.data.hasOwnProperty('danfossHeatRequired')) {
+            if (msg.data.hasOwnProperty('danfossOutputStatus')) {
                 if (msg.data['danfossOutputStatus'] === 1) {
                     result[postfixWithEndpointName('danfossOutputStatus', msg, model)] = true;
                     result[postfixWithEndpointName('running_state', msg, model)] = 'heat';

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3604,10 +3604,10 @@ const converters = {
             }
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
                 if (msg.data['danfossOutputStatus'] === 1) {
-                    result[postfixWithEndpointName('danfossOutputStatus', msg, model)] = true;
+                    result[postfixWithEndpointName('output_status', msg, model)] = true;
                     result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
                 } else {
-                    result[postfixWithEndpointName('danfossOutputStatus', msg, model)] = false;
+                    result[postfixWithEndpointName('output_status', msg, model)] = false;
                     result[postfixWithEndpointName('running_state', msg, model)] = 'off';
                 }
             }

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3596,12 +3596,12 @@ const converters = {
                         constants.danfossRoomStatusCode[msg.data['danfossRoomStatusCode']] :
                         msg.data['danfossRoomStatusCode'];
             }
-            if (msg.data.hasOwnProperty('danfossOutputStatus')) {
-                result[postfixWithEndpointName('output_status', msg, model)] =
-                    constants.danfossOutputStatus.hasOwnProperty(msg.data['danfossOutputStatus']) ?
-                        constants.danfossOutputStatus[msg.data['danfossOutputStatus']] :
-                        msg.data['danfossOutputStatus'];
-            }
+            // if (msg.data.hasOwnProperty('danfossOutputStatus')) {
+            //     result[postfixWithEndpointName('output_status', msg, model)] =
+            //         constants.danfossOutputStatus.hasOwnProperty(msg.data['danfossOutputStatus']) ?
+            //             constants.danfossOutputStatus[msg.data['danfossOutputStatus']] :
+            //             msg.data['danfossOutputStatus'];
+            // }
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
                 if (msg.data['danfossOutputStatus'] === 1) {
                     result[postfixWithEndpointName('output_status', msg, model)] = true;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3598,10 +3598,10 @@ const converters = {
             }
             if (msg.data.hasOwnProperty('danfossOutputStatus')) {
                 if (msg.data['danfossOutputStatus'] === 1) {
-                    result[postfixWithEndpointName('output_status', msg, model)] = "active";
+                    result[postfixWithEndpointName('output_status', msg, model)] = 'active';
                     result[postfixWithEndpointName('running_state', msg, model)] = 'heat';
                 } else {
-                    result[postfixWithEndpointName('output_status', msg, model)] = "inactive";
+                    result[postfixWithEndpointName('output_status', msg, model)] = 'inactive';
                     result[postfixWithEndpointName('running_state', msg, model)] = 'idle';
                 }
             }

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -228,7 +228,7 @@ module.exports = [
                 if (i!=16) {
                     features.push(e.battery().withEndpoint(epName));
                     features.push(exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5)
-                        .withLocalTemperature().withRunningState(['off', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
+                        .withLocalTemperature().withSystemMode(['heat', 'off']).withEndpoint(epName));
                     features.push(exposes.numeric('abs_min_heat_setpoint_limit', ea.STATE)
                         .withUnit('°C').withEndpoint(epName)
                         .withDescription('Absolute min temperature allowed on the device'));

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -228,7 +228,7 @@ module.exports = [
                 if (i!=16) {
                     features.push(e.battery().withEndpoint(epName));
                     features.push(exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5)
-                        .withLocalTemperature().withRunningState(['off', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
+                        .withLocalTemperature().withRunningState(['idle', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
                     features.push(exposes.numeric('abs_min_heat_setpoint_limit', ea.STATE)
                         .withUnit('°C').withEndpoint(epName)
                         .withDescription('Absolute min temperature allowed on the device'));

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -204,6 +204,7 @@ module.exports = [
             tz.thermostat_local_temperature,
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_system_mode,
+            tz.thermostat_running_state,
             tz.thermostat_min_heat_setpoint_limit,
             tz.thermostat_max_heat_setpoint_limit,
             tz.danfoss_output_status,

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -243,8 +243,8 @@ module.exports = [
                         .withEndpoint(epName).withDescription('Max temperature limit set on the device'));
                     features.push(exposes.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
                         .withEndpoint(epName));
-                    // features.push(exposes.enum('output_status', ea.STATE_GET, ['inactive', 'active'])
-                    //     .withEndpoint(epName).withDescription('Danfoss Output Status [Active vs Inactive])'));
+                    features.push(exposes.enum('output_status', ea.STATE_GET, ['inactive', 'active'])
+                        .withEndpoint(epName).withDescription('Danfoss Output Status [Active vs Inactive])'));
                     features.push(exposes.enum('room_status_code', ea.STATE_GET, ['no_error', 'missing_rt',
                         'rt_touch_error', 'floor_sensor_short_circuit', 'floor_sensor_disconnected'])
                         .withEndpoint(epName).withDescription('Thermostat status'));
@@ -286,7 +286,7 @@ module.exports = [
 
                     // Danfoss Icon Thermostat Specific
                     await endpoint.read('hvacThermostat', [
-                        // 'danfossOutputStatus',
+                        'danfossOutputStatus',
                         'danfossRoomStatusCode'], options);
 
                     // Standard Thermostat

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -227,8 +227,8 @@ module.exports = [
                 const epName = `l${i}`;
                 if (i!=16) {
                     features.push(e.battery().withEndpoint(epName));
-                    features.push(exposes.climate().withSetpoint('occupied_heating_setpoint', 4, 30, 0.5)
-                        .withLocalTemperature().withSystemMode(['heat']).withEndpoint(epName));
+                    features.push(exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5)
+                        .withLocalTemperature().withPiHeatingDemand().withRunningState(['idle', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
                     features.push(exposes.numeric('abs_min_heat_setpoint_limit', ea.STATE)
                         .withUnit('°C').withEndpoint(epName)
                         .withDescription('Absolute min temperature allowed on the device'));
@@ -236,10 +236,10 @@ module.exports = [
                         .withUnit('°C').withEndpoint(epName)
                         .withDescription('Absolute max temperature allowed on the device'));
                     features.push(exposes.numeric('min_heat_setpoint_limit', ea.ALL)
-                        .withValueMin(4).withValueMax(30).withValueStep(0.5).withUnit('°C')
+                        .withValueMin(4).withValueMax(35).withValueStep(0.5).withUnit('°C')
                         .withEndpoint(epName).withDescription('Min temperature limit set on the device'));
                     features.push(exposes.numeric('max_heat_setpoint_limit', ea.ALL)
-                        .withValueMin(4).withValueMax(30).withValueStep(0.5).withUnit('°C')
+                        .withValueMin(4).withValueMax(35).withValueStep(0.5).withUnit('°C')
                         .withEndpoint(epName).withDescription('Max temperature limit set on the device'));
                     features.push(exposes.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
                         .withEndpoint(epName));

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -228,7 +228,7 @@ module.exports = [
                 if (i!=16) {
                     features.push(e.battery().withEndpoint(epName));
                     features.push(exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5)
-                        .withLocalTemperature().withSystemMode(['heat', 'off']).withEndpoint(epName));
+                        .withLocalTemperature().withRunningState(['off', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
                     features.push(exposes.numeric('abs_min_heat_setpoint_limit', ea.STATE)
                         .withUnit('°C').withEndpoint(epName)
                         .withDescription('Absolute min temperature allowed on the device'));

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -243,8 +243,8 @@ module.exports = [
                         .withEndpoint(epName).withDescription('Max temperature limit set on the device'));
                     features.push(exposes.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
                         .withEndpoint(epName));
-                    features.push(exposes.enum('output_status', ea.STATE_GET, ['inactive', 'active'])
-                        .withEndpoint(epName).withDescription('Danfoss Output Status [Active vs Inactive])'));
+                    // features.push(exposes.enum('output_status', ea.STATE_GET, ['inactive', 'active'])
+                    //     .withEndpoint(epName).withDescription('Danfoss Output Status [Active vs Inactive])'));
                     features.push(exposes.enum('room_status_code', ea.STATE_GET, ['no_error', 'missing_rt',
                         'rt_touch_error', 'floor_sensor_short_circuit', 'floor_sensor_disconnected'])
                         .withEndpoint(epName).withDescription('Thermostat status'));
@@ -286,7 +286,7 @@ module.exports = [
 
                     // Danfoss Icon Thermostat Specific
                     await endpoint.read('hvacThermostat', [
-                        'danfossOutputStatus',
+                        // 'danfossOutputStatus',
                         'danfossRoomStatusCode'], options);
 
                     // Standard Thermostat

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -228,7 +228,7 @@ module.exports = [
                 if (i!=16) {
                     features.push(e.battery().withEndpoint(epName));
                     features.push(exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5)
-                        .withLocalTemperature().withPiHeatingDemand().withRunningState(['idle', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
+                        .withLocalTemperature().withRunningState(['off', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
                     features.push(exposes.numeric('abs_min_heat_setpoint_limit', ea.STATE)
                         .withUnit('°C').withEndpoint(epName)
                         .withDescription('Absolute min temperature allowed on the device'));


### PR DESCRIPTION
the earlier converter restricted the maximum allowed temperature to 30 Celsius, it threw an error time-to-time, when the regulator send out an update where the maximum allowed temperature is 35. 
Also added a running_state attribute, based on the output status, so it can be visible on the thermostat card, if the actuator is active or not.