### PR TITLE
preferHS for Osram gardenpole RGBW

### DIFF
--- a/devices/osram.js
+++ b/devices/osram.js
@@ -252,7 +252,7 @@ module.exports = [
         model: '4058075047853',
         vendor: 'OSRAM',
         description: 'Smart+ gardenpole 4W RGBW',
-        extend: extend.ledvance.light_onoff_brightness_colortemp_color(),
+        extend: extend.ledvance.light_onoff_brightness_colortemp_color({supportsHS: true, preferHS: true}),
         meta: {disableDefaultResponse: true},
         ota: ota.ledvance,
     },


### PR DESCRIPTION
This is an updated version of this pr: https://github.com/Koenkk/zigbee-herdsman-converters/pull/3708

Colors were not represented correctly with XY, so prefer HS mode.

Tested with home assistant as working, giving the correct colors.