### PR TITLE
Added new model id for the same Lupus 12050 plug/switch

### DIFF
--- a/devices/lupus.js
+++ b/devices/lupus.js
@@ -28,7 +28,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['PSMP5_00.00.03.11TC'],
+        zigbeeModel: ['PSMP5_00.00.03.11TC', 'PSMP5_00.00.05.12TC'],
         model: '12050',
         vendor: 'Lupus',
         description: 'LUPUSEC mains socket with power meter',


### PR DESCRIPTION
The same switch https://www.zigbee2mqtt.io/devices/12050.html but with new `PSMP5_00.00.05.12TC` model id.
Tested on own device with procedure https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html