### PR TITLE
Support thermostat Lytko 101Z

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5548,6 +5548,21 @@ const converters = {
             }
         },
     },
+    lytko_thermostat: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const ep_name = getKey(model.endpoint(msg.device), msg.endpoint.ID);
+            const result = {};
+     
+            // Sensor type
+            if(msg.data.hasOwnProperty('1024')) {
+                result[`sensor_type_${ep_name}`] = sensorTypeValues[msg.data['1024']];
+            }
+     
+            return result;
+        },
+    },
     xiaomi_power: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -22,6 +22,7 @@ const manufacturerOptions = {
     sinope: {manufacturerCode: herdsman.Zcl.ManufacturerCode.SINOPE_TECH},
     tint: {manufacturerCode: herdsman.Zcl.ManufacturerCode.MUELLER_LICHT_INT},
     legrand: {manufacturerCode: herdsman.Zcl.ManufacturerCode.VANTAGE, disableDefaultResponse: true},
+    lytko: {manufacturerCode: herdsman.Zcl.ManufacturerCode.JENNIC},
     viessmann: {manufacturerCode: herdsman.Zcl.ManufacturerCode.VIESSMAN_ELEKTRO},
 };
 
@@ -4598,6 +4599,22 @@ const converters = {
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', [0xf000, 0xf001, 0xf002]);
         },
+    },
+    lytko_sensorType: {
+        key: ['sensor_type'],     
+        convertSet: async (entity, key, value, meta) => {            
+            const sensorTypes = [
+                '3.3kOhm', '5kOhm', '6.8kOhm', '10kOhm', '12kOhm', '14.8kOhm', '15kOhm', '20kOhm', '33kOhm', 'Binded'
+            ];
+
+            let newValue = sensorTypes.indexOf(value);
+            let payload = {1024: {value: newValue, type: 0x30}};
+            await entity.write('hvacThermostat', payload, manufacturerOptions.lytko);
+            return {state: {[key]: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', [0x1024], manufacturerOptions.lytko);
+       },
     },
     etop_thermostat_system_mode: {
         key: ['system_mode'],

--- a/devices/lytko.js
+++ b/devices/lytko.js
@@ -1,0 +1,106 @@
+const exposes = require('../lib/exposes');
+const fz = { ...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee };
+const tz = require('../converters/toZigbee');
+
+function genL101ZThermostatExposes(epName) {
+    const sensorTypes = [
+        '3.3kOhm', '5kOhm', '6.8kOhm', '10kOhm', '12kOhm', '14.8kOhm', '15kOhm', '20kOhm', '33kOhm', 'Binded'
+    ];
+
+    return [
+        exposes.climate()
+            .withSystemMode(['off', 'auto'])
+            .withLocalTemperature()
+            .withLocalTemperatureCalibration(0.0, 2.5, 0.5)
+            .withSetpoint('occupied_heating_setpoint', 5.0, 75.0, 0.5)
+            .withEndpoint(epName),
+        
+        exposes.enum('sensor_type', ea.ALL, sensorTypes).withEndpoint(epName),
+    ]
+}
+
+function genL101ZExposes(has_second_channel) {
+    let exposes = [];
+
+    if (has_second_channel) {
+        exposes.push(...genL101ZThermostatExposes('l3'));
+        exposes.push(...genL101ZThermostatExposes('l4'));
+    } else {
+        exposes.push(...genL101ZThermostatExposes('l3'));
+    }
+
+    return exposes;
+}
+
+function genL101ZDevice(name, desc, has_second_channel) {
+    return {
+        zigbeeModel: ["L101Z-" + name],
+        model: "L101Z-" + name,
+        description: desc,
+        fromZigbee: [
+            fz.thermostat,
+            fz.lytko_thermostat,
+        ],
+        toZigbee: [
+            tz.thermostat_system_mode,
+            tz.thermostat_local_temperature,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_local_temperature_calibration,
+            tz.lytko_sensorType
+        ],
+        meta: {
+            multiEndpoint: true
+        },
+        endpoint: (device) => {
+            if (has_second_channel) {
+                return {
+                    'l1': 1,  // Basic, Identify, OTA
+                    'l2': 2,  // Reserved for hardware
+                    'l3': 3,  // Thermostat 1
+                    'l4': 4   // Thermostat 2
+                };
+            } else {
+                return {
+                    'l1': 1,  // Basic, Identify, OTA
+                    'l2': 2,  // Reserved for hardware
+                    'l3': 3,  // Thermostat 1
+                };
+            }
+        },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            let eps = [];
+            if (has_second_channel) {
+                eps = [device.getEndpoint(3), device.getEndpoint(4)];
+            } else {
+                eps = [device.getEndpoint(3), device.getEndpoint(4)];
+            }
+
+            // Read thermostat channels values
+            // FIXME: Rework with binding
+            for (const ep of eps) {
+                await ep.read('hvacThermostat', [
+                    'systemMode',
+                    'localTemp',
+                    'minSetpointDeadBand',
+                    'occupiedHeatingSetpoint',
+                    'localTemperatureCalibration'
+                ]);
+
+                const options = {manufacturerCode: 0x1037};
+                await ep.read('hvacThermostat', [1024], options);
+            }
+        },
+        exposes: genL101ZExposes(has_second_channel),
+        //ota: ???
+    }
+}
+
+module.exports = [
+    genL101ZDevice("DBN", "Big screen dual channel thermostat", true),
+    genL101ZDevice("DMN", "Small screen dual channel thermostat", true),
+    genL101ZDevice("DLN", "Headless dual channel thermostat", true),
+
+    genL101ZDevice("SBN", "Big screen single channel thermostat", false),
+    genL101ZDevice("SMN", "Small screen single channel thermostat", false),
+    genL101ZDevice("SLN", "Headless single channel thermostat", false),
+];


### PR DESCRIPTION
## Description

Lytko 101Z is a thermostat based on NXP JN5189, customizable, with single/dual relay and any analog sensor support, using the ZCL standard with minimal deviations.

## Zigbee structure

1. Basic, Identify, OTA
2. Reserved
3. Thermostat and temperature (for binding)
4. Same as third

Forth endpoint is enabled only on dual channel version

## TODO

- [ ] Hysteresis
- [ ] OTA