### PR TITLE
Add support for Schneider Electric 1GANG/DIMMER/1

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -346,6 +346,27 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['1GANG/DIMMER/1'],
+        model: 'MEG5113-0300/MEG5171-0000',
+        vendor: 'Schneider Electric',
+        description: 'Merten MEG5171 Universal dimmer insert, 1-gang with Merten Wiser System M Push Button (1fold)',
+        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.wiser_lighting_ballast_configuration],
+        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config, tz.wiser_dimmer_mode],
+        exposes: [e.light_brightness().withLevelConfig(),
+            exposes.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the minimum light output of the ballast'),
+            exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the maximum light output of the ballast'),
+            exposes.enum('dimmer_mode', ea.ALL, ['auto', 'rc', 'rl', 'rl_led'])
+                .withDescription('Sets dimming mode to autodetect or fixed RC/RL/RL_LED mode (max load is reduced in RL_LED)')],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
+            const endpoint = device.getEndpoint(3);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
+        }
+    {
         zigbeeModel: ['CH2AX/SWITCH/1'],
         model: '41E2PBSWMZ/356PB2MBTZ',
         vendor: 'Schneider Electric',

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -365,7 +365,8 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
             await reporting.onOff(endpoint);
             await reporting.brightness(endpoint);
-        }
+        },
+    },
     {
         zigbeeModel: ['CH2AX/SWITCH/1'],
         model: '41E2PBSWMZ/356PB2MBTZ',


### PR DESCRIPTION
Add support for MEG5171-0000 Universal dimmer insert in combination with MEG5113-0300 Wiser push button 1-gang sold under the Merten Brand in Germany. Used device descriptor from Schneider Electric CCT5010-0001 1:1 (flush-mounted module with same functions in the Wiser product lineup for France) and successfully tested including special functions : dimmer mode (RC, RL, Auto) and ballast config.

npm run lint and npm test run successfully