### PR TITLE
Corrects Device Definition for Tuya IH-K009 being Recognized as WSD500A

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1026,11 +1026,25 @@ module.exports = [
         fingerprint: [
             {modelID: 'TS0201', manufacturerName: '_TZ3000_bguser20'},
             {modelID: 'TS0201', manufacturerName: '_TZ3000_fllyghyj'},
-            {modelID: 'TS0201', manufacturerName: '_TZ3000_dowj6gyi'},
             {modelID: 'TS0201', manufacturerName: '_TZ3000_yd2e749y'},
             {modelID: 'TS0201', manufacturerName: '_TZ3000_6uzkisv2'},
         ],
         model: 'WSD500A',
+        vendor: 'TuYa',
+        description: 'Temperature & humidity sensor',
+        fromZigbee: [fzLocal.TS0201_battery, fz.temperature, fz.humidity],
+        toZigbee: [],
+        exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('genBasic', ['manufacturerName', 'zclVersion', 'appVersion', 'modelId', 'powerSource', 0xfffe]);
+        },
+    },
+    {
+        fingerprint: [
+            {modelID: 'TS0201', manufacturerName: '_TZ3000_dowj6gyi'},
+        ],
+        model: 'IH-K009',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor',
         fromZigbee: [fzLocal.TS0201_battery, fz.temperature, fz.humidity],


### PR DESCRIPTION
The device with model ID `TS0201` & manufacturer name `_TZ3000_dowj6gyi` was incorrectly being identified as a `WSD500A` when in fact it is a `IH-K009` device. Device information provided here as well. https://zigbee.blakadder.com/Tuya_IH-K009.html A request for support was mentioned here. https://github.com/Koenkk/zigbee2mqtt/issues/12759