### PR TITLE
Publication of the `illuminance` state from attribute 11 of the heartbeat-message only for Xiaomi `RTCGQ11LM`

### DIFF
--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -191,10 +191,7 @@ const numericAttributes2Payload = (msg, meta, model, options, dataObject) => {
             }
             break;
         case '11':
-            if (['JT-BZ-01AQ/A', 'QBKG25LM', 'ZNLDP13LM'].includes(model.model)) {
-                // We don't know what the value means for these devices.
-                // https://github.com/Koenkk/zigbee2mqtt/issues/12451
-            } else {
+            if (['RTCGQ11LM'].includes(model.model)) {
                 payload.illuminance = calibrateAndPrecisionRoundOptions(value, options, 'illuminance');
                 // DEPRECATED: remove illuminance_lux here.
                 payload.illuminance_lux = calibrateAndPrecisionRoundOptions(value, options, 'illuminance_lux');


### PR DESCRIPTION
Based on the [discussion](https://github.com/Koenkk/zigbee2mqtt/discussions/13284), when checking, it turned out that the _attribute 11_ of the heartbeat-message is the `illuminance` state only for Xiaomi `RTCGQ11LM`, and the rest of the Xiaomi sensors with `illuminance` exposure use _attributes 100 and 101_:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/b6321b3055193af1955864d1b26b37c1483a22c9/lib/xiaomi.js#L246-L248

https://github.com/Koenkk/zigbee-herdsman-converters/blob/b6321b3055193af1955864d1b26b37c1483a22c9/lib/xiaomi.js#L272-L276