### PR TITLE
Add _TZ3000_qja6nq5z as manufacturerName for tuya smart knob

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2521,7 +2521,7 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS004F', manufacturerName: '_TZ3000_4fjiwweb'}, {modelID: 'TS004F', manufacturerName: '_TZ3000_uri7ongn'},
-            {modelID: 'TS004F', manufacturerName: '_TZ3000_ixla93vd'},{modelID: 'TS004F', manufacturerName: '_TZ3000_qja6nq5z'}],
+            {modelID: 'TS004F', manufacturerName: '_TZ3000_ixla93vd'}, {modelID: 'TS004F', manufacturerName: '_TZ3000_qja6nq5z'}],
         model: 'ERS-10TZBVK-AA',
         vendor: 'TuYa',
         description: 'Smart knob',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2521,7 +2521,7 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS004F', manufacturerName: '_TZ3000_4fjiwweb'}, {modelID: 'TS004F', manufacturerName: '_TZ3000_uri7ongn'},
-            {modelID: 'TS004F', manufacturerName: '_TZ3000_ixla93vd'}],
+            {modelID: 'TS004F', manufacturerName: '_TZ3000_ixla93vd'},{modelID: 'TS004F', manufacturerName: '_TZ3000_qja6nq5z'}],
         model: 'ERS-10TZBVK-AA',
         vendor: 'TuYa',
         description: 'Smart knob',


### PR DESCRIPTION
Just got one of these and it has a different vendor name to the ones listed, model number on base matches this. 