### PR TITLE
Add support for updated Hue Go (7602031PU)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -406,7 +406,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness(),
     },
     {
-        zigbeeModel: ['LCT026', '7602031P7', '7602031U7'],
+        zigbeeModel: ['LCT026', '7602031P7', '7602031U7', '7602031PU'],
         model: '7602031P7',
         vendor: 'Philips',
         description: 'Hue Go with Bluetooth',


### PR DESCRIPTION
The updated Philips Hue Go Lamp has differing model numbers for EU and UK models - [https://www.assets.signify.com/is/content/Signify/Assets/signify/global/PHILIPS-HUE-PORTABLE-LUMINAIRES-202109-UK-DoC.pdf](url).

This adds support for UK models through adding the model number to the `zigbeeModel` array.

Tested working using an external convertor.