### PR TITLE
ubisys OTA: return latest firmware if multiple files match

### DIFF
--- a/lib/ota/ubisys.js
+++ b/lib/ota/ubisys.js
@@ -21,22 +21,25 @@ async function getImageMeta(current, logger, device) {
 
     imageRegex.lastIndex = 0; // reset (global) regex for next exec to match from the beginning again
     let imageMatch = imageRegex.exec(firmwarePageHtml);
+    let highestMatch = null;
     while (imageMatch != null) {
         logger.debug(`OTA ubisys: image found: ${imageMatch[0]}`);
         if (parseInt(imageMatch[1], 16) === imageType &&
             parseInt(imageMatch[2], 16) <= hardwareVersion && hardwareVersion <= parseInt(imageMatch[3], 16)) {
-            break;
+            if (highestMatch === null || parseInt(highestMatch[4], 16) < parseInt(imageMatch[4], 16)) {
+                highestMatch = imageMatch;
+            }
         }
         imageMatch = imageRegex.exec(firmwarePageHtml);
     }
-    assert(imageMatch !== null,
+    assert(highestMatch !== null,
         `No image available for imageType '0x${imageType.toString(16)}' with hardware version ${hardwareVersion}`);
 
     return {
-        hardwareVersionMin: parseInt(imageMatch[2], 16),
-        hardwareVersionMax: parseInt(imageMatch[3], 16),
-        fileVersion: parseInt(imageMatch[4], 16),
-        url: url.resolve(firmwareHtmlPageUrl, imageMatch[0]),
+        hardwareVersionMin: parseInt(highestMatch[2], 16),
+        hardwareVersionMax: parseInt(highestMatch[3], 16),
+        fileVersion: parseInt(highestMatch[4], 16),
+        url: url.resolve(firmwareHtmlPageUrl, highestMatch[0]),
     };
 }
 


### PR DESCRIPTION
This is a followup for #4466 

As mentioned in https://github.com/Koenkk/zigbee2mqtt/issues/12526 the current approach fails, if multiple firmware update files are valid.

This patch tries to return only the firmware with the highest fileVersion.