### PR TITLE
Error When Referring to fz.command_store

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1094,9 +1094,9 @@ const converters = {
         cluster: 'genScenes',
         type: 'commandStore',
         convert: (model, msg, publish, options, meta) => {
-            if (utils.hasAlreadyProcessedMessage(msg)) return;
-            const payload = {action: utils.postfixWithEndpointName(`store_${msg.data.sceneid}`, msg, model, meta)};
-            utils.addActionGroup(payload, msg, model);
+            if (hasAlreadyProcessedMessage(msg)) return;
+            const payload = {action: postfixWithEndpointName(`store_${msg.data.sceneid}`, msg, model, meta)};
+            addActionGroup(payload, msg, model);
             return payload;
         },
     },


### PR DESCRIPTION
I built a custom external converter and did a reference (in "definitition.fromZegbee") to various converters from "fromZigbee.js". The only one that rises an error is "fz.command_store". So I looked into the code and I think I found the problem (see proposed changes).
I also tried to create a "fzLocal.command_store" in my external converter, copying the code from original file "fromZigbee.js", and applying my changes: it worked well.
Sorry for my english. I hope I have explained.