### PR TITLE
Add ZBEK-6 to adeo devices

### DIFF
--- a/devices/adeo.js
+++ b/devices/adeo.js
@@ -37,6 +37,13 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 454]}),
     },
     {
+        zigbeeModel: ['ZBEK-6'],
+        model: 'IG-CDZB2AG009RA-MZN-01',
+        vendor: 'ADEO',
+        description: 'ENKI LEXMAN E27 Led white bulb',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 454]}),
+    },
+    {
         zigbeeModel: ['ZBEK-4'],
         model: 'IM-CDZDGAAA0005KA_MAN',
         vendor: 'ADEO',


### PR DESCRIPTION
Add the ZBEK-6 light bulb from Adeo

It's this light https://www.leroymerlin.fr/produits/decoration-eclairage/ampoule-et-led/ampoule-led/ampoule-e27/ampoule-connectee-led-globe-95mm-e27-1055lm-75w-variation-de-blancs-lexman-84372277.html?clk=true#component-displaycomp