### PR TITLE
Iluminize Shutter: Update position+state based on liftPercentage

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1544,7 +1544,8 @@ const converters = {
             if (msg.data.hasOwnProperty('currentPositionLiftPercentage') && msg.data['currentPositionLiftPercentage'] <= 100) {
                 const value = msg.data['currentPositionLiftPercentage'];
                 result[postfixWithEndpointName('position', msg, model, meta)] = invert ? value : 100 - value;
-                result[postfixWithEndpointName('state', msg, model, meta)] = invert ? (value > 0 ? 'CLOSE' : 'OPEN') : (value > 0 ? 'OPEN' : 'CLOSE');
+                result[postfixWithEndpointName('state', msg, model, meta)] =
+                    invert ? (value > 0 ? 'CLOSE' : 'OPEN') : (value > 0 ? 'OPEN' : 'CLOSE');
             }
             if (msg.data.hasOwnProperty('currentPositionTiltPercentage') && msg.data['currentPositionTiltPercentage'] <= 100) {
                 const value = msg.data['currentPositionTiltPercentage'];

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1544,6 +1544,7 @@ const converters = {
             if (msg.data.hasOwnProperty('currentPositionLiftPercentage') && msg.data['currentPositionLiftPercentage'] <= 100) {
                 const value = msg.data['currentPositionLiftPercentage'];
                 result[postfixWithEndpointName('position', msg, model, meta)] = invert ? value : 100 - value;
+                result[postfixWithEndpointName('state', msg, model, meta)] = invert ? (value > 0 ? 'CLOSE' : 'OPEN') : (value > 0 ? 'OPEN' : 'CLOSE');
             }
             if (msg.data.hasOwnProperty('currentPositionTiltPercentage') && msg.data['currentPositionTiltPercentage'] <= 100) {
                 const value = msg.data['currentPositionTiltPercentage'];

--- a/devices/iluminize.js
+++ b/devices/iluminize.js
@@ -115,7 +115,7 @@ module.exports = [
         model: '5128.10',
         vendor: 'Iluminize',
         description: 'Zigbee 3.0 switch shutter SW with level control',
-        fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],
+        fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff, fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_via_brightness],
         exposes: [e.cover_position()],
         ota: ota.zigbeeOTA,


### PR DESCRIPTION
(My first PullRequest)
My Iluminize device do have 'cover_state_via_onoff', but it's giving me the state "Is the device currently OPENING or CLOSING".
Also the position was'nt read out. I had to report on the attribute 'currentPositionLiftPercentage'.
This attribute was given me what I needed.
So I had to update the position and the state based on this attribute.