### PR TITLE
Add Ubisys H1

### DIFF
--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -4,6 +4,7 @@ const tz = require('../converters/toZigbee');
 const ota = require('../lib/ota');
 const utils = require('../lib/utils');
 const reporting = require('../lib/reporting');
+const constants = require('../lib/constants');
 const herdsman = require('zigbee-herdsman');
 const e = exposes.presets;
 const ea = exposes.access;
@@ -88,6 +89,15 @@ const ubisys = {
                     });
                 }
                 return {configure_device_setup: result};
+            },
+        },
+        thermostat_vacation_mode: {
+            cluster: 'hvacThermostat',
+            type: ['attributeReport', 'readResponse'],
+            convert: (model, msg, publish, options, meta) => {
+                if (msg.data.hasOwnProperty('ocupancy')) {
+                    return {vacation_mode: msg.data.ocupancy === 0};
+                }
             },
         },
     },
@@ -503,6 +513,12 @@ const ubisys = {
                     manufacturerOptions.ubisysNull);
             },
         },
+        thermostat_vacation_mode: {
+            key: ['vacation_mode'],
+            convertGet: async (entity, key, meta) => {
+                await entity.read('hvacThermostat', ['ocupancy']);
+            },
+        },
     },
 };
 
@@ -768,6 +784,67 @@ module.exports = [
             for (const ep of [5, 6]) {
                 await reporting.bind(device.getEndpoint(ep), coordinatorEndpoint, ['genScenes', 'closuresWindowCovering']);
             }
+        },
+        ota: ota.ubisys,
+    },
+    {
+        zigbeeModel: ['H1'],
+        model: 'H1',
+        vendor: 'Ubisys',
+        description: 'Heating Regulator H1',
+        fromZigbee: [fz.battery, fz.thermostat, fz.thermostat_weekly_schedule, ubisys.fz.thermostat_vacation_mode],
+        toZigbee: [
+            tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_local_temperature, tz.thermostat_system_mode,
+            tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule,
+            tz.thermostat_running_mode, ubisys.tz.thermostat_vacation_mode,
+            tz.thermostat_pi_heating_demand,
+        ],
+        exposes: [
+            e.battery(),
+            exposes.climate()
+                .withSystemMode(['off', 'heat'], ea.ALL)
+                .withRunningMode(['off', 'heat'])
+                .withSetpoint('occupied_heating_setpoint', 7, 30, 0.5)
+                .withLocalTemperature()
+                .withPiHeatingDemand(ea.STATE_GET),
+            exposes.binary('vacation_mode', ea.STATE_GET, true, false)
+                .withDescription('When Vacation Mode is active the schedule is disabled and unoccupied_heating_setpoint is used.'),
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            const binds = ['genBasic', 'genPowerCfg', 'genTime', 'hvacThermostat'];
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+
+            // reporting
+            // NOTE: temperature is 0.5 deg steps
+            // NOTE: unoccupied_heating_setpoint cannot be set via the device itself
+            //       so we do not need to setup reporting for this, as reporting slots
+            //       seem to be limited.
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatRunningMode(endpoint);
+            await reporting.thermostatTemperature(endpoint,
+                {min: 0, max: constants.repInterval.HOUR, change: 50});
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint,
+                {min: 0, max: constants.repInterval.HOUR, change: 50});
+            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatOcupancy(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint,
+                {min: constants.repInterval.HOUR, max: 43200, change: 1});
+
+
+            // read attributes
+            // NOTE: configuring reporting on hvacThermostat seems to trigger an imediat
+            //       report, so the values are available after configure has run.
+            //       this does not seem to be the case for genPowerCfg, so we read
+            //       the battery percentage
+            await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
+
+            // write attributes
+            // NOTE: device checks in every 1h once the device has entered deepsleep
+            //       this might be a bit long if you want to set the temperature remotely
+            //       update this to every 15 minutes. (value is in 1/4th of a second)
+            await endpoint.write('genPollCtrl', {'checkinInterval': (4 * 60 * 15)});
         },
         ota: ota.ubisys,
     },

--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -791,7 +791,7 @@ module.exports = [
         zigbeeModel: ['H1'],
         model: 'H1',
         vendor: 'Ubisys',
-        description: 'Heating Regulator H1',
+        description: 'Heating regulator',
         fromZigbee: [fz.battery, fz.thermostat, fz.thermostat_weekly_schedule, ubisys.fz.thermostat_vacation_mode],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -407,6 +407,14 @@ class Climate extends Base {
         return this;
     }
 
+    withRunningMode(modes, access=a.STATE_GET) {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        const allowed = ['off', 'cool', 'heat'];
+        modes.forEach((m) => assert(allowed.includes(m)));
+        this.features.push(new Enum('running_mode', access, modes).withDescription('The current running mode'));
+        return this;
+    }
+
     withFanMode(modes, access=a.ALL) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         const allowed = ['off', 'low', 'medium', 'high', 'on', 'auto', 'smart'];

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -170,6 +170,14 @@ module.exports = {
         const p = payload('runningState', 0, repInterval.HOUR, 0, overrides);
         await endpoint.configureReporting('hvacThermostat', p);
     },
+    thermostatRunningMode: async (endpoint, overrides) => {
+        const p = payload('runningMode', 0, repInterval.HOUR, 0, overrides);
+        await endpoint.configureReporting('hvacThermostat', p);
+    },
+    thermostatOcupancy: async (endpoint, overrides) => {
+        const p = payload('ocupancy', 0, repInterval.HOUR, 0, overrides);
+        await endpoint.configureReporting('hvacThermostat', p);
+    },
     thermostatTemperatureSetpointHold: async (endpoint, overrides) => {
         const p = payload('tempSetpointHold', 0, repInterval.HOUR, 0, overrides);
         await endpoint.configureReporting('hvacThermostat', p);


### PR DESCRIPTION
Once this lands, I'll open PR against zigbee2mqtt.io repo with an image and some notes.

There are some things missing like setting vacation_mode and temperature calibration,
however hvacThermostat.localTemperatureCalibration is unsupported:

```
error 2022-08-01 16:16:56Publish 'set' 'read' to 'trv/office' failed: 'Error: Read 0x001fee0000009911/1 hvacThermostat(["localTemperatureCalibration"], {"sendWhen":"active","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'
```

And hvacThermostat.ocupancy is readonly:

```
error 2022-08-01 16:18:01Publish 'set' 'write' to 'trv/office' failed: 'Error: Write 0x001fee0000009911/1 hvacThermostat({"ocupancy":0}, {"sendWhen":"active","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'READ_ONLY')'
```

I've logged a ticket with Ubisys, but there response time is... usually in the range of months not days.

<img width="1507" alt="image" src="https://user-images.githubusercontent.com/379665/182169288-fa360013-1623-49c5-ac4a-472f882410fe.png">
