### PR TITLE
Fix thermostatRunningMode default reporting

### DIFF
--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -171,7 +171,7 @@ module.exports = {
         await endpoint.configureReporting('hvacThermostat', p);
     },
     thermostatRunningMode: async (endpoint, overrides) => {
-        const p = payload('runningMode', 0, repInterval.HOUR, 0, overrides);
+        const p = payload('runningMode', 10, repInterval.HOUR, null, overrides);
         await endpoint.configureReporting('hvacThermostat', p);
     },
     thermostatOcupancy: async (endpoint, overrides) => {


### PR DESCRIPTION
Made a mistake when moving things from my external converter to lib/reporting.
runningMode is very much like systemMode, it just reflects the 'current' state e.g. heat/cool/off depending on if the system is operating or not, so we should use the same defaults.