### PR TITLE
ZMAM02 Ignore undefined data points

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -8445,6 +8445,9 @@ const converters = {
                     break;
                 }
                 break;
+            case tuya.dataPoints.AM02AddRemoter: // DP 101: Ignore until need is defined
+            case tuya.dataPoints.AM02TimeTotal: // DP 10: Ignore until need is defined
+                break;
             default: // Unknown code
                 meta.logger.warn(`ZMAM02_cover: Unhandled DP #${dp} for ${meta.device.manufacturerName}:
                     ${JSON.stringify(dpValue)}`);


### PR DESCRIPTION
For the ZMAM02_cover definition in converters/fromZigbee.js, there are two data points that are continually sent by the device that are not handled in the definition - 10 (AM02TimeTotal) and 101(AM02AddRemoter).  This change will ignore these data points to supress the constant warnings.

ZMAM02_cover: Unhandled DP #10 for _TZE200_iossyxra: {"dp":10,"datatype":2,"data":{"type":"Buffer","data":[0,0,3,232]}}
ZMAM02_cover: Unhandled DP #101 for _TZE200_iossyxra: {"dp":101,"datatype":1,"data":{"type":"Buffer","data":[0]}}

A developer can later provide configuration for these DPs when the need arises. 