### PR TITLE
Support istar cct light controller

### DIFF
--- a/devices/istar.js
+++ b/devices/istar.js
@@ -10,12 +10,12 @@ module.exports = [
         meta: {turnsOffAtBrightness1: true},
     },
     {
-      zigbeeModel: ['iStar CCT Light'],
-      model: 'SCCV2403-2',
-      vendor: 'iStar smart',
-      description: 'Zigbee 3.0 LED controller, dimmable white spectrum',
-      extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
-      meta: {turnsOffAtBrightness1: true},
+        zigbeeModel: ['iStar CCT Light'],
+        model: 'SCCV2403-2',
+        vendor: 'iStar smart',
+        description: 'Zigbee 3.0 LED controller, dimmable white spectrum',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
+        meta: {turnsOffAtBrightness1: true},
     },
 ];
 

--- a/devices/istar.js
+++ b/devices/istar.js
@@ -9,4 +9,14 @@ module.exports = [
         extend: extend.light_onoff_brightness(),
         meta: {turnsOffAtBrightness1: true},
     },
+    {
+      zigbeeModel: ['iStar CCT Light'],
+      model: 'SCCV2403-2',
+      vendor: 'iStar smart',
+      description: 'Zigbee 3.0 LED controller, dimmable white spectrum',
+      extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
+      meta: {turnsOffAtBrightness1: true},
+    },
 ];
+
+

--- a/devices/istar.js
+++ b/devices/istar.js
@@ -12,11 +12,9 @@ module.exports = [
     {
         zigbeeModel: ['iStar CCT Light'],
         model: 'SCCV2403-2',
-        vendor: 'iStar smart',
+        vendor: 'iStar',
         description: 'Zigbee 3.0 LED controller, dimmable white spectrum',
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
         meta: {turnsOffAtBrightness1: true},
     },
 ];
-
-


### PR DESCRIPTION
i added. support for this model of istar light controllers used by a german manufacturer "Bopp"
it is related to https://github.com/Koenkk/zigbee2mqtt.io/pull/1511
