### PR TITLE
Add 1741830P7 as a zigbeeModel for the Phillips Hue Lily outdoor spot light.

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2078,7 +2078,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp_color(),
     },
     {
-        zigbeeModel: ['LCS001'],
+        zigbeeModel: ['LCS001', '1741830P7'],
         model: '1741830P7',
         vendor: 'Philips',
         description: 'Hue Lily outdoor spot light',


### PR DESCRIPTION
Seen working here:

![image](https://user-images.githubusercontent.com/753278/184840182-49c1f702-25df-413c-b50b-5e615d99f1dc.png)
