### PR TITLE
new model name for 3417831P6 (1 spot lamp) - tested and works

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -975,7 +975,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp(),
     },
     {
-        zigbeeModel: ['3417831P6'],
+        zigbeeModel: ['3417831P6', '929003056101'],
         model: '3417831P6',
         vendor: 'Philips',
         description: 'Hue white ambiance Adore spotlight with Bluetooth (1 spot)',


### PR DESCRIPTION
I recently bought 2 of those https://www.zigbee2mqtt.io/devices/3417831P6.html#philips-3417831p6
But a brand new version with new Philips Remote and everything.

unfortunately they new have some kind of new ID and weren't recognized in my zigbee2mqtt software.

I've patched them using 

```
sed -i "s/\['3417831P6'\]/['3417831P6', '929003056101']/g" ./node_modules/zigbee-herdsman-converters/devices/philips.js
```

and they work fine, picture is displayed, everything looks great.

would be happy to get this into mainline

thanks and kind regrads