### PR TITLE
OSRAM 4052899926110 doesn't support color temp startup

### DIFF
--- a/devices/osram.js
+++ b/devices/osram.js
@@ -227,7 +227,7 @@ module.exports = [
         model: '4052899926110',
         vendor: 'OSRAM',
         description: 'Flex RGBW',
-        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [125, 666], supportsHS: true, preferHS: true}),
+        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [125, 666], supportsHS: true, preferHS: true, disableColorTempStartup: true}),
         ota: ota.ledvance,
     },
     {


### PR DESCRIPTION
`Publish 'set' 'color_temp_startup' to 'LED rack' failed: 'Error: Write 0x7cb03eaa00adf03a/3 lightingColorCtrl({"startUpColorTemperature":125}, {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'`