### PR TITLE
feat: Support added for Philips 3402931P7

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2741,4 +2741,11 @@ module.exports = [
         description: 'Hue White E26 806 lumen',
         extend: hueExtend.light_onoff_brightness(),
     },
+    {
+        zigbeeModel: ['3402931P7'],
+        model: '3402931P7',
+        vendor: 'Philips',
+        description: 'Philips Hue Adore Bathroom Mirror Light',
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+    },
 ];


### PR DESCRIPTION
## Why?

The Philips Hue Mirror Light 3402931P7 it is actually not supported by the library.
![Philips_3402931P7](https://user-images.githubusercontent.com/139323/186857894-3d69fd16-68cd-4aa3-8aff-7fb8a9ad5256.jpeg)

(Not sure it is still available to buy as, on the Philips WebSite, I can find only a new version of it).

## What?
Added the light support for
```
brightness
color temperature
on/off
ota
```

Tested in my local installation
<img width="1393" alt="image" src="https://user-images.githubusercontent.com/139323/186858432-f5021c6f-a9cd-4ce8-bfde-e93419c24d82.png">

