### PR TITLE
Added file for Garza vendor with converter for A60 Standard light bulb

### DIFF
--- a/devices/garza.js
+++ b/devices/garza.js
@@ -1,12 +1,4 @@
-const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
-const tz = require('zigbee-herdsman-converters/converters/toZigbee');
-const exposes = require('zigbee-herdsman-converters/lib/exposes');
-const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
-const ota = require('zigbee-herdsman-converters/lib/ota');
-const tuya = require('zigbee-herdsman-converters/lib/tuya');
-const e = exposes.presets;
-const ea = exposes.access;
+const extend = require('../lib/extend');
 
 const definition = {
     fingerprint: [

--- a/devices/garza.js
+++ b/devices/garza.js
@@ -8,5 +8,5 @@ module.exports = [
         vendor: 'Garza Smart',
         description: 'Garza Smart Zigbee Standard A60',
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
-    }
+    },
 ];

--- a/devices/garza.js
+++ b/devices/garza.js
@@ -2,12 +2,7 @@ const extend = require('../lib/extend');
 
 module.exports = [
     {
-        fingerprint: [
-            {
-                modelID: 'TS0505B',
-                manufacturerName: '_TZ3210_sln7ah6r'
-            },
-        ],
+        fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3210_sln7ah6r'}],
         zigbeeModel: ['TS0505B'],
         model: 'Garza-Standard-A60',
         vendor: 'Garza Smart',

--- a/devices/garza.js
+++ b/devices/garza.js
@@ -3,10 +3,9 @@ const extend = require('../lib/extend');
 module.exports = [
     {
         fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3210_sln7ah6r'}],
-        zigbeeModel: ['TS0505B'],
         model: 'Garza-Standard-A60',
         vendor: 'Garza Smart',
-        description: 'Garza Smart Zigbee Standard A60',
+        description: 'Standard A60 bulb',
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
 ];

--- a/devices/garza.js
+++ b/devices/garza.js
@@ -1,17 +1,17 @@
 const extend = require('../lib/extend');
 
-const definition = {
-    fingerprint: [
-        {
-            modelID: 'TS0505B',
-            manufacturerName: '_TZ3210_sln7ah6r'
-        },
-    ],
-    zigbeeModel: ['TS0505B'],
-    model: 'Garza-Standard-A60',
-    vendor: 'Garza Smart',
-    description: 'Garza Smart Zigbee Standard A60',
-    extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
-};
-
-module.exports = definition;
+module.exports = [
+    {
+        fingerprint: [
+            {
+                modelID: 'TS0505B',
+                manufacturerName: '_TZ3210_sln7ah6r'
+            },
+        ],
+        zigbeeModel: ['TS0505B'],
+        model: 'Garza-Standard-A60',
+        vendor: 'Garza Smart',
+        description: 'Garza Smart Zigbee Standard A60',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+    }
+];

--- a/devices/garza.js
+++ b/devices/garza.js
@@ -1,0 +1,25 @@
+const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
+const tz = require('zigbee-herdsman-converters/converters/toZigbee');
+const exposes = require('zigbee-herdsman-converters/lib/exposes');
+const reporting = require('zigbee-herdsman-converters/lib/reporting');
+const extend = require('zigbee-herdsman-converters/lib/extend');
+const ota = require('zigbee-herdsman-converters/lib/ota');
+const tuya = require('zigbee-herdsman-converters/lib/tuya');
+const e = exposes.presets;
+const ea = exposes.access;
+
+const definition = {
+    fingerprint: [
+        {
+            modelID: 'TS0505B',
+            manufacturerName: '_TZ3210_sln7ah6r'
+        },
+    ],
+    zigbeeModel: ['TS0505B'],
+    model: 'Garza-Standard-A60',
+    vendor: 'Garza Smart',
+    description: 'Garza Smart Zigbee Standard A60',
+    extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+};
+
+module.exports = definition;


### PR DESCRIPTION
Added Garza vendor file. 

Included converter for A60 Standard Light Bulb, product reference:

https://garza.es/iluminacion/461154-garza-smart-bombilla-led-zigbee-estandar-a60-11w-equivale-a-75w-de-incandescencia-e27-requiere-puentebridge-rgb-cct-8430624013117.html