### PR TITLE
Add support for Yale YMC 420 D

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3112,35 +3112,35 @@ const converters = {
         },
     },
     yale_ymc_420_d_lock_operation_event: {
-      cluster: 'closuresDoorLock',
-      type: 'raw',
-      convert: (model, msg, publish, options, meta) => {
-        const lookup = {
-          0: 'keypad_unlock',
-          1: 'zigbee_unlock',
-          2: 'Auto_lock',
-          3: 'rfid_unlock',
-          4: 'finger_unlock',
-          5: 'Unlock_failure_invalid_pin_or_id',
-          6: 'Unlock_failure_invalid_schedule',
-          7: 'one_touch_lock',
-          8: 'Key_lock',
-          9: 'Key_unlock',
-          10: 'auto_lock',
-          11: 'Schedule_lock',
-          12: 'Schedule_unlock',
-          13: 'Manual_lock',
-          14: 'manual_unlock',
-          15: 'Non_access_user_operational_event'
-        };
+        cluster: 'closuresDoorLock',
+        type: 'raw',
+        convert: (model, msg, publish, options, meta) => {
+            const lookup = {
+                0: 'keypad_unlock',
+                1: 'zigbee_unlock',
+                2: 'Auto_lock',
+                3: 'rfid_unlock',
+                4: 'finger_unlock',
+                5: 'Unlock_failure_invalid_pin_or_id',
+                6: 'Unlock_failure_invalid_schedule',
+                7: 'one_touch_lock',
+                8: 'Key_lock',
+                9: 'Key_unlock',
+                10: 'auto_lock',
+                11: 'Schedule_lock',
+                12: 'Schedule_unlock',
+                13: 'Manual_lock',
+                14: 'manual_unlock',
+                15: 'Non_access_user_operational_event'
+            };
 
-        return {
-          action: lookup[msg.data['opereventcode']],
-          action_user: msg.data['userid'],
-          action_source: msg.data['opereventsrc'],
-          action_source_name: constants.lockSourceName[msg.data['opereventsrc']],
-        };
-      },
+            return {
+                action: lookup[msg.data['opereventcode']],
+                action_user: msg.data['userid'],
+                action_source: msg.data['opereventsrc'],
+                action_source_name: constants.lockSourceName[msg.data['opereventsrc']],
+            };
+        },
     },
     livolo_switch_state_raw: {
         cluster: 'genPowerCfg',

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3131,7 +3131,7 @@ const converters = {
                 12: 'Schedule_unlock',
                 13: 'Manual_lock',
                 14: 'manual_unlock',
-                15: 'Non_access_user_operational_event'
+                15: 'Non_access_user_operational_event',
             };
 
             return {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3111,6 +3111,37 @@ const converters = {
             }
         },
     },
+    yale_ymc_420_d_lock_operation_event: {
+      cluster: 'closuresDoorLock',
+      type: 'raw',
+      convert: (model, msg, publish, options, meta) => {
+        const lookup = {
+          0: 'keypad_unlock',
+          1: 'zigbee_unlock',
+          2: 'Auto_lock',
+          3: 'rfid_unlock',
+          4: 'finger_unlock',
+          5: 'Unlock_failure_invalid_pin_or_id',
+          6: 'Unlock_failure_invalid_schedule',
+          7: 'one_touch_lock',
+          8: 'Key_lock',
+          9: 'Key_unlock',
+          10: 'auto_lock',
+          11: 'Schedule_lock',
+          12: 'Schedule_unlock',
+          13: 'Manual_lock',
+          14: 'manual_unlock',
+          15: 'Non_access_user_operational_event'
+        };
+
+        return {
+          action: lookup[msg.data['opereventcode']],
+          action_user: msg.data['userid'],
+          action_source: msg.data['opereventsrc'],
+          action_source_name: constants.lockSourceName[msg.data['opereventsrc']],
+        };
+      },
+    },
     livolo_switch_state_raw: {
         cluster: 'genPowerCfg',
         type: ['raw'],

--- a/devices/yale.js
+++ b/devices/yale.js
@@ -130,14 +130,14 @@ module.exports = [
         vendor: 'Yale',
         description: 'Biometric digital lock',
         fromZigbee: [
-          fz.yale_ymc_420_d_lock_operation_event,
-          fz.lock_programming_event,
-          fz.lock_pin_code_response,
-          fz.lock_user_status_response,
-          fz.lock,
-          fz.battery
+            fz.yale_ymc_420_d_lock_operation_event,
+            fz.lock_programming_event,
+            fz.lock_pin_code_response,
+            fz.lock_user_status_response,
+            fz.lock,
+            fz.battery,
         ],
-        extend: lockExtend({ timeout: 20000 }), //
+        extend: lockExtend({timeout: 20000}), //
     },
     {
         zigbeeModel: ['c700000202', '06ffff2029'],

--- a/devices/yale.js
+++ b/devices/yale.js
@@ -125,6 +125,21 @@ module.exports = [
         extend: lockExtend(),
     },
     {
+        zigbeeModel: ['YMC 420 D'],
+        model: 'YMC 420 D',
+        vendor: 'Yale',
+        description: 'Biometric digital lock',
+        fromZigbee: [
+          fz.yale_ymc_420_d_lock_operation_event,
+          fz.lock_programming_event,
+          fz.lock_pin_code_response,
+          fz.lock_user_status_response,
+          fz.lock,
+          fz.battery
+        ],
+        extend: lockExtend({ timeout: 20000 }), //
+    },
+    {
         zigbeeModel: ['c700000202', '06ffff2029'],
         model: 'YDF40',
         vendor: 'Yale',


### PR DESCRIPTION
This PR seems unusual... The source code for yale.js uses fz lock_operation_event and, for some reason, this model 420 D needs data type to be 'raw', I've just create a clone, just changing data mapping and data type.

Yale.js has an edited version of this function in module.exports (I saw an example of this from fz "easycode_action" and device easyaccess.js).

Feel free to change it all! I was just trying to understand how does it all work, and trying to make a PR from this issue https://github.com/Koenkk/zigbee2mqtt/issues/8946.

Thanks for you incredible work here, @Koenkk !