### PR TITLE
Fix battery_low sensor for Woox R7049

### DIFF
--- a/devices/woox.js
+++ b/devices/woox.js
@@ -34,6 +34,7 @@ const fzLocal = {
                 case 14: {
                     const batteryLevels = {0: 'low', 1: 'middle', 2: 'high'};
                     result.battery_level = batteryLevels[value];
+                    result.battery_low = value === 0;
                     break;
                 }
                 case 16:


### PR DESCRIPTION
The `battery_low` sensor was not working on the Woox R7049. It is exposed, but was never assigned a value since moving away from the generic `tuya_woox_smoke` converter.
I chose to assign a value to the sensor rather than removing it from `exposes` altogether since it is the only standardized `binary_sensor` with `device_class: battery` for this device in Home Assistant.

Koenkk/zigbee2mqtt#11702 is related.