### PR TITLE
Add new fingerprint for QS-Zigbee-D02-TRIAC-L

### DIFF
--- a/devices/lonsonho.js
+++ b/devices/lonsonho.js
@@ -134,7 +134,7 @@ module.exports = [
         },
     },
     {
-        fingerprint: [{modelID: 'TS110F', manufacturerName: '_TZ3000_ktuoyvt5'}],
+        fingerprint: [{modelID: 'TS110F', manufacturerName: '_TZ3000_ktuoyvt5'}, {modelID: 'TS110E', manufacturerName: '_TZ3210_weaqkhab'}],
         model: 'QS-Zigbee-D02-TRIAC-L',
         vendor: 'Lonsonho',
         description: '1 gang smart dimmer switch module without neutral',


### PR DESCRIPTION
Add fingerprint for "1 gang smart dimmer switch module without neutral" by Lonsonho
Model QS-Zigbee-D02-TRIAC-L bought on AliExpress, which should be supported by Zigbee2MQTT
https://www.aliexpress.com/item/4001279149071.html