### PR TITLE
add LED2101G4

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -398,6 +398,13 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
     },
     {
+        zigbeeModel: ['TRADFRI bulb E14 WS globe 470lm'],
+        model: 'LED2101G4',
+        vendor: 'IKEA',
+        description: 'TRADFRI bulb E14 WS globe 470lm, dimmable, white spectrum, opal white',
+        extend: tradfriExtend.light_onoff_brightness_colortemp(),
+    }
+    {
         zigbeeModel: ['TRADFRI bulb GU10 WW 400lm'],
         model: 'LED1837R5',
         vendor: 'IKEA',

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -403,7 +403,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'TRADFRI bulb E14 WS globe 470lm, dimmable, white spectrum, opal white',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),
-    }
+    },
     {
         zigbeeModel: ['TRADFRI bulb GU10 WW 400lm'],
         model: 'LED1837R5',


### PR DESCRIPTION
I have added TRADFRI bulb E14 WS globe 470lm with model number LED2101G4 to the Ikea vendor file.