### PR TITLE
Add coverInverted to Tuya TS130F

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1104,6 +1104,7 @@ module.exports = [
         description: 'Curtain/blind switch',
         fromZigbee: [fz.cover_position_tilt, fz.tuya_backlight_mode, fz.tuya_cover_options],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.tuya_cover_calibration, tz.tuya_cover_reversal, tz.tuya_backlight_mode],
+        meta: {coverInverted: true},
         whiteLabel: [{vendor: 'LoraTap', model: 'SC400'}],
         exposes: [e.cover_position(), exposes.enum('moving', ea.STATE, ['UP', 'STOP', 'DOWN']),
             exposes.binary('calibration', ea.ALL, 'ON', 'OFF'), exposes.binary('motor_reversal', ea.ALL, 'ON', 'OFF'),


### PR DESCRIPTION
This fixes https://github.com/Koenkk/zigbee2mqtt/issues/13805 https://github.com/Koenkk/zigbee2mqtt/issues/13847 https://github.com/Koenkk/zigbee2mqtt/issues/13813 and maybe some more...

Is a breaking change and I'm not too sure if this is the correct solution...
Since this commits:
https://github.com/Koenkk/zigbee-herdsman-converters/commit/1cc7c2301d58233ef541d7e1ecb746414d02ca8a
https://github.com/Koenkk/zigbee-herdsman-converters/commit/2bc158c3cc20ee45bd8b39fdf84df49f21fc0175
The state for the Tuya TS130F is incorrect. It shows CLOSED when OPEN and the inverse.

I suppose the new meta tag must show when the state of the cover is inverted over the zigbee standard: if the device shows 100 when Open, the meta tag must be there indicating is reversed.

This is the case of the TS130F, and I've added this meta tag. The problem is that we added the `invert_cover` config option to all this covers, so this is a breaking change, and we must remove this config.

Is this correct or maybe there is a some bug in commits? I'm not too sure of the intention of the commits, maybe it must use the value "inverted" to get the state and not the original value, that is another option. What do you think @Koenkk ?