### PR TITLE
Add vendor Hatsy and its  tuya based device  modelId TS011F

### DIFF
--- a/devices/hatsy.js
+++ b/devices/hatsy.js
@@ -1,0 +1,30 @@
+const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
+const tz = require('zigbee-herdsman-converters/converters/toZigbee');
+const exposes = require('zigbee-herdsman-converters/lib/exposes');
+const reporting = require('zigbee-herdsman-converters/lib/reporting');
+const extend = require('zigbee-herdsman-converters/lib/extend');
+const e = exposes.presets;
+const ea = exposes.access;
+const tuya = require("zigbee-herdsman-converters/lib/tuya");
+
+const definition = {
+    fingerprint: [
+        {
+            modelID: 'TS011F',
+            manufacturerName: '_TZ3000_anhq0jsb'
+        },
+    ],
+    model: 'BS-500Z',
+    vendor: 'Hatsy',
+    description: 'Smart Light Socket',
+    fromZigbee: [fz.on_off],
+    toZigbee: [tz.on_off],    
+    configure: async (device, coordinatorEndpoint, logger) => {
+        const endpoint = device.getEndpoint(1);
+        await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
+    },
+    exposes: [e.switch()],
+};
+
+module.exports = definition;
+


### PR DESCRIPTION
https://www.lazada.com.ph/products/hatsy-zigbee-smart-light-socket-v3-ac100-240v-works-with-hatsy-smart-app-amazon-alexa-google-home-and-siri-shortcut-zigbee-gateway-required-i2338117942-s10616312959.html

https://store.hatsy-enterprise.com/listing/zigbee-smart-bulb-socket?page=1&categories=0=19