### PR TITLE
Fix zigbee2mqtt/13861

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1510,6 +1510,12 @@ const converters = {
             await entity.read('msTemperatureMeasurement', ['measuredValue']);
         },
     },
+    illuminance: {
+        key: ['illuminance', 'illuminance_lux'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('msIlluminanceMeasurement', ['measuredValue']);
+        },
+    },
     // #endregion
 
     // #region Non-generic converters

--- a/devices/kmpcil.js
+++ b/devices/kmpcil.js
@@ -6,6 +6,7 @@ const reporting = require('../lib/reporting');
 const globalStore = require('../lib/store');
 const utils = require('../lib/utils');
 const e = exposes.presets;
+const ea = exposes.access;
 
 const kmpcilOptions={
     presence_timeout_dc: () => {
@@ -74,11 +75,11 @@ module.exports = [
         model: 'KMPCIL_RES005',
         vendor: 'KMPCIL',
         description: 'Environment sensor',
-        exposes: [e.battery(), e.temperature(), e.humidity(), e.pressure(), e.illuminance(), e.illuminance_lux(), e.occupancy(),
-            e.switch()],
+        exposes: [e.battery(), e.temperature(), e.humidity(), e.pressure(), e.illuminance().withAccess(ea.STATE_GET),
+            e.illuminance_lux().withAccess(ea.STATE_GET), e.occupancy(), e.switch()],
         fromZigbee: [fz.battery, fz.temperature, fz.humidity, fz.pressure, fz.illuminance, fz.kmpcil_res005_occupancy,
             fz.kmpcil_res005_on_off],
-        toZigbee: [tz.kmpcil_res005_on_off],
+        toZigbee: [tz.kmpcil_res005_on_off, tz.illuminance],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(8);
             const binds = ['genPowerCfg', 'msTemperatureMeasurement', 'msRelativeHumidity', 'msPressureMeasurement',

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1685,7 +1685,7 @@ module.exports = [
         whiteLabel: [{vendor: 'Xiaomi', model: 'YTC4043GL'}],
         description: 'MiJia light intensity sensor',
         fromZigbee: [fz.battery, fz.illuminance, fz.aqara_opple],
-        toZigbee: [],
+        toZigbee: [tz.illuminance],
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -1693,7 +1693,8 @@ module.exports = [
             await reporting.illuminance(endpoint, {min: 15, max: constants.repInterval.HOUR, change: 500});
             await endpoint.read('genPowerCfg', ['batteryVoltage']);
         },
-        exposes: [e.battery(), e.battery_voltage(), e.illuminance(), e.illuminance_lux(), e.power_outage_count(false)],
+        exposes: [e.battery(), e.battery_voltage(), e.illuminance().withAccess(ea.STATE_GET),
+            e.illuminance_lux().withAccess(ea.STATE_GET), e.power_outage_count(false)],
     },
     {
         zigbeeModel: ['lumi.light.rgbac1'],


### PR DESCRIPTION
https://github.com/Koenkk/zigbee2mqtt/issues/13861

This should handle the issue logged, I only added it to KMPCIL_RES005 which the reporter is using and to lumi.sen_ill.mgl01 which I have access to an used to test if this works.

Given these are battery powered devices, the request will probably timeout unless the device is awake, but it does work.

```
debug 2022-09-05 19:26:11: Publishing get 'get' 'illuminance' to 'lux/office'
debug 2022-09-05 19:26:16: Received Zigbee message from 'lux/office', type 'readResponse', cluster 'msIlluminanceMeasurement', data '{"measuredValue":27068}' from endpoint 1 with groupID 0
info  2022-09-05 19:26:16: MQTT publish: topic 'zigbee2mqtt/lux/office', payload '{"battery":100,"illuminance":27068,"illuminance_lux":509,"linkquality":51,"voltage":3200}'
```

I think it would be OK to add this everywhere where fz.illuminance is used, I can make the extra change if you also think this will be OK.