### PR TITLE
Add GIDERWEL C05Z RGB+CCT LED Controller

### DIFF
--- a/devices/giderwel.js
+++ b/devices/giderwel.js
@@ -8,4 +8,15 @@ module.exports = [
         description: 'Smart Zigbee RGB LED strip controller',
         extend: extend.light_onoff_brightness_color({supportsHS: false}),
     },
+    {
+        fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3210_ijczzg9h'}],
+        model: 'C05Z',
+        vendor: 'GIDERWEL',
+        description: 'Zigbee RGB+CCT LED strip controller',
+        extend: extend.light_onoff_brightness_colortemp_color({
+            colorTempRange: [153, 500],
+            disableColorTempStartup: true,
+            disableEffect: true,
+        }),
+    },
 ];


### PR DESCRIPTION
Add GIDERWEL C05Z RGB+CCT LED Controller.

Disabled effects on this as they just blinked the LEDs once. 

See: https://github.com/Koenkk/zigbee2mqtt.io/pull/1555 for device documentation.