### PR TITLE
Adds Support for Pincode Management to Kwikset 99140-031 Device

### DIFF
--- a/devices/kwikset.js
+++ b/devices/kwikset.js
@@ -55,15 +55,16 @@ module.exports = [
         model: '99140-031',
         vendor: 'Kwikset',
         description: 'SmartCode traditional electronic deadbolt',
-        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery],
-        toZigbee: [tz.lock],
+        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery, fz.lock_programming_event, fz.lock_pin_code_response],
+        toZigbee: [tz.lock, tz.pincode_lock],
+        meta: {pinCodeCount: 30},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
             await reporting.lockState(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.lock(), e.battery(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user()],
+        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user()],
     },
     {
         zigbeeModel: ['SMARTCODE_DEADBOLT_5'],


### PR DESCRIPTION
Adds missing support to the `99140-031` Kwikset deadbolt smartlock for pincode management.

Closes #4556
