### PR TITLE
Remove `meta: CoverInverted` from zigfred plus converter by Siglis AG

### DIFF
--- a/devices/siglis.js
+++ b/devices/siglis.js
@@ -184,7 +184,7 @@ module.exports = [
             tz.cover_position_tilt,
             coverAndLightToZigbee,
         ],
-        meta: {multiEndpoint: true, coverInverted: true},
+        meta: {multiEndpoint: true},
         endpoint: (device) => {
             return {
                 'l1': zigfredEndpoint,


### PR DESCRIPTION
The cover state logic on zigfred plus is double inverted due to a misunderstanding regarding `README.md` and `exposes.js`.

- https://github.com/Koenkk/zigbee-herdsman-converters/blob/c12ec4e825f467b4151480545db1eabf26350039/README.md?plain=1#L25
- https://github.com/Koenkk/zigbee-herdsman-converters/blob/51c60c455533343b13869652389d856ec9f51ba8/lib/exposes.js#L504

This pull request will remove the `meta: {CoverInverted: true}` from the zigfred plus converter.

Best regards and many thanks 😊
Markus, Team zigfred