### PR TITLE
add support for SA-029-1 smart plug

### DIFF
--- a/devices/sonoff.js
+++ b/devices/sonoff.js
@@ -213,16 +213,4 @@ module.exports = [
             device.save();
         },
     },
-    {
-        zigbeeModel: ['SA-029-1'],
-        model: 'SA-029-1',
-        vendor: 'Sonoff',
-        description: 'Smart Plug',
-        extend: extend.switch(),
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
-            await reporting.onOff(endpoint);
-        },
-    },
 ];

--- a/devices/sonoff.js
+++ b/devices/sonoff.js
@@ -213,4 +213,16 @@ module.exports = [
             device.save();
         },
     },
+    {
+        zigbeeModel: ['SA-029-1'],
+        model: 'SA-029-1',
+        vendor: 'Sonoff',
+        description: 'Smart Plug',
+        extend: extend.switch(),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        },
+    },
 ];

--- a/devices/woolley.js
+++ b/devices/woolley.js
@@ -3,7 +3,7 @@ const reporting = require('../lib/reporting');
 
 module.exports = [
     {
-        zigbeeModel: ['Z111PL0H-1JX'],
+        zigbeeModel: ['Z111PL0H-1JX', 'SA-029-1'],
         model: 'SA-029',
         vendor: 'Woolley',
         description: 'Smart Plug',


### PR DESCRIPTION
I've bought a few 'Woolley Zigbee Smart Plug SA-029 Type F' since I saw that you've recently added support for them (1). To my surprise, they advertised their vendor as 'Sonoff' and their model id as 'SA-09-1' and I ended up adding an external converter to my setup to get them running.

Hopefully this PR helps to avoid this additional step in the future.

Please let me know about any recommended adjustments to get this accepted. 

(1) See https://github.com/Koenkk/zigbee-herdsman-converters/blob/8f088634ed5585724472986cf0ebaadab72b2366/devices/woolley.js#L4