### PR TITLE
Add support for HEIMAN HS2WDSR-E

### DIFF
--- a/devices/heiman.js
+++ b/devices/heiman.js
@@ -445,6 +445,20 @@ module.exports = [
         },
     },
     {
+        fingerprint: [{modelID: 'ColorDimmerSw-EM-3.0', manufacturerName: 'HEIMAN'}],
+        model: 'HS2WDSR-E',
+        vendor: 'HEIMAN',
+        description: 'Remote dimmer and color control',
+        fromZigbee: [fz.battery, fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.command_move_to_color],
+        exposes: [e.battery(), e.action(['on', 'off', 'move', 'stop', 'color_move'])],
+        toZigbee: [],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl']);
+            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+        },
+    },
+    {
         zigbeeModel: ['GASSensor-EM'],
         model: 'HS1CG-E',
         vendor: 'HEIMAN',


### PR DESCRIPTION
Adds support for the HEIMAN remote dimmer and color controller HS2WDSR-E (the remote on [this](https://www.amazon.de/dp/B096M5X2CY)/[this](https://www.amazon.es/-/pt/gp/product/B08LYPMS8R) kit).