### PR TITLE
Avoid negative power values for SPLZB-131

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -43,7 +43,7 @@ module.exports = [
         model: 'SPLZB-131',
         vendor: 'Develco',
         description: 'Power plug',
-        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
+        fromZigbee: [fz.on_off, fzLocal.SPLZB134_electrical_measurement, fzLocal.SPLZB134_metering],
         toZigbee: [tz.on_off],
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
Similar to the SPLZB-134 I get random negative spikes from my 17 SPLZB-131 devices. (Completely messing up HA graphs I might add).