### PR TITLE
Added 'pause' motor_state for lumi.curtain.agl001

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1594,7 +1594,7 @@ module.exports = [
             e.battery_voltage().withAccess(ea.STATE_GET),
             e.device_temperature(),
             e.action(['manual_open', 'manual_close']),
-            exposes.enum('motor_state', ea.STATE, ['stopped', 'opening', 'closing'])
+            exposes.enum('motor_state', ea.STATE, ['stopped', 'opening', 'closing', 'pause'])
                 .withDescription('Motor state'),
             exposes.binary('running', ea.STATE, true, false)
                 .withDescription('Whether the motor is moving or not'),


### PR DESCRIPTION
Added 'pause' motor_state because of

MQTT publish: topic 'zigbee2mqtt/Livingroom Curtain Front Right', payload '{"action":null,"battery":100,"charging":false,"device_temperature":23,"hooks_state":"locked","linkquality":255,"motor_state":"stopped","position":100,"power_outage_count":0,"power_source":"battery","running":false,"state":"CLOSE","target_position":100,"update":{"state":"available"},"update_available":true,"voltage":3000}'