### PR TITLE
Add dynamic expose support regarding deviceEnabled attribute for Siglis zigfred smart in-wall switches

### DIFF
--- a/devices/siglis.js
+++ b/devices/siglis.js
@@ -256,74 +256,76 @@ module.exports = [
             };
         },
         configure: async (device, coordinatorEndpoint, logger) => {
-            // Bind Control EP (LED)
-            const controlEp = device.getEndpoint(zigfredEndpoint);
-            device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.frontSurfaceEnabled) {
-                await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
-                await reporting.onOff(controlEp);
-                await reporting.brightness(controlEp);
-            }
-
-            // Bind Dimmer 1 EP
-            const dimmer1Ep = device.getEndpoint(7);
-            device.dimmer1Enabled = (await dimmer1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.dimmer1Enabled) {
-                await reporting.bind(dimmer1Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-                await reporting.onOff(dimmer1Ep);
-                await reporting.brightness(dimmer1Ep);
-            }
-
-            // Bind Dimmer 2 EP
-            const dimmer2Ep = device.getEndpoint(8);
-            device.dimmer2Enabled = (await dimmer2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.dimmer2Enabled) {
-                await reporting.bind(dimmer2Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-                await reporting.onOff(dimmer2Ep);
-                await reporting.brightness(dimmer2Ep);
-            }
-
-            // Bind Dimmer 3 EP
-            const dimmer3Ep = device.getEndpoint(9);
-            device.dimmer3Enabled = (await dimmer3Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.dimmer3Enabled) {
-                await reporting.bind(dimmer3Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-                await reporting.onOff(dimmer3Ep);
-                await reporting.brightness(dimmer3Ep);
-            }
-
-            // Bind Dimmer 4 EP
-            const dimmer4Ep = device.getEndpoint(10);
-            device.dimmer4Enabled = (await dimmer4Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.dimmer4Enabled) {
-                await reporting.bind(dimmer4Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-                await reporting.onOff(dimmer4Ep);
-                await reporting.brightness(dimmer4Ep);
-            }
-
-            // Bind Cover 1 EP
-            const cover1Ep = device.getEndpoint(11);
-            device.cover1Enabled = (await cover1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.cover1Enabled) {
-                await reporting.bind(cover1Ep, coordinatorEndpoint, ['closuresWindowCovering']);
-                await reporting.currentPositionLiftPercentage(cover1Ep);
-                device.cover1TiltEnabled =
-                    (await cover1Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
-                if (device.cover1TiltEnabled) {
-                    await reporting.currentPositionTiltPercentage(cover1Ep);
+            if (device != null) {
+                // Bind Control EP (LED)
+                const controlEp = device.getEndpoint(zigfredEndpoint);
+                device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.frontSurfaceEnabled) {
+                    await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
+                    await reporting.onOff(controlEp);
+                    await reporting.brightness(controlEp);
                 }
-            }
 
-            // Bind Cover 2 EP
-            const cover2Ep = device.getEndpoint(12);
-            device.cover2Enabled = (await cover2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.cover2Enabled) {
-                await reporting.bind(cover2Ep, coordinatorEndpoint, ['closuresWindowCovering']);
-                await reporting.currentPositionLiftPercentage(cover2Ep);
-                device.cover2TiltEnabled =
-                    (await cover2Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
-                if (device.cover2TiltEnabled) {
-                    await reporting.currentPositionTiltPercentage(cover2Ep);
+                // Bind Dimmer 1 EP
+                const dimmer1Ep = device.getEndpoint(7);
+                device.dimmer1Enabled = (await dimmer1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.dimmer1Enabled) {
+                    await reporting.bind(dimmer1Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                    await reporting.onOff(dimmer1Ep);
+                    await reporting.brightness(dimmer1Ep);
+                }
+
+                // Bind Dimmer 2 EP
+                const dimmer2Ep = device.getEndpoint(8);
+                device.dimmer2Enabled = (await dimmer2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.dimmer2Enabled) {
+                    await reporting.bind(dimmer2Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                    await reporting.onOff(dimmer2Ep);
+                    await reporting.brightness(dimmer2Ep);
+                }
+
+                // Bind Dimmer 3 EP
+                const dimmer3Ep = device.getEndpoint(9);
+                device.dimmer3Enabled = (await dimmer3Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.dimmer3Enabled) {
+                    await reporting.bind(dimmer3Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                    await reporting.onOff(dimmer3Ep);
+                    await reporting.brightness(dimmer3Ep);
+                }
+
+                // Bind Dimmer 4 EP
+                const dimmer4Ep = device.getEndpoint(10);
+                device.dimmer4Enabled = (await dimmer4Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.dimmer4Enabled) {
+                    await reporting.bind(dimmer4Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                    await reporting.onOff(dimmer4Ep);
+                    await reporting.brightness(dimmer4Ep);
+                }
+
+                // Bind Cover 1 EP
+                const cover1Ep = device.getEndpoint(11);
+                device.cover1Enabled = (await cover1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.cover1Enabled) {
+                    await reporting.bind(cover1Ep, coordinatorEndpoint, ['closuresWindowCovering']);
+                    await reporting.currentPositionLiftPercentage(cover1Ep);
+                    device.cover1TiltEnabled =
+                        (await cover1Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
+                    if (device.cover1TiltEnabled) {
+                        await reporting.currentPositionTiltPercentage(cover1Ep);
+                    }
+                }
+
+                // Bind Cover 2 EP
+                const cover2Ep = device.getEndpoint(12);
+                device.cover2Enabled = (await cover2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.cover2Enabled) {
+                    await reporting.bind(cover2Ep, coordinatorEndpoint, ['closuresWindowCovering']);
+                    await reporting.currentPositionLiftPercentage(cover2Ep);
+                    device.cover2TiltEnabled =
+                        (await cover2Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
+                    if (device.cover2TiltEnabled) {
+                        await reporting.currentPositionTiltPercentage(cover2Ep);
+                    }
                 }
             }
         },

--- a/devices/siglis.js
+++ b/devices/siglis.js
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 const fz = require('../converters/fromZigbee');
 const tz = require('../converters/toZigbee');
 const exposes = require('../lib/exposes');
@@ -5,40 +6,36 @@ const reporting = require('../lib/reporting');
 const e = exposes.presets;
 
 
-const siglisManufacturerCode = 0x129C;
 const zigfredEndpoint = 5;
 
-const zifgredFromZigbee = {
+const buttonLookup = {
+    0: 'button_1',
+    1: 'button_2',
+    2: 'button_3',
+    3: 'button_4',
+};
+
+const actionLookup = {
+    0: 'release',
+    1: 'single',
+    2: 'double',
+    3: 'hold',
+};
+
+const zifgredFromZigbeeButtonEvent = {
     cluster: 'manuSpecificSiglisZigfred',
-    type: ['attributeReport'],
+    type: ['commandSiglisZigfredButtonEvent'],
     convert: (model, msg, publish, options, meta) => {
-        const buttonEvent = msg.data['buttonEvent'];
+        console.log(msg);
+        const button = msg.data.button;
+        const type = msg.data.type;
 
-        if (buttonEvent != null) {
-            const buttonLookup = {
-                0: 'button_1',
-                1: 'button_2',
-                2: 'button_3',
-                3: 'button_4',
-            };
+        const buttonName = buttonLookup[button];
+        const typeName = actionLookup[type];
 
-            const actionLookup = {
-                0: 'release',
-                1: 'single',
-                2: 'double',
-                3: 'hold',
-            };
-
-            const button = buttonEvent & 0xff;
-            const state = (buttonEvent >> 8) & 0xff;
-
-            const buttonName = buttonLookup[button];
-            const stateName = actionLookup[state];
-
-            if (buttonName && stateName) {
-                const action = `${buttonName}_${stateName}`;
-                return {action};
-            }
+        if (buttonName && typeName) {
+            const action = `${buttonName}_${typeName}`;
+            return {action};
         }
     },
 };
@@ -63,6 +60,12 @@ const coverAndLightToZigbee = {
     },
 };
 
+const buttonEventExposes = e.action([
+    'button_1_single', 'button_1_double', 'button_1_hold', 'button_1_release',
+    'button_2_single', 'button_2_double', 'button_2_hold', 'button_2_release',
+    'button_3_single', 'button_3_double', 'button_3_hold', 'button_3_release',
+    'button_4_single', 'button_4_double', 'button_4_hold', 'button_4_release',
+]);
 
 module.exports = [
     {
@@ -70,15 +73,27 @@ module.exports = [
         model: 'ZFU-1D-CH',
         vendor: 'Siglis',
         description: 'zigfred uno smart in-wall switch',
-        exposes: [e.light_brightness_colorxy().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.light_brightness().withEndpoint('l3'),
-            e.action([
-                'button_1_single', 'button_1_double', 'button_1_hold', 'button_1_release',
-                'button_2_single', 'button_2_double', 'button_2_hold', 'button_2_release',
-                'button_3_single', 'button_3_double', 'button_3_hold', 'button_3_release',
-                'button_4_single', 'button_4_double', 'button_4_hold', 'button_4_release',
-            ])],
+        exposes: (device, options) => {
+            const expose = [];
+
+            expose.push(buttonEventExposes);
+
+            if (device.frontSurfaceEnabled) {
+                expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
+            }
+
+            if (device.relayEnabled) {
+                expose.push(e.switch().withEndpoint('l2'));
+            }
+
+            if (device.dimmerEnabled) {
+                expose.push(e.light_brightness().withEndpoint('l3'));
+            }
+
+            return expose;
+        },
         fromZigbee: [
-            zifgredFromZigbee,
+            zifgredFromZigbeeButtonEvent,
             fz.color_colortemp,
             fz.on_off,
             fz.brightness,
@@ -114,25 +129,27 @@ module.exports = [
             const dimmerEp = device.getEndpoint(7);
 
             // Bind Control EP (LED)
-            await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
-            await reporting.onOff(controlEp);
-            await reporting.brightness(controlEp);
-            const payload = [{
-                attribute: 'buttonEvent',
-                minimumReportInterval: 0,
-                maximumReportInterval: 0,
-                reportableChange: 0,
-            }];
-            await controlEp.configureReporting('manuSpecificSiglisZigfred', payload, {manufacturerCode: siglisManufacturerCode});
+            device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.frontSurfaceEnabled) {
+                await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
+                await reporting.onOff(controlEp);
+                await reporting.brightness(controlEp);
+            }
 
             // Bind Relay EP
-            await reporting.bind(relayEp, coordinatorEndpoint, ['genOnOff']);
-            await reporting.onOff(relayEp);
+            device.relayEnabled = (await relayEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.relayEnabled) {
+                await reporting.bind(relayEp, coordinatorEndpoint, ['genOnOff']);
+                await reporting.onOff(relayEp);
+            }
 
             // Bind Dimmer EP
-            await reporting.bind(dimmerEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(dimmerEp);
-            await reporting.brightness(dimmerEp);
+            device.dimmerEnabled = (await dimmerEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.dimmerEnabled) {
+                await reporting.bind(dimmerEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                await reporting.onOff(dimmerEp);
+                await reporting.brightness(dimmerEp);
+            }
         },
     },
     {
@@ -140,24 +157,59 @@ module.exports = [
         model: 'ZFP-1A-CH',
         vendor: 'Siglis',
         description: 'zigfred plus smart in-wall switch',
-        exposes: [
-            e.light_brightness_colorxy().withEndpoint('l1'),
-            e.light_brightness().withEndpoint('l2'),
-            e.light_brightness().withEndpoint('l3'),
-            e.light_brightness().withEndpoint('l4'),
-            e.light_brightness().withEndpoint('l5'),
-            exposes.cover().setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
-                .withPosition().withTilt().withEndpoint('l6'),
-            exposes.cover().setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
-                .withPosition().withTilt().withEndpoint('l7'),
-            e.action([
-                'button_1_single', 'button_1_double', 'button_1_hold', 'button_1_release',
-                'button_2_single', 'button_2_double', 'button_2_hold', 'button_2_release',
-                'button_3_single', 'button_3_double', 'button_3_hold', 'button_3_release',
-                'button_4_single', 'button_4_double', 'button_4_hold', 'button_4_release',
-            ])],
+        exposes: (device, options) => {
+            const expose = [];
+
+            expose.push(buttonEventExposes);
+
+            if (device.frontSurfaceEnabled) {
+                expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
+            }
+
+            if (device.dimmer1Enabled) {
+                expose.push(e.light_brightness().withEndpoint('l2'));
+            }
+
+            if (device.dimmer2Enabled) {
+                expose.push(e.light_brightness().withEndpoint('l3'));
+            }
+
+            if (device.dimmer3Enabled) {
+                expose.push(e.light_brightness().withEndpoint('l4'));
+            }
+
+            if (device.dimmer4Enabled) {
+                expose.push(e.light_brightness().withEndpoint('l5'));
+            }
+
+            if (device.cover1Enabled) {
+                if (device.cover1TiltEnabled) {
+                    expose.push(exposes.cover()
+                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                        .withPosition().withTilt().withEndpoint('l6'));
+                } else {
+                    expose.push(exposes.cover()
+                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                        .withPosition().withEndpoint('l6'));
+                }
+            }
+
+            if (device.cover2Enabled) {
+                if (device.cover1TiltEnabled) {
+                    expose.push(exposes.cover()
+                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                        .withPosition().withTilt().withEndpoint('l7'));
+                } else {
+                    expose.push(exposes.cover()
+                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                        .withPosition().withEndpoint('l7'));
+                }
+            }
+
+            return expose;
+        },
         fromZigbee: [
-            zifgredFromZigbee,
+            zifgredFromZigbeeButtonEvent,
             fz.color_colortemp,
             fz.on_off,
             fz.brightness,
@@ -199,52 +251,74 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             // Bind Control EP (LED)
             const controlEp = device.getEndpoint(zigfredEndpoint);
-            await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
-            await reporting.onOff(controlEp);
-            await reporting.brightness(controlEp);
-            const payload = [{
-                attribute: 'buttonEvent',
-                minimumReportInterval: 0,
-                maximumReportInterval: 0,
-                reportableChange: 0,
-            }];
-            await controlEp.configureReporting('manuSpecificSiglisZigfred', payload, {manufacturerCode: siglisManufacturerCode});
+            device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.frontSurfaceEnabled) {
+                await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
+                await reporting.onOff(controlEp);
+                await reporting.brightness(controlEp);
+            }
 
             // Bind Dimmer 1 EP
             const dimmer1Ep = device.getEndpoint(7);
-            await reporting.bind(dimmer1Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(dimmer1Ep);
-            await reporting.brightness(dimmer1Ep);
+            device.dimmer1Enabled = (await dimmer1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.dimmer1Enabled) {
+                await reporting.bind(dimmer1Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                await reporting.onOff(dimmer1Ep);
+                await reporting.brightness(dimmer1Ep);
+            }
 
             // Bind Dimmer 2 EP
             const dimmer2Ep = device.getEndpoint(8);
-            await reporting.bind(dimmer2Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(dimmer2Ep);
-            await reporting.brightness(dimmer2Ep);
+            device.dimmer2Enabled = (await dimmer2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.dimmer2Enabled) {
+                await reporting.bind(dimmer2Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                await reporting.onOff(dimmer2Ep);
+                await reporting.brightness(dimmer2Ep);
+            }
 
             // Bind Dimmer 3 EP
             const dimmer3Ep = device.getEndpoint(9);
-            await reporting.bind(dimmer3Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(dimmer3Ep);
-            await reporting.brightness(dimmer3Ep);
+            device.dimmer3Enabled = (await dimmer3Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.dimmer3Enabled) {
+                await reporting.bind(dimmer3Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                await reporting.onOff(dimmer3Ep);
+                await reporting.brightness(dimmer3Ep);
+            }
 
             // Bind Dimmer 4 EP
             const dimmer4Ep = device.getEndpoint(10);
-            await reporting.bind(dimmer4Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(dimmer4Ep);
-            await reporting.brightness(dimmer4Ep);
+            device.dimmer4Enabled = (await dimmer4Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.dimmer4Enabled) {
+                await reporting.bind(dimmer4Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                await reporting.onOff(dimmer4Ep);
+                await reporting.brightness(dimmer4Ep);
+            }
 
             // Bind Cover 1 EP
             const cover1Ep = device.getEndpoint(11);
-            await reporting.bind(cover1Ep, coordinatorEndpoint, ['closuresWindowCovering']);
-            await reporting.currentPositionLiftPercentage(cover1Ep);
-            await reporting.currentPositionTiltPercentage(cover1Ep);
+            device.cover1Enabled = (await cover1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+            if (device.cover1Enabled) {
+                await reporting.bind(cover1Ep, coordinatorEndpoint, ['closuresWindowCovering']);
+                await reporting.currentPositionLiftPercentage(cover1Ep);
+                device.cover1TiltEnabled =
+                    (await cover1Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
+                if (device.cover1TiltEnabled) {
+                    await reporting.currentPositionTiltPercentage(cover1Ep);
+                }
+            }
 
             // Bind Cover 2 EP
             const cover2Ep = device.getEndpoint(12);
-            await reporting.bind(cover2Ep, coordinatorEndpoint, ['closuresWindowCovering']);
-            await reporting.currentPositionLiftPercentage(cover2Ep);
-            await reporting.currentPositionTiltPercentage(cover2Ep);
+            device.cover2Enabled = await cover2Ep.read('genBasic', ['deviceEnabled']).deviceEnabled;
+            if (device.cover2Enabled) {
+                await reporting.bind(cover2Ep, coordinatorEndpoint, ['closuresWindowCovering']);
+                await reporting.currentPositionLiftPercentage(cover2Ep);
+                device.cover2TiltEnabled =
+                    (await cover2Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
+                if (device.cover2TiltEnabled) {
+                    await reporting.currentPositionTiltPercentage(cover2Ep);
+                }
+            }
         },
     },
 ];

--- a/devices/siglis.js
+++ b/devices/siglis.js
@@ -26,7 +26,6 @@ const zifgredFromZigbeeButtonEvent = {
     cluster: 'manuSpecificSiglisZigfred',
     type: ['commandSiglisZigfredButtonEvent'],
     convert: (model, msg, publish, options, meta) => {
-        console.log(msg);
         const button = msg.data.button;
         const type = msg.data.type;
 
@@ -195,7 +194,7 @@ module.exports = [
             }
 
             if (device.cover2Enabled) {
-                if (device.cover1TiltEnabled) {
+                if (device.cover2TiltEnabled) {
                     expose.push(exposes.cover()
                         .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
                         .withPosition().withTilt().withEndpoint('l7'));
@@ -309,7 +308,7 @@ module.exports = [
 
             // Bind Cover 2 EP
             const cover2Ep = device.getEndpoint(12);
-            device.cover2Enabled = await cover2Ep.read('genBasic', ['deviceEnabled']).deviceEnabled;
+            device.cover2Enabled = (await cover2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
             if (device.cover2Enabled) {
                 await reporting.bind(cover2Ep, coordinatorEndpoint, ['closuresWindowCovering']);
                 await reporting.currentPositionLiftPercentage(cover2Ep);

--- a/devices/siglis.js
+++ b/devices/siglis.js
@@ -4,6 +4,7 @@ const tz = require('../converters/toZigbee');
 const exposes = require('../lib/exposes');
 const reporting = require('../lib/reporting');
 const e = exposes.presets;
+const ea = exposes.access;
 
 
 const zigfredEndpoint = 5;
@@ -66,28 +67,50 @@ const buttonEventExposes = e.action([
     'button_4_single', 'button_4_double', 'button_4_hold', 'button_4_release',
 ]);
 
+function checkOption(options, key) {
+    if (options && options.hasOwnProperty(key)) {
+        return options[key];
+    } else {
+        return false;
+    }
+}
+
+function setOption(options, key, enabled) {
+    if (options) {
+        options[key] = enabled;
+    }
+}
+
 module.exports = [
     {
         zigbeeModel: ['zigfred uno'],
         model: 'ZFU-1D-CH',
         vendor: 'Siglis',
         description: 'zigfred uno smart in-wall switch',
+        options: [
+            exposes.binary(`front_surface_enabled`, ea.SET, true, false)
+                .withDescription('Front Surface LED enabled'),
+            exposes.binary(`relay_enabled`, ea.SET, true, false)
+                .withDescription('Relay enabled'),
+            exposes.binary(`dimmer_enabled`, ea.SET, true, false)
+                .withDescription('Dimmer enabled'),
+        ],
         exposes: (device, options) => {
             const expose = [];
 
             expose.push(buttonEventExposes);
             expose.push(e.linkquality());
 
-            if (device != null) {
-                if (device.frontSurfaceEnabled) {
+            if (device != null && options != null) {
+                if (checkOption(options, 'front_surface_enabled')) {
                     expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
                 }
 
-                if (device.relayEnabled) {
+                if (checkOption(options, 'relay_enabled')) {
                     expose.push(e.switch().withEndpoint('l2'));
                 }
 
-                if (device.dimmerEnabled) {
+                if (checkOption(options, 'dimmer_enabled')) {
                     expose.push(e.light_brightness().withEndpoint('l3'));
                 }
             }
@@ -125,30 +148,30 @@ module.exports = [
                 'l3': 7,
             };
         },
-        configure: async (device, coordinatorEndpoint, logger) => {
+        configure: async (device, coordinatorEndpoint, logger, options) => {
             if (device != null) {
                 const controlEp = device.getEndpoint(zigfredEndpoint);
                 const relayEp = device.getEndpoint(6);
                 const dimmerEp = device.getEndpoint(7);
 
                 // Bind Control EP (LED)
-                device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.frontSurfaceEnabled) {
+                setOption(options, 'front_surface_enabled', (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'front_surface_enabled')) {
                     await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
                     await reporting.onOff(controlEp);
                     await reporting.brightness(controlEp);
                 }
 
                 // Bind Relay EP
-                device.relayEnabled = (await relayEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.relayEnabled) {
+                setOption(options, 'relay_enabled', (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'relay_enabled')) {
                     await reporting.bind(relayEp, coordinatorEndpoint, ['genOnOff']);
                     await reporting.onOff(relayEp);
                 }
 
                 // Bind Dimmer EP
-                device.dimmerEnabled = (await dimmerEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.dimmerEnabled) {
+                setOption(options, 'dimmer_enabled', (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'dimmer_enabled')) {
                     await reporting.bind(dimmerEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
                     await reporting.onOff(dimmerEp);
                     await reporting.brightness(dimmerEp);
@@ -161,35 +184,55 @@ module.exports = [
         model: 'ZFP-1A-CH',
         vendor: 'Siglis',
         description: 'zigfred plus smart in-wall switch',
+        options: [
+            exposes.binary(`front_surface_enabled`, ea.SET, true, false)
+                .withDescription('Front Surface LED enabled'),
+            exposes.binary(`dimmer_1_enabled`, ea.SET, true, false)
+                .withDescription('Dimmer 1 enabled'),
+            exposes.binary(`dimmer_2_enabled`, ea.SET, true, false)
+                .withDescription('Dimmer 2 enabled'),
+            exposes.binary(`dimmer_3_enabled`, ea.SET, true, false)
+                .withDescription('Dimmer 3 enabled'),
+            exposes.binary(`dimmer_4_enabled`, ea.SET, true, false)
+                .withDescription('Dimmer 4 enabled'),
+            exposes.binary(`cover_1_enabled`, ea.SET, true, false)
+                .withDescription('Cover 1 enabled'),
+            exposes.binary(`cover_1_tilt_enabled`, ea.SET, true, false)
+                .withDescription('Cover 1 tiltable'),
+            exposes.binary(`cover_2_enabled`, ea.SET, true, false)
+                .withDescription('Cover 2 enabled'),
+            exposes.binary(`cover_2_tilt_enabled`, ea.SET, true, false)
+                .withDescription('Cover 2 tiltable'),
+        ],
         exposes: (device, options) => {
             const expose = [];
 
             expose.push(buttonEventExposes);
             expose.push(e.linkquality());
 
-            if (device != null) {
-                if (device.frontSurfaceEnabled) {
+            if (device != null && options != null) {
+                if (checkOption(options, 'front_surface_enabled')) {
                     expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
                 }
 
-                if (device.dimmer1Enabled) {
+                if (checkOption(options, 'dimmer_1_enabled')) {
                     expose.push(e.light_brightness().withEndpoint('l2'));
                 }
 
-                if (device.dimmer2Enabled) {
+                if (checkOption(options, 'dimmer_2_enabled')) {
                     expose.push(e.light_brightness().withEndpoint('l3'));
                 }
 
-                if (device.dimmer3Enabled) {
+                if (checkOption(options, 'dimmer_3_enabled')) {
                     expose.push(e.light_brightness().withEndpoint('l4'));
                 }
 
-                if (device.dimmer4Enabled) {
+                if (checkOption(options, 'dimmer_4_enabled')) {
                     expose.push(e.light_brightness().withEndpoint('l5'));
                 }
 
-                if (device.cover1Enabled) {
-                    if (device.cover1TiltEnabled) {
+                if (checkOption(options, 'cover_1_enabled')) {
+                    if (checkOption(options, 'cover_2_tilt_enabled')) {
                         expose.push(exposes.cover()
                             .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
                             .withPosition().withTilt().withEndpoint('l6'));
@@ -200,8 +243,8 @@ module.exports = [
                     }
                 }
 
-                if (device.cover2Enabled) {
-                    if (device.cover2TiltEnabled) {
+                if (checkOption(options, 'cover_2_enabled')) {
+                    if (checkOption(options, 'cover_2_tilt_enabled')) {
                         expose.push(exposes.cover()
                             .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
                             .withPosition().withTilt().withEndpoint('l7'));
@@ -255,12 +298,12 @@ module.exports = [
                 'l7': 12,
             };
         },
-        configure: async (device, coordinatorEndpoint, logger) => {
+        configure: async (device, coordinatorEndpoint, logger, options) => {
             if (device != null) {
                 // Bind Control EP (LED)
                 const controlEp = device.getEndpoint(zigfredEndpoint);
-                device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.frontSurfaceEnabled) {
+                setOption(options, 'front_surface_enabled', (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'front_surface_enabled')) {
                     await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
                     await reporting.onOff(controlEp);
                     await reporting.brightness(controlEp);
@@ -268,8 +311,8 @@ module.exports = [
 
                 // Bind Dimmer 1 EP
                 const dimmer1Ep = device.getEndpoint(7);
-                device.dimmer1Enabled = (await dimmer1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.dimmer1Enabled) {
+                setOption(options, 'dimmer_1_enabled', (await dimmer1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'dimmer_1_enabled')) {
                     await reporting.bind(dimmer1Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
                     await reporting.onOff(dimmer1Ep);
                     await reporting.brightness(dimmer1Ep);
@@ -277,8 +320,8 @@ module.exports = [
 
                 // Bind Dimmer 2 EP
                 const dimmer2Ep = device.getEndpoint(8);
-                device.dimmer2Enabled = (await dimmer2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.dimmer2Enabled) {
+                setOption(options, 'dimmer_2_enabled', (await dimmer2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'dimmer_2_enabled')) {
                     await reporting.bind(dimmer2Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
                     await reporting.onOff(dimmer2Ep);
                     await reporting.brightness(dimmer2Ep);
@@ -286,8 +329,8 @@ module.exports = [
 
                 // Bind Dimmer 3 EP
                 const dimmer3Ep = device.getEndpoint(9);
-                device.dimmer3Enabled = (await dimmer3Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.dimmer3Enabled) {
+                setOption(options, 'dimmer_3_enabled', (await dimmer3Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'dimmer_3_enabled')) {
                     await reporting.bind(dimmer3Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
                     await reporting.onOff(dimmer3Ep);
                     await reporting.brightness(dimmer3Ep);
@@ -295,8 +338,8 @@ module.exports = [
 
                 // Bind Dimmer 4 EP
                 const dimmer4Ep = device.getEndpoint(10);
-                device.dimmer4Enabled = (await dimmer4Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.dimmer4Enabled) {
+                setOption(options, 'dimmer_4_enabled', (await dimmer4Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'dimmer_4_enabled')) {
                     await reporting.bind(dimmer4Ep, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
                     await reporting.onOff(dimmer4Ep);
                     await reporting.brightness(dimmer4Ep);
@@ -304,26 +347,30 @@ module.exports = [
 
                 // Bind Cover 1 EP
                 const cover1Ep = device.getEndpoint(11);
-                device.cover1Enabled = (await cover1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.cover1Enabled) {
+                setOption(options, 'cover_1_enabled', (await cover1Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'cover_1_enabled')) {
                     await reporting.bind(cover1Ep, coordinatorEndpoint, ['closuresWindowCovering']);
                     await reporting.currentPositionLiftPercentage(cover1Ep);
-                    device.cover1TiltEnabled =
-                        (await cover1Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
-                    if (device.cover1TiltEnabled) {
+                    setOption(
+                        options,
+                        'cover_1_tilt_enabled',
+                        (await cover1Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08);
+                    if (checkOption(options, 'cover_1_tilt_enabled')) {
                         await reporting.currentPositionTiltPercentage(cover1Ep);
                     }
                 }
 
                 // Bind Cover 2 EP
                 const cover2Ep = device.getEndpoint(12);
-                device.cover2Enabled = (await cover2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-                if (device.cover2Enabled) {
+                setOption(options, 'cover_2_enabled', (await cover2Ep.read('genBasic', ['deviceEnabled'])).deviceEnabled);
+                if (checkOption(options, 'cover_2_enabled')) {
                     await reporting.bind(cover2Ep, coordinatorEndpoint, ['closuresWindowCovering']);
                     await reporting.currentPositionLiftPercentage(cover2Ep);
-                    device.cover2TiltEnabled =
-                        (await cover2Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08;
-                    if (device.cover2TiltEnabled) {
+                    setOption(
+                        options,
+                        'cover_2_tilt_enabled',
+                        (await cover2Ep.read('closuresWindowCovering', ['windowCoveringType'])).windowCoveringType === 0x08);
+                    if (checkOption(options, 'cover_2_tilt_enabled')) {
                         await reporting.currentPositionTiltPercentage(cover2Ep);
                     }
                 }

--- a/devices/siglis.js
+++ b/devices/siglis.js
@@ -76,17 +76,20 @@ module.exports = [
             const expose = [];
 
             expose.push(buttonEventExposes);
+            expose.push(e.linkquality());
 
-            if (device.frontSurfaceEnabled) {
-                expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
-            }
+            if (device != null) {
+                if (device.frontSurfaceEnabled) {
+                    expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
+                }
 
-            if (device.relayEnabled) {
-                expose.push(e.switch().withEndpoint('l2'));
-            }
+                if (device.relayEnabled) {
+                    expose.push(e.switch().withEndpoint('l2'));
+                }
 
-            if (device.dimmerEnabled) {
-                expose.push(e.light_brightness().withEndpoint('l3'));
+                if (device.dimmerEnabled) {
+                    expose.push(e.light_brightness().withEndpoint('l3'));
+                }
             }
 
             return expose;
@@ -123,31 +126,33 @@ module.exports = [
             };
         },
         configure: async (device, coordinatorEndpoint, logger) => {
-            const controlEp = device.getEndpoint(zigfredEndpoint);
-            const relayEp = device.getEndpoint(6);
-            const dimmerEp = device.getEndpoint(7);
+            if (device != null) {
+                const controlEp = device.getEndpoint(zigfredEndpoint);
+                const relayEp = device.getEndpoint(6);
+                const dimmerEp = device.getEndpoint(7);
 
-            // Bind Control EP (LED)
-            device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.frontSurfaceEnabled) {
-                await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
-                await reporting.onOff(controlEp);
-                await reporting.brightness(controlEp);
-            }
+                // Bind Control EP (LED)
+                device.frontSurfaceEnabled = (await controlEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.frontSurfaceEnabled) {
+                    await reporting.bind(controlEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificSiglisZigfred']);
+                    await reporting.onOff(controlEp);
+                    await reporting.brightness(controlEp);
+                }
 
-            // Bind Relay EP
-            device.relayEnabled = (await relayEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.relayEnabled) {
-                await reporting.bind(relayEp, coordinatorEndpoint, ['genOnOff']);
-                await reporting.onOff(relayEp);
-            }
+                // Bind Relay EP
+                device.relayEnabled = (await relayEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.relayEnabled) {
+                    await reporting.bind(relayEp, coordinatorEndpoint, ['genOnOff']);
+                    await reporting.onOff(relayEp);
+                }
 
-            // Bind Dimmer EP
-            device.dimmerEnabled = (await dimmerEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
-            if (device.dimmerEnabled) {
-                await reporting.bind(dimmerEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-                await reporting.onOff(dimmerEp);
-                await reporting.brightness(dimmerEp);
+                // Bind Dimmer EP
+                device.dimmerEnabled = (await dimmerEp.read('genBasic', ['deviceEnabled'])).deviceEnabled;
+                if (device.dimmerEnabled) {
+                    await reporting.bind(dimmerEp, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+                    await reporting.onOff(dimmerEp);
+                    await reporting.brightness(dimmerEp);
+                }
             }
         },
     },
@@ -160,48 +165,51 @@ module.exports = [
             const expose = [];
 
             expose.push(buttonEventExposes);
+            expose.push(e.linkquality());
 
-            if (device.frontSurfaceEnabled) {
-                expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
-            }
-
-            if (device.dimmer1Enabled) {
-                expose.push(e.light_brightness().withEndpoint('l2'));
-            }
-
-            if (device.dimmer2Enabled) {
-                expose.push(e.light_brightness().withEndpoint('l3'));
-            }
-
-            if (device.dimmer3Enabled) {
-                expose.push(e.light_brightness().withEndpoint('l4'));
-            }
-
-            if (device.dimmer4Enabled) {
-                expose.push(e.light_brightness().withEndpoint('l5'));
-            }
-
-            if (device.cover1Enabled) {
-                if (device.cover1TiltEnabled) {
-                    expose.push(exposes.cover()
-                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
-                        .withPosition().withTilt().withEndpoint('l6'));
-                } else {
-                    expose.push(exposes.cover()
-                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
-                        .withPosition().withEndpoint('l6'));
+            if (device != null) {
+                if (device.frontSurfaceEnabled) {
+                    expose.push(e.light_brightness_colorxy().withEndpoint('l1'));
                 }
-            }
 
-            if (device.cover2Enabled) {
-                if (device.cover2TiltEnabled) {
-                    expose.push(exposes.cover()
-                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
-                        .withPosition().withTilt().withEndpoint('l7'));
-                } else {
-                    expose.push(exposes.cover()
-                        .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
-                        .withPosition().withEndpoint('l7'));
+                if (device.dimmer1Enabled) {
+                    expose.push(e.light_brightness().withEndpoint('l2'));
+                }
+
+                if (device.dimmer2Enabled) {
+                    expose.push(e.light_brightness().withEndpoint('l3'));
+                }
+
+                if (device.dimmer3Enabled) {
+                    expose.push(e.light_brightness().withEndpoint('l4'));
+                }
+
+                if (device.dimmer4Enabled) {
+                    expose.push(e.light_brightness().withEndpoint('l5'));
+                }
+
+                if (device.cover1Enabled) {
+                    if (device.cover1TiltEnabled) {
+                        expose.push(exposes.cover()
+                            .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                            .withPosition().withTilt().withEndpoint('l6'));
+                    } else {
+                        expose.push(exposes.cover()
+                            .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                            .withPosition().withEndpoint('l6'));
+                    }
+                }
+
+                if (device.cover2Enabled) {
+                    if (device.cover2TiltEnabled) {
+                        expose.push(exposes.cover()
+                            .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                            .withPosition().withTilt().withEndpoint('l7'));
+                    } else {
+                        expose.push(exposes.cover()
+                            .setAccess('state', exposes.access.STATE_SET | exposes.access.STATE_GET)
+                            .withPosition().withEndpoint('l7'));
+                    }
                 }
             }
 


### PR DESCRIPTION
Add dynamic expose support regarding deviceEnabled attribute of Basic cluster and `windowCoveringType` on Siglis zigfred smart in-wall switches. Improve latency for button events by switching from button event attribute to custom button event command.