### PR TITLE
support Moes heat valve  TS0601 _TZE200_7yoranx2

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1913,6 +1913,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_husqqvux'}, /* model: 'TSL-TRV-TV01ZG', vendor: 'Tesla Smart' */
             {modelID: 'TS0601', manufacturerName: '_TZE200_lllliz3p'}, /* model: 'TV02-Zigbee', vendor: 'TuYa' */
             {modelID: 'TS0601', manufacturerName: '_TZE200_mudxchsu'}, /* model: 'TV05-ZG curve', vendor: 'TuYa' */
+            {modelID: 'TS0601', manufacturerName: '_TZE200_7yoranx2'}, /* model: 'TV01-ZB', vendor: 'Moes' */
         ],
         model: 'TV02-Zigbee',
         vendor: 'TuYa',


### PR DESCRIPTION
cheers,
got Moes heat valve from aliexpress which is identical to _TZE200_e9ba97vf, that I already have in household
![image](https://user-images.githubusercontent.com/85880743/192149711-35c4292c-cd0b-4349-bb02-a2c4b6abe03f.png)

  but started getting errors
**warn  2022-09-25 17:13:34: Received message from unsupported device with Zigbee model 'TS0601' and manufacturer name '_TZE200_7yoranx2'**

I suppose it  is just new revision of original Valve
chnages were tested locally by creating custom converter with copy-pasted code,everything works fine
