### PR TITLE
Add Hue Flourish light model 929003052601

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -701,6 +701,13 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
+        zigbeeModel: ['929003052601'],
+        model: '929003052601',
+        vendor: 'Philips',
+        description: 'Hue Flourish white and color ambiance table light with Bluetooth',
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+    },
+    {
         zigbeeModel: ['LCG002'],
         model: '929001953101',
         vendor: 'Philips',


### PR DESCRIPTION
Add Philips Hue Flourish table lamp model 929003052601. Note this is the North American model that comes with an E26 bulb and technically different from the existing entry for the European model with an E27 bulb, model 4090431P9.