### PR TITLE
Add support for Philips Hue White PAR38 bulb

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1506,6 +1506,13 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness(),
     },
     {
+        zigbeeModel: ['LWS001'],
+        model: '9290018189',
+        vendor: 'Philips',
+        description: 'Hue white PAR38 outdoor',
+        extend: hueExtend.light_onoff_brightness(),
+    },
+    {
         zigbeeModel: ['LLC010'],
         model: '7199960PH',
         vendor: 'Philips',


### PR DESCRIPTION
The 9290018189 model is recognized as "LWS001" by zigbee2mqtt.
Product link: https://www.philips-hue.com/en-us/p/hue-white-dual-pack-par38-outdoor/046677476823