### PR TITLE
Add emergency_heating for heating to SLR2b/c

### DIFF
--- a/devices/hive.js
+++ b/devices/hive.js
@@ -344,7 +344,7 @@ module.exports = [
         },
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()
-                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withEndpoint('heat'),
+                .withSystemMode(['off', 'auto', 'heat', 'emergency_heating']).withRunningState(['idle', 'heat']).withEndpoint('heat'),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
                     ' Must be set to `false` when system_mode = off or `true` for heat').withEndpoint('heat'),
@@ -396,7 +396,7 @@ module.exports = [
         },
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()
-                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']).withEndpoint('heat'),
+                .withSystemMode(['off', 'auto', 'heat', 'emergency_heating']).withRunningState(['idle', 'heat']).withEndpoint('heat'),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
                     ' Must be set to `false` when system_mode = off or `true` for heat').withEndpoint('heat'),


### PR DESCRIPTION
SLR2c (which I have) supports system mode emergency_heating for the heating control as well as water. The SLR2b (which I don't have) has information about using emergency_heating for controlling heating, but not water. I assume that also supports it, but the possible value for withSystemMode has not been included by mistake. This pull request adds it to both.