### PR TITLE
Added the slower mode of the Setpoint command for scheduled heatpoint changes

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -3563,6 +3563,18 @@ const converters = {
             return result;
         },
     },
+    danfoss_thermostat_setpoint_scheduled: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result = {};
+            if (msg.data.hasOwnProperty('occupiedHeatingSetpoint')) {
+                result[postfixWithEndpointName('occupied_heating_setpoint_scheduled', msg, model, meta)] =
+                    precisionRound(msg.data['occupiedHeatingSetpoint'], 2) / 100;
+            }
+            return result;
+        },
+    },
     danfoss_icon_battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2850,8 +2850,8 @@ const converters = {
             await entity.read('hvacThermostat', ['occupiedHeatingSetpoint']);
         },
     },
-    danfoss_thermostat_occupied_heating_scheduled_setpoint: {
-        key: ['occupied_heating_scheduled_setpoint'],
+    danfoss_thermostat_occupied_heating_setpoint_scheduled: {
+        key: ['occupied_heating_setpoint_scheduled'],
         convertSet: async (entity, key, value, meta) => {
             const payload = {
                 // 0: "Schedule Change" Just changes occupied heating setpoint. No special behavior,

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2839,7 +2839,24 @@ const converters = {
         key: ['occupied_heating_setpoint'],
         convertSet: async (entity, key, value, meta) => {
             const payload = {
+                // 1: "User Interaction" Changes occupied heating setpoint and triggers an aggressive reaction
+                //   of the actuator as soon as control SW runs, to replicate the behavior of turning the dial on the eTRV.
                 setpointType: 1,
+                setpoint: (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100,
+            };
+            await entity.command('hvacThermostat', 'danfossSetpointCommand', payload, manufacturerOptions.danfoss);
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['occupiedHeatingSetpoint']);
+        },
+    },
+    danfoss_thermostat_occupied_heating_scheduled_setpoint: {
+        key: ['occupied_heating_scheduled_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            const payload = {
+                // 0: "Schedule Change" Just changes occupied heating setpoint. No special behavior,
+                //   the PID control setpoint will be update with the new setpoint.
+                setpointType: 0,
                 setpoint: (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100,
             };
             await entity.command('hvacThermostat', 'danfossSetpointCommand', payload, manufacturerOptions.danfoss);

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -17,7 +17,8 @@ module.exports = [
         description: 'Ally thermostat',
         whiteLabel: [{vendor: 'Danfoss', model: '014G2463'}],
         meta: {thermostat: {dontMapPIHeatingDemand: true}},
-        fromZigbee: [fz.battery, fz.thermostat, fz.thermostat_weekly_schedule, fz.hvac_user_interface, fz.danfoss_thermostat],
+        fromZigbee: [fz.battery, fz.thermostat, fz.thermostat_weekly_schedule, fz.hvac_user_interface,
+            fz.danfoss_thermostat, fz.danfoss_thermostat_setpoint_scheduled],
         toZigbee: [tz.danfoss_thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature, tz.danfoss_mounted_mode_active,
             tz.danfoss_mounted_mode_control, tz.danfoss_thermostat_vertical_orientation, tz.danfoss_algorithm_scale_factor,
             tz.danfoss_heat_available, tz.danfoss_heat_required, tz.danfoss_day_of_week, tz.danfoss_trigger_time,
@@ -27,7 +28,7 @@ module.exports = [
             tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_programming_operation_mode,
             tz.danfoss_window_open_feature, tz.danfoss_preheat_status, tz.danfoss_adaptation_status, tz.danfoss_adaptation_settings,
             tz.danfoss_adaptation_control, tz.danfoss_regulation_setpoint_offset,
-            tz.danfoss_thermostat_occupied_heating_scheduled_setpoint],
+            tz.danfoss_thermostat_occupied_heating_setpoint_scheduled],
         exposes: [e.battery(), e.keypad_lockout(), e.programming_operation_mode(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +
@@ -49,6 +50,11 @@ module.exports = [
                 .withDescription('Values observed are `0` (manual), `1` (schedule) or `2` (externally)'),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5).withLocalTemperature().withPiHeatingDemand()
                 .withSystemMode(['heat']).withRunningState(['idle', 'heat'], ea.STATE),
+            exposes.numeric('occupied_heating_setpoint_scheduled', ea.ALL)
+                .withValueMin(5).withValueMax(35).withValueStep(0.5).withUnit('°C')
+                .withDescription('Scheduled change of the setpoint. Alternative method for changing the setpoint. In the opposite ' +
+                  'to occupied_heating_setpoint it does not trigger an aggressive response from the actuator. ' +
+                  '(More suitable for scheduled changes.)'),
             exposes.numeric('external_measured_room_sensor', ea.ALL)
                 .withDescription('If `radiator_covered` is `true`: Set at maximum 30 minutes interval but not more often than every ' +
                 '5 minutes and 0.1 degrees difference. Resets every 35 minutes to standard. If `radiator_covered` is `false`: ' +

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -54,7 +54,7 @@ module.exports = [
                 .withValueMin(5).withValueMax(35).withValueStep(0.5).withUnit('°C')
                 .withDescription('Scheduled change of the setpoint. Alternative method for changing the setpoint. In the opposite ' +
                   'to occupied_heating_setpoint it does not trigger an aggressive response from the actuator. ' +
-                  '(More suitable for scheduled changes.)'),
+                  '(more suitable for scheduled changes)'),
             exposes.numeric('external_measured_room_sensor', ea.ALL)
                 .withDescription('If `radiator_covered` is `true`: Set at maximum 30 minutes interval but not more often than every ' +
                 '5 minutes and 0.1 degrees difference. Resets every 35 minutes to standard. If `radiator_covered` is `false`: ' +

--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -26,7 +26,8 @@ module.exports = [
             tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.danfoss_load_balancing_enable, tz.danfoss_load_room_mean,
             tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule, tz.thermostat_programming_operation_mode,
             tz.danfoss_window_open_feature, tz.danfoss_preheat_status, tz.danfoss_adaptation_status, tz.danfoss_adaptation_settings,
-            tz.danfoss_adaptation_control, tz.danfoss_regulation_setpoint_offset],
+            tz.danfoss_adaptation_control, tz.danfoss_regulation_setpoint_offset,
+            tz.danfoss_thermostat_occupied_heating_scheduled_setpoint],
         exposes: [e.battery(), e.keypad_lockout(), e.programming_operation_mode(),
             exposes.binary('mounted_mode_active', ea.STATE_GET, true, false)
                 .withDescription('Is the unit in mounting mode. This is set to `false` for mounted (already on ' +


### PR DESCRIPTION
Added the Danfoss setpoint command with parameter 0 which is useful for scheduled heatpoint changes.

For Details see [Programming guide ](https://assets.danfoss.com/documents/202524/AU417130778872en-000101.pdf) on[ Danfoss Ally™ support](https://www.danfoss.com/en/products/dhs/smart-heating/smart-heating/danfoss-ally/danfoss-ally-support/#tab-documents) website


