### PR TITLE
MOSZB-140 some minor cleanup and fixes

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -516,20 +516,21 @@ module.exports = [
             return {default: 35};
         },
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint1 = device.getEndpoint(35);
-            await reporting.bind(endpoint1, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint1, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-            await endpoint1.read('genPowerCfg', ['batteryVoltage']);
-            await endpoint1.read('genBasic', ['develcoLedControl'], manufacturerOptions);
-            await endpoint1.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
+            const endpoint35 = device.getEndpoint(35);
+            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
+            await endpoint35.read('genBasic', ['develcoLedControl'], manufacturerOptions);
+            await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
 
-            const endpoint2 = device.getEndpoint(38);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint2);
+            const endpoint38 = device.getEndpoint(38);
+            await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
+            await reporting.temperature(endpoint38,
+                {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 100});
 
-            const endpoint3 = device.getEndpoint(39);
-            await reporting.bind(endpoint3, coordinatorEndpoint, ['msIlluminanceMeasurement']);
-            await reporting.illuminance(endpoint3);
+            const endpoint39 = device.getEndpoint(39);
+            await reporting.bind(endpoint39, coordinatorEndpoint, ['msIlluminanceMeasurement']);
+            await reporting.illuminance(endpoint39,
+                {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 500});
         },
     },
     {

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -519,8 +519,10 @@ module.exports = [
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-            await endpoint35.read('genBasic', ['develcoLedControl'], manufacturerOptions);
-            await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
+            try {
+                await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
+                await endpoint35.read('genBasic', ['develcoLedControl'], manufacturerOptions);
+            } catch (error) {/* some reports of timeouts on reading these */}
 
             const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -121,10 +121,12 @@ function postfixWithEndpointName(value, msg, definition, meta) {
     if (definition.meta && definition.meta.multiEndpoint) {
         const endpointName = definition.hasOwnProperty('endpoint') ?
             getKey(definition.endpoint(meta.device), msg.endpoint.ID) : msg.endpoint.ID;
-        return `${value}_${endpointName}`;
-    } else {
-        return value;
+
+        // NOTE: endpointName can be undefined if we have a definition.endpoint and the endpoint is
+        //       not listed.
+        if (endpointName) return `${value}_${endpointName}`;
     }
+    return value;
 }
 
 function getKey(object, value, fallback, convertTo) {


### PR DESCRIPTION
A few bits pulled in from https://github.com/Koenkk/zigbee-herdsman-converters/pull/4731#issuecomment-1268553608

I did fire off an e-mail to develco, but the last time I did that I got no answer from them, so I am not very hopeful. This PR cherry picks a few minor things from that one.

- improvement for postfixWithEndpointName in case an endpoint is not listed in the endpoint object, so no more `propertyname_undefined` now (was hitting this with the other PR, but still a good general improvement)
- batteryVoltage was read twice, once by the configure it self and once my the reporting setup
- wrap the develco* attributes in a try/catch, over on zigbee2mqtt there is an open issue of people hitting timeouts during configure on these

Although i can't reproduce the issues myself, based on #4731 I have a bit less faith in the technical manual.