### PR TITLE
Add support - Candeo C204

### DIFF
--- a/devices/candeo.js
+++ b/devices/candeo.js
@@ -1,5 +1,5 @@
 const exposes = require('../lib/exposes');
-const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const fz = require('../converters/fromZigbee');
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
 const e = exposes.presets;

--- a/devices/candeo.js
+++ b/devices/candeo.js
@@ -1,5 +1,8 @@
+const exposes = require('../lib/exposes');
+const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
+const e = exposes.presets;
 
 module.exports = [
     {
@@ -19,6 +22,28 @@ module.exports = [
             // giving the appearance that the values are jumping around.
             // Limit the reporting to once a second to give a smoother reporting of brightness.
             await reporting.brightness(endpoint, {min: 1});
+        },
+    },
+    {
+        zigbeeModel: ['C204'],
+        model: 'C204',
+        vendor: 'Candeo',
+        description: 'Zigbee micro smart dimmer',
+        fromZigbee: extend.light_onoff_brightness().fromZigbee.concat([fz.electrical_measurement, fz.metering, fz.ignore_genOta]),
+        toZigbee: extend.light_onoff_brightness().toZigbee,
+        exposes: [e.light_brightness(), e.power(), e.voltage(), e.current(), e.energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            const binds = ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering'];
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.activePower(endpoint);
+            await reporting.rmsCurrent(endpoint, {min: 10, change: 10});
+            await reporting.rmsVoltage(endpoint, {min: 10});
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint);
         },
     },
 ];


### PR DESCRIPTION
Previously hardware supported as whitelabel, identified as Sunricher SR-ZG9040A, now exposed as Candeo C204