### PR TITLE
Update titan_products.js

### DIFF
--- a/devices/titan_products.js
+++ b/devices/titan_products.js
@@ -5,7 +5,7 @@ const e = exposes.presets;
 
 module.exports = [
     {
-        zigbeeModel: ['TPZRCO2HT-Z3'],
+        zigbeeModel: ['TPZRCO2HT-Z3', 'TPZRCO2HT-Z3/L'],
         model: 'TPZRCO2HT-Z3',
         vendor: 'Titan Products',
         description: 'Room CO2, humidity & temperature sensor',


### PR DESCRIPTION
Hi there,

i recently bought a Titan Products TPZRCO2HT-Z3 sensor which identifies as "TPZRCO2HT-Z3/L". It is identical to the "TPZRCO2HT-Z3" except for a led which indicates the current air quality. However zigbee2mqtt recognizes it as unsupported. 

I manually added the device to the converter and it has been working problem free for a couple of weeks.

Please consider merging this pull request.

Thanks.