### PR TITLE
Remove withSensor() from Climate in favour of separate select

### DIFF
--- a/devices/connecte.js
+++ b/devices/connecte.js
@@ -30,8 +30,8 @@ module.exports = [
                 .withLocalTemperature(ea.STATE)
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
                 .withSystemMode(['heat', 'auto'], ea.STATE_SET)
-                .withRunningState(['idle', 'heat'], ea.STATE)
-                .withSensor(['internal', 'external', 'both']),
+                .withRunningState(['idle', 'heat'], ea.STATE),
+            e.temperature_sensor_select(['internal', 'external', 'both']),
             exposes.numeric('external_temperature', ea.STATE)
                 .withUnit('°C')
                 .withDescription('Current temperature measured on the external sensor (floor)'),

--- a/devices/elko.js
+++ b/devices/elko.js
@@ -61,8 +61,8 @@ module.exports = [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 50, 1)
                 .withLocalTemperature(ea.STATE)
                 .withLocalTemperatureCalibration(-30, 30, 0.1)
-                .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat'])
-                .withSensor(['air', 'floor', 'supervisor_floor']),
+                .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat']),
+            e.temperature_sensor_select(['air', 'floor', 'supervisor_floor']),
             exposes.numeric('floor_temp', ea.STATE_GET).withUnit('°C')
                 .withDescription('Current temperature measured from the floor sensor'),
             exposes.numeric('max_floor_temp', ea.ALL).withUnit('°C')

--- a/devices/hgkg.js
+++ b/devices/hgkg.js
@@ -40,8 +40,8 @@ module.exports = [
                 .withSystemMode(['off', 'cool'], ea.STATE_SET)
                 // .withRunningState(['off','on'], ea.STATE)
                 .withPreset(['hold', 'program'])
-                .withSensor(['IN', 'AL', 'OU'], ea.STATE_SET)
                 .withFanMode(['off', 'low', 'medium', 'high', 'auto'], ea.STATE_SET),
+            e.temperature_sensor_select(['IN', 'AL', 'OU']),
             exposes.composite('programming_mode')
                 .withDescription(
                     'Schedule MODE ⏱ - In this mode, the device executes a preset week programming temperature time and temperature.',

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -186,7 +186,8 @@ module.exports = [
             exposes.climate().withSetpoint('current_heating_setpoint', 5, 30, 1, ea.STATE_SET)
                 .withLocalTemperature(ea.STATE).withLocalTemperatureCalibration(-30, 30, 0.1, ea.STATE_SET)
                 .withSystemMode(['off', 'heat'], ea.STATE_SET).withRunningState(['idle', 'heat', 'cool'], ea.STATE)
-                .withPreset(['hold', 'program']).withSensor(['IN', 'AL', 'OU'], ea.STATE_SET)],
+                .withPreset(['hold', 'program']),
+            e.temperature_sensor_select(['IN', 'AL', 'OU'])],
         onEvent: tuya.onEventSetLocalTime,
     },
     {

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2768,7 +2768,8 @@ module.exports = [
             exposes.climate().withSetpoint('current_heating_setpoint', 5, 60, 0.5, ea.STATE_SET)
                 .withLocalTemperature(ea.STATE).withLocalTemperatureCalibration(-9.9, 9.9, 0.1, ea.STATE_SET)
                 .withSystemMode(['off', 'heat'], ea.STATE_SET).withRunningState(['idle', 'heat'], ea.STATE)
-                .withPreset(['manual', 'program']).withSensor(['internal', 'external', 'both'], ea.STATE_SET),
+                .withPreset(['manual', 'program']),
+            e.temperature_sensor_select(['internal', 'external', 'both']),
             exposes.text('schedule', ea.STATE_SET).withDescription('There are 8 periods in the schedule in total. ' +
                 '6 for workdays and 2 for holidays. It should be set in the following format for each of the periods: ' +
                 '`hours:minutes/temperature`. All periods should be set at once and delimited by the space symbol. ' +

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -424,12 +424,6 @@ class Climate extends Base {
         return this;
     }
 
-    withSensor(sensors) {
-        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
-        this.features.push(new Enum('sensor', access.STATE_SET, sensors).withDescription('Select temperature sensor to use'));
-        return this;
-    }
-
     withPreset(modes, description='Mode of this device (similar to system_mode)') {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         this.features.push(new Enum('preset', access.STATE_SET, modes).withDescription(description));
@@ -618,6 +612,7 @@ module.exports = {
         switch_type_2: () => new Enum('switch_type', access.ALL, ['toggle', 'state', 'momentary']).withDescription('Switch type settings'),
         tamper: () => new Binary('tamper', access.STATE, true, false).withDescription('Indicates whether the device is tampered'),
         temperature: () => new Numeric('temperature', access.STATE).withUnit('°C').withDescription('Measured temperature value'),
+        temperature_sensor_select: (sensor_names) => new Enum('sensor', access.STATE_SET, sensor_names).withDescription('Select temperature sensor to use'),
         test: () => new Binary('test', access.STATE, true, false).withDescription('Indicates whether the device is being tested'),
         valve_position: () => new Numeric('position', access.ALL).withValueMin(0).withValueMax(100).withDescription('Position of the valve'),
         valve_switch: () => new Binary('state', access.ALL, 'OPEN', 'CLOSE').withDescription('Valve state if open or closed'),


### PR DESCRIPTION
In line with not having too many things bundled together under `exposes.climate` (see https://github.com/Koenkk/zigbee2mqtt/pull/14368#issuecomment-1270332591) this creates a separate `exposes.enum` for sensor selection rather than mingling it in with the rest of the Climate related things.