### PR TITLE
Add support for ABL Juno Connect Wafer lights

### DIFF
--- a/devices/acuity_brands_lighting.js
+++ b/devices/acuity_brands_lighting.js
@@ -1,0 +1,11 @@
+const extend = require('../lib/extend');
+
+module.exports = [
+    {
+        zigbeeModel: ['ABL-LIGHT-Z-001'],
+        model: 'Juno Connect Wafer',
+        vendor: 'Acuity Brands Lighting (ABL)',
+        description: '4" and 6" LED Smart Wafer Downlight',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200,370]}),
+    },
+];


### PR DESCRIPTION
Tested with the 4" Contractor Select Smart Wafer Downlight, but I believe there are multiple form factors that all share a single Zigbee model number:

- [Contractor Select Smart Flat Wafer Downlight](https://www.acuitybrands.com/products/detail/1755360/juno/contractor-select-smart-flat-wafer-downlight/4-and-6-led-smart-wafer-downlight)
- [Contractor Select Smart Regressed Wafer Downlight](https://www.acuitybrands.com/products/detail/1755363/juno/contractor-select-smart-regressed-wafer-downlight/4-and-6-led-smart-wafer-canless-downlight)
- [Smart Adjustable Wafer Downlight](https://www.acuitybrands.com/products/detail/1755366/juno/smart-adjustable-wafer-downlight/4-and-6-led-adjustable-smart-wafer-downlight)


Not sure what makes sense for labeling of `vendor`/`model`/`description` but I used my best judgement

- Manufacturer is Acuity Brands Lighting, but sold under their "Juno" brand, and specifically their "Juno Connect" line.
- It might also be somehow linked to Samsung because [SmartThings has a line](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy#L43) that lists their manufacturer as Samsung

If this feeds documentation pages and you want it to be searchable, it might make sense to copy this multiple times so it's indexed under all potential manufacturer/model names?

Feel free to modify!