### PR TITLE
Updates to new TuYa format

### DIFF
--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1227,7 +1227,7 @@ const tzDataPoints = {
             }
             if (dpEntry[3] && dpEntry[3].skip && dpEntry[3].skip(meta)) continue;
             const dpId = dpEntry[0];
-            const convertedValue = dpEntry[2].to(value);
+            const convertedValue = dpEntry[2].to(value, meta);
             let sendDataPoint;
             if (dpEntry[3] && dpEntry[3].datatype) sendDataPoint = dpEntry[3].datatype;
             if (sendDataPoint !== undefined) {

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1228,7 +1228,11 @@ const tzDataPoints = {
             if (dpEntry[3] && dpEntry[3].skip && dpEntry[3].skip(meta)) continue;
             const dpId = dpEntry[0];
             const convertedValue = dpEntry[2].to(value);
-            if (typeof convertedValue === 'boolean') {
+            let sendDataPoint;
+            if (dpEntry[3] && dpEntry[3].datatype) sendDataPoint = dpEntry[3].datatype;
+            if (sendDataPoint !== undefined) {
+                await sendDataPoint(entity, dpId, convertedValue, 'dataRequest', 1);
+            } else if (typeof convertedValue === 'boolean') {
                 await sendDataPointBool(entity, dpId, convertedValue, 'dataRequest', 1);
             } else if (typeof convertedValue === 'number') {
                 await sendDataPointValue(entity, dpId, convertedValue, 'dataRequest', 1);

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1232,6 +1232,10 @@ const tzDataPoints = {
                 await sendDataPointBool(entity, dpId, convertedValue, 'dataRequest', 1);
             } else if (typeof convertedValue === 'number') {
                 await sendDataPointValue(entity, dpId, convertedValue, 'dataRequest', 1);
+            } else if (typeof convertedValue === 'string') {
+                await sendDataPointStringBuffer(entity, dpId, convertedValue, 'dataRequest', 1);
+            } else if (Array.isArray(convertedValue)) {
+                await sendDataPointRaw(entity, dpId, convertedValue, 'dataRequest', 1);
             } else {
                 throw new Error(`Don't know how to send type '${typeof convertedValue}'`);
             }


### PR DESCRIPTION
These commits extends current functionally to simplify creating of converters.

Currently, you don't have the ability to set data to a value type other than boolean or number. This commit adds more data types.
https://github.com/Koenkk/zigbee-herdsman-converters/commit/735f32f52e549e42b486fb922c2eb85f588c070f

It would be useful to be able to set custom data types for each datapoint. You can use already defined converter, but send it with a different data type. It also allows you to specify that you want to send enum or bitmap data, that can't currently be sent in the new format.
https://github.com/Koenkk/zigbee-herdsman-converters/commit/ea4eeee7f69059fe144c00a1c5055512b0f13ee2

Meta in a converter can be very useful. For example, it allows to use the state of another property and create more complex logic.
https://github.com/Koenkk/zigbee-herdsman-converters/commit/b43400bc4fa4de0a96d2ccabdf32dce8e90473d8