### PR TITLE
Add _TZE200_ji1gn7rw, a Tuya compatible switch

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1326,7 +1326,10 @@ module.exports = [
         },
     },
     {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_nkjintbl'}],
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_nkjintbl'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_ji1gn7rw'},
+        ],
         model: 'TS0601_switch_2_gang',
         vendor: 'TuYa',
         description: '2 gang switch',


### PR DESCRIPTION
I bought some switches here in Brazil that showed up as unsupported. I started reading on how to add new devices,  but it looked too much like a generic Tuya compatible switch. I tried just adding it's manufacturer Name to the list in tuya.js. And it seems to have worked!
Pics of the switch:
![mynewswitch](https://user-images.githubusercontent.com/8564525/194785861-e3ce9dc7-2f90-4f91-bd55-9e7cb11ef42d.png)
![mynewswitch2](https://user-images.githubusercontent.com/8564525/194785862-f50db274-8d0b-40cf-9c14-402e0e50dad5.png)

Please let me know if I'm doing something wrong, or should conduct further testing.
