### PR TITLE
Add coverInverted to Legrand 067776

### DIFF
--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -107,6 +107,7 @@ module.exports = [
             // support binary report on moving state (supposed)
             fz.legrand_binary_input_moving, fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingEnableLedInDark],
+        meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);


### PR DESCRIPTION
According to the discussion at the end of this PR https://github.com/Koenkk/zigbee2mqtt/issues/13813 the Legrand 067776 needs the `coverInverted` meta tag.