### PR TITLE
Add delta attribute for converters using simulated brightness

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1218,9 +1218,12 @@ const converters = {
             addActionGroup(payload, msg, model);
 
             if (options.simulated_brightness) {
+                const currentBrightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', 255);
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', msg.data.level);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = msg.data.level;
+                const delta_property = postfixWithEndpointName('delta', msg, model, meta);
+                payload[delta_property] = msg.data.level - currentBrightness;
             }
 
             return payload;
@@ -1252,7 +1255,8 @@ const converters = {
                         brightness = numberWithinRange(brightness, 0, 255);
                         globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
                         const property = postfixWithEndpointName('brightness', msg, model, meta);
-                        publish({[property]: brightness});
+                        const delta_property = postfixWithEndpointName('delta', msg, model, meta);
+                        publish({[property]: brightness, [delta_property]: delta});
                     }, intervalOpts);
 
                     globalStore.putValue(msg.endpoint, 'simulated_brightness_timer', timer);
@@ -1284,6 +1288,8 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = brightness;
+                const delta_property = postfixWithEndpointName('delta', msg, model, meta);
+                payload[delta_property] = delta;
             }
 
             return payload;
@@ -7279,6 +7285,7 @@ const converters = {
                 const delta = button === 'up' ? deltaOpts : deltaOpts * -1;
                 const brightness = globalStore.getValue(msg.endpoint, 'brightness', 255) + delta;
                 payload.brightness = numberWithinRange(brightness, 0, 255);
+                payload.delta = delta;
                 globalStore.putValue(msg.endpoint, 'brightness', payload.brightness);
             }
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -7287,7 +7287,7 @@ const converters = {
                 const delta = button === 'up' ? deltaOpts : deltaOpts * -1;
                 const brightness = globalStore.getValue(msg.endpoint, 'brightness', 255) + delta;
                 payload.brightness = numberWithinRange(brightness, 0, 255);
-                payload.delta = delta;
+                payload.action_brightness_delta = delta;
                 globalStore.putValue(msg.endpoint, 'brightness', payload.brightness);
             }
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1222,8 +1222,8 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', msg.data.level);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = msg.data.level;
-                const delta_property = postfixWithEndpointName('delta', msg, model, meta);
-                payload[delta_property] = msg.data.level - currentBrightness;
+                const deltaProperty = postfixWithEndpointName('delta', msg, model, meta);
+                payload[deltaProperty] = msg.data.level - currentBrightness;
             }
 
             return payload;
@@ -1255,8 +1255,8 @@ const converters = {
                         brightness = numberWithinRange(brightness, 0, 255);
                         globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
                         const property = postfixWithEndpointName('brightness', msg, model, meta);
-                        const delta_property = postfixWithEndpointName('delta', msg, model, meta);
-                        publish({[property]: brightness, [delta_property]: delta});
+                        const deltaProperty = postfixWithEndpointName('delta', msg, model, meta);
+                        publish({[property]: brightness, [deltaProperty]: delta});
                     }, intervalOpts);
 
                     globalStore.putValue(msg.endpoint, 'simulated_brightness_timer', timer);
@@ -1288,8 +1288,8 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = brightness;
-                const delta_property = postfixWithEndpointName('delta', msg, model, meta);
-                payload[delta_property] = delta;
+                const deltaProperty = postfixWithEndpointName('delta', msg, model, meta);
+                payload[deltaProperty] = delta;
             }
 
             return payload;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1222,7 +1222,7 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', msg.data.level);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = msg.data.level;
-                const deltaProperty = postfixWithEndpointName('delta', msg, model, meta);
+                const deltaProperty = postfixWithEndpointName('action_brightness_delta', msg, model, meta);
                 payload[deltaProperty] = msg.data.level - currentBrightness;
             }
 
@@ -1255,7 +1255,7 @@ const converters = {
                         brightness = numberWithinRange(brightness, 0, 255);
                         globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
                         const property = postfixWithEndpointName('brightness', msg, model, meta);
-                        const deltaProperty = postfixWithEndpointName('delta', msg, model, meta);
+                        const deltaProperty = postfixWithEndpointName('action_brightness_delta', msg, model, meta);
                         publish({[property]: brightness, [deltaProperty]: delta});
                     }, intervalOpts);
 
@@ -1288,7 +1288,7 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', brightness);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = brightness;
-                const deltaProperty = postfixWithEndpointName('delta', msg, model, meta);
+                const deltaProperty = postfixWithEndpointName('action_brightness_delta', msg, model, meta);
                 payload[deltaProperty] = delta;
             }
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -22,7 +22,7 @@ const utils = require('../lib/utils');
 const exposes = require('../lib/exposes');
 const xiaomi = require('../lib/xiaomi');
 
-const DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS = 255;
+const defaultSimulatedBrightness = 255;
 
 const converters = {
     // #region Generic/recommended converters
@@ -1220,7 +1220,7 @@ const converters = {
             addActionGroup(payload, msg, model);
 
             if (options.simulated_brightness) {
-                const currentBrightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS);
+                const currentBrightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', defaultSimulatedBrightness);
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', msg.data.level);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = msg.data.level;
@@ -1250,7 +1250,7 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_direction', direction);
                 if (globalStore.getValue(msg.endpoint, 'simulated_brightness_timer') === undefined) {
                     const timer = setInterval(() => {
-                        let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS);
+                        let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', defaultSimulatedBrightness);
                         const delta = globalStore.getValue(msg.endpoint, 'simulated_brightness_direction') === 'up' ?
                             deltaOpts : -1 * deltaOpts;
                         brightness += delta;
@@ -1283,7 +1283,7 @@ const converters = {
             addActionGroup(payload, msg, model);
 
             if (options.simulated_brightness) {
-                let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS);
+                let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', defaultSimulatedBrightness);
                 const delta = direction === 'up' ? msg.data.stepsize : -1 * msg.data.stepsize;
                 brightness += delta;
                 brightness = numberWithinRange(brightness, 0, 255);

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -22,6 +22,8 @@ const utils = require('../lib/utils');
 const exposes = require('../lib/exposes');
 const xiaomi = require('../lib/xiaomi');
 
+const DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS = 255;
+
 const converters = {
     // #region Generic/recommended converters
     fan: {
@@ -1218,7 +1220,7 @@ const converters = {
             addActionGroup(payload, msg, model);
 
             if (options.simulated_brightness) {
-                const currentBrightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', 255);
+                const currentBrightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS);
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_brightness', msg.data.level);
                 const property = postfixWithEndpointName('brightness', msg, model, meta);
                 payload[property] = msg.data.level;
@@ -1248,7 +1250,7 @@ const converters = {
                 globalStore.putValue(msg.endpoint, 'simulated_brightness_direction', direction);
                 if (globalStore.getValue(msg.endpoint, 'simulated_brightness_timer') === undefined) {
                     const timer = setInterval(() => {
-                        let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', 255);
+                        let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS);
                         const delta = globalStore.getValue(msg.endpoint, 'simulated_brightness_direction') === 'up' ?
                             deltaOpts : -1 * deltaOpts;
                         brightness += delta;
@@ -1281,7 +1283,7 @@ const converters = {
             addActionGroup(payload, msg, model);
 
             if (options.simulated_brightness) {
-                let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', 255);
+                let brightness = globalStore.getValue(msg.endpoint, 'simulated_brightness_brightness', DEFAULT_SIMULATED_BRIGHTNESS_BRIGHTNESS);
                 const delta = direction === 'up' ? msg.data.stepsize : -1 * msg.data.stepsize;
                 brightness += delta;
                 brightness = numberWithinRange(brightness, 0, 255);

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -498,7 +498,7 @@ module.exports = {
         occupancy_timeout_2: () => new Numeric(`occupancy_timeout`, access.SET).withValueMin(0).withValueStep(0.1).withUnit('s').withDescription('Time in seconds after which occupancy is cleared after detecting it (default is "detection_interval" + 2 seconds). The value must be equal to or greater than "detection_interval", and it can also be a fraction.'),
         vibration_timeout: () => new Numeric(`vibration_timeout`, access.SET).withValueMin(0).withDescription('Time in seconds after which vibration is cleared after detecting it (default 90 seconds).'),
         simulated_brightness: (extraNote='') => new Composite('simulated_brightness', 'simulated_brightness')
-            .withDescription(`Simulate a brightness value. If this device provides a brightness_move_up or brightness_move_down action it is possible to specify the update interval and delta.${extraNote}`)
+            .withDescription(`Simulate a brightness value. If this device provides a brightness_move_up or brightness_move_down action it is possible to specify the update interval and delta. The action_brightness_delta indicates the delta for each interval. ${extraNote}`)
             .withFeature(new Numeric('delta', access.SET).withValueMin(0).withDescription('Delta per interval, 20 by default'))
             .withFeature(new Numeric('interval', access.SET).withValueMin(0).withUnit('ms').withDescription('Interval duration')),
         no_occupancy_since_true: () => new List(`no_occupancy_since`, access.SET).withDescription('Sends a message the last time occupancy (occupancy: true) was detected. When setting this for example to [10, 60] a `{"no_occupancy_since": 10}` will be send after 10 seconds and a `{"no_occupancy_since": 60}` after 60 seconds.'),


### PR DESCRIPTION
This PR adds additional `delta` attribute alongside `brightness` for simulated brightness related updates.

Background:
Just `brightness` is fine for devices that can't get out of sync but in any event the devices get out of sync relying only on `brightness` causes the state to jump considerably eg.
Remote sets light brightness to 80%, someone later changes that light brightness manually to 30% the next time someone uses the remote the brightness will jump back to around 80% because that's the state saved by this module.

This could have been hacked around by comparing from and to states but because brightness is limited to a range that leaves edge case (literal ones at the edges of the range :grin:) where the state couldn't be updated anymore because the difference would be 0 (simulated brightness is at 255 and someone is trying to increase it).

Adding this `delta` attribute opens way for more seamless automations which take into account the actual current state of device no matter how it was changed.