### PR TITLE
Fix gas reporting for HS3CG

### DIFF
--- a/devices/heiman.js
+++ b/devices/heiman.js
@@ -104,7 +104,7 @@ module.exports = [
         model: 'HS3CG',
         vendor: 'HEIMAN',
         description: 'Combustible gas sensor',
-        fromZigbee: [fz.ias_gas_alarm_1],
+        fromZigbee: [fz.ias_gas_alarm_2],
         toZigbee: [],
         exposes: [e.gas(), e.battery_low(), e.tamper()],
     },


### PR DESCRIPTION
HS3CG reports iasZoneStatus 34 when gas detected/test button pressed, so it should  use fz.ias_gas_alarm_2 to report gas leak correctly 34 & 1 -> false (ias_gas_alarm_1)
34 & 1<<1 -> true (ias_gas_alarm_2)
Issue: https://github.com/Koenkk/zigbee2mqtt/issues/14495