### PR TITLE
Fix INVALID_DATA_TYPE setting Develco InterfaceMode

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -218,7 +218,7 @@ const develco = {
             key: ['interface_mode'],
             convertSet: async (entity, key, value, meta) => {
                 const payload = {'develcoInterfaceMode': utils.getKey(constants.develcoInterfaceMode, value, undefined, Number)};
-                await entity.write('seMetering', payload, manufacturerOptions.develco);
+                await entity.write('seMetering', payload, manufacturerOptions);
                 return {readAfterWriteTime: 200, state: {'interface_mode': value}};
             },
             convertGet: async (entity, key, meta) => {


### PR DESCRIPTION
Since PR #4726, there is an error when setting interface mode and it cannot be set.  This PR corrects that error and allows setting of interface mode again.