### PR TITLE
Fix wrong window status reporting for BRT-100-TRV

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -369,7 +369,7 @@ module.exports = [
         exposes: [
             e.battery(), e.child_lock(), e.eco_mode(), e.eco_temperature(), e.max_temperature().withValueMax(45), e.min_temperature(),
             e.valve_state(), e.position(), e.window_detection(),
-            exposes.binary('window', ea.STATE, 'CLOSED', 'OPEN').withDescription('Window status closed or open '),
+            exposes.binary('window', ea.STATE, 'OPEN', 'CLOSED').withDescription('Window status closed or open '),
             exposes.climate()
                 .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET)
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)


### PR DESCRIPTION
The window detector of the BRT-100-TRV comes out with the wrong state. I understand that the corresponding `fromZigbee` already maps `0` to `OPEN` and `1` to `CLOSED`, so the states should not be flipped again in the exposed sensor.

I suspect that the similar TuYa TRV has the same problem but I don't have the device to check.

(I am new here, I hope sending a PR directly without issue is ok!)