### PR TITLE
Inovelli VZM35-SN fix for energy reporting

### DIFF
--- a/devices/inovelli.js
+++ b/devices/inovelli.js
@@ -25,26 +25,25 @@ const buttonLookup = {
 };
 
 const ledEffects = {
-    'Off': 0,
-    'Solid': 1,
-    'Fast Blink': 2,
-    'Slow Blink': 3,
-    'Pulse': 4,
-    'Chase': 5,
-    'Open/Close': 6,
-    'Small to Big': 7,
-    'Aurora': 8,
-    'Clear Notification': 255,
+    'off': 0,
+    'solid': 1,
+    'fast_blink': 2,
+    'slow_blink': 3,
+    'pulse': 4,
+    'chase': 5,
+    'open_close': 6,
+    'small_to_big': 7,
+    'clear_effect': 255,
 };
 
 const individualLedEffects = {
-    'Off': 0,
-    'Solid': 1,
-    'Fast Blink': 2,
-    'Slow Blink': 3,
-    'Pulse': 4,
-    'Chase': 5,
-    'Clear Notification': 255,
+    'off': 0,
+    'solid': 1,
+    'fast_blink': 2,
+    'slow_blink': 3,
+    'pulse': 4,
+    'chase': 5,
+    'clear_effect': 255,
 };
 
 const UINT8 = 32;
@@ -636,6 +635,8 @@ const ATTRIBUTES = {
 
 const tzLocal = {};
 
+// Generate toZigbee items from attribute list.
+
 tzLocal.inovelli_vzw31sn_parameters = {
     key: Object.keys(ATTRIBUTES).filter((a) => !ATTRIBUTES[a].readOnly),
     convertSet: async (entity, key, value, meta) => {
@@ -1048,20 +1049,19 @@ const exposesList = [
     e.power(),
     e.energy(),
     exposes
-        .composite('ledEffect', 'ledEffect')
+        .composite('led_effect', 'led_effect')
         .withFeature(
             exposes
                 .enum('effect', ea.SET_STATE, [
-                    'Off',
-                    'Solid',
-                    'Chase',
-                    'Fast Blink',
-                    'Slow Blink',
-                    'Pulse',
-                    'Open/Close',
-                    'Small to Big',
-                    'Aurora',
-                    'Clear Notification',
+                    'off',
+                    'solid',
+                    'chase',
+                    'fast_blink',
+                    'slow_blink',
+                    'pulse',
+                    'open_close',
+                    'small_to_big',
+                    'clear_effect',
                 ])
                 .withDescription('Animation Effect to use for the LEDs'),
         )
@@ -1093,7 +1093,7 @@ const exposesList = [
                 ),
         ),
     exposes
-        .composite('individualLedEffect', 'individualLedEffect')
+        .composite('individual_led_effect', 'individual_led_effect')
         .withFeature(
             exposes
                 .enum('led', ea.SET_STATE, ['1', '2', '3', '4', '5', '6', '7'])
@@ -1102,13 +1102,13 @@ const exposesList = [
         .withFeature(
             exposes
                 .enum('effect', ea.SET_STATE, [
-                    'Off',
-                    'Solid',
-                    'Fast Blink',
-                    'Slow Blink',
-                    'Pulse',
-                    'Chase',
-                    'Clear Notification',
+                    'off',
+                    'solid',
+                    'fast_blink',
+                    'slow_blink',
+                    'pulse',
+                    'chase',
+                    'clear_effect',
                 ])
                 .withDescription('Animation Effect to use for the LED'),
         )
@@ -1199,7 +1199,7 @@ module.exports = [
         zigbeeModel: ['VZM31-SN'],
         model: 'VZM31-SN',
         vendor: 'Inovelli',
-        description: 'Inovelli 2-in-1 Switch + Dimmer',
+        description: 'Inovelli 2-in-1 switch + dimmer',
         exposes: exposesList,
         toZigbee: toZigbee,
         fromZigbee: [

--- a/devices/inovelli.js
+++ b/devices/inovelli.js
@@ -1206,20 +1206,30 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, [
-                'genOnOff',
-                'genLevelCtrl',
+                'seMetering',
+                'haElectricalMeasurement',
             ]);
-
             // Bind for Button Event Reporting
             const endpoint2 = device.getEndpoint(2);
             await reporting.bind(endpoint2, coordinatorEndpoint, [
                 'manuSpecificInovelliVZM31SN',
             ]);
+            await endpoint.read('haElectricalMeasurement', [
+                'acPowerMultiplier',
+                'acPowerDivisor',
+            ]);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
 
-            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
-            await reporting.readMeteringMultiplierDivisors(endpoint);
-            await reporting.activePower(endpoint);
-            await reporting.currentSummDelivered(endpoint);
+            await reporting.activePower(endpoint, {
+                min: 1,
+                max: 3600,
+                change: 1,
+            });
+            await reporting.currentSummDelivered(endpoint, {
+                min: 1,
+                max: 3600,
+                change: 0,
+            });
         },
     },
 ];


### PR DESCRIPTION
The VZM35-SN is missing some parameters in the metering cluster that are queried in the energy reporting helpers preventing the device from configuring.  This replaces the reporting helpers with the raw commands.