### PR TITLE
Fix LED effects for the Inovelli VZM31SN with a few other attribute fixes

### DIFF
--- a/devices/inovelli.js
+++ b/devices/inovelli.js
@@ -177,19 +177,19 @@ const ATTRIBUTES = {
         ID: 13,
         dataType: UINT8,
         min: 0,
-        max: 100,
+        max: 255,
         description:
       'Default level for the dimmer when it is turned on at the switch.' +
-      ' A setting of 0 means that the switch will return to the level that it was on before it was turned off.',
+      ' A setting of 255 means that the switch will return to the level that it was on before it was turned off.',
     },
     defaultLevelRemote: {
         ID: 14,
         dataType: UINT8,
         min: 0,
-        max: 100,
+        max: 255,
         description:
       'Default level for the dimmer when it is turned on from the hub.' +
-      ' A setting of 0 means that the switch will return to the level that it was on before it was turned off.',
+      ' A setting of 255 means that the switch will return to the level that it was on before it was turned off.',
     },
     stateAfterPowerRestored: {
         ID: 15,
@@ -197,7 +197,7 @@ const ATTRIBUTES = {
         min: 0,
         max: 255,
         description:
-      'The state the switch should return to when power is restored after power failure. 0 = off, 1-100 = level, 101 = previous.',
+      'The state the switch should return to when power is restored after power failure. 0 = off, 1-254 = level, 255 = previous.',
     },
     loadLevelIndicatorTimeout: {
         ID: 17,
@@ -272,6 +272,8 @@ const ATTRIBUTES = {
         dataType: UINT8,
         values: {
             '0ms': 0,
+            '100ms': 1,
+            '200ms': 2,
             '300ms': 3,
             '400ms': 4,
             '500ms': 5,

--- a/devices/inovelli.js
+++ b/devices/inovelli.js
@@ -700,7 +700,7 @@ tzLocal.inovelli_vzw31sn_parameters_readOnly = {
 };
 
 tzLocal.inovelli_led_effect = {
-    key: ['ledEffect'],
+    key: ['led_effect'],
     convertSet: async (entity, key, values, meta) => {
         await entity.command(
             'manuSpecificInovelliVZM31SN',
@@ -718,7 +718,7 @@ tzLocal.inovelli_led_effect = {
 };
 
 tzLocal.inovelli_individual_led_effect = {
-    key: ['individualLedEffect'],
+    key: ['individual_led_effect'],
     convertSet: async (entity, key, values, meta) => {
         await entity.command(
             'manuSpecificInovelliVZM31SN',


### PR DESCRIPTION
# What changed?
- Fix the key for the `led_effect` converters
- Fix the default dimmer attributes (`defaultLevelLocal`, `defaultLevelRemote`) max values
- Fix the description for the `stateAfterPowerRestored` attribute

# Why?
- The key for the converters are supposed to match what was in the `exposes` list
- According to the [official doc](https://community.inovelli.com/docs?topic=10349#parameter-list-18), the `defaultLevelLocal` and `defaultLevelRemote` attributes should have a max of 255
- Fixed the description to match the official doc for the `stateAfterPowerRestored` attribute