### PR TITLE
Remove preferHS from Osram Flex RGBW

### DIFF
--- a/devices/osram.js
+++ b/devices/osram.js
@@ -227,7 +227,7 @@ module.exports = [
         model: '4052899926110',
         vendor: 'OSRAM',
         description: 'Flex RGBW',
-        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [125, 666], supportsHS: true, preferHS: true}),
+        extend: extend.ledvance.light_onoff_brightness_colortemp_color({colorTempRange: [125, 666], supportsHS: true}),
         ota: ota.ledvance,
     },
     {


### PR DESCRIPTION
Remove preferHS: true from OSRAM Flex RGBW 4052899926110.  This causes compatibility issues for people running Firmware build date is 20160204N****, which is newer than the firmware available for OTA.

This change should still allow use of hs_color in Home Assistant automations and the use of the color wheel. 

Tested xy color in my environment with no issues. Unable to validate hs_color since my lights do not support it.

This resolves issue: https://github.com/Koenkk/zigbee2mqtt/issues/13990