### PR TITLE
Added device RB-279-T, clone of RB-278-T

### DIFF
--- a/devices/innr.js
+++ b/devices/innr.js
@@ -160,6 +160,14 @@ module.exports = [
         meta: {applyRedFix: true, turnsOffAtBrightness1: true},
     },
     {
+        zigbeeModel: ['RB 279 T'],
+        model: 'RB 279 T',
+        vendor: 'Innr',
+        description: 'Smart bulb tunable white E27',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 555]}),
+        meta: {applyRedFix: true, turnsOffAtBrightness1: true},
+    },
+    {
         zigbeeModel: ['RB 285 C'],
         model: 'RB 285 C',
         vendor: 'Innr',


### PR DESCRIPTION
Got a new bulb RB 279 T with my last purchase.

I got it to work on my local HA lab with the config in this:
![image](https://user-images.githubusercontent.com/8180250/197015086-af23b59f-ee82-4a59-a67d-01bf48301cb9.png)

Here is a picture of what it looks like in my instance of HA
![image](https://user-images.githubusercontent.com/8180250/197014865-69384e67-b2da-4571-83f9-c91cccaedd84.png)
![image](https://user-images.githubusercontent.com/8180250/197014958-56c1841f-336d-4ab0-bc61-4908e2607f82.png)


I've already submitted PR to update the documentation here: 
https://github.com/Koenkk/zigbee2mqtt.io/pull/1648