### PR TITLE
develco: MOSZB-140 re-order configuration

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -534,24 +534,25 @@ module.exports = [
             return {default: 35};
         },
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint35 = device.getEndpoint(35);
-            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-            try {
-                await endpoint35.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
-                await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
-                await endpoint35.read('genBasic', ['develcoLedControl'], manufacturerOptions);
-            } catch (error) {/* some reports of timeouts on reading these */}
+            const endpoint39 = device.getEndpoint(39);
+            await reporting.bind(endpoint39, coordinatorEndpoint, ['msIlluminanceMeasurement']);
+            await reporting.illuminance(endpoint39,
+                {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 500});
 
             const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.temperature(endpoint38,
                 {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 100});
 
-            const endpoint39 = device.getEndpoint(39);
-            await reporting.bind(endpoint39, coordinatorEndpoint, ['msIlluminanceMeasurement']);
-            await reporting.illuminance(endpoint39,
-                {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 500});
+            const endpoint35 = device.getEndpoint(35);
+            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
+            await endpoint35.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
+
+            try {
+                await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
+                await endpoint35.read('genBasic', ['develcoLedControl'], manufacturerOptions);
+            } catch (error) {/* some reports of timeouts on reading these */}
         },
     },
     {


### PR DESCRIPTION
Looks like older firmware 3.x.x does not support develcoLedControl and it timesout.

For now re-order the configuration steps so we handle msIlluminanceMeasurement, msTemperatureMeasurement first and we try to read develcoLedControl last.