### PR TITLE
Added initial support for Vimar IoT Thermostat firmware

### DIFF
--- a/devices/vimar.js
+++ b/devices/vimar.js
@@ -54,7 +54,12 @@ module.exports = [
         vendor: 'Vimar',
         description: 'Vimar IoT Thermostat',
         fromZigbee: [fz.thermostat],
-        toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_cooling_setpoint, tz.thermostat_system_mode],
+        toZigbee: [
+            tz.thermostat_local_temperature,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_occupied_cooling_setpoint,
+            tz.thermostat_system_mode
+        ],
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 4, 40, 0.1)
                 .withSetpoint('occupied_cooling_setpoint', 4, 40, 0.1)

--- a/devices/vimar.js
+++ b/devices/vimar.js
@@ -62,10 +62,10 @@ module.exports = [
                 .withSystemMode(['heat', 'cool'])
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
-           const endpoint = device.getEndpoint(10);
-           const binds = ['genBasic', 'genIdentify', 'hvacThermostat'];
-           await reporting.bind(endpoint, coordinatorEndpoint, binds);
-           await reporting.thermostatTemperature(endpoint);
+            const endpoint = device.getEndpoint(10);
+            const binds = ['genBasic', 'genIdentify', 'hvacThermostat'];
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatTemperature(endpoint);
         },
     },
 ];

--- a/devices/vimar.js
+++ b/devices/vimar.js
@@ -52,7 +52,7 @@ module.exports = [
         zigbeeModel: ['Thermostat_v0.1'],
         model: '02973.B',
         vendor: 'Vimar',
-        description: 'Vimar IoT Thermostat',
+        description: 'Vimar IoT thermostat',
         fromZigbee: [fz.thermostat],
         toZigbee: [
             tz.thermostat_local_temperature,

--- a/devices/vimar.js
+++ b/devices/vimar.js
@@ -58,13 +58,13 @@ module.exports = [
             tz.thermostat_local_temperature,
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_occupied_cooling_setpoint,
-            tz.thermostat_system_mode
+            tz.thermostat_system_mode,
         ],
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 4, 40, 0.1)
                 .withSetpoint('occupied_cooling_setpoint', 4, 40, 0.1)
                 .withLocalTemperature()
-                .withSystemMode(['heat', 'cool'])
+                .withSystemMode(['heat', 'cool']),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(10);

--- a/devices/vimar.js
+++ b/devices/vimar.js
@@ -48,4 +48,24 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
         },
     },
+    {
+        zigbeeModel: ['Thermostat_v0.1'],
+        model: '02973.B',
+        vendor: 'Vimar',
+        description: 'Vimar IoT Thermostat',
+        fromZigbee: [fz.thermostat],
+        toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_occupied_cooling_setpoint, tz.thermostat_system_mode],
+        exposes: [
+            exposes.climate().withSetpoint('occupied_heating_setpoint', 4, 40, 0.1)
+                .withSetpoint('occupied_cooling_setpoint', 4, 40, 0.1)
+                .withLocalTemperature()
+                .withSystemMode(['heat', 'cool'])
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+           const endpoint = device.getEndpoint(10);
+           const binds = ['genBasic', 'genIdentify', 'hvacThermostat'];
+           await reporting.bind(endpoint, coordinatorEndpoint, binds);
+           await reporting.thermostatTemperature(endpoint);
+        },
+    },
 ];


### PR DESCRIPTION
This firmware (according to Vimar) is currently in Beta. All Vimar IoT devices support either Bluetooth or Zigbee firmwares which can be changed via the Vimar View application.

The firmware currently doesn't report manual changes made on the device, or a running state so usability is limited at present - lets hope for more functionality later down the line..