### PR TITLE
develco: read fw/hw version + make MOSZB-140 dynamic

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -535,7 +535,7 @@ module.exports = [
         exposes: (device, options) => {
             const dynExposes = [];
             dynExposes.push(e.occupancy());
-            if (device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 3) {
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 3) {
                 dynExposes.push(exposes.numeric('occupancy_timeout', ea.ALL).withUnit('second').
                     withValueMin(20).withValueMax(65535));
             }
@@ -544,10 +544,11 @@ module.exports = [
             dynExposes.push(e.tamper());
             dynExposes.push(e.battery_low());
             dynExposes.push(e.battery());
-            if (device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 4) {
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 4) {
                 dynExposes.push(exposes.enum('led_control', ea.ALL, ['off', 'fault_only', 'motion_only', 'both']).
                     withDescription('Control LED indicator usage.'));
             }
+            dynExposes.push(e.linkquality());
             return dynExposes;
         },
         meta: {battery: {voltageToPercentage: '3V_2500'}},
@@ -570,10 +571,10 @@ module.exports = [
             await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
 
             // zigbee2mqtt#14277 some features are not available on older firmwares
-            if (device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 3) {
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 3) {
                 await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
             }
-            if (device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 4) {
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 4) {
                 await endpoint35.read('genBasic', ['develcoLedControl'], manufacturerOptions);
             }
         },

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -25,6 +25,31 @@ const develcoLedControlMap = {
     0xFF: 'both',
 };
 
+
+const fwOnEvent = async (type, data, device, options, state) => {
+    /**
+     * Develco devices have a manufacturer specific field on genBasic
+     *   for sw and hw versions.
+     *
+     * We read those during deviceInterview
+     *   so that this information is usable during configure() calls
+     *   to skip some features on older devices that might cause
+     *   timeouts and other issues.
+     */
+    if (type === 'deviceInterview') { // WARN: also reading on deviceAnnounce hits a timeout!
+        try {
+            const data = await device.endpoints[0].read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
+            if (data.hasOwnProperty('develcoPrimarySwVersion')) {
+                device.softwareBuildID = data.develcoPrimarySwVersion.join('.');
+            }
+
+            if (data.hasOwnProperty('develcoPrimaryHwVersion')) {
+                device.hardwareVersion = data.develcoPrimaryHwVersion.join('.');
+            }
+        } catch (error) {/* catch timeouts of sleeping devices */}
+    }
+};
+
 // develco specific convertors
 const develco = {
     fz: {
@@ -81,24 +106,6 @@ const develco = {
                 if (msg.data.hasOwnProperty('status')) {
                     result['battery_low'] = (msg.data.status & 2) > 0;
                     result['check_meter'] = (msg.data.status & 1) > 0;
-                }
-
-                return result;
-            },
-        },
-        firmware_version: {
-            cluster: 'genBasic',
-            type: ['attributeReport', 'readResponse'],
-            convert: (model, msg, publish, options, meta) => {
-                const result = {};
-                if (msg.data.hasOwnProperty('develcoPrimarySwVersion')) {
-                    const firmware = msg.data.develcoPrimarySwVersion.join('.');
-                    result.current_firmware = firmware;
-                    meta.device.softwareBuildID = firmware;
-                }
-
-                if (msg.data.hasOwnProperty('develcoPrimaryHwVersion')) {
-                    meta.device.hardwareVersion = msg.data.develcoPrimaryHwVersion.join('.');
                 }
 
                 return result;
@@ -374,12 +381,11 @@ module.exports = [
         model: 'EMIZB-132',
         vendor: 'Develco',
         description: 'Wattle AMS HAN power-meter sensor',
-        fromZigbee: [develco.fz.metering, develco.fz.electrical_measurement, develco.fz.firmware_version],
+        fromZigbee: [develco.fz.metering, develco.fz.electrical_measurement],
         toZigbee: [tz.EMIZB_132_mode],
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
-            await endpoint.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
             await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
 
             try {
@@ -402,6 +408,7 @@ module.exports = [
         exposes: [e.power(), e.energy(), e.current(), e.voltage(), e.current_phase_b(), e.voltage_phase_b(), e.current_phase_c(),
             e.voltage_phase_c()],
         onEvent: async (type, data, device) => {
+            fwOnEvent(type, data, device);
             if (type === 'message' && data.type === 'attributeReport' && data.cluster === 'seMetering' && data.data['divisor']) {
                 // Device sends wrong divisior (512) while it should be fixed to 1000
                 // https://github.com/Koenkk/zigbee-herdsman-converters/issues/3066
@@ -415,16 +422,16 @@ module.exports = [
         vendor: 'Develco',
         description: 'Smoke detector with siren',
         fromZigbee: [fz.temperature, fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report,
-            develco.fz.firmware_version, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
+            fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
+        onEvent: fwOnEvent,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(35);
 
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']);
             await reporting.batteryVoltage(endpoint);
-            await endpoint.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
@@ -449,15 +456,15 @@ module.exports = [
         vendor: 'Develco',
         description: 'Fire detector with siren',
         fromZigbee: [fz.temperature, fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report,
-            develco.fz.firmware_version, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
+            fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
+        onEvent: fwOnEvent,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(35);
 
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']);
             await reporting.batteryVoltage(endpoint);
-            await endpoint.read('genBasic', ['develcoPrimarySwVersion'], manufacturerOptions);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
@@ -519,9 +526,10 @@ module.exports = [
         description: 'Motion sensor',
         fromZigbee: [
             fz.temperature, fz.illuminance, fz.ias_occupancy_alarm_1, fz.battery,
-            develco.fz.led_control, develco.fz.ias_occupancy_timeout, develco.fz.firmware_version,
+            develco.fz.led_control, develco.fz.ias_occupancy_timeout,
         ],
         toZigbee: [develco.tz.led_control, develco.tz.ias_occupancy_timeout],
+        onEvent: fwOnEvent,
         exposes: [
             e.occupancy(), e.battery(), e.battery_low(),
             e.tamper(), e.temperature(), e.illuminance_lux(),
@@ -547,7 +555,6 @@ module.exports = [
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-            await endpoint35.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
 
             try {
                 await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
@@ -677,14 +684,14 @@ module.exports = [
         model: 'SIRZB-110',
         vendor: 'Develco',
         description: 'Customizable siren',
-        fromZigbee: [fz.temperature, fz.battery, fz.ias_enroll, fz.ias_wd, develco.fz.firmware_version, fz.ias_siren],
+        fromZigbee: [fz.temperature, fz.battery, fz.ias_enroll, fz.ias_wd, fz.ias_siren],
         toZigbee: [tz.warning, tz.warning_simple, tz.ias_max_duration, tz.squawk],
+        onEvent: fwOnEvent,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(43);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic']);
             await reporting.batteryVoltage(endpoint);
-            await endpoint.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('ssIasWd', ['maxDuration']);
 
@@ -743,8 +750,9 @@ module.exports = [
         model: 'IOMZB-110',
         vendor: 'Develco',
         description: 'IO module',
-        fromZigbee: [fz.on_off, develco.fz.input, develco.fz.firmware_version],
+        fromZigbee: [fz.on_off, develco.fz.input],
         toZigbee: [tz.on_off, develco.tz.input],
+        onEvent: fwOnEvent,
         meta: {multiEndpoint: true},
         exposes: [
             exposes.binary('input', ea.STATE_GET, true, false).withEndpoint('l1').withDescription('State of input 1'),
@@ -760,7 +768,6 @@ module.exports = [
             const ep2 = device.getEndpoint(112);
             await reporting.bind(ep2, coordinatorEndpoint, ['genBinaryInput', 'genBasic']);
             await reporting.presentValue(ep2, {min: 0});
-            await ep2.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], options);
 
             const ep3 = device.getEndpoint(113);
             await reporting.bind(ep3, coordinatorEndpoint, ['genBinaryInput']);


### PR DESCRIPTION
This PR replaces `develco.fz.firmwre_version` with a new onEvent function that will read the `develcoPrimarySwVersion` and `develcoPrimaryHwVersion` attributes after device interview is completed.

Since this data is now available before `configure()` is calkled for the MOSZB-140 we can use this to skip certain features on older firmwares.

For now if the firmware's major version is >=3 we read `develcoAlarmOffDelay` and enable the exposes of `occupancy_timeout`.
If the firmware's major version is >=4 we also read `develcoLedControl` and enable the exposes of `led_control`.

Once this is merged I'll ask @X4LD1M0 to update to the latest dev to see if everything is still OK.

If the `develcoPrimarySwVersion` wasn't stored in `device.softwareBuildID` we won't expose/read any of the newer attributes. This does mean that for people might need to leave/join the device to get the new features but that seems like a small price to pay to not hit weird timeouts and errors.

Here is a debug log from my joining my MOSZB-140 with sw version 4.0.3:
```
Zigbee2MQTT:debug 2022-10-21 20:43:22: Loaded state from file /opt/zigbee2mqtt/data/state.json
Zigbee2MQTT:info  2022-10-21 20:43:22: Logging to console and directory: '/opt/zigbee2mqtt/data/log/2022-10-21.20-43-22' filename: log.txt
Zigbee2MQTT:debug 2022-10-21 20:43:22: Removing old log directory '/opt/zigbee2mqtt/data/log/2022-10-21.20-09-29'
Zigbee2MQTT:info  2022-10-21 20:43:22: Starting Zigbee2MQTT version 1.28.0-dev (commit #a426ee10)
Zigbee2MQTT:info  2022-10-21 20:43:22: Starting zigbee-herdsman (0.14.66)
Zigbee2MQTT:debug 2022-10-21 20:43:22: Using zigbee-herdsman with settings: '{"adapter":{"concurrent":null,"delay":null,"disableLED":false},"backupPath":"/opt/zigbee2mqtt/data/coordinator_backup.json","databaseBackupPath":"/opt/zigbee2mqtt/data/database.db.backup","databasePath":"/opt/zigbee2mqtt/data/database.db","network":{"channelList":[11],"extendedPanID":[221,221,221,221,221,221,221,221],"networkKey":"HIDDEN","panID":24340},"serialPort":{"path":"/dev/cu.usbserial-2230"}}'
Zigbee2MQTT:info  2022-10-21 20:43:23: zigbee-herdsman started (resumed)
Zigbee2MQTT:info  2022-10-21 20:43:23: Coordinator firmware version: '{"meta":{"maintrel":1,"majorrel":2,"minorrel":7,"product":1,"revision":20220928,"transportrev":2},"type":"zStack3x0"}'
Zigbee2MQTT:debug 2022-10-21 20:43:23: Zigbee network parameters: {"channel":11,"extendedPanID":"0x00124b001e17ef39","panID":24340}
Zigbee2MQTT:info  2022-10-21 20:43:23: Currently 0 devices are joined:
Zigbee2MQTT:info  2022-10-21 20:43:23: Zigbee: disabling joining new devices.
Zigbee2MQTT:info  2022-10-21 20:43:23: Connecting to MQTT server at mqtt://localhost
Zigbee2MQTT:debug 2022-10-21 20:43:23: Using MQTT anonymous login
Zigbee2MQTT:info  2022-10-21 20:43:23: Connected to MQTT server
Zigbee2MQTT:info  2022-10-21 20:43:23: MQTT publish: topic 'zigbee2mqtt/bridge/state', payload 'online'
Zigbee2MQTT:debug 2022-10-21 20:43:23: Received MQTT message on 'zigbee2mqtt/bridge/info' with data '{"commit":"a426ee10","config":{"advanced":{"adapter_concurrent":null,"adapter_delay":null,"availability_blacklist":[],"availability_blocklist":[],"availability_passlist":[],"availability_whitelist":[],"cache_state":true,"cache_state_persistent":true,"cache_state_send_on_startup":true,"channel":11,"elapsed":false,"ext_pan_id":[221,221,221,221,221,221,221,221],"last_seen":"disable","legacy_api":true,"legacy_availability_payload":true,"log_directory":"/opt/zigbee2mqtt/data/log/%TIMESTAMP%","log_file":"log.txt","log_level":"debug","log_output":["console","file"],"log_rotation":true,"log_symlink_current":false,"log_syslog":{},"output":"json","pan_id":24340,"report":false,"soft_reset_timeout":0,"timestamp_format":"YYYY-MM-DD HH:mm:ss"},"blocklist":[],"device_options":{},"devices":{"0x0015bc001a0238ec":{"friendly_name":"0x0015bc001a0238ec"}},"external_converters":[],"frontend":{"host":"0.0.0.0","port":8080},"groups":{},"homeassistant":false,"map_options":{"graphviz":{"colors":{"fill":{"coordinator":"#e04e5d","enddevice":"#fff8ce","router":"#4ea3e0"},"font":{"coordinator":"#ffffff","enddevice":"#000000","router":"#ffffff"},"line":{"active":"#009900","inactive":"#994444"}}}},"mqtt":{"base_topic":"zigbee2mqtt","force_disable_retain":false,"include_device_information":false,"server":"mqtt://localhost"},"ota":{"disable_automatic_update_check":false,"update_check_interval":1440},"passlist":[],"permit_join":false,"serial":{"disable_led":false,"port":"/dev/cu.usbserial-2230"}},"config_schema":{"definitions":{"device":{"properties":{"debounce":{"description":"Debounces messages of this device","title":"Debounce","type":"number"},"debounce_ignore":{"description":"Protects unique payload values of specified payload properties from overriding within debounce time","examples":["action"],"items":{"type":"string"},"title":"Ignore debounce","type":"array"},"filtered_attributes":{"description":"Filter attributes with regex from published payload.","examples":["^temperature$","^battery$","^action$"],"items":{"type":"string"},"title":"Filtered publish attributes","type":"array"},"filtered_cache":{"description":"Filter attributes with regex from being added to the cache, this prevents the attribute from being in the published payload when the value didn't change.","examples":["^input_actions$"],"items":{"type":"string"},"title":"Filtered attributes from cache","type":"array"},"filtered_optimistic":{"description":"Filter attributes with regex from optimistic publish payload when calling /set. (This has no effect if optimistic is set to false).","examples":["^color_(mode|temp)$","color"],"items":{"type":"string"},"title":"Filtered optimistic attributes","type":"array"},"friendly_name":{"description":"Used in the MQTT topic of a device. By default this is the device ID","readOnly":true,"title":"Friendly name","type":"string"},"homeassistant":{"properties":{"name":{"description":"Name of the device in Home Assistant","title":"Home Assistant name","type":"string"}},"title":"Home Assistant","type":["object","null"]},"icon":{"description":"The user-defined device icon for the frontend. It can be a link to an image (not a path to a file) or base64 encoded data URL like: image/svg+xml;base64,PHN2ZyB3aW....R0aD","title":"Icon","type":"string"},"optimistic":{"default":true,"description":"Publish optimistic state after set","title":"Optimistic","type":"boolean"},"qos":{"description":"QoS level for MQTT messages of this device","title":"QoS","type":"number"},"retain":{"description":"Retain MQTT messages of this device","title":"Retain","type":"boolean"},"retention":{"description":"Sets the MQTT Message Expiry in seconds, Make sure to set mqtt.version to 5","title":"Retention","type":"number"}},"required":["friendly_name"],"type":"object"},"group":{"properties":{"devices":{"items":{"type":"string"},"type":"array"},"filtered_attributes":{"items":{"type":"string"},"type":"array"},"friendly_name":{"type":"string"},"off_state":{"default":"auto","description":"Control when to publish state OFF for a group. 'all_members_off': only publish state OFF when all group memebers are in state OFF, 'last_member_state': publish state OFF whenever one of its members changes to OFF","enum":["all_members_off","last_member_state"],"requiresRestart":true,"title":"Group off state","type":["string"]},"optimistic":{"type":"boolean"},"qos":{"type":"number"},"retain":{"type":"boolean"}},"required":["friendly_name"],"type":"object"}},"properties":{"advanced":{"properties":{"adapter_concurrent":{"description":"Adapter concurrency (e.g. 2 for CC2531 or 16 for CC26X2R1) (default: null, uses recommended value)","requiresRestart":true,"title":"Adapter concurrency","type":["number","null"]},"adapter_delay":{"description":"Adapter delay","requiresRestart":true,"title":"Adapter delay","type":["number","null"]},"cache_state":{"default":true,"description":"MQTT message payload will contain all attributes, not only changed ones. Has to be true when integrating via Home Assistant","title":"Cache state","type":"boolean"},"cache_state_persistent":{"default":true,"description":"Persist cached state, only used when cache_state: true","title":"Persist cache state","type":"boolean"},"cache_state_send_on_startup":{"default":true,"description":"Send cached state on startup, only used when cache_state: true","title":"Send cached state on startup","type":"boolean"},"channel":{"default":11,"description":"Zigbee channel, changing requires repairing all devices! (Note: use a ZLL channel: 11, 15, 20, or 25 to avoid Problems)","examples":[15,20,25],"maximum":26,"minimum":11,"requiresRestart":true,"title":"ZigBee channel","type":"number"},"elapsed":{"default":false,"description":"Add an elapsed attribute to MQTT messages, contains milliseconds since the previous msg","title":"Elapsed","type":"boolean"},"ext_pan_id":{"description":"Zigbee extended pan ID, changing requires repairing all devices!","items":{"type":"number"},"requiresRestart":true,"title":"Ext Pan ID","type":"array"},"last_seen":{"default":"disable","description":"Add a last_seen attribute to MQTT messages, contains date/time of last Zigbee message","enum":["disable","ISO_8601","ISO_8601_local","epoch"],"title":"Last seen","type":"string"},"legacy_api":{"default":true,"description":"Disables the legacy api (false = disable)","requiresRestart":true,"title":"Legacy API","type":"boolean"},"legacy_availability_payload":{"default":true,"description":"Payload to be used for device availabilty and bridge/state topics. true = text, false = JSON","requiresRestart":true,"title":"Legacy availability payload","type":"boolean"},"log_directory":{"description":"Location of log directory","examples":["data/log/%TIMESTAMP%"],"requiresRestart":true,"title":"Log directory","type":"string"},"log_file":{"default":"log.txt","description":"Log file name, can also contain timestamp","examples":["zigbee2mqtt_%TIMESTAMP%.log"],"requiresRestart":true,"title":"Log file","type":"string"},"log_level":{"default":"info","description":"Logging level","enum":["info","warn","error","debug"],"title":"Log level","type":"string"},"log_output":{"description":"Output location of the log, leave empty to suppress logging","items":{"enum":["console","file","syslog"],"type":"string"},"requiresRestart":true,"title":"Log output","type":"array"},"log_rotation":{"default":true,"description":"Log rotation","requiresRestart":true,"title":"Log rotation","type":"boolean"},"log_symlink_current":{"default":false,"description":"Create symlink to current logs in the log directory","requiresRestart":true,"title":"Log symlink current","type":"boolean"},"log_syslog":{"properties":{"app_name":{"default":"Zigbee2MQTT","description":"The name of the application (Default: Zigbee2MQTT).","title":"Localhost","type":"string"},"eol":{"default":"/n","description":"The end of line character to be added to the end of the message (Default: Message without modifications).","title":"eol","type":"string"},"host":{"default":"localhost","description":"The host running syslogd, defaults to localhost.","title":"Host","type":"string"},"localhost":{"default":"localhost","description":"Host to indicate that log messages are coming from (Default: localhost).","title":"Localhost","type":"string"},"path":{"default":"/dev/log","description":"The path to the syslog dgram socket (i.e. /dev/log or /var/run/syslog for OS X).","examples":["/var/run/syslog"],"title":"Path","type":"string"},"pid":{"default":"process.pid","description":"PID of the process that log messages are coming from (Default process.pid).","title":"PID","type":"string"},"port":{"default":123,"description":"The port on the host that syslog is running on, defaults to syslogd's default port.","title":"Port","type":"number"},"protocol":{"default":"tcp4","description":"The network protocol to log over (e.g. tcp4, udp4, tls4, unix, unix-connect, etc).","examples":["udp4","tls4","unix","unix-connect"],"title":"Protocol","type":"string"},"type":{"default":"5424","description":"The type of the syslog protocol to use (Default: BSD, also valid: 5424).","title":"Type","type":"string"}},"title":"syslog","type":"object"},"network_key":{"description":"Network encryption key, changing requires repairing all devices!","oneOf":[{"title":"Network key(string)","type":"string"},{"items":{"type":"number"},"title":"Network key(array)","type":"array"}],"requiresRestart":true,"title":"Network key"},"output":{"description":"Examples when 'state' of a device is published json: topic: 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}' attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON' attribute_and_json: both json and attribute (see above)","enum":["attribute_and_json","attribute","json"],"title":"MQTT output type","type":"string"},"pan_id":{"description":"ZigBee pan ID, changing requires repairing all devices!","oneOf":[{"title":"Pan ID (string)","type":"string"},{"title":"Pan ID (number)","type":"number"}],"requiresRestart":true,"title":"Pan ID"},"timestamp_format":{"description":"Log timestamp format","examples":["YYYY-MM-DD HH:mm:ss"],"requiresRestart":true,"title":"Timestamp format","type":"string"},"transmit_power":{"description":"Transmit power of adapter, only available for Z-Stack (CC253*/CC2652/CC1352) adapters, CC2652 = 5dbm, CC1352 max is = 20dbm (5dbm default)","requiresRestart":true,"title":"Transmit power","type":["number","null"]}},"title":"Advanced","type":"object"},"availability":{"description":"Checks whether devices are online/offline","oneOf":[{"title":"Availability (simple)","type":"boolean"},{"properties":{"active":{"description":"Options for active devices (routers/mains powered)","properties":{"timeout":{"default":10,"description":"Time after which an active device will be marked as offline in minutes","requiresRestart":true,"title":"Timeout","type":"number"}},"requiresRestart":true,"title":"Active","type":"object"},"passive":{"description":"Options for passive devices (mostly battery powered)","properties":{"timeout":{"default":1500,"description":"Time after which an passive device will be marked as offline in minutes","requiresRestart":true,"title":"Timeout","type":"number"}},"requiresRestart":true,"title":"Passive","type":"object"}},"title":"Availability (advanced)","type":"object"}],"requiresRestart":true,"title":"Availability"},"ban":{"items":{"type":"string"},"readOnly":true,"requiresRestart":true,"title":"Ban (deprecated, use blocklist)","type":"array"},"blocklist":{"description":"Block devices from the network (by ieeeAddr)","items":{"type":"string"},"requiresRestart":true,"title":"Blocklist","type":"array"},"device_options":{"title":"Options that are applied to all devices","type":"object"},"devices":{"patternProperties":{"^.*$":{"$ref":"#/definitions/device"}},"propertyNames":{"pattern":"^0x[\\d\\w]{16}$"},"type":"object"},"external_converters":{"description":"You can define external converters to e.g. add support for a DiY device","examples":["DIYRuZ_FreePad.js"],"items":{"type":"string"},"requiresRestart":true,"title":"External converters","type":"array"},"frontend":{"oneOf":[{"title":"Frontend (simple)","type":"boolean"},{"properties":{"auth_token":{"description":"Enables authentication, disabled by default","requiresRestart":true,"title":"Auth token","type":["string","null"]},"host":{"default":"0.0.0.0","description":"Frontend binding host","requiresRestart":true,"title":"Bind host","type":"string"},"port":{"default":8080,"description":"Frontend binding port","requiresRestart":true,"title":"Port","type":"number"},"url":{"description":"URL on which the frontend can be reached, currently only used for the Home Assistant device configuration page","requiresRestart":true,"title":"URL","type":["string","null"]}},"title":"Frontend (advanced)","type":"object"}],"requiresRestart":true,"title":"Frontend"},"groups":{"patternProperties":{"^.*$":{"$ref":"#/definitions/group"}},"propertyNames":{"pattern":"^[\\w].*$"},"type":"object"},"homeassistant":{"default":false,"description":"Home Assistant integration (MQTT discovery)","oneOf":[{"title":"Home Assistant (simple)","type":"boolean"},{"properties":{"discovery_topic":{"description":"Home Assistant discovery topic","examples":["homeassistant"],"requiresRestart":true,"title":"Homeassistant discovery topic","type":"string"},"legacy_entity_attributes":{"default":true,"description":"Home Assistant legacy entity attributes, when enabled Zigbee2MQTT will add state attributes to each entity, additional to the separate entities and devices it already creates","title":"Home Assistant legacy entity attributes","type":"boolean"},"legacy_triggers":{"default":true,"description":"Home Assistant legacy triggers, when enabled Zigbee2mqt will send an empty 'action' or 'click' after one has been send. A 'sensor_action' and 'sensor_click' will be discoverd","title":"Home Assistant legacy triggers","type":"boolean"},"status_topic":{"description":"Home Assistant status topic","examples":["homeassistant/status"],"requiresRestart":true,"title":"Home Assistant status topic","type":"string"}},"title":"Home Assistant (advanced)","type":"object"}],"requiresRestart":true,"title":"Home Assistant integration"},"map_options":{"properties":{"graphviz":{"properties":{"colors":{"properties":{"fill":{"properties":{"coordinator":{"type":"string"},"enddevice":{"type":"string"},"router":{"type":"string"}},"type":"object"},"font":{"properties":{"coordinator":{"type":"string"},"enddevice":{"type":"string"},"router":{"type":"string"}},"type":"object"},"line":{"properties":{"active":{"type":"string"},"inactive":{"type":"string"}},"type":"object"}},"type":"object"}},"type":"object"}},"title":"Networkmap","type":"object"},"mqtt":{"properties":{"base_topic":{"default":"zigbee2mqtt","description":"MQTT base topic for Zigbee2MQTT MQTT messages","examples":["zigbee2mqtt"],"requiresRestart":true,"title":"Base topic","type":"string"},"ca":{"description":"Absolute path to SSL/TLS certificate of CA used to sign server and client certificates","examples":["/etc/ssl/mqtt-ca.crt"],"requiresRestart":true,"title":"Certificate authority","type":"string"},"cert":{"description":"Absolute path to SSL/TLS certificate for client-authentication","examples":["/etc/ssl/mqtt-client.crt"],"requiresRestart":true,"title":"SSL/TLS certificate","type":"string"},"client_id":{"description":"MQTT client ID","examples":["MY_CLIENT_ID"],"requiresRestart":true,"title":"Client ID","type":"string"},"force_disable_retain":{"default":false,"description":"Disable retain for all send messages. ONLY enable if you MQTT broker doesn't support retained message (e.g. AWS IoT core, Azure IoT Hub, Google Cloud IoT core, IBM Watson IoT Platform). Enabling will break the Home Assistant integration","requiresRestart":true,"title":"Force disable retain","type":"boolean"},"include_device_information":{"default":false,"description":"Include device information to mqtt messages","title":"Include device information","type":"boolean"},"keepalive":{"default":60,"description":"MQTT keepalive in second","requiresRestart":true,"title":"Keepalive","type":"number"},"key":{"description":"Absolute path to SSL/TLS key for client-authentication","examples":["/etc/ssl/mqtt-client.key"],"requiresRestart":true,"title":"SSL/TLS key","type":"string"},"password":{"description":"MQTT server authentication password","examples":["ILOVEPELMENI"],"requiresRestart":true,"title":"Password","type":"string"},"reject_unauthorized":{"default":true,"description":"Disable self-signed SSL certificate","requiresRestart":true,"title":"Reject unauthorized","type":"boolean"},"server":{"description":"MQTT server URL (use mqtts:// for SSL/TLS connection)","examples":["mqtt://localhost:1883"],"requiresRestart":true,"title":"MQTT server","type":"string"},"user":{"description":"MQTT server authentication user","examples":["johnnysilverhand"],"requiresRestart":true,"title":"User","type":"string"},"version":{"default":4,"description":"MQTT protocol version","examples":[5],"requiresRestart":true,"title":"Version","type":["number","null"]}},"required":["server"],"title":"MQTT","type":"object"},"ota":{"properties":{"disable_automatic_update_check":{"default":false,"description":"Zigbee devices may request a firmware update, and do so frequently, causing Zigbee2MQTT to reach out to third party servers. If you disable these device initiated checks, you can still initiate a firmware update check manually.","title":"Disable automatic update check","type":"boolean"},"ikea_ota_use_test_url":{"default":false,"description":"Use IKEA TRADFRI OTA test server, see OTA updates documentation","requiresRestart":true,"title":"IKEA TRADFRI OTA use test url","type":"boolean"},"update_check_interval":{"default":1440,"description":"Your device may request a check for a new firmware update. This value determines how frequently third party servers may actually be contacted to look for firmware updates. The value is set in minutes, and the default is 1 day.","title":"Update check interval","type":"number"},"zigbee_ota_override_index_location":{"description":"Location of override OTA index file","examples":["index.json"],"requiresRestart":true,"title":"OTA index override file name","type":"string"}},"title":"OTA updates","type":"object"},"passlist":{"description":"Allow only certain devices to join the network (by ieeeAddr). Note that all devices not on the passlist will be removed from the network!","items":{"type":"string"},"requiresRestart":true,"title":"Passlist","type":"array"},"permit_join":{"default":false,"description":"Allow new devices to join (re-applied at restart)","title":"Permit join","type":"boolean"},"serial":{"properties":{"adapter":{"default":"auto","description":"Adapter type, not needed unless you are experiencing problems","enum":["deconz","zstack","zigate","ezsp","auto"],"requiresRestart":true,"title":"Adapter","type":["string"]},"baudrate":{"description":"Baud rate speed for serial port, this can be anything firmware support but default is 115200 for Z-Stack and EZSP, 38400 for Deconz, however note that some EZSP firmware need 57600","examples":[38400,57600,115200],"requiresRestart":true,"title":"Baudrate","type":"number"},"disable_led":{"default":false,"description":"Disable LED of the adapter if supported","requiresRestart":true,"title":"Disable led","type":"boolean"},"port":{"description":"Location of the adapter. To autodetect the port, set null","examples":["/dev/ttyACM0"],"requiresRestart":true,"title":"Port","type":["string","null"]},"rtscts":{"description":"RTS / CTS Hardware Flow Control for serial port","requiresRestart":true,"title":"RTS / CTS","type":"boolean"}},"title":"Serial","type":"object"},"whitelist":{"items":{"type":"string"},"readOnly":true,"requiresRestart":true,"title":"Whitelist (deprecated, use passlist)","type":"array"}},"required":["mqtt"],"type":"object"},"coordinator":{"ieee_address":"0x00124b001e17ef39","meta":{"maintrel":1,"majorrel":2,"minorrel":7,"product":1,"revision":20220928,"transportrev":2},"type":"zStack3x0"},"log_level":"debug","network":{"channel":11,"extended_pan_id":"0x00124b001e17ef39","pan_id":24340},"permit_join":false,"restart_required":false,"version":"1.28.0-dev"}'
Zigbee2MQTT:debug 2022-10-21 20:43:23: Received MQTT message on 'zigbee2mqtt/bridge/devices' with data '[{"definition":null,"endpoints":{"1":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"10":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"11":{"bindings":[],"clusters":{"input":["ssIasAce"],"output":["ssIasZone","ssIasWd"]},"configured_reportings":[],"scenes":[]},"110":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"12":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"13":{"bindings":[],"clusters":{"input":["genOta"],"output":[]},"configured_reportings":[],"scenes":[]},"2":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"242":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"3":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"4":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"47":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"5":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"6":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]},"8":{"bindings":[],"clusters":{"input":[],"output":[]},"configured_reportings":[],"scenes":[]}},"friendly_name":"Coordinator","ieee_address":"0x00124b001e17ef39","interview_completed":true,"interviewing":false,"network_address":0,"supported":false,"type":"Coordinator"}]'
Zigbee2MQTT:debug 2022-10-21 20:43:23: Received MQTT message on 'zigbee2mqtt/bridge/groups' with data '[]'
Zigbee2MQTT:debug 2022-10-21 20:43:23: Received MQTT message on 'zigbee2mqtt/bridge/extensions' with data '[]'
Zigbee2MQTT:debug 2022-10-21 20:43:23: Received MQTT message on 'zigbee2mqtt/bridge/config' with data '{"commit":"a426ee10","coordinator":{"meta":{"maintrel":1,"majorrel":2,"minorrel":7,"product":1,"revision":20220928,"transportrev":2},"type":"zStack3x0"},"log_level":"debug","network":{"channel":11,"extendedPanID":"0x00124b001e17ef39","panID":24340},"permit_join":false,"version":"1.28.0-dev"}'
Zigbee2MQTT:info  2022-10-21 20:43:23: Started frontend on port 0.0.0.0:8080
Zigbee2MQTT:info  2022-10-21 20:43:23: MQTT publish: topic 'zigbee2mqtt/bridge/config', payload '{"commit":"a426ee10","coordinator":{"meta":{"maintrel":1,"majorrel":2,"minorrel":7,"product":1,"revision":20220928,"transportrev":2},"type":"zStack3x0"},"log_level":"debug","network":{"channel":11,"extendedPanID":"0x00124b001e17ef39","panID":24340},"permit_join":false,"version":"1.28.0-dev"}'
Zigbee2MQTT:debug 2022-10-21 20:43:49: Received MQTT message on 'zigbee2mqtt/bridge/request/permit_join' with data '{"device":null,"time":254,"transaction":"qqevf-1","value":true}'
Zigbee2MQTT:info  2022-10-21 20:43:49: Zigbee: allowing new devices to join.
Zigbee2MQTT:info  2022-10-21 20:43:49: MQTT publish: topic 'zigbee2mqtt/bridge/response/permit_join', payload '{"data":{"time":254,"value":true},"status":"ok","transaction":"qqevf-1"}'
Zigbee2MQTT:info  2022-10-21 20:43:58: Device '0x0015bc001a0238ec' joined
Zigbee2MQTT:info  2022-10-21 20:43:58: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x0015bc001a0238ec","ieee_address":"0x0015bc001a0238ec"},"type":"device_joined"}'
Zigbee2MQTT:info  2022-10-21 20:43:58: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"message":{"friendly_name":"0x0015bc001a0238ec"},"type":"device_connected"}'
Zigbee2MQTT:info  2022-10-21 20:43:58: Starting interview of '0x0015bc001a0238ec'
Zigbee2MQTT:info  2022-10-21 20:43:58: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x0015bc001a0238ec","ieee_address":"0x0015bc001a0238ec","status":"started"},"type":"device_interview"}'
Zigbee2MQTT:info  2022-10-21 20:43:58: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"message":"interview_started","meta":{"friendly_name":"0x0015bc001a0238ec"},"type":"pairing"}'
Zigbee2MQTT:debug 2022-10-21 20:43:58: Device '0x0015bc001a0238ec' announced itself
Zigbee2MQTT:info  2022-10-21 20:43:58: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x0015bc001a0238ec","ieee_address":"0x0015bc001a0238ec"},"type":"device_announce"}'
Zigbee2MQTT:info  2022-10-21 20:43:58: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"message":"announce","meta":{"friendly_name":"0x0015bc001a0238ec"},"type":"device_announced"}'
Zigbee2MQTT:debug 2022-10-21 20:44:12: Received Zigbee message from '0x0015bc001a0238ec', type 'commandQueryNextImageRequest', cluster 'genOta', data '{"fieldControl":0,"fileVersion":262147,"imageType":386,"manufacturerCode":4117}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:12: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:12: Received Zigbee message from '0x0015bc001a0238ec', type 'commandStatusChangeNotification', cluster 'ssIasZone', data '{"extendedstatus":0,"zonestatus":53}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:12: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{"modelId":"MOSZB-140"}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{"manufacturerName":"frient A/S"}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{"powerSource":3}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{"zclVersion":1}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:13: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{"dateCode":"20220305 08:08"}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:13: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:14: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 34 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:14: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:14: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:14: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:14: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:14: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:14: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:14: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:14: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:14: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:14: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 38 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:14: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:15: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 38 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:15: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:15: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 38 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:15: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:15: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 38 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:15: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:15: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 39 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:15: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:15: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 39 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:15: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:15: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 39 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:15: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:15: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 39 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:15: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:16: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 40 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:16: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:16: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 40 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:16: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:16: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 40 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:16: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:16: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 40 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:16: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:16: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 41 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:16: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:16: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 41 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:16: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:17: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 41 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:17: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:17: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{}' from endpoint 41 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:17: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:17: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'ssIasZone', data '{"iasCieAddr":"0x00124b001e17ef39","zoneState":1}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:17: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:debug 2022-10-21 20:44:19: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genPollCtrl', data '{"checkinInterval":14400}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:19: Skipping message, definition is undefined and still interviewing
Zigbee2MQTT:info  2022-10-21 20:44:19: Successfully interviewed '0x0015bc001a0238ec', device has successfully been paired
Zigbee2MQTT:info  2022-10-21 20:44:19: Device '0x0015bc001a0238ec' is supported, identified as: Develco Motion sensor (MOSZB-140)
Zigbee2MQTT:info  2022-10-21 20:44:19: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"definition":{"description":"Motion sensor","exposes":[{"access":1,"description":"Indicates whether the device detected occupancy","name":"occupancy","property":"occupancy","type":"binary","value_off":false,"value_on":true},{"access":1,"description":"Measured temperature value","name":"temperature","property":"temperature","type":"numeric","unit":"°C"},{"access":1,"description":"Measured illuminance in lux","name":"illuminance_lux","property":"illuminance_lux","type":"numeric","unit":"lx"},{"access":1,"description":"Indicates whether the device is tampered","name":"tamper","property":"tamper","type":"binary","value_off":false,"value_on":true},{"access":1,"description":"Indicates if the battery of this device is almost empty","name":"battery_low","property":"battery_low","type":"binary","value_off":false,"value_on":true},{"access":1,"description":"Remaining battery in %","name":"battery","property":"battery","type":"numeric","unit":"%","value_max":100,"value_min":0}],"model":"MOSZB-140","options":[{"access":2,"description":"Number of digits after decimal point for temperature, takes into effect on next report of device.","name":"temperature_precision","property":"temperature_precision","type":"numeric","value_max":3,"value_min":0},{"access":2,"description":"Calibrates the temperature value (absolute offset), takes into effect on next report of device.","name":"temperature_calibration","property":"temperature_calibration","type":"numeric"},{"access":2,"description":"Calibrates the illuminance value (percentual offset), takes into effect on next report of device.","name":"illuminance_calibration","property":"illuminance_calibration","type":"numeric"},{"access":2,"description":"Calibrates the illuminance_lux value (percentual offset), takes into effect on next report of device.","name":"illuminance_lux_calibration","property":"illuminance_lux_calibration","type":"numeric"}],"supports_ota":false,"vendor":"Develco"},"friendly_name":"0x0015bc001a0238ec","ieee_address":"0x0015bc001a0238ec","status":"successful","supported":true},"type":"device_interview"}'
Zigbee2MQTT:info  2022-10-21 20:44:19: Configuring '0x0015bc001a0238ec'
Zigbee2MQTT:info  2022-10-21 20:44:19: MQTT publish: topic 'zigbee2mqtt/bridge/log', payload '{"message":"interview_successful","meta":{"description":"Motion sensor","friendly_name":"0x0015bc001a0238ec","model":"MOSZB-140","supported":true,"vendor":"Develco"},"type":"pairing"}'
Zigbee2MQTT:debug 2022-10-21 20:44:20: Received Zigbee message from '0x0015bc001a0238ec', type 'attributeReport', cluster 'msIlluminanceMeasurement', data '{"measuredValue":14211}' from endpoint 39 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:20: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"illuminance":14211,"illuminance_lux":26,"linkquality":193}'
Zigbee2MQTT:debug 2022-10-21 20:44:20: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{"develcoPrimaryHwVersion":{"data":[2,2,0],"type":"Buffer"},"develcoPrimarySwVersion":{"data":[4,0,3],"type":"Buffer"}}' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:21: Received Zigbee message from '0x0015bc001a0238ec', type 'attributeReport', cluster 'msTemperatureMeasurement', data '{"measuredValue":2581}' from endpoint 38 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:21: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"illuminance":14211,"illuminance_lux":26,"linkquality":189,"temperature":25.81}'
Zigbee2MQTT:debug 2022-10-21 20:44:22: Received Zigbee message from '0x0015bc001a0238ec', type 'attributeReport', cluster 'msIlluminanceMeasurement', data '{"measuredValue":14181}' from endpoint 39 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:22: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"illuminance":14181,"illuminance_lux":26,"linkquality":182,"temperature":25.81}'
Zigbee2MQTT:debug 2022-10-21 20:44:23: Received Zigbee message from '0x0015bc001a0238ec', type 'read', cluster 'genTime', data '["time"]' from endpoint 35 with groupID 0
Zigbee2MQTT:debug 2022-10-21 20:44:23: Received Zigbee message from '0x0015bc001a0238ec', type 'attributeReport', cluster 'msTemperatureMeasurement', data '{"measuredValue":2581}' from endpoint 38 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:23: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"illuminance":14181,"illuminance_lux":26,"linkquality":196,"temperature":25.81}'
Zigbee2MQTT:debug 2022-10-21 20:44:23: Received Zigbee message from '0x0015bc001a0238ec', type 'attributeReport', cluster 'msTemperatureMeasurement', data '{"measuredValue":2581}' from endpoint 38 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:23: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"illuminance":14181,"illuminance_lux":26,"linkquality":193,"temperature":25.81}'
Zigbee2MQTT:debug 2022-10-21 20:44:25: Received Zigbee message from '0x0015bc001a0238ec', type 'attributeReport', cluster 'genPowerCfg', data '{"batteryAlarmState":0,"batteryVoltage":30}' from endpoint 35 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:25: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"battery":100,"battery_low":false,"illuminance":14181,"illuminance_lux":26,"linkquality":182,"temperature":25.81,"voltage":3000}'
Zigbee2MQTT:debug 2022-10-21 20:44:26: Received Zigbee message from '0x0015bc001a0238ec', type 'attributeReport', cluster 'genPowerCfg', data '{"batteryAlarmState":0,"batteryVoltage":30}' from endpoint 35 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:26: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"battery":100,"battery_low":false,"illuminance":14181,"illuminance_lux":26,"linkquality":189,"temperature":25.81,"voltage":3000}'
Zigbee2MQTT:debug 2022-10-21 20:44:26: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genPowerCfg', data '{"batteryVoltage":30}' from endpoint 35 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:26: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"battery":100,"battery_low":false,"illuminance":14181,"illuminance_lux":26,"linkquality":189,"temperature":25.81,"voltage":3000}'
Zigbee2MQTT:debug 2022-10-21 20:44:28: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'ssIasZone', data '{"develcoAlarmOffDelay":20}' from endpoint 35 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:28: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"battery":100,"battery_low":false,"illuminance":14181,"illuminance_lux":26,"linkquality":189,"occupancy_timeout":20,"temperature":25.81,"voltage":3000}'
Zigbee2MQTT:debug 2022-10-21 20:44:28: Received Zigbee message from '0x0015bc001a0238ec', type 'readResponse', cluster 'genBasic', data '{"develcoLedControl":255}' from endpoint 35 with groupID 0
Zigbee2MQTT:info  2022-10-21 20:44:28: MQTT publish: topic 'zigbee2mqtt/0x0015bc001a0238ec', payload '{"battery":100,"battery_low":false,"illuminance":14181,"illuminance_lux":26,"led_control":"both","linkquality":189,"occupancy_timeout":20,"temperature":25.81,"voltage":3000}'
Zigbee2MQTT:info  2022-10-21 20:44:28: Successfully configured '0x0015bc001a0238ec'
```


Resulting in this expose and reporting configuration:
<img width="1054" alt="Screen Shot 2022-10-21 at 20 46 05" src="https://user-images.githubusercontent.com/379665/197267995-f311639d-8685-46c8-a8f0-a9b47b47454f.png">


<img width="1307" alt="image" src="https://user-images.githubusercontent.com/379665/197267779-5fcc84a2-afd5-42c7-b626-e7a2888a1e86.png">

<img width="1576" alt="image" src="https://user-images.githubusercontent.com/379665/197267833-6954a09b-0057-4b71-848f-fc4646d63819.png">


Which is what we expect for a sw firmware >= 4
