### PR TITLE
Remove `ballast_physical_*_level`

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1588,12 +1588,6 @@ const converters = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             const result = {};
-            if (msg.data.hasOwnProperty('physicalMinLevel')) {
-                result['ballast_physical_minimum_level'] = msg.data.physicalMinLevel;
-            }
-            if (msg.data.hasOwnProperty('physicalMaxLevel')) {
-                result['ballast_physical_maximum_level'] = msg.data.physicalMaxLevel;
-            }
             if (msg.data.hasOwnProperty('ballastStatus')) {
                 const ballastStatus = msg.data.ballastStatus;
                 result['ballast_status_non_operational'] = ballastStatus & 1 ? true : false;

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -605,8 +605,6 @@ const converters = {
         convertGet: async (entity, key, meta) => {
             let result = {};
             for (const attrName of [
-                'physical_min_level',
-                'physical_max_level',
                 'ballast_status',
                 'min_level',
                 'max_level',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -578,8 +578,6 @@ const converters = {
     },
     ballast_config: {
         key: ['ballast_config',
-            'ballast_physical_minimum_level',
-            'ballast_physical_maximum_level',
             'ballast_minimum_level',
             'ballast_maximum_level',
             'ballast_power_on_level'],

--- a/devices/leviton.js
+++ b/devices/leviton.js
@@ -100,11 +100,7 @@ module.exports = [
             exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
                 .withDescription('Specifies the maximum brightness value'),
             exposes.numeric('ballast_power_on_level', ea.ALL).withValueMin(1).withValueMax(254)
-                .withDescription('Specifies the initialisation light level. Can not be set lower than "ballast_minimum_level"'),
-            exposes.numeric('ballast_physical_minimum_level', ea.STATE_GET).withValueMin(0).withValueMax(255)
-                .withDescription('Specifies the minimum light output the ballast can achieve.'),
-            exposes.numeric('ballast_physical_maximum_level', ea.STATE_GET).withValueMin(0).withValueMax(255)
-                .withDescription('Specifies the maximum light output the ballast can achieve.')],
+                .withDescription('Specifies the initialisation light level. Can not be set lower than "ballast_minimum_level"')],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);

--- a/devices/leviton.js
+++ b/devices/leviton.js
@@ -101,9 +101,9 @@ module.exports = [
                 .withDescription('Specifies the maximum brightness value'),
             exposes.numeric('ballast_power_on_level', ea.ALL).withValueMin(1).withValueMax(254)
                 .withDescription('Specifies the initialisation light level. Can not be set lower than "ballast_minimum_level"'),
-            exposes.numeric('ballast_physical_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
+            exposes.numeric('ballast_physical_minimum_level', ea.STATE_GET).withValueMin(0).withValueMax(255)
                 .withDescription('Specifies the minimum light output the ballast can achieve.'),
-            exposes.numeric('ballast_physical_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
+            exposes.numeric('ballast_physical_maximum_level', ea.STATE_GET).withValueMin(0).withValueMax(255)
                 .withDescription('Specifies the maximum light output the ballast can achieve.')],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);

--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -671,10 +671,6 @@ module.exports = [
             ubisys.tz.dimmer_setup_genLevelCtrl, ubisys.tz.configure_device_setup, tz.ignore_transition, tz.light_brightness_move,
             tz.light_brightness_step],
         exposes: [e.light_brightness().withLevelConfig(), e.power(),
-            exposes.numeric('ballast_physical_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
-                .withDescription('Specifies the minimum light output the ballast can achieve.'),
-            exposes.numeric('ballast_physical_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
-                .withDescription('Specifies the maximum light output the ballast can achieve.'),
             exposes.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
                 .withDescription('Specifies the minimum light output of the ballast'),
             exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)


### PR DESCRIPTION
This is not settable, and the range is 0-255 not 1-254

```
Read result of 'lightingBallastCfg': {"physicalMinLevel":0,"physicalMaxLevel":255}
```

and
```
First occurred: October 16, 2022 at 11:22:54 PM (2670 occurrences)
Last logged: 2:44:12 PM

    Invalid value for number.0x25c823ffffa60700_ballast_physical_minimum_level: 0 (range 1.0 - 254.0)
    Invalid value for number.0x25c823ffffa60700_ballast_physical_maximum_level: 255 (range 1.0 - 254.0)
```

and

```
Publish 'set' 'write' to '0x25c823ffffa60700' failed: 'Error: Write 0x25c823ffffa60700/1 lightingBallastCfg({"physicalMinLevel":6}, {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'READ_ONLY')'
```