### PR TITLE
Update moes.js to add support for led indicator

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -1,5 +1,5 @@
 const exposes = require('../lib/exposes');
-const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const fz = require('../converters/fromZigbee');
 const tz = require('../converters/toZigbee');
 const ota = require('../lib/ota');
 const tuya = require('../lib/tuya');
@@ -32,7 +32,7 @@ module.exports = [
             exposes.enum('power_outage_memory', ea.ALL, ['on', 'off', 'restore'])
                 .withDescription('Recover state after power outage'),
             exposes.enum('indicator_mode', ea.ALL, ['off', 'off/on', 'on/off', 'on'])
-            .withDescription('Plug LED indicator mode'), e.child_lock()],
+                .withDescription('Plug LED indicator mode'), e.child_lock()],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
@@ -52,8 +52,8 @@ module.exports = [
         model: 'MS-104Z',
         description: 'Smart light switch module (1 gang)',
         vendor: 'Moes',
-        toZigbee: extend.switch().toZigbee.concat([tz.moes_power_on_behavior,tz.ts011f_plug_indicator_mod]),
-        fromZigbee: extend.switch().fromZigbee.concat([fz.moes_power_on_behavior, tz.ts011f_plug_indicator_mode]),
+        toZigbee: extend.switch().toZigbee.concat([tz.moes_power_on_behavior]),
+        fromZigbee: extend.switch().fromZigbee.concat([fz.moes_power_on_behavior]),
         extend: extend.switch(),
         exposes: [e.switch(),
             exposes.enum('power_on_behavior', ea.ALL, ['on', 'off', 'previous'])

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -26,11 +26,13 @@ module.exports = [
         model: 'ZP-LZ-FR2U',
         vendor: 'Moes',
         description: 'Zigbee 3.0 dual USB wireless socket plug',
-        fromZigbee: [fz.on_off, fz.tuya_switch_power_outage_memory, fz.ts011f_plug_child_mode],
-        toZigbee: [tz.on_off, tz.tuya_switch_power_outage_memory, tz.ts011f_plug_child_mode],
+        fromZigbee: [fz.on_off, fz.tuya_switch_power_outage_memory, fz.ts011f_plug_indicator_mode, fz.ts011f_plug_child_mode],
+        toZigbee: [tz.on_off, tz.tuya_switch_power_outage_memory, tz.ts011f_plug_indicator_mode, tz.ts011f_plug_child_mode],
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
             exposes.enum('power_outage_memory', ea.ALL, ['on', 'off', 'restore'])
-                .withDescription('Recover state after power outage'), e.child_lock()],
+                .withDescription('Recover state after power outage'),
+            exposes.enum('indicator_mode', ea.ALL, ['off', 'off/on', 'on/off', 'on'])
+            .withDescription('Plug LED indicator mode'), e.child_lock()],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
@@ -50,8 +52,8 @@ module.exports = [
         model: 'MS-104Z',
         description: 'Smart light switch module (1 gang)',
         vendor: 'Moes',
-        toZigbee: extend.switch().toZigbee.concat([tz.moes_power_on_behavior]),
-        fromZigbee: extend.switch().fromZigbee.concat([fz.moes_power_on_behavior]),
+        toZigbee: extend.switch().toZigbee.concat([tz.moes_power_on_behavior,tz.ts011f_plug_indicator_mod]),
+        fromZigbee: extend.switch().fromZigbee.concat([fz.moes_power_on_behavior, tz.ts011f_plug_indicator_mode]),
         extend: extend.switch(),
         exposes: [e.switch(),
             exposes.enum('power_on_behavior', ea.ALL, ['on', 'off', 'previous'])


### PR DESCRIPTION
The ZP-LZ-FR2U supports control of the indicator LED.  When it was being incorrectly identified as a TS011F (in an early version of the converters) this function was exposed and working.  I am proposing these changes to give support to this feature.  Cheers, Barry