### PR TITLE
develco: impove firmware reading

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -29,28 +29,23 @@ const develcoLedControlMap = {
 const develco = {
     configure: {
         read_sw_hw_version: async (device, logger) => {
-	    logger.warn("MOSZB-140 develcoConfigureReadVersion: BEGIN");
-	    for (const ep of device.endpoints) {
-		logger.warn(`MOSZB-140 develcoConfigureReadVersion: checking ep ${ep.ID} for genBasic cluster '${ep.supportsInputCluster('genBasic')}' ...`);
-		if (ep.supportsInputCluster('genBasic')) {
-		    logger.warn(`MOSZB-140 develcoConfigureReadVersion: read genBasic.develcoPrimarySwVersion and genBasic.develcoPrimaryHwVersion from ${ep.ID} ...`);
-		    try {
-			const data = await ep.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'],
-			    manufacturerOptions);
-			logger.warn(`MOSZB-140 develcoConfigureReadVersion: readResponse ${JSON.stringify(data)}`);
+            for (const ep of device.endpoints) {
+                if (ep.supportsInputCluster('genBasic')) {
+                    try {
+                        const data = await ep.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'],
+                            manufacturerOptions);
 
-			if (data.hasOwnProperty('develcoPrimarySwVersion')) {
-			    device.softwareBuildID = data.develcoPrimarySwVersion.join('.');
-			}
+                        if (data.hasOwnProperty('develcoPrimarySwVersion')) {
+                            device.softwareBuildID = data.develcoPrimarySwVersion.join('.');
+                        }
 
-			if (data.hasOwnProperty('develcoPrimaryHwVersion')) {
-			    device.hardwareVersion = data.develcoPrimaryHwVersion.join('.');
-			}
-		    } catch (error) {/* catch timeouts of sleeping devices */}
-		    break;
-		}
-	    }
-	    logger.warn("MOSZB-140 develcoConfigureReadVersion: END");
+                        if (data.hasOwnProperty('develcoPrimaryHwVersion')) {
+                            device.hardwareVersion = data.develcoPrimaryHwVersion.join('.');
+                        }
+                    } catch (error) {/* catch timeouts of sleeping devices */}
+                    break;
+                }
+            }
         },
     },
     fz: {


### PR DESCRIPTION
This PR moves away from using an OnEvent to read the Sw/Hw versions from the Develco specific attributes and instead does it during configuration.

Before we would not always pick the same endpoint and this was causing problems, we now grab the first endpoint we find with genBasic. Before we somtimes read from an endpoint without genBasic cluster!

I've also added this to the configure of AQSZB-110, it also correctly returned the additional info.

I think it is probably safe to just do this for all Develco devices but I did not add this, I only added it to devices I have my hands on to test or to the ones that were already reading it before my fun adventure with the MOSZB-140.