### PR TITLE
WBMSW3: Removed reading values when configuring

### DIFF
--- a/devices/sprut.js
+++ b/devices/sprut.js
@@ -273,10 +273,10 @@ module.exports = [
                 .withDescription('The minimum noise level at which the detector will work (default: 50)'),
             e.enum('co2_autocalibration', ea.ALL, switchActionValues)
                 .withDescription('Automatic calibration of the CO2 sensor. If ON, the CO2 sensor will automatically calibrate '+
-                    'every 7 days.'),
+                    'every 7 days. (MH-Z19B)'),
             e.enum('co2_manual_calibration', ea.ALL, switchActionValues)
                 .withDescription('Ventilate the room for 20 minutes, turn on manual calibration, and turn it off after one second. '+
-                    'After about 5 minutes the CO2 sensor will show 400ppm. Calibration completed'),
+                    'After about 5 minutes the CO2 sensor will show 400ppm. Calibration completed. (MH-Z19B)'),
             e.enum('th_heater', ea.ALL, switchActionValues)
                 .withDescription('Turn on when working in conditions of high humidity (more than 70 %, RH) or condensation, '+
                     'if the sensor shows 0 or 100 %.'),
@@ -307,14 +307,6 @@ module.exports = [
 
             // buzzer
             await device.getEndpoint(4).read('genOnOff', ['onOff']);
-
-            // Read data at start
-            await endpoint1.read('msTemperatureMeasurement', ['measuredValue']);
-            await endpoint1.read('msIlluminanceMeasurement', ['measuredValue']);
-            await endpoint1.read('msRelativeHumidity', ['measuredValue']);
-            await endpoint1.read('msOccupancySensing', ['occupancy']);
-            await endpoint1.read('sprutNoise', ['noise']);
-            await endpoint1.read('sprutNoise', ['noiseDetected']);
         },
         endpoint: (device) => {
             return {'default': 1, 'l1': 2, 'l2': 3, 'l3': 4};

--- a/devices/sprut.js
+++ b/devices/sprut.js
@@ -273,10 +273,10 @@ module.exports = [
                 .withDescription('The minimum noise level at which the detector will work (default: 50)'),
             e.enum('co2_autocalibration', ea.ALL, switchActionValues)
                 .withDescription('Automatic calibration of the CO2 sensor. If ON, the CO2 sensor will automatically calibrate '+
-                    'every 7 days. (MH-Z19B)'),
+                    'every 7 days. (MH-Z19B sensor)'),
             e.enum('co2_manual_calibration', ea.ALL, switchActionValues)
                 .withDescription('Ventilate the room for 20 minutes, turn on manual calibration, and turn it off after one second. '+
-                    'After about 5 minutes the CO2 sensor will show 400ppm. Calibration completed. (MH-Z19B)'),
+                    'After about 5 minutes the CO2 sensor will show 400ppm. Calibration completed. (MH-Z19B sensor)'),
             e.enum('th_heater', ea.ALL, switchActionValues)
                 .withDescription('Turn on when working in conditions of high humidity (more than 70 %, RH) or condensation, '+
                     'if the sensor shows 0 or 100 %.'),


### PR DESCRIPTION
WBMSW3:
- Removed reading values when configuring, because sometimes there were errors. The sensor itself will send the value in a few seconds.
- Added clarification about CO2 sensor model.