### PR TITLE
TV02-Zigbee expose fix

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2084,7 +2084,7 @@ module.exports = [
         onEvent: tuya.onEventSetLocalTime,
         configure: tuya.configureMagicPacket,
         exposes: [
-            e.battery(), e.child_lock(), e.open_window(), e.open_window_temperature().withValueMin(5).withValueMax(30),
+            e.battery_low(), e.child_lock(), e.open_window(), e.open_window_temperature().withValueMin(5).withValueMax(30),
             e.comfort_temperature().withValueMin(5).withValueMax(30), e.eco_temperature().withValueMin(5).withValueMax(30),
             exposes.climate().withSystemMode(['off', 'heat'], ea.STATE_SET, 'When switched to the "off" mode, the device will display ' +
                 '"HS" and the valve will be fully closed. Press the pair button to cancel or switch back to "heat" mode. Battery life ' +


### PR DESCRIPTION
I forgot to replace the `battery` expose with `battery_low` the last time. The device supports only `battery_low` which already exists in the converter, so this fixes it.