### PR TITLE
Brennenstuhl HT CZ 01 support

### DIFF
--- a/devices/siterwell.js
+++ b/devices/siterwell.js
@@ -14,7 +14,8 @@ module.exports = [
             {modelId: 'TS0601', manufacturerName: '_TZE200_hhrtiq0x'},
             {modelId: 'TS0601', manufacturerName: '_TZE200_ps5v5jor'},
             {modelId: 'TS0601', manufacturerName: '_TZE200_jeaxp72v'},
-            {modelId: 'TS0601', manufacturerName: '_TZE200_owwdxjbx'}],
+            {modelId: 'TS0601', manufacturerName: '_TZE200_owwdxjbx'},
+            {modelId: 'TS0601', manufacturerName: '_TZE200_2cs6g9i7'}],
         model: 'GS361A-H04',
         vendor: 'Siterwell',
         description: 'Radiator valve with thermostat',
@@ -31,7 +32,8 @@ module.exports = [
             {vendor: 'Unitec', description: 'Thermostatic Radiator Valve Controller', model: '30946'},
             {vendor: 'Tesla', description: 'Thermostatic Radiator Valve Controller', model: 'TSL-TRV-GS361A'},
             {vendor: 'Nedis', description: 'Thermostatic Radiator Valve Controller', model: 'ZBHTR10WT'},
-            {vendor: 'TCP Smart', description: 'Smart Thermostatic Radiator Valve', model: 'TBUWTRV'}],
+            {vendor: 'TCP Smart', description: 'Smart Thermostatic Radiator Valve', model: 'TBUWTRV'},
+            {vendor: 'Brennenstuhl', description: 'Radiator Thermostat', model: 'HT CZ 01'}],
         exposes: [e.child_lock(), e.window_detection(), e.battery(), e.valve_detection(), e.position(), exposes.climate()
             .withSetpoint('current_heating_setpoint', 5, 30, 0.5, ea.STATE_SET).withLocalTemperature(ea.STATE)
             .withSystemMode(['off', 'auto', 'heat'], ea.STATE_SET)


### PR DESCRIPTION
Model HT CZ 01 manufactured by Brennenstuhl
Zigbee ID: TS0601 / _TZE200_2cs6g9i7

This device is a Siterwell GS361 whitelabel TRV.

zigpy adds support for Brennenstuhl HT CZ 01 the same way:
https://github.com/zigpy/zha-device-handlers/blob/249ec6d01bfdb0938486bbf27b9b2e6615ba5288/zhaquirks/tuya/ts0601_trv.py#L1475