### PR TITLE
Sinope switch expose status LED control

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4405,6 +4405,30 @@ const converters = {
             }
         },
     },
+    sinope_led_color_on: {
+        // DM2500ZB and SW2500ZB
+        key: ['led_color_on'],
+        convertSet: async (entity, key, value, meta) => {
+            const r = (value.r >= 0 && value.r <= 255) ? value.r : 0;
+            const g = (value.g >= 0 && value.g <= 255) ? value.g : 0;
+            const b = (value.b >= 0 && value.b <= 255) ? value.b : 0;
+
+            const valueHex = r + g * 256 + (b * 256 ** 2);
+            await entity.write('manuSpecificSinope', {ledColorOn: valueHex});
+        },
+    },
+    sinope_led_color_off: {
+        // DM2500ZB and SW2500ZB
+        key: ['led_color_off'],
+        convertSet: async (entity, key, value, meta) => {
+            const r = (value.r >= 0 && value.r <= 255) ? value.r : 0;
+            const g = (value.g >= 0 && value.g <= 255) ? value.g : 0;
+            const b = (value.b >= 0 && value.b <= 255) ? value.b : 0;
+
+            const valueHex = r + g * 256 + b * 256 ** 2;
+            await entity.write('manuSpecificSinope', {ledColorOff: valueHex});
+        },
+    },
     sinope_minimum_brightness: {
         // DM2500ZB
         key: ['minimum_brightness'],

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -241,10 +241,63 @@ module.exports = [
         vendor: 'Sinopé',
         description: 'Zigbee smart light switch',
         extend: extend.switch(),
+        exposes: [e.switch(),
+            exposes.numeric('led_intensity_on', ea.SET).withValueMin(0).withValueMax(100)
+                .withDescription('Control status LED intensity when load ON'),
+            exposes.numeric('led_intensity_off', ea.SET).withValueMin(0).withValueMax(100)
+                .withDescription('Control status LED intensity when load OFF'),
+            exposes.composite('led_color_on', 'led_color_on')
+                .withFeature(exposes.numeric('r', ea.ALL))
+                .withFeature(exposes.numeric('g', ea.ALL))
+                .withFeature(exposes.numeric('b', ea.ALL))
+                .withDescription('Control status LED intensity when load ON'),
+            exposes.composite('led_color_off', 'led_color_off')
+                .withFeature(exposes.numeric('r', ea.ALL))
+                .withFeature(exposes.numeric('g', ea.ALL))
+                .withFeature(exposes.numeric('b', ea.ALL))
+                .withDescription('Control status LED color when load OFF'),
+        ],
+        fromZigbee: [fz.on_off, fz.electrical_measurement],
+        toZigbee: [tz.on_off, tz.sinope_led_intensity_on, tz.sinope_led_intensity_off, tz.sinope_led_color_on, tz.sinope_led_color_off],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['DM2500ZB'],
+        model: 'DM2500ZB',
+        vendor: 'Sinopé',
+        description: 'Zigbee smart dimmer',
+        extend: extend.light_onoff_brightness({noConfigure: true}),
+        exposes: [e.light_brightness(),
+            exposes.numeric('led_intensity_on', ea.SET).withValueMin(0).withValueMax(100)
+                .withDescription('Control status LED when load ON'),
+            exposes.numeric('led_intensity_off', ea.SET).withValueMin(0).withValueMax(100)
+                .withDescription('Control status LED when load OFF'),
+            exposes.numeric('minimum_brightness', ea.SET).withValueMin(0).withValueMax(3000)
+                .withDescription('Control minimum dimmer brightness'),
+            exposes.composite('led_color_on', 'led_color_on')
+                .withFeature(exposes.numeric('r', ea.ALL))
+                .withFeature(exposes.numeric('g', ea.ALL))
+                .withFeature(exposes.numeric('b', ea.ALL))
+                .withDescription('Control status LED intensity when load ON'),
+            exposes.composite('led_color_off', 'led_color_off')
+                .withFeature(exposes.numeric('r', ea.ALL))
+                .withFeature(exposes.numeric('g', ea.ALL))
+                .withFeature(exposes.numeric('b', ea.ALL))
+                .withDescription('Control status LED color when load OFF'),
+        ],
+        fromZigbee: [fz.on_off, fz.brightness, fz.electrical_measurement],
+        toZigbee: [tz.light_onoff_brightness, tz.sinope_led_intensity_on, tz.sinope_led_intensity_off,
+            tz.sinope_minimum_brightness, tz.sinope_led_color_on, tz.sinope_led_color_off],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
         },
     },
     {
@@ -277,26 +330,6 @@ module.exports = [
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.onOff(endpoint);
             await reporting.activePower(endpoint, {min: 10, change: 1});
-        },
-    },
-    {
-        zigbeeModel: ['DM2500ZB'],
-        model: 'DM2500ZB',
-        vendor: 'Sinopé',
-        description: 'Zigbee smart dimmer',
-        extend: extend.light_onoff_brightness({noConfigure: true}),
-        exposes: [e.light_brightness(), e.effect(), exposes.numeric('led_intensity_on', ea.SET).withValueMin(0).withValueMax(100)
-            .withDescription('Control status LED when load ON'), exposes.numeric('led_intensity_off', ea.SET).withValueMin(0)
-            .withValueMax(100).withDescription('Control status LED when load OFF'), exposes.numeric('minimum_brightness', ea.SET)
-            .withValueMin(0).withValueMax(3000).withDescription('Control minimum dimmer brightness')],
-        toZigbee: [tz.light_onoff_brightness, tz.effect, tz.sinope_led_intensity_on, tz.sinope_led_intensity_off,
-            tz.sinope_minimum_brightness],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(endpoint);
-            await reporting.brightness(endpoint);
         },
     },
     {

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -240,7 +240,6 @@ module.exports = [
         model: 'SW2500ZB',
         vendor: 'Sinopé',
         description: 'Zigbee smart light switch',
-        extend: extend.switch(),
         exposes: [e.switch(),
             exposes.numeric('led_intensity_on', ea.SET).withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED intensity when load ON'),
@@ -270,7 +269,6 @@ module.exports = [
         model: 'DM2500ZB',
         vendor: 'Sinopé',
         description: 'Zigbee smart dimmer',
-        extend: extend.light_onoff_brightness({noConfigure: true}),
         exposes: [e.light_brightness(),
             exposes.numeric('led_intensity_on', ea.SET).withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED when load ON'),


### PR DESCRIPTION
Expose some more feature from the Sinope switch and dimmer

This is my first work on that code base so don't hesitate to make suggestions if I missed anything.

Also have two questions that I'm not sure if it could be done better.
1. In a device definition, it seems that the extend get overwritten when we define a section (like expose or to/from zigbee) and so I needed to add back what is defined inside the "parent device". Is that the right way?
2. I know the front end is out of scope of this repo, I was trying to get the color widget for both status led, unfortunately the FE directly use the exposed name to show the correct widget and so, both properties would be shown as 'color_xy' which is clearly misleading. Did I miss something to help the FE and also 3rd party automation software to be able to display a color selector based on what currently exist ( I can ask the question in the zigbee2mqtt repo if more appropriate)