### PR TITLE
Add system mode support for TZE200_dv8abrrz thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4098,9 +4098,10 @@ const converters = {
             const dp = dpValue.dp; // First we get the data point ID
             const value = tuya.getDataValue(dpValue);
             const presetLookup = {0: 'auto', 1: 'manual', 2: 'off', 3: 'on'};
+            const systemModeLookup = {0: 'auto', 1: 'auto', 2: 'off', 3: 'heat'};
             switch (dp) {
             case tuya.dataPoints.haozeeSystemMode:
-                return {preset: presetLookup[value]};
+                return {preset: presetLookup[value], system_mode: systemModeLookup[value]};
             case tuya.dataPoints.haozeeHeatingSetpoint:
                 return {current_heating_setpoint: (value / 10).toFixed(1)};
             case tuya.dataPoints.haozeeLocalTemp:

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3514,10 +3514,21 @@ const converters = {
             return tuya.sendDataPointRaw(entity, tuya.dataPoints.moesSschedule, payload);
         },
     },
-    haozee_thermostat_system_mode: {
+    haozee_thermostat_preset: {
         key: ['preset'],
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'auto': 0, 'manual': 1, 'off': 2, 'on': 3};
+            await tuya.sendDataPointEnum(entity, tuya.dataPoints.haozeeSystemMode, lookup[value]);
+        },
+    },
+    haozee_thermostat_system_mode: {
+        key: ['system_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            // mapping 'heat' system mode to 100% heating (same as preset 'ON'),
+            // mapping 'auto' system mode to heating up to the set point temperature (same as preset 'MANUAL')
+            // mapping 'off' system mode to idle (same as preset 'OFF')
+            // programmed schedule can be enabled by using preset mode 'AUTO' instead of 'MANUAL'
+            const lookup = {'auto': 1, 'off': 2, 'heat': 3};
             await tuya.sendDataPointEnum(entity, tuya.dataPoints.haozeeSystemMode, lookup[value]);
         },
     },

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2258,7 +2258,7 @@ module.exports = [
             tz.haozee_thermostat_system_mode, tz.haozee_thermostat_current_heating_setpoint, tz.haozee_thermostat_boost_heating,
             tz.haozee_thermostat_boost_heating_countdown, tz.haozee_thermostat_window_detection,
             tz.haozee_thermostat_child_lock, tz.haozee_thermostat_temperature_calibration, tz.haozee_thermostat_max_temperature,
-            tz.haozee_thermostat_min_temperature,
+            tz.haozee_thermostat_min_temperature, tz.haozee_thermostat_preset
         ],
         exposes: [
             e.battery(), e.child_lock(), e.max_temperature(), e.min_temperature(),
@@ -2272,7 +2272,8 @@ module.exports = [
                     'When the set temperature is lower than the "minimum temperature", the valve is closed (forced closed). ' +
                     'AUTO MODE ⏱ - In this mode, the device executes a preset week programming temperature time and temperature. ' +
                     'ON - In this mode, the thermostat stays open ' +
-                    'OFF - In this mode, the thermostat stays closed'),
+                    'OFF - In this mode, the thermostat stays closed')
+                .withSystemMode(['auto', 'heat', 'off'], ea.STATE_SET),
             exposes.composite('programming_mode').withDescription('Auto MODE ⏱ - In this mode, ' +
                     'the device executes a preset week programming temperature time and temperature. ')
                 .withFeature(exposes.text('monday_schedule', ea.STATE))

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2258,7 +2258,7 @@ module.exports = [
             tz.haozee_thermostat_system_mode, tz.haozee_thermostat_current_heating_setpoint, tz.haozee_thermostat_boost_heating,
             tz.haozee_thermostat_boost_heating_countdown, tz.haozee_thermostat_window_detection,
             tz.haozee_thermostat_child_lock, tz.haozee_thermostat_temperature_calibration, tz.haozee_thermostat_max_temperature,
-            tz.haozee_thermostat_min_temperature, tz.haozee_thermostat_preset
+            tz.haozee_thermostat_min_temperature, tz.haozee_thermostat_preset,
         ],
         exposes: [
             e.battery(), e.child_lock(), e.max_temperature(), e.min_temperature(),


### PR DESCRIPTION
So far, TZE200_dv8abrrz (haozee_thermostat)  has no support for setting the HVAC / system mode from HA, since the device's mode has been mapped to the preset entity, not to the system mode entity. 
This causes inability to use the standard HA Thermostat card:
- z2m does not report available modes, so the entity displays buttons for all possible modes (off, auto, heat, COOL, DRY, FAN ONLY)
- pressing any of these buttons does not cause any effect, neither calling climate.set_hvac_mode service
The only way to operate this entity is to select preset mode.

This small change maps three system modes to device modes:
- 'off' mode mapped to device's 'off' mode
- 'heat' mode mapped to device's 'on' mode (which causes 100% opening of the valve and full heating)
- 'auto' mode mapped to device's 'manual' mode (which allows to select the  desired temperature and heating is started/stopped automatically)
I've decided not to map 'auto' system mode to 'auto' preset, since it enables the built-in schedule, which is NOT supported (yet?) to be setup from z2m. I guess, this preset mode should be called 'schedule' instead of 'auto', but I've not changed the name due to backward compatibility.

As a result, system mode and preset are a bit overlapping, but I guess it's necessary, since there is no way to distinguish between auto mode with manual temperature set point and built-in scheduler.