### PR TITLE
Added generic batteryVoltageToPercentage converter

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -142,6 +142,7 @@ function getKey(object, value, fallback, convertTo) {
 
 function batteryVoltageToPercentage(voltage, option) {
     let percentage = null;
+    const optionSplit = option.split("_",);
     if (option === '3V_2100') {
         if (voltage < 2100) {
             percentage = 0;
@@ -179,6 +180,29 @@ function batteryVoltageToPercentage(voltage, option) {
     } else if (option === 'Add_1V_42V_CSM300z2v2') {
         voltage = voltage + 1000;
         percentage = toPercentage(voltage, 2900, 4100);
+    } else if (optionSplit[0] === 'GENERIC') {
+        if (optionSplit[1] && optionSplit[2]) {
+            let thresholdMin;
+            let thresholdMax;
+
+            try {
+                thresholdMin = parseInt(optionSplit[1]);
+            } catch {
+                throw new Error(`batteryVoltageToPercentage invalid minimum threshold value supplied: ${optionSplit[1]}`);
+            }
+
+            try {
+                thresholdMax = parseInt(optionSplit[2]);
+            } catch {
+                throw new Error(`batteryVoltageToPercentage invalid maximum threshold value supplied: ${optionSplit[2]}`);
+            }
+
+            if ((thresholdMin && thresholdMax) && (thresholdMin < thresholdMax)) {
+                percentage = toPercentage(voltage, thresholdMin, thresholdMax); 
+            }
+        } else {
+            throw new Error(`batteryVoltageToPercentage generic used without min or max threshold: ${option}`);
+        }
     } else {
         throw new Error(`Not batteryVoltageToPercentage type supported: ${option}`);
     }


### PR DESCRIPTION
It would be useful to have a 'generic' `voltageToPercentage` converter in utils to be able to handle device oddities without cluttering up the list with edge cases