### PR TITLE
Support new lonsonho light bulb

### DIFF
--- a/devices/lonsonho.js
+++ b/devices/lonsonho.js
@@ -208,7 +208,8 @@ module.exports = [
     {
         zigbeeModel: ['ZB-RGBCW'],
         fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'},
-            {modelID: 'ZB-CL02', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLi\u0001\u0000\u0010'}],
+            {modelID: 'ZB-CL02', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLi\u0001\u0000\u0010'},
+             {modelID: 'Z102LG03-1', manufacturerName: 'eWeLink'}],
         model: 'ZB-RGBCW',
         vendor: 'Lonsonho',
         description: 'Zigbee 3.0 LED-bulb, RGBW LED',

--- a/devices/lonsonho.js
+++ b/devices/lonsonho.js
@@ -209,7 +209,7 @@ module.exports = [
         zigbeeModel: ['ZB-RGBCW'],
         fingerprint: [{modelID: 'ZB-CL01', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLink'},
             {modelID: 'ZB-CL02', manufacturerName: 'eWeLight'}, {modelID: 'ZB-CL01', manufacturerName: 'eWeLi\u0001\u0000\u0010'},
-             {modelID: 'Z102LG03-1', manufacturerName: 'eWeLink'}],
+            {modelID: 'Z102LG03-1', manufacturerName: 'eWeLink'}],
         model: 'ZB-RGBCW',
         vendor: 'Lonsonho',
         description: 'Zigbee 3.0 LED-bulb, RGBW LED',


### PR DESCRIPTION
Hello, 
Recently I have bought additional light bulb from the same seller that sold me a Lonsonho light bulb.  The new bulb was not recognised while the seller claimed it is the same model as previously sold to me.  I figured out that new bulbs may have different fingerprint. Thus I am adding it here, I confirm that it works. 

zigbee2mqtt conf panel showing entity:
<img width="990" alt="image" src="https://user-images.githubusercontent.com/63973370/199255483-40c7cf1f-7d3b-4e8e-aabd-de53b4b43cc8.png">

