### PR TITLE
add support for Philips zigbeeModel 929003045801

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2881,6 +2881,6 @@ module.exports = [
         model: '929003045801',
         vendor: 'Philips',
         description: 'Runner Single spot (white)',
-        extend: extend.light_onoff_brightness_colortemp(),
+        extend: hueExtend.light_onoff_brightness_colortemp(),
     }
 ];

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2876,4 +2876,11 @@ module.exports = [
         description: 'Hue white ambiance Garnea downlight',
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
+    {
+        zigbeeModel: ['929003045801'],
+        model: '929003045801',
+        vendor: 'Philips',
+        description: 'Runner Single spot (white)',
+        extend: extend.light_onoff_brightness_colortemp(),
+    }
 ];


### PR DESCRIPTION
This will add support for the Philips Runner Single Spot (white).

https://www.philips-hue.com/en-gb/p/hue-white-ambiance-runner-single-spotlight/8719514338203

Warning from the zigbee2mqtt log:

> Warning 2022-11-01 20:32:50Device 'Flur Wand' with Zigbee model '929003045801' and manufacturer name 'Philips' is NOT supported, please follow https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html

**Here from Hue bridge before**
<img width="364" alt="image" src="https://user-images.githubusercontent.com/155578/199331234-c9a4a08b-62fe-4e83-af6c-ec99ae499d25.png">


**Now in zigbee2mqtt**🥳
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/155578/199330988-0ead682b-7e08-4a20-b0f4-75382405d2e7.png">
