### PR TITLE
Update moes.js

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -125,7 +125,7 @@ module.exports = [
             tz.moes_thermostat_deadzone_temperature, tz.moes_thermostat_max_temperature_limit, tz.moes_thermostat_min_temperature_limit,
             tz.moes_thermostat_program_schedule],
         exposes: [e.child_lock(), e.deadzone_temperature(), e.max_temperature_limit(), e.min_temperature_limit(),
-            exposes.climate().withSetpoint('current_heating_setpoint', 5, 30, 1, ea.STATE_SET)
+            exposes.climate().withSetpoint('current_heating_setpoint', 5, 35, 1, ea.STATE_SET)
                 .withLocalTemperature(ea.STATE).withLocalTemperatureCalibration(-30, 30, 0.1, ea.STATE_SET)
                 .withSystemMode(['off', 'heat'], ea.STATE_SET).withRunningState(['idle', 'heat', 'cool'], ea.STATE)
                 .withPreset(['hold', 'program']),


### PR DESCRIPTION
35 degrees - according to the standard settings of the device. The device supports this. Please update in the configuration.

35 градусов - согласно стандартных настроек устройства. Устройство это поддерживает