### PR TITLE
Add support for Philips Hue 9290031452 (LTE005)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2876,4 +2876,11 @@ module.exports = [
         description: 'Hue white ambiance Garnea downlight',
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
+    {
+        zigbeeModel: ['LTE005'],
+        model: '9290031452',
+        vendor: 'Philips',
+        description: 'Hue white ambiance filament E14 (with Bluetooth)',
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
+    },
 ];


### PR DESCRIPTION
This will add support for Philips Hue White Ambiance Filament E14 (9290031452): https://www.philips-hue.com/en-gb/p/hue-white-ambiance-filament-single-bulb-e14/8719514411807

This is a filament version of 9290022944, or the white balance version of 9290024795.