### PR TITLE
Update bitron.js

### DIFF
--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -189,7 +189,7 @@ module.exports = [
         model: 'AV2010/32',
         vendor: 'SMaBiT (Bitron Video)',
         description: 'Wireless wall thermostat with relay',
-        fromZigbee: [fz.legacy.bitron_thermostat_att_report, fz.battery, fz.hvac_user_interface],
+        fromZigbee: [fz.legacy.thermostat_att_report, fz.battery, fz.hvac_user_interface],
         toZigbee: [tz.thermostat_control_sequence_of_operation, tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_occupied_cooling_setpoint, tz.thermostat_local_temperature_calibration, tz.thermostat_local_temperature,
             tz.thermostat_running_state, tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode],


### PR DESCRIPTION
By this modification, the bitron /32 thermostat is able to control the cooling and heating features. With the actual version, it is enabled just in heating mode.