### PR TITLE
Add support for Dresden Elektronik FLS-A lp

### DIFF
--- a/devices/dresden_elektronik.js
+++ b/devices/dresden_elektronik.js
@@ -1,6 +1,7 @@
 const exposes = require('../lib/exposes');
 const ota = require('../lib/ota');
 const extend = require('../lib/extend');
+const reporting = require('../lib/reporting');
 const e = exposes.presets;
 
 module.exports = [
@@ -30,5 +31,32 @@ module.exports = [
         description: 'Zigbee 3.0 dimm actuator',
         extend: extend.light_onoff_brightness(),
         ota: ota.zigbeeOTA,
+    },
+    {
+        zigbeeModel: ['FLS-A lp (1-10V)'],
+        model: 'BN-600078',
+        vendor: 'Dresden Elektronik',
+        description: 'Zigbee controller for 1-10V/PWM',
+        extend: extend.light_onoff_brightness({noConfigure: true}),
+        exposes: [e.light_brightness().withEndpoint('l1'), e.light_brightness().withEndpoint('l2'),
+            e.light_brightness().withEndpoint('l3'), e.light_brightness().withEndpoint('l4')],
+        endpoint: (device) => {
+            return {'l1': 11, 'l2': 12, 'l3': 13, 'l4': 14};
+        },
+        meta: {multiEndpoint: true, disableDefaultResponse: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(11), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
+            await reporting.bind(device.getEndpoint(12), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
+            await reporting.bind(device.getEndpoint(13), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
+            await reporting.bind(device.getEndpoint(14), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
+            await reporting.onOff(device.getEndpoint(11));
+            await reporting.brightness(device.getEndpoint(11));
+            await reporting.onOff(device.getEndpoint(12));
+            await reporting.brightness(device.getEndpoint(12));
+            await reporting.onOff(device.getEndpoint(13));
+            await reporting.brightness(device.getEndpoint(13));
+            await reporting.onOff(device.getEndpoint(14));
+            await reporting.brightness(device.getEndpoint(14));
+        },
     },
 ];

--- a/devices/dresden_elektronik.js
+++ b/devices/dresden_elektronik.js
@@ -1,7 +1,6 @@
 const exposes = require('../lib/exposes');
 const ota = require('../lib/ota');
 const extend = require('../lib/extend');
-const reporting = require('../lib/reporting');
 const e = exposes.presets;
 
 module.exports = [
@@ -37,26 +36,12 @@ module.exports = [
         model: 'BN-600078',
         vendor: 'Dresden Elektronik',
         description: 'Zigbee controller for 1-10V/PWM',
-        extend: extend.light_onoff_brightness({noConfigure: true}),
+        extend: extend.light_onoff_brightness(),
         exposes: [e.light_brightness().withEndpoint('l1'), e.light_brightness().withEndpoint('l2'),
             e.light_brightness().withEndpoint('l3'), e.light_brightness().withEndpoint('l4')],
         endpoint: (device) => {
             return {'l1': 11, 'l2': 12, 'l3': 13, 'l4': 14};
         },
         meta: {multiEndpoint: true, disableDefaultResponse: true},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await reporting.bind(device.getEndpoint(11), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
-            await reporting.bind(device.getEndpoint(12), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
-            await reporting.bind(device.getEndpoint(13), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
-            await reporting.bind(device.getEndpoint(14), coordinatorEndpoint, ['genLevelCtrl', 'genOnOff']);
-            await reporting.onOff(device.getEndpoint(11));
-            await reporting.brightness(device.getEndpoint(11));
-            await reporting.onOff(device.getEndpoint(12));
-            await reporting.brightness(device.getEndpoint(12));
-            await reporting.onOff(device.getEndpoint(13));
-            await reporting.brightness(device.getEndpoint(13));
-            await reporting.onOff(device.getEndpoint(14));
-            await reporting.brightness(device.getEndpoint(14));
-        },
     },
 ];


### PR DESCRIPTION
The device identifies as "FLS-A2" over Zigbee, but FLS-A lp is the documented name by the vendor.

https://github.com/Koenkk/zigbee2mqtt/issues/14225