### PR TITLE
Add support for Müller Licht 45727 Amela 42cm

### DIFF
--- a/devices/müller_licht.js
+++ b/devices/müller_licht.js
@@ -192,4 +192,12 @@ module.exports = [
         description: 'Tint Armaro',
         extend: extend.light_onoff_brightness_colortemp(),
     },
+    {
+        zigbeeModel: ['Bulb white'],
+        model: '45727',
+        vendor: 'Müller Licht',
+        description: 'Tint Amela 42cm, white+ambiance (1800-6500K)',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 555]}),
+        toZigbee: extend.light_onoff_brightness_colortemp().toZigbee.concat([tz.tint_scene]),
+    },
 ];

--- a/devices/müller_licht.js
+++ b/devices/müller_licht.js
@@ -193,7 +193,7 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp(),
     },
     {
-        zigbeeModel: ['Bulb white'],
+        fingerprint: [{manufacturerName: 'MLI', modelID: 'Bulb white'}],
         model: '45727',
         vendor: 'Müller Licht',
         description: 'Tint Amela 42cm, white+ambiance (1800-6500K)',


### PR DESCRIPTION
This adds support für the ceiling lamp "Amela" made by "Müller Licht". The manufacturers model number is 45727.