### PR TITLE
ikea: restore level_config.on_level

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -45,6 +45,18 @@ const bulbOnEvent = async (type, data, device, options, state) => {
         if (state !== undefined && state.level_config !== undefined && state.level_config.execute_if_off === true) {
             device.endpoints[0].write('genLevelCtrl', {'options': 1});
         }
+        if (state !== undefined && state.level_config !== undefined && state.level_config.on_level !== undefined) {
+            let onLevel = state.level_config.on_level;
+            if (typeof onLevel === 'string' && onLevel.toLowerCase() == 'previous') {
+                onLevel = 255;
+            } else {
+                onLevel = Number(onLevel);
+            }
+            if (onLevel > 255) onLevel = 254;
+            if (onLevel < 1) onLevel = 1;
+
+            device.endpoints[0].write('genLevelCtrl', {onLevel});
+        }
     }
 };
 


### PR DESCRIPTION
Ikea bulbs tend to forget a lot of there settings when they are powered off, also restore level_config.on_level.

Tested by @Wireheadbe https://github.com/Koenkk/zigbee2mqtt/discussions/14779#discussioncomment-4063188