### PR TITLE
Add support for LTB003

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2890,4 +2890,11 @@ module.exports = [
         description: 'Hue white ambiance filament E14 (with Bluetooth)',
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [222, 454]}),
     },
+    {
+        zigbeeModel: ['LTB003'],
+        model: '046677578138',
+        vendor: 'Philips',
+        description: 'Hue White ambiance BR30 E26',
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+    }   
 ];

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -2896,5 +2896,5 @@ module.exports = [
         vendor: 'Philips',
         description: 'Hue White ambiance BR30 E26',
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
-    }   
+    },
 ];


### PR DESCRIPTION
Link to product: https://www.philips-hue.com/en-us/p/hue-white-ambiance-2-pack-br30-e26/046677578138

database.db entry for the LTB003
```json
{
  "id": 18,
  "type": "Router",
  "ieeeAddr": "0x001788010d00848a",
  "nwkAddr": 60369,
  "manufId": 4107,
  "manufName": "Signify Netherlands B.V.",
  "powerSource": "Mains (single phase)",
  "modelId": "LTB003",
  "epList": [
    11,
    242
  ],
  "endpoints": {
    "11": {
      "profId": 260,
      "epId": 11,
      "devId": 268,
      "inClusterList": [
        0,
        3,
        4,
        5,
        6,
        8,
        4096,
        64515,
        768
      ],
      "outClusterList": [
        25
      ],
      "clusters": {
        "genBasic": {
          "attributes": {
            "modelId": "LTB003",
            "manufacturerName": "Signify Netherlands B.V.",
            "powerSource": 1,
            "zclVersion": 2,
            "appVersion": 2,
            "stackVersion": 1,
            "hwVersion": 1,
            "dateCode": "20220215",
            "swBuildId": "1.93.10"
          }
        },
        "lightingColorCtrl": {
          "attributes": {
            "colorCapabilities": 16,
            "colorTempPhysicalMin": 153,
            "colorTempPhysicalMax": 454
          }
        }
      },
      "binds": [],
      "configuredReportings": [],
      "meta": {}
    },
    "242": {
      "profId": 41440,
      "epId": 242,
      "devId": 97,
      "inClusterList": [],
      "outClusterList": [
        33
      ],
      "clusters": {},
      "binds": [],
      "configuredReportings": [],
      "meta": {}
    }
  },
  "appVersion": 2,
  "stackVersion": 1,
  "hwVersion": 1,
  "dateCode": "20220215",
  "swBuildId": "1.93.10",
  "zclVersion": 2,
  "interviewCompleted": true,
  "meta": {
    "configured": 88764544
  },
  "lastSeen": 1667697698675,
  "defaultSendRequestWhen": "immediate"
}
```
