### PR TITLE
improve BRT-100-TRV system_mode compatibility with Home Assistant

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -3420,6 +3420,12 @@ const converters = {
             return tuya.sendDataPointRaw(entity, tuya.dataPoints.moesSchedule, payload);
         },
     },
+    moesS_thermostat_system_mode: {
+        key: ['system_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            return {state: {system_mode: 'heat'}};
+        },
+    },
     moesS_thermostat_preset: {
         key: ['preset'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -299,7 +299,8 @@ module.exports = [
             tz.moesS_thermostat_boost_heating, tz.moesS_thermostat_boostHeatingCountdownTimeSet,
             tz.moesS_thermostat_eco_temperature, tz.moesS_thermostat_max_temperature,
             tz.moesS_thermostat_min_temperature, tz.moesS_thermostat_moesSecoMode,
-            tz.moesS_thermostat_preset, tz.moesS_thermostat_schedule_programming],
+            tz.moesS_thermostat_preset, tz.moesS_thermostat_schedule_programming,
+            tz.moesS_thermostat_system_mode],
         exposes: [
             e.battery(), e.child_lock(), e.eco_mode(),
             e.eco_temperature().withValueMin(5), e.max_temperature().withValueMax(45), e.min_temperature().withValueMin(5),
@@ -308,7 +309,7 @@ module.exports = [
             exposes.climate()
                 .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 35, 1, ea.STATE_SET)
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
-                .withSystemMode(['heat'], ea.STATE)
+                .withSystemMode(['heat'], ea.STATE_SET)
                 .withRunningState(['idle', 'heat'], ea.STATE)
                 .withPreset(['programming', 'manual', 'temporary_manual', 'holiday'],
                     'MANUAL MODE ☝ - In this mode, the device executes manual temperature setting. '+


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/14771 by implementing a fake system_mode converter that only changes the internal Z2M state. This seems to satisfy Home Assistant as it can now set the mode to 'heat', and then never change it again as it's the only possible value.