### PR TITLE
Added: BTF-LIGHTING Zigbee 3.0 CCT LED Controller

### DIFF
--- a/devices/miboxer.js
+++ b/devices/miboxer.js
@@ -50,8 +50,11 @@ module.exports = [
         onEvent: tuya.onEventSetTime,
     },
     {
-        fingerprint: [{modelID: 'TS0502B', manufacturerName: '_TZ3210_frm6149r'},
-            {modelID: 'TS0502B', manufacturerName: '_TZ3210_jtifm80b'}],
+        fingerprint: [
+            {modelID: 'TS0502B', manufacturerName: '_TZ3210_frm6149r'},
+            {modelID: 'TS0502B', manufacturerName: '_TZ3210_jtifm80b'},
+            {modelID: 'TS0502B', manufacturerName: '_TZ3210_xwqng7ol'},
+        ],
         model: 'FUT035Z',
         description: 'Dual white LED controller',
         vendor: 'Miboxer',


### PR DESCRIPTION
`manufacturerName` found in [this product listing](https://www.amazon.com/dp/B0B2J2NVZB?psc=1&ref=ppx_yo2ov_dt_b_product_details) on Amazon.

Tested with BTF-LIGHTING FCOB CCT 10mm LED Strip and default power supply.