### PR TITLE
re-compute local temperature when calibration of BRT-100-TRV has changed

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4086,7 +4086,12 @@ const converters = {
             case tuya.dataPoints.moesSvalvePosition:
                 return {position: value};
             case tuya.dataPoints.moesScompensationTempSet:
-                return {local_temperature_calibration: value};
+                return {
+                    local_temperature_calibration: value,
+                    ...(meta && meta.state && meta.state.local_temperature != null && meta.state.local_temperature_calibration != null) ?
+                        {local_temperature: meta.state.local_temperature + (value - meta.state.local_temperature_calibration)} :
+                        {},
+                };
             case tuya.dataPoints.moesSecoMode:
                 return {eco_mode: value ? 'ON' : 'OFF'};
             case tuya.dataPoints.moesSecoModeTempSet:

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4088,6 +4088,8 @@ const converters = {
             case tuya.dataPoints.moesScompensationTempSet:
                 return {
                     local_temperature_calibration: value,
+                    // local_temperature is now stale: the valve does not report the re-calibrated value until an actual temperature change
+                    // so update local_temperature by subtracting the old calibration and adding the new one
                     ...(meta && meta.state && meta.state.local_temperature != null && meta.state.local_temperature_calibration != null) ?
                         {local_temperature: meta.state.local_temperature + (value - meta.state.local_temperature_calibration)} :
                         {},


### PR DESCRIPTION
My best attempt at fixing https://github.com/Koenkk/zigbee2mqtt/issues/14179

In short: the BRT-100-TRV does *not* report the local temperature when one changes the calibration value, so the converter has to do the computation locally.

There is a danger: if the Z2M state gets out of sync with the valve for any reason, then changing the calibration may return wrong values. I can't predict exactly how, because I am not familiar with how the values are updated on e.g. reconnection, and in which order.

However, since with the current converter the value is wrong *every* time one changes the calibration, this patch should still be an improvement.