### PR TITLE
Add Samotech SM308-S

### DIFF
--- a/devices/samotech.js
+++ b/devices/samotech.js
@@ -14,6 +14,17 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['SM308-S'],
+        model: 'SM308-S',
+        vendor: 'Samotech',
+        description: 'Zigbee in wall smart switch',
+        extend: extend.switch(),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff']);
+        },
+    },
+    {
         zigbeeModel: ['SM309-S'],
         model: 'SM309-S',
         vendor: 'Samotech',


### PR DESCRIPTION
Adds basic support for [Samotech's SM308-S](https://www.samotech.co.uk/products/zigbee-switch-sm308-s/).

PR for zigbee2mqtt.io docs: Koenkk/zigbee2mqtt.io/pull/1686