### PR TITLE
Fix GiEX QT06 water valve units

### DIFF
--- a/devices/giex.js
+++ b/devices/giex.js
@@ -118,18 +118,18 @@ module.exports = [
             e.battery(),
             exposes.binary('state', ea.STATE_SET, 'ON', 'OFF').withDescription('State'),
             exposes.enum('mode', ea.STATE_SET, ['duration', 'capacity']).withDescription('Irrigation mode'),
-            exposes.numeric('irrigation_target', exposes.access.STATE_SET).withValueMin(0).withValueMax(1440).withUnit('minutes or Litres')
-                .withDescription('Irrigation Target, duration in minutes or capacity in Litres (depending on mode)'),
-            exposes.numeric('cycle_irrigation_num_times', exposes.access.STATE_SET).withValueMin(0).withValueMax(100).withUnit('#')
+            exposes.numeric('irrigation_target', exposes.access.STATE_SET).withValueMin(0).withValueMax(3600).withUnit('seconds or litres')
+                .withDescription('Irrigation target, duration in seconds or capacity in litres (depending on mode)'),
+            exposes.numeric('cycle_irrigation_num_times', exposes.access.STATE_SET).withValueMin(0).withValueMax(100)
                 .withDescription('Number of cycle irrigation times, set to 0 for single cycle'),
-            exposes.numeric('cycle_irrigation_interval', exposes.access.STATE_SET).withValueMin(0).withValueMax(1440).withUnit('min')
+            exposes.numeric('cycle_irrigation_interval', exposes.access.STATE_SET).withValueMin(0).withValueMax(3600).withUnit('sec')
                 .withDescription('Cycle irrigation interval'),
-            exposes.numeric('irrigation_start_time', ea.STATE).withUnit('GMT+8').withDescription('Irrigation start time'),
-            exposes.numeric('irrigation_end_time', ea.STATE).withUnit('GMT+8').withDescription('Irrigation end time'),
-            exposes.numeric('last_irrigation_duration', exposes.access.STATE).withUnit('min')
+            exposes.numeric('irrigation_start_time', ea.STATE).withDescription('Last irrigation start time (GMT)'),
+            exposes.numeric('irrigation_end_time', ea.STATE).withDescription('Last irrigation end time (GMT)'),
+            exposes.numeric('last_irrigation_duration', exposes.access.STATE)
                 .withDescription('Last irrigation duration'),
             exposes.numeric('water_consumed', exposes.access.STATE).withUnit('L')
-                .withDescription('Water consumed (Litres)'),
+                .withDescription('Last irrigation water consumption'),
         ],
     },
 ];


### PR DESCRIPTION
I made some fixes and improvements to the GiEX QT06 water valve:
- Replaced minutes with seconds. I realized that this device measures in seconds as soon as I set 2 irrigation cycles of 1 minute each with 1 minute interval and it just went crazy with instant on and offs. I set 60 "minutes" instead and it behaved as expected.
- Adjusted the max values to `3600` (seconds in an hour) because the existing `1440` (minutes in a day) didn't make sense anymore and setting `86400` (seconds in a day) just sounded ridiculous to me.
- Spelled `litres` instead of `Litres` as uppercase is just for the abbreviation (L).
- Removed some unnecessary units, especially the incorrect `GMT+8` for times as the device uses GMT (Zulu time).
- Improved some descriptions, especially those referring to last irrigation info.