### PR TITLE
 Add _TZE200_bvu2wnxz to SEA801-Zigbee/SEA802-Zigbee

### DIFF
--- a/devices/saswell.js
+++ b/devices/saswell.js
@@ -21,6 +21,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_zr9c0day'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_0dvm9mva'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_h4cgnbzg'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_bvu2wnxz'},
         ],
         model: 'SEA801-Zigbee/SEA802-Zigbee',
         vendor: 'Saswell',


### PR DESCRIPTION
Adding another manufacturerName for this device. Mine came whitelabeled as "ME167", but it's the exact same as others listed.