### PR TITLE
Update villeroy_boch.js

### DIFF
--- a/devices/villeroy_boch.js
+++ b/devices/villeroy_boch.js
@@ -2,7 +2,7 @@ const extend = require('../lib/extend');
 
 module.exports = [
     {
-        zigbeeModel: ['5991711'],
+        zigbeeModel: ['5991711', '5991713'],
         model: 'C5850000',
         vendor: 'Villeroy & Boch',
         description: 'Subway 3.0 Zigbee home automation kit',


### PR DESCRIPTION
Hi,

I got a new version of the sink light controller. Can you please add the new model ID? I tested the new ID on my HA instance and everything is working as it should.

Zigbee model number: 5991713

![image](https://user-images.githubusercontent.com/49448463/201491901-38c761e2-cd3c-452a-b286-b2d87275b44d.png)
![index](https://user-images.githubusercontent.com/49448463/201491908-f78d7659-b1e2-4573-9f72-d8e1b6e87d00.jpg)
