### PR TITLE
Added support for "auto" modes of Legrand (412171)

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4752,6 +4752,22 @@ const converters = {
             await entity.read('manuSpecificLegrandDevices2', [0x0000], manufacturerOptions.legrand);
         },
     },
+    legrand_autoMode: {
+        key: ['auto_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            const mode = {
+                'off': 0x00,
+                'auto': 0x02,
+                'on_override': 0x03
+            };
+            const payload = {data: Buffer.from([mode[value]])};
+            await entity.command('manuSpecificLegrandDevices3', 'command0', payload);
+            return {state: {'auto_mode': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificLegrandDevices3', [0x0000], manufacturerOptions.legrand);
+        },
+    },
     legrand_powerAlarm: {
         key: ['power_alarm'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -27,7 +27,9 @@ module.exports = [
         toZigbee: [tz.legrand_deviceMode, tz.on_off, tz.legrand_identify, tz.electrical_measurement_power],
         exposes: [exposes.switch().withState('state', true, 'On/off (works only if device is in "switch" mode)'),
             e.power().withAccess(ea.STATE_GET), exposes.enum('device_mode', ea.ALL, ['switch', 'auto'])
-                .withDescription('switch: allow on/off, auto will use wired action via C1/C2 on contactor for example with HC/HP')],
+                .withDescription('switch: allow manual on/off, auto uses contact\'s C1/C2 wired actions for Peak/Off-Peak electricity rates'),
+                exposes.enum('auto_mode', ea.ALL, ['off', 'auto', 'on_override'])
+                .withDescription('Off/auto/on (override) (works only if device is set to "auto" mode)')],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'haElectricalMeasurement']);


### PR DESCRIPTION
Added new cluster definition to fully support device: Legrand (412171) - DIN contactor module ( Bticino FC80CC), referenced here [14812](https://github.com/Koenkk/zigbee2mqtt/issues/14812)