### PR TITLE
Fix electrical measurements for ROB_200-026-0

### DIFF
--- a/devices/robb.js
+++ b/devices/robb.js
@@ -277,15 +277,16 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint1 = device.getEndpoint(1);
             const endpoint2 = device.getEndpoint(2);
+            const endpoint11 = device.getEndpoint(11);
             await reporting.bind(endpoint1, coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint1);
             await reporting.onOff(endpoint2);
-            await endpoint1.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
-            await reporting.bind(endpoint1, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
-            await reporting.activePower(endpoint1);
-            await reporting.readMeteringMultiplierDivisor(endpoint1);
-            await reporting.currentSummDelivered(endpoint1, {min: 60, change: 1});
+            await endpoint11.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
+            await reporting.bind(endpoint11, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
+            await reporting.activePower(endpoint11);
+            await reporting.readMeteringMultiplierDivisor(endpoint11);
+            await reporting.currentSummDelivered(endpoint11, {min: 60, change: 1});
         },
     },
     {


### PR DESCRIPTION
I'm not totally confident if I'm not missing something here. What is the `l1`: `1` mapping for? Should I have added one for endpoint 11? It does seem to work fine though:
![image](https://user-images.githubusercontent.com/22001007/201777190-3fde1f07-9f50-4f42-a814-04b89dff9507.png)
