### PR TITLE
Fix Typo in latest Tradfri bulb TRADFRIbulbPAR38WS900lm

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -1000,7 +1000,7 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
-        zigbeeModel: ['TTRADFRIbulbPAR38WS900lm'],
+        zigbeeModel: ['TRADFRIbulbPAR38WS900lm'],
         model: 'LED2006R9',
         vendor: 'IKEA',
         description: 'TRADFRI E26 PAR38 LED bulb 900 lumen, dimmable, white spectrum, downlight',


### PR DESCRIPTION
Fixed Typo in TRADFRIbulbPAR38WS900lm - removed extra T