### PR TITLE
Fixed Tradfri Par38 Typo

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -1000,7 +1000,7 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
-        zigbeeModel: ['TTRADFRIbulbPAR38WS900lm'],
+        zigbeeModel: ['TRADFRIbulbPAR38WS900lm'],
         model: 'LED2006R9',
         vendor: 'IKEA',
         description: 'TRADFRI E26 PAR38 LED bulb 900 lumen, dimmable, white spectrum, downlight',

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -999,4 +999,11 @@ module.exports = [
         description: 'STOFTMOLN ceiling/wall lamp 24 warm light dimmable',
         extend: tradfriExtend.light_onoff_brightness(),
     },
+    {
+        zigbeeModel: ['TTRADFRIbulbPAR38WS900lm'],
+        model: 'TRADFRIbulbPAR38WS900lm',
+        vendor: 'IKEA',
+        description: 'TRADFRI E26 PAR38 LED bulb 900 lumen, dimmable, white spectrum, downlight',
+        extend: tradfriExtend.light_onoff_brightness_colortemp(),
+    },
 ];

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -1001,7 +1001,7 @@ module.exports = [
     },
     {
         zigbeeModel: ['TTRADFRIbulbPAR38WS900lm'],
-        model: 'TRADFRIbulbPAR38WS900lm',
+        model: 'LED2006R9',
         vendor: 'IKEA',
         description: 'TRADFRI E26 PAR38 LED bulb 900 lumen, dimmable, white spectrum, downlight',
         extend: tradfriExtend.light_onoff_brightness_colortemp(),


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#14969

Comment about an extra 'T' in the zigbee model identifier