### PR TITLE
Adding unoccupied_heating_setpoint setting

### DIFF
--- a/devices/acova.js
+++ b/devices/acova.js
@@ -21,6 +21,7 @@ module.exports = [
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 7, 28, 0.5)
+                .withSetpoint('unoccupied_heating_setpoint', 7, 28, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'auto'])
                 .withRunningState(['idle', 'heat']),
@@ -50,6 +51,7 @@ module.exports = [
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 7, 28, 0.5)
+                .withSetpoint('unoccupied_heating_setpoint', 7, 28, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'auto'])
                 .withRunningState(['idle', 'heat']),
@@ -81,6 +83,7 @@ module.exports = [
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 7, 28, 0.5)
+                .withSetpoint('unoccupied_heating_setpoint', 7, 28, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'auto'])
                 .withRunningState(['idle', 'heat']),


### PR DESCRIPTION
By default in auto mode, the heater drops gradually to the lowest available temperature when unoccupied (7 °C by default, which is freezing). This setting to help controlling the unoccupied temperature target