### PR TITLE
Add support for Philips LWA028 bulb

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -211,7 +211,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
     {
-        zigbeeModel: ['LWA018'],
+        zigbeeModel: ['LWA018', 'LWA028'],
         model: '9290024693',
         vendor: 'Philips',
         description: 'Hue white A60 bulb B22 1055lm with Bluetooth',


### PR DESCRIPTION
This is the 2022 model of the LWA018.

Product link is here: https://www.philips-hue.com/en-au/p/hue-white-ambiance-a60---b22-smart-bulb---1100/8719514393332

The model number is the same as the LWA018.