### PR TITLE
Adjust behaviour of hive receiver commands

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1221,6 +1221,7 @@ const converters = {
                     tempSetpointHoldDuration: 0,
                     systemMode,
                 });
+                break;
             case 'heat':
                 // Send a message that matches what the thermostat remote control sends
                 await entity.write('hvacThermostat', {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1231,15 +1231,8 @@ const converters = {
                     systemMode,
                 });
                 return {readAfterWriteTime: 250, state: {system_mode: value, occupied_heating_setpoint: occupiedHeatingSetpoint / 100}};
-            case 'emergency_heating':
-                await entity.write('hvacThermostat', {
-                    occupiedHeatingSetpoint,
-                    tempSetpointHold: 1,
-                    tempSetpointHoldDuration: 30, // Thermostat defaults to a minimum of 30mins.
-                    systemMode,
-                });
-                return {readAfterWriteTime: 250, state: {system_mode: value, occupied_heating_setpoint: occupiedHeatingSetpoint/100}};
             default:
+                // Default handling for 'emergency_heating', 'auto' system modes.
                 // No special message needed, just send systemMode.
                 await entity.write('hvacThermostat', {systemMode});
                 return {readAfterWriteTime: 250, state: {system_mode: value}};

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1214,34 +1214,34 @@ const converters = {
 
             const occupiedHeatingSetpoint = 2000; // 20.00°C - When selecting manual (heat), the hive always selects this temperature.
             switch (value) {
-                case 'off':
-                    // Send a message that matches what the thermostat remote control sends
-                    await entity.write('hvacThermostat', {
-                        tempSetpointHold: 0,
-                        tempSetpointHoldDuration: 0,
-                        systemMode
-                    });
-                case 'heat':
-                    // Send a message that matches what the thermostat remote control sends
-                    await entity.write('hvacThermostat', {
-                        occupiedHeatingSetpoint,
-                        tempSetpointHold: 1,
-                        tempSetpointHoldDuration: 65535, // The thermostat will set this anyway, saves a message if we do it here (?)
-                        systemMode
-                    });
-                    return { readAfterWriteTime: 250, state: { system_mode: value, occupied_heating_setpoint: occupiedHeatingSetpoint / 100 } };
-                case 'emergency_heating':
-                    await entity.write('hvacThermostat', {
-                        occupiedHeatingSetpoint,
-                        tempSetpointHold: 1,
-                        tempSetpointHoldDuration: 30, // Thermostat defaults to a minimum of 30mins.
-                        systemMode
-                    });
-                    return {readAfterWriteTime: 250, state: {system_mode: value, occupied_heating_setpoint: occupiedHeatingSetpoint/100}}
-                default:
-                    // No special message needed, just send systemMode.
-                    await entity.write('hvacThermostat', { systemMode });
-                    return { readAfterWriteTime: 250, state: { system_mode: value } };
+            case 'off':
+                // Send a message that matches what the thermostat remote control sends
+                await entity.write('hvacThermostat', {
+                    tempSetpointHold: 0,
+                    tempSetpointHoldDuration: 0,
+                    systemMode,
+                });
+            case 'heat':
+                // Send a message that matches what the thermostat remote control sends
+                await entity.write('hvacThermostat', {
+                    occupiedHeatingSetpoint,
+                    tempSetpointHold: 1,
+                    tempSetpointHoldDuration: 65535, // The thermostat will set this anyway, saves a message if we do it here (?)
+                    systemMode,
+                });
+                return {readAfterWriteTime: 250, state: {system_mode: value, occupied_heating_setpoint: occupiedHeatingSetpoint / 100}};
+            case 'emergency_heating':
+                await entity.write('hvacThermostat', {
+                    occupiedHeatingSetpoint,
+                    tempSetpointHold: 1,
+                    tempSetpointHoldDuration: 30, // Thermostat defaults to a minimum of 30mins.
+                    systemMode,
+                });
+                return {readAfterWriteTime: 250, state: {system_mode: value, occupied_heating_setpoint: occupiedHeatingSetpoint/100}};
+            default:
+                // No special message needed, just send systemMode.
+                await entity.write('hvacThermostat', {systemMode});
+                return {readAfterWriteTime: 250, state: {system_mode: value}};
             }
         },
         convertGet: async (entity, key, meta) => {

--- a/devices/hive.js
+++ b/devices/hive.js
@@ -236,7 +236,7 @@ module.exports = [
             tz.thermostat_clear_weekly_schedule, tz.thermostat_temperature_setpoint_hold, tz.thermostat_temperature_setpoint_hold_duration],
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()
-                .withSystemMode(['off', 'auto', 'heat', 'emergency_heating']).withRunningState(['idle', 'heat']),
+                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
                     ' Must be set to `false` when system_mode = off or `true` for heat'),

--- a/devices/hive.js
+++ b/devices/hive.js
@@ -169,7 +169,7 @@ module.exports = [
         vendor: 'Hive',
         description: 'Heating thermostat',
         fromZigbee: [fz.thermostat, fz.thermostat_weekly_schedule],
-        toZigbee: [tz.thermostat_local_temperature, tz.thermostat_system_mode, tz.thermostat_running_state,
+        toZigbee: [tz.thermostat_local_temperature, tz.hive_thermostat_system_mode, tz.thermostat_running_state,
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation, tz.thermostat_weekly_schedule,
             tz.thermostat_clear_weekly_schedule, tz.thermostat_temperature_setpoint_hold, tz.thermostat_temperature_setpoint_hold_duration],
         exposes: [
@@ -231,12 +231,12 @@ module.exports = [
         vendor: 'Hive',
         description: 'Heating thermostat',
         fromZigbee: [fz.thermostat, fz.thermostat_weekly_schedule],
-        toZigbee: [tz.thermostat_local_temperature, tz.thermostat_system_mode, tz.thermostat_running_state,
+        toZigbee: [tz.thermostat_local_temperature, tz.hive_thermostat_system_mode, tz.thermostat_running_state,
             tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation, tz.thermostat_weekly_schedule,
             tz.thermostat_clear_weekly_schedule, tz.thermostat_temperature_setpoint_hold, tz.thermostat_temperature_setpoint_hold_duration],
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 5, 32, 0.5).withLocalTemperature()
-                .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat']),
+                .withSystemMode(['off', 'auto', 'heat', 'emergency_heating']).withRunningState(['idle', 'heat']),
             exposes.binary('temperature_setpoint_hold', ea.ALL, true, false)
                 .withDescription('Prevent changes. `false` = run normally. `true` = prevent from making changes.' +
                     ' Must be set to `false` when system_mode = off or `true` for heat'),

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -394,7 +394,7 @@ class Climate extends Base {
         return this;
     }
 
-    withHiveSystemMode(modes, access = a.ALL, description = "Mode of this device") {
+    withHiveSystemMode(modes, access = a.ALL, description = 'Mode of this device') {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         const allowed = ['off', 'heat', 'auto', 'dry', 'fan_only', 'sleep', 'emergency_heating'];
         modes.forEach((m) => assert(allowed.includes(m)));

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -394,6 +394,14 @@ class Climate extends Base {
         return this;
     }
 
+    withHiveSystemMode(modes, access = a.ALL, description = "Mode of this device") {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        const allowed = ['off', 'heat', 'auto', 'dry', 'fan_only', 'sleep', 'emergency_heating'];
+        modes.forEach((m) => assert(allowed.includes(m)));
+        this.features.push(new Enum('hive_system_mode', access, modes).withDescription(description));
+        return this;
+    }
+
     withRunningState(modes, access=a.STATE_GET) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         const allowed = ['idle', 'heat', 'cool', 'fan_only'];


### PR DESCRIPTION
Hi, at the moment, when selecting `system_mode: heat` for example, only that attribute is sent. This is not enough for the hive receiver to turn on the heating. This PR adjusts the behaviour of `system_mode` calls to mimic the data sent by the hive remote control

When selecting `system_mode: heat` this code sends a default temperature of 20*C. This mimics the actions I have observed being sent by my remote. On my remote (SLT6 / mini), when selecting "manual" mode for heating, it always sends an initial setpoint of 20 degrees.

`system_mode: emergency_heat` Appears to work, although it appears what when this is set, the hive ignores any changes from zigbee2mqtt to `tempSetPointHoldDuration`.

I would love to have your feedback on this. Thank you!

\- James