### PR TITLE
Add decoding of tuya data point 26 from moes BHT-002 thermostat

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4024,6 +4024,8 @@ const converters = {
                 return {child_lock: value ? 'LOCK' : 'UNLOCK'};
             case tuya.dataPoints.moesHeatingSetpoint:
                 return {current_heating_setpoint: value};
+            case tuya.dataPoints.moesMinTempLimit:
+                return {min_temperature_limit: value};
             case tuya.dataPoints.moesMaxTempLimit:
                 return {max_temperature_limit: value};
             case tuya.dataPoints.moesMaxTemp:


### PR DESCRIPTION
This was an omission from the previous PR #4744 meaning that this data point could only be written, but not decoded when sent by the thermostat. Adding the relevant code to `fromZigbee.js` fixes this.

This is in response to https://github.com/Koenkk/zigbee-herdsman-converters/pull/4744#issuecomment-1309552358