### PR TITLE
Add _TZE200_z1tyspqw to TS0601_thermostat_1

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2267,6 +2267,7 @@ module.exports = [
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE200_a4bpgplm'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_dv8abrrz'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_z1tyspqw'},
         ],
         model: 'TS0601_thermostat_1',
         vendor: 'TuYa',


### PR DESCRIPTION
I got my fourth thermostat yesterday. I ordered the very same model from Amazon as the previous three, it came with an identical barcode on the box and everything looks absolutely similar.

But still, it presents itself with a different `manufacturerName`, is much quieter and reacts way faster. From what I can tell, it seems to use exactly the same converter as the other `TS0601_thermostat_1` already known. I just copied the definition into an external converter and it works.

I don't know if the technical improvements (quieter, faster) come together with changes to the firmware and the data points used. Can I do anything to verify everything besides just trying it out? So far, I don't see any problems, and all works as expected...