### PR TITLE
Remove tamper sensor

### DIFF
--- a/devices/sonoff.js
+++ b/devices/sonoff.js
@@ -199,7 +199,7 @@ module.exports = [
             await reporting.batteryVoltage(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery(), e.battery_voltage()],
+        exposes: [e.occupancy(), e.battery_low(), e.battery(), e.battery_voltage()],
     },
     {
         zigbeeModel: ['S26R2ZB'],


### PR DESCRIPTION
The SNZB-03 physically does not have a tamper sensor so the value of this is meaningless and should be removed