### PR TITLE
Added support for status LED control on Niko light switches

### DIFF
--- a/devices/niko.js
+++ b/devices/niko.js
@@ -36,6 +36,20 @@ const local = {
                 return state;
             },
         },
+        switch_status_led: {
+            cluster: 'manuSpecificNiko1',
+            type: ['attributeReport', 'readResponse'],
+            convert: (model, msg, publish, options, meta) => {
+                const state = {};
+                if (msg.data.hasOwnProperty('outletLedState')) {
+                    state['led_enable'] = (msg.data['outletLedState'] == 1);
+                }
+                if (msg.data.hasOwnProperty('outletLedColor')) {
+                    state['led_state'] = (msg.data['outletLedColor'] == 255);
+                }
+                return state;
+            },
+        },
         outlet: {
             cluster: 'manuSpecificNiko1',
             type: ['attributeReport', 'readResponse'],
@@ -67,6 +81,26 @@ const local = {
             },
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificNiko1', ['switchOperationMode']);
+            },
+        },
+        switch_led_enable: {
+            key: ['led_enable'],
+            convertSet: async (entity, key, value, meta) => {
+                await entity.write('manuSpecificNiko1', {'outletLedState': ((value) ? 1 : 0)});
+                return {state: {led_enable: ((value) ? true : false)}};
+            },
+            convertGet: async (entity, key, meta) => {
+                await entity.read('manuSpecificNiko1', ['outletLedState']);
+            },
+        },
+        switch_led_state: {
+            key: ['led_state'],
+            convertSet: async (entity, key, value, meta) => {
+                await entity.write('manuSpecificNiko1', {'outletLedColor': ((value) ? 255 : 0)});
+                return {state: {led_state: ((value) ? true : false)}};
+            },
+            convertGet: async (entity, key, meta) => {
+                await entity.read('manuSpecificNiko1', ['outletLedColor']);
             },
         },
         outlet_child_lock: {
@@ -198,18 +232,22 @@ module.exports = [
         model: '552-721X1',
         vendor: 'Niko',
         description: 'Single connectable switch',
-        fromZigbee: [fz.on_off, local.fz.switch_operation_mode, local.fz.switch_action],
-        toZigbee: [tz.on_off, local.tz.switch_operation_mode],
+        fromZigbee: [fz.on_off, local.fz.switch_operation_mode, local.fz.switch_action, local.fz.switch_status_led],
+        toZigbee: [tz.on_off, local.tz.switch_operation_mode, local.tz.switch_led_enable, local.tz.switch_led_state],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
             await endpoint.read('manuSpecificNiko1', ['switchOperationMode']);
+            await endpoint.read('manuSpecificNiko1', ['outletLedState']);
+            await endpoint.read('manuSpecificNiko1', ['outletLedColor']);
         },
         exposes: [
             e.switch(),
             e.action(['single', 'hold', 'release']),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']),
+            exposes.binary('led_enable', ea.ALL, true, false).withDescription('Enable LED'),
+            exposes.binary('led_state', ea.ALL, true, false).withDescription('LED State'),
         ],
     },
     {
@@ -217,8 +255,8 @@ module.exports = [
         model: '552-721X2',
         vendor: 'Niko',
         description: 'Double connectable switch',
-        fromZigbee: [fz.on_off, local.fz.switch_operation_mode, local.fz.switch_action],
-        toZigbee: [tz.on_off, local.tz.switch_operation_mode],
+        fromZigbee: [fz.on_off, local.fz.switch_operation_mode, local.fz.switch_action, local.fz.switch_status_led],
+        toZigbee: [tz.on_off, local.tz.switch_operation_mode, local.tz.switch_led_enable, local.tz.switch_led_state],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
@@ -232,6 +270,10 @@ module.exports = [
             await reporting.onOff(ep2);
             await ep1.read('manuSpecificNiko1', ['switchOperationMode']);
             await ep2.read('manuSpecificNiko1', ['switchOperationMode']);
+            await ep1.read('manuSpecificNiko1', ['outletLedState']);
+            await ep2.read('manuSpecificNiko1', ['outletLedState']);
+            await ep1.read('manuSpecificNiko1', ['outletLedColor']);
+            await ep2.read('manuSpecificNiko1', ['outletLedColor']);
         },
         exposes: [
             e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
@@ -239,6 +281,10 @@ module.exports = [
             e.action(['single', 'hold', 'release']).withEndpoint('l2'),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']).withEndpoint('l1'),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']).withEndpoint('l2'),
+            exposes.binary('led_enable', ea.ALL, true, false).withEndpoint('l1').withDescription('Enable LED'),
+            exposes.binary('led_enable', ea.ALL, true, false).withEndpoint('l2').withDescription('Enable LED'),
+            exposes.binary('led_state', ea.ALL, true, false).withEndpoint('l1').withDescription('LED State'),
+            exposes.binary('led_state', ea.ALL, true, false).withEndpoint('l2').withDescription('LED State'),
         ],
     },
     {

--- a/devices/niko.js
+++ b/devices/niko.js
@@ -87,6 +87,7 @@ const local = {
             key: ['led_enable'],
             convertSet: async (entity, key, value, meta) => {
                 await entity.write('manuSpecificNiko1', {'outletLedState': ((value.toLowerCase() === 'off') ? 0 : 1)});
+                await entity.read('manuSpecificNiko1', ['outletLedColor']);
                 return {state: {led_enable: ((value.toLowerCase() === 'off') ? 'OFF' : 'ON')}};
             },
             convertGet: async (entity, key, meta) => {

--- a/devices/niko.js
+++ b/devices/niko.js
@@ -42,7 +42,7 @@ const local = {
             convert: (model, msg, publish, options, meta) => {
                 const state = {};
                 if (msg.data.hasOwnProperty('outletLedState')) {
-                    state['led_enable'] = (msg.data['outletLedState'] == 1 ? 'ON' : 'OFF');
+                    state['led_enable'] = (msg.data['outletLedState'] == 1);
                 }
                 if (msg.data.hasOwnProperty('outletLedColor')) {
                     state['led_state'] = (msg.data['outletLedColor'] == 255 ? 'ON' : 'OFF');
@@ -59,7 +59,7 @@ const local = {
                     state['child_lock'] = (msg.data['outletChildLock'] == 0 ? 'LOCK' : 'UNLOCK');
                 }
                 if (msg.data.hasOwnProperty('outletLedState')) {
-                    state['led_enable'] = (msg.data['outletLedState'] == 1 ? 'ON' : 'OFF');
+                    state['led_enable'] = (msg.data['outletLedState'] == 1);
                 }
                 return state;
             },
@@ -86,9 +86,9 @@ const local = {
         switch_led_enable: {
             key: ['led_enable'],
             convertSet: async (entity, key, value, meta) => {
-                await entity.write('manuSpecificNiko1', {'outletLedState': ((value.toLowerCase() === 'off') ? 0 : 1)});
+                await entity.write('manuSpecificNiko1', {'outletLedState': ((value) ? 1 : 0)});
                 await entity.read('manuSpecificNiko1', ['outletLedColor']);
-                return {state: {led_enable: ((value.toLowerCase() === 'off') ? 'OFF' : 'ON')}};
+                return {state: {led_enable: ((value) ? true : false)}};
             },
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificNiko1', ['outletLedState']);
@@ -117,8 +117,8 @@ const local = {
         outlet_led_enable: {
             key: ['led_enable'],
             convertSet: async (entity, key, value, meta) => {
-                await entity.write('manuSpecificNiko1', {'outletLedState': ((value.toLowerCase() === 'off') ? 0 : 1)});
-                return {state: {led_enable: ((value.toLowerCase() === 'off') ? 'OFF' : 'ON')}};
+                await entity.write('manuSpecificNiko1', {'outletLedState': ((value) ? 1 : 0)});
+                return {state: {led_enable: ((value) ? true : false)}};
             },
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificNiko1', ['outletLedState']);
@@ -163,7 +163,7 @@ module.exports = [
             e.power().withAccess(ea.STATE_GET), e.current(), e.voltage(),
             e.energy().withAccess(ea.STATE_GET),
             exposes.binary('child_lock', ea.ALL, 'LOCK', 'UNLOCK').withDescription('Enables/disables physical input on the device'),
-            exposes.binary('led_enable', ea.ALL, 'ON', 'OFF').withDescription('Enable LED'),
+            exposes.binary('led_enable', ea.ALL, true, false).withDescription('Enable LED'),
         ],
     },
     {
@@ -245,7 +245,7 @@ module.exports = [
             e.switch(),
             e.action(['single', 'hold', 'release']),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']),
-            exposes.binary('led_enable', ea.ALL, 'ON', 'OFF').withDescription('Enable LED'),
+            exposes.binary('led_enable', ea.ALL, true, false).withDescription('Enable LED'),
             exposes.binary('led_state', ea.ALL, 'ON', 'OFF').withDescription('LED State'),
         ],
     },
@@ -276,8 +276,8 @@ module.exports = [
             e.action(['single', 'hold', 'release']).withEndpoint('l2'),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']).withEndpoint('l1'),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']).withEndpoint('l2'),
-            exposes.binary('led_enable', ea.ALL, 'ON', 'OFF').withEndpoint('l1').withDescription('Enable LED'),
-            exposes.binary('led_enable', ea.ALL, 'ON', 'OFF').withEndpoint('l2').withDescription('Enable LED'),
+            exposes.binary('led_enable', ea.ALL, true, false).withEndpoint('l1').withDescription('Enable LED'),
+            exposes.binary('led_enable', ea.ALL, true, false).withEndpoint('l2').withDescription('Enable LED'),
             exposes.binary('led_state', ea.ALL, 'ON', 'OFF').withEndpoint('l1').withDescription('LED State'),
             exposes.binary('led_state', ea.ALL, 'ON', 'OFF').withEndpoint('l2').withDescription('LED State'),
         ],


### PR DESCRIPTION
I've implemented control of the LED on the Niko 552-721X1 and 552-721X2 switches. It seems to use the same attributes as the smart outlets. Setting the LED state works fine both with the relay being controlled directly or being decoupled, but obviously when it is being controlled (given that the led is not disabled), it will update to the match the relay state on the next action.

The Niko switch is really fast standalone or connected to Zigbee2Mqtt. When connected to the Niko hub, it is just as slow as the EasyWave variant of the switches. Which indicates to me that Niko probably always has the relay decoupled and fully controls both the relay and LED from the Hub based on the switch input. So with these additional properties it should be possible to mimic that behavior through an automation platform like HomeAssistant or OpenHAB. For example: I have all of my EasyWave switches set to inverse LED behavior, so the LED is on when the light is off (so you see the switch when it's dark in the room).

I have some duplication in the converters between the switches and the outlets, because I thought it may be prudent to keep them separated. But if it's preferable, they could be merged to some extent. I only have a 552-721X1 switch myself. The double and dimmer switches I have are all EasyWave, so I was not able to test with those. But given the existing config, it seems reasonable to assume that at least the double 552-721X2 will behave exactly the same. It will probably also go for the dimmer switch, but since those are still somewhat different in functionality, I figured I'd not add it if I can't test it.

Finally, 2 things I observed whilst testing this:
- Like the smart socket, the light switches seem to support the outletChildLock attribute, but I couldn't quite pin down how it's supposed to work. Maybe it's not supposed to work or has a firmware bug...
- The smart socket's LED can also be controlled, but it seems to reset to the active state of the socket automatically after a second or so.