### PR TITLE
Adding Support for TS0601 Thermostat from vendor Avatto

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2028,6 +2028,7 @@ module.exports = [
             '_TZE200_mudxchsu', /* model: 'TV05-ZG curve', vendor: 'TuYa' */
             '_TZE200_7yoranx2', /* model: 'TV01-ZB', vendor: 'Moes' */
             '_TZE200_kds0pmmv', /* model: 'TV01-ZB', vendor: 'Moes' */
+            '_TZE200_bvu2wnxz', /* model: 'ME167', vendor: 'Avatto' */
         ]),
         model: 'TV02-Zigbee',
         vendor: 'TuYa',


### PR DESCRIPTION
Adding Support for AVATTO TS0601 by adding vendor-id
(product i.e. here: https://de.aliexpress.com/item/1005003952150617.html)