### PR TITLE
Fix 'NHPB/SWITCH/1' endpoint number

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -423,7 +423,7 @@ module.exports = [
         description: 'Odace connectable relay switch 10A',
         extend: extend.switch(),
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(10);
+            const endpoint = device.getEndpoint(21);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
         },


### PR DESCRIPTION
I have this device, it autodetected correctly, but the state reporting never worked.

The device does not appear to have an endpoint 10 at all, but changing to 21 fixes it.