### PR TITLE
New model 929003045801 for Philips Hue White ambiance Runner spot whi…

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -330,7 +330,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
     {
-        zigbeeModel: ['929003046001'],
+        zigbeeModel: ['929003046001', '929003045801'],
         model: '5309031P8',
         vendor: 'Philips',
         description: 'Hue White ambiance Runner spot white (1 spot)',


### PR DESCRIPTION
This is to add a new model for Philips Hue White ambiance Runner spot white (1 spot), as manufacturer introduces new revision of device.

From logs:

`Warning 2022-12-03 10:40:10Device '0x001788010c3facd0' with Zigbee model '929003045801' and manufacturer name 'Philips' is NOT supported, please follow https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html`


![Screen Shot 2022-12-03 at 10 40 52](https://user-images.githubusercontent.com/2051775/205434497-ba699cef-45fd-45e6-920b-631479f496b5.png)
