### PR TITLE
Add support for eWeLink SWITCH-ZR03-1 switch

### DIFF
--- a/devices/ewelink.js
+++ b/devices/ewelink.js
@@ -36,6 +36,21 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['SWITCH-ZR03-1'],
+        model: 'SWITCH-ZR03-1',
+        vendor: 'eWeLink',
+        description: 'Zigbee smart switch',
+        extend: extend.switch(),
+        fromZigbee: [fz.on_off_skip_duplicate_transaction],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+        },
+        onEvent: async (type, data, device) => {
+            device.skipDefaultResponse = true;
+        },
+    },
+    {
         zigbeeModel: ['ZB-SW01'],
         model: 'ZB-SW01',
         vendor: 'eWeLink',


### PR DESCRIPTION
Add support for eWeLink SWITCH-ZR03-1 switch.  You can purchase them under the name "CMARS Smart Plug, ZigBee Switch Mini Smart Outlet"