### PR TITLE
Fix for _TZ3000_qeuvnohg incorrectly detected as TuYa TS011F_plug_3

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -3006,7 +3006,7 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_8bxrzyxz'},
-            {modelID: 'TS011F', manufacturerName: '_TZ3000_ky0fq4ho'}],
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_ky0fq4ho'}, {modelID: 'TS011F', manufacturerName: '_TZ3000_qeuvnohg'}],
         model: 'TS011F_din_smart_relay',
         description: 'Din smart relay (with power monitoring)',
         vendor: 'TuYa',


### PR DESCRIPTION
Hello,
I think we should be making sure : TS011F / _TZ3000_qeuvnohg is detected as  TS011F_din_smart_relay
and not TS011F_plug_3 as it supports energy monitoring without polling

This was working well until 2 days ago and I think the refactoring in commit 95da3769713b473d455d7b004366b1648b0e2667 caused it
---
To be noted (for google search) not for issue/fix
- OTA doesn't work on this device / Error: No image available for imageType '5634'
- Regular messages saying : 
No converter available for 'TS011F_din_smart_relay' with cluster 'msTemperatureMeasurement' and type 'attributeReport' and data '{"measuredValue":-630}'

---

Thank you ! 