### PR TITLE
IM6001-WLP01 battery is highly inaccurate

### DIFF
--- a/devices/smartthings.js
+++ b/devices/smartthings.js
@@ -393,12 +393,11 @@ module.exports = [
         description: 'Water leak sensor (2018 model)',
         fromZigbee: [fz.temperature, fz.ias_water_leak_alarm_1, fz.battery, fz.ias_water_leak_alarm_1_report],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
             await reporting.temperature(endpoint);
-            await reporting.batteryVoltage(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
         },
         exposes: [e.temperature(), e.water_leak(), e.battery_low(), e.tamper(), e.battery()],
     },


### PR DESCRIPTION
My IM6001-WLP01 was reporting switching between 20% and 72%, it looks like the device would very occasionally send an attributeReport for batteryPercentageRemaining would frequently send batteryVoltage. The inaccuracy seems to come from the voltage -> % mapping. 

To figure out if we needed to divide the value or not, I put in a fresh CR2 battery (I got because it was reporting 20%) and it jumped back to 100% with a value of 200 being reported. Switching back to the original battery made it report ~70% again with a value of around 140-144. So we can just do the standard mapping.