### PR TITLE
Don't use endpoint-prefixed state/brightness for Busch-Jaeger devices

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -516,6 +516,17 @@ const converters = {
             }
         },
     },
+    brightness_force_single_endpoint: {
+        cluster: 'genLevelCtrl',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            // This converter is needed instead of `fz.brightness` for multi-endpoint devices (`{multiEndpoint: true}`)
+            // which only have a single state. This prevents unnecessary prefixing of the brightness attribute.
+            if (msg.data.hasOwnProperty('currentLevel')) {
+                return {brightness: msg.data['currentLevel']};
+            }
+        },
+    },
     level_config: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -795,6 +806,17 @@ const converters = {
                 const endpointName = model.hasOwnProperty('endpoint') ?
                     utils.getKey(model.endpoint(meta.device), msg.endpoint.ID) : msg.endpoint.ID;
                 return {[`state_${endpointName}`]: msg.data['onOff'] === 1 ? 'ON' : 'OFF'};
+            }
+        },
+    },
+    on_off_force_single_endpoint: {
+        cluster: 'genOnOff',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            // This converter is needed instead of `fz.on_off` for multi-endpoint devices (`{multiEndpoint: true}`)
+            // which only have a single state. This prevents unnecessary prefixing of the state attribute.
+            if (msg.data.hasOwnProperty('onOff')) {
+                return {state: msg.data['onOff'] === 1 ? 'ON' : 'OFF'};
             }
         },
     },

--- a/devices/busch-jaeger.js
+++ b/devices/busch-jaeger.js
@@ -80,8 +80,8 @@ module.exports = [
                 await reporting.bind(endpoint18, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
             }
         },
-        fromZigbee: [fz.ignore_basic_report, fz.on_off, fz.brightness, fz.legacy.RM01_on_click, fz.legacy.RM01_off_click,
-            fz.legacy.RM01_up_hold, fz.legacy.RM01_down_hold, fz.legacy.RM01_stop],
+        fromZigbee: [fz.ignore_basic_report, fz.on_off_force_single_endpoint, fz.brightness_force_single_endpoint,
+            fz.legacy.RM01_on_click, fz.legacy.RM01_off_click, fz.legacy.RM01_up_hold, fz.legacy.RM01_down_hold, fz.legacy.RM01_stop],
         toZigbee: [tz.RM01_light_onoff_brightness, tz.RM01_light_brightness_step, tz.RM01_light_brightness_move],
         onEvent: async (type, data, device) => {
             const switchEndpoint = device.getEndpoint(0x12);


### PR DESCRIPTION
The Busch-Jaeger devices may have multiple endpoints, depending on the rocker type which is installed. The following endpoints may be present:

- 10, 11, 12, 13: These are the endpoints for the rockers which report events. They do not report any state/brightness (genOnOff/genLevelCtrl only in output-cluster).

- 18: Only present if the device is controlling a relay or a dimmer. This is the only endpoint which reports a state/brightness (genOnOff/ genLevelCtrl only in input-cluster).

The `meta.multiEndpoint` setting is required for prefixing the events reported by endpoints 10 to 13 with the endpoint name (row number in this case). However this device only has a single state (reported by endpoint 18) as it only controls up to one relay/dimmer.

This is why a prefixed state attribute such as `state_relay` does not make sense here and needlessly breaks both Home Assistant discovery (state of discovered lights never update) and the web frontend, which both only care about the `state` property.

Since these devices only have (up to) one state we can remove the endpoint prefix for both `state` and `brightness`.

:warning: @Koenkk This has a few implications:

- :warning: `state_relay` is not being updated any more and cannot be set any more. This is potentially a breaking change, depending on which attribute people were using in the past. I guess this can only be included in a new major Z2M release.
- :question: We are effectively removing the `state_relay` attribute with this PR, but it will rot forever in the `state.json` file of older installations. Is there anything we can do about that?
- :heavy_check_mark: Fixes Koenkk/zigbee2mqtt#7077
- :heavy_check_mark: Home Assistant auto-discovery will finally be working for these devices