### PR TITLE
philips: decode more of the gradient payload

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -115,7 +115,7 @@ const fzLocal = {
                 if (msg.data.hasOwnProperty('state')) {
                     const input = msg.data['state'].toString('hex');
                     const gradient = philips.decodeGradientColors(input, opts);
-                    return {gradient};
+                    return {gradient: gradient.colors};
                 }
                 return {};
             },

--- a/lib/philips.js
+++ b/lib/philips.js
@@ -30,16 +30,69 @@ const decodeScaledGradientToRGB = (p) => {
 function decodeGradientColors(input, opts) {
     // Example set:         500104001350000000f3297ff3bd52f3bd52f3297ff3bd522800
     // Example get  4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800
-    const offset = input.indexOf('0000000') + 7;
-    const points = input.slice(offset, - 4);
-    const pairs = points.match(/.{6}/g);
-    const colors = pairs.map(decodeScaledGradientToRGB);
+
+    // 4b01 - mode? (4) (0b00 single color?, 4b01 gradient?)
+    //     01 - on/off (2) or is it 1 full byte?
+    //       64 - brightness (2)
+    //         fb74346b - unknown (8)
+    //                 13 - length (2)
+    //                   50 - ncolors (2)
+    //                     000000 - unknown (6)
+    //                           f3297fda7d55da7d55f3297fda7d55 - colors (6 * ncolors)
+    //                                                         28 - segments (2)
+    //                                                           00 - offset (2)
+
+    // Skip the unknown prefix (4 bytes)
+    input = input.slice(4);
+
+    // On/off (1 byte)
+    const on = parseInt(input.slice(0, 2), 16) === 1;
+    input = input.slice(2);
+
+    // Brightness (2 bytes)
+    const brightness = parseInt(input.slice(0, 2), 16);
+    input = input.slice(2);
+
+    // Unknown (8 bytes)
+    input = input.slice(8);
+
+    // Length (2 bytes)
+    input = input.slice(2);
+
+    // Number of colors (2 bytes)
+    const nColors = parseInt(input.slice(0, 2), 16) >> 4;
+    input = input.slice(2);
+
+    // Unknown (6 bytes)
+    input = input.slice(6);
+
+    // Colors (6 * nColors bytes)
+    const colorsPayload = input.slice(0, 6 * nColors);
+    input = input.slice(6 * nColors);
+    const colors = colorsPayload.match(/.{6}/g).map(decodeScaledGradientToRGB);
+
+    // Segments (2 bytes)
+    const segments = parseInt(input.slice(0, 2), 16) >> 3;
+    input = input.slice(2);
+
+    // Offset (2 bytes)
+    const offset = parseInt(input.slice(0, 2), 16) >> 3;
 
     if (opts.reverse) {
         colors.reverse();
     }
 
-    return colors;
+    return {
+        colors,
+
+        gradient_extras: {
+            colors: nColors,
+            segments,
+            offset,
+            brightness,
+            on,
+        },
+    };
 }
 
 // Value is a list of RGB HEX colors
@@ -61,19 +114,34 @@ function encodeGradientColors(value, opts) {
     // support it by extending the API.
     // If number of colors is less than the number of segments, the colors will repeat.
     // It seems like the maximum number of colors is 9, and the maximum number of segments is 31.
-    const nColors = (value.length << 4).toString(16);
-    const segments = (value.length << 3).toString(16);
+    const nColors = (value.length << 4).toString(16).padStart(2, '0');
+
+    let segments = value.length;
+    if (opts.segments) {
+        segments = opts.segments;
+    }
+
+    if (segments < 1 || segments > 31) {
+        throw new Error(`Expected segments to be between 1 and 31 (inclusive), got ${segments}`);
+    }
+    const segmentsPayload = (segments << 3).toString(16).padStart(2, '0');
 
     // Encode the colors
     const colorsPayload = value.map(encodeRGBToScaledGradient).join('');
 
-    // Offset of the first color, left shifted 3 bits. 0 means the first segment uses the first color.
-    const offset = '00';
+    // Offset of the first color. 0 means the first segment uses the first color. (min 0, max 31)
+    let offset = 0;
+    if (opts.offset) {
+        offset = opts.offset;
+    }
+    const offsetPayload = (offset << 3).toString(16).padStart(2, '0');
 
     // Payload length
-    const length = (1 + 3 * (value.length + 1)).toString(16);
+    const length = (1 + 3 * (value.length + 1)).toString(16).padStart(2, '0');
 
-    const scene = `50010400${length}${nColors}000000${colorsPayload}${segments}${offset}`;
+    // 5001 - mode? set gradient?
+    // 0400 - unknown
+    const scene = `50010400${length}${nColors}000000${colorsPayload}${segmentsPayload}${offsetPayload}`;
 
     return scene;
 }

--- a/test/philips.test.js
+++ b/test/philips.test.js
@@ -1,30 +1,52 @@
-const { formToJSON } = require('axios');
 const philips = require('../lib/philips');
 
 describe('lib/philips.js', () => {
     describe('decodeGradientColors', () => {
-        it('scene 1', () => {
-            const ret = philips.decodeGradientColors("4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", { reverse: true });
-            expect(ret).toStrictEqual(["#0c32ff","#1137ff","#2538ff","#7951ff", "#ff77f8"])
+        test.each([
+            ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", ["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"]],
+            ["4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800", ["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"]],
+            ["4b010127a0526f5410400000000727640e9f5d0727640e9f5d2000", ["#ff0500", "#ffffff", "#ff0500", "#ffffff"]],
+        ])("colors(%s) should be %s", (input, expected) => {
+            const ret = philips.decodeGradientColors(input, { reverse: true });
+            expect(ret.colors).toStrictEqual(expected);
         })
-        it('scene 2', () => {
-            const ret = philips.decodeGradientColors("4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800", { reverse: true });
-            expect(ret).toStrictEqual(["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"])
+
+        test.each([
+            ["4b010110ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 16],
+            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 100],
+        ])("brightness(%s) should be %s", (input, expected) => {
+            const ret = philips.decodeGradientColors(input, { reverse: true });
+            expect(ret.gradient_extras.brightness).toBe(expected);
+        })
+
+        test.each([
+            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", true],
+            ["4b010026ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", false],
+        ])("power(%s) should be %s", (input, expected) => {
+            const ret = philips.decodeGradientColors(input, { reverse: true });
+            expect(ret.gradient_extras.on).toBe(expected);
+        })
+
+        test.each([
+            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 0],
+            ["4b01012701b1ea4e13500000000e9f5d0727640e9f5d0727640e9f5d2810", 2],
+        ])("offset(%s) should be %s", (input, expected) => {
+            const ret = philips.decodeGradientColors(input, { reverse: true });
+            expect(ret.gradient_extras.offset).toBe(expected);
         })
     });
 
     describe('encodeGradientColors', () => {
-        it('scene 1', () => {
-            const ret = philips.encodeGradientColors(["#0c32ff","#1137ff","#2538ff","#7951ff", "#ff77f8"], { reverse: true });
-            expect(ret).toStrictEqual("500104001350000000b2474df0353e29e42e98332c7043292800")
-        })
-        it('scene 1', () => {
-            const ret = philips.encodeGradientColors(["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"], { reverse: true });
-            expect(ret).toStrictEqual("500104001350000000f3297fd56d55d56d55f3297fd56d552800")
-        })
-        it('single', () => {
-            const ret = philips.encodeGradientColors(["#ffffff"], { reverse: true });
-            expect(ret).toStrictEqual("50010400710000000072764800")
-        })
+        test.each([
+            [["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"], { reverse: true }, "500104001350000000b2474df0353e29e42e98332c7043292800"],
+            [["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"], { reverse: false }, "50010400135000000070432998332c29e42ef0353eb2474d2800"],
+            [["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"], { reverse: true }, "500104001350000000f3297fd56d55d56d55f3297fd56d552800"],
+            [["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"], { reverse: true, offset: 2 }, "500104001350000000f3297fd56d55d56d55f3297fd56d552810"],
+            [["#ffffff"], { reverse: true }, "5001040007100000000727640800"],
+            [["#ffffff"], { reverse: false }, "5001040007100000000727640800"],
+        ])("colors(%s) opts(%s) should be %s", (colors, opts, expected) => {
+            const ret = philips.encodeGradientColors(colors, opts);
+            expect(ret).toStrictEqual(expected);
+        });
     });
 });


### PR DESCRIPTION
Also fixes the encoding of gradients with less than 5 colors, and added more tests.

`gradient_extras` is not used for anything more than testing at the moment. The `offset` and `segments` values _does_ affect the light effect on the device, and have been added to both the encoder and the decoder. This does not include a public API to get/set those values, it might come in another PR if we can find a good design for it.

