### PR TITLE
Support calibration and precision options for TuYa devices using new integration

### DIFF
--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1652,6 +1652,17 @@ const tuyaFz = {
     datapoints: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'commandActiveStatusReport', 'commandActiveStatusReportAlt'],
+        options: (definition) => {
+            const result = [];
+            for (const datapoint of definition.meta.tuyaDatapoints) {
+                const dpKey = datapoint[1];
+                if (dpKey in utils.calibrateAndPrecisionRoundOptionsDefaultPrecision) {
+                    const type = utils.calibrateAndPrecisionRoundOptionsIsPercentual(dpKey) ? 'percentual' : 'absolute';
+                    result.push(exposes.options.precision(dpKey), exposes.options.calibration(dpKey, type));
+                }
+            }
+            return result;
+        },
         convert: (model, msg, publish, options, meta) => {
             let result = {};
             if (!model.meta || !model.meta.tuyaDatapoints) throw new Error('No datapoints map defined');
@@ -1669,6 +1680,14 @@ const tuyaFz = {
                 } else {
                     meta.logger.debug(`Datapoint ${dpId} not defined for '${meta.device.manufacturerName}' ` +
                         `with data ${JSON.stringify(dpValue)}`);
+                }
+            }
+
+            // Apply calibrateAndPrecisionRoundOptions
+            const keys = Object.keys(utils.calibrateAndPrecisionRoundOptionsDefaultPrecision);
+            for (const entry of Object.entries(result)) {
+                if (keys.includes(entry[0])) {
+                    result[entry[0]] = utils.calibrateAndPrecisionRoundOptions(entry[1], options, entry[0]);
                 }
             }
             return result;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,13 +75,18 @@ function hasAlreadyProcessedMessage(msg, model, ID=null, key=null) {
     return false;
 }
 
-const defaultPrecision = {temperature: 2, humidity: 2, pressure: 1, pm25: 0, power: 2, current: 2, current_phase_b: 2, current_phase_c: 2,
-    voltage: 2, voltage_phase_b: 2, voltage_phase_c: 2, power_phase_b: 2, power_phase_c: 2};
+const calibrateAndPrecisionRoundOptionsDefaultPrecision = {
+    temperature: 2, humidity: 2, pressure: 1, pm25: 0, power: 2, current: 2, current_phase_b: 2, current_phase_c: 2,
+    voltage: 2, voltage_phase_b: 2, voltage_phase_c: 2, power_phase_b: 2, power_phase_c: 2,
+};
+function calibrateAndPrecisionRoundOptionsIsPercentual(type) {
+    return type.startsWith('current') || type.startsWith('voltage') || type.startsWith('power') || type.startsWith('illuminance');
+}
 function calibrateAndPrecisionRoundOptions(number, options, type) {
     // Calibrate
     const calibrateKey = `${type}_calibration`;
     let calibrationOffset = options && options.hasOwnProperty(calibrateKey) ? options[calibrateKey] : 0;
-    if (type.startsWith('current') || type.startsWith('voltage') || type.startsWith('power') || type.startsWith('illuminance')) {
+    if (calibrateAndPrecisionRoundOptionsIsPercentual(type)) {
         // linear calibration because measured value is zero based
         // +/- percent
         calibrationOffset = Math.round(number * calibrationOffset / 100);
@@ -90,7 +95,7 @@ function calibrateAndPrecisionRoundOptions(number, options, type) {
 
     // Precision round
     const precisionKey = `${type}_precision`;
-    const defaultValue = defaultPrecision[type] || 0;
+    const defaultValue = calibrateAndPrecisionRoundOptionsDefaultPrecision[type] || 0;
     const precision = options && options.hasOwnProperty(precisionKey) ? options[precisionKey] : defaultValue;
     return precisionRound(number, precision);
 }
@@ -436,6 +441,8 @@ module.exports = {
     mapNumberRange,
     hasAlreadyProcessedMessage,
     calibrateAndPrecisionRoundOptions,
+    calibrateAndPrecisionRoundOptionsIsPercentual,
+    calibrateAndPrecisionRoundOptionsDefaultPrecision,
     toPercentage,
     addActionGroup,
     postfixWithEndpointName,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -521,6 +521,12 @@ describe('index.js', () => {
         }
     });
 
+    it('Check TuYa tuya.fz.datapoints calibration/presicion options', () => {
+        const TS0601_soil = index.definitions.find((d) => d.model == 'TS0601_soil');
+        expect(TS0601_soil.options.map((t) => t.name)).toStrictEqual(
+            ['humidity_precision', 'humidity_calibration', 'temperature_precision', 'temperature_calibration']);
+    });
+
     it('List expose number', () => {
         // Example payload:
         // {"temperatures": [19,21,30]}


### PR DESCRIPTION
Expose calibrate and precision options automatically for TuYa devices using `tuya.fz.datapoints`.

Requested in https://github.com/Koenkk/zigbee2mqtt/issues/15128#issuecomment-1343298569