### PR TITLE
Add support for a variant of the Tuya tubular motor

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1988,6 +1988,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_g5wdnuow'},
             // Tubular motors:
             {modelID: 'TS0601', manufacturerName: '_TZE200_5sbebbzs'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_udank5zs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuz7f94z'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_68nvbio9'},
         ],


### PR DESCRIPTION
{modelID: 'TS0601', manufacturerName: '_TZE200_udank5zs'}
![IMG_1716](https://user-images.githubusercontent.com/12756754/206797981-a8792436-b276-4fdc-98d4-799ee02778c6.jpg)
I own these and they are the same as the Zemismart Tubular motor that I also own (_TZE200_fzo2pocs)