### PR TITLE
ikea: Enable turnsOffAtBrightness1 for LED1925G6

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -901,6 +901,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb E14 470 lumen, opal, dimmable, white spectrum, color spectrum',
         extend: tradfriExtend.light_onoff_brightness_colortemp_color(),
+        meta: {turnsOffAtBrightness1: true},
     },
     {
         zigbeeModel: ['TRADFRIbulbE14WWclear250lm', 'TRADFRIbulbE12WWclear250lm'],


### PR DESCRIPTION
This is the default behavior in the latest firmware

Signed-off-by: Michal Chvíla <michal@chvila.sk>