### PR TITLE
lib/philips: parse xy and temperature modes

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -112,10 +112,12 @@ const fzLocal = {
             cluster: 'manuSpecificPhilips2',
             type: ['attributeReport', 'readResponse'],
             convert: (model, msg, publish, options, meta) => {
-                if (msg.data.hasOwnProperty('state')) {
+                if (msg.data && msg.data.hasOwnProperty('state')) {
                     const input = msg.data['state'].toString('hex');
-                    const gradient = philips.decodeGradientColors(input, opts);
-                    return {gradient: gradient.colors};
+                    const decoded = philips.decodeGradientColors(input, opts);
+                    if (decoded.color_mode === 'gradient') {
+                        return {gradient: decoded.colors};
+                    }
                 }
                 return {};
             },

--- a/lib/philips.js
+++ b/lib/philips.js
@@ -27,25 +27,45 @@ const decodeScaledGradientToRGB = (p) => {
     return new ColorXY(xx, yy).toRGB().toHEX();
 };
 
-function decodeGradientColors(input, opts) {
-    // Example set:         500104001350000000f3297ff3bd52f3bd52f3297ff3bd522800
-    // Example get  4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800
+const COLOR_MODE_GRADIENT = '4b01';
+const COLOR_MODE_COLOR_XY = '0b00';
+const COLOR_MODE_COLOR_TEMP = '0f00';
 
+// decoder for manuSpecificPhilips2.state
+function decodeGradientColors(input, opts) {
+    // Gradient mode (4b01)
+    // Example: 4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800
     // 4b01 - mode? (4) (0b00 single color?, 4b01 gradient?)
-    //     01 - on/off (2) or is it 1 full byte?
+    //     01 - on/off (2)
     //       64 - brightness (2)
-    //         fb74346b - unknown (8)
+    //         fb74346b - unknown (8) - Might be XY Color?
     //                 13 - length (2)
     //                   50 - ncolors (2)
     //                     000000 - unknown (6)
     //                           f3297fda7d55da7d55f3297fda7d55 - colors (6 * ncolors)
     //                                                         28 - segments (2)
     //                                                           00 - offset (2)
+    //
+    // Temperature mode (0f00)
+    // Example: 0f0000044d01ab6f7067
+    // 0f00 - mode (4)
+    //     01 - on/off (2)
+    //       1a - brightness (2)
+    //          4d01 - color temperature (4)
+    //              ab6f7067 - unknown (8)
+    //
+    // XY Color mode (0b00)
+    // Example: 0b00010460b09c4e
+    // 0b00 - mode (4) == 0b00 single color mode
+    //     01 - on/off (2)
+    //       04 - brightness (2)
+    //         60b09c4e - color (8) (xLow, xHigh, yLow, yHigh)
 
-    // Skip the unknown prefix (4 bytes)
+    // Device color mode
+    const mode = input.slice(0, 4);
     input = input.slice(4);
 
-    // On/off (1 byte)
+    // On/off (2 bytes)
     const on = parseInt(input.slice(0, 2), 16) === 1;
     input = input.slice(2);
 
@@ -53,46 +73,85 @@ function decodeGradientColors(input, opts) {
     const brightness = parseInt(input.slice(0, 2), 16);
     input = input.slice(2);
 
-    // Unknown (8 bytes)
-    input = input.slice(8);
+    // Gradient mode
+    if (mode === COLOR_MODE_GRADIENT) {
+        // Unknown (8 bytes)
+        input = input.slice(8);
 
-    // Length (2 bytes)
-    input = input.slice(2);
+        // Length (2 bytes)
+        input = input.slice(2);
 
-    // Number of colors (2 bytes)
-    const nColors = parseInt(input.slice(0, 2), 16) >> 4;
-    input = input.slice(2);
+        // Number of colors (2 bytes)
+        const nColors = parseInt(input.slice(0, 2), 16) >> 4;
+        input = input.slice(2);
 
-    // Unknown (6 bytes)
-    input = input.slice(6);
+        // Unknown (6 bytes)
+        input = input.slice(6);
 
-    // Colors (6 * nColors bytes)
-    const colorsPayload = input.slice(0, 6 * nColors);
-    input = input.slice(6 * nColors);
-    const colors = colorsPayload.match(/.{6}/g).map(decodeScaledGradientToRGB);
+        // Colors (6 * nColors bytes)
+        const colorsPayload = input.slice(0, 6 * nColors);
+        input = input.slice(6 * nColors);
+        const colors = colorsPayload.match(/.{6}/g).map(decodeScaledGradientToRGB);
 
-    // Segments (2 bytes)
-    const segments = parseInt(input.slice(0, 2), 16) >> 3;
-    input = input.slice(2);
+        // Segments (2 bytes)
+        const segments = parseInt(input.slice(0, 2), 16) >> 3;
+        input = input.slice(2);
 
-    // Offset (2 bytes)
-    const offset = parseInt(input.slice(0, 2), 16) >> 3;
+        // Offset (2 bytes)
+        const offset = parseInt(input.slice(0, 2), 16) >> 3;
 
-    if (opts.reverse) {
-        colors.reverse();
-    }
+        if (opts && opts.reverse) {
+            colors.reverse();
+        }
 
-    return {
-        colors,
-
-        gradient_extras: {
-            colors: nColors,
+        return {
+            color_mode: 'gradient',
+            colors,
             segments,
             offset,
             brightness,
             on,
-        },
-    };
+        };
+    } else if (mode === COLOR_MODE_COLOR_XY) {
+        // XY Color mode
+        const xLow = parseInt(input.slice(0, 2), 16);
+        input = input.slice(2);
+        const xHigh = parseInt(input.slice(0, 2), 16) << 8;
+        input = input.slice(2);
+        const yHigh = parseInt(input.slice(0, 2), 16);
+        input = input.slice(2);
+        const yLow = parseInt(input.slice(0, 2), 16) << 8;
+        input = input.slice(2);
+
+        const x = xHigh | xLow;
+        const y = yHigh | yLow;
+
+        return {
+            color_mode: 'color_xy',
+            x: Math.round(x / 65535 * 10000) / 10000,
+            y: Math.round(y / 65535 * 10000) / 10000,
+            brightness,
+            on,
+        };
+    } else if (mode === COLOR_MODE_COLOR_TEMP) {
+        // Color temperature mode
+        const low = parseInt(input.slice(0, 2), 16);
+        input = input.slice(2);
+        const high = parseInt(input.slice(0, 2), 16) << 8;
+        input = input.slice(2);
+
+        const temp = high | low;
+
+        return {
+            color_mode: 'color_temp',
+            color_temp: temp,
+            brightness,
+            on,
+        };
+    }
+
+    // Unknown mode
+    return {};
 }
 
 // Value is a list of RGB HEX colors

--- a/test/philips.test.js
+++ b/test/philips.test.js
@@ -3,37 +3,76 @@ const philips = require('../lib/philips');
 describe('lib/philips.js', () => {
     describe('decodeGradientColors', () => {
         test.each([
-            ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", ["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"]],
-            ["4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800", ["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"]],
-            ["4b010127a0526f5410400000000727640e9f5d0727640e9f5d2000", ["#ff0500", "#ffffff", "#ff0500", "#ffffff"]],
-        ])("colors(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input, { reverse: true });
+            ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", true, ["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"]],
+            ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", false, ["#ff77f8",  "#7951ff", "#2538ff","#1137ff", "#0c32ff"]],
+            ["4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800", true, ["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"]],
+            ["4b010127a0526f5410400000000727640e9f5d0727640e9f5d2000", true, ["#ff0500", "#ffffff", "#ff0500", "#ffffff"]],
+        ])("colors(%s) should be %s", (input, opts_reverse, expected) => {
+            const ret = philips.decodeGradientColors(input, { reverse: opts_reverse });
             expect(ret.colors).toStrictEqual(expected);
         })
 
+        // XY Color
         test.each([
-            ["4b010110ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 16],
-            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 100],
-        ])("brightness(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input, { reverse: true });
-            expect(ret.gradient_extras.brightness).toBe(expected);
+            ["0b00015c05b1ec4e", [0.6915, 0.3083]], // Red (#ff0500)
+            ["0b00015c842b32b3", [0.1700, 0.7000]], // Green (#00ff0e)
+            ["0b00011d37272c0c", [0.1532, 0.0475]], // Blue (#0a00ff)
+        ])(`xy(%s) should be %s`, (input, expected) => {
+            const ret = philips.decodeGradientColors(input);
+            expect([ret.x, ret.y]).toStrictEqual(expected);
         })
 
         test.each([
-            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", true],
+            ["4b010110ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 16], 
+            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 100],
+            ["0f0001044d01ab6f7067", 4], 
+            ["0f00011a4d01ab6f7067", 26],
+            ["0f0000b2ff004c628461", 178],
+            ["0b00015c842b32b3", 92],
+            ["0b00011d842b32b3", 29],
+        ])("brightness(%s) should be %s", (input, expected) => {
+            const ret = philips.decodeGradientColors(input);
+            expect(ret.brightness).toBe(expected);
+        })
+
+        test.each([
+            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", true], 
             ["4b010026ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", false],
+            ["0f0000044d01ab6f7067", false], 
+            ["0f0001044d01ab6f7067", true],
+            ["0b00015c842b32b3", true], 
+            ["0b00001d842b32b3", false],
+            ,
         ])("power(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input, { reverse: true });
-            expect(ret.gradient_extras.on).toBe(expected);
+            const ret = philips.decodeGradientColors(input);
+            expect(ret.on).toBe(expected);
         })
 
         test.each([
             ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 0],
             ["4b01012701b1ea4e13500000000e9f5d0727640e9f5d0727640e9f5d2810", 2],
         ])("offset(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input, { reverse: true });
-            expect(ret.gradient_extras.offset).toBe(expected);
+            const ret = philips.decodeGradientColors(input);
+            expect(ret.offset).toBe(expected);
         })
+
+        test.each([
+            ["0f00011dfa0094611b61", 250],
+            ["0f00011d7201ab751969", 370],
+            ["0f00015cf401d486ce69", 500],
+        ])(`colorTemperature(%s) should be %s`, (input, expected) => {
+            const ret = philips.decodeGradientColors(input);
+            expect(ret.color_temp).toBe(expected);
+        })
+
+        test.each([
+            ["0f00011dfa0094611b61", "color_temp"],
+            ["0b00015c842b32b3", "color_xy"],
+            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "gradient"],
+        ])(`color_mode(%s) should be %s`, (input, expected) => {
+            const ret = philips.decodeGradientColors(input);
+            expect(ret.color_mode).toBe(expected);
+        });
     });
 
     describe('encodeGradientColors', () => {


### PR DESCRIPTION
The devices exposes color_xy and color_temp information on the same endpoint that has the gradient data.

This fixes an error where gradient data would be attempted to be decoded (null pointer exception) when the device is in a different color mode.

The extra decoded information is not used anywhere yet.