### PR TITLE
align color_mode values for hue gradient lights

### DIFF
--- a/lib/philips.js
+++ b/lib/philips.js
@@ -127,7 +127,7 @@ function decodeGradientColors(input, opts) {
         const y = yHigh | yLow;
 
         return {
-            color_mode: 'color_xy',
+            color_mode: 'xy',
             x: Math.round(x / 65535 * 10000) / 10000,
             y: Math.round(y / 65535 * 10000) / 10000,
             brightness,

--- a/test/philips.test.js
+++ b/test/philips.test.js
@@ -67,7 +67,7 @@ describe('lib/philips.js', () => {
 
         test.each([
             ["0f00011dfa0094611b61", "color_temp"],
-            ["0b00015c842b32b3", "color_xy"],
+            ["0b00015c842b32b3", "xy"],
             ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "gradient"],
         ])(`color_mode(%s) should be %s`, (input, expected) => {
             const ret = philips.decodeGradientColors(input);


### PR DESCRIPTION
lib/color sets color_mode to 'xy', 'hs', or 'color_temp'.

This change aligns the newer gradient lights to also use 'xy' instead of 'color_xy' as color_mode value introduce in #5132