### PR TITLE
Added Aqara SJCGQ13LM

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -58,6 +58,23 @@ const daysLookup = {
 
 
 const fzLocal = {
+    aqara_s1_co2: {
+        cluster: 'msCO2',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            return {co2: Math.floor(msg.data.measuredValue)};
+        },
+    },
+    aqara_s1_pm25: {
+        cluster: 'heimanSpecificPM25Measurement',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.data['measuredValue']) {
+                return {pm25: msg.data['measuredValue'] / 1000};
+            }
+        },
+    },
+
     aqara_trv: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -416,6 +433,15 @@ module.exports = [
             await endpoint.read('genPowerCfg', ['batteryVoltage']);
         },
         ota: ota.zigbeeOTA,
+    },
+    {
+        zigbeeModel: ['lumi.airm.fhac01'],
+        model: 'KQJCMB11LM',
+        vendor: 'Aqara',
+        description: 'Aqara Air Monitoring Panel S1',
+        fromZigbee: [fz.temperature, fz.humidity, fzLocal.aqara_s1_pm25, fzLocal.aqara_s1_co2],
+        toZigbee: [],
+        exposes: [e.temperature(), e.humidity(), e.pm25(), e.co2()],
     },
     {
         zigbeeModel: ['lumi.magnet.acn001'],

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -74,7 +74,6 @@ const fzLocal = {
             }
         },
     },
-
     aqara_trv: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -437,8 +436,8 @@ module.exports = [
     {
         zigbeeModel: ['lumi.airm.fhac01'],
         model: 'KQJCMB11LM',
-        vendor: 'Aqara',
-        description: 'Aqara Air Monitoring Panel S1',
+        vendor: 'Xiaomi',
+        description: 'Aqara air monitoring panel S1',
         fromZigbee: [fz.temperature, fz.humidity, fzLocal.aqara_s1_pm25, fzLocal.aqara_s1_co2],
         toZigbee: [],
         exposes: [e.temperature(), e.humidity(), e.pm25(), e.co2()],


### PR DESCRIPTION
This PR adds support for  Aqara Air Monitoring Panel S1. It seems like pm25 and co2 values are returned in different units now, so I had to add separate convertors.

Attached screenshot from z2m device expose tab
<img width="911" alt="Screenshot 2022-12-13 at 20 09 49" src="https://user-images.githubusercontent.com/1757017/207411802-f4752c22-f9f6-487f-8d28-a4f633e6962c.png">
