### PR TITLE
Add support for Aurora MPROZX Downlight

### DIFF
--- a/devices/aurora_lighting.js
+++ b/devices/aurora_lighting.js
@@ -104,7 +104,7 @@ module.exports = [
         zigbeeModel: ['TWMPROZXBulb50AU'],
         model: 'AU-A1ZBMPRO1ZX',
         vendor: 'Aurora Lighting',
-        description: 'AOne MPROZX Fixed IP65 Fire Rated Smart Tuneable LED Downlight',
+        description: 'AOne MPROZX fixed IP65 fire rated smart tuneable LED downlight',
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200, 455]}),
     },
     {

--- a/devices/aurora_lighting.js
+++ b/devices/aurora_lighting.js
@@ -101,6 +101,13 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp(),
     },
     {
+        zigbeeModel: ['TWMPROZXBulb50AU'],
+        model: 'AU-A1ZBMPRO1ZX',
+        vendor: 'Aurora Lighting',
+        description: 'AOne MPROZX Fixed IP65 Fire Rated Smart Tuneable LED Downlight',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200, 455]}),
+    },
+    {
         zigbeeModel: ['FWG125Bulb50AU'],
         model: 'AU-A1VG125Z5E/19',
         vendor: 'Aurora Lighting',


### PR DESCRIPTION
This commit adds support for the Aurora AOne MPROZX downlight[1], which is a dimmable and color tuneable downlight.

[1] https://auroralighting.com/gb/trade/ProductDetail/AU-A1ZBMPRO1ZX