### PR TITLE
Hookup ota for MOSZB-140

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -556,6 +556,7 @@ module.exports = [
             dynExposes.push(e.linkquality());
             return dynExposes;
         },
+        ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         endpoint: (device) => {
             return {default: 35};


### PR DESCRIPTION
Looks like the firmware for v4.0.2 is already present in Zigbee-OTA repo, mine are 1 version newer still but it would be nice to allow 3.x users to update.

Ref: https://github.com/Koenkk/zigbee2mqtt/discussions/14178#discussioncomment-4400951