### PR TITLE
Support for a new Moes dimmer (Tuya TS0601 dimmer)

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1207,6 +1207,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_ojzhk75b'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_swaamsoy'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_3p5ydos3'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_p0gzbqct'},
         ],
         model: 'TS0601_dimmer',
         vendor: 'TuYa',


### PR DESCRIPTION
Today I got a new Moes dimmer which looked exactly the same as another moes dimmer that I already have. But it was not supported. The manufacturer name was not found. This adds support for the new dimmer,