### PR TITLE
Add 915005987301 - Philips Hue Signe gradient table lamp (white)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -3012,6 +3012,13 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
     },
     {
+        zigbeeModel: ['915005987301'],
+        model: '915005987301',
+        vendor: 'Philips',
+        description: 'Hue Gradient Signe table lamp (white)',
+        extend: hueExtend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
+    },
+    {
         zigbeeModel: ['929003526301'],
         model: '929003526301',
         vendor: 'Philips',


### PR DESCRIPTION
Add support for the Philips Hue Signe gradient table lamp (white).
https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-gradient-signe-table-lamp/046677803483