### PR TITLE
Support Aurora Lighting AU-A1ZB2WDM in Slave mode

### DIFF
--- a/devices/aurora_lighting.js
+++ b/devices/aurora_lighting.js
@@ -173,7 +173,7 @@ module.exports = [
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
-        zigbeeModel: ['WallDimmerMaster'],
+        zigbeeModel: ['WallDimmerMaster', 'WallDimmerSlave'],
         model: 'AU-A1ZB2WDM',
         vendor: 'Aurora Lighting',
         description: 'AOne 250W smart rotary dimmer module',


### PR DESCRIPTION
The device AU-A1ZB2WDM has a slave mode where it acts as a switch / dimmer, and reports changes to zigbee but doesn't actuate them to the loaded devices, leaving that to the master in the circuit.  See: https://assets.db.aurora.co/FamilyData/23913/13999/FileUpload/288765.pdf With this change I was able to:
- successfully toggle the backlight LED 
- see the switch and brightness states change in the UI
- bind the onoff and levelctrl clusters to a AU-A1ZB2WDM in Master mode, but I could only use on off control. The onoff also acted as a stateful switch, alternately sending on and off instead of toggling the master switch.

Is there a precedent for handling dual mode (Master / Slave) devices like this, where to a certain extent the capabilities have changed? Should I create a separate device rather than overloading the existing one? e.g. In slave mode the on/off and level control aren't writeable, so I suspect these shouldn't be exposed? I'd appreciate some guidance.