### PR TITLE
add zigbeeModel variation for Philips Hue Iris Copper 4th gen

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -405,6 +405,13 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
+        zigbeeModel: ['929002376803'],
+        model: '929002376803',
+        vendor: 'Philips',
+        description: 'Hue Iris copper special edition (generation 4)',
+        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+    },
+    {
         zigbeeModel: ['5063130P7'],
         model: '5063130P7',
         vendor: 'Philips',


### PR DESCRIPTION
I bought two Hue Iris lights in december 2021 (rosé & copper), however, the `zigbeeModel` for my copper variant was not supported. Added it locally to test with Home Assistant and it works flawlessly.