### PR TITLE
Add BTicino LN4570CWI and fix capitalization

### DIFF
--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -262,7 +262,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.identify, fz.on_off],
         toZigbee: [tz.on_off, tz.legrand_identify],
-        whiteLabel: [{vendor: 'Bticino', model: '3584C'}],
+        whiteLabel: [{vendor: 'BTicino', model: '3584C'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genBinaryInput']);

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -278,6 +278,7 @@ module.exports = [
         exposes: [e.battery(), e.action(['enter', 'leave', 'sleep', 'wakeup', 'center'])],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
+        whiteLabel: [{vendor: 'BTicino', model: 'LN4570CWI'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genPowerCfg']);


### PR DESCRIPTION
Hi,

I've bought a [BTicino LN4570CWI](https://catalogo.bticino.it/BTI-LN4570CWI-IT) hoping to add the support for it. However it's already supported and recognised as [Legrand 064873](https://www.zigbee2mqtt.io/devices/064873.html). I've added it as a white label device for the Legrand 064873, so if anyone is searching the documentation it will show up as supported.

As I was doing this I've noticed that another white label device in the same file (BTicino 3584C) had the brand name spelled with the wrong capitalization, which caused the brand to show up twice in the documentation.  I've also updated that to match all other BTicino devices.

Thanks!