### PR TITLE
Added TS0601 | _TZE200_3ylew7b4 and used iteration for tuya_cover in fromZigbee

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2011,6 +2011,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_udank5zs'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zuz7f94z'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_68nvbio9'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_3ylew7b4'},
         ],
         model: 'TS0601_cover',
         vendor: 'TuYa',


### PR DESCRIPTION
While adding support for a tuya tubular motor TS0601 _TZE200_3ylew7b4, the tuya.firstDpValue function logs that a for loop shall be used to process addtional datapoints in one zigbee message which is the exact case for this model, otherwise only retreiving the first dpvalue returns no useful information.

Have tested this model as well as another tuya curtain model which does not need such for loop implementation, and they both work well.