### PR TITLE
Added TS0601 Smart knob dimmer

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1344,6 +1344,29 @@ module.exports = [
         ],
     },
     {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_p0gzbqct']),
+        model: 'TS0601_dimmer',
+        vendor: 'TuYa',
+        description: 'Zigbee smart knob dimmer',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [tuya.exposes.lightBrightness(), tuya.exposes.lightType()],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
+                [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
+                [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
+                [4, 'light_type', tuya.valueConverter.lightType],
+                [21, 'indicator_light_mode', tuya.moesSwitch.indicateLight],
+            ],
+        },
+        whiteLabel: [
+            {vendor: 'Moes', model: 'WS-SY-EURD'},
+            {vendor: 'Moes', model: 'WS-SY-EURD-WH-MS'},
+        ],
+    },
+    {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_oiymh3qu'}],
         model: 'TS011F_socket_module',
         vendor: 'TuYa',


### PR DESCRIPTION
Added the TS0601 Smart knob dimmer from TuYa, branded/sold by Moes. Maybe the whitelabel is wrong. The device can be found here:

https://moeshouse.com/collections/smart-dimmer-switch/products/new-wifi-smart-rotary-light-dimmer-switch-schedule-timer-brightness-memory-eu