### PR TITLE
Added TS0601 Smart knob dimmer

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1351,7 +1351,8 @@ module.exports = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType(), /*tuya.exposes.indicatorModeNoneRelayPos()*/],
+        exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType()
+		    /* tuya.exposes.indicatorModeNoneRelayPos() */],
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1344,6 +1344,29 @@ module.exports = [
         ],
     },
     {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_p0gzbqct']),
+        model: 'TS0601_dimmer',
+        vendor: 'TuYa',
+        description: 'Zigbee smart knob dimmer',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [tuya.exposes.lightBrightness(), tuya.exposes.lightType()],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
+                [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
+                [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
+                [4, 'light_type', tuya.valueConverter.lightType],
+                [21, 'indicator_light_mode', tuya.moesSwitch.indicateLight],
+            ],
+        },
+        whiteLabel: [
+            {vendor: 'Moes', model: 'WS-SY-EURD'},
+            {vendor: 'Moes', model: 'WS-SY-EURD-WH-MS'},
+        ],
+    },
+    {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_oiymh3qu'}],
         model: 'TS011F_socket_module',
         vendor: 'TuYa',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1351,15 +1351,15 @@ module.exports = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType()],
-        /* tuya.exposes.indicatorModeNoneRelayPos() */
+        exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType(),
+        tuya.exposes.indicatorModeNoneRelayPos()],
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
                 [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
                 [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [4, 'light_type', tuya.valueConverter.lightType],
-                // [21, 'indicator_mode', tuya.valueConverterBasic.lookup({0: 'none', 1: 'relay', 2: 'pos'})],
+                [21, 'indicator_mode', tuya.valueConverterBasic.lookup({0: 'none', 1: 'relay', 2: 'pos'})],
             ],
         },
         whiteLabel: [

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1351,15 +1351,15 @@ module.exports = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType()
-		    /* tuya.exposes.indicatorModeNoneRelayPos() */],
+        exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType()],
+	    /* tuya.exposes.indicatorModeNoneRelayPos() */
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
                 [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
                 [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [4, 'light_type', tuya.valueConverter.lightType],
-                //[21, 'indicator_mode', tuya.valueConverterBasic.lookup({0: 'none', 1: 'relay', 2: 'pos'})],
+                // [21, 'indicator_mode', tuya.valueConverterBasic.lookup({0: 'none', 1: 'relay', 2: 'pos'})],
             ],
         },
         whiteLabel: [

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1345,7 +1345,7 @@ module.exports = [
     },
     {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_p0gzbqct']),
-        model: 'TS0601_dimmer',
+        model: 'TS0601_dimmer_knob',
         vendor: 'TuYa',
         description: 'Zigbee smart knob dimmer',
         fromZigbee: [tuya.fz.datapoints],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1351,12 +1351,12 @@ module.exports = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        exposes: [tuya.exposes.lightBrightness()/*.withMinBrightness()*/, tuya.exposes.lightType(), /*tuya.exposes.indicatorModeNoneRelayPos()*/],
+        exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType(), /*tuya.exposes.indicatorModeNoneRelayPos()*/],
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
                 [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
-                //[3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
+                [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [4, 'light_type', tuya.valueConverter.lightType],
                 //[21, 'indicator_mode', tuya.valueConverterBasic.lookup({0: 'none', 1: 'relay', 2: 'pos'})],
             ],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1351,6 +1351,7 @@ module.exports = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
+    //    exposes: [tuya.exposes.lightBrightness(), tuya.exposes.lightType(), tuya.exposes.indicatorMode()],
         exposes: [tuya.exposes.lightBrightness(), tuya.exposes.lightType()],
         meta: {
             tuyaDatapoints: [
@@ -1358,7 +1359,7 @@ module.exports = [
                 [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
                 [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [4, 'light_type', tuya.valueConverter.lightType],
-                [21, 'indicator_light_mode', tuya.moesSwitch.indicateLight],
+    //            [21, 'indicator_light_mode', tuya.tuyaTz.backlight_indicator_mode],
             ],
         },
         whiteLabel: [

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1352,7 +1352,7 @@ module.exports = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType(),
-        tuya.exposes.indicatorModeNoneRelayPos()],
+            tuya.exposes.indicatorModeNoneRelayPos()],
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1351,15 +1351,14 @@ module.exports = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-    //    exposes: [tuya.exposes.lightBrightness(), tuya.exposes.lightType(), tuya.exposes.indicatorMode()],
-        exposes: [tuya.exposes.lightBrightness(), tuya.exposes.lightType()],
+        exposes: [tuya.exposes.lightBrightness()/*.withMinBrightness()*/, tuya.exposes.lightType(), /*tuya.exposes.indicatorModeNoneRelayPos()*/],
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
                 [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
-                [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
+                //[3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [4, 'light_type', tuya.valueConverter.lightType],
-    //            [21, 'indicator_light_mode', tuya.tuyaTz.backlight_indicator_mode],
+                //[21, 'indicator_mode', tuya.valueConverterBasic.lookup({0: 'none', 1: 'relay', 2: 'pos'})],
             ],
         },
         whiteLabel: [

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1352,7 +1352,7 @@ module.exports = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType()],
-       /* tuya.exposes.indicatorModeNoneRelayPos() */
+        /* tuya.exposes.indicatorModeNoneRelayPos() */
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1352,7 +1352,7 @@ module.exports = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET), tuya.exposes.lightType()],
-	    /* tuya.exposes.indicatorModeNoneRelayPos() */
+       /* tuya.exposes.indicatorModeNoneRelayPos() */
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1163,6 +1163,8 @@ const tuyaExposes = {
     backlightModeOffNormalInverted: () => exposes.enum('backlight_mode', ea.ALL, ['off', 'normal', 'inverted'])
         .withDescription('Mode of the backlight'),
     indicatorMode: () => exposes.enum('indicator_mode', ea.ALL, ['off', 'off/on', 'on/off', 'on']).withDescription('LED indicator mode'),
+    indicatorModeNoneRelayPos: () => exposes.enum('indicator_mode', ea.ALL, ['none', 'relay', 'pos'])
+        .withDescription('Mode of the indicator light'),
     powerOutageMemory: () => exposes.enum('power_outage_memory', ea.ALL, ['on', 'off', 'restore'])
         .withDescription('Recover state after power outage'),
     batteryState: () => exposes.enum('battery_state', ea.STATE, ['low', 'medium', 'high']).withDescription('State of the battery'),


### PR DESCRIPTION
Added the TS0601 Smart knob dimmer from TuYa, branded/sold by Moes. Maybe the whitelabel is wrong. The device can be found here:

https://moeshouse.com/collections/smart-dimmer-switch/products/new-wifi-smart-rotary-light-dimmer-switch-schedule-timer-brightness-memory-eu

Unfortunately, I am not sure how to use the 'indicatorMode' correctly, since I didnÄt found the right vonverter.

PR for zigbee2mqtt.io: https://github.com/Koenkk/zigbee2mqtt.io/pull/1781