### PR TITLE
Add additional model number for Hue Resonate

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1693,7 +1693,7 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp_color(),
     },
     {
-        zigbeeModel: ['1746430P7'],
+        zigbeeModel: ['1746430P7', '929003098701'],
         model: '1746430P7',
         vendor: 'Philips',
         description: 'Hue outdoor Resonate wall lamp (black)',


### PR DESCRIPTION
Adds [929003098701](https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-resonate-outdoor-wall-light/046677576080), which is the same as Philips [1746430P7](https://www.zigbee2mqtt.io/devices/1746430P7.html).