### PR TITLE
Updated Moes TS0601 thermostat (_TZE200_b6wax7g0)

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -290,9 +290,9 @@ module.exports = [
             e.valve_state(), e.position(), e.window_detection(),
             exposes.binary('window', ea.STATE, 'OPEN', 'CLOSED').withDescription('Window status closed or open '),
             exposes.climate()
-                .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 35, 1, ea.STATE_SET)
+                .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 45, 0.5, ea.STATE_SET)
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
-                .withSystemMode(['heat'], ea.STATE_SET)
+                .withSystemMode(['off', 'heat'], ea.STATE_SET)
                 .withRunningState(['idle', 'heat'], ea.STATE)
                 .withPreset(['programming', 'manual', 'temporary_manual', 'holiday'],
                     'MANUAL MODE ☝ - In this mode, the device executes manual temperature setting. '+


### PR DESCRIPTION
The Moes TS0601 thermostat (_TZE200_b6wax7g0) has setpoints from 5 to 45 °C in 0.5 °C steps. Additionally, the systemMode can be 'off'.