### PR TITLE
Added 'indicatorModeNoneRelayPos'

### DIFF
--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -864,6 +864,9 @@ const dataPoints = {
     HPSZPresenceTime: 101,
     HPSZLeavingTime: 102,
     HPSZLEDState: 103,
+    //TS0601 Moes Dimmer
+    TS0601LightType: 4,
+    TS0601IndicatorLight: 21,
 };
 
 const thermostatWeekFormat = {
@@ -1163,6 +1166,7 @@ const tuyaExposes = {
     backlightModeOffNormalInverted: () => exposes.enum('backlight_mode', ea.ALL, ['off', 'normal', 'inverted'])
         .withDescription('Mode of the backlight'),
     indicatorMode: () => exposes.enum('indicator_mode', ea.ALL, ['off', 'off/on', 'on/off', 'on']).withDescription('LED indicator mode'),
+    indicatorModeNoneRelayPos: () => exposes.enum('indicator_mode', ea.ALL, ['none', 'relay', 'pos']).withDescription('Mode of the indicator light'),
     powerOutageMemory: () => exposes.enum('power_outage_memory', ea.ALL, ['on', 'off', 'restore'])
         .withDescription('Recover state after power outage'),
     batteryState: () => exposes.enum('battery_state', ea.STATE, ['low', 'medium', 'high']).withDescription('State of the battery'),


### PR DESCRIPTION
Added 'indicatorModeNoneRelayPos' for the indicator light state of some devices, e.g. the TS0601 smart knob dimmer (https://github.com/Koenkk/zigbee-herdsman-converters/pull/5204)

![light_mode](https://user-images.githubusercontent.com/4464088/209669263-eba341d9-9319-4710-ad5f-a17798eb40a8.png)