### PR TITLE
Revert "Support for a new Moes dimmer (Tuya TS0601 dimmer)"

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1218,7 +1218,6 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_ojzhk75b'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_swaamsoy'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_3p5ydos3'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_p0gzbqct'},
         ],
         model: 'TS0601_dimmer',
         vendor: 'TuYa',


### PR DESCRIPTION
This was not the correct solution for supporting this new Moes dimmer. I saw another pull request with the correct implementation.