### PR TITLE
Remove _TZ3000_6ygjfyll from ZB003-X, Add _TZ3000_6ygjfyll to IH012-RT01

### DIFF
--- a/devices/fantem.js
+++ b/devices/fantem.js
@@ -49,7 +49,6 @@ module.exports = [
     {
         fingerprint: [{modelID: 'TS0202', manufacturerName: '_TZ3210_rxqls8v0'},
             {modelID: 'TS0202', manufacturerName: '_TZ3210_zmy9hjay'},
-            {modelID: 'TS0202', manufacturerName: '_TZ3000_6ygjfyll'},
             {modelID: 'TS0202', manufacturerName: '_TZ3210_wuhzzfqg'}],
         model: 'ZB003-X',
         vendor: 'Fantem',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1144,7 +1144,7 @@ module.exports = [
         configure: tuya.configureMagicPacket,
     },
     {
-        fingerprint: tuya.fingerprint('TS0202', ['_TZ3000_mcxw5ehu', '_TZ3040_6ygjfyll']),
+        fingerprint: tuya.fingerprint('TS0202', ['_TZ3000_mcxw5ehu', '_TZ3000_6ygjfyll', '_TZ3040_6ygjfyll']),
         model: 'IH012-RT01',
         vendor: 'TuYa',
         description: 'Motion sensor',


### PR DESCRIPTION
To resolve the fact that a newer revision of IH012-RT01 is not working with zigbee2mqtt. 

See: https://github.com/Koenkk/zigbee2mqtt/issues/9757#issuecomment-1367716461

There's no sign that this new model closely resemble Fantem ZB003-X, but rather the same sensor as Tuya IH012-RT01. 

Tested working as of now. Cheers