### PR TITLE
Add support for Hue 6 inch High Luminance White Ambiance Downlight

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -3259,4 +3259,11 @@ module.exports = [
         description: 'Hue white E27 1100lm with Bluetooth',
         extend: hueExtend.light_onoff_brightness(),
     },
+    {
+        zigbeeModel: ['LTD017'],
+        model: '578526',
+        vendor: 'Philips',
+        description: 'Hue White Ambiance Extra Bright High Lumen Dimmable LED Smart Retrofit Recessed 6" Downlight',
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 500]}),
+    },
 ];

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -3263,7 +3263,7 @@ module.exports = [
         zigbeeModel: ['LTD017'],
         model: '578526',
         vendor: 'Philips',
-        description: 'Hue White Ambiance Extra Bright High Lumen Dimmable LED Smart Retrofit Recessed 6" Downlight',
+        description: 'Hue white ambiance extra bright high lumen dimmable LED smart retrofit recessed 6" downlight',
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 500]}),
     },
 ];


### PR DESCRIPTION
* Added support for new 6 inch White Ambiance High Luminance version of downlight.
* This is the Amazon/US link for reference: https://www.amazon.com/gp/product/B0B6L38LK4