### PR TITLE
Expose led_in_dark setting for Legrand 067776

### DIFF
--- a/devices/heiman.js
+++ b/devices/heiman.js
@@ -476,7 +476,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['GASSensor-EM', '358e4e3e03c644709905034dae81433e'],
+        zigbeeModel: ['GASSensor-EM'],
         model: 'HS1CG-E',
         vendor: 'HEIMAN',
         description: 'Combustible gas sensor',

--- a/devices/heiman.js
+++ b/devices/heiman.js
@@ -476,7 +476,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['GASSensor-EM'],
+        zigbeeModel: ['GASSensor-EM', '358e4e3e03c644709905034dae81433e'],
         model: 'HS1CG-E',
         vendor: 'HEIMAN',
         description: 'Combustible gas sensor',

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -130,7 +130,9 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
             await reporting.currentPositionLiftPercentage(endpoint);
         },
-        exposes: [e.cover_position()],
+        exposes: [e.cover_position(),
+            exposes.binary('led_in_dark', ea.ALL, 'ON', 'OFF').withDescription(`Enables the LED when the power socket is turned off,
+            allowing to see it in the dark`)],
     },
     {
         // swbuildid 001a requires coverInverted: https://github.com/Koenkk/zigbee2mqtt/issues/15101#issuecomment-1356787490


### PR DESCRIPTION
Expose led_in_dark setting for Legrand 067776 (same as Legrand 067775/741811)

tested with my devices at home.

npm lint / npm test performed without issues.