### PR TITLE
Add support for HEIMAN custom HS1CG-E (358e4e3e03c644709905034dae81433e)

### DIFF
--- a/devices/heiman.js
+++ b/devices/heiman.js
@@ -476,7 +476,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['GASSensor-EM'],
+        zigbeeModel: ['GASSensor-EM', '358e4e3e03c644709905034dae81433e'],
         model: 'HS1CG-E',
         vendor: 'HEIMAN',
         description: 'Combustible gas sensor',

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -130,9 +130,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
             await reporting.currentPositionLiftPercentage(endpoint);
         },
-        exposes: [e.cover_position(),
-            exposes.binary('led_in_dark', ea.ALL, 'ON', 'OFF').withDescription(`Enables the LED when the power socket is turned off,
-            allowing to see it in the dark`)],
+        exposes: [e.cover_position()],
     },
     {
         // swbuildid 001a requires coverInverted: https://github.com/Koenkk/zigbee2mqtt/issues/15101#issuecomment-1356787490

--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -130,7 +130,9 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
             await reporting.currentPositionLiftPercentage(endpoint);
         },
-        exposes: [e.cover_position()],
+        exposes: [e.cover_position(),
+            exposes.binary('led_in_dark', ea.ALL, 'ON', 'OFF').withDescription(`Enables the LED when the power socket is turned off,
+            allowing to see it in the dark`)],
     },
     {
         // swbuildid 001a requires coverInverted: https://github.com/Koenkk/zigbee2mqtt/issues/15101#issuecomment-1356787490


### PR DESCRIPTION
I have a HEIMAN HS1CG-E returning '358e4e3e03c644709905034dae81433e' as zigbeeModel.
it also existist with different branding (according [here](https://zigbee.blakadder.com/Orvibo_SG20.html))

Mine is branded HEIMAN. I bought [here](https://www.domadoo.fr/fr/peripheriques/5883-heiman-capteur-de-gaz-combustible-intelligent-zigbee-30.html

tested with my device with sucess