### PR TITLE
philips: fix binding for gradient lights

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -75,8 +75,8 @@ const hueExtend = {
         return result;
     },
     light_onoff_brightness_colortemp_color_gradient: (options={}) => {
-        options = {supportsHS: true, disableEffect: true, noConfigure: true, extraEffects: [], ...options};
-        const result = extendDontUse.light_onoff_brightness_colortemp_color({supportsHS: true, ...options});
+        options = {supportsHS: true, disableEffect: true, extraEffects: [], ...options};
+        const result = extendDontUse.light_onoff_brightness_colortemp_color({noConfigure: true, ...options});
         result['ota'] = ota.zigbeeOTA;
         result['meta'] = {turnsOffAtBrightness1: true};
         result['toZigbee'] = result['toZigbee'].concat([


### PR DESCRIPTION
Looks like this broke in the refactoring in #5192.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/15883

(The issue is that `noConfigure` was true on line 88, when creating the `configure` function).