### PR TITLE
Support power_on_behavior for 3RSB015BZ

### DIFF
--- a/devices/third_reality.js
+++ b/devices/third_reality.js
@@ -109,6 +109,9 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
         },
+        toZigbee: extend.switch().toZigbee.concat([tz.power_on_behavior]),
+        fromZigbee: extend.switch().fromZigbee.concat([fz.power_on_behavior]),
+        exposes: [e.switch(), e.power_on_behavior()],
     },
     {
         zigbeeModel: ['3RSB015BZ'],


### PR DESCRIPTION
I think there's a dependency on firmware 1.00.29 for power_on_behavior to actually work, but it's valid nonetheless.  I've tested this locally with several of my plugs running 1.00.29.