### PR TITLE
Fix GIDEALED ZC05M maximum color temperature

### DIFF
--- a/devices/gidealed.js
+++ b/devices/gidealed.js
@@ -6,6 +6,6 @@ module.exports = [
         model: 'ZC05M',
         vendor: 'GIDEALED',
         description: 'Smart Zigbee RGB LED strip controller',
-        extend: extend.light_onoff_brightness_colortemp_color({supportsHS: true, colorTempRange: [153, 500]}),
+        extend: extend.light_onoff_brightness_colortemp_color({supportsHS: true, colorTempRange: [153, 370]}),
     },
 ];


### PR DESCRIPTION
Setting it to "warmest", it goes back to 370 and only the warm LEDs are on, the original issue also mentions 370 as the maximum: https://github.com/Koenkk/zigbee2mqtt/issues/11501