### PR TITLE
Added Hue Effects support to the Hue Gradient Lightstrip and Hue Ensis White and Black

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -458,7 +458,7 @@ module.exports = [
         model: '929002994901',
         vendor: 'Philips',
         description: 'Hue gradient lightstrip',
-        extend: hueExtend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
+        extend: hueExtend.light_onoff_brightness_colortemp_color_gradient({disableHueEffects: false, colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['929003045401'],
@@ -738,14 +738,14 @@ module.exports = [
         model: '4090331P9',
         vendor: 'Philips',
         description: 'Hue Ensis (white)',
-        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        extend: hueExtend.light_onoff_brightness_colortemp_color({disableHueEffects: false, colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['4090330P9_01', '4090330P9_02', '929003052501_01', '929003052501_02'],
         model: '4090330P9',
         vendor: 'Philips',
         description: 'Hue Ensis (black)',
-        extend: hueExtend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+        extend: hueExtend.light_onoff_brightness_colortemp_color({disableHueEffects: false, colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['929003055901', '929003055901_01', '929003055901_02', '929003055901_03'],


### PR DESCRIPTION
I noticed in the Philips devices file that none of the Hue Gradient lights have the Hue Effects enabled. I only have the Hue Gradient lightstrip, but this one does support the Hue Effects in the Hue app. Also, I only have the black Hue Ensis light, but I added the Hue Effect support for the white one, as well. I will create a pull request to update the functionality in the Zigbee2mqtt.io devices page, as well.