### PR TITLE
philips: expose current effect

### DIFF
--- a/lib/philips.js
+++ b/lib/philips.js
@@ -43,7 +43,7 @@ const knownEffects = {
 
 
 // decoder for manuSpecificPhilips2.state
-function decodeGradientColors(input, opts) {
+function decodeState(input, opts) {
     // Gradient mode (4b01)
     // Example: 4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800
     // 4b01 - mode? (4) (0b00 single color?, 4b01 gradient?)
@@ -247,6 +247,6 @@ function encodeGradientColors(value, opts) {
 }
 
 module.exports = {
-    decodeGradientColors,
+    decodeState,
     encodeGradientColors,
 };

--- a/test/philips.test.js
+++ b/test/philips.test.js
@@ -1,14 +1,14 @@
 const philips = require('../lib/philips');
 
 describe('lib/philips.js', () => {
-    describe('decodeGradientColors', () => {
+    describe('decodeState', () => {
         test.each([
             ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", true, ["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"]],
             ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", false, ["#ff77f8",  "#7951ff", "#2538ff","#1137ff", "#0c32ff"]],
             ["4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800", true, ["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"]],
             ["4b010127a0526f5410400000000727640e9f5d0727640e9f5d2000", true, ["#ff0500", "#ffffff", "#ff0500", "#ffffff"]],
         ])("colors(%s) should be %s", (input, opts_reverse, expected) => {
-            const ret = philips.decodeGradientColors(input, { reverse: opts_reverse });
+            const ret = philips.decodeState(input, { reverse: opts_reverse });
             expect(ret.colors).toStrictEqual(expected);
         })
 
@@ -18,7 +18,7 @@ describe('lib/philips.js', () => {
             ["0b00015c842b32b3", [0.1700, 0.7000]], // Green (#00ff0e)
             ["0b00011d37272c0c", [0.1532, 0.0475]], // Blue (#0a00ff)
         ])(`xy(%s) should be %s`, (input, expected) => {
-            const ret = philips.decodeGradientColors(input);
+            const ret = philips.decodeState(input);
             expect([ret.x, ret.y]).toStrictEqual(expected);
         })
 
@@ -35,7 +35,7 @@ describe('lib/philips.js', () => {
             ["03000164", 100],
             ["030001fe", 254],
         ])("brightness(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input);
+            const ret = philips.decodeState(input);
             expect(ret.brightness).toBe(expected);
         })
 
@@ -51,7 +51,7 @@ describe('lib/philips.js', () => {
             ["03000164", true],
             ["0300004f", false],
         ])("power(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input);
+            const ret = philips.decodeState(input);
             expect(ret.on).toBe(expected);
         })
 
@@ -59,7 +59,7 @@ describe('lib/philips.js', () => {
             ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 0],
             ["4b01012701b1ea4e13500000000e9f5d0727640e9f5d0727640e9f5d2810", 2],
         ])("offset(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input);
+            const ret = philips.decodeState(input);
             expect(ret.offset).toBe(expected);
         })
 
@@ -68,7 +68,7 @@ describe('lib/philips.js', () => {
             ["0f00011d7201ab751969", 370],
             ["0f00015cf401d486ce69", 500],
         ])(`colorTemperature(%s) should be %s`, (input, expected) => {
-            const ret = philips.decodeGradientColors(input);
+            const ret = philips.decodeState(input);
             expect(ret.color_temp).toBe(expected);
         })
 
@@ -78,7 +78,7 @@ describe('lib/philips.js', () => {
             ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "gradient"],
             ["ab000153df7e446a0180", "xy"],
         ])(`color_mode(%s) should be %s`, (input, expected) => {
-            const ret = philips.decodeGradientColors(input);
+            const ret = philips.decodeState(input);
             expect(ret.color_mode).toBe(expected);
         });
 
@@ -88,7 +88,7 @@ describe('lib/philips.js', () => {
             ["ab0001febe92ab650380", "colorloop"],
             ["ab0001febe92ab659999", "unknown_9999"],
         ])("effect(%s) should be %s", (input, expected) => {
-            const ret = philips.decodeGradientColors(input);
+            const ret = philips.decodeState(input);
             expect(ret.name).toBe(expected);
         });
     });


### PR DESCRIPTION
This fixes https://github.com/Koenkk/zigbee2mqtt/issues/15891

* Exposes `effect` for all devices that have custom Philips effects (defaults to `null` if no effect is in use).
* Changes the `gradient` state to default to an empty list if the gradient no longer is in use (gradient capable devices only).
* Renamed `decodeGradientColors` -> `decodeState` and `fzLocal.gradient` -> `philipsState` as it's now clear that the same attribute does more than just gradients.
* Updates the binding to only bind `manuSpecificPhilips2` on endpoint 11. The binding on all endpoints was an error, back from when I first added gradient support.

One question:

It seems like Hue devices with older firmware versions doesn't always have a `manuSpecificPhilips2` cluster. Would it be a good idea to wrap the binding in a try/catch? Or does that cause more harm than it prevents.