### PR TITLE
Fix state problems for Eurotronic SPZB0001

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2622,10 +2622,10 @@ const converters = {
                 result.current_heating_setpoint = precisionRound(msg.data[0x4003], 2) / 100;
             }
             if (typeof msg.data[0x4008] == 'number') {
-                result.child_protection = (result.eurotronic_host_flags & (1 << 7)) != 0;
-                result.mirror_display = (result.eurotronic_host_flags & (1 << 1)) != 0;
-                result.boost = (result.eurotronic_host_flags & 1 << 2) != 0;
-                result.window_open = (result.eurotronic_host_flags & (1 << 4)) != 0;
+                result.child_protection = (msg.data[0x4008] & (1 << 7)) != 0;
+                result.mirror_display = (msg.data[0x4008] & (1 << 1)) != 0;
+                result.boost = (msg.data[0x4008] & 1 << 2) != 0;
+                result.window_open = (msg.data[0x4008] & (1 << 4)) != 0;
 
                 if (result.boost) result.system_mode = constants.thermostatSystemModes[4];
                 else if (result.window_open) result.system_mode = constants.thermostatSystemModes[0];

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -4166,6 +4166,7 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const payload = {0x4001: {value, type: 0x20}};
             await entity.write('hvacThermostat', payload, manufacturerOptions.eurotronic);
+            return {state: {[key]: value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4001], manufacturerOptions.eurotronic);


### PR DESCRIPTION
Lately I played around a bit with my Eurotronic SPZB0001 devices and discovered, that they are all running in legacy mode in my installation. Never had serious problems with it, but being legacy triggered me. ;)
I changed the legacy flag to false and discovered, that there are state problems:
1. In trv mode 1 the valve position is not in state after setting it. 875e28794d7a5163bfe29d03993554c9fd1cdb38 fixes it.
2. In trv mode 2 changing the system mode is not in state. 10ccd7455040b356a89cfa6f361e794e3674dcdd fixes it.
With those two fixes the devices behave the same as in legacy mode when using trv mode 2. Using trv mode 1 was not possible for me in legacy mode because of state problems, so this is a plus for not using legacy mode anymore.