### PR TITLE
ubisys: avoid INSUFFICIENT_SPACE while reading config

### DIFF
--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -86,7 +86,7 @@ const ubisys = {
             cluster: 'manuSpecificUbisysDeviceSetup',
             type: ['attributeReport', 'readResponse'],
             convert: (model, msg, publish, options, meta) => {
-                const result = {};
+                const result = meta.state.hasOwnProperty('configure_device_setup') ? meta.state.configure_device_setup : {};
                 if (msg.data['inputConfigurations'] != null) {
                     result['input_configurations'] = msg.data['inputConfigurations'];
                 }
@@ -516,7 +516,9 @@ const ubisys = {
 
             convertGet: async (entity, key, meta) => {
                 const devMgmtEp = meta.device.getEndpoint(232);
-                await devMgmtEp.read('manuSpecificUbisysDeviceSetup', ['inputConfigurations', 'inputActions'],
+                await devMgmtEp.read('manuSpecificUbisysDeviceSetup', ['inputConfigurations'],
+                    manufacturerOptions.ubisysNull);
+                await devMgmtEp.read('manuSpecificUbisysDeviceSetup', ['inputActions'],
                     manufacturerOptions.ubisysNull);
             },
         },

--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -511,7 +511,7 @@ const ubisys = {
                 }
 
                 // re-read effective settings and dump them to the log
-                ubisys.tz.configure_device_setup.convertGet(entity, key, meta);
+                await ubisys.tz.configure_device_setup.convertGet(entity, key, meta);
             },
 
             convertGet: async (entity, key, meta) => {

--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -501,7 +501,7 @@ const ubisys = {
                         endpoint += 1;
                     }
 
-                    meta.logger.debug(`ubisys: input_actions to be sent to '${meta.options.friendlyName}': ` +
+                    meta.logger.debug(`ubisys: input_actions to be sent to '${meta.options.friendly_name}': ` +
                         JSON.stringify(resultingInputActions));
                     await devMgmtEp.write(
                         'manuSpecificUbisysDeviceSetup',


### PR DESCRIPTION
https://github.com/Koenkk/zigbee2mqtt/issues/15875

- tz: read inputConfiguration and inputActions seperately
- fz: merge correctly because they are 2 reads now

This change allows me to at least read my C4 and S2, this doesn't address the weird binds being reset however.