### PR TITLE
Add missing apparentPower attribute for some Legrand devices

### DIFF
--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -253,6 +253,7 @@ module.exports = [
             await reporting.onOff(endpoint);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint);
+            await reporting.apparentPower(endpoint);
         },
     },
     {
@@ -310,6 +311,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'genIdentify']);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint);
+            await reporting.apparentPower(endpoint);
             // Read configuration values that are not sent periodically as well as current power (activePower).
             await endpoint.read('haElectricalMeasurement', ['activePower', 0xf000, 0xf001, 0xf002]);
         },
@@ -377,6 +379,7 @@ module.exports = [
             exposes.enum('cable_outlet_mode', ea.ALL, ['comfort', 'comfort-1', 'comfort-2', 'eco', 'frost_protection', 'off']),
             exposes.switch().withState('state', true, 'Works only when the pilot wire is deactivated'),
             e.power().withAccess(ea.STATE_GET),
+            e.power_apparent(),
             e.power_on_behavior().withDescription(`Controls the behavior when the device is powered on. Works only when the pilot wire is
                 deactivated`)],
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -385,6 +388,7 @@ module.exports = [
             await reporting.onOff(endpoint);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint);
+            await reporting.apparentPower(endpoint);
         },
     },
     {

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -202,6 +202,10 @@ module.exports = {
         const p = payload('activePower', 5, repInterval.HOUR, 1, overrides);
         await endpoint.configureReporting('haElectricalMeasurement', p);
     },
+    apparentPower: async (endpoint, overrides) => {
+        const p = payload('apparentPower', 5, repInterval.HOUR, 1, overrides);
+        await endpoint.configureReporting('haElectricalMeasurement', p);
+    },
     rmsCurrent: async (endpoint, overrides) => {
         const p = payload('rmsCurrent', 5, repInterval.HOUR, 1, overrides);
         await endpoint.configureReporting('haElectricalMeasurement', p);


### PR DESCRIPTION
In addition with the PR #5264, Legrand 064882 device (Cable outlet with pilot wire and consumption measurement) also exposed "apparent_power" in "haElectricalMeasurement" cluster

### Log from my Z2M instance
`Received Zigbee message from 'Radiateur Chambre', type 'attributeReport', cluster 'haElectricalMeasurement', data '{"apparentPower":0}' from endpoint 1 with groupID 0`