### PR TITLE
Update sunricher.js

### DIFF
--- a/devices/sunricher.js
+++ b/devices/sunricher.js
@@ -606,7 +606,7 @@ module.exports = [
         },
     },
     {
-        fingerprint: [{modelID: 'TERNCY-DC01', manufacturer: 'Sunricher'}],
+        fingerprint: [{modelID: 'SR-ZG9010A', manufacturer: 'Sunricher'}],
         model: 'SR-ZG9010A',
         vendor: 'Sunricher',
         description: 'Door windows sensor',

--- a/devices/sunricher.js
+++ b/devices/sunricher.js
@@ -606,7 +606,7 @@ module.exports = [
         },
     },
     {
-        fingerprint: [{modelID: 'SR-ZG9010A', manufacturer: 'Sunricher'}],
+        fingerprint: [{modelID: 'TERNCY-DC01', manufacturerName: 'Sunricher'}],
         model: 'SR-ZG9010A',
         vendor: 'Sunricher',
         description: 'Door windows sensor',


### PR DESCRIPTION
The mis-copy of the modelID from Terncy causes the Terncy devices to be [mis-identified and no longer function](https://github.com/Koenkk/zigbee2mqtt/issues/15979). I am assuming here that the modelID is correct, based on the other information provided.