### PR TITLE
Add support for _TZ3000_okaz9tjs (TS011F_plug_3)

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2561,8 +2561,7 @@ module.exports = [
         onEvent: (type, data, device, options) =>
             tuya.onEventMeasurementPoll(type, data, device, options,
                 device.applicationVersion !== 66, // polling for voltage, current and power
-                device.applicationVersion === 160 || device.applicationVersion === 100 ||
-                device.applicationVersion === 66, // polling for energy
+                [66, 100, 160].includes(device.applicationVersion), // polling for energy
             ),
     },
     {

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1278,7 +1278,7 @@ module.exports = [
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
-                [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
+                [2, 'brightness', tuya.valueConverter.scale0_254to0_,0],
                 [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [4, 'light_type', tuya.valueConverter.lightType],
                 [5, 'max_brightness', tuya.valueConverter.scale0_254to0_1000],
@@ -2561,7 +2561,8 @@ module.exports = [
         onEvent: (type, data, device, options) =>
             tuya.onEventMeasurementPoll(type, data, device, options,
                 device.applicationVersion !== 66, // polling for voltage, current and power
-                device.applicationVersion === 160 || device.applicationVersion === 100 || device.applicationVersion === 66, // polling for energy
+                device.applicationVersion === 160 || device.applicationVersion === 100 ||
+                device.applicationVersion === 66, // polling for energy
             ),
     },
     {

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1278,7 +1278,7 @@ module.exports = [
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
-                [2, 'brightness', tuya.valueConverter.scale0_254to0_,0],
+                [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
                 [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [4, 'light_type', tuya.valueConverter.lightType],
                 [5, 'max_brightness', tuya.valueConverter.scale0_254to0_1000],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2540,7 +2540,7 @@ module.exports = [
         },
     },
     {
-        fingerprint: [160, 69, 68, 65, 64, 66].map((applicationVersion) => {
+        fingerprint: [160, 100, 69, 68, 65, 64, 66].map((applicationVersion) => {
             return {modelID: 'TS011F', applicationVersion, priority: -1};
         }),
         model: 'TS011F_plug_3',
@@ -2561,7 +2561,7 @@ module.exports = [
         onEvent: (type, data, device, options) =>
             tuya.onEventMeasurementPoll(type, data, device, options,
                 device.applicationVersion !== 66, // polling for voltage, current and power
-                device.applicationVersion === 160 || device.applicationVersion === 66, // polling for energy
+                device.applicationVersion === 160 || device.applicationVersion === 100 || device.applicationVersion === 66, // polling for energy
             ),
     },
     {


### PR DESCRIPTION
I have a couple of `_TZ3000_okaz9tjs` plugs that were incorrectly identified as `TS011F_plug_1` while they seem to be `TS011F_plug_3` instead. Here's an example entry from the `database.db` of one of the devices after I applied the patch from my PR locally:

```
{"id":7,"type":"Router","ieeeAddr":"0x70b3d52b6001b8f8","nwkAddr":44681,"manufId":4660,"manufName":"_TZ3000_okaz9tjs","powerSource":"Mains (single phase)","modelId":"TS011F","epList":[1],"endpoints":{"1":{"profId":260,"epId":1,"devId":81,"inClusterList":[0,6,3,4,5,57345,2820,1794],"outClusterList":[],"clusters":{"genBasic":{"attributes":{"modelId":"TS011F","manufacturerName":"_TZ3000_okaz9tjs","powerSource":1,"zclVersion":2,"appVersion":100,"stackVersion":1,"hwVersion":3,"dateCode":"20210625","swBuildId":"20B+TZSKT11BS108"}},"seMetering":{"attributes":{"currentSummDelivered":[0,51],"divisor":100,"multiplier":1}},"genOnOff":{"attributes":{"onOff":1}},"haElectricalMeasurement":{"attributes":{"acCurrentDivisor":1000,"acCurrentMultiplier":1,"rmsVoltage":227,"rmsCurrent":47,"activePower":2}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0029de0e22","endpointID":1},{"cluster":2820,"type":"endpoint","deviceIeeeAddress":"0x00124b0029de0e22","endpointID":1},{"cluster":1794,"type":"endpoint","deviceIeeeAddress":"0x00124b0029de0e22","endpointID":1}],"configuredReportings":[],"meta":{}}},"appVersion":100,"stackVersion":1,"hwVersion":3,"dateCode":"20210625","swBuildId":"20B+TZSKT11BS108","zclVersion":2,"interviewCompleted":true,"meta":{"configured":2123427102},"lastSeen":1673097681565,"defaultSendRequestWhen":"immediate"}
```

After the patch, I receive energy data correctly (before the patch I did not see any energy readings):

```
{
    "linkquality": 78,
    "state": "ON",
    "child_lock": null,
    "current": 0.05,
    "energy": 0.51,
    "indicator_mode": null,
    "power": 2,
    "power_outage_memory": null,
    "update": {
        "installed_version": -1,
        "latest_version": -1,
        "state": null
    },
    "update_available": null,
    "voltage": 226
}
```