### PR TITLE
Fix move _TZE200_9yapgbuv to the correct model

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1668,7 +1668,6 @@ module.exports = [
             {modelID: 'TS0201', manufacturerName: '_TZ3000_yd2e749y'},
             {modelID: 'TS0201', manufacturerName: '_TZ3000_6uzkisv2'},
             {modelID: 'TS0201', manufacturerName: '_TZ3000_xr3htd96'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_9yapgbuv'},
         ],
         model: 'WSD500A',
         vendor: 'TuYa',
@@ -1698,7 +1697,7 @@ module.exports = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_yjjdcqsq']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_yjjdcqsq', '_TZE200_9yapgbuv']),
         model: 'ZTH01',
         vendor: 'TuYa',
         description: 'Temperature and humidity sensor',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1701,18 +1701,10 @@ module.exports = [
         model: 'ZTH01',
         vendor: 'TuYa',
         description: 'Temperature and humidity sensor',
-        fromZigbee: [tuya.fz.datapoints, tuya.fz.gateway_connection_status],
-        toZigbee: [tuya.tz.datapoints],
+        fromZigbee: [fz.tuya_temperature_humidity_sensor],
+        toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.temperature(), e.humidity(), tuya.exposes.batteryState(), e.battery_low()],
-        meta: {
-            tuyaDatapoints: [
-                [1, 'temperature', tuya.valueConverter.divideBy10],
-                [2, 'humidity', tuya.valueConverter.raw],
-                [3, 'battery_state', tuya.valueConverter.batteryState],
-                // [9, 'temperature_unit', tuya.valueConverter.raw], This DP is not properly supported by the device
-            ],
-        },
     },
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_3zofvcaa'}],

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1705,6 +1705,14 @@ module.exports = [
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.temperature(), e.humidity(), tuya.exposes.batteryState(), e.battery_low()],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'temperature', tuya.valueConverter.divideBy10],
+                [2, 'humidity', tuya.valueConverter.raw],
+                [3, 'battery_state', tuya.valueConverter.batteryState],
+                // [9, 'temperature_unit', tuya.valueConverter.raw], This DP is not properly supported by the device
+            ],
+        },
     },
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_3zofvcaa'}],


### PR DESCRIPTION
### Moves the Tuya TS0601 from `WSD500A` to `ZTH01`.

When my Tuya temp and humidity sensor was recognized as `WSD500A` they stopped reporting temperatures and neither resetting, pressing the button or re-pairing worked. I also made sure there was temperature changes when testing, as it only reports when there has been a change.

At the time `_TZE200_9yapgbuv` was added to the `WSD500A` model (#4994), the `ZTH01` had not been created yet (#5234).
I'm not sure if it ever worked for @floxboy (#4994), but I couldn't get it to work in the current version (1.29.1).

It has worked perfectly now for the last ~24 hours.
Previously I used a hacked together external converter for this device which also worked well.

Other relevant issues/PRs:
- https://github.com/Koenkk/zigbee2mqtt/issues/15729
- https://github.com/Koenkk/zigbee2mqtt/issues/14819

This should close https://github.com/Koenkk/zigbee2mqtt/issues/15774

---

Thank you for this great software! It's one of the few which is a pleasure to use. :)