### PR TITLE
Improvements for Bosch BTH-RA

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -248,6 +248,7 @@ const fzLocal = {
             }
             if (data.hasOwnProperty(0x4020)) {
                 result.pi_heating_demand = data[0x4020];
+                result.running_state = result.pi_heating_demand >= 10 ? 'heat' : 'idle';
             }
 
             return result;
@@ -441,7 +442,8 @@ const definition = [
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
                 .withLocalTemperatureCalibration(-5, 5, 0.5)
                 .withSystemMode(['off', 'heat', 'auto'])
-                .withPiHeatingDemand(ea.STATE),
+                .withPiHeatingDemand(ea.STATE)
+                .withRunningState(['idle', 'heat']),
             exposes.binary('boost', ea.ALL, 'ON', 'OFF')
                 .withDescription('Activate Boost heating'),
             exposes.binary('window_open', ea.ALL, 'ON', 'OFF')
@@ -453,7 +455,8 @@ const definition = [
                 .withValueMax(30)
                 .withValueStep(0.1)
                 .withUnit('°C')
-                .withDescription('Input for remote temperature sensor'),
+                .withDescription('Input for remote temperature sensor. ' +
+                    'Setting this will disable the internal temperature sensor until batteries are removed!'),
             exposes.numeric('display_ontime', ea.ALL)
                 .withValueMin(5)
                 .withValueMax(30)

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -50,7 +50,7 @@ const displayOrientation = {
 const displayedTemperature = {
     'target': 0,
     'measured': 1,
-}
+};
 
 // Radiator Thermostat II
 const tzLocal = {
@@ -86,8 +86,9 @@ const tzLocal = {
                 return {state: {system_mode: value}};
             }
             if (key === 'remote_temperature') {
-                const remoteTemperature = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100
-                await entity.write('hvacThermostat', {0x4040: {value: remoteTemperature, type: herdsman.Zcl.DataType.int16}}, boschManufacturer);
+                const remoteTemperature = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
+                await entity.write('hvacThermostat',
+                    {0x4040: {value: remoteTemperature, type: herdsman.Zcl.DataType.int16}}, boschManufacturer);
                 return {state: {remote_temperature: value}};
             }
         },

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -5,6 +5,7 @@ const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 const utils = require('../lib/utils');
 const constants = require('../lib/constants');
+const ota = require('../lib/ota');
 const e = exposes.presets;
 const ea = exposes.access;
 
@@ -396,6 +397,7 @@ const definition = [
         model: 'BTH-RA',
         vendor: 'Bosch',
         description: 'Radiator thermostat II',
+        ota: ota.zigbeeOTA,
         fromZigbee: [fz.thermostat, fz.battery, fzLocal.bosch_thermostat, fzLocal.bosch_userInterface],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint,

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -443,7 +443,7 @@ const definition = [
                 .withLocalTemperatureCalibration(-5, 5, 0.5)
                 .withSystemMode(['off', 'heat', 'auto'])
                 .withPiHeatingDemand(ea.STATE)
-                .withRunningState(['idle', 'heat']),
+                .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.binary('boost', ea.ALL, 'ON', 'OFF')
                 .withDescription('Activate Boost heating'),
             exposes.binary('window_open', ea.ALL, 'ON', 'OFF')


### PR DESCRIPTION
- Add input for remote temperature sensor. Setting `remote_temperature` will override the value of `local_temperature`.
- Add `displayed_temperature` to choose which temperature is shown on the thermostat display
- Fix range of `local_temperature_calibration`
- Add running state

Unfortunately I haven't figured out yet how to "exit" this remote temperature mode. Writing 0 just sets the internal temperature to 0°C.