### PR TITLE
Aqara FP1 regions basic support

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1798,8 +1798,10 @@ module.exports = [
         vendor: 'Xiaomi',
         description: 'Aqara presence detector FP1 (experimental region support)',
         fromZigbee: [fz.aqara_opple, fzLocal.aqara_fp1_region_events],
-        toZigbee: [tz.RTCZCGQ11LM_presence, tz.RTCZCGQ11LM_monitoring_mode, tz.RTCZCGQ11LM_approach_distance,
-            tz.aqara_motion_sensitivity, tz.RTCZCGQ11LM_reset_nopresence_status, tzLocal.aqara_fp1_regions_config],
+        toZigbee: [
+            tz.RTCZCGQ11LM_presence, tz.RTCZCGQ11LM_monitoring_mode, tz.RTCZCGQ11LM_approach_distance,
+            tz.aqara_motion_sensitivity, tz.RTCZCGQ11LM_reset_nopresence_status, tzLocal.aqara_fp1_regions_config,
+        ],
         exposes: [
             e.presence().withAccess(ea.STATE_GET),
             exposes.enum('presence_event', ea.STATE, ['enter', 'leave', 'left_enter', 'right_leave', 'right_enter', 'left_leave',
@@ -1812,7 +1814,13 @@ module.exports = [
             exposes.enum('motion_sensitivity', ea.ALL, ['low', 'medium', 'high']).withDescription('Different sensitivities ' +
                 'means different static human body recognition rate and response speed of occupied'),
             exposes.enum('reset_nopresence_status', ea.SET, ['']).withDescription('Reset the status of no presence'),
-            e.device_temperature(), e.power_outage_count(), exposes.text('regions_config', ea.SET),
+            e.device_temperature(), e.power_outage_count(),
+            exposes.text('regions_config', ea.SET).withDescription('Input used to update device\'s regions configuration. ' +
+                'Provide a JSON-encoded array of commands to be sent to the device, to either "create", "modify" or "delete" regions. ' +
+                'Creating or modifying a region requires zone definitions, specifying which zones of a 7x4 detection grid ' +
+                'should be active for that zone. An example command for creating a new zone: ' +
+                '[{"regionId": 1, "action": "create", "definition": {"1": [1, 2]}}]. ' +
+                'More information available in the Z2M documentation page (https://www.zigbee2mqtt.io/devices/RTCZCGQ11LM.html).'),
             exposes.enum('region_event', ea.STATE, ['region_*_enter', 'region_*_leave', 'region_*_occupied',
                 'region_*_unoccupied']).withDescription('Most recent region event. Event template is "region_<REGION_ID>_<EVENT_TYPE>", ' +
                 'where <REGION_ID> is region number (1-10), <EVENT_TYPE> is one of "enter", "leave", "occupied", "unoccupied". ' +

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1845,7 +1845,7 @@ module.exports = [
                 'means different static human body recognition rate and response speed of occupied'),
             exposes.enum('reset_nopresence_status', ea.SET, ['']).withDescription('Reset the status of no presence'),
             e.device_temperature(), e.power_outage_count(),
-            exposes.enum('region_event', ea.STATE, ['region_*_enter', 'region_*_leave', 'region_*_occupied',
+            exposes.enum('action', ea.STATE, ['region_*_enter', 'region_*_leave', 'region_*_occupied',
                 'region_*_unoccupied']).withDescription('Most recent region event. Event template is "region_<REGION_ID>_<EVENT_TYPE>", ' +
                 'where <REGION_ID> is region number (1-10), <EVENT_TYPE> is one of "enter", "leave", "occupied", "unoccupied". ' +
                 '"enter" / "leave" events are usually triggered first, followed by "occupied" / "unoccupied" after a couple of seconds.'),

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1577,7 +1577,8 @@ module.exports = [
         fromZigbee: [fz.aqara_opple, fzLocal.aqara_fp1_region_events],
         toZigbee: [tz.RTCZCGQ11LM_presence, tz.RTCZCGQ11LM_monitoring_mode, tz.RTCZCGQ11LM_approach_distance,
             tz.aqara_motion_sensitivity, tz.RTCZCGQ11LM_reset_nopresence_status],
-        exposes: [e.presence().withAccess(ea.STATE_GET),
+        exposes: [
+            e.presence().withAccess(ea.STATE_GET),
             exposes.enum('presence_event', ea.STATE, ['enter', 'leave', 'left_enter', 'right_leave', 'right_enter', 'left_leave',
                 'approach', 'away']).withDescription('Presence events: "enter", "leave", "left_enter", "right_leave", ' +
                 '"right_enter", "left_leave", "approach", "away"'),
@@ -1588,7 +1589,13 @@ module.exports = [
             exposes.enum('motion_sensitivity', ea.ALL, ['low', 'medium', 'high']).withDescription('Different sensitivities ' +
                 'means different static human body recognition rate and response speed of occupied'),
             exposes.enum('reset_nopresence_status', ea.SET, ['']).withDescription('Reset the status of no presence'),
-            e.device_temperature(), e.power_outage_count()],
+            e.device_temperature(), e.power_outage_count(), exposes.text('regions_config', ea.SET),
+            exposes.enum('region_event', ea.STATE, ['region_*_enter', 'region_*_leave', 'region_*_occupied',
+                'region_*_unoccupied']).withDescription('Most recent region event. Event template is "region_<REGION_ID>_<EVENT_TYPE>", ' +
+                'where <REGION_ID> is region number (1-10), <EVENT_TYPE> is one of "enter", "leave", "occupied", "unoccupied". ' +
+                '"enter" / "leave" events are usually triggered first, followed by "occupied" / "unoccupied" after a couple of seconds.'),
+            exposes.text('exits_entrances', ea.SET), exposes.text('interference_sources', ea.SET), exposes.text('edges', ea.SET),
+        ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read('aqaraOpple', [0x010c], {manufacturerCode: 0x115f});

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -11,7 +11,8 @@ const globalStore = require('../lib/store');
 const xiaomi = require('../lib/xiaomi');
 const utils = require('../lib/utils');
 const {printNumberAsHex, printNumbersAsHexSequence, readNumberLike} = utils;
-const {xiaomiDefinitions: definitions, xiaomiMappers: mappers, manufacturerCodes} = constants;
+const {manufacturerCodes} = constants;
+const {constants: xiaomiConstants, mappers} = xiaomi;
 
 const xiaomiExtend = {
     light_onoff_brightness_colortemp: (options={disableColorTempStartup: true}) => ({
@@ -86,10 +87,10 @@ const isAqaraFp1RegionZoneDefinition = (value) => {
         'y' in value &&
         typeof value.x === 'number' &&
         typeof value.y === 'number' &&
-        value.x >= definitions.aqara_fp1.region_config_zoneX_min &&
-        value.x <= definitions.aqara_fp1.region_config_zoneX_max &&
-        value.y >= definitions.aqara_fp1.region_config_zoneY_min &&
-        value.y <= definitions.aqara_fp1.region_config_zoneY_max
+        value.x >= xiaomiConstants.aqara_fp1.region_config_zoneX_min &&
+        value.x <= xiaomiConstants.aqara_fp1.region_config_zoneX_max &&
+        value.y >= xiaomiConstants.aqara_fp1.region_config_zoneY_min &&
+        value.y <= xiaomiConstants.aqara_fp1.region_config_zoneY_max
     );
 };
 
@@ -102,8 +103,8 @@ const isAqaraFp1RegionZoneDefinition = (value) => {
 const isAqaraFp1RegionId = (value) => {
     return (
         typeof value === 'number' &&
-        value >= definitions.aqara_fp1.region_config_regionId_min &&
-        value <= definitions.aqara_fp1.region_config_regionId_max
+        value >= xiaomiConstants.aqara_fp1.region_config_regionId_min &&
+        value <= xiaomiConstants.aqara_fp1.region_config_regionId_max
     );
 };
 
@@ -384,7 +385,7 @@ const fzLocal = {
                 const eventKeyHex = printNumberAsHex(eventKey, 4);
 
                 switch (eventKey) {
-                case definitions.aqara_fp1.region_event_key: {
+                case xiaomiConstants.aqara_fp1.region_event_key: {
                     if (
                         !Buffer.isBuffer(value) ||
                         !(typeof value[0] === 'string' || typeof value[0] === 'number') ||
@@ -407,7 +408,7 @@ const fzLocal = {
 
                         break;
                     }
-                    if (!Object.values(definitions.aqara_fp1.region_event_types).includes(eventTypeCode)) {
+                    if (!Object.values(xiaomiConstants.aqara_fp1.region_event_types).includes(eventTypeCode)) {
                         meta.logger.warn(createLoggerMsg(`region_event: Unknown region event type "${eventTypeCode}"`));
 
                         break;
@@ -687,9 +688,9 @@ const tzLocal = {
             const deviceConfig = new Uint8Array(7);
 
             // Command parameters
-            deviceConfig[0] = definitions.aqara_fp1.region_config_cmds.create;
+            deviceConfig[0] = xiaomiConstants.aqara_fp1.region_config_cmds.create;
             deviceConfig[1] = command.region_id;
-            deviceConfig[6] = definitions.aqara_fp1.region_config_cmd_suffix_upsert;
+            deviceConfig[6] = xiaomiConstants.aqara_fp1.region_config_cmd_suffix_upsert;
             // Zones definition
             deviceConfig[2] |= encodeXCellsDefinition(sortedZones['1']);
             deviceConfig[2] |= encodeXCellsDefinition(sortedZones['2']) << 4;
@@ -707,9 +708,9 @@ const tzLocal = {
             await entity.write(
                 'aqaraOpple',
                 {
-                    [definitions.aqara_fp1.region_config_write_attribute]: {
+                    [xiaomiConstants.aqara_fp1.region_config_write_attribute]: {
                         value: deviceConfig,
-                        type: definitions.aqara_fp1.region_config_write_attribute_type,
+                        type: xiaomiConstants.aqara_fp1.region_config_write_attribute_type,
                     },
                 },
                 {
@@ -740,9 +741,9 @@ const tzLocal = {
             const deviceConfig = new Uint8Array(7);
 
             // Command parameters
-            deviceConfig[0] = definitions.aqara_fp1.region_config_cmds.delete;
+            deviceConfig[0] = xiaomiConstants.aqara_fp1.region_config_cmds.delete;
             deviceConfig[1] = command.region_id;
-            deviceConfig[6] = definitions.aqara_fp1.region_config_cmd_suffix_delete;
+            deviceConfig[6] = xiaomiConstants.aqara_fp1.region_config_cmd_suffix_delete;
             // Zones definition
             deviceConfig[2] = 0;
             deviceConfig[3] = 0;
@@ -757,9 +758,9 @@ const tzLocal = {
             await entity.write(
                 'aqaraOpple',
                 {
-                    [definitions.aqara_fp1.region_config_write_attribute]: {
+                    [xiaomiConstants.aqara_fp1.region_config_write_attribute]: {
                         value: deviceConfig,
-                        type: definitions.aqara_fp1.region_config_write_attribute_type,
+                        type: xiaomiConstants.aqara_fp1.region_config_write_attribute_type,
                     },
                 },
                 {
@@ -1858,8 +1859,8 @@ module.exports = [
                 )
                 .withFeature(
                     exposes.numeric('region_id', ea.SET)
-                        .withValueMin(definitions.aqara_fp1.region_config_regionId_min)
-                        .withValueMax(definitions.aqara_fp1.region_config_regionId_max),
+                        .withValueMin(xiaomiConstants.aqara_fp1.region_config_regionId_min)
+                        .withValueMax(xiaomiConstants.aqara_fp1.region_config_regionId_max),
                 )
                 .withFeature(
                     exposes.list(
@@ -1868,13 +1869,13 @@ module.exports = [
                         exposes.composite('zone_position', ea.SET)
                             .withFeature(
                                 exposes.numeric('x', ea.SET)
-                                    .withValueMin(definitions.aqara_fp1.region_config_zoneX_min)
-                                    .withValueMax(definitions.aqara_fp1.region_config_zoneX_max),
+                                    .withValueMin(xiaomiConstants.aqara_fp1.region_config_zoneX_min)
+                                    .withValueMax(xiaomiConstants.aqara_fp1.region_config_zoneX_max),
                             )
                             .withFeature(
                                 exposes.numeric('y', ea.SET)
-                                    .withValueMin(definitions.aqara_fp1.region_config_zoneY_min)
-                                    .withValueMax(definitions.aqara_fp1.region_config_zoneY_max),
+                                    .withValueMin(xiaomiConstants.aqara_fp1.region_config_zoneY_min)
+                                    .withValueMax(xiaomiConstants.aqara_fp1.region_config_zoneY_max),
                             ),
                     ),
                 ),
@@ -1882,8 +1883,8 @@ module.exports = [
                 .withDescription('Region definition to be deleted from the device.')
                 .withFeature(
                     exposes.numeric('region_id', ea.SET)
-                        .withValueMin(definitions.aqara_fp1.region_config_regionId_min)
-                        .withValueMax(definitions.aqara_fp1.region_config_regionId_max),
+                        .withValueMin(xiaomiConstants.aqara_fp1.region_config_regionId_min)
+                        .withValueMax(xiaomiConstants.aqara_fp1.region_config_regionId_max),
                 ),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -300,14 +300,18 @@ const xiaomiMappers = {
             [xiaomiDefinitions.aqara_fp1.region_event_types.Enter]: 'enter',
             [xiaomiDefinitions.aqara_fp1.region_event_types.Leave]: 'leave',
             [xiaomiDefinitions.aqara_fp1.region_event_types.Occupied]: 'occupied',
-            [xiaomiDefinitions.aqara_fp1.region_event_types.Unoccupied]: 'unoccupied'
+            [xiaomiDefinitions.aqara_fp1.region_event_types.Unoccupied]: 'unoccupied',
         },
         region_config_cmd_type_names: new Map([
-            [ xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Create, 'create' ],
-            [ xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Modify, 'modify' ],
-            [ xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Delete, 'delete' ],
+            [xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Create, 'create'],
+            [xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Modify, 'modify'],
+            [xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Delete, 'delete'],
         ]),
     },
+};
+
+const manufacturerCodes = {
+    xiaomi: 0x115f,
 };
 
 module.exports = {
@@ -343,4 +347,5 @@ module.exports = {
     wiserDimmerControlMode,
     xiaomiDefinitions,
     xiaomiMappers,
+    manufacturerCodes,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -268,56 +268,6 @@ const wiserDimmerControlMode = {
     3: 'rl_led',
 };
 
-const xiaomiDefinitions = {
-    aqara_fp1: {
-        region_event_key: 0x0151,
-        region_event_types: {
-            Enter: 1,
-            Leave: 2,
-            Occupied: 4,
-            Unoccupied: 8,
-        },
-        region_config_write_attribute: 0x0150,
-        region_config_write_attribute_type: 0x41,
-        region_config_cmds: {
-            /**
-             * Creates new region (or force replaces existing one)
-             * with new zones definition.
-             */
-            create: 1,
-            /**
-             * Modifies existing region.
-             * Note: unused, as it seems to break existing regions
-             * (region stops reporting new detection events).
-             * Use "create" instead, as it replaces existing region with new one.
-             */
-            modify: 2,
-            /**
-             * Deletes existing region.
-             */
-            delete: 3,
-        },
-        region_config_regionId_min: 1,
-        region_config_regionId_max: 10,
-        region_config_zoneY_min: 1,
-        region_config_zoneY_max: 7,
-        region_config_zoneX_min: 1,
-        region_config_zoneX_max: 4,
-        region_config_cmd_suffix_upsert: 0xff,
-        region_config_cmd_suffix_delete: 0x00,
-    },
-};
-const xiaomiMappers = {
-    aqara_fp1: {
-        region_event_type_names: {
-            [xiaomiDefinitions.aqara_fp1.region_event_types.Enter]: 'enter',
-            [xiaomiDefinitions.aqara_fp1.region_event_types.Leave]: 'leave',
-            [xiaomiDefinitions.aqara_fp1.region_event_types.Occupied]: 'occupied',
-            [xiaomiDefinitions.aqara_fp1.region_event_types.Unoccupied]: 'unoccupied',
-        },
-    },
-};
-
 const manufacturerCodes = {
     xiaomi: 0x115f,
 };
@@ -353,7 +303,5 @@ module.exports = {
     lockUserStatus,
     easyCodeTouchActions,
     wiserDimmerControlMode,
-    xiaomiDefinitions,
-    xiaomiMappers,
     manufacturerCodes,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -279,10 +279,23 @@ const xiaomiDefinitions = {
         },
         region_config_write_attribute: 0x0150,
         region_config_write_attribute_type: 0x41,
-        region_config_cmd_types: {
-            Create: 1,
-            Modify: 2,
-            Delete: 3,
+        region_config_cmds: {
+            /**
+             * Creates new region (or force replaces existing one)
+             * with new zones definition.
+             */
+            create: 1,
+            /**
+             * Modifies existing region.
+             * Note: unused, as it seems to break existing regions
+             * (region stops reporting new detection events).
+             * Use "create" instead, as it replaces existing region with new one.
+             */
+            modify: 2,
+            /**
+             * Deletes existing region.
+             */
+            delete: 3,
         },
         region_config_regionId_min: 1,
         region_config_regionId_max: 10,
@@ -302,11 +315,6 @@ const xiaomiMappers = {
             [xiaomiDefinitions.aqara_fp1.region_event_types.Occupied]: 'occupied',
             [xiaomiDefinitions.aqara_fp1.region_event_types.Unoccupied]: 'unoccupied',
         },
-        region_config_cmd_type_names: new Map([
-            [xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Create, 'create'],
-            [xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Modify, 'modify'],
-            [xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Delete, 'delete'],
-        ]),
     },
 };
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -268,6 +268,48 @@ const wiserDimmerControlMode = {
     3: 'rl_led',
 };
 
+const xiaomiDefinitions = {
+    aqara_fp1: {
+        region_event_key: 0x0151,
+        region_event_types: {
+            Enter: 1,
+            Leave: 2,
+            Occupied: 4,
+            Unoccupied: 8,
+        },
+        region_config_write_attribute: 0x0150,
+        region_config_write_attribute_type: 0x41,
+        region_config_cmd_types: {
+            Create: 1,
+            Modify: 2,
+            Delete: 3,
+        },
+        region_config_regionId_min: 1,
+        region_config_regionId_max: 10,
+        region_config_zoneY_min: 1,
+        region_config_zoneY_max: 7,
+        region_config_zoneX_min: 1,
+        region_config_zoneX_max: 4,
+        region_config_cmd_suffix_upsert: 0xff,
+        region_config_cmd_suffix_delete: 0x00,
+    },
+};
+const xiaomiMappers = {
+    aqara_fp1: {
+        region_event_type_names: {
+            [xiaomiDefinitions.aqara_fp1.region_event_types.Enter]: 'enter',
+            [xiaomiDefinitions.aqara_fp1.region_event_types.Leave]: 'leave',
+            [xiaomiDefinitions.aqara_fp1.region_event_types.Occupied]: 'occupied',
+            [xiaomiDefinitions.aqara_fp1.region_event_types.Unoccupied]: 'unoccupied'
+        },
+        region_config_cmd_type_names: new Map([
+            [ xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Create, 'create' ],
+            [ xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Modify, 'modify' ],
+            [ xiaomiDefinitions.aqara_fp1.region_config_cmd_types.Delete, 'delete' ],
+        ]),
+    },
+};
+
 module.exports = {
     OneJanuary2000,
     repInterval,
@@ -299,4 +341,6 @@ module.exports = {
     lockUserStatus,
     easyCodeTouchActions,
     wiserDimmerControlMode,
+    xiaomiDefinitions,
+    xiaomiMappers,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -268,10 +268,6 @@ const wiserDimmerControlMode = {
     3: 'rl_led',
 };
 
-const manufacturerCodes = {
-    xiaomi: 0x115f,
-};
-
 module.exports = {
     OneJanuary2000,
     repInterval,
@@ -303,5 +299,4 @@ module.exports = {
     lockUserStatus,
     easyCodeTouchActions,
     wiserDimmerControlMode,
-    manufacturerCodes,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -460,10 +460,7 @@ function attachOutputCluster(device, clusterKey) {
  * @return {string}
  */
 function printNumberAsHex(value, hexLength) {
-    const hexValue = value
-        .toString(16)
-        .padStart(hexLength, '0');
-
+    const hexValue = value.toString(16).padStart(hexLength, '0');
     return `0x${hexValue}`;
 }
 
@@ -473,27 +470,20 @@ function printNumberAsHex(value, hexLength) {
  * @return {string}
  */
 function printNumbersAsHexSequence(numbers, hexLength) {
-    return numbers
-        .map((value) => {
-            return value
-                .toString(16)
-                .padStart(hexLength, '0');
-        })
-        .join(':');
+    return numbers.map((v) => v.toString(16).padStart(hexLength, '0')).join(':');
 }
 
+// Note: this is valid typescript-flavored JSDoc
+// eslint-disable-next-line valid-jsdoc
 /**
- * @param {number | string} value Value to be safely converted into number
- * @param {number} radix Conversion radix (to be used in case of de-stringification). Defaults to `10` (decimal).
- * @return {number}
+ * @param {logger} logger
+ * @param {vendor} vendor
+ * @param {key} key
+ * @returns {(level: string, message: string) => void}
  */
-function readNumberLike(value, radix = 10) {
-    return (
-        typeof value === 'number' ?
-            value :
-            parseInt(value, radix)
-    );
-}
+const createLogger = (logger, vendor, key) => (level, message) => {
+    logger[level](`zigbee-herdsman-converters:${vendor}:${key}: ${message}`);
+};
 
 module.exports = {
     noOccupancySince,
@@ -533,5 +523,5 @@ module.exports = {
     attachOutputCluster,
     printNumberAsHex,
     printNumbersAsHexSequence,
-    readNumberLike,
+    createLogger,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -454,6 +454,44 @@ function attachOutputCluster(device, clusterKey) {
     }
 }
 
+/**
+ * @param {number} value
+ * @param {number} hexLength
+ */
+function printNumberAsHex(value, hexLength) {
+    const hexValue = value
+        .toString(16)
+        .padStart(hexLength, '0');
+
+    return `0x${hexValue}`;
+};
+
+/**
+ * @param {number[]} numbers
+ * @param {number} hexLength
+ */
+function printNumbersAsHexSequence(numbers, hexLength) {
+    return numbers
+        .map((value) => {
+            return value
+                .toString(16)
+                .padStart(hexLength, '0');
+        })
+        .join(':');
+};
+
+/**
+ * @param {number | string} value Value to be safely converted into number
+ * @param {number} radix Conversion radix (to be used in case of de-stringification). Defaults to `10` (decimal).
+ */
+function readNumberLike(value, radix = 10) {
+    return (
+        typeof value === 'number'
+            ? value
+            : parseInt(value, radix)
+    );
+}
+
 module.exports = {
     noOccupancySince,
     getOptions,
@@ -490,4 +528,7 @@ module.exports = {
     getSceneState,
     extendDevice,
     attachOutputCluster,
+    printNumberAsHex,
+    printNumbersAsHexSequence,
+    readNumberLike,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -457,6 +457,7 @@ function attachOutputCluster(device, clusterKey) {
 /**
  * @param {number} value
  * @param {number} hexLength
+ * @return {string}
  */
 function printNumberAsHex(value, hexLength) {
     const hexValue = value
@@ -464,11 +465,12 @@ function printNumberAsHex(value, hexLength) {
         .padStart(hexLength, '0');
 
     return `0x${hexValue}`;
-};
+}
 
 /**
  * @param {number[]} numbers
  * @param {number} hexLength
+ * @return {string}
  */
 function printNumbersAsHexSequence(numbers, hexLength) {
     return numbers
@@ -478,17 +480,18 @@ function printNumbersAsHexSequence(numbers, hexLength) {
                 .padStart(hexLength, '0');
         })
         .join(':');
-};
+}
 
 /**
  * @param {number | string} value Value to be safely converted into number
  * @param {number} radix Conversion radix (to be used in case of de-stringification). Defaults to `10` (decimal).
+ * @return {number}
  */
 function readNumberLike(value, radix = 10) {
     return (
-        typeof value === 'number'
-            ? value
-            : parseInt(value, radix)
+        typeof value === 'number' ?
+            value :
+            parseInt(value, radix)
     );
 }
 

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -684,9 +684,61 @@ const numericAttributes2Options = (definition) => {
     return result;
 };
 
+const constants = {
+    aqara_fp1: {
+        region_event_key: 0x0151,
+        region_event_types: {
+            Enter: 1,
+            Leave: 2,
+            Occupied: 4,
+            Unoccupied: 8,
+        },
+        region_config_write_attribute: 0x0150,
+        region_config_write_attribute_type: 0x41,
+        region_config_cmds: {
+            /**
+             * Creates new region (or force replaces existing one)
+             * with new zones definition.
+             */
+            create: 1,
+            /**
+             * Modifies existing region.
+             * Note: unused, as it seems to break existing regions
+             * (region stops reporting new detection events).
+             * Use "create" instead, as it replaces existing region with new one.
+             */
+            modify: 2,
+            /**
+             * Deletes existing region.
+             */
+            delete: 3,
+        },
+        region_config_regionId_min: 1,
+        region_config_regionId_max: 10,
+        region_config_zoneY_min: 1,
+        region_config_zoneY_max: 7,
+        region_config_zoneX_min: 1,
+        region_config_zoneX_max: 4,
+        region_config_cmd_suffix_upsert: 0xff,
+        region_config_cmd_suffix_delete: 0x00,
+    },
+};
+const mappers = {
+    aqara_fp1: {
+        region_event_type_names: {
+            [constants.aqara_fp1.region_event_types.Enter]: 'enter',
+            [constants.aqara_fp1.region_event_types.Leave]: 'leave',
+            [constants.aqara_fp1.region_event_types.Occupied]: 'occupied',
+            [constants.aqara_fp1.region_event_types.Unoccupied]: 'unoccupied',
+        },
+    },
+};
+
 module.exports = {
     buffer2DataObject,
     numericAttributes2Payload,
     numericAttributes2Options,
     VOCKQJK11LMDisplayUnit,
+    constants,
+    mappers,
 };

--- a/lib/xiaomi.js
+++ b/lib/xiaomi.js
@@ -684,53 +684,180 @@ const numericAttributes2Options = (definition) => {
     return result;
 };
 
-const constants = {
-    aqara_fp1: {
-        region_event_key: 0x0151,
-        region_event_types: {
-            Enter: 1,
-            Leave: 2,
-            Occupied: 4,
-            Unoccupied: 8,
-        },
-        region_config_write_attribute: 0x0150,
-        region_config_write_attribute_type: 0x41,
-        region_config_cmds: {
-            /**
-             * Creates new region (or force replaces existing one)
-             * with new zones definition.
-             */
-            create: 1,
-            /**
-             * Modifies existing region.
-             * Note: unused, as it seems to break existing regions
-             * (region stops reporting new detection events).
-             * Use "create" instead, as it replaces existing region with new one.
-             */
-            modify: 2,
-            /**
-             * Deletes existing region.
-             */
-            delete: 3,
-        },
-        region_config_regionId_min: 1,
-        region_config_regionId_max: 10,
-        region_config_zoneY_min: 1,
-        region_config_zoneY_max: 7,
-        region_config_zoneX_min: 1,
-        region_config_zoneX_max: 4,
-        region_config_cmd_suffix_upsert: 0xff,
-        region_config_cmd_suffix_delete: 0x00,
+// For RTCZCGQ11LM
+/**
+ * @typedef {{
+*  x: number,
+*  y: number,
+* }} AqaraFP1RegionZone
+*/
+const fp1Constants = {
+    region_event_key: 0x0151,
+    region_event_types: {
+        Enter: 1,
+        Leave: 2,
+        Occupied: 4,
+        Unoccupied: 8,
     },
+    region_config_write_attribute: 0x0150,
+    region_config_write_attribute_type: 0x41,
+    region_config_cmds: {
+        /**
+         * Creates new region (or force replaces existing one)
+         * with new zones definition.
+         */
+        create: 1,
+        /**
+         * Modifies existing region.
+         * Note: unused, as it seems to break existing regions
+         * (region stops reporting new detection events).
+         * Use "create" instead, as it replaces existing region with new one.
+         */
+        modify: 2,
+        /**
+         * Deletes existing region.
+         */
+        delete: 3,
+    },
+    region_config_regionId_min: 1,
+    region_config_regionId_max: 10,
+    region_config_zoneY_min: 1,
+    region_config_zoneY_max: 7,
+    region_config_zoneX_min: 1,
+    region_config_zoneX_max: 4,
+    region_config_cmd_suffix_upsert: 0xff,
+    region_config_cmd_suffix_delete: 0x00,
 };
-const mappers = {
+const fp1Mappers = {
     aqara_fp1: {
         region_event_type_names: {
-            [constants.aqara_fp1.region_event_types.Enter]: 'enter',
-            [constants.aqara_fp1.region_event_types.Leave]: 'leave',
-            [constants.aqara_fp1.region_event_types.Occupied]: 'occupied',
-            [constants.aqara_fp1.region_event_types.Unoccupied]: 'unoccupied',
+            [fp1Constants.region_event_types.Enter]: 'enter',
+            [fp1Constants.region_event_types.Leave]: 'leave',
+            [fp1Constants.region_event_types.Occupied]: 'occupied',
+            [fp1Constants.region_event_types.Unoccupied]: 'unoccupied',
         },
+    },
+};
+const fp1 = {
+    constants: fp1Constants,
+    mappers: fp1Mappers,
+    /**
+     * @param {undefined | Set<number>} xCells
+     * @return {number}
+     */
+    encodeXCellsDefinition: (xCells) => {
+        if (!xCells || !xCells.size) {
+            return 0;
+        }
+        return [...xCells.values()].reduce((accumulator, marker) => accumulator + fp1.encodeXCellIdx(marker), 0);
+    },
+    /**
+     * @param {number} cellXIdx
+     * @return {number}
+     */
+    encodeXCellIdx: (cellXIdx) => {
+        return 2 ** (cellXIdx - 1);
+    },
+    // Note: let TypeScript infer the return type to enable union discrimination
+    // eslint-disable-next-line valid-jsdoc
+    /**
+     * @param {unknown} input
+     */
+    parseAqaraFp1RegionDeleteInput: (input) => {
+        if (!input || typeof input !== 'object') {
+            return fp1.failure({reason: 'NOT_OBJECT'});
+        }
+
+        if (!('region_id' in input) || !fp1.isAqaraFp1RegionId(input.region_id)) {
+            return fp1.failure({reason: 'INVALID_REGION_ID'});
+        }
+
+        return {
+            /** @type true */
+            isSuccess: true,
+            payload: {
+                command: {
+                    region_id: input.region_id,
+                },
+            },
+        };
+    },
+    // Note: let TypeScript infer the return type to enable union discrimination
+    // eslint-disable-next-line valid-jsdoc
+    /**
+     * @param {unknown} input
+     */
+    parseAqaraFp1RegionUpsertInput: (input) => {
+        if (!input || typeof input !== 'object') {
+            return fp1.failure({reason: 'NOT_OBJECT'});
+        }
+
+        if (!('region_id' in input) || !fp1.isAqaraFp1RegionId(input.region_id)) {
+            return fp1.failure({reason: 'INVALID_REGION_ID'});
+        }
+
+        if (!('zones' in input) || !Array.isArray(input.zones) || !input.zones.length) {
+            return fp1.failure({reason: 'ZONES_LIST_EMPTY'});
+        }
+
+        if (!input.zones.every(fp1.isAqaraFp1RegionZoneDefinition)) {
+            return fp1.failure({reason: 'INVALID_ZONES'});
+        }
+
+        return {
+            /** @type true */
+            isSuccess: true,
+            payload: {
+                command: {
+                    region_id: input.region_id,
+                    zones: input.zones,
+                },
+            },
+        };
+    },
+    // Note: this is valid typescript JSDoc
+    // eslint-disable-next-line valid-jsdoc
+    /**
+     * @param {unknown} value
+     * @returns {value is number}
+     */
+    isAqaraFp1RegionId: (value) => {
+        return (
+            typeof value === 'number' &&
+            value >= fp1.constants.region_config_regionId_min &&
+            value <= fp1.constants.region_config_regionId_max
+        );
+    },
+    // Note: this is valid typescript JSDoc
+    // eslint-disable-next-line valid-jsdoc
+    /**
+     * @param {unknown} value
+     * @returns {value is AqaraFP1RegionZone}
+     */
+    isAqaraFp1RegionZoneDefinition: (value) => {
+        return (
+            value &&
+            typeof value === 'object' &&
+            'x' in value &&
+            'y' in value &&
+            typeof value.x === 'number' &&
+            typeof value.y === 'number' &&
+            value.x >= fp1.constants.region_config_zoneX_min &&
+            value.x <= fp1.constants.region_config_zoneX_max &&
+            value.y >= fp1.constants.region_config_zoneY_min &&
+            value.y <= fp1.constants.region_config_zoneY_max
+        );
+    },
+    /**
+     * @template {Record<string, unknown>} ErrorType
+     * @param {ErrorType} error
+     * @return { { isSuccess: false, error: ErrorType } }
+     */
+    failure: (error) => {
+        return {
+            isSuccess: false,
+            error,
+        };
     },
 };
 
@@ -739,6 +866,6 @@ module.exports = {
     numericAttributes2Payload,
     numericAttributes2Options,
     VOCKQJK11LMDisplayUnit,
-    constants,
-    mappers,
+    fp1,
+    manufacturerCode: 0x115f,
 };


### PR DESCRIPTION
Changelog:
- Adds basic support for `region_event`, exposing most recent detected region event, as handled by `fzLocal.aqara_fp1_region_events`
- Adds basic support for regions-related configuration, configured by issuing JSON-encoded commands in `regions_config` input field
  - Each command should follow [these type definitions](https://github.com/Koenkk/zigbee-herdsman-converters/compare/master...mdziekon:zigbee-herdsman-converters:aqara-fp1-regions-basic-support?expand=1#diff-2d16489d92b9b8bfd6140c0045ff1f2f7e9caf7df7e92445313f1d1a7609da1aR68-R81) to be correctly handled and sent to the device
  - I'm planning to add this to the device's documentation repo, so that users can read more about this on zigbee2mqtt.io
- No "Other regions" support yet, simply because I didn't have time for this today. I'll try to add this as well in the upcoming days.

Based on:
- research by @Otnow (and some other people) in this thread https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5928#issuecomment-1166545226
- initial implementation by @patmalcolm91 from this thread https://github.com/Koenkk/zigbee2mqtt/issues/13711#issuecomment-1356182773