### PR TITLE
Fixes for Busch-Jaeger devices

### DIFF
--- a/devices/busch-jaeger.js
+++ b/devices/busch-jaeger.js
@@ -71,33 +71,37 @@ module.exports = [
                 }
             }
 
+            // The total number of bindings seems to be severely limited with some of these devices.
+            // In order to be able to toggle groups, we need to remove the scenes cluster from RM01.
+            const dropScenesCluster = device.modelID == 'RM01';
+
             const endpoint11 = device.getEndpoint(0x0b);
             if (endpoint11 != null) {
-                // The total number of bindings seems to be severely limited with these devices.
-                // In order to be able to toggle groups, we need to remove the scenes cluster
-                const index = endpoint11.outputClusters.indexOf(5);
-                if (index > -1) {
-                    endpoint11.outputClusters.splice(index, 1);
+                if (dropScenesCluster) {
+                    const index = endpoint11.outputClusters.indexOf(5);
+                    if (index > -1) {
+                        endpoint11.outputClusters.splice(index, 1);
+                    }
                 }
                 await reporting.bind(endpoint11, coordinatorEndpoint, ['genLevelCtrl']);
             }
             const endpoint12 = device.getEndpoint(0x0c);
             if (endpoint12 != null) {
-                // The total number of bindings seems to be severely limited with these devices.
-                // In order to be able to toggle groups, we need to remove the scenes cluster
-                const index = endpoint12.outputClusters.indexOf(5);
-                if (index > -1) {
-                    endpoint12.outputClusters.splice(index, 1);
+                if (dropScenesCluster) {
+                    const index = endpoint12.outputClusters.indexOf(5);
+                    if (index > -1) {
+                        endpoint12.outputClusters.splice(index, 1);
+                    }
                 }
                 await reporting.bind(endpoint12, coordinatorEndpoint, ['genLevelCtrl']);
             }
             const endpoint13 = device.getEndpoint(0x0d);
             if (endpoint13 != null) {
-                // The total number of bindings seems to be severely limited with these devices.
-                // In order to be able to toggle groups, we need to remove the scenes cluster
-                const index = endpoint13.outputClusters.indexOf(5);
-                if (index > -1) {
-                    endpoint13.outputClusters.splice(index, 1);
+                if (dropScenesCluster) {
+                    const index = endpoint13.outputClusters.indexOf(5);
+                    if (index > -1) {
+                        endpoint13.outputClusters.splice(index, 1);
+                    }
                 }
                 await reporting.bind(endpoint13, coordinatorEndpoint, ['genLevelCtrl']);
             }

--- a/devices/busch-jaeger.js
+++ b/devices/busch-jaeger.js
@@ -44,6 +44,7 @@ module.exports = [
                 expose.push(e.light_brightness().withEndpoint('relay'));
                 // Exposing the device as a switch without endpoint is actually wrong, but this is the historic
                 // definition and we are keeping it for compatibility reasons.
+                // DEPRECATED and should be removed in the future
                 expose.push(e.switch());
             }
             // Not all devices support all actions (depends on number of rocker rows and if relay/dimmer is installed),

--- a/devices/busch-jaeger.js
+++ b/devices/busch-jaeger.js
@@ -42,6 +42,9 @@ module.exports = [
             //  2. The top rocker will not be usable (not emit any events) as it's hardwired to the relay/dimmer
             if (!device || device.getEndpoint(0x12) != null) {
                 expose.push(e.light_brightness().withEndpoint('relay'));
+                // Exposing the device as a switch without endpoint is actually wrong, but this is the historic
+                // definition and we are keeping it for compatibility reasons.
+                expose.push(e.switch());
             }
             // Not all devices support all actions (depends on number of rocker rows and if relay/dimmer is installed),
             // but defining all possible actions here won't do any harm.


### PR DESCRIPTION
This PR adds a number of improvements and fixes for Busch-Jaeger ZLL devices:

* Add support for Busch-Jaeger dimmer module (6715 U) by exposing device as a dimmable light
* Expose the correct endpoint for the light device (see #5097 for a discussion about this)
* Do not expose state for Busch-Jaeger switch-only devices (without `relay` endpoint)
* Do not remove the scenes cluster from battery-operated Busch-Jaeger switch (RB01) as this is not required for these devices

This PR has a few implications:

* ~~Home Assistant auto-discovery will be changed as the device type changes from switch to light (in order to support dimming)~~
* If people want to bind previously paired RB01 devices to ZigBee scenes, they need to remove and re-pair them to Z2M. However there is no actual need to re-pair these devices if this feature is not important for people and they will continue to work fine.
* Existing BJ devices will be reconfigured, which means that the default bindings will be created again. It should be noted in the release notes that users should check their bindings, if they have messed with them.

Fixes Koenkk/zigbee2mqtt#7077