### PR TITLE
Added support for Bosch Plug Compact

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -508,6 +508,26 @@ const definition = [
             exposes.enum('heartbeat', ea.ALL, Object.keys(stateOffOn)).withDescription('Enable/disable heartbeat'),
         ],
     },
+    {
+        zigbeeModel: ['RBSH-SP-ZB-EU'],
+        model: 'BSP-FZ2',
+        vendor: 'Bosch',
+        description: 'Plug Compact EU',
+        fromZigbee: [fz.on_off, fz.power_on_behavior, fz.electrical_measurement, fz.metering],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('genOnOff', ['onOff', 'startUpOnOff']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering']);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint, {change: [0, 1]});
+            await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement']);
+            await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
+            await reporting.activePower(endpoint);
+        },
+        exposes: [e.switch(), e.power_on_behavior(), e.power(), e.energy()],
+    },
 ];
 
 module.exports = definition;

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -512,7 +512,7 @@ const definition = [
         zigbeeModel: ['RBSH-SP-ZB-EU'],
         model: 'BSP-FZ2',
         vendor: 'Bosch',
-        description: 'Plug Compact EU',
+        description: 'Plug compact EU',
         fromZigbee: [fz.on_off, fz.power_on_behavior, fz.electrical_measurement, fz.metering],
         toZigbee: [tz.on_off, tz.power_on_behavior],
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
Relates to Koenkk/zigbee2mqtt#13069

This PR implements support for the [Bosch Plug Compact](https://www.bosch-smarthome.com/de/de/produkte/geraete/zwischenstecker-kompakt/). It currently only supports basic functionality.

Maybe someone can add support for OTA updates, I'm new to the Z2M business and don't know how to achieve that.