### PR TITLE
Updated Datek sensors & new converter to read HW version

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -8318,7 +8318,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const result = {};
             if (msg.data.hasOwnProperty('hwVersion')) result['hw_version'] = msg.data.hwVersion;
-            return result;  
+            return result;
         },
     },
     // #endregion

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -8312,6 +8312,15 @@ const converters = {
             return result;
         },
     },
+    hw_version: {
+        cluster: 'genBasic',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result = {};
+            if (msg.data.hasOwnProperty('hwVersion')) result['hw_version'] = msg.data.hwVersion;
+            return result;  
+        },
+    },
     // #endregion
 
     // #region Ignore converters (these message dont need parsing).

--- a/devices/datek.js
+++ b/devices/datek.js
@@ -10,7 +10,7 @@ const ea = exposes.access;
 
 module.exports = [
     {
-        zigbeeModel: ['PoP'],
+        fingerprint: [{modelID: 'PoP', manufacturerName: 'Eva'}],
         model: 'HLU2909K',
         vendor: 'Datek',
         description: 'APEX smart plug 16A',
@@ -31,21 +31,23 @@ module.exports = [
         exposes: [e.power(), e.current(), e.voltage(), e.switch(), e.temperature()],
     },
     {
-        zigbeeModel: ['Meter Reader'],
+        fingerprint: [{modelID: 'Meter Reader', manufacturerName: 'Eva'}],
         model: 'HSE2905E',
         vendor: 'Datek',
         description: 'Datek Eva AMS HAN power-meter sensor',
-        fromZigbee: [fz.metering_datek, fz.electrical_measurement, fz.temperature],
+        fromZigbee: [fz.metering_datek, fz.electrical_measurement, fz.temperature, fzLocal.hw_version],
         toZigbee: [],
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering', 'msTemperatureMeasurement']);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.readMeteringMultiplierDivisor(endpoint);
             try {
-                await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
-            } catch (error) {
-                /* fails for some: https://github.com/Koenkk/zigbee2mqtt/issues/11867 */
+                // hwVersion < 2 do not support hwVersion attribute, so we are testing if this is hwVersion 1 or 2
+                await endpoint.read('genBasic', ['hwVersion']);
+            } catch (e) {
+                e;
             }
             const payload = [{
                 attribute: 'rmsVoltagePhB',
@@ -78,8 +80,6 @@ module.exports = [
             await reporting.currentSummDelivered(endpoint, {min: 60, max: 3600, change: [1, 1]});
             await reporting.currentSummReceived(endpoint);
             await reporting.temperature(endpoint, {min: 60, max: 3600, change: 0});
-            device.powerSource = 'DC source';
-            device.save();
         },
         exposes: [e.power(), e.energy(), e.current(), e.voltage(), e.current_phase_b(), e.voltage_phase_b(), e.current_phase_c(),
             e.voltage_phase_c(), e.temperature()],
@@ -113,7 +113,7 @@ module.exports = [
             exposes.numeric('occupancy_timeout', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(65535)],
     },
     {
-        zigbeeModel: ['ID Lock 150'],
+        fingerprint: [{modelID: 'ID Lock 150', manufacturerName: 'Eva'}],
         model: '0402946',
         vendor: 'Datek',
         description: 'Zigbee module for ID lock 150',
@@ -187,7 +187,7 @@ module.exports = [
                 'random_pin_24_hours']).withDescription('Service Mode of the Lock')],
     },
     {
-        zigbeeModel: ['Water Sensor'],
+        fingerprint: [{modelID: 'Water Sensor', manufacturerName: 'Eva'}],
         model: 'HSE2919E',
         vendor: 'Datek',
         description: 'Eva water leak sensor',
@@ -228,6 +228,7 @@ module.exports = [
                 'brightness_move_down', 'brightness_move_up', 'brightness_stop'])],
     },
     {
+        fingerprint: [{modelID: 'Door/Window Sensor', manufacturerName: 'Eva'}],
         zigbeeModel: ['Door/Window Sensor'],
         model: 'HSE2920E',
         vendor: 'Datek',

--- a/devices/datek.js
+++ b/devices/datek.js
@@ -35,7 +35,7 @@ module.exports = [
         model: 'HSE2905E',
         vendor: 'Datek',
         description: 'Datek Eva AMS HAN power-meter sensor',
-        fromZigbee: [fz.metering_datek, fz.electrical_measurement, fz.temperature, fzLocal.hw_version],
+        fromZigbee: [fz.metering_datek, fz.electrical_measurement, fz.temperature, fz.hw_version],
         toZigbee: [],
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
- Added fingerprint to all except 1 sensor from Datek
Reason are that all their products are now rebranded to Eva

- Added new converter `fz.hw_version`
Product `HLU2909K` has been revised, only possible way to see difference are the HW version

- Updated HLU2909K to show HW version if `hasOwnProperty` has value