### PR TITLE
enable hue effects for model 1743930P7

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1288,7 +1288,7 @@ module.exports = [
         model: '1743930P7',
         vendor: 'Philips',
         description: 'Hue Outdoor Econic wall lantern',
-        extend: hueExtend.light_onoff_brightness_colortemp_color(),
+        extend: hueExtend.light_onoff_brightness_colortemp_color({disableHueEffects: false, colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['929003053001'],


### PR DESCRIPTION
Related to this discussion:
https://github.com/Koenkk/zigbee2mqtt/discussions/16108

I have tested and verified this works.

I do not know if the `colorTempRange: [153, 500]` is correct, but it is working. If this should be removed or modified let me know and I can make that change.