### PR TITLE
Aqara SRTS-A01 fix missing OTA cluster

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -2696,6 +2696,9 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read('aqaraOpple', [0x040a], {manufacturerCode: 0x115f});
+
+            // This cluster is not discovered automatically and needs to be explicitly attached to enable OTA
+            utils.attachOutputCluster(device, 'genOta');
         },
         ota: ota.zigbeeOTA,
     },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const globalStore = require('./store');
+const herdsman = require('zigbee-herdsman');
 
 function isLegacyEnabled(options) {
     return !options.hasOwnProperty('legacy') || options.legacy;
@@ -443,6 +444,16 @@ function noOccupancySince(endpoint, options, publish, action) {
     }
 }
 
+function attachOutputCluster(device, clusterKey) {
+    const clusterId = herdsman.Zcl.Utils.getCluster(clusterKey).ID;
+    const endpoint = device.getEndpoint(1);
+
+    if (!endpoint.outputClusters.includes(clusterId)) {
+        endpoint.outputClusters.push(clusterId);
+        device.save();
+    }
+}
+
 module.exports = {
     noOccupancySince,
     getOptions,
@@ -478,4 +489,5 @@ module.exports = {
     deleteSceneState,
     getSceneState,
     extendDevice,
+    attachOutputCluster,
 };


### PR DESCRIPTION
Fix missing OTA update functionality by adding the missing `genOta` cluster as suggested in https://github.com/Koenkk/zigbee2mqtt/issues/13993#issuecomment-1346644669. Closes #5304.

Due to a lack of understanding how Z2M works, I do not know whether this is a proper fix or if the lack of automated discovery of this cluster hints at a deeper issue which should rather be fixed instead. I hope a reviewer can clear this up.