### PR TITLE
Extend support for Moes MS-105B

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1911,35 +1911,6 @@ const converters = {
             return result;
         },
     },
-    moes_105_dimmer: {
-        cluster: 'manuSpecificTuya',
-        type: ['commandDataResponse', 'commandDataReport'],
-        convert: (model, msg, publish, options, meta) => {
-            const multiEndpoint = model.meta && model.meta.multiEndpoint;
-            const dpValue = tuya.firstDpValue(msg, meta, 'moes_105_dimmer');
-            const dp = dpValue.dp;
-            const value = tuya.getDataValue(dpValue);
-
-            meta.logger.debug(`from moes_105_dimmer, dp=[${dp}], datatype=[${dpValue.datatype}], value=[${value}]`);
-
-            const state = value ? 'ON': 'OFF';
-            const brightness = mapNumberRange(value, 0, 1000, 0, 254);
-
-            switch (dp) {
-            case tuya.dataPoints.moes105DimmerState1:
-                return {[multiEndpoint ? 'state_l1' : 'state']: state};
-            case tuya.dataPoints.moes105DimmerLevel1:
-                return {[multiEndpoint ? 'brightness_l1' : 'brightness']: brightness};
-            case tuya.dataPoints.moes105DimmerState2:
-                return {state_l2: state};
-            case tuya.dataPoints.moes105DimmerLevel2:
-                return {brightness_l2: brightness};
-            default:
-                meta.logger.debug(`zigbee-herdsman-converters:moes_105_dimmer:` +
-                    `NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
-            }
-        },
-    },
     ias_smoke_alarm_1_develco: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -6583,37 +6583,11 @@ const converters = {
         },
     },
     moes_105_dimmer: {
-        key: ['state', 'brightness'],
+        key: ['brightness'],
         convertSet: async (entity, key, value, meta) => {
-            meta.logger.debug(`to moes_105_dimmer key=[${key}], value=[${value}]`);
-
-            const multiEndpoint = utils.getMetaValue(entity, meta.mapped, 'multiEndpoint', 'allEqual', false);
-            const lookupState = {l1: tuya.dataPoints.moes105DimmerState1, l2: tuya.dataPoints.moes105DimmerState2};
-            const lookupBrightness = {l1: tuya.dataPoints.moes105DimmerLevel1, l2: tuya.dataPoints.moes105DimmerLevel2};
-            const stateKeyId = multiEndpoint ? lookupState[meta.endpoint_name] : lookupState.l1;
-            const brightnessKeyId = multiEndpoint ? lookupBrightness[meta.endpoint_name] : lookupBrightness.l1;
-
-            switch (key) {
-            case 'state':
-                await tuya.sendDataPointBool(entity, stateKeyId, value === 'ON', 'dataRequest', 1);
-                break;
-
-            case 'brightness':
-                if (value >= 0 && value <= 254) {
-                    const newValue = utils.mapNumberRange(value, 0, 254, 0, 1000);
-                    if (newValue === 0) {
-                        await tuya.sendDataPointBool(entity, stateKeyId, false, 'dataRequest', 1);
-                    } else {
-                        await tuya.sendDataPointBool(entity, stateKeyId, true, 'dataRequest', 1);
-                    }
-                    await tuya.sendDataPointValue(entity, brightnessKeyId, newValue, 'dataRequest', 1);
-                    break;
-                } else {
-                    throw new Error('Dimmer brightness is out of range 0..254');
-                }
-
-            default:
-                throw new Error(`Unsupported Key=[${key}]`);
+            if (key === 'brightness') {
+                meta.message['state'] = value > 0 ? 'ON' : 'OFF';
+                return tuya.tz.datapoints.convertSet(entity, key, value, meta);
             }
         },
     },

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -327,8 +327,12 @@ module.exports = [
             tuyaDatapoints: [
                 [1, 'state_l1', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
                 [2, 'brightness_l1', tuya.valueConverter.scale0_254to0_1000],
+                [3, 'min_brightness_l1', tuya.valueConverter.scale0_254to0_1000],
+                [4, 'light_type_l1', tuya.valueConverter.lightType],
                 [7, 'state_l2', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
                 [8, 'brightness_l2', tuya.valueConverter.scale0_254to0_1000],
+                [9, 'min_brightness_l2', tuya.valueConverter.scale0_254to0_1000],
+                [10, 'light_type_l2', tuya.valueConverter.lightType],
             ],
         },
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -336,8 +340,10 @@ module.exports = [
             if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
         },
         exposes: [
-            tuya.exposes.lightBrightness().withEndpoint('l1'),
-            tuya.exposes.lightBrightness().withEndpoint('l2'),
+            tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET).withEndpoint('l1'),
+            tuya.exposes.lightType().withEndpoint('l1'),
+            tuya.exposes.lightBrightness().withMinBrightness().setAccess('min_brightness', ea.STATE_SET).withEndpoint('l2'),
+            tuya.exposes.lightType().withEndpoint('l2'),
         ],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 1};

--- a/devices/moes.js
+++ b/devices/moes.js
@@ -319,15 +319,26 @@ module.exports = [
         model: 'MS-105B',
         vendor: 'Moes',
         description: 'Smart dimmer module (2 gang)',
-        fromZigbee: [fz.moes_105_dimmer, fz.ignore_basic_report],
-        toZigbee: [tz.moes_105_dimmer],
-        meta: {turnsOffAtBrightness1: true, multiEndpoint: true},
+        fromZigbee: [tuya.fz.datapoints, fz.ignore_basic_report, fz.ignore_tuya_set_time],
+        toZigbee: [tz.moes_105_dimmer, tuya.tz.datapoints],
+        meta: {
+            turnsOffAtBrightness1: true,
+            multiEndpoint: true,
+            tuyaDatapoints: [
+                [1, 'state_l1', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
+                [2, 'brightness_l1', tuya.valueConverter.scale0_254to0_1000],
+                [7, 'state_l2', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
+                [8, 'brightness_l2', tuya.valueConverter.scale0_254to0_1000],
+            ],
+        },
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
             if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
         },
-        exposes: [e.light_brightness().withEndpoint('l1').setAccess('state', ea.STATE_SET).setAccess('brightness', ea.STATE_SET),
-            e.light_brightness().withEndpoint('l2').setAccess('state', ea.STATE_SET).setAccess('brightness', ea.STATE_SET)],
+        exposes: [
+            tuya.exposes.lightBrightness().withEndpoint('l1'),
+            tuya.exposes.lightBrightness().withEndpoint('l2'),
+        ],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 1};
         },

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -625,11 +625,6 @@ const dataPoints = {
     tuyaSabCOalarm: 1,
     tuyaSabCO: 2,
     lidlTimer: 5,
-    // Moes MS-105 Dimmer
-    moes105DimmerState1: 1,
-    moes105DimmerLevel1: 2,
-    moes105DimmerState2: 7,
-    moes105DimmerLevel2: 8,
     // TuYa Radar Sensor
     trsPresenceState: 1,
     trsSensitivity: 2,


### PR DESCRIPTION
* Use generic tuya datapoints accessors in Moes MS-105B
* Add support for new attributes:
  * `min_brightness` 
  * `light_type`