### PR TITLE
Handle `hvacFanCtrl` messages without `fanMode` data

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -30,8 +30,10 @@ const converters = {
         cluster: 'hvacFanCtrl',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const key = getKey(constants.fanMode, msg.data.fanMode);
-            return {fan_mode: key, fan_state: key === 'off' ? 'OFF' : 'ON'};
+            if (msg.data.hasOwnProperty('fanMode')) {
+                const key = getKey(constants.fanMode, msg.data.fanMode);
+                return {fan_mode: key, fan_state: key === 'off' ? 'OFF' : 'ON'};
+            }
         },
     },
     thermostat: {


### PR DESCRIPTION
This handles `hvacFanCtrl` messages where `fanMode` isn't present, such as `{"fanModeSequence":1}` (such as that generated by the Mercator SSWF01G fan controller, reported in https://github.com/Koenkk/zigbee2mqtt/issues/15186). Previously, without `fanMode` present in the message, the state was assumed to be on given the lookup implementation.

Section 6.4.2.2 of the ZCL mentions that `FanMode` and `FanModeSequence` should be mandatory but at least the SSWF01G sends these attributes in separate messages.