### PR TITLE
Fix Lidl 14156408L supporting colors

### DIFF
--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -566,7 +566,7 @@ module.exports = [
         model: '14156408L',
         vendor: 'Lidl',
         description: 'Livarno Lux smart LED ceiling light',
-        ...extend.light_onoff_brightness_colortemp_color(
+        ...extend.light_onoff_brightness_colortemp(
             {disableColorTempStartup: true, disablePowerOnBehavior: true, colorTempRange: [153, 500]}),
         meta: {applyRedFix: true, enhancedHue: false},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
The Lidl 14156408L does not support colors as it only supports tempeture between 153 and 500.

More information:
https://www.lidl.de/p/livarno-home-deckenleuchte-mit-lichtfarbensteuerung-zigbee-smart-home/p100339376