### PR TITLE
Add support for Filament Style Bulb

### DIFF
--- a/devices/ajax_online.js
+++ b/devices/ajax_online.js
@@ -38,4 +38,11 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500], disableColorTempStartup: true}),
         meta: {applyRedFix: true, enhancedHue: false},
     },
+    {
+        zigbeeModel: ['ZB-CCT_Filament'],
+        model: 'ZB-CCT_Filament',
+        vendor: 'Ajax Online',
+        description: 'Zigbee LED filament light dimmable E27, edison ST64, flame 2200K',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+    },
 ];


### PR DESCRIPTION
Add support for the Ajax  Online E27 ZB-CCT Filament style bulb.