### PR TITLE
Adding new cleverio devices

### DIFF
--- a/devices/cleverio.js
+++ b/devices/cleverio.js
@@ -1,0 +1,56 @@
+const exposes = require('../lib/exposes');
+const fz = {...require('../converters/fromZigbee'), legacy: require('../lib/legacy').fromZigbee};
+const tz = require('../converters/toZigbee');
+const reporting = require('../lib/reporting');
+const tuya = require('../lib/tuya');
+const e = exposes.presets;
+const ea = exposes.access;
+
+module.exports = [
+    {
+        fingerprint: [{modelID: 'TS0219', manufacturerName: '_TZ3000_vdfwjopk'}],
+        model: 'IK117089',
+        vendor: 'Cleverio',
+        description: 'Smart siren',
+        fromZigbee: [fz.ts0216_siren, fz.ias_alarm_only_alarm_1, fz.power_source],
+        toZigbee: [tz.warning, tz.ts0216_volume],
+        exposes: [e.warning(), exposes.binary('alarm', ea.STATE, true, false),
+            exposes.numeric('volume', ea.ALL).withValueMin(0).withValueMax(100).withDescription('Volume of siren')],
+        meta: {disableDefaultResponse: true},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            const bindClusters = ['genPowerCfg'];
+        await reporting.bind(endpoint, coordinatorEndpoint, bindClusters);
+    },
+    },
+    {
+        zigbeeModel: ['TS0041A'],
+        fingerprint: [{manufacturerName: '_TYZB01_4qw4rl1u'}],
+        model: 'TS0041A',
+        vendor: 'Cleverio',
+        description: 'Wireless switch with 1 button',
+        exposes: [e.battery(), e.action(['single', 'double', 'hold'])],
+        fromZigbee: [fz.tuya_on_off_action, fz.battery],
+        toZigbee: [],
+        configure: tuya.configureMagicPacket,
+
+    },
+    {
+        zigbeeModel: ['TS0203'],
+        model: 'TS0203',
+        vendor: 'Cleverio',
+        description: 'Door sensor',
+        fingerprint: [{manufacturerName: '_TYZB01_yet4gkcj'}],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.battery, fz.ignore_basic_report, fz.ias_contact_alarm_1_report],
+        toZigbee: [],
+        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            try {
+                const endpoint = device.getEndpoint(1);
+                await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+                await reporting.batteryPercentageRemaining(endpoint);
+                await reporting.batteryVoltage(endpoint);
+            } catch (error) {/* Fails for some*/}
+        },
+    },
+];

--- a/devices/cleverio.js
+++ b/devices/cleverio.js
@@ -20,8 +20,8 @@ module.exports = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const bindClusters = ['genPowerCfg'];
-        await reporting.bind(endpoint, coordinatorEndpoint, bindClusters);
-    },
+            await reporting.bind(endpoint, coordinatorEndpoint, bindClusters);
+        },
     },
     {
         fingerprint: [{modelID: 'TS0041A', manufacturerName: '_TYZB01_4qw4rl1u'}],

--- a/devices/cleverio.js
+++ b/devices/cleverio.js
@@ -9,7 +9,7 @@ const ea = exposes.access;
 module.exports = [
     {
         fingerprint: [{modelID: 'TS0219', manufacturerName: '_TZ3000_vdfwjopk'}],
-        model: 'IK117089',
+        model: 'SA100',
         vendor: 'Cleverio',
         description: 'Smart siren',
         fromZigbee: [fz.ts0216_siren, fz.ias_alarm_only_alarm_1, fz.power_source],
@@ -24,9 +24,8 @@ module.exports = [
     },
     },
     {
-        zigbeeModel: ['TS0041A'],
-        fingerprint: [{manufacturerName: '_TYZB01_4qw4rl1u'}],
-        model: 'TS0041A',
+        fingerprint: [{modelID: 'TS0041A', manufacturerName: '_TYZB01_4qw4rl1u'}],
+        model: 'SB100',
         vendor: 'Cleverio',
         description: 'Wireless switch with 1 button',
         exposes: [e.battery(), e.action(['single', 'double', 'hold'])],
@@ -36,11 +35,10 @@ module.exports = [
 
     },
     {
-        zigbeeModel: ['TS0203'],
-        model: 'TS0203',
+        model: 'SS100',
         vendor: 'Cleverio',
         description: 'Door sensor',
-        fingerprint: [{manufacturerName: '_TYZB01_yet4gkcj'}],
+        fingerprint: [{modelID: 'TS0203', manufacturerName: '_TYZB01_yet4gkcj'}],
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery, fz.ignore_basic_report, fz.ias_contact_alarm_1_report],
         toZigbee: [],
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery(), e.battery_voltage()],


### PR DESCRIPTION
Mostly based on Tuya and other devices. 


[1 button](https://www.kjell.com/se/produkter/smarta-hem/smarta-hem-losningar/cleverio-smarta-hem/cleverio-sb100-zigbee-multifunktionsknapp-p51830) - new version of TS0041 with A at the and(TS0041A)
[door sensor](https://www.kjell.com/se/produkter/smarta-hem/smarta-sensorer/smarta-magnetkontakter/cleverio-ss100-smart-magnetsensor-med-zigbee-3.0-p51826) - adding based on manufacturer
[siren](https://www.kjell.com/se/produkter/smarta-hem/smarta-hem-losningar/cleverio-smarta-hem/cleverio-sa100-smart-siren-med-zigbee-3.0-p51832) - same as woox TS0219, but without battery. So I stripped the battery options.