### PR TITLE
Add other models for the Philips 3418131P6

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1009,7 +1009,7 @@ module.exports = [
         extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
     {
-        zigbeeModel: ['3418131P6', '929003056401', '929003056401_01', '929003056401_02' , '929003056401_03'],
+        zigbeeModel: ['3418131P6', '929003056401', '929003056401_01', '929003056401_02', '929003056401_03'],
         model: '3418131P6',
         vendor: 'Philips',
         description: 'Hue white ambiance Adore GU10 with Bluetooth (3 spots)',

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1009,7 +1009,7 @@ module.exports = [
         extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
     {
-        zigbeeModel: ['3418131P6', '929003056401'],
+        zigbeeModel: ['3418131P6', '929003056401', '929003056401_01', '929003056401_02' , '929003056401_03'],
         model: '3418131P6',
         vendor: 'Philips',
         description: 'Hue white ambiance Adore GU10 with Bluetooth (3 spots)',


### PR DESCRIPTION
I have 3 bulbs Philips 3418131P6. The modelId attribute is different for all the three bulbs:

- 929003056401_01
- 929003056401_02
- 929003056401_03