### PR TITLE
Add philips 929003574401

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -102,7 +102,7 @@ module.exports = [
         extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
     {
-        zigbeeModel: ['915005996801', '915005996901'],
+        zigbeeModel: ['915005996801', '915005996901', '929003574401'],
         model: '915005996901',
         vendor: 'Philips',
         description: 'Hue white ambiance ceiling light Enrave L with Bluetooth',


### PR DESCRIPTION
This seems to be a variant of `915005996801`/`915005996901`: <https://www.philips-hue.com/en-us/p/hue-white-ambiance-enrave-large-ceiling-lamp/046677580834>
This was tested to work by a third party with an external converter using the code from the mentioned devices above.
Thanks to @digiblur for helping with the converter.