### PR TITLE
Fix calibration limits of BTH-RA

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -410,7 +410,7 @@ const definition = [
             exposes.climate()
                 .withLocalTemperature(ea.STATE)
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
-                .withLocalTemperatureCalibration(-12, 12, 0.5)
+                .withLocalTemperatureCalibration(-5, 5, 0.1)
                 .withSystemMode(['off', 'heat', 'auto'])
                 .withPiHeatingDemand(ea.STATE),
             exposes.binary('boost', ea.ALL, 'ON', 'OFF')


### PR DESCRIPTION
While using the BetterThermostat custom component, I kept getting errors during its calibration procedure with my Bosch Heizkörper-Thermostat II. Checking the TRV's capabilities in the Bosch app, I discovered it can only calibrated in a range from -5 to +5°C. Further, the converter only allowed steppings of .5°C, while really .1°C is possible.

See attached screenshots of the Bosch app for reference.

![bosch](https://user-images.githubusercontent.com/8737970/212819952-838a988a-4a1f-436d-a401-6bfe5327e853.png)
