### PR TITLE
Add philips floor lamp 929003516101

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1576,6 +1576,13 @@ module.exports = [
         extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
     },
     {
+        zigbeeModel: ['929003516101'],
+        model: '929003516101',
+        vendor: 'Philips',
+        description: 'Hue Gradient Signe floor lamp (wood)',
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
+    },
+    {
         zigbeeModel: ['LCT020'],
         model: '4080148P7',
         vendor: 'Philips',


### PR DESCRIPTION
Another variant of Philips hue Signe gradient floor lamp wood/oak 
Model `929003516101` is listed here-  https://www.philips-hue.com/en-gb/p/hue-white-and-colour-ambiance-signe-gradient-floor-lamp/8719514445291#specifications

Similar to model 929003479701, tested working with custom converter.
