### PR TITLE
Aqara feeder C1 local time

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -2734,6 +2734,10 @@ module.exports = [
                 .withUnit('g'),
         ],
         ota: ota.zigbeeOTA,
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('aqaraOpple', [0xfff1], {manufacturerCode: 0x115f});
+        },
     },
     {
         zigbeeModel: ['lumi.remote.acn007'],

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ module.exports = {
         // Aqara feeder C1 polls the time during the interview, need to send back the local time instead of the UTC.
         // The device.definition has not yet been set - therefore the device.definition.onEvent method does not work.
         if (type === 'message' && data.type === 'read' && data.cluster === 'genTime' &&
-            device.modelID ==="aqara.feeder.acn001") {
+            device.modelID === 'aqara.feeder.acn001') {
             device.skipTimeResponse = true;
             const oneJanuary2000 = new Date('January 01, 2000 00:00:00 UTC+00:00').getTime();
             const secondsUTC = Math.round(((new Date()).getTime() - oneJanuary2000) / 1000);

--- a/index.js
+++ b/index.js
@@ -228,5 +228,15 @@ module.exports = {
             const payload = {0xf00: {value: 23, type: 35}};
             await endpoint.readResponse('genBasic', data.meta.zclTransactionSequenceNumber, payload, options);
         }
+        // Aqara feeder C1 polls the time during the interview, need to send back the local time instead of the UTC.
+        // The device.definition has not yet been set - therefore the device.definition.onEvent method does not work.
+        if (type === 'message' && data.type === 'read' && data.cluster === 'genTime' &&
+            device.modelID ==="aqara.feeder.acn001") {
+            device.skipTimeResponse = true;
+            const oneJanuary2000 = new Date('January 01, 2000 00:00:00 UTC+00:00').getTime();
+            const secondsUTC = Math.round(((new Date()).getTime() - oneJanuary2000) / 1000);
+            const secondsLocal = secondsUTC - (new Date()).getTimezoneOffset() * 60;
+            await device.getEndpoint(1).readResponse('genTime', data.meta.zclTransactionSequenceNumber, {time: secondsLocal});
+        }
     },
 };


### PR DESCRIPTION
Aqara feeder C1 polls the time during the interview, need to send back the local time instead of the UTC.
At this moment, the device.definition has not yet been set - therefore the onEvent method does not work.

https://github.com/Koenkk/zigbee2mqtt/discussions/16157