### PR TITLE
Revert "Add `off` system mode and improve `current_heating_setpoint` …

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -291,9 +291,9 @@ module.exports = [
             e.valve_state(), e.position(), e.window_detection(),
             exposes.binary('window', ea.STATE, 'OPEN', 'CLOSED').withDescription('Window status closed or open '),
             exposes.climate()
-                .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 45, 0.5, ea.STATE_SET)
+                .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 35, 1, ea.STATE_SET)
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
-                .withSystemMode(['off', 'heat'], ea.STATE_SET)
+                .withSystemMode(['heat'], ea.STATE_SET)
                 .withRunningState(['idle', 'heat'], ea.STATE)
                 .withPreset(['programming', 'manual', 'temporary_manual', 'holiday'],
                     'MANUAL MODE ☝ - In this mode, the device executes manual temperature setting. '+


### PR DESCRIPTION
…range for Moes BRT-100-TRV (#5207)"

This reverts commit 14583fdc66838ce8f239a5ed1f21a0daa41a824d.

Closes https://github.com/Koenkk/zigbee-herdsman-converters/issues/5370