### PR TITLE
Remove redundant and unused temperature parameter

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -735,7 +735,7 @@ module.exports = [
         fromZigbee: [fz.ignore_basic_report, fz.ignore_genOta, fz.ignore_zclversion_read, fz.battery, fz.hvac_user_interface,
             fz.wiser_smart_thermostat_client, fz.wiser_smart_setpoint_command_client, fz.schneider_temperature],
         toZigbee: [tz.wiser_sed_zone_mode, tz.wiser_sed_occupied_heating_setpoint],
-        exposes: [e.battery(), e.temperature(),
+        exposes: [e.battery(),
             exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5, ea.STATE_SET)
                 .withLocalTemperature(ea.STATE),
             exposes.enum('zone_mode',


### PR DESCRIPTION
- The local measured temperature is exposed via "local_temperature"