### PR TITLE
Added support for Schneider Electric CCT591011_AS

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -1006,4 +1006,13 @@ module.exports = [
             await endpoint.read('genPowerCfg', ['batteryVoltage', 'batteryPercentageRemaining']);
         },
     },
+    {
+        zigbeeModel: ['CCT591011_AS'],
+        model: 'CCT591011_AS',
+        vendor: 'Schneider Electric',
+        description: 'Wiser window/door sensor',
+        fromZigbee: [fz.ias_contact_alarm_1, fz.ias_contact_alarm_1_report],
+        toZigbee: [],
+        exposes: [e.battery_low(), e.contact(), e.tamper()],
+    },
 ];


### PR DESCRIPTION
Added support for Schneider Electric CCT591011_AS.

I have run the actual device for roughly a week now. With this configuration the sensor reports its status correctly (door is open or closed) and zigbee2mqtt does not receive any unconverted messages.

I was not able to test the battery and tamper signals, but considering the other Schneider Electric devices also report these values, I would be confident this one will work exactly the same as every other by the same manufacturer.

Picture of the sensor was submitted as a PR to zigbee2mqtt.io project.