### PR TITLE
Add power/energy metering to Samotech SM309-S

### DIFF
--- a/devices/samotech.js
+++ b/devices/samotech.js
@@ -1,5 +1,8 @@
+const fz = require('../converters/fromZigbee');
+const exposes = require('../lib/exposes');
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
+const e = exposes.presets;
 
 module.exports = [
     {
@@ -28,14 +31,22 @@ module.exports = [
         zigbeeModel: ['SM309-S'],
         model: 'SM309-S',
         vendor: 'Samotech',
-        description: 'Zigbee dimmer 400W',
-        extend: extend.light_onoff_brightness({noConfigure: true}),
+        description: 'Zigbee dimmer 400W with power and energy metering',
+        fromZigbee: extend.light_onoff_brightness().fromZigbee.concat([fz.electrical_measurement, fz.metering]),
+        toZigbee: extend.light_onoff_brightness().toZigbee,
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.rmsVoltage(endpoint, {min: 10, change: 20});
+            await reporting.rmsCurrent(endpoint, {min: 10, change: 10});
+            await reporting.activePower(endpoint, {min: 10, change: 15});
+            await reporting.currentSummDelivered(endpoint, {min: 300});
             await reporting.onOff(endpoint);
         },
+        exposes: extend.light_onoff_brightness().exposes.concat([e.power(), e.current(), e.voltage(), e.energy()]),
     },
     {
         zigbeeModel: ['SM309'],


### PR DESCRIPTION
When the device support was originally added, it was a straight copy of the `SM309` code.  This newer variant exposes power/energy use.

The reporting `min` and `change` parameters shamelessly cargo culted from https://github.com/Koenkk/zigbee-herdsman-converters/blob/f130b98ab32491848a4beeaea1d8e0a50519baad/devices/micromatic.js#L24-L27 but they look like sensible enough settings to me.

Tested with home assistant and the zigbee2mqtt addon.  Seems to work just fine.

```json
{
    "brightness": 254,
    "linkquality": 140,
    "power_on_behavior": "previous",
    "state": "ON",
    "current": 1.15,
    "energy": 2.71,
    "power": 275.5,
    "voltage": 238.4
}
```