### PR TITLE
Fix type of Danfoss window_open_internal

### DIFF
--- a/devices/danfoss.js
+++ b/devices/danfoss.js
@@ -80,7 +80,8 @@ module.exports = [
                 'has no (noticable?) effect.'),
             exposes.binary('window_open_feature', ea.ALL, true, false)
                 .withDescription('Whether or not the window open feature is enabled'),
-            exposes.numeric('window_open_internal', ea.STATE_GET).withValueMin(0).withValueMax(4)
+            exposes.enum('window_open_internal', ea.STATE_GET,
+                ['quarantine', 'closed', 'hold', 'open', 'external_open'])
                 .withDescription('0=Quarantine, 1=Windows are closed, 2=Hold - Windows are maybe about to open, ' +
                     '3=Open window detected, 4=In window open state from external but detected closed locally'),
             exposes.binary('window_open_external', ea.ALL, true, false)


### PR DESCRIPTION
This entity was exposed as a number, but it's actually an enum now:
<img src="https://user-images.githubusercontent.com/431167/213919512-08c096e9-6d4a-4d4b-91f3-91fb7bdc794d.png" width="300"/>
