### PR TITLE
zosung: Handle empty and 0 sequence

### DIFF
--- a/lib/zosung.js
+++ b/lib/zosung.js
@@ -10,8 +10,9 @@ function nextSeq(entity) {
 
 function messagesGet(entity, seq) {
     const info = entity.irMessageInfo;
-    if (info.seq!=seq) {
-        throw new Error(`Unexpected sequence value (expected: ${info.seq} current: ${seq}).`);
+    const expected = (info&&info.seq) || 0;
+    if (expected!==seq) {
+        throw new Error(`Unexpected sequence value (expected: ${expected} current: ${seq}).`);
     }
     return info.data;
 }
@@ -21,18 +22,19 @@ function messagesSet(entity, seq, data) {
 
 function messagesClear(entity, seq) {
     const info = entity.irMessageInfo;
-    if (info.seq!=seq) {
-        throw new Error(`Unexpected sequence value (expected: ${info.seq} current: ${seq}).`);
+    const expected = (info&&info.seq) || 0;
+    if (expected!==seq) {
+        throw new Error(`Unexpected sequence value (expected: ${expected} current: ${seq}).`);
     }
     delete entity.irMessageInfo;
 }
 
 function calcArrayCrc(values) {
-    return Array.from(values.values()).reduce((a, b)=>a+b)%0x100;
+    return Array.from(values.values()).reduce((a, b)=>a+b, 0)%0x100;
 }
 
 function calcStringCrc(str) {
-    return str.split('').map((x)=>x.charCodeAt(0)).reduce((a, b)=>a+b)%0x100;
+    return str.split('').map((x)=>x.charCodeAt(0)).reduce((a, b)=>a+b, 0)%0x100;
 }
 
 


### PR DESCRIPTION
Fixes these errors:
```
Zigbee2MQTT:error 2023-01-23 12:27:14: Exception while calling fromZigbee converter: Reduce of empty array with no initial value}
Zigbee2MQTT:debug 2023-01-23 12:27:14: TypeError: Reduce of empty array with no initial value
    at Array.reduce (<anonymous>)
    at calcStringCrc (zigbee2mqtt/node_modules/zigbee-herdsman-converters/lib/zosung.js:35:52)
    at Object.convert (zigbee2mqtt/node_modules/zigbee-herdsman-converters/lib/zosung.js:59:25)
    at Receive.onDeviceMessage (zigbee2mqtt/lib/extension/receive.ts:143:51)
    at EventEmitter.emit (node:events:525:35)
    at EventBus.emitDeviceMessage (zigbee2mqtt/lib/eventBus.ts:102:22)
    at Controller.<anonymous> (zigbee2mqtt/lib/zigbee.ts:106:27)
    at Controller.emit (node:events:513:28)
    at Controller.selfAndDeviceEmit (zigbee2mqtt/node_modules/zigbee-herdsman/src/controller/controller.ts:515:14)
```
```
Zigbee2MQTT:error 2023-01-23 12:32:14: Exception while calling fromZigbee converter: Cannot read properties of undefined (reading 'seq')}
Zigbee2MQTT:debug 2023-01-23 12:32:14: TypeError: Cannot read properties of undefined (reading 'seq')
    at messagesClear (zigbee2mqtt/node_modules/zigbee-herdsman-converters/lib/zosung.js:24:14)
    at Object.convert (zigbee2mqtt/node_modules/zigbee-herdsman-converters/lib/zosung.js:84:13)
    at Receive.onDeviceMessage (zigbee2mqtt/lib/extension/receive.ts:143:35)
```
(Second appears after adding the `0` to the `reduce` call) I haven't dug into if there's a deeper issue here but at least it clears the logs.