### PR TITLE
Add support for the Hive TRV003

### DIFF
--- a/devices/hive.js
+++ b/devices/hive.js
@@ -158,7 +158,7 @@ module.exports = [
         },
     },
     extendDevice(require('./danfoss'), '014G2461', {
-        zigbeeModel: ['TRV001'],
+        zigbeeModel: ['TRV001', 'TRV003'],
         model: 'UK7004240',
         vendor: 'Hive',
         description: 'Radiator valve based on Danfoss Ally (014G2461)',


### PR DESCRIPTION
I've just picked up one of the new Hive TRVs; I think the equivalent of the Danfoss Ally mentioned in https://github.com/Koenkk/zigbee2mqtt/issues/15464 and added in https://github.com/Koenkk/zigbee-herdsman-converters/commit/f508840114c7419f9a6f9bcb9f3fd1a64234819a. In case anyone's searching, the device reported itself as zigbee model "TRV003", zigbee manufacturer "Danfoss", the firmware build date is 20221217 and the firmware version is 02.50.0008 02.50.

I've added it as an external converter (by copying and pasting the Danfoss 014G2461 definition - I couldn't get the `extendDevice()` function working for some reason), and all seems to be working.