### PR TITLE
SMaBiT AV2010/32 does not support system_mode = auto

### DIFF
--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -194,7 +194,7 @@ module.exports = [
             tz.thermostat_occupied_cooling_setpoint, tz.thermostat_local_temperature_calibration, tz.thermostat_local_temperature,
             tz.thermostat_running_state, tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode],
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5).withLocalTemperature()
-            .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat', 'cool'])
+            .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat', 'cool'])
             .withLocalTemperatureCalibration(-30, 30, 0.1), e.keypad_lockout()],
         meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
```
debug 2023-01-25 14:56:04: Received MQTT message on 'zigbee2mqtt/0x000d6f0018c114b8/set' with data '{"system_mode":"auto"}'
debug 2023-01-25 14:56:04: Publishing 'set' 'system_mode' to '0x000d6f0018c114b8'
error 2023-01-25 14:56:06: Publish 'set' 'system_mode' to '0x000d6f0018c114b8' failed: 'Error: Write 0x000d6f0018c114b8/1 hvacThermostat({"systemMode":1}, {"sendWhen":"active","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'INVALID_VALUE')'
debug 2023-01-25 14:56:06: Error: Write 0x000d6f0018c114b8/1 hvacThermostat({"systemMode":1}, {"sendWhen":"active","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'INVALID_VALUE')
```