### PR TITLE
SMaBiT Thermostat only support heating

### DIFF
--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -194,7 +194,7 @@ module.exports = [
             tz.thermostat_occupied_cooling_setpoint, tz.thermostat_local_temperature_calibration, tz.thermostat_local_temperature,
             tz.thermostat_running_state, tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode],
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5).withLocalTemperature()
-            .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat', 'cool'])
+            .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat')
             .withLocalTemperatureCalibration(-30, 30, 0.1), e.keypad_lockout()],
         meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -194,7 +194,7 @@ module.exports = [
             tz.thermostat_occupied_cooling_setpoint, tz.thermostat_local_temperature_calibration, tz.thermostat_local_temperature,
             tz.thermostat_running_state, tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode],
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5).withLocalTemperature()
-            .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat')
+            .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat'])
             .withLocalTemperatureCalibration(-30, 30, 0.1), e.keypad_lockout()],
         meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
In the previous PR I dropped 'auto' from system_mode as the device rejects this with INVALID_VALUE. The device also rejects 'cool' as a system_mode so there is no way for the running state to end up being 'cool' it can only be 'heat' or 'idle' when not heating/off.

```
error 2023-01-26 14:38:37: Publish 'set' 'system_mode' to 'thermostat/home' failed: 'Error: Write 0x000d6f0018c114b8/1 hvacThermostat({"systemMode":3}, {"sendWhen":"active","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'INVALID_VALUE')'
debug 2023-01-26 14:38:37: Error: Write 0x000d6f0018c114b8/1 hvacThermostat({"systemMode":3}, {"sendWhen":"active","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'INVALID_VALUE')
    at Endpoint.checkStatus (/opt/zigbee2mqtt/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:317:28)
    at Endpoint.write (/opt/zigbee2mqtt/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:397:22)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Object.convertSet (/opt/zigbee2mqtt/node_modules/zigbee-herdsman-converters/converters/toZigbee.js:1249:13)
    at Publish.onMQTTMessage (/opt/zigbee2mqtt/lib/extension/publish.ts:246:36)
```