### PR TITLE
Expose 3RSS009Z battery percentage

### DIFF
--- a/devices/third_reality.js
+++ b/devices/third_reality.js
@@ -15,7 +15,12 @@ module.exports = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.on_off, fz.battery],
         toZigbee: [tz.on_off, tz.ignore_transition],
-        exposes: [e.switch(), e.battery_voltage()],
+        meta: {battery: {dontDividePercentage: true}},
+        exposes: [e.switch(), e.battery(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            device.powerSource = 'Battery';
+            device.save();
+        },
     },
     {
         zigbeeModel: ['3RSS008Z'],


### PR DESCRIPTION
exposes battery percentage for 3RSS009Z and also fixes its incorrectly-reported power source

confirmed that this device exposes `batteryPercentageRemaining` with max 100 range
<img width="892" alt="Screenshot 2023-01-26 at 8 36 59 PM" src="https://user-images.githubusercontent.com/718789/215010404-043ec3d2-25d9-4db8-b753-59af99c62e70.png">
