### PR TITLE
Fix support for KAMI motion sensor

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -6862,7 +6862,9 @@ const converters = {
         cluster: 'msOccupancySensing',
         type: ['raw'],
         convert: (model, msg, publish, options, meta) => {
-            return {occupancy: msg.data[7] === 0};
+            if (msg.data[7] === 1) {
+                return {action: 'motion'};
+            }
         },
     },
     DNCKAT_S00X_buttons: {

--- a/devices/kami.js
+++ b/devices/kami.js
@@ -7,9 +7,9 @@ module.exports = [
         zigbeeModel: ['Z3ContactSensor'],
         model: 'N20',
         vendor: 'KAMI',
-        description: 'Entry sensor',
+        description: 'Contact sensor or motion sensor',
         fromZigbee: [fz.KAMI_contact, fz.KAMI_occupancy],
         toZigbee: [],
-        exposes: [e.contact(), e.occupancy()],
+        exposes: [e.contact(), e.action(['motion'])],
     },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "zigbee-herdsman-converters",
       "version": "15.0.33",
       "license": "MIT",
       "dependencies": {
@@ -3298,6 +3297,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.2.0",
         "jest-util": "^29.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "zigbee-herdsman-converters",
       "version": "15.0.33",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3298,7 +3298,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.2.0",
         "jest-util": "^29.3.1",


### PR DESCRIPTION
The [KAMI motion sensor](https://www.zigbee2mqtt.io/devices/N20.html) (which has the same zigbeeModel as the KAMI contact sensor) only sends "occupied" messages. It also doesn't keep sending occupied messages as motion continues to be detected (it only sends it once until motion is no longer detected for 5 seconds). As a result, the current converter for this device isn't a good fit. Also, the current converter defined occupancy when `msg.data[7]` is 0, but it's actually when it's 1, so I updated that. 

Because this device doesn't keep sending occupied messages as motion continues to be detected, I don't think it makes sense to use the occupancy_with_timeout converter with this device. I updated the device entry and converter for this device to simply expose an action entity that returns "motion" whenever motion is detected.

This is probably considered to be a breaking change for this device, but since the current converter doesn't actually work properly, it probably doesn't matter.