### PR TITLE
Add Lightsolutions 30W Zigbee CCT LED driver.

### DIFF
--- a/devices/lightsolutions.js
+++ b/devices/lightsolutions.js
@@ -27,4 +27,11 @@ module.exports = [
             await reporting.onOff(endpoint);
         },
     },
+    {
+        zigbeeModel: ['42-032'],
+        model: '42-032',
+        vendor: 'LightSolutions',
+        description: 'LED driver CCT 12V - 30W - CCT',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [160, 450]}),
+    },
 ];


### PR DESCRIPTION
 Lightsolutions 30W Zigbee CCT LED driver is basically a Sunricher white-labeled device, similar to Sunricher HK-ZD-CCT-A.