### PR TITLE
Add Support for 2W A60 bulbs on FW 1.3

### DIFF
--- a/devices/ajax_online.js
+++ b/devices/ajax_online.js
@@ -16,7 +16,7 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495], disableEffect: true}),
     },
     {
-        zigbeeModel: ['AJ_ZBPROA60'],
+        zigbeeModel: ['AJ_ZBPROA60', 'AJ_ZBPROA6'],
         model: 'AJ_ZIGPROA60',
         vendor: 'Ajax Online',
         description: 'Smart Zigbee pro 12W A60 bulb',


### PR DESCRIPTION
These bulbs on FW version 1.3 show as "AJ_ZBPROA6" so I have added that model to support that firmware version.