### PR TITLE
Additional exposes for Yale Assure locks

### DIFF
--- a/devices/yale.js
+++ b/devices/yale.js
@@ -8,14 +8,15 @@ const lockExtend = (meta, lockStateOptions=null, binds=['closuresDoorLock', 'gen
     return {
         fromZigbee: [fz.lock, fz.battery, fz.lock_operation_event, fz.lock_programming_event, fz.lock_pin_code_response,
             fz.lock_user_status_response],
-        toZigbee: [tz.lock, tz.pincode_lock, tz.lock_userstatus],
+        toZigbee: [tz.lock, tz.pincode_lock, tz.lock_userstatus, tz.lock_auto_relock_time, tz.lock_sound_volume],
         meta: {pinCodeCount: 250, ...meta},
-        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user()],
+        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user(), e.auto_relock_time(), e.sound_volume(), e.battery_low()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.lockState(endpoint, lockStateOptions);
             await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.batteryAlarmState(endpoint);
         },
     };
 };

--- a/devices/yale.js
+++ b/devices/yale.js
@@ -10,7 +10,7 @@ const lockExtend = (meta, lockStateOptions=null, binds=['closuresDoorLock', 'gen
             fz.lock_user_status_response],
         toZigbee: [tz.lock, tz.pincode_lock, tz.lock_userstatus, tz.lock_auto_relock_time, tz.lock_sound_volume],
         meta: {pinCodeCount: 250, ...meta},
-        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user(), e.auto_relock_time(), e.sound_volume(), e.battery_low()],
+        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user(), e.auto_relock_time().withValueMin(0).withValueMax(3600), e.sound_volume(), e.battery_low()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, binds);

--- a/devices/yale.js
+++ b/devices/yale.js
@@ -10,7 +10,8 @@ const lockExtend = (meta, lockStateOptions=null, binds=['closuresDoorLock', 'gen
             fz.lock_user_status_response],
         toZigbee: [tz.lock, tz.pincode_lock, tz.lock_userstatus, tz.lock_auto_relock_time, tz.lock_sound_volume],
         meta: {pinCodeCount: 250, ...meta},
-        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user(), e.auto_relock_time().withValueMin(0).withValueMax(3600), e.sound_volume(), e.battery_low()],
+        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user(),
+            e.auto_relock_time().withValueMin(0).withValueMax(3600), e.sound_volume(), e.battery_low()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, binds);

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -69,6 +69,7 @@ module.exports = {
     batteryAlarmState: async (endpoint, overrides) => {
         const p = payload('batteryAlarmState', repInterval.HOUR, repInterval.MAX, 0, overrides);
         await endpoint.configureReporting('genPowerCfg', p);
+        await endpoint.read('genPowerCfg', ['batteryAlarmState']);
     },
     onOff: async (endpoint, overrides) => {
         const p = payload('onOff', 0, repInterval.HOUR, 0, overrides);


### PR DESCRIPTION
Exposes the following entities for Yale Assure locks:

- `auto_relock_time`
- `battery_low`
- `sound_volume`

I have been using this configuration in my own Home Assistant setup for some time, see https://github.com/joshuaspence/home-assistant-config/blob/master/zigbee2mqtt/converters/yale.js. It has been tested with a YRD226 lock.