### PR TITLE
Update ajax_online.js

### DIFF
--- a/devices/ajax_online.js
+++ b/devices/ajax_online.js
@@ -39,7 +39,7 @@ module.exports = [
         meta: {applyRedFix: true, enhancedHue: false},
     },
     {
-        zigbeeModel: ['ZB-CCT_Filament'],
+        zigbeeModel: ['CCT Light'],
         model: 'ZB-CCT_Filament',
         vendor: 'Ajax Online',
         description: 'Zigbee LED filament light dimmable E27, edison ST64, flame 2200K',


### PR DESCRIPTION
I tried to add support for this in the last release, it however still came up unsupported as you can see from the log extract:

`Zigbee2MQTT:debug 2023-02-01 17:12:30: Received Zigbee message from '0x00158d0005091306', type 'commandQueryNextImageRequest', cluster 'genOta', data '{"fieldControl":0,"fileVersion":537276435,"imageType":4364,"manufacturerCode":4137}' from endpoint 1 with groupID 0 Zigbee2MQTT:warn 2023-02-01 17:12:30: Received message from unsupported device with Zigbee model 'CCT Light' and manufacturer name 'ZB/Ajax Online' Zigbee2MQTT:warn 2023-02-01 17:12:30: Please see: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html`

This is the finger print I got when I was trying to add support with the external converter:
`fingerprint: [{modelID: 'CCT Light', manufacturerName: 'ZB/Ajax Online', manufacturerID: 4137},
{modelID: 'CCT Light', manufacturerName: 'ZB/Ajax Online', manufacturerID: 4137}]`