### PR TITLE
Fingerprint for _TZE200_dq1mfjug for Tuya TS0601 smoke detector ES63-D5Z

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2659,7 +2659,7 @@ module.exports = [
     {
         zigbeeModel: ['5p1vj8r'],
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_t5p1vj8r', '_TZE200_uebojraa', '_TZE200_vzekyi4c', '_TZE200_yh7aoahi',
-            '_TZE200_dnz6yvl2']),
+            '_TZE200_dnz6yvl2', '_TZE200_dq1mfjug']),
         model: 'TS0601_smoke',
         vendor: 'TuYa',
         description: 'Smoke sensor',


### PR DESCRIPTION
Fingerprint for Tuya TS0601 smoke detector ES63-D5Z

![image](https://user-images.githubusercontent.com/98490303/216594373-d8d5c5e3-607b-4592-af79-3aecbbccd820.png)
