### PR TITLE
Update ajax_online.js

### DIFF
--- a/devices/ajax_online.js
+++ b/devices/ajax_online.js
@@ -39,7 +39,7 @@ module.exports = [
         meta: {applyRedFix: true, enhancedHue: false},
     },
     {
-        zigbeeModel: ['ZB-CCT_Filament'],
+        fingerprint: [{modelID: 'CCT Light', manufacturerName: 'ZB/Ajax Online', manufacturerID: 4137}],
         model: 'ZB-CCT_Filament',
         vendor: 'Ajax Online',
         description: 'Zigbee LED filament light dimmable E27, edison ST64, flame 2200K',


### PR DESCRIPTION
After adding support for this device, I realise I made an error and have amended it, the device doesn't expose itself as `ZB-CCT_Filament`, the amendment I made now reflects my external converter exactly. This amendment now means that the filament bulb I tried to add will now actually be supported as it still came up as unsupported when I had converter as `zigbeemodel: ZB-CCT_Filament`.