### PR TITLE
Add Moes whitelabel to TuYa TS0044

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1828,7 +1828,7 @@ module.exports = [
         vendor: 'TuYa',
         description: 'Wireless switch with 4 buttons',
         whiteLabel: [{vendor: 'Lonsonho', model: 'TS0044'}, {vendor: 'Haozee', model: 'ESW-OZAA-EU'},
-            {vendor: 'LoraTap', model: 'SS6400ZB'}],
+            {vendor: 'LoraTap', model: 'SS6400ZB'}, {vendor: 'Moes', model: 'ZT-SY-EU-G-4S-WH-MS'}],
         fromZigbee: [fz.tuya_on_off_action, fz.battery],
         exposes: [e.battery(), e.action(['1_single', '1_double', '1_hold', '2_single', '2_double', '2_hold',
             '3_single', '3_double', '3_hold', '4_single', '4_double', '4_hold'])],


### PR DESCRIPTION
Got this switch from Amazon.de in the 4-gang variant, it's white labeled by Moes with "powered by TuYa" in the corner of the box, interviewed as Tuya TS0044 and works perfectly. Didn't find it under Moes it in the device compatibility list initially, so I thought I'd add the whitelabel and autogenerated docs pick it up from here.

There seem to also exist 1-, 2- and 3-gang variants that share the same box and manual, and presumably internals. However I couldn't quickly find exact matches in the existing TuYa devices (or for sale, for that matter), so I only added the 4-gang that I can confirm matches and works.