### PR TITLE
Updated time units for BRT-100-TRV (TS0601)

### DIFF
--- a/devices/moes.js
+++ b/devices/moes.js
@@ -308,9 +308,9 @@ module.exports = [
                 'You can set up to 4 stages of temperature every for WEEKDAY ➀➁➂➃➄,  SATURDAY ➅ and SUNDAY ➆.'),
             exposes.binary('boost_heating', ea.STATE_SET, 'ON', 'OFF').withDescription('Boost Heating: press and hold "+" for 3 seconds, ' +
                 'the device will enter the boost heating mode, and the ▷╵◁ will flash. The countdown will be displayed in the APP'),
-            exposes.numeric('boost_heating_countdown', ea.STATE).withUnit('Min').withDescription('Countdown in minutes')
+            exposes.numeric('boost_heating_countdown', ea.STATE).withUnit('minutes').withDescription('Countdown in minutes')
                 .withValueMin(0).withValueMax(15),
-            exposes.numeric('boost_heating_countdown_time_set', ea.STATE_SET).withUnit('second')
+            exposes.numeric('boost_heating_countdown_time_set', ea.STATE_SET).withUnit('seconds')
                 .withDescription('Boost Time Setting 100 sec - 900 sec, (default = 300 sec)').withValueMin(100)
                 .withValueMax(900).withValueStep(100)],
     },


### PR DESCRIPTION
Made time units for BRT-100-TRV (TS0601) compatible with home assistant.

This should solve the error "Entity sensor...._boost_heating_countdown (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement 'Min' which is not a valid unit for the device class ('duration') it is using; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22"