### PR TITLE
SMaBiT AV2010/32 does support cool when configured via ctrlSeqOfOper

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1266,8 +1266,12 @@ const converters = {
             if (val === undefined) {
                 val = utils.getKey(constants.thermostatControlSequenceOfOperations, value, value, Number);
             }
-            await entity.write('hvacThermostat', {ctrlSeqeOfOper: val});
-            return {state: {control_sequence_of_operation: value}};
+            const attributes = {ctrlSeqeOfOper: val};
+            await entity.write('hvacThermostat', attributes);
+            // NOTE: update the cluster attribute we store as this is used by
+            //       SMaBiT AV2010/32's dynamic expose function.
+            entity.saveClusterAttributeKeyValue('hvacThermostat', attributes);
+            return {readAfterWriteTime: 250, state: {control_sequence_of_operation: value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['ctrlSeqeOfOper']);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1267,6 +1267,7 @@ const converters = {
                 val = utils.getKey(constants.thermostatControlSequenceOfOperations, value, value, Number);
             }
             await entity.write('hvacThermostat', {ctrlSeqeOfOper: val});
+            return {state: {control_sequence_of_operation: value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['ctrlSeqeOfOper']);

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -102,6 +102,12 @@ const converters = {
             await entity.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
     },
+    battery_voltage: {
+        key: ['battery', 'voltage'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('genPowerCfg', ['batteryVoltage']);
+        },
+    },
     power_on_behavior: {
         key: ['power_on_behavior'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -204,12 +204,12 @@ module.exports = [
             ];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.thermostatTemperature(endpoint);
-            await reporting.thermostatTemperatureCalibration(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatOccupiedCoolingSetpoint(endpoint);
             await reporting.thermostatRunningState(endpoint);
             await reporting.batteryAlarmState(endpoint);
             await reporting.batteryVoltage(endpoint);
+            await endpoint.read('hvacThermostat', ['ctrlSeqeOfOper', 'localTemperatureCalibration']);
         },
     },
     {

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -196,7 +196,7 @@ module.exports = [
         exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5).withLocalTemperature()
             .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat'])
             .withLocalTemperatureCalibration(), e.keypad_lockout()],
-        meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
+        meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const binds = [

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -4,6 +4,7 @@ const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 const extend = require('../lib/extend');
 const e = exposes.presets;
+const ea = exposes.access;
 
 module.exports = [
     {
@@ -190,12 +191,21 @@ module.exports = [
         vendor: 'SMaBiT (Bitron Video)',
         description: 'Wireless wall thermostat with relay',
         fromZigbee: [fz.legacy.thermostat_att_report, fz.battery, fz.hvac_user_interface],
-        toZigbee: [tz.thermostat_control_sequence_of_operation, tz.thermostat_occupied_heating_setpoint,
-            tz.thermostat_occupied_cooling_setpoint, tz.thermostat_local_temperature_calibration, tz.thermostat_local_temperature,
-            tz.thermostat_running_state, tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode],
-        exposes: [e.battery(), exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 0.5).withLocalTemperature()
-            .withSystemMode(['off', 'heat']).withRunningState(['idle', 'heat'])
-            .withLocalTemperatureCalibration(), e.keypad_lockout()],
+        toZigbee: [
+            tz.thermostat_control_sequence_of_operation, tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_occupied_cooling_setpoint, tz.thermostat_local_temperature_calibration,
+            tz.thermostat_local_temperature, tz.thermostat_running_state, tz.thermostat_temperature_display_mode,
+            tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.battery_voltage,
+        ],
+        exposes: [
+            exposes.climate()
+                .withSetpoint('occupied_heating_setpoint', 7, 30, 0.5)
+                .withLocalTemperature()
+                .withSystemMode(['off', 'heat', 'cool'])
+                .withRunningState(['idle', 'heat', 'cool'])
+                .withLocalTemperatureCalibration(),
+            e.battery().withAccess(ea.STATE_GET), e.keypad_lockout(),
+        ],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -220,7 +220,7 @@ module.exports = [
                 .withSystemMode(['off'].concat(modes))
                 .withRunningState(['idle'].concat(modes))
                 .withLocalTemperatureCalibration()
-                .withCtrlSeqeOfOper(['heating_only', 'cooling_only'], ea.ALL));
+                .withControlSequenceOfOperation(['heating_only', 'cooling_only'], ea.ALL));
             dynExposes.push(e.keypad_lockout());
             dynExposes.push(e.battery().withAccess(ea.STATE_GET));
             dynExposes.push(e.battery_low());

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -199,7 +199,7 @@ module.exports = [
         ],
         exposes: (device, options) => {
             const dynExposes = [];
-            let ctrlSeqeOfOper = device.getEndpoint(1).getClusterAttributeValue('hvacThermostat', 'ctrlSeqeOfOper');
+            let ctrlSeqeOfOper = device ? device.getEndpoint(1).getClusterAttributeValue('hvacThermostat', 'ctrlSeqeOfOper') : null;
             const modes = [];
 
             // NOTE: ctrlSeqeOfOper defaults to 2 for this device (according to the manual)

--- a/devices/bitron.js
+++ b/devices/bitron.js
@@ -197,15 +197,21 @@ module.exports = [
             tz.thermostat_local_temperature, tz.thermostat_running_state, tz.thermostat_temperature_display_mode,
             tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tz.battery_voltage,
         ],
-        exposes: [
-            exposes.climate()
+        exposes: (device, options) => {
+            const dynExposes = [];
+            dynExposes.push(exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 7, 30, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'cool'])
                 .withRunningState(['idle', 'heat', 'cool'])
-                .withLocalTemperatureCalibration(),
-            e.battery().withAccess(ea.STATE_GET), e.keypad_lockout(),
-        ],
+                .withLocalTemperatureCalibration()
+                .withCtrlSeqeOfOper(['heating_only', 'cooling_only'], ea.ALL));
+            dynExposes.push(e.keypad_lockout());
+            dynExposes.push(e.battery().withAccess(ea.STATE_GET));
+            dynExposes.push(e.battery_low());
+            dynExposes.push(e.linkquality());
+            return dynExposes;
+        },
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -449,7 +449,7 @@ class Climate extends Base {
         return this;
     }
 
-    withCtrlSeqeOfOper(modes, access=a.STATE) {
+    withControlSequenceOfOperation(modes, access=a.STATE) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         const allowed = ['cooling_only', 'cooling_with_reheat', 'heating_only', 'heating_with_reheat', 'cooling_and_heating_4-pipes', 'cooling_and_heating_4-pipes_with_reheat'];
         modes.forEach((m) => assert(allowed.includes(m)));

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -449,6 +449,14 @@ class Climate extends Base {
         return this;
     }
 
+    withCtrlSeqeOfOper(modes, access=a.STATE) {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        const allowed = ['cooling_only', 'cooling_with_reheat', 'heating_only', 'heating_with_reheat', 'cooling_and_heating_4-pipes', 'cooling_and_heating_4-pipes_with_reheat'];
+        modes.forEach((m) => assert(allowed.includes(m)));
+        this.features.push(new Enum('control_sequence_of_operation', access, modes).withDescription('Operating environment of the thermostat'));
+        return this;
+    }
+
     withAcLouverPosition(positions, access=a.ALL) {
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         const allowed = ['fully_open', 'fully_closed', 'half_open', 'quarter_open', 'three_quarters_open'];


### PR DESCRIPTION
https://github.com/Koenkk/zigbee-herdsman-converters/pull/5399#issuecomment-1419194233

This device will support cool or heat depending on the ctrlSeqOfOper value. The manual it has logic for heating_only and cooling_only.

<img width="956" alt="image" src="https://user-images.githubusercontent.com/379665/217332428-21d23486-dedf-482a-8d20-736c48dbd417.png">

The device now has a 'dynamic expose' function that returns the correct supported modes based on `ctrlSeqOfOper`. I also added batteryVoltage reading, fixed the battery calculation. I also extended `Climate` expose to add a withCtrlSeweofOper methode.

We should update the notes for this device that a restart of z2m is needed after changing ctrlSeqOfOper for the expose data to be updated.