### PR TITLE
Add "_TYZB01_cc3jzhlj" for TS0210

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -3266,6 +3266,7 @@ module.exports = [
         fingerprint: [{modelID: 'TS0210', manufacturerName: '_TYZB01_3zv6oleo'},
             {modelID: 'TS0210', manufacturerName: '_TYZB01_j9xxahcl'},
             {modelID: 'TS0210', manufacturerName: '_TYZB01_kulduhbj'},
+            {modelID: 'TS0210', manufacturerName: '_TYZB01_cc3jzhlj'},
             {modelID: 'TS0210', manufacturerName: '_TZ3000_bmfw9ykl'},
             {modelID: 'TS0210', manufacturerName: '_TZ3000_fkxmyics'}],
         model: 'TS0210',


### PR DESCRIPTION
My Tuya TS0210 has the manufacturer name set to "_TYZB01_cc3jzhlj" so I've added this to the list of recognised fingerprints.

This has been tested with these devices and works perfectly (see attached images).

![SCR-20230207-ufc](https://user-images.githubusercontent.com/85526412/217375520-2f07ba3f-7cce-49d4-b022-b7c51b1efd7d.png)
![SCR-20230207-uf2](https://user-images.githubusercontent.com/85526412/217375533-278f2699-d712-4835-a70c-4c1023d72eb3.png)