### PR TITLE
Set `fanModeSequence` on configure for Mercator SSWF01G

### DIFF
--- a/devices/mercator.js
+++ b/devices/mercator.js
@@ -183,6 +183,10 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genIdentify', 'manuSpecificTuya', 'hvacFanCtrl']);
             await reporting.onOff(endpoint);
             await reporting.fanMode(endpoint);
+
+            // Device ships with {fanModeSequence: 1} which restricts physical speed
+            // button to low/high. Set to 0 to allow low/med/high from physical press.
+            await endpoint.write('hvacFanCtrl', {fanModeSequence: 0});
         },
     },
     {


### PR DESCRIPTION
The SSWF01G / TS05010 sets `{fanModeSequence: 1}` upon joining a Zigbee network which changes its physical speed button to only allowing low/high, despite being physically capable of three speeds (and its physical buttons allowing low/med/high prior to joining). Setting `fanMode` via Zigbee to any speed always works but changing to `{fanModeSequence: 0}` allows for the full range of speeds (low/med/high speeds) from its physical button controls.

This PR sets this value upon joining the network to address the issue described at https://github.com/Koenkk/zigbee-herdsman-converters/pull/4594#issuecomment-1412791359 (and also noted at https://github.com/zigpy/zha-device-handlers/issues/1577).