### PR TITLE
Add Salus miniSmartPlug

### DIFF
--- a/devices/salus_controls.js
+++ b/devices/salus_controls.js
@@ -44,6 +44,24 @@ module.exports = [
         ota: ota.salus,
     },
     {
+        zigbeeModel: ['SX885ZB'],
+        model: 'SX885ZB',
+        vendor: 'Salus Controls',
+        description: 'miniSmartPlug',
+        fromZigbee: [fz.on_off, fz.metering],
+        toZigbee: [tz.on_off],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(9);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
+            await reporting.onOff(endpoint);
+            await reporting.instantaneousDemand(endpoint, {min: 5, change: 10});
+            await reporting.currentSummDelivered(endpoint, {min: 5, change: [0, 10]});
+            await endpoint.read('seMetering', ['multiplier', 'divisor']);
+        },
+        ota: ota.salus,
+        exposes: [e.switch(), e.power(), e.energy()],
+    },
+    {
         zigbeeModel: ['SR600'],
         model: 'SR600',
         vendor: 'Salus Controls',


### PR DESCRIPTION
To make `SX885ZB`, I copied `Smart plug (EU socket)` and changed the model and description.

I tested with a device with a known power consumption level to ensure that the reported power was correct (i.e. to check that the `UK socket` override is not required - it's not). Also the value matches what is reported via the Rainforest Automation cloud portal.

refs:
- https://shop.salusinc.com/pages/salus-sx885zb-minismartplug
- https://rainforestautomation.com/us-retail-store/smart-plug/
- https://rfa-device-library.s3-us-west-2.amazonaws.com/latest/SALUS/SX885ZB/device.xml

device picture PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/1889