### PR TITLE
Adding support for IKEA T2105 STOFTMOLN ceiling/wall lamp WW10

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -985,7 +985,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'STOFTMOLN ceiling/wall lamp 10 warm light dimmable',
         extend: tradfriExtend.light_onoff_brightness(),
-    },    
+    },
     {
         zigbeeModel: ['TRADFRIbulbPAR38WS900lm'],
         model: 'LED2006R9',

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -980,6 +980,13 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
+        zigbeeModel: ['STOFTMOLN ceiling/wall lamp WW10'],
+        model: 'T2105',
+        vendor: 'IKEA',
+        description: 'STOFTMOLN ceiling/wall lamp 10 warm light dimmable',
+        extend: tradfriExtend.light_onoff_brightness(),
+    },    
+    {
         zigbeeModel: ['TRADFRIbulbPAR38WS900lm'],
         model: 'LED2006R9',
         vendor: 'IKEA',


### PR DESCRIPTION
To support T2015, I copied Ikea T2035 and changed the model and description.

I tested with a device from IKEA and its works as expected with same features of T2035

refs:


https://www.ikea.com/us/en/p/stoftmoln-led-ceiling-wall-lamp-smart-wireless-dimmable-warm-white-white-20505551/
device picture PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/1890