### PR TITLE
New device _TZE200_rhblgy0z

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2819,6 +2819,55 @@ module.exports = [
         },
     },
     {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_rhblgy0z']),
+        model: 'TS0601_din_3',
+        vendor: 'TuYa',
+        description: 'Zigbee DIN energy meter',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        whiteLabel: [{vendor: 'XOCA', model: 'DAC2161C'}],
+        exposes: [tuya.exposes.switch(), e.energy(), e.produced_energy(), e.power(), e.voltage(), e.current(),
+            exposes.enum('fault', ea.STATE, ['clear', 'over_current_threshold', 'over_power_threshold',
+                'over_voltage threshold', 'wrong_frequency_threshold']).withDescription('Fault status of the device (clear = nothing)'),
+            exposes.enum('threshold_1', ea.STATE, ['not_set', 'over_current_threshold', 'over_voltage_threshold'])
+                .withDescription('State of threshold_1'),
+            exposes.binary('threshold_1_protection', ea.STATE, 'ON', 'OFF')
+                .withDescription('OFF - alarm only, ON - relay will be off when threshold reached'),
+            exposes.numeric('threshold_1_value', ea.STATE)
+                .withDescription('Can be in Volt or Ampere depending on threshold setting. Setup the value on the device'),
+            exposes.enum('threshold_2', ea.STATE, ['not_set', 'over_current_threshold', 'over_voltage_threshold'])
+                .withDescription('State of threshold_2'),
+            exposes.binary('threshold_2_protection', ea.STATE, 'ON', 'OFF')
+                .withDescription('OFF - alarm only, ON - relay will be off when threshold reached'),
+            exposes.numeric('threshold_2_value', ea.STATE)
+                .withDescription('Setup value on the device'),
+            exposes.binary('clear_fault', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('Turn ON to clear last the fault'),
+            exposes.text('meter_id', ea.STATE).withDescription('Meter ID (ID of device)'),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'energy', tuya.valueConverter.divideBy100],
+                [2, 'produced_energy', tuya.valueConverter.divideBy100],
+                [3, null, null], // Monthly, but sends data only after request
+                [4, null, null], // Dayly, but sends data only after request
+                [6, null, tuya.valueConverter.phaseVariant2], // voltage and current
+                [10, 'fault', tuya.valueConverterBasic.lookup({'clear': 0, 'over_current_threshold': 1,
+                    'over_power_threshold': 2, 'over_voltage_threshold': 4, 'wrong_frequency_threshold': 8})],
+                [11, null, null], // Frozen - strange function, in native app - nothing is clear
+                [16, 'state', tuya.valueConverter.onOff],
+                [17, null, tuya.valueConverter.threshold], // It's settable, but can't write converter
+                [18, 'meter_id', tuya.valueConverter.raw],
+                [20, 'clear_fault', tuya.valueConverter.onOff], // Clear fault
+                [21, null, null], // Forward Energy T1 - don't know what this
+                [22, null, null], // Forward Energy T2 - don't know what this
+                [23, null, null], // Forward Energy T3 - don't know what this
+                [24, null, null], // Forward Energy T4 - don't know what this
+            ],
+        },
+    },
+    {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_byzdayie'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_fsb6zw01'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_ewxhg6o9'}],


### PR DESCRIPTION
This device seem to be identical to _TZE200_lsanae15, but it has reverse metering capabilites.

This is basically a copy-paste of _TZE200_lsanae15, with e.produced_energy() and datapoint 2 defined.

If it is more reasonable to merge the two devices into one, please do so.

