### PR TITLE
Ensure heating temp can be set and read for Tuya TV02-Zigbee Thermostat

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2250,7 +2250,7 @@ module.exports = [
             e.battery_low(), e.child_lock(), e.open_window(), e.open_window_temperature().withValueMin(5).withValueMax(30),
             e.comfort_temperature().withValueMin(5).withValueMax(30), e.eco_temperature().withValueMin(5).withValueMax(30),
             exposes.climate().withPreset(['auto', 'manual', 'holiday']).withLocalTemperatureCalibration(-5, 5, 0.1, ea.STATE_SET)
-                .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 30, 0.5, ea.SET)
+                .withLocalTemperature(ea.STATE).withSetpoint('current_heating_setpoint', 5, 30, 0.5, ea.STATE_SET)
                 .withSystemMode(['off', 'heat'], ea.STATE_SET, 'Only for Homeassistant'),
             exposes.binary('heating_stop', ea.STATE_SET, 'ON', 'OFF').withDescription('Battery life can be prolonged'+
                     ' by switching the heating off. To achieve this, the valve is closed fully. To activate the '+


### PR DESCRIPTION
This PR ensures `current_heating_setpoint` can be set and read.

Incorrect access prevents this device from appearing in Hombridge as the device is not considered a thermostat unless the temperature can be set as well as read.

This pull fixes https://github.com/itavero/homebridge-z2m/issues/635

---

This is my first PR in the Zigbee ecosystem. Please shout if I have need to make changes - advice welcome.