### PR TITLE
Add energy monitoring on sinope th1300zb

### DIFF
--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -766,7 +766,7 @@ module.exports = [
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
             tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
             tzLocal.thermostat_occupancy, tzLocal.floor_control_mode, tzLocal.ambiant_max_heat_setpoint, tzLocal.floor_min_heat_setpoint,
-            tzLocal.floor_max_heat_setpoint, tzLocal.temperature_sensor],
+            tzLocal.floor_max_heat_setpoint, tzLocal.temperature_sensor, tz.electrical_measurement_power],
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 5, 36, 0.5)
@@ -787,17 +787,18 @@ module.exports = [
                 .withDescription('Control backlight dimming behavior'),
             exposes.enum('keypad_lockout', ea.ALL, ['unlock', 'lock1'])
                 .withDescription('Enables or disables the device’s buttons'),
-            e.power(), e.current(), e.voltage()],
+            e.power(), e.current(), e.voltage(), e.energy()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const binds = [
                 'genBasic', 'genIdentify', 'genGroups', 'hvacThermostat', 'hvacUserInterfaceCfg',
-                'haElectricalMeasurement', 'msTemperatureMeasurement', 'manuSpecificSinope'];
+                'haElectricalMeasurement', 'msTemperatureMeasurement', 'seMetering', 'manuSpecificSinope'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
+            await reporting.currentSummDelivered(endpoint, {min: 10, max: 303, change: [1, 1]});
             try {
                 await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
                 await reporting.activePower(endpoint, {min: 10, max: 305, change: 1}); // divider 1: 1W

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -787,7 +787,7 @@ module.exports = [
                 .withDescription('Control backlight dimming behavior'),
             exposes.enum('keypad_lockout', ea.ALL, ['unlock', 'lock1'])
                 .withDescription('Enables or disables the device’s buttons'),
-            e.power(), e.current(), e.voltage(), e.energy()],
+            e.power().withAccess(ea.STATE_GET), e.current(), e.voltage(), e.energy()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const binds = [

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -798,7 +798,9 @@ module.exports = [
             await reporting.thermostatPIHeatingDemand(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
-            await reporting.currentSummDelivered(endpoint, {min: 10, max: 303, change: [1, 1]});
+            try {
+                await reporting.currentSummDelivered(endpoint, {min: 10, max: 303, change: [1, 1]});
+            } catch (error) {/* Do nothing*/}
             try {
                 await endpoint.read('haElectricalMeasurement', ['acPowerMultiplier', 'acPowerDivisor']);
                 await reporting.activePower(endpoint, {min: 10, max: 305, change: 1}); // divider 1: 1W


### PR DESCRIPTION
IMPORTANT, this change apparently break the device, not to be merged before we can confirm it to work.

Added energy information for the Sinope th1300zb based on information from someone that was able to retrieve this data. I don't own the device directly and couldn't test. But the person who has it try the modification and had a strange behaviour that made his device unrecognized:

with this modification

    Zigbee2MQTT:info  2023-02-13 23:11:04: SINOPETH1300ZB5 (0x500b9140000xxxxx): Not supported (Router)

With the original device converter

    Zigbee2MQTT:info  2023-02-13 23:17:13: SINOPETH1300ZB5 (0x500b9140000xxxxx): TH1300ZB - Sinopé Zigbee smart floor heating thermostat (Router)

I'm not sure what could have caused it

cc'ing related contributors in case you could test the change if you own the device: @MattL0 @embak 

