### PR TITLE
Disable unsupported powerOnBehaviour for AC03648

### DIFF
--- a/devices/osram.js
+++ b/devices/osram.js
@@ -335,7 +335,7 @@ module.exports = [
         model: 'AC03648',
         vendor: 'OSRAM',
         description: 'SMART+ spot GU5.3 tunable white',
-        extend: extend.ledvance.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
+        extend: extend.ledvance.light_onoff_brightness_colortemp({colorTempRange: [153, 370], disablePowerOnBehavior: true}),
         ota: ota.ledvance,
     },
     {


### PR DESCRIPTION
OSRAM AC03648 does not support power on behaviour as seen in the below log, opened this PR to disable and clean up entities in HA that don't work.

`'Error: Read 0x7cb03eaa00abe562/3 genOnOff(["startUpOnOff"], {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'`