### PR TITLE
Update lidl.js add TZ3000_oznonj5q

### DIFF
--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -484,6 +484,7 @@ module.exports = [
     {
         fingerprint: [
             {modelID: 'TS011F', manufacturerName: '_TZ3000_wzauvbcs'}, // EU
+            {modelID: 'TS011F', manufacturerName: '_TZ3000_oznonj5q'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_1obwwnmq'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_4uf3d0ax'}, // FR
             {modelID: 'TS011F', manufacturerName: '_TZ3000_vzopcetz'}, // CZ


### PR DESCRIPTION
The Modell was not recognized as Lidl, it is on 1.05 same as my _TZ3000_1obwwnmq On ZHA they both work.