### PR TITLE
Update tuya.js Device _TZ3000_4o16jdca doesn't support switchType and backlightModeOffOn 

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2042,7 +2042,24 @@ module.exports = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_vsasbzkf', '_TZ3000_odzoiovu', '_TZ3000_4o16jdca']),
+        fingerprint: [{modelID: 'TS0003', manufacturerName: '_TZ3000_4o16jdca'}],
+        model: 'TS0003_switch_module_3',
+        vendor: 'TuYa',
+        description: '3 gang switch module',
+        extend: tuya.extend.switch({endpoints: ['l1', 'l2', 'l3']}),
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2, 'l3': 3};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_vsasbzkf', '_TZ3000_odzoiovu']),
         model: 'TS0003_switch_module',
         vendor: 'TuYa',
         description: '3 gang switch module',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2043,7 +2043,7 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'TS0003', manufacturerName: '_TZ3000_4o16jdca'}],
-        model: 'TS0003_switch_module_3',
+        model: 'TS0003_switch_module_2',
         vendor: 'TuYa',
         description: '3 gang switch module',
         extend: tuya.extend.switch({endpoints: ['l1', 'l2', 'l3']}),
@@ -2060,7 +2060,7 @@ module.exports = [
     },
     {
         fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_vsasbzkf', '_TZ3000_odzoiovu']),
-        model: 'TS0003_switch_module',
+        model: 'TS0003_switch_module_1',
         vendor: 'TuYa',
         description: '3 gang switch module',
         whiteLabel: [{vendor: 'OXT', model: 'SWTZ23'}],


### PR DESCRIPTION
Device _TZ3000_4o16jdca doesn't support switchType and backlightModeOffOn like _TZ3000_vsasbzkf, _TZ3000_odzoiovu removed from
added new record for _TZ3000_4o16jdca