### PR TITLE
ubisys: H1 tweak pi_heating_demand reporting

### DIFF
--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -903,7 +903,8 @@ module.exports = [
                 {min: 0, max: constants.repInterval.HOUR, change: 50});
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint,
                 {min: 0, max: constants.repInterval.HOUR, change: 50});
-            await reporting.thermostatPIHeatingDemand(endpoint);
+            await reporting.thermostatPIHeatingDemand(endpoint,
+                {min: 15, max: constants.repInterval.HOUR, change: 1});
             await reporting.thermostatOccupancy(endpoint);
             await reporting.batteryPercentageRemaining(endpoint,
                 {min: constants.repInterval.HOUR, max: 43200, change: 1});


### PR DESCRIPTION
Since this uses 0-100 for the valve percentage, it also seems to only update in ~3% increments. With the defaults it doesn't always report the valve is closed, sometimes it takes close to 1 hour. Which is undesirable for example if you have other automations that trigger the boiler based on demand.

After this change we knock it down to 1% changes before it is allowed to report. However we do cap the minimal reporting interval at 15 so it doesn't spam messages when it's making a position change. (All my position changes seem to take around 5-10 seconds)