### PR TITLE
Renamed PM25 cluster as in zigbee-herdsman cluster definition

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5927,7 +5927,7 @@ const converters = {
         },
     },
     heiman_pm25: {
-        cluster: 'heimanSpecificPM25Measurement',
+        cluster: 'pm25Measurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             if (msg.data['measuredValue']) {

--- a/devices/heiman.js
+++ b/devices/heiman.js
@@ -564,7 +564,7 @@ module.exports = [
                 configureReporting: {
                     pm25MeasuredValue: async (endpoint, overrides) => {
                         const payload = reporting.payload('measuredValue', 0, constants.repInterval.HOUR, 1, overrides);
-                        await endpoint.configureReporting('heimanSpecificPM25Measurement', payload);
+                        await endpoint.configureReporting('pm25Measurement', payload);
                     },
                     formAldehydeMeasuredValue: async (endpoint, overrides) => {
                         const payload = reporting.payload('measuredValue', 0, constants.repInterval.HOUR, 1, overrides);
@@ -591,7 +591,7 @@ module.exports = [
 
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, [
-                'genPowerCfg', 'genTime', 'msTemperatureMeasurement', 'msRelativeHumidity', 'heimanSpecificPM25Measurement',
+                'genPowerCfg', 'genTime', 'msTemperatureMeasurement', 'msRelativeHumidity', 'pm25Measurement',
                 'heimanSpecificFormaldehydeMeasurement', 'heimanSpecificAirQuality']);
 
             await reporting.batteryPercentageRemaining(endpoint);

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -68,7 +68,7 @@ const fzLocal = {
         },
     },
     aqara_s1_pm25: {
-        cluster: 'heimanSpecificPM25Measurement',
+        cluster: 'pm25Measurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             if (msg.data['measuredValue']) {


### PR DESCRIPTION
I've renamed the PM25 cluster in `zigbee-herdsman`, this PR reflects the name changes for `zigbee-herdsman-convertes`. Should be merged at the same time as https://github.com/Koenkk/zigbee-herdsman/pull/671