### PR TITLE
Make hvacThermostat weekly_schedule more user friendly

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -158,7 +158,7 @@ const converters = {
             const days = [];
             for (let i = 0; i < 8; i++) {
                 if ((msg.data['dayofweek'] & 1<<i) > 0) {
-                    days.push(constants.dayOfWeek[i]);
+                    days.push(constants.thermostatDayOfWeek[i]);
                 }
             }
 
@@ -2191,7 +2191,7 @@ const converters = {
                 return {
                     // Same as in hvacThermostat:getWeeklyScheduleRsp hvacThermostat:setWeeklySchedule cluster format
                     weekly_schedule: {
-                        days: [constants.dayOfWeek[dayOfWeek]],
+                        days: [constants.thermostatDayOfWeek[dayOfWeek]],
                         transitions: dataToTransitions(value, maxTransitions, dataOffset),
                     },
                 };
@@ -3533,8 +3533,8 @@ const converters = {
             }
             if (msg.data.hasOwnProperty('danfossDayOfWeek')) {
                 result[postfixWithEndpointName('day_of_week', msg, model, meta)] =
-                    constants.dayOfWeek.hasOwnProperty(msg.data['danfossDayOfWeek']) ?
-                        constants.dayOfWeek[msg.data['danfossDayOfWeek']] :
+                    constants.thermostatDayOfWeek.hasOwnProperty(msg.data['danfossDayOfWeek']) ?
+                        constants.thermostatDayOfWeek[msg.data['danfossDayOfWeek']] :
                         msg.data['danfossDayOfWeek'];
             }
             if (msg.data.hasOwnProperty('danfossTriggerTime')) {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1223,8 +1223,8 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const payload = {
                 numoftrans: value.numoftrans,
-                dayofweek: value.dayofweek,
-                mode: value.mode,
+                dayofweek: utils.getKey(constants.dayOfWeek, value.dayofweek, value.dayofweek, Number),
+                mode: utils.getKey(constants.thermostatWeeklyScheduleMode, value.mode, value.mode, Number),
                 transitions: value.transitions,
             };
             for (const elem of payload['transitions']) {
@@ -1235,6 +1235,7 @@ const converters = {
                     elem['coolSetpoint'] = Math.round(elem['coolSetpoint'] * 100);
                 }
             }
+            meta.logger.warn(`schedule data: ${JSON.stringify(payload)}`);
             await entity.command('hvacThermostat', 'setWeeklySchedule', payload, utils.getOptions(meta.mapped, entity));
         },
         convertGet: async (entity, key, meta) => {

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1223,8 +1223,8 @@ const converters = {
         convertSet: async (entity, key, value, meta) => {
             const payload = {
                 numoftrans: value.numoftrans,
-                dayofweek: utils.getKey(constants.dayOfWeek, value.dayofweek, value.dayofweek, Number),
-                mode: utils.getKey(constants.thermostatWeeklyScheduleMode, value.mode, value.mode, Number),
+                dayofweek: utils.getKey(constants.thermostatDayOfWeek, value.dayofweek, value.dayofweek, Number),
+                mode: utils.getKey(constants.thermostatScheduleMode, value.mode, value.mode, Number),
                 transitions: value.transitions,
             };
             for (const elem of payload['transitions']) {
@@ -2913,7 +2913,7 @@ const converters = {
     danfoss_day_of_week: {
         key: ['day_of_week'],
         convertSet: async (entity, key, value, meta) => {
-            const payload = {'danfossDayOfWeek': utils.getKey(constants.dayOfWeek, value, undefined, Number)};
+            const payload = {'danfossDayOfWeek': utils.getKey(constants.thermostatDayOfWeek, value, undefined, Number)};
             await entity.write('hvacThermostat', payload, manufacturerOptions.danfoss);
             return {readAfterWriteTime: 200, state: {'day_of_week': value}};
         },

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1228,14 +1228,22 @@ const converters = {
                 transitions: value.transitions,
             };
             for (const elem of payload['transitions']) {
-                if (typeof elem['heatSetpoint'] == 'number') {
+                if (typeof elem['heatSetpoint'] === 'number') {
                     elem['heatSetpoint'] = Math.round(elem['heatSetpoint'] * 100);
                 }
-                if (typeof elem['coolSetpoint'] == 'number') {
+                if (typeof elem['coolSetpoint'] === 'number') {
                     elem['coolSetpoint'] = Math.round(elem['coolSetpoint'] * 100);
                 }
+                // accept 24h time notation (e.g. 19:30)
+                if (typeof elem['transitionTime'] === 'string') {
+                    const time = elem['transitionTime'].split(':');
+                    if ((time.length != 2) || isNaN(time[0]) || isNaN(time[1])) {
+                        meta.logger.warn(`weekly_schedule: expected 24h time notation (e.g. 19:30) but got '${elem['transitionTime']}'!`);
+                    } else {
+                        elem['transitionTime'] = ((parseInt(time[0]) * 60) + parseInt(time[1]));
+                    }
+                }
             }
-            meta.logger.warn(`schedule data: ${JSON.stringify(payload)}`);
             await entity.command('hvacThermostat', 'setWeeklySchedule', payload, utils.getOptions(meta.mapped, entity));
         },
         convertGet: async (entity, key, meta) => {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -83,6 +83,11 @@ const thermostatAcLouverPositions = {
     5: 'three_quarters_open',
 };
 
+const thermostatWeeklyScheduleMode = {
+    1: 'heat',
+    2: 'cool',
+};
+
 const fanMode = {
     'off': 0,
     'low': 1,
@@ -284,6 +289,7 @@ module.exports = {
     thermostatRunningStates,
     thermostatRunningMode,
     thermostatAcLouverPositions,
+    thermostatWeeklyScheduleMode,
     dayOfWeek,
     fanMode,
     temperatureDisplayMode,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -45,7 +45,7 @@ const thermostatRunningMode= {
     4: 'heat',
 };
 
-const dayOfWeek = {
+const thermostatDayOfWeek = {
     0: 'sunday',
     1: 'monday',
     2: 'tuesday',
@@ -83,9 +83,9 @@ const thermostatAcLouverPositions = {
     5: 'three_quarters_open',
 };
 
-const thermostatWeeklyScheduleMode = {
-    1: 'heat',
-    2: 'cool',
+const thermostatScheduleMode = {
+    0: 'heat',
+    1: 'cool',
 };
 
 const fanMode = {
@@ -289,8 +289,8 @@ module.exports = {
     thermostatRunningStates,
     thermostatRunningMode,
     thermostatAcLouverPositions,
-    thermostatWeeklyScheduleMode,
-    dayOfWeek,
+    thermostatScheduleMode,
+    thermostatDayOfWeek,
     fanMode,
     temperatureDisplayMode,
     danfossAdaptionRunControl,


### PR DESCRIPTION
Took a while to figure out how this works, did I miss a piece of documentation somewhere?

I also made it more user friendly, before you had to write this:
```
mosquitto_pub -t zigbee2mqtt/trv/office/set -m '{"weekly_schedule":{"dayofweek":1,"mode":1,"numoftrans":5,"transitions":[{"heatSetpoint":16,"transitionTime":0},{"heatSetpoint":22,"transitionTime":390},{"heatSetpoint":18,"transitionTime":540},{"heatSetpoint":22,"transitionTime":1200},{"heatSetpoint":16,"transitionTime":1320}]}}'
```

Now you can also (this is backwards compatible) write:
```
mosquitto_pub -t zigbee2mqtt/trv/office/set -m '{"weekly_schedule":{"dayofweek":"monday","mode":"heat","numoftrans":5,"transitions":[{"heatSetpoint":16,"transitionTime":"00:00"},{"heatSetpoint":22,"transitionTime":"06:30"},{"heatSetpoint":18,"transitionTime":"09:00"},{"heatSetpoint":22,"transitionTime":"20:00"},{"heatSetpoint":16,"transitionTime":"22:00"}]}}'
```

Which to me is a lot more readable and easier, no more doing minutes since 00:00 calculations for transitionTime, no more wondering if sunday is 0 or 7 for dayofweek, ...