### PR TITLE
Add support for switching scenes with LIDL FB21-001 remote control

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2886,6 +2886,18 @@ const converters = {
             return {action: `${button}${clickMapping[msg.data[3]]}`};
         },
     },
+    tuya_switch_scene: {
+        cluster: 'genOnOff',
+        type: 'raw',
+        convert: (model, msg, publish, options, meta) => {
+            if (hasAlreadyProcessedMessage(msg, model, msg.data[1])) return;
+            // Since it is a non standard ZCL command, no default response is send from zigbee-herdsman
+            // Send the defaultResponse here, otherwise the second button click delays.
+            // https://github.com/Koenkk/zigbee2mqtt/issues/8149
+            msg.endpoint.defaultResponse(0xfd, 0, 6, msg.data[1]).catch((error) => {});
+            return {action: 'switch_scene', action_scene: msg.data[3]};
+        },
+    },
     tuya_water_leak: {
         cluster: 'manuSpecificTuya',
         type: 'commandDataReport',

--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -575,8 +575,8 @@ module.exports = [
         vendor: 'Lidl',
         description: 'Livarno Lux switch and dimming light remote control',
         exposes: [e.action(['on', 'off', 'brightness_stop', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up',
-            'brightness_move_down'])],
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop],
+            'brightness_move_down', 'switch_scene'])],
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.tuya_switch_scene],
         toZigbee: [],
     },
     {


### PR DESCRIPTION
After pairing and using the LIDL FB21-001 remote control (which comes with the "[LIVARNO home LED-Deckenleuchte](https://www.lidl.de/p/livarno-home-led-deckenleuchte-16-millionen-farben-zigbee-smart-home/p100357323)") I've noticed the following debug messages when pressing the On-button multiple times:

```
# 1st press
Zigbee2MQTT:debug 2023-03-03 19:57:31: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:31: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:32: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:32: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:33: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:33: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:33: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:33: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:34: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:34: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'

# 2nd press
Zigbee2MQTT:debug 2023-03-03 19:57:36: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:36: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:36: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:36: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:37: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:37: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:38: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:38: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:38: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:38: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'

# 3rd press
Zigbee2MQTT:debug 2023-03-03 19:57:40: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,97,253,2],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:40: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,97,253,2],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:40: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,97,253,2],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:40: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,97,253,2],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:41: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,97,253,2],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:41: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,97,253,2],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:42: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,97,253,2],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:42: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,97,253,2],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:42: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,97,253,2],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:42: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,97,253,2],"type":"Buffer"}'

# 4th press
Zigbee2MQTT:debug 2023-03-03 19:57:44: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,98,253,3],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:44: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,98,253,3],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:45: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,98,253,3],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:45: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,98,253,3],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:45: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,98,253,3],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:45: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,98,253,3],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:46: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,98,253,3],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:46: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,98,253,3],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:47: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,98,253,3],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:47: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,98,253,3],"type":"Buffer"}'

# 5th press
Zigbee2MQTT:debug 2023-03-03 19:57:31: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:31: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:32: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:32: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:33: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:33: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:33: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:33: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:34: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,95,253,0],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:34: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,95,253,0],"type":"Buffer"}'

# 6th press
Zigbee2MQTT:debug 2023-03-03 19:57:36: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:36: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:36: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:36: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:37: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:37: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:38: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:38: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'
Zigbee2MQTT:debug 2023-03-03 19:57:38: Received Zigbee message from '0x8cf681fffe4b6272', type 'raw', cluster 'genOnOff', data '{"data":[1,96,253,1],"type":"Buffer"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2023-03-03 19:57:38: No converter available for 'FB21-001' with cluster 'genOnOff' and type 'raw' and data '{"data":[1,96,253,1],"type":"Buffer"}'

[...]
```

The data in the raw message contains a counter (4th octet) which counts from 0 to 3 and starts over.  Apparently this looks like a scene switcher. After installing the Lidl Home app, I was able to confirm that the function is intended for switching scenes.

This PR implements a new converter "tuya_switch_scene" which does the following: 

1st press on On-Button: publish {"action":"on", ...}
2nd press on On-Button: publish {"action":"switch_scene", "scene": 0}
3rd press on On-Button: publish {"action":"switch_scene", "scene": 1}
4th press on On-Button: publish {"action":"switch_scene", "scene": 2}
5th press on On-Button: publish {"action":"switch_scene", "scene": 3}
[... repeat from scene 0 ...]

Pressing the Off-Button resets the scene counter to 0




