### PR TITLE
Fix discarded 0 PM2.5 measurements

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -412,7 +412,7 @@ const converters = {
         cluster: 'pm25Measurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
-            if (msg.data['measuredValue']) {
+            if (msg.data.hasOwnProperty('measuredValue')) {
                 return {pm25: msg.data['measuredValue']};
             }
         },


### PR DESCRIPTION
If I am not mistaken, the current implementation prevents measurements with the value 0. In the case of PM2.5, however, such values can certainly be measured.