### PR TITLE
Add another OEM variant of Tuya SM0201

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1740,7 +1740,7 @@ module.exports = [
         configure: tuya.configureMagicPacket,
     },
     {
-        fingerprint: [{modelID: 'SM0201', manufacturerName: '_TYZB01_cbiezpds'}],
+        fingerprint: tuya.fingerprint('SM0201', ['_TYZB01_cbiezpds', '_TYZB01_zqvwka4k']),
         model: 'SM0201',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor with LED screen',


### PR DESCRIPTION
This adds support for an OEM variant of the Tuya SM0201 sensor sold under the Marmitek brand and named "Sense MO".
The device yields correct values once the different manufacturerName is recognized.

Looking at their website the brand carries a lot of the other Tuya OEM Zigbee devices as well but I can only verify the manufacturerName for this device currently.