### PR TITLE
[WIP] weekly_schedule expose

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1229,16 +1229,19 @@ const converters = {
             if (Array.isArray(payload.transitions)) {
                 // calculate numoftrans
                 if (typeof value.numoftrans !== 'undefined') {
-                    meta.logger.warn(`weekly_schedule: igonoring provided numoftrans value (${JSON.stringify(value.numoftrans)}),\
-                         this is now calculated automatically`);
+                    meta.logger.warn(
+                        `weekly_schedule: ignoring provided numoftrans value (${JSON.stringify(value.numoftrans)}), ` +
+                        'this is now calculated automatically',
+                    );
                 }
                 payload.numoftrans = payload.transitions.length;
 
                 // mode is calculated below
                 if (typeof value.mode !== 'undefined') {
                     meta.logger.warn(
-                        `weekly_schedule: igonoring provided mode value (${JSON.stringify(value.mode)}),\
-                         this is now calculated automatically`);
+                        `weekly_schedule: ignoring provided mode value (${JSON.stringify(value.mode)}), ` +
+                        'this is now calculated automatically',
+                    );
                 }
                 payload.mode = [];
 
@@ -1270,6 +1273,27 @@ const converters = {
                         } else {
                             elem['transitionTime'] = ((parseInt(time[0]) * 60) + parseInt(time[1]));
                         }
+                    } else if (typeof elem['transitionTime'] === 'object') {
+                        if (!elem['transitionTime'].hasOwnProperty('hour') || !elem['transitionTime'].hasOwnProperty('minute')) {
+                            throw new Error(
+                                'weekly_schedule: expected 24h time object (e.g. {"hour": 19, "minute": 30}), ' +
+                                `but got '${JSON.stringify(elem['transitionTime'])}'!`,
+                            );
+                        } else if (isNaN(elem['transitionTime']['hour'])) {
+                            throw new Error(
+                                'weekly_schedule: expected time.hour to be a number, ' +
+                                `but got '${elem['transitionTime']['hour']}'!`,
+                            );
+                        } else if (isNaN(elem['transitionTime']['minute'])) {
+                            throw new Error(
+                                'weekly_schedule: expected time.minute to be a number, ' +
+                                `but got '${elem['transitionTime']['minute']}'!`,
+                            );
+                        } else {
+                            elem['transitionTime'] = (
+                                (parseInt(elem['transitionTime']['hour']) * 60) + parseInt(elem['transitionTime']['minute'])
+                            );
+                        }
                     }
                 }
             } else {
@@ -1298,6 +1322,7 @@ const converters = {
                 payload.dayofweek = dayofweek;
             }
 
+            meta.logger.error(JSON.stringify(payload));
             await entity.command('hvacThermostat', 'setWeeklySchedule', payload, utils.getOptions(meta.mapped, entity));
         },
         convertGet: async (entity, key, meta) => {

--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -883,7 +883,8 @@ module.exports = [
                 .withRunningMode(['off', 'heat'])
                 .withSetpoint('occupied_heating_setpoint', 7, 30, 0.5)
                 .withLocalTemperature()
-                .withPiHeatingDemand(ea.STATE_GET),
+                .withPiHeatingDemand(ea.STATE_GET)
+                .withWeeklySchedule(['heat']),
             exposes.binary('vacation_mode', ea.STATE_GET, true, false)
                 .withDescription('When Vacation Mode is active the schedule is disabled and unoccupied_heating_setpoint is used.'),
         ],

--- a/devices/viessmann.js
+++ b/devices/viessmann.js
@@ -14,11 +14,13 @@ module.exports = [
         fromZigbee: [fz.legacy.viessmann_thermostat_att_report, fz.battery, fz.legacy.hvac_user_interface],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_control_sequence_of_operation,
             tz.thermostat_system_mode, tz.thermostat_keypad_lockout, tz.viessmann_window_open, tz.viessmann_window_open_force,
-            tz.viessmann_assembly_mode,
+            tz.viessmann_assembly_mode, tz.thermostat_weekly_schedule, tz.thermostat_clear_weekly_schedule,
         ],
         exposes: [
             exposes.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1)
-                .withLocalTemperature().withSystemMode(['heat', 'sleep']),
+                .withLocalTemperature()
+                .withSystemMode(['heat', 'sleep'])
+                .withWeeklySchedule(['heat']),
             exposes.binary('window_open', ea.STATE_GET, true, false)
                 .withDescription('Detected by sudden temperature drop or set manually.'),
             exposes.binary('window_open_force', ea.ALL, true, false)

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -470,10 +470,10 @@ class Climate extends Base {
         const allowed = ['heat', 'cool'];
         modes.forEach((m) => assert(allowed.includes(m)));
 
-        const featureDayOfWeek = new List('dayofweek', a.SET, new Enum('day', a.SET, [
+        const featureDayOfWeek = new List('dayofweek', a.SET, new Composite('day', 'dayofweek', a.SET).withFeature(new Enum('day', a.SET, [
             'monday', 'tuesday', 'wednesday', 'thursday', 'friday',
             'saturday', 'sunday', 'away_or_vacation',
-        ])).withLengthMin(1).withLengthMax(8).withDescription('Days on which the schedule will be active.');
+        ]))).withLengthMin(1).withLengthMax(8).withDescription('Days on which the schedule will be active.');
 
         const featureTransitionTime = new Composite('time', 'transitionTime', a.SET)
             .withFeature(new Numeric('hour', a.SET))

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -464,6 +464,38 @@ class Climate extends Base {
         this.features.push(new Enum('ac_louver_position', access, positions).withDescription('Ac louver position of this device'));
         return this;
     }
+
+    withWeeklySchedule(modes, access=a.ALL) {
+        assert(!this.endpoint, 'Cannot add feature after adding endpoint');
+        const allowed = ['heat', 'cool'];
+        modes.forEach((m) => assert(allowed.includes(m)));
+
+        const featureDayOfWeek = new List('dayofweek', a.SET, new Enum('day', a.SET, [
+            'monday', 'tuesday', 'wednesday', 'thursday', 'friday',
+            'saturday', 'sunday', 'away_or_vacation',
+        ])).withLengthMin(1).withLengthMax(8).withDescription('Days on which the schedule will be active.');
+
+        const featureTransitionTime = new Composite('time', 'transitionTime', a.SET)
+            .withFeature(new Numeric('hour', a.SET))
+            .withFeature(new Numeric('minute', a.SET))
+            .withDescription('Trigger transition X minutes after 00:00.');
+        const featureTransitionHeatSetPoint = new Numeric('heatSetpoint', a.SET)
+            .withDescription('Target heat setpoint');
+        const featureTransitionCoolSetPoint = new Numeric('coolSetpoint', a.SET)
+            .withDescription('Target cool setpoint');
+        let featureTransition = new Composite('transition', 'transition', a.SET).withFeature(featureTransitionTime);
+        if (modes.includes('heat')) featureTransition = featureTransition.withFeature(featureTransitionHeatSetPoint);
+        if (modes.includes('cool')) featureTransition = featureTransition.withFeature(featureTransitionCoolSetPoint);
+        const featureTransitions = new List('transitions', a.SET, featureTransition)
+            .withLengthMin(1).withLengthMax(10);
+
+        const schedule = new Composite('schedule', 'weekly_schedule', access)
+            .withFeature(featureDayOfWeek)
+            .withFeature(featureTransitions);
+
+        this.features.push(schedule);
+        return this;
+    }
 }
 /**
  * The access property is a 3-bit bitmask.


### PR DESCRIPTION
-  [x] Fixed a bug that snuck into the last PR
-  [x] Start calculated derived values: mode and numoftrans
   -  [x] if we encounter a heatSetPoint we add "heat" to mode
   -  [x] if we encouter a coolSetPoint we add "cool" to mode
   -  [x] numoftrans = transitions.length (we now check if it's an array and error out otherwise)
- [ ] expose data

Since we now calculate the derived values, this should make the exposes data simpler.

The following now works correctly:
```
mosquitto_pub -t zigbee2mqtt/trv/office/set -m '{"weekly_schedule":{"dayofweek":["saturday","sunday"],"transitions":[{"transitionTime":"00:00","heatSetpoint":16},{"transitionTime":"09:00","heatSetpoint":20},{"transitionTime":"22:00","heatSetpoint":16}]}}'
```