### PR TITLE
add support for Aurora 9W smart GLS B22 - zigbee model FWBulb51AU

### DIFF
--- a/devices/aurora_lighting.js
+++ b/devices/aurora_lighting.js
@@ -120,7 +120,7 @@ module.exports = [
         model: 'AU-A1GSZ9B/27',
         vendor: 'Aurora Lighting',
         description: 'AOne 9W smart GLS B22',
-        extend: extend.light_onoff_brightness_colortemp(),
+        extend: extend.light_onoff_brightness(),
     },
     {
         zigbeeModel: ['FWGU10Bulb50AU', 'FWGU10Bulb01UK'],

--- a/devices/aurora_lighting.js
+++ b/devices/aurora_lighting.js
@@ -116,6 +116,13 @@ module.exports = [
         extend: extend.light_onoff_brightness(),
     },
     {
+        zigbeeModel: ['FWBulb51AU'],
+        model: 'AU-A1GSZ9B/27',
+        vendor: 'Aurora Lighting',
+        description: 'AOne 9W smart GLS B22',
+        extend: extend.light_onoff_brightness_colortemp(),
+    },
+    {
         zigbeeModel: ['FWGU10Bulb50AU', 'FWGU10Bulb01UK'],
         model: 'AU-A1GUZB5/30',
         vendor: 'Aurora Lighting',


### PR DESCRIPTION
I've been using this for over a year with the change in this PR to aurora_lighting.js
I wasn't really competent in git until now. Now that I know how PR's work I thought I would submit it to be included.

It's this bulb in the link below. I got mine from Amazon UK but it's not on there any more.
https://www.edwardes.co.uk/products/aurora-au-a1gsz9b-27-9w-smart-dimmable-gls-lamp-bc
