### PR TITLE
Slightly change XY color conversion

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1514,8 +1514,8 @@ const converters = {
             const payload = {
                 action: postfixWithEndpointName(`color_move`, msg, model, meta),
                 action_color: {
-                    x: precisionRound(msg.data.colorx / 65536, 3),
-                    y: precisionRound(msg.data.colory / 65536, 3),
+                    x: precisionRound(msg.data.colorx / 65535, 3),
+                    y: precisionRound(msg.data.colory / 65535, 3),
                 },
                 action_transition_time: msg.data.transtime,
             };


### PR DESCRIPTION
This basically reverts:
- https://github.com/Koenkk/zigbee-herdsman-converters/pull/3656

Like mentioned in [my comment in that PR](https://github.com/Koenkk/zigbee-herdsman-converters/pull/3656#issuecomment-1186347420), this was only changed in one of many places.

They're unsigned 16 bit integers, so the max size is 65535. 0 to 65535 is 65536 (which might be what the specs are talking about?)

As I'm not sure the change was even correct in the first place (and ZHA ended up keeping 65535 + deCONZ also uses this), this PR changes that to match all other mentioned places again (so 65535 again).

This generally shouldn't make a difference, but it's better to be consistent everywhere.