### PR TITLE
Disable color_temp_startup on WF4C_WF6C unsupport

### DIFF
--- a/devices/acuity_brands_lighting.js
+++ b/devices/acuity_brands_lighting.js
@@ -6,6 +6,6 @@ module.exports = [
         model: 'WF4C_WF6C',
         vendor: 'Acuity Brands Lighting (ABL)',
         description: 'Juno 4" and 6" LED smart wafer downlight',
-        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200, 370]}),
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200, 370], disableColorTempStartup: true}),
     },
 ];


### PR DESCRIPTION
Getting error when setting color_temp_startup on two different variants of WF4C_WF6C, don't think this feature is supported. I think I got the syntax correct. Error
Publish 'set' 'color_temp_startup' to 'Juno6Fixed' failed: 'Error: Write 0x88571dfffe5dbea4/8 lightingColorCtrl({"startUpColorTemperature":250}, {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')