### PR TITLE
Update Philips 915005987701 to support additional zigbee model

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1614,7 +1614,7 @@ module.exports = [
         extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
     },
     {
-        zigbeeModel: ['929003479701'],
+        zigbeeModel: ['929003479701', '915005987701'],
         model: '915005987701',
         vendor: 'Philips',
         description: 'Hue Gradient Signe floor lamp (wood)',


### PR DESCRIPTION
I cannot confirm if the original zigbee model here is in error, or if Philips present the same lamp with multiple zigbeeModels.

I can however confirm that my version of this lamp does in fact use the amended model. 

This change therefore appends support for a known model that was otherwise unsupported.


