### PR TITLE
Fix missing converters for pi_heating_demand on Bosch `BTH-RA` thermostat

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -49,7 +49,7 @@ const displayOrientation = {
 // Radiator Thermostat II
 const tzLocal = {
     bosch_thermostat: {
-        key: ['window_open', 'boost', 'system_mode'],
+        key: ['window_open', 'boost', 'system_mode', 'pi_heating_demand'],
         convertSet: async (entity, key, value, meta) => {
             if (key === 'window_open') {
                 value = value.toUpperCase();
@@ -79,6 +79,11 @@ const tzLocal = {
                 await entity.write('hvacThermostat', {0x4007: {value: opMode, type: herdsman.Zcl.DataType.enum8}}, boschManufacturer);
                 return {state: {system_mode: value}};
             }
+            if (key === 'pi_heating_demand') {
+                let heatingDemand = value;
+                await entity.write('hvacThermostat', {0x4020: {value: heatingDemand, type: herdsman.Zcl.DataType.enum8}}, boschManufacturer);
+                return {state: {pi_heating_demand: value}};
+            }
         },
         convertGet: async (entity, key, meta) => {
             switch (key) {
@@ -90,6 +95,9 @@ const tzLocal = {
                 break;
             case 'system_mode':
                 await entity.read('hvacThermostat', [0x4007], boschManufacturer);
+                break;
+            case 'pi_heating_demand':
+                await entity.read('hvacThermostat', [0x4020], boschManufacturer);
                 break;
 
             default: // Unknown key

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -66,7 +66,7 @@ const tzLocal = {
                 return {state: {boost: value}};
             }
             if (key === 'system_mode') {
-                // Map system_mode (Off/Auto/Heat) to Boschg operating mode
+                // Map system_mode (Off/Auto/Heat) to Bosch operating mode
                 value = value.toLowerCase();
 
                 let opMode = operatingModes.manual; // OperatingMode 1 = Manual (Default)

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -80,8 +80,9 @@ const tzLocal = {
                 return {state: {system_mode: value}};
             }
             if (key === 'pi_heating_demand') {
-                let heatingDemand = value;
-                await entity.write('hvacThermostat', {0x4020: {value: heatingDemand, type: herdsman.Zcl.DataType.enum8}}, boschManufacturer);
+                await entity.write('hvacThermostat',
+                    {0x4020: {value: value, type: herdsman.Zcl.DataType.enum8}},
+                    boschManufacturer);
                 return {state: {pi_heating_demand: value}};
             }
         },
@@ -434,7 +435,7 @@ const definition = [
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
                 .withLocalTemperatureCalibration(-5, 5, 0.1)
                 .withSystemMode(['off', 'heat', 'auto'])
-                .withPiHeatingDemand(ea.STATE),
+                .withPiHeatingDemand(ea.ALL),
             exposes.binary('boost', ea.ALL, 'ON', 'OFF')
                 .withDescription('Activate Boost heating'),
             exposes.binary('window_open', ea.ALL, 'ON', 'OFF')


### PR DESCRIPTION
The documentation for the Bosch BTH-RA states that the `pi_heating_demand` entity should be read- and set-able. In reality, this isn't the case due to missing converters between the entity and the Zigbee attribute 0x4020 in cluster 0x0201. This PR adds that conversion.

The valve position is fixed to this position for 15 minutes, regardless of the `occupied_heating_setpoint` or `system_mode` entity. Only enabling the `boost` entity overwrites this behavior. After 15 minutes without change to the `pi_heating_demand` entity, the thermostat starts to control the valve position again under consideration of the current settings. 

This issue fixes https://github.com/Koenkk/zigbee2mqtt/issues/16538. It's tested and working with firmware version v3.04.04. Please note, that some people report that the valve position isn't changed as stated by the `pi_heating_demand` entity in firmware versions earlier to v3.04.04. Therefore, it may be necessary to update the firmware.