### PR TITLE
Bosch `BTH-RA`: Report boost setting

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -473,6 +473,13 @@ const definition = [
                 maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: 1,
             }], boschManufacturer);
+            // report boost as it's disabled by thermostat after some time
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: {ID: 0x4043, type: herdsman.Zcl.DataType.enum8},
+                minimumReportInterval: 0,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1,
+            }], boschManufacturer);
 
             await endpoint.read('hvacThermostat', ['localTemperatureCalibration']);
             await endpoint.read('hvacThermostat', [0x4007, 0x4020, 0x4042, 0x4043], boschManufacturer);


### PR DESCRIPTION
The boost setting isn't reported on the `BTH-RA` right now. This PR changes this, as the boost is disabled by the thermostat automatically after some time (feels like 5 minutes).