### PR TITLE
Adds support for SYMFONISK sound remote gen2 (E2123)

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -254,8 +254,7 @@ const ikea = {
                     2: 'dot_double',
                     3: 'dot_long',
                 };
-        
-                return { action: `${msg.data[5]}${lookup[msg.data[6]]}` };
+                return {action: `${msg.data[5]}${lookup[msg.data[6]]}`};
             },
         },
     },

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -245,6 +245,19 @@ const ikea = {
                 }
             },
         },
+        command_dots: {
+            cluster: 64639,
+            type: 'raw',
+            convert: (model, msg, publish, options, meta) => {
+                const lookup = {
+                    1: 'dot_single',
+                    2: 'dot_double',
+                    3: 'dot_long',
+                };
+        
+                return { action: `${msg.data[5]}${lookup[msg.data[6]]}` };
+            },
+        },
     },
     tz: {
         air_purifier_fan_mode: {
@@ -772,6 +785,23 @@ module.exports = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genLevelCtrl', 'genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['SYMFONISK sound remote gen2'],
+        model: 'E2123',
+        vendor: 'IKEA',
+        description: 'SYMFONISK sound remote gen2',
+        fromZigbee: [fz.battery, fz.command_toggle, fz.command_move, fz.command_step, ikea.fz.command_dots],
+        toZigbee: [tz.battery_percentage_remaining],
+        exposes: [
+            e.battery().withAccess(ea.STATE_GET),
+        ],
+        ota: ota.tradfri,
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
         },
     },


### PR DESCRIPTION
This PR adds first support for the new IKEA SYMFONISK sound remote gen2 (E2123)

![E2123](https://raw.githubusercontent.com/Koenkk/zigbee2mqtt.io/59f9a529f89a3f8d15a22c9cc05d7ad0c2d75bae/public/images/devices/E2123.jpg)

Link: https://www.ikea.com/at/de/p/symfonisk-fernbedienung-fuer-soundsystem-generation-2-90524607/
PR for device picture: https://github.com/Koenkk/zigbee2mqtt.io/pull/1953

**Current Status**

- All buttons are working (including single, double and long press on "dot"-buttons)
- I'm unsure about the battery status. I've seen 50% and 100% with the same battery. (Help and input apprechiated)
- Not sure if OTA updates work. (Help and input apprechiated)

Response on OTA request:
```
error 2023-03-13 19:34:43Failed to check if update available for '0x1c34f1fffee22666' (No image available for imageType '4366')
debug 2023-03-13 19:34:43Error: No image available for imageType '4366' at getImageMeta (/opt/zigbee2mqtt/node_modules/zigbee-herdsman-converters/lib/ota/tradfri.js:18:15) at runMicrotasks (<anonymous>) at processTicksAndRejections (node:internal/process/task_queues:96:5) at isNewImageAvailable (/opt/zigbee2mqtt/node_modules/zigbee-herdsman-converters/lib/ota/common.js:260:18) at Object.isUpdateAvailable (/opt/zigbee2mqtt/node_modules/zigbee-herdsman-converters/lib/ota/common.js:251:29) at OTAUpdate.onMQTTMessage (/opt/zigbee2mqtt/lib/extension/otaUpdate.ts:203:45)
```

This is my first contribution, please excuse any mistakes and feel free to comment.