### PR TITLE
Add support for Lupus 12071 LUPUSEC main power meter

### DIFF
--- a/devices/lupus.js
+++ b/devices/lupus.js
@@ -71,4 +71,19 @@ module.exports = [
             await reporting.bind(endpoint2, coordinatorEndpoint, ['genOnOff']);
         },
     },
+    {
+        zigbeeModel: ['PCM_00.00.03.09TC'],
+        model: '12071',
+        vendor: 'Lupus',
+        description: 'LUPUSEC main power meter',
+        fromZigbee: [fz.ZNMS12LM_low_battery, fz.impulse_metering],
+        toZigbee: [],
+        exposes: [e.battery_low(), e.energy(), e.power()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering', 'genPowerCfg']);
+            endpoint.saveClusterAttributeKeyValue('seMetering', {multiplier: 10});
+        },
+    },
+
 ];


### PR DESCRIPTION
Add Support for the Lupus main power meter

![12071](https://user-images.githubusercontent.com/14112170/224984900-a864ee83-5cea-4a75-b3be-61d5eea2a925.jpg)

Required a modified metering converter because the divisor needed to be configurable by the user depending on the installed meter. The converter creates an option to configure the impulses per kWh of the meter. (eg. 10000 Imp./kWh in the image below) 

![ArtNr_12071_Hauptstromzaehler_demo1_150dpi](https://user-images.githubusercontent.com/14112170/224985994-cbd9db59-ef92-4c42-860e-c30fdeb20f06.jpg)


I also open a PR to add an image https://github.com/Koenkk/zigbee2mqtt.io/pull/1952