### PR TITLE
Adds support for AutomatOn underfloor heating controller AUT000069

### DIFF
--- a/devices/automaton.js
+++ b/devices/automaton.js
@@ -3,9 +3,57 @@ const tz = require('../converters/toZigbee');
 const exposes = require('../lib/exposes');
 const reporting = require('../lib/reporting');
 const tuya = require('../lib/tuya');
+const utils = require('../lib/utils');
 const e = exposes.presets;
-const fzLocal = tuya.fzLocal;
-const tzLocal = tuya.tzLocal;
+
+const fzLocal = {
+  power_on_behavior: {
+      cluster: 'manuSpecificTuya_3',
+      type: ['attributeReport', 'readResponse'],
+      convert: (model, msg, publish, options, meta) => {
+          const attribute = 'powerOnBehavior';
+          const lookup = { 0: 'off', 1: 'on', 2: 'previous' };
+
+          if (msg.data.hasOwnProperty(attribute)) {
+              const property = utils.postfixWithEndpointName('power_on_behavior', msg, model, meta);
+              return { [property]: lookup[msg.data[attribute]] };
+          }
+      },
+  },
+  child_lock: {
+      cluster: 'genOnOff',
+      type: ['attributeReport', 'readResponse'],
+      convert: (model, msg, publish, options, meta) => {
+          if (msg.data.hasOwnProperty('32768')) {
+              const value = msg.data['32768'];
+              return { child_lock: value ? 'LOCK' : 'UNLOCK' };
+          }
+      },
+  }
+}
+
+const tzLocal = {
+  power_on_behavior: {
+      key: ['power_on_behavior'],
+      convertSet: async (entity, key, value, meta) => {
+          value = value.toLowerCase();
+          const lookup = { 'off': 0, 'on': 1, 'previous': 2 };
+          utils.validateValue(value, Object.keys(lookup));
+          const pState = lookup[value];
+          await entity.write('manuSpecificTuya_3', { 'powerOnBehavior': pState }, { disableDefaultResponse: true });
+          return { state: { power_on_behavior: value } };
+      },
+      convertGet: async (entity, key, meta) => {
+          await entity.read('manuSpecificTuya_3', ['powerOnBehavior']);
+      },
+  },
+  child_lock: {
+      key: ['child_lock'],
+      convertSet: async (entity, key, value, meta) => {
+          await entity.write('genOnOff', { 0x8000: { value: value === 'LOCK', type: 0x10 } });
+      },
+  }
+}
 
 const definition = {
     fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_j0ktmul1']),

--- a/devices/automaton.js
+++ b/devices/automaton.js
@@ -1,0 +1,46 @@
+const fz = require('../converters/fromZigbee');
+const tz = require('../converters/toZigbee');
+const exposes = require('../lib/exposes');
+const reporting = require('../lib/reporting');
+const tuya = require('../lib/tuya');
+const e = exposes.presets;
+const fzLocal = tuya.fzLocal;
+const tzLocal = tuya.tzLocal;
+
+const definition = {
+    fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_j0ktmul1']),
+    model: 'AUT000069',
+    vendor: 'AutomatOn',
+    description: 'Underfloor heating controller - 5 zones',
+    fromZigbee: [fz.on_off, fz.ignore_basic_report, fzLocal.power_on_behavior, fzLocal.child_lock],
+    toZigbee: [tz.on_off, tzLocal.power_on_behavior, tzLocal.child_lock],
+    exposes: [
+        e.child_lock(),
+        e.switch().withEndpoint('l1'),
+        e.switch().withEndpoint('l2'),
+        e.switch().withEndpoint('l3'),
+        e.switch().withEndpoint('l4'),
+        e.switch().withEndpoint('l5'),
+        e.power_on_behavior().withEndpoint('l1'),
+        e.power_on_behavior().withEndpoint('l2'),
+        e.power_on_behavior().withEndpoint('l3'),
+        e.power_on_behavior().withEndpoint('l4'),
+        e.power_on_behavior().withEndpoint('l5'),
+    ],
+    endpoint: (device) => {
+        return { 'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5 };
+    },
+    meta: { multiEndpoint: true },
+    configure: async (device, coordinatorEndpoint, logger) => {
+        await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+        await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+        await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+        await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+        await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+        await reporting.bind(device.getEndpoint(5), coordinatorEndpoint, ['genOnOff']);
+        device.powerSource = 'Mains (single phase)';
+        device.save();
+    },
+};
+
+module.exports = definition;

--- a/devices/automaton.js
+++ b/devices/automaton.js
@@ -3,92 +3,42 @@ const tz = require('../converters/toZigbee');
 const exposes = require('../lib/exposes');
 const reporting = require('../lib/reporting');
 const tuya = require('../lib/tuya');
-const utils = require('../lib/utils');
 const e = exposes.presets;
 
-const fzLocal = {
-  power_on_behavior: {
-      cluster: 'manuSpecificTuya_3',
-      type: ['attributeReport', 'readResponse'],
-      convert: (model, msg, publish, options, meta) => {
-          const attribute = 'powerOnBehavior';
-          const lookup = { 0: 'off', 1: 'on', 2: 'previous' };
-
-          if (msg.data.hasOwnProperty(attribute)) {
-              const property = utils.postfixWithEndpointName('power_on_behavior', msg, model, meta);
-              return { [property]: lookup[msg.data[attribute]] };
-          }
-      },
-  },
-  child_lock: {
-      cluster: 'genOnOff',
-      type: ['attributeReport', 'readResponse'],
-      convert: (model, msg, publish, options, meta) => {
-          if (msg.data.hasOwnProperty('32768')) {
-              const value = msg.data['32768'];
-              return { child_lock: value ? 'LOCK' : 'UNLOCK' };
-          }
-      },
-  }
-}
-
-const tzLocal = {
-  power_on_behavior: {
-      key: ['power_on_behavior'],
-      convertSet: async (entity, key, value, meta) => {
-          value = value.toLowerCase();
-          const lookup = { 'off': 0, 'on': 1, 'previous': 2 };
-          utils.validateValue(value, Object.keys(lookup));
-          const pState = lookup[value];
-          await entity.write('manuSpecificTuya_3', { 'powerOnBehavior': pState }, { disableDefaultResponse: true });
-          return { state: { power_on_behavior: value } };
-      },
-      convertGet: async (entity, key, meta) => {
-          await entity.read('manuSpecificTuya_3', ['powerOnBehavior']);
-      },
-  },
-  child_lock: {
-      key: ['child_lock'],
-      convertSet: async (entity, key, value, meta) => {
-          await entity.write('genOnOff', { 0x8000: { value: value === 'LOCK', type: 0x10 } });
-      },
-  }
-}
-
-const definition = {
-    fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_j0ktmul1']),
-    model: 'AUT000069',
-    vendor: 'AutomatOn',
-    description: 'Underfloor heating controller - 5 zones',
-    fromZigbee: [fz.on_off, fz.ignore_basic_report, fzLocal.power_on_behavior, fzLocal.child_lock],
-    toZigbee: [tz.on_off, tzLocal.power_on_behavior, tzLocal.child_lock],
-    exposes: [
-        e.child_lock(),
-        e.switch().withEndpoint('l1'),
-        e.switch().withEndpoint('l2'),
-        e.switch().withEndpoint('l3'),
-        e.switch().withEndpoint('l4'),
-        e.switch().withEndpoint('l5'),
-        e.power_on_behavior().withEndpoint('l1'),
-        e.power_on_behavior().withEndpoint('l2'),
-        e.power_on_behavior().withEndpoint('l3'),
-        e.power_on_behavior().withEndpoint('l4'),
-        e.power_on_behavior().withEndpoint('l5'),
-    ],
-    endpoint: (device) => {
-        return { 'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5 };
+module.exports = [
+    {
+        fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_j0ktmul1']),
+        model: 'AUT000069',
+        vendor: 'AutomatOn',
+        description: 'Underfloor heating controller - 5 zones',
+        fromZigbee: [fz.on_off, fz.ignore_basic_report, tuya.fz.power_on_behavior_2, tuya.fz.child_lock],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tuya.tz.child_lock],
+        exposes: [
+            e.child_lock(),
+            e.switch().withEndpoint('l1'),
+            e.switch().withEndpoint('l2'),
+            e.switch().withEndpoint('l3'),
+            e.switch().withEndpoint('l4'),
+            e.switch().withEndpoint('l5'),
+            e.power_on_behavior().withEndpoint('l1'),
+            e.power_on_behavior().withEndpoint('l2'),
+            e.power_on_behavior().withEndpoint('l3'),
+            e.power_on_behavior().withEndpoint('l4'),
+            e.power_on_behavior().withEndpoint('l5'),
+        ],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(5), coordinatorEndpoint, ['genOnOff']);
+            device.powerSource = 'Mains (single phase)';
+            device.save();
+        },
     },
-    meta: { multiEndpoint: true },
-    configure: async (device, coordinatorEndpoint, logger) => {
-        await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
-        await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-        await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-        await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
-        await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
-        await reporting.bind(device.getEndpoint(5), coordinatorEndpoint, ['genOnOff']);
-        device.powerSource = 'Mains (single phase)';
-        device.save();
-    },
-};
-
-module.exports = definition;
+];

--- a/devices/lellki.js
+++ b/devices/lellki.js
@@ -121,7 +121,7 @@ module.exports = [
         extend: extend.switch(),
         fromZigbee: [fz.on_off_force_multiendpoint, fz.electrical_measurement, fz.metering, fz.ignore_basic_report,
             tuya.fz.power_outage_memory],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -133,20 +133,6 @@ const tzLocal = {
             return {state: {[key]: value}};
         },
     },
-    power_on_behavior: {
-        key: ['power_on_behavior'],
-        convertSet: async (entity, key, value, meta) => {
-            value = value.toLowerCase();
-            const lookup = {'off': 0, 'on': 1, 'previous': 2};
-            utils.validateValue(value, Object.keys(lookup));
-            const pState = lookup[value];
-            await entity.write('manuSpecificTuya_3', {'powerOnBehavior': pState}, {disableDefaultResponse: true});
-            return {state: {power_on_behavior: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('manuSpecificTuya_3', ['powerOnBehavior']);
-        },
-    },
     zb_sm_cover: {
         key: ['state', 'position', 'reverse_direction', 'top_limit', 'bottom_limit', 'favorite_position', 'goto_positon', 'report'],
         convertSet: async (entity, key, value, meta) => {
@@ -537,19 +523,6 @@ const fzLocal = {
             if (dp === 4) return {battery: value};
             else {
                 meta.logger.warn(`zigbee-herdsman-converters:ZM35HQ: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
-            }
-        },
-    },
-    power_on_behavior: {
-        cluster: 'manuSpecificTuya_3',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            const attribute = 'powerOnBehavior';
-            const lookup = {0: 'off', 1: 'on', 2: 'previous'};
-
-            if (msg.data.hasOwnProperty(attribute)) {
-                const property = utils.postfixWithEndpointName('power_on_behavior', msg, model, meta);
-                return {[property]: lookup[msg.data[attribute]]};
             }
         },
     },
@@ -1918,7 +1891,7 @@ module.exports = [
         vendor: 'TuYa',
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.ignore_basic_report,
             tuya.fz.power_outage_memory, tuya.fz.switch_type],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior, tuya.tz.switch_type],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tuya.tz.switch_type],
         configure: async (device, coordinatorEndpoint, logger) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);
@@ -1963,9 +1936,9 @@ module.exports = [
         model: 'TS000F_power',
         description: 'Switch with power monitoring',
         vendor: 'TuYa',
-        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.ignore_basic_report, tuya.fz.power_on_behavior,
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.ignore_basic_report, tuya.fz.power_on_behavior_1,
             tuya.fz.switch_type],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior, tuya.tz.switch_type],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tuya.tz.switch_type],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
@@ -2593,7 +2566,7 @@ module.exports = [
         vendor: 'TuYa',
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.ignore_basic_report, tuya.fz.power_outage_memory,
             tuya.fz.indicator_mode],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior, tuya.tz.backlight_indicator_mode_1],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tuya.tz.backlight_indicator_mode_1],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
@@ -3208,8 +3181,8 @@ module.exports = [
         model: 'TS0004',
         vendor: 'TuYa',
         description: 'Smart light switch - 4 gang with neutral wire',
-        fromZigbee: [fz.on_off, fzLocal.power_on_behavior, fz.ignore_basic_report],
-        toZigbee: [tz.on_off, tzLocal.power_on_behavior],
+        fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fz.ignore_basic_report],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2],
         exposes: [e.switch().withEndpoint('l1'), e.power_on_behavior().withEndpoint('l1'), e.switch().withEndpoint('l2'),
             e.power_on_behavior().withEndpoint('l2'), e.switch().withEndpoint('l3'), e.power_on_behavior().withEndpoint('l3'),
             e.switch().withEndpoint('l4'), e.power_on_behavior().withEndpoint('l4')],
@@ -3414,7 +3387,7 @@ module.exports = [
         vendor: 'TuYa',
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.ignore_basic_report, tuya.fz.power_outage_memory,
             fz.tuya_relay_din_led_indicator],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior, tz.tuya_relay_din_led_indicator],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tz.tuya_relay_din_led_indicator],
         whiteLabel: [{vendor: 'MatSee Plus', model: 'ATMS1602Z'}, {vendor: 'Tongou', model: 'TO-Q-SY1-JZT'}],
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -3440,7 +3413,7 @@ module.exports = [
         description: 'Din smart relay (without power monitoring)',
         vendor: 'TuYa',
         fromZigbee: [fz.on_off, fz.ignore_basic_report, tuya.fz.power_outage_memory, fz.tuya_relay_din_led_indicator],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior, tz.tuya_relay_din_led_indicator],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tz.tuya_relay_din_led_indicator],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
@@ -3989,10 +3962,10 @@ module.exports = [
         vendor: 'TuYa',
         description: '1 channel dimmer',
         fromZigbee: extend.light_onoff_brightness({disablePowerOnBehavior: true, disableMoveStep: true, disableTransition: true})
-            .fromZigbee.concat([tuya.fz.power_on_behavior, fzLocal.TS110E_switch_type, fzLocal.TS110E]),
+            .fromZigbee.concat([tuya.fz.power_on_behavior_1, fzLocal.TS110E_switch_type, fzLocal.TS110E]),
         toZigbee: utils.replaceInArray(
             extend.light_onoff_brightness({disablePowerOnBehavior: true, disableMoveStep: true, disableTransition: true})
-                .toZigbee.concat([tuya.tz.power_on_behavior, tzLocal.TS110E_options]),
+                .toZigbee.concat([tuya.tz.power_on_behavior_1, tzLocal.TS110E_options]),
             [tz.light_onoff_brightness],
             [tzLocal.TS110E_light_onoff_brightness],
         ),
@@ -4009,8 +3982,8 @@ module.exports = [
         vendor: 'TuYa',
         description: '1 channel dimmer',
         whiteLabel: [{vendor: 'RTX', model: 'QS-Zigbee-D02-TRIAC-LN'}],
-        fromZigbee: [fzLocal.TS110E, fzLocal.TS110E_light_type, tuya.fz.power_on_behavior, fz.on_off],
-        toZigbee: [tzLocal.TS110E_onoff_brightness, tzLocal.TS110E_options, tuya.tz.power_on_behavior, tz.light_brightness_move],
+        fromZigbee: [fzLocal.TS110E, fzLocal.TS110E_light_type, tuya.fz.power_on_behavior_1, fz.on_off],
+        toZigbee: [tzLocal.TS110E_onoff_brightness, tzLocal.TS110E_options, tuya.tz.power_on_behavior_1, tz.light_brightness_move],
         exposes: [
             e.light_brightness().withMinBrightness().withMaxBrightness(),
             tuya.exposes.lightType().withAccess(ea.ALL), e.power_on_behavior().withAccess(ea.ALL)],
@@ -4027,10 +4000,10 @@ module.exports = [
         vendor: 'TuYa',
         description: '2 channel dimmer',
         fromZigbee: extend.light_onoff_brightness({disablePowerOnBehavior: true, disableMoveStep: true, disableTransition: true})
-            .fromZigbee.concat([tuya.fz.power_on_behavior, fzLocal.TS110E_switch_type, fzLocal.TS110E]),
+            .fromZigbee.concat([tuya.fz.power_on_behavior_1, fzLocal.TS110E_switch_type, fzLocal.TS110E]),
         toZigbee: utils.replaceInArray(
             extend.light_onoff_brightness({disablePowerOnBehavior: true, disableMoveStep: true, disableTransition: true})
-                .toZigbee.concat([tuya.tz.power_on_behavior, tzLocal.TS110E_options]),
+                .toZigbee.concat([tuya.tz.power_on_behavior_1, tzLocal.TS110E_options]),
             [tz.light_onoff_brightness],
             [tzLocal.TS110E_light_onoff_brightness],
         ),
@@ -4057,8 +4030,8 @@ module.exports = [
         model: 'TS110E_2gang_2',
         vendor: 'TuYa',
         description: '2 channel dimmer',
-        fromZigbee: [fzLocal.TS110E, fzLocal.TS110E_light_type, tuya.fz.power_on_behavior, fz.on_off],
-        toZigbee: [tzLocal.TS110E_onoff_brightness, tzLocal.TS110E_options, tuya.tz.power_on_behavior, tz.light_brightness_move],
+        fromZigbee: [fzLocal.TS110E, fzLocal.TS110E_light_type, tuya.fz.power_on_behavior_1, fz.on_off],
+        toZigbee: [tzLocal.TS110E_onoff_brightness, tzLocal.TS110E_options, tuya.tz.power_on_behavior_1, tz.light_brightness_move],
         meta: {multiEndpoint: true},
         exposes: [
             e.light_brightness().withMinBrightness().withMaxBrightness().withEndpoint('l1'),

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1519,7 +1519,7 @@ const valueConverter = {
 };
 
 const tuyaTz = {
-    power_on_behavior: {
+    power_on_behavior_1: {
         key: ['power_on_behavior', 'power_outage_memory'],
         convertSet: async (entity, key, value, meta) => {
             // Legacy: remove power_outage_memory
@@ -1532,6 +1532,20 @@ const tuyaTz = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['moesStartUpOnOff']);
+        },
+    },
+    power_on_behavior_2: {
+        key: ['power_on_behavior'],
+        convertSet: async (entity, key, value, meta) => {
+            value = value.toLowerCase();
+            const lookup = {'off': 0, 'on': 1, 'previous': 2};
+            utils.validateValue(value, Object.keys(lookup));
+            const pState = lookup[value];
+            await entity.write('manuSpecificTuya_3', {'powerOnBehavior': pState});
+            return {state: {power_on_behavior: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificTuya_3', ['powerOnBehavior']);
         },
     },
     switch_type: {
@@ -1675,7 +1689,7 @@ const tuyaFz = {
             await msg.endpoint.command('manuSpecificTuya', 'mcuGatewayConnectionStatus', payload, {});
         },
     },
-    power_on_behavior: {
+    power_on_behavior_1: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
@@ -1683,6 +1697,18 @@ const tuyaFz = {
                 const lookup = {0: 'off', 1: 'on', 2: 'previous'};
                 const property = utils.postfixWithEndpointName('power_on_behavior', msg, model, meta);
                 return {[property]: lookup[msg.data['moesStartUpOnOff']]};
+            }
+        },
+    },
+    power_on_behavior_2: {
+        cluster: 'manuSpecificTuya_3',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const attribute = 'powerOnBehavior';
+            const lookup = {0: 'off', 1: 'on', 2: 'previous'};
+            if (msg.data.hasOwnProperty(attribute)) {
+                const property = utils.postfixWithEndpointName('power_on_behavior', msg, model, meta);
+                return {[property]: lookup[msg.data[attribute]]};
             }
         },
     },
@@ -1830,11 +1856,11 @@ const tuyaExtend = {
         if (options.powerOutageMemory) {
             // Legacy, powerOnBehavior is preferred
             fromZigbee.push(tuyaFz.power_outage_memory);
-            toZigbee.push(tuyaTz.power_on_behavior);
+            toZigbee.push(tuyaTz.power_on_behavior_1);
             exposes.push(tuyaExposes.powerOutageMemory());
         } else {
-            fromZigbee.push(tuyaFz.power_on_behavior);
-            toZigbee.push(tuyaTz.power_on_behavior);
+            fromZigbee.push(tuyaFz.power_on_behavior_1);
+            toZigbee.push(tuyaTz.power_on_behavior_1);
             exposes.push(e.power_on_behavior());
         }
 


### PR DESCRIPTION
This PR adds support for AutomatOn underfloor heating controller AUT000069

<img width="200" alt="AUT000069" src="https://user-images.githubusercontent.com/12434847/225162865-d96824f4-f508-4a30-88a5-11377d72c8e2.png">

Link: https://sklep.automat-on.pl/Sterownik_ogrzewania_podlogowego_Zigbee_5_stref.html

PR for device picture: https://github.com/Koenkk/zigbee2mqtt.io/pull/1956

#### Current Status
* all 5 zone switches work
* power_on_behavior works separately for all 5 switches
* child lock works

#### Doubts
1. I'm not sure why it works only if I name the endpoints `l1`, `l2`, and so on. I'd prefer them to be named `ch1`, `ch2`, and so on, because this is how they are labeled on the device - however then I get `no converter for power_on_behavior_ch1`
2. In db entry for this device there are some backlight attributes that seem to do nothing

#### DB entry
```json
{
    "id": 5,
    "type": "Router",
    "ieeeAddr": "0xa4c138f1b957e4c9",
    "nwkAddr": 33204,
    "manufId": 4417,
    "manufName": "_TZ3000_j0ktmul1",
    "powerSource": "Mains (single phase)",
    "modelId": "TS011F",
    "epList": [
        1,
        2,
        242,
        3,
        4,
        5
    ],
    "endpoints": {
        "1": {
            "profId": 260,
            "epId": 1,
            "devId": 266,
            "inClusterList": [
                3,
                4,
                5,
                6,
                57344,
                57345,
                0
            ],
            "outClusterList": [
                25,
                10
            ],
            "clusters": {
                "genBasic": {
                    "attributes": {
                        "65506": 48,
                        "65508": 0,
                        "65534": 0,
                        "modelId": "TS011F",
                        "manufacturerName": "_TZ3000_j0ktmul1",
                        "powerSource": 1,
                        "zclVersion": 3,
                        "appVersion": 67,
                        "stackVersion": 0,
                        "hwVersion": 1,
                        "dateCode": ""
                    }
                },
                "genOnOff": {
                    "attributes": {
                        "32768": 0,
                        "onOff": 0,
                        "onTime": 0,
                        "offWaitTime": 0,
                        "tuyaBacklightMode": 1,
                        "moesStartUpOnOff": 2,
                        "tuyaBacklightSwitch": 1
                    }
                },
                "manuSpecificTuya_3": {
                    "attributes": {
                        "powerOnBehavior": 2,
                        "switchType": 0
                    }
                }
            },
            "binds": [
                {
                    "cluster": 6,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b0024c3c715",
                    "endpointID": 242
                },
                {
                    "cluster": 2820,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b0024c3c715",
                    "endpointID": 242
                },
                {
                    "cluster": 1794,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b0024c3c715",
                    "endpointID": 242
                }
            ],
            "configuredReportings": [],
            "meta": {}
        },
        "2": {
            "profId": 260,
            "epId": 2,
            "devId": 266,
            "inClusterList": [
                4,
                5,
                6,
                57345
            ],
            "outClusterList": [],
            "clusters": {
                "genOnOff": {
                    "attributes": {
                        "onOff": 1,
                        "onTime": 0,
                        "offWaitTime": 0
                    }
                },
                "manuSpecificTuya_3": {
                    "attributes": {
                        "powerOnBehavior": 2
                    }
                }
            },
            "binds": [
                {
                    "cluster": 6,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b0024c3c715",
                    "endpointID": 242
                }
            ],
            "configuredReportings": [],
            "meta": {}
        },
        "3": {
            "profId": 260,
            "epId": 3,
            "devId": 266,
            "inClusterList": [
                4,
                5,
                6,
                57345
            ],
            "outClusterList": [],
            "clusters": {
                "genOnOff": {
                    "attributes": {
                        "onOff": 0,
                        "onTime": 0,
                        "offWaitTime": 0
                    }
                },
                "manuSpecificTuya_3": {
                    "attributes": {
                        "powerOnBehavior": 2
                    }
                }
            },
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        },
        "4": {
            "profId": 260,
            "epId": 4,
            "devId": 266,
            "inClusterList": [
                4,
                5,
                6,
                57345
            ],
            "outClusterList": [],
            "clusters": {
                "genOnOff": {
                    "attributes": {
                        "onOff": 0,
                        "onTime": 0,
                        "offWaitTime": 0
                    }
                },
                "manuSpecificTuya_3": {
                    "attributes": {
                        "powerOnBehavior": 2
                    }
                }
            },
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        },
        "5": {
            "profId": 260,
            "epId": 5,
            "devId": 266,
            "inClusterList": [
                4,
                5,
                6,
                57345
            ],
            "outClusterList": [],
            "clusters": {
                "genOnOff": {
                    "attributes": {
                        "onOff": 0,
                        "onTime": 0,
                        "offWaitTime": 0
                    }
                },
                "manuSpecificTuya_3": {
                    "attributes": {
                        "powerOnBehavior": 2
                    }
                }
            },
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        },
        "242": {
            "profId": 41440,
            "epId": 242,
            "devId": 97,
            "inClusterList": [],
            "outClusterList": [
                33
            ],
            "clusters": {},
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        }
    },
    "appVersion": 67,
    "stackVersion": 0,
    "hwVersion": 1,
    "dateCode": "",
    "zclVersion": 3,
    "interviewCompleted": true,
    "meta": {},
    "lastSeen": 1678492687167,
    "defaultSendRequestWhen": "immediate"
}
```

#### Acknowledgement
Thanks to @Noclavil for help