### PR TITLE
feat: add support for Xfinity Keypad UEHK2AZ0

### DIFF
--- a/devices/universal_electronics_inc.js
+++ b/devices/universal_electronics_inc.js
@@ -81,10 +81,10 @@ module.exports = [
         model: 'UEHK2AZ0',
         vendor: 'Universal Electronics Inc',
         description: 'Xfinity security keypad',
-        meta: { battery: { voltageToPercentage: '3V_2100' } },
+        meta: {battery:{voltageToPercentage: '3V_2100'}},
         fromZigbee: [
             fz.command_arm_with_transaction, fz.temperature, fz.battery, fz.ias_occupancy_alarm_1,
-            fz.identify, fz.ias_contact_alarm_1, fz.ias_ace_occupancy_with_timeout
+            fz.identify, fz.ias_contact_alarm_1, fz.ias_ace_occupancy_with_timeout,
         ],
         toZigbee: [tz.arm_mode],
         exposes: [
@@ -115,5 +115,5 @@ module.exports = [
                 );
             }
         },
-    }
+    },
 ];

--- a/devices/universal_electronics_inc.js
+++ b/devices/universal_electronics_inc.js
@@ -76,4 +76,44 @@ module.exports = [
             }
         },
     },
+    {
+        zigbeeModel: ['H34450BA00-00007'],
+        model: 'UEHK2AZ0',
+        vendor: 'Universal Electronics Inc',
+        description: 'Xfinity security keypad',
+        meta: { battery: { voltageToPercentage: '3V_2100' } },
+        fromZigbee: [
+            fz.command_arm_with_transaction, fz.temperature, fz.battery, fz.ias_occupancy_alarm_1,
+            fz.identify, fz.ias_contact_alarm_1, fz.ias_ace_occupancy_with_timeout
+        ],
+        toZigbee: [tz.arm_mode],
+        exposes: [
+            e.battery(), e.battery_voltage(), e.occupancy(), e.battery_low(),
+            e.tamper(), e.presence(), e.contact(), e.temperature(),
+            exposes.numeric('action_code', ea.STATE).withDescription('Pin code introduced.'),
+            exposes.numeric('action_transaction', ea.STATE).withDescription('Last action transaction number.'),
+            exposes.text('action_zone', ea.STATE).withDescription('Alarm zone. Default value 0'),
+            e.action([
+                'disarm', 'arm_day_zones', 'identify', 'arm_night_zones', 'arm_all_zones', 'exit_delay', 'emergency',
+            ])],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            const clusters = ['msTemperatureMeasurement', 'genPowerCfg', 'ssIasZone', 'ssIasAce', 'genBasic', 'genIdentify'];
+            await reporting.bind(endpoint, coordinatorEndpoint, clusters);
+            await reporting.temperature(endpoint);
+            await reporting.batteryVoltage(endpoint);
+        },
+        onEvent: async (type, data, device) => {
+            if (type === 'message' && data.type === 'commandGetPanelStatus' && data.cluster === 'ssIasAce' &&
+                globalStore.hasValue(device.getEndpoint(1), 'panelStatus')) {
+                const payload = {
+                    panelstatus: globalStore.getValue(device.getEndpoint(1), 'panelStatus'),
+                    secondsremain: 0x00, audiblenotif: 0x00, alarmstatus: 0x00,
+                };
+                await device.getEndpoint(1).commandResponse(
+                    'ssIasAce', 'getPanelStatusRsp', payload, {}, data.meta.zclTransactionSequenceNumber,
+                );
+            }
+        },
+    }
 ];

--- a/devices/universal_electronics_inc.js
+++ b/devices/universal_electronics_inc.js
@@ -81,7 +81,7 @@ module.exports = [
         model: 'UEHK2AZ0',
         vendor: 'Universal Electronics Inc',
         description: 'Xfinity security keypad',
-        meta: {battery:{voltageToPercentage: '3V_2100'}},
+        meta: {battery: {voltageToPercentage: '3V_2100'}},
         fromZigbee: [
             fz.command_arm_with_transaction, fz.temperature, fz.battery, fz.ias_occupancy_alarm_1,
             fz.identify, fz.ias_contact_alarm_1, fz.ias_ace_occupancy_with_timeout,


### PR DESCRIPTION
Adds support for the H34450BA00-00007 

[FCC Docs](https://fccid.io/MG3-H34450)
[Xfinity](https://www.xfinity.com/support/articles/installing-batteries-xhk1-ue-keypad)

[https://github.com/Koenkk/zigbee2mqtt.io/pull/1959](https://github.com/Koenkk/zigbee2mqtt.io/pull/1959)