### PR TITLE
[New Device Support] IKEA E2123

### DIFF
--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -247,22 +247,19 @@ const ikea = {
         },
         ikea_dots_click_v1: {
             // For remotes with firmware 1.0.012 (20211214)
-            cluster: '64639',
+            cluster: 64639,
             type: 'raw',
             convert: (model, msg, publish, options, meta) => {
-                let direction;
+                if (!Buffer.isBuffer(msg.data)) return;
                 let action;
-                switch (msg.data[5]) {
-                case 1: direction = '1'; break; // 1 dot
-                case 2: direction = '2'; break; // 2 dot
-                }
+                const button = msg.data[5];
                 switch (msg.data[6]) {
                 case 1: action = 'initial_press'; break;
                 case 2: action = 'double_press'; break;
                 case 3: action = 'long_press'; break;
                 }
 
-                return {action: `dots_${direction}_${action}`};
+                return {action: `dots_${button}_${action}`};
             },
         },
         ikea_dots_click_v2: {
@@ -270,11 +267,12 @@ const ikea = {
             cluster: 'heimanSpecificScenes',
             type: 'raw',
             convert: (model, msg, publish, options, meta) => {
-                let direction;
+                if (!Buffer.isBuffer(msg.data)) return;
+                let button;
                 let action;
                 switch (msg.endpoint.ID) {
-                case 2: direction = '1'; break; // 1 dot
-                case 3: direction = '2'; break; // 2 dot
+                case 2: button = '1'; break; // 1 dot
+                case 3: button = '2'; break; // 2 dot
                 }
                 switch (msg.data[4]) {
                 case 1: action = 'initial_press'; break;
@@ -284,7 +282,7 @@ const ikea = {
                 case 6: action = 'double_press'; break;
                 }
 
-                return {action: `dots_${direction}_${action}`};
+                return {action: `dots_${button}_${action}`};
             },
         },
         ikea_volume_click: {
@@ -1158,8 +1156,12 @@ module.exports = [
             const endpoint2 = device.getEndpoint(2);
             const endpoint3 = device.getEndpoint(3);
             await reporting.bind(endpoint1, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genPollCtrl']);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ['heimanSpecificScenes']);
-            await reporting.bind(endpoint3, coordinatorEndpoint, ['heimanSpecificScenes']);
+            if (endpoint2) {
+                await reporting.bind(endpoint2, coordinatorEndpoint, ['heimanSpecificScenes']);
+            }
+            if (endpoint3) {
+                await reporting.bind(endpoint3, coordinatorEndpoint, ['heimanSpecificScenes']);
+            }
             await reporting.batteryVoltage(endpoint1);
         },
     },

--- a/devices/ikea.js
+++ b/devices/ikea.js
@@ -250,14 +250,19 @@ const ikea = {
             cluster: '64639',
             type: 'raw',
             convert: (model, msg, publish, options, meta) => {
-                if (utils.hasAlreadyProcessedMessage(msg, model)) return;
-                if (msg.data.value === 2) {
-                    // This is send on toggle hold, ignore it as a toggle_hold is already handled above.
-                    return;
+                let direction;
+                let action;
+                switch (msg.data[5]) {
+                case 1: direction = '1'; break; // 1 dot
+                case 2: direction = '2'; break; // 2 dot
+                }
+                switch (msg.data[6]) {
+                case 1: action = 'initial_press'; break;
+                case 2: action = 'double_press'; break;
+                case 3: action = 'long_press'; break;
                 }
 
-                const direction = msg.data.data === '[21,124,17,2,1,2,1]' ? '1' : '2';
-                return {action: `dots_${direction}_initial_press`};
+                return {action: `dots_${direction}_${action}`};
             },
         },
         ikea_dots_click_v2: {


### PR DESCRIPTION
This merge request contains a converter for the new IKEA Symfonisk Sound Remote.

The Github Issues https://github.com/Koenkk/zigbee2mqtt/issues/16808 had quiet a discussion about wether one should use "light-remote" namings for actions or introduce "volume/sound - remote" ones. 

I have chosen to use the toggle-converter from the previous symfonisk remote, but add new `volume_<up|down>[_hold]` and `track_<previous|next>` actions as the buttons on the remote a clearly meant for audio and not light control. 

If you prefer to use already existing actions let me know.

Documentation on the main repository will be done in the coming days/after the merge request goes through.