### PR TITLE
WS-USC03 & ROM001: remove default behavior of binding genOnOff to coordinator

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1919,8 +1919,6 @@ module.exports = [
         exposes: [e.battery(), e.action(['on', 'off', 'skip_backward', 'skip_forward', 'press', 'hold', 'release'])],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-
             const options = {manufacturerCode: 0x100B, disableDefaultResponse: true};
             await endpoint.write('genBasic', {0x0031: {value: 0x000B, type: 0x19}}, options);
             await reporting.bind(endpoint, coordinatorEndpoint, ['manuSpecificPhilips', 'genPowerCfg']);

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1030,7 +1030,6 @@ module.exports = [
         extend: extend.switch(),
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
         },
         ota: ota.zigbeeOTA,


### PR DESCRIPTION
## Related Devices: 
- WS-USC03: Aqara wall switch (controlling my bathroom light)
- ROM001: Philips Hue Smart Button

## Problems I had & solution: 
Both devices binds `genOnOff` to coordinator by default on configuration, which causes unexpected behavior of Hue smart button toggling my bathroom light immediately after pairing to z2m, with no automations configured between them. 

I don't get the point of binding `genOnOff` (same for `genLevelCtrl`) at pairing by default, thus rendering this PR to remove them. 

Any thoughts? 