### PR TITLE
viessmann(TRV): exposing battery for HA mqtt discovering

### DIFF
--- a/devices/viessmann.js
+++ b/devices/viessmann.js
@@ -24,6 +24,7 @@ module.exports = [
             exposes.binary('window_open_force', ea.ALL, true, false)
                 .withDescription('Manually set window_open, ~1 minute to take affect.'),
             e.keypad_lockout(),
+            e.battery(),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Hey Koen,

I moved to Home Assistant on weekend and i was wondering that the battery sensor was not created while mqtt discover.
would be nice to add it. many other devices we exposing battery sensor as default.

greetz
Chris