### PR TITLE
Add duration set support for Woox R7051 Smart Indoor Siren

### DIFF
--- a/devices/woox.js
+++ b/devices/woox.js
@@ -160,10 +160,11 @@ module.exports = [
         vendor: 'Woox',
         description: 'Smart siren',
         fromZigbee: [fz.battery, fz.ts0216_siren, fz.ias_alarm_only_alarm_1, fz.power_source],
-        toZigbee: [tz.warning, tz.ts0216_volume],
+        toZigbee: [tz.warning, tz.ts0216_volume, tz.ts0216_duration],
         exposes: [e.battery(), e.battery_voltage(), e.warning(), exposes.binary('alarm', ea.STATE, true, false),
             exposes.binary('ac_connected', ea.STATE, true, false).withDescription('Is the device plugged in'),
-            exposes.numeric('volume', ea.ALL).withValueMin(0).withValueMax(100).withDescription('Volume of siren')],
+            exposes.numeric('volume', ea.ALL).withValueMin(0).withValueMax(100).withDescription('Volume of siren'),
+            exposes.numeric('duration', ea.ALL).withValueMin(0).withValueMax(3600).withDescription('Duration of siren')],
         meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Add the ability to set the siren duration for Woox R7051 Smart Indoor Siren.

There's still some weird stuff that I haven't been able to solve. The duration shows as blank until the `reload` icon is pressed, and I haven't been able to figure out why.

See #5606 for more details.