### PR TITLE
Add FUT035Z+ support

### DIFF
--- a/devices/miboxer.js
+++ b/devices/miboxer.js
@@ -34,6 +34,15 @@ module.exports = [
             {modelID: 'TS0502B', manufacturerName: '_TZ3210_xwqng7ol'},
         ],
         model: 'FUT035Z',
+        description: 'Dual white 2 in 1 LED Controller',
+        vendor: 'Miboxer',
+        extend: tuya.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500], disablePowerOnBehavior: true}),
+    },
+    {
+        fingerprint: [
+            {modelID: 'TS0502B', manufacturerName: '_TZB210_lmqquxus'},
+        ],
+        model: 'FUT035Z+',
         description: 'Dual white LED controller',
         vendor: 'Miboxer',
         extend: tuya.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500], disablePowerOnBehavior: true}),


### PR DESCRIPTION
This PR adds support for the Miboxer FUT035Z+ (2 in 1 variant of FUT035Z) device. 

https://miboxer.com/en/product/2-in-1-led-controller-zigbee-3-0-2-4g