### PR TITLE
Added: Basic support for QBKG29LM - Aqara H1 (No Neutral, Triple Rocker)

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5379,7 +5379,7 @@ const converters = {
             if (['QBKG39LM', 'QBKG41LM', 'WS-EUK02', 'WS-EUK04', 'QBKG20LM', 'QBKG28LM', 'QBKG31LM'].includes(model.model)) {
                 buttonLookup = {41: 'left', 42: 'right', 51: 'both'};
             }
-            if (['QBKG25LM', 'QBKG26LM', 'QBKG34LM', 'ZNQBKG31LM'].includes(model.model)) {
+            if (['QBKG25LM', 'QBKG26LM', 'QBKG29LM', 'QBKG34LM', 'ZNQBKG31LM'].includes(model.model)) {
                 buttonLookup = {
                     41: 'left', 42: 'center', 43: 'right',
                     51: 'left_center', 52: 'left_right', 53: 'center_right',

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2217,7 +2217,7 @@ const converters = {
         key: ['power_outage_memory'],
         convertSet: async (entity, key, value, meta) => {
             if (['SP-EUC01', 'ZNCZ04LM', 'ZNCZ12LM', 'ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM', 'SSM-U01', 'SSM-U02', 'DLKZMK11LM', 'DLKZMK12LM',
-                'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM',
+                'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM', 'QBKG29LM',
                 'QBKG31LM', 'QBKG34LM', 'QBKG38LM', 'QBKG39LM', 'QBKG40LM', 'QBKG41LM', 'ZNDDMK11LM', 'ZNLDP13LM',
                 'WS-USC02', 'WS-USC04', 'ZNQBKG31LM',
             ].includes(meta.mapped.model)) {
@@ -2242,7 +2242,7 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             if (['SP-EUC01', 'ZNCZ04LM', 'ZNCZ12LM', 'ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM', 'SSM-U01', 'SSM-U02', 'DLKZMK11LM', 'DLKZMK12LM',
-                'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM',
+                'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM', 'QBKG29LM',
                 'QBKG31LM', 'QBKG34LM', 'QBKG38LM', 'QBKG39LM', 'QBKG40LM', 'QBKG41LM', 'ZNDDMK11LM', 'ZNLDP13LM',
                 'WS-USC02', 'WS-USC04', 'ZNQBKG31LM',
             ].includes(meta.mapped.model)) {
@@ -2362,7 +2362,7 @@ const converters = {
         key: ['led_disabled_night'],
         convertSet: async (entity, key, value, meta) => {
             if (['ZNCZ04LM', 'ZNCZ12LM', 'ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM', 'QBKG19LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM',
-                'QBKG28LM', 'QBKG31LM', 'QBKG34LM', 'DLKZMK11LM', 'SSM-U01', 'WS-EUK01', 'WS-EUK02',
+                'QBKG28LM', 'QBKG29LM', 'QBKG31LM', 'QBKG34LM', 'DLKZMK11LM', 'SSM-U01', 'WS-EUK01', 'WS-EUK02',
                 'WS-EUK03', 'WS-EUK04', 'SP-EUC01'].includes(meta.mapped.model)) {
                 await entity.write('aqaraOpple', {0x0203: {value: value ? 1 : 0, type: 0x10}}, manufacturerOptions.xiaomi);
             } else if (['ZNCZ11LM'].includes(meta.mapped.model)) {
@@ -2378,7 +2378,7 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             if (['ZNCZ04LM', 'ZNCZ12LM', 'ZNCZ15LM', 'QBCZ15LM', 'QBCZ14LM', 'QBKG19LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM',
-                'QBKG28LM', 'QBKG31LM', 'QBKG34LM', 'DLKZMK11LM', 'SSM-U01', 'WS-EUK01', 'WS-EUK02',
+                'QBKG28LM', 'QBKG29LM', 'QBKG31LM', 'QBKG34LM', 'DLKZMK11LM', 'SSM-U01', 'WS-EUK01', 'WS-EUK02',
                 'WS-EUK03', 'WS-EUK04', 'SP-EUC01'].includes(meta.mapped.model)) {
                 await entity.read('aqaraOpple', [0x0203], manufacturerOptions.xiaomi);
             } else {

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1176,42 +1176,42 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ["lumi.switch.l3acn1"],
-        model: "QBKG29LM",
-        vendor: "Xiaomi",
-        description: "Aqara smart wall switch H1 EU (no neutral, triple rocker)",
-        fromZigbee: [fz.on_off, fz.xiaomi_multistate_action , fz.aqara_opple],
+        zigbeeModel: ['lumi.switch.l3acn1'],
+        model: 'QBKG29LM',
+        vendor: 'Xiaomi',
+        description: 'Aqara smart wall switch H1 EU (no neutral, triple rocker)',
+        fromZigbee: [fz.on_off, fz.xiaomi_multistate_action, fz.aqara_opple],
         toZigbee: [tz.on_off, tz.xiaomi_switch_operation_mode_opple, tz.xiaomi_switch_power_outage_memory,
             tz.xiaomi_flip_indicator_light, tz.xiaomi_led_disabled_night, tz.aqara_switch_mode_switch],
-        meta: { multiEndpoint: true },
-        endpoint: (device) => ({ left: 1, center: 2, right: 3, }),
+        meta: {multiEndpoint: true},
+        endpoint: (device) => ({left: 1, center: 2, right: 3}),
         exposes: [
-            e.switch().withEndpoint("left"), e.switch().withEndpoint("center"), e.switch().withEndpoint("right"),
+            e.switch().withEndpoint('left'), e.switch().withEndpoint('center'), e.switch().withEndpoint('right'),
             e.power_outage_memory(), e.flip_indicator_light(), e.led_disabled_night(), e.power_outage_count(),
-          exposes
-            .enum("operation_mode", ea.ALL, ["control_relay", "decoupled"])
-            .withDescription("Decoupled mode for left button")
-            .withEndpoint("left"),
-          exposes
-            .enum("operation_mode", ea.ALL, ["control_relay", "decoupled"])
-            .withDescription("Decoupled mode for center button")
-            .withEndpoint("center"),
-          exposes
-            .enum("operation_mode", ea.ALL, ["control_relay", "decoupled"])
-            .withDescription("Decoupled mode for right button")
-            .withEndpoint("right"),
-          exposes
-            .enum("mode_switch", ea.ALL, ["anti_flicker_mode", "quick_mode"])
-            .withDescription(
-              "Anti flicker mode can be used to solve blinking issues of some lights." +
-                "Quick mode makes the device respond faster."
-            ),
-          e.device_temperature().withAccess(ea.STATE),
-          e.action([
-            "single_left", "double_left", "single_center", "double_center", "single_right", "double_right",
-            "single_left_center", "double_left_center", "single_left_right", "double_left_right",
-            "single_center_right", "double_center_right", "single_all", "double_all",
-          ]),
+            exposes
+                .enum('operation_mode', ea.ALL, ['control_relay', 'decoupled'])
+                .withDescription('Decoupled mode for left button')
+                .withEndpoint('left'),
+            exposes
+                .enum('operation_mode', ea.ALL, ['control_relay', 'decoupled'])
+                .withDescription('Decoupled mode for center button')
+                .withEndpoint('center'),
+            exposes
+                .enum('operation_mode', ea.ALL, ['control_relay', 'decoupled'])
+                .withDescription('Decoupled mode for right button')
+                .withEndpoint('right'),
+            exposes
+                .enum('mode_switch', ea.ALL, ['anti_flicker_mode', 'quick_mode'])
+                .withDescription(
+                'Anti flicker mode can be used to solve blinking issues of some lights.' +
+                    'Quick mode makes the device respond faster.'
+                ),
+            e.device_temperature().withAccess(ea.STATE),
+            e.action([
+                'single_left', 'double_left', 'single_center', 'double_center', 'single_right', 'double_right',
+                'single_left_center', 'double_left_center', 'single_left_right', 'double_left_right',
+                'single_center_right', 'double_center_right', 'single_all', 'double_all',
+            ]),
         ],
         onEvent: preventReset,
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1176,6 +1176,49 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ["lumi.switch.l3acn1"],
+        model: "QBKG29LM",
+        vendor: "Xiaomi",
+        description: "Aqara smart wall switch H1 EU (no neutral, triple rocker)",
+        fromZigbee: [fz.on_off, fz.xiaomi_multistate_action , fz.aqara_opple],
+        toZigbee: [tz.on_off, tz.xiaomi_switch_operation_mode_opple, tz.xiaomi_switch_power_outage_memory,
+            tz.xiaomi_flip_indicator_light, tz.xiaomi_led_disabled_night, tz.aqara_switch_mode_switch],
+        meta: { multiEndpoint: true },
+        endpoint: (device) => ({ left: 1, center: 2, right: 3, }),
+        exposes: [
+            e.switch().withEndpoint("left"), e.switch().withEndpoint("center"), e.switch().withEndpoint("right"),
+            e.power_outage_memory(), e.flip_indicator_light(), e.led_disabled_night(), e.power_outage_count(),
+          exposes
+            .enum("operation_mode", ea.ALL, ["control_relay", "decoupled"])
+            .withDescription("Decoupled mode for left button")
+            .withEndpoint("left"),
+          exposes
+            .enum("operation_mode", ea.ALL, ["control_relay", "decoupled"])
+            .withDescription("Decoupled mode for center button")
+            .withEndpoint("center"),
+          exposes
+            .enum("operation_mode", ea.ALL, ["control_relay", "decoupled"])
+            .withDescription("Decoupled mode for right button")
+            .withEndpoint("right"),
+          exposes
+            .enum("mode_switch", ea.ALL, ["anti_flicker_mode", "quick_mode"])
+            .withDescription(
+              "Anti flicker mode can be used to solve blinking issues of some lights." +
+                "Quick mode makes the device respond faster."
+            ),
+          e.device_temperature().withAccess(ea.STATE),
+          e.action([
+            "single_left", "double_left", "single_center", "double_center", "single_right", "double_right",
+            "single_left_center", "double_left_center", "single_left_right", "double_left_right",
+            "single_center_right", "double_center_right", "single_all", "double_all",
+          ]),
+        ],
+        onEvent: preventReset,
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await device.getEndpoint(1).write('aqaraOpple', {'mode': 1}, {manufacturerCode: 0x115f, disableResponse: true});
+        },
+    },
+    {
         zigbeeModel: ['lumi.switch.n1aeu1'],
         model: 'WS-EUK03',
         vendor: 'Xiaomi',

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1203,9 +1203,8 @@ module.exports = [
             exposes
                 .enum('mode_switch', ea.ALL, ['anti_flicker_mode', 'quick_mode'])
                 .withDescription(
-                'Anti flicker mode can be used to solve blinking issues of some lights.' +
-                    'Quick mode makes the device respond faster.'
-                ),
+                    'Anti flicker mode can be used to solve blinking issues of some lights.' +
+                    'Quick mode makes the device respond faster.'),
             e.device_temperature().withAccess(ea.STATE),
             e.action([
                 'single_left', 'double_left', 'single_center', 'double_center', 'single_right', 'double_right',


### PR DESCRIPTION
Tested, works exactly like the QBKG26LM, features all supported when model added to converters.