### PR TITLE
Adding basic support for ubisys router R0

### DIFF
--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -928,10 +928,9 @@ module.exports = [
     {
         zigbeeModel: ['R0 (5501)'],
         model: 'R0',
-        vendor: 'ubisys',
-        description: 'Zigbee Router R0',
-        supports: 'Router',
-        fromZigbee: [],
+        vendor: 'Ubisys',
+        description: 'Zigbee Router',
+        fromZigbee: [fz.linkquality_from_basic],
         toZigbee: [],
         exposes: [],
         ota: ota.ubisys,

--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -935,5 +935,5 @@ module.exports = [
         toZigbee: [],
         exposes: [],
         ota: ota.ubisys,
-    }
+    },
 ];

--- a/devices/ubisys.js
+++ b/devices/ubisys.js
@@ -925,4 +925,15 @@ module.exports = [
         },
         ota: ota.ubisys,
     },
+    {
+        zigbeeModel: ['R0 (5501)'],
+        model: 'R0',
+        vendor: 'ubisys',
+        description: 'Zigbee Router R0',
+        supports: 'Router',
+        fromZigbee: [],
+        toZigbee: [],
+        exposes: [],
+        ota: ota.ubisys,
+    }
 ];


### PR DESCRIPTION
Adding basic support for ubisys R0 router (https://www.ubisys.de/wp-content/uploads/ubisys-r0-technical-reference.pdf).
I'm a novice at zigbee and z2m, thus I struggle to understand the possible configuration options. The router does not seem to expose anything, but it would allow some limited configuration.
With the configuration added here, I was able to join the ubisys R0 in z2m, see "last seen" and "lqi" in Homeassistant and update the firmware through OTA.

Any advice how to complete the config is very welcome (@sjorge seems to have done most of ubisys converters, I hope he sees this :) )

Once this PR is ready to merge, I will also add a picture and description to the z2m repo.