### PR TITLE
Enable LED management in the 41E2PBSWMZ/356PB2MBTZ 2AX switch

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -10,8 +10,7 @@ const e = exposes.presets;
 const ea = exposes.access;
 
 const exposesLocal = {
-    indicator_mode: exposes.enum('indicator_mode', ea.ALL,
-        ['off/on', 'on/off', 'off', 'on'])
+    indicator_mode: exposes.enum('indicator_mode', ea.ALL, ['consistent_with_load', 'reverse_with_load', 'always_off', 'always_on'])
         .withDescription('Led Indicator Mode'),
 };
 
@@ -27,8 +26,7 @@ const tzLocal = {
         key: ['indicator_mode'],
         convertSet: async (entity, key, value, meta) => {
             const endpoint = entity.getDevice().getEndpoint(21);
-            const lookup = {'on/off': 2, 'off/on': 0, 'off': 3, 'on': 1};
-            // value = value.toLowerCase();
+            const lookup = {'reverse_with_load': 2, 'consistent_with_load': 0, 'always_off': 3, 'always_on': 1};
             utils.validateValue(value, Object.keys(lookup));
             await endpoint.write(0xFF17, {0x0000: {value: lookup[value], type: 0x30}}, {manufacturerCode: 0x105e});
             return {state: {indicator_mode: value}};
@@ -196,12 +194,7 @@ const fzLocal = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             const result = {};
-            const lookup = {
-                0: 'off/on',
-                1: 'on',
-                2: 'on/off',
-                3: 'off',
-            };
+            const lookup = {0: 'consistent_with_load', 1: 'always_on', 2: 'reverse_with_load', 3: 'always_off'};
             if ('indicator_mode' in msg.data) {
                 result.indicator_mode = lookup[msg.data['indicator_mode']];
             }

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -410,8 +410,8 @@ module.exports = [
                 ['Reverse with load', 'Consistent with load', 'Always off', 'Always on'])
                 .withDescription('Led Indicator Mode'),
             ],
-            fromZigbee: [fz.on_off, fzLocal.switchindication],
-            toZigbee: [tz.on_off, tzLocal.switchindication],
+            fromZigbee: [fzLocal.switchindication],
+            toZigbee: [tzLocal.switchindication],
         }),
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -385,13 +385,16 @@ module.exports = [
         model: '41EPBDWCLMZ/354PBDMBTZ',
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series Module Dimmer',
-        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.lighting_ballast_configuration],
-        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config],
+        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.lighting_ballast_configuration, fzLocal.switchindication],
+        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config, tzLocal.switchindication],
         exposes: [e.light_brightness(),
             exposes.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
                 .withDescription('Specifies the minimum light output of the ballast'),
             exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
-                .withDescription('Specifies the maximum light output of the ballast')],
+                .withDescription('Specifies the maximum light output of the ballast'),
+            exposes.enum('switchindication', ea.ALL,
+                ['Reverse with load', 'Consistent with load', 'Always off', 'Always on'])
+                .withDescription('Led Indicator Mode')],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(3);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
@@ -424,7 +427,14 @@ module.exports = [
         model: '41E10PBSWMZ-VW',
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series module switch 10A with ControlLink',
-        extend: extend.switch(),
+        extend: extend.switch({
+            exposes: [exposes.enum('switchindication', ea.ALL,
+                ['Reverse with load', 'Consistent with load', 'Always off', 'Always on'])
+                .withDescription('Led Indicator Mode'),
+            ],
+            fromZigbee: [fzLocal.switchindication],
+            toZigbee: [tzLocal.switchindication],
+        }),
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);


### PR DESCRIPTION
This PR enables the ability to manage the switch's internal LED state.
Fixes Koenkk/zigbee-herdsman-converters#5635
(Thanks @DanielNagy for the sample code)

Passes lint

![z2m evidence](https://user-images.githubusercontent.com/69124219/230577169-dae10ecd-7fb5-424a-ac52-77bef31a31f0.png)
