### PR TITLE
Update Bosch BTH2 - Add Input for Remote Temperature

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -559,7 +559,7 @@ const definition = [
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
                 .withLocalTemperatureCalibration(-5, 5, 0.1)
                 .withSystemMode(['off', 'heat', 'auto'])
-                .withPiHeatingDemand(ea.STATE)
+                .withPiHeatingDemand(ea.ALL)
                 .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.binary('boost', ea.ALL, 'ON', 'OFF')
                 .withDescription('Activate Boost heating'),

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -47,6 +47,12 @@ const displayOrientation = {
 };
 
 // Radiator Thermostat II
+const displayedTemperature = {
+    'target': 0,
+    'measured': 1,
+};
+
+// Radiator Thermostat II
 const tzLocal = {
     bwa1: {
         key: ['alarm_on_motion', 'test'],
@@ -69,7 +75,7 @@ const tzLocal = {
         },
     },
     bosch_thermostat: {
-        key: ['window_open', 'boost', 'system_mode', 'pi_heating_demand'],
+        key: ['window_open', 'boost', 'system_mode', 'pi_heating_demand', 'remote_temperature'],
         convertSet: async (entity, key, value, meta) => {
             if (key === 'window_open') {
                 value = value.toUpperCase();
@@ -105,6 +111,12 @@ const tzLocal = {
                     boschManufacturer);
                 return {state: {pi_heating_demand: value}};
             }
+            if (key === 'remote_temperature') {
+                const remoteTemperature = (Math.round((value * 2).toFixed(1)) / 2).toFixed(1) * 100;
+                await entity.write('hvacThermostat',
+                    {0x4040: {value: remoteTemperature, type: herdsman.Zcl.DataType.int16}}, boschManufacturer);
+                return {state: {remote_temperature: value}};
+            }
         },
         convertGet: async (entity, key, meta) => {
             switch (key) {
@@ -120,6 +132,9 @@ const tzLocal = {
             case 'pi_heating_demand':
                 await entity.read('hvacThermostat', [0x4020], boschManufacturer);
                 break;
+            case 'remote_temperature':
+                await entity.read('hvacThermostat', [0x4040], boschManufacturer);
+                break;
 
             default: // Unknown key
                 throw new Error(`Unhandled key toZigbee.bosch_thermostat.convertGet ${key}`);
@@ -127,7 +142,7 @@ const tzLocal = {
         },
     },
     bosch_userInterface: {
-        key: ['display_orientation', 'display_ontime', 'display_brightness', 'child_lock'],
+        key: ['display_orientation', 'display_ontime', 'display_brightness', 'child_lock', 'displayed_temperature'],
         convertSet: async (entity, key, value, meta) => {
             if (key === 'display_orientation') {
                 const index = displayOrientation[value];
@@ -147,6 +162,11 @@ const tzLocal = {
                 await entity.write('hvacUserInterfaceCfg', {keypadLockout});
                 return {state: {child_lock: value}};
             }
+            if (key === 'displayed_temperature') {
+                const index = displayedTemperature[value];
+                await entity.write('hvacUserInterfaceCfg', {0x4039: {value: index, type: herdsman.Zcl.DataType.enum8}}, boschManufacturer);
+                return {state: {displayed_temperature: value}};
+            }
         },
         convertGet: async (entity, key, meta) => {
             switch (key) {
@@ -161,6 +181,9 @@ const tzLocal = {
                 break;
             case 'child_lock':
                 await entity.read('hvacUserInterfaceCfg', ['keypadLockout']);
+                break;
+            case 'displayed_temperature':
+                await entity.read('hvacUserInterfaceCfg', [0x4039], boschManufacturer);
                 break;
             default: // Unknown key
                 throw new Error(`Unhandled key toZigbee.bosch_userInterface.convertGet ${key}`);
@@ -281,6 +304,9 @@ const fzLocal = {
         convert: (model, msg, publish, options, meta) => {
             const result = {};
             const data = msg.data;
+            if (data.hasOwnProperty(0x4040)) {
+                result.remote_temperature = utils.precisionRound(data[0x4040], 2) / 100;
+            }
             if (data.hasOwnProperty(0x4042)) {
                 result.window_open = (Object.keys(stateOffOn)[data[0x4042]]);
             }
@@ -293,6 +319,7 @@ const fzLocal = {
             }
             if (data.hasOwnProperty(0x4020)) {
                 result.pi_heating_demand = data[0x4020];
+                result.running_state = result.pi_heating_demand >= 10 ? 'heat' : 'idle';
             }
 
             return result;
@@ -306,6 +333,9 @@ const fzLocal = {
             const data = msg.data;
             if (data.hasOwnProperty(0x400b)) {
                 result.display_orientation = (Object.keys(displayOrientation)[data[0x400b]]);
+            }
+            if (data.hasOwnProperty(0x4039)) {
+                result.displayed_temperature = (Object.keys(displayedTemperature)[data[0x4039]]);
             }
             if (data.hasOwnProperty(0x403a)) {
                 result.display_ontime = data[0x403a];
@@ -529,13 +559,21 @@ const definition = [
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
                 .withLocalTemperatureCalibration(-5, 5, 0.1)
                 .withSystemMode(['off', 'heat', 'auto'])
-                .withPiHeatingDemand(ea.ALL),
+                .withPiHeatingDemand(ea.STATE)
+                .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.binary('boost', ea.ALL, 'ON', 'OFF')
                 .withDescription('Activate Boost heating'),
             exposes.binary('window_open', ea.ALL, 'ON', 'OFF')
                 .withDescription('Window open'),
             exposes.enum('display_orientation', ea.ALL, Object.keys(displayOrientation))
                 .withDescription('Display orientation'),
+            exposes.numeric('remote_temperature', ea.ALL)
+                .withValueMin(0)
+                .withValueMax(30)
+                .withValueStep(0.1)
+                .withUnit('°C')
+                .withDescription('Input for remote temperature sensor. ' +
+                    'Setting this will disable the internal temperature sensor until batteries are removed!'),
             exposes.numeric('display_ontime', ea.ALL)
                 .withValueMin(5)
                 .withValueMax(30)
@@ -544,6 +582,8 @@ const definition = [
                 .withValueMin(0)
                 .withValueMax(10)
                 .withDescription('Specifies the brightness value of the display'),
+            exposes.enum('displayed_temperature', ea.ALL, Object.keys(displayedTemperature))
+                .withDescription('Temperature displayed on the thermostat'),
             e.child_lock().setAccess('state', ea.ALL),
             e.battery(),
         ],
@@ -585,10 +625,10 @@ const definition = [
             }], boschManufacturer);
 
             await endpoint.read('hvacThermostat', ['localTemperatureCalibration']);
-            await endpoint.read('hvacThermostat', [0x4007, 0x4020, 0x4042, 0x4043], boschManufacturer);
+            await endpoint.read('hvacThermostat', [0x4007, 0x4020, 0x4040, 0x4042, 0x4043], boschManufacturer);
 
             await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);
-            await endpoint.read('hvacUserInterfaceCfg', [0x400b, 0x403a, 0x403b], boschManufacturer);
+            await endpoint.read('hvacUserInterfaceCfg', [0x400b, 0x4039, 0x403a, 0x403b], boschManufacturer);
         },
     },
     {


### PR DESCRIPTION
Working improvements from @compujuckel  ( #5297 ) 

- Add input for remote temperature sensor. Setting remote_temperature will override the value of local_temperature.
- Add displayed_temperature to choose which temperature is shown on the thermostat display

Both Features are working well - as expected, using them now for more than 4 Weeks.