### PR TITLE
Fix backlight_mode values for TuYa TS130F

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1450,7 +1450,7 @@ module.exports = [
         whiteLabel: [{vendor: 'LoraTap', model: 'SC400'}],
         exposes: [e.cover_position(), exposes.enum('moving', ea.STATE, ['UP', 'STOP', 'DOWN']),
             exposes.binary('calibration', ea.ALL, 'ON', 'OFF'), exposes.binary('motor_reversal', ea.ALL, 'ON', 'OFF'),
-            exposes.enum('backlight_mode', ea.ALL, ['LOW', 'MEDIUM', 'HIGH']),
+            exposes.enum('backlight_mode', ea.ALL, ['low', 'medium', 'high']),
             exposes.numeric('calibration_time', ea.STATE).withUnit('S').withDescription('Calibration time')],
     },
     {


### PR DESCRIPTION
I have a [TuYa TS130F](https://www.zigbee2mqtt.io/devices/TS130F.html) device which always shows this error in Home Assistant:

<img width="701" alt="image" src="https://user-images.githubusercontent.com/488594/230644429-66c9490e-7c56-49f8-9fca-057898582be6.png">

I _think_ this should be the correct way to fix it, since it's just the case that is incorrect. I've checked it in the `State` tab for this device in Zigbee2MQTT WebUI and this is what I get:

```
{
    "backlight_mode": "low",
    "calibration": "OFF",
    "calibration_time": 23.1,
    "linkquality": 10,
    "motor_reversal": "OFF",
    "moving": "STOP",
    "position": 100,
    "state": "OPEN"
}
```