### PR TITLE
Nous L13Z module correct converter linked

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2000,7 +2000,7 @@ module.exports = [
     },
     {
         fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_01gpyda5', '_TZ3000_bvrlqyj7', '_TZ3000_7ed9cqgi',
-        '_TZ3000_zmy4lslw', '_TZ3000_ruxexjfz']),
+            '_TZ3000_zmy4lslw', '_TZ3000_ruxexjfz']),
         model: 'TS0002_switch_module',
         vendor: 'TuYa',
         description: '2 gang switch module',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1999,7 +1999,8 @@ module.exports = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_01gpyda5', '_TZ3000_bvrlqyj7', '_TZ3000_7ed9cqgi', '_TZ3000_zmy4lslw', '_TZ3000_ruxexjfz']),
+        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_01gpyda5', '_TZ3000_bvrlqyj7', '_TZ3000_7ed9cqgi',
+        '_TZ3000_zmy4lslw', '_TZ3000_ruxexjfz']),
         model: 'TS0002_switch_module',
         vendor: 'TuYa',
         description: '2 gang switch module',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1999,11 +1999,11 @@ module.exports = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_01gpyda5', '_TZ3000_bvrlqyj7', '_TZ3000_7ed9cqgi', '_TZ3000_zmy4lslw']),
+        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_01gpyda5', '_TZ3000_bvrlqyj7', '_TZ3000_7ed9cqgi', '_TZ3000_zmy4lslw', '_TZ3000_ruxexjfz']),
         model: 'TS0002_switch_module',
         vendor: 'TuYa',
         description: '2 gang switch module',
-        whiteLabel: [{vendor: 'OXT', model: 'SWTZ22'}],
+        whiteLabel: [{vendor: 'OXT', model: 'SWTZ22'}, {vendor: 'Nous', model: 'L13Z'}],
         extend: tuya.extend.switch({switchType: true, endpoints: ['l1', 'l2']}),
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};


### PR DESCRIPTION
Nous L13Z 2 channel switch module was being recognized incorrectly as a touch switch and switch_type wasn't available. Found a converter that works I linked the fingerprint and added the "L13Z" as a white label.