### PR TITLE
fix dp code comparison

### DIFF
--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1829,7 +1829,7 @@ const tuyaFz = {
             const datapoints = model.meta.tuyaDatapoints;
             for (const dpValue of msg.data.dpValues) {
                 const dpId = dpValue.dp;
-                const dpEntry = datapoints.find((d) => d[0] === dpId);
+                const dpEntry = datapoints.find((d) => d[0].toString() === dpId.toString());
                 if (dpEntry) {
                     const value = getDataValue(dpValue);
                     if (dpEntry[1]) {


### PR DESCRIPTION
meta.tuyaDatapoints hold dpId as string while data holds it as numeric

should address issue reported at [zigbee2mqtt repo #16966](https://github.com/Koenkk/zigbee2mqtt/issues/16966)