### PR TITLE
Support Schneider WDE002960

### DIFF
--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -361,6 +361,27 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['NHPB/UNIDIM/1'],
+        model: 'WDE002960',
+        vendor: 'Schneider Electric',
+        description: 'Push button dimmer',
+        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.wiser_lighting_ballast_configuration],
+        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config, tz.wiser_dimmer_mode],
+        exposes: [e.light_brightness().withLevelConfig(),
+            exposes.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the minimum light output of the ballast'),
+            exposes.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
+                .withDescription('Specifies the maximum light output of the ballast'),
+            exposes.enum('dimmer_mode', ea.ALL, ['auto', 'rc', 'rl', 'rl_led'])
+                .withDescription('Sets dimming mode to autodetect or fixed RC/RL/RL_LED mode (max load is reduced in RL_LED)')],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(3);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
+        },
+    }
+    {
         zigbeeModel: ['NHPB/DIMMER/1'],
         model: 'WDE002386',
         vendor: 'Schneider Electric',

--- a/devices/schneider_electric.js
+++ b/devices/schneider_electric.js
@@ -380,7 +380,7 @@ module.exports = [
             await reporting.onOff(endpoint);
             await reporting.brightness(endpoint);
         },
-    }
+    },
     {
         zigbeeModel: ['NHPB/DIMMER/1'],
         model: 'WDE002386',


### PR DESCRIPTION
Add support for Schneider Electric WDE002960 Push button dimmer.

It's literally WDE002386, but new generation and works exactly the same as WDE002961 (Rotary push button).

[Link to device](https://www.se.com/se/sv/product/WDE002960/tryckdimmer-med-m%C3%B6jlighet-att-ansluta-neutralledare-exxact-styrs-via-wiser-by-se-zigbee-3-0-rc-0130w-rl-080w-vit/)