### PR TITLE
Added 5123.1110 by cloning 5120.2110

### DIFF
--- a/devices/iluminize.js
+++ b/devices/iluminize.js
@@ -75,6 +75,19 @@ module.exports = [
         },
     },
     {
+        zigbeeModel: ['5123.1110'],
+        model: '5123.1110',
+        vendor: 'Iluminize',
+        description: 'Zigbee 3.0 controller with adjustable current 250-1500mA, max. 50W / 48V SELV',
+        extend: extend.light_onoff_brightness({noConfigure: true}),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.onOff(endpoint);
+        },
+    },
+    {
         zigbeeModel: ['511.010'],
         model: '511.010',
         vendor: 'Iluminize',


### PR DESCRIPTION
Tested the Configuration on Device at Hand Iluminize 5123.1110. No Error or Warning yet.  I tested:
-On/Off
-Set Brightness
-Dimm via Push Switch

Device is a combination of adjustable Constant Current power supply with added Dimmer logic similar to said "Mini Dimming actuators" (5120.2110, 5120.1110) so it makes sense that they have the same internal configuration as they share the same push switch logic and probably compose of pwm dimming internaly.