### PR TITLE
Add basic support for BMCT-SLZ Light/Shutter Control II

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -741,7 +741,7 @@ const definition = [
         zigbeeModel: ['RBSH-MMS-ZB-EU'],
         model: 'BMCT-SLZ',
         vendor: 'Bosch',
-        description: 'Bosch Light/Shutter Control II',
+        description: 'Light/shutter control II',
         extend: extend.switch(),
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],
         endpoint: (device) => {

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -737,6 +737,34 @@ const definition = [
         },
         exposes: [e.switch(), e.power_on_behavior(), e.power(), e.energy()],
     },
+    {
+        zigbeeModel: ['RBSH-MMS-ZB-EU'],
+        model: 'BMCT-SLZ',
+        vendor: 'Bosch',
+        description: 'Bosch Light/Shutter Control II',
+        extend: extend.switch(),
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],
+        endpoint: (device) => {
+            return {'l1': 2, 'l2': 3};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+
+            // Configuration values:
+            //                   0x0000    0x0001
+            // Roller Shutter       1         3
+            // Window Blind         2         3
+            // Light Switch         4         3
+
+            // Configure device as dual switch.
+            // Device will perform a rejoin after this write
+            await device.getEndpoint(1).write(0xfca0, {0x0000: {value: 0x04, type: 0x30}, 0x0001: {value: 0x03, type: 0x30}});
+
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+        },
+    };
+
 ];
 
 module.exports = definition;

--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -4,6 +4,7 @@ const fz = require('../converters/fromZigbee');
 const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
 const utils = require('../lib/utils');
+const extend = require('../lib/extend');
 const constants = require('../lib/constants');
 const ota = require('../lib/ota');
 const e = exposes.presets;
@@ -749,7 +750,6 @@ const definition = [
         },
         meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
-
             // Configuration values:
             //                   0x0000    0x0001
             // Roller Shutter       1         3
@@ -763,8 +763,7 @@ const definition = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
         },
-    };
-
+    },
 ];
 
 module.exports = definition;


### PR DESCRIPTION
I could briefly get my hands on a [Bosch BMCT-SLZ Light/Shutter Control II] (https://www.bosch-smarthome.com/uk/en/products/devices/light-shutter-control/).

This device is a little bit tricky, because it supports two different operation modes: Light Control and Roller Shutter. After the initial join, the device expects a configuration message (see comments in the code). When it receives that message, the device leaves, and rejoins either as a switch or roller shutter.
I did not find another example of a device with two different operation modes, so I only set it up as a 2-channel switch now. Switching and reporting the on/off state works, additional features such as power metering, child lock etc. are not supported yet.

