### PR TITLE
Fix action/operation_mode for Niko 552-721X2

### DIFF
--- a/devices/niko.js
+++ b/devices/niko.js
@@ -36,12 +36,12 @@ const local = {
                         48: 'release',
                     } : {
                         16: null,
-                        64: 'left_single',
-                        32: 'left_hold',
-                        48: 'left_release',
-                        4096: 'right_single',
-                        8192: 'right_hold',
-                        12288: 'right_release',
+                        64: 'single_left',
+                        32: 'hold_left',
+                        48: 'release_left',
+                        4096: 'single_right',
+                        8192: 'hold_right',
+                        12288: 'release_right',
                     };
 
                     state['action'] = actionMap[msg.data.switchAction];
@@ -292,8 +292,8 @@ module.exports = [
         exposes: [
             e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
             e.action([
-                'left_single', 'left_hold', 'left_release',
-                'right_single', 'right_hold', 'right_release',
+                'single_left', 'hold_left', 'release_left',
+                'single_right', 'hold_right', 'release_right',
             ]),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']),
             exposes.binary('led_enable', ea.ALL, true, false).withEndpoint('l1').withDescription('Enable LED'),

--- a/devices/niko.js
+++ b/devices/niko.js
@@ -29,9 +29,22 @@ const local = {
                 if (msg.data.hasOwnProperty('switchAction')) {
                     // NOTE: a single press = two seperate values reported, 16 followed by 64
                     //       a hold/release cyle = three seperate values, 16, 32, and 48
-                    const actionProperty = `action${meta.endpoint_name ? `_${meta.endpoint_name}` : ''}`;
-                    const actionMap = {16: null, 64: 'single', 32: 'hold', 48: 'release'};
-                    state[actionProperty] = actionMap[msg.data.switchAction];
+                    const actionMap = (model.model == '552-721X1') ? {
+                        16: null,
+                        64: 'single',
+                        32: 'hold',
+                        48: 'release',
+                    } : {
+                        16: null,
+                        64: 'left_single',
+                        32: 'left_hold',
+                        48: 'left_release',
+                        4096: 'right_single',
+                        8192: 'right_hold',
+                        12288: 'right_release',
+                    };
+
+                    state['action'] = actionMap[msg.data.switchAction];
                 }
                 return state;
             },
@@ -272,8 +285,10 @@ module.exports = [
         },
         exposes: [
             e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
-            e.action(['single', 'hold', 'release']).withEndpoint('l1'),
-            e.action(['single', 'hold', 'release']).withEndpoint('l2'),
+            e.action([
+                'left_single', 'left_hold', 'left_release',
+                'right_single', 'right_hold', 'right_release',
+            ]),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']).withEndpoint('l1'),
             exposes.enum('operation_mode', ea.ALL, ['control_relay', 'decoupled']).withEndpoint('l2'),
             exposes.binary('led_enable', ea.ALL, true, false).withEndpoint('l1').withDescription('Enable LED'),


### PR DESCRIPTION
Fixes:
- koenkk/zigbee2mqtt#13737
- koenkk/zigbee2mqtt#17346

actionMap was extended and expose updates so everything ends up under `action` as expected, also fixed operation_mode as it could only be set on l1 and effected both relays, with multiEndpointEnforce meta we can now also fix this.

