### PR TITLE
fix(namron-4512737/4512738): remove `occupancy` reporting attribute

### DIFF
--- a/devices/namron.js
+++ b/devices/namron.js
@@ -481,13 +481,6 @@ module.exports = [
             await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatKeypadLockMode(endpoint);
 
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: 'occupancy',
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null,
-            }]);
-
             // Metering
             await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
             await endpoint.read('haElectricalMeasurement', ['acCurrentDivisor']);


### PR DESCRIPTION
After the new firmware upgrade for this device, the occupancy/away_mode issue has been fixed and this attribute is there for removed from the device.
The device will not configure itself correctly without this code change after the new firmware.

Firmware PR: https://github.com/Koenkk/zigbee-OTA/pull/294