### PR TITLE
Add a converter for TLW Global K10-1220Z Smart LED Dimmer

### DIFF
--- a/devices/tlwglobal.js
+++ b/devices/tlwglobal.js
@@ -21,18 +21,18 @@ module.exports = [
         extend: extend.light_onoff_brightness(),
     },
     // K10-1230Z and K10-1250Z untested, but assumed to be consistent with K10-1220W
-    //{
-    //    zigbeeModel: ['K10-1230Z'],
-    //    model: 'K10-1230Z',
-    //    vendor: 'TLW Global',
-    //    description: '12V LED smart driver 30W with 6-port micro plug connector',
-    //    extend: extend.light_onoff_brightness(),
-    //},
-    //{
-    //    zigbeeModel: ['K10-1250Z'],
-    //    model: 'K10-1250Z',
-    //    vendor: 'TLW Global',
-    //    description: '12V LED smart driver 50W with 6-port micro plug connector',
-    //    extend: extend.light_onoff_brightness(),
-    //},
+    {
+        zigbeeModel: ['K10-1230Z'],
+        model: 'K10-1230Z',
+        vendor: 'TLW Global',
+        description: '12V LED smart driver 30W with 6-port micro plug connector',
+        extend: extend.light_onoff_brightness(),
+    },
+    {
+        zigbeeModel: ['K10-1250Z'],
+        model: 'K10-1250Z',
+        vendor: 'TLW Global',
+        description: '12V LED smart driver 50W with 6-port micro plug connector',
+        extend: extend.light_onoff_brightness(),
+    },
 ];

--- a/devices/tlwglobal.js
+++ b/devices/tlwglobal.js
@@ -1,17 +1,7 @@
-const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
-const tz = require('zigbee-herdsman-converters/converters/toZigbee');
-const exposes = require('zigbee-herdsman-converters/lib/exposes');
-const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
-const ota = require('zigbee-herdsman-converters/lib/ota');
-const tuya = require('zigbee-herdsman-converters/lib/tuya');
-const utils = require('zigbee-herdsman-converters/lib/utils');
-const globalStore = require('zigbee-herdsman-converters/lib/store');
-const e = exposes.presets;
-const ea = exposes.access;
+const extend = require('../lib/extend');
 
 module.exports = [
-    // Tested working with firmare 2.5.3_r58: dimming, on/off, and effects give no 
+    // Tested working with firmare 2.5.3_r58: dimming, on/off, and effects give no
     // errors (although the stop effect and the finish effect do nothing).
     {
         zigbeeModel: ['K10-1220Z'],

--- a/devices/tlwglobal.js
+++ b/devices/tlwglobal.js
@@ -1,0 +1,38 @@
+const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
+const tz = require('zigbee-herdsman-converters/converters/toZigbee');
+const exposes = require('zigbee-herdsman-converters/lib/exposes');
+const reporting = require('zigbee-herdsman-converters/lib/reporting');
+const extend = require('zigbee-herdsman-converters/lib/extend');
+const ota = require('zigbee-herdsman-converters/lib/ota');
+const tuya = require('zigbee-herdsman-converters/lib/tuya');
+const utils = require('zigbee-herdsman-converters/lib/utils');
+const globalStore = require('zigbee-herdsman-converters/lib/store');
+const e = exposes.presets;
+const ea = exposes.access;
+
+module.exports = [
+    // Tested working with firmare 2.5.3_r58: dimming, on/off, and effects give no 
+    // errors (although the stop effect and the finish effect do nothing).
+    {
+        zigbeeModel: ['K10-1220Z'],
+        model: 'K10-1220Z',
+        vendor: 'TLW Global',
+        description: '12V LED smart driver 15W with 6-port micro plug connector',
+        extend: extend.light_onoff_brightness(),
+    },
+    // K10-1230Z and K10-1250Z untested, but assumed to be consistent with K10-1220W
+    //{
+    //    zigbeeModel: ['K10-1230Z'],
+    //    model: 'K10-1230Z',
+    //    vendor: 'TLW Global',
+    //    description: '12V LED smart driver 30W with 6-port micro plug connector',
+    //    extend: extend.light_onoff_brightness(),
+    //},
+    //{
+    //    zigbeeModel: ['K10-1250Z'],
+    //    model: 'K10-1250Z',
+    //    vendor: 'TLW Global',
+    //    description: '12V LED smart driver 50W with 6-port micro plug connector',
+    //    extend: extend.light_onoff_brightness(),
+    //},
+];


### PR DESCRIPTION
I bought a K10-1220Z Smart LED driver on eBay and it required this converter to make it work. 

- The K10-1220Z has a button concealed under a flap labelled "Prog" . Long pressing it causes the device to send a status message.
- Switch the device off and then on three times to enter pairing mode.
- The Stop and Finished effects do nothing

K10-1220Z [12V 15W Zigbee Smart LED Driver With 6-Port Micro Plug Connector (tlwglobal.com)](https://www.tlwglobal.com/product/smart-driver-12v-led-smart-driver-15w-with-6-port-micro-plug-connector/)

These two higher-power drivers from the same vendor are also enabled with the assumption that the model ID string matches the vendor website: 
K10-1230Z [12V 30W Zigbee Smart LED Driver With 6-Port Micro Plug Connector (tlwglobal.com)](https://www.tlwglobal.com/product/smart-driver-12v-led-smart-driver-30w-with-6-port-micro-plug-connector/)
K10-1250Z [12V 50W Zigbee Smart LED Driver With 6-Port Micro Plug Connector (tlwglobal.com)](https://www.tlwglobal.com/product/smart-driver-12v-led-smart-driver-50w-with-6-port-micro-plug-connector/#)