### PR TITLE
Add Keypad Action Reporting and Keypad lock feature for Sinope Switch SW2500ZB

### DIFF
--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -181,11 +181,11 @@ const fzLocal = {
             }
             if (msg.data.hasOwnProperty('actionReport')) {
                 const lookup = {2: 'key_up_pressed', 3: 'key_up_held', 4: 'key_up_pressed2x',
-                18: 'key_dn_pressed', 19: 'key_dn_held', 20: 'key_dn_pressed2x'};
+                    18: 'key_dn_pressed', 19: 'key_dn_held', 20: 'key_dn_pressed2x'};
                 result.action_report = lookup[msg.data['actionReport']];
             }
             if (msg.data.hasOwnProperty('keypadLockout')) {
-                const lookup = {0: 'unlock',1: 'lock'};
+                const lookup = {0: 'unlock', 1: 'lock'};
                 result.keypad_lockout = lookup[msg.data['keypadLockout']];
             }
             return result;
@@ -486,8 +486,8 @@ const tzLocal = {
         // SW2500ZB
         key: ['keypad_lockout'],
         convertSet: async (entity, key, value, meta) => {
-                const lookup = {'unlock': 0, 'lock': 1};
-                await entity.write('manuSpecificSinope', {keypadLockout: lookup[value]});
+            const lookup = {'unlock': 0, 'lock': 1};
+            await entity.write('manuSpecificSinope', {keypadLockout: lookup[value]});
             return {state: {keypad_lockout: value}};
         },
         convertGet: async (entity, key, meta) => {
@@ -995,9 +995,9 @@ module.exports = [
         toZigbee: [tz.on_off, tzLocal.timer_seconds, tzLocal.led_intensity_on, tzLocal.led_intensity_off,
             tzLocal.led_color_on, tzLocal.led_color_off, tzLocal.keypad_lock],
         exposes: [e.switch(),
-            exposes.enum('action_report',ea.STATE,['key_up_pressed', 'key_up_pressed2x', 'key_up_held',
-                    'key_dn_pressed', 'key_dn_pressed2x', 'key_dn_held'])
-                    .withDescription('Triggered action (e.g. a button click)'),
+            exposes.enum('action_report', ea.STATE, ['key_up_pressed', 'key_up_pressed2x', 'key_up_held',
+                'key_dn_pressed', 'key_dn_pressed2x', 'key_dn_held'])
+                .withDescription('Triggered action (e.g. a button click)'),
             exposes.numeric('timer_seconds', ea.ALL).withValueMin(0).withValueMax(10800)
                 .withDescription('Automatically turn off load after x seconds'),
             exposes.numeric('led_intensity_on', ea.ALL).withValueMin(0).withValueMax(100)
@@ -1026,7 +1026,7 @@ module.exports = [
                 minimumReportInterval: 0,
                 maximumReportInterval: 0,
                 reportableChange: 0,
-                }];
+            }];
             await endpoint.configureReporting('manuSpecificSinope', payload);
         },
     },

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -182,7 +182,7 @@ const fzLocal = {
             if (msg.data.hasOwnProperty('actionReport')) {
                 const lookup = {2: 'up_single', 3: 'up_hold', 4: 'up_double',
                     18: 'down_single', 19: 'down_hold', 20: 'down_double'};
-                result.action_report = lookup[msg.data['actionReport']];
+                result.action = lookup[msg.data['actionReport']];
             }
             if (msg.data.hasOwnProperty('keypadLockout')) {
                 const lookup = {0: 'unlock', 1: 'lock'};
@@ -995,9 +995,7 @@ module.exports = [
         toZigbee: [tz.on_off, tzLocal.timer_seconds, tzLocal.led_intensity_on, tzLocal.led_intensity_off,
             tzLocal.led_color_on, tzLocal.led_color_off, tzLocal.keypad_lock],
         exposes: [e.switch(),
-            exposes.enum('action_report', ea.STATE, ['up_single', 'up_double', 'up_hold',
-                'down_single', 'down_double', 'down_hold'])
-                .withDescription('Triggered action (e.g. a button click)'),
+            e.action(['up_single', 'up_double', 'up_hold', 'down_single', 'down_double', 'down_hold']),
             exposes.numeric('timer_seconds', ea.ALL).withValueMin(0).withValueMax(10800)
                 .withDescription('Automatically turn off load after x seconds'),
             exposes.numeric('led_intensity_on', ea.ALL).withValueMin(0).withValueMax(100)

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -995,7 +995,7 @@ module.exports = [
         toZigbee: [tz.on_off, tzLocal.timer_seconds, tzLocal.led_intensity_on, tzLocal.led_intensity_off,
             tzLocal.led_color_on, tzLocal.led_color_off, tzLocal.keypad_lock],
         exposes: [e.switch(),
-            exposes.enum('action_report',ea.STATE,['up_single', 'up_double', 'up_hold',
+            exposes.enum('action_report', ea.STATE, ['up_single', 'up_double', 'up_hold',
                 'down_single', 'down_double', 'down_hold'])
                 .withDescription('Triggered action (e.g. a button click)'),
             exposes.numeric('timer_seconds', ea.ALL).withValueMin(0).withValueMax(10800)

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -180,8 +180,8 @@ const fzLocal = {
                 result.minimum_brightness = msg.data['minimumBrightness'];
             }
             if (msg.data.hasOwnProperty('actionReport')) {
-                const lookup = {2: 'key_up_pressed', 3: 'key_up_held', 4: 'key_up_pressed2x',
-                    18: 'key_dn_pressed', 19: 'key_dn_held', 20: 'key_dn_pressed2x'};
+                const lookup = {2: 'up_single', 3: 'up_hold', 4: 'up_double',
+                    18: 'down_single', 19: 'down_hold', 20: 'down_double'};
                 result.action_report = lookup[msg.data['actionReport']];
             }
             if (msg.data.hasOwnProperty('keypadLockout')) {
@@ -995,8 +995,8 @@ module.exports = [
         toZigbee: [tz.on_off, tzLocal.timer_seconds, tzLocal.led_intensity_on, tzLocal.led_intensity_off,
             tzLocal.led_color_on, tzLocal.led_color_off, tzLocal.keypad_lock],
         exposes: [e.switch(),
-            exposes.enum('action_report', ea.STATE, ['key_up_pressed', 'key_up_pressed2x', 'key_up_held',
-                'key_dn_pressed', 'key_dn_pressed2x', 'key_dn_held'])
+            exposes.enum('action_report',ea.STATE,['up_single', 'up_double', 'up_hold',
+                'down_single', 'down_double', 'down_hold'])
                 .withDescription('Triggered action (e.g. a button click)'),
             exposes.numeric('timer_seconds', ea.ALL).withValueMin(0).withValueMax(10800)
                 .withDescription('Automatically turn off load after x seconds'),


### PR DESCRIPTION
The Sinope Switch SW2500ZB can report keypad actions (clicks) single, double, hold (or long) press, up and down.  This function can be used to trigger automation or to call scenes.

It is also possible to disable (lock) the keypad.  In the lock configuration, the switch no longer controle the load.  Keypad actions are still reported.

The modifications add these 2 features.

Note: this is my first pull request.  I appologize in advance if I'm not doing it the right way.