### PR TITLE
Support for Philips Hue - Xamento Hue

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -620,7 +620,7 @@ module.exports = [
         extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
     },
     {
-        zigbeeModel: ['LCG002', '929003047701', '929003047701', '929003526202_01', '929003526202_02', '929003526202_03'],
+        zigbeeModel: ['LCG002', '929003047701', '929003047701', '929003526202_01', '929003526202_02', '929003526202_03', '929003526101'],
         model: '929001953101',
         vendor: 'Philips',
         description: 'Hue White and Color Ambiance GU10',


### PR DESCRIPTION
The device added is a single packaged device (Philips Hue - Xamento Hue recessed black) which is the same as the one from the package with three lights ('929003526202_01', '929003526202_02', '929003526202_03').

I own all four of the devices and the change proposed enables my last bulb :)