### PR TITLE
Allow for different definition model, vendor and description based on whitelabel

### DIFF
--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -785,16 +785,6 @@ module.exports = [
         },
     },
     {
-        fingerprint: [{modelID: 'TS0502A', manufacturerName: '_TZ3000_oborybow'}],
-        model: 'HG06492B',
-        vendor: 'Lidl',
-        description: 'Livarno Lux E14 candle CCT',
-        extend: tuya.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500], noConfigure: true}),
-        configure: async (device, coordinatorEndpoint, logger) => {
-            device.getEndpoint(1).saveClusterAttributeKeyValue('lightingColorCtrl', {colorCapabilities: 16});
-        },
-    },
-    {
         fingerprint: [{modelID: 'TS0502A', manufacturerName: '_TZ3000_49qchf10'}],
         model: 'HG06492C',
         vendor: 'Lidl',

--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -1690,7 +1690,13 @@ module.exports = [
         model: 'TS0502A',
         vendor: 'TuYa',
         description: 'Light controller',
-        extend: tuya.extend.light_onoff_brightness_colortemp(),
+        extend: tuya.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500], noConfigure: true}),
+        whiteLabel: [
+            tuya.whitelabel('Lidl', 'HG06492B', 'Livarno Lux E14 candle CCT', ['_TZ3000_oborybow']),
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            device.getEndpoint(1).saveClusterAttributeKeyValue('lightingColorCtrl', {colorCapabilities: 16});
+        },
     },
     {
         zigbeeModel: ['TS0502B'],

--- a/index.js
+++ b/index.js
@@ -131,6 +131,22 @@ function findByZigbeeModel(zigbeeModel) {
 }
 
 function findByDevice(device) {
+    let definition = findDefintion(device);
+    if (definition && definition.whiteLabel) {
+        const match = definition.whiteLabel.find((w) => w.fingerprint && w.fingerprint.find((f) => isFingerprintMatch(f, device)));
+        if (match) {
+            definition = {
+                ...definition,
+                model: match.model,
+                vendor: match.vendor,
+                description: match.description || definition.description,
+            };
+        }
+    }
+    return definition;
+}
+
+function findDefintion(device) {
     if (!device) {
         return null;
     }

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1179,6 +1179,13 @@ const fingerprint = (modelID, manufacturerNames) => {
     });
 };
 
+const whitelabel = (vendor, model, description, manufacturerNames) => {
+    const fingerprint = manufacturerNames.map((manufacturerName) => {
+        return {manufacturerName};
+    });
+    return {vendor, model, description, fingerprint};
+};
+
 class Base {
     constructor(value) {
         this.value = value;
@@ -1973,6 +1980,7 @@ module.exports = {
     skip,
     configureMagicPacket,
     fingerprint,
+    whitelabel,
     enum: (value) => new Enum(value),
     bitmap: (value) => new Bitmap(value),
     valueConverter,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -287,7 +287,7 @@ describe('index.js', () => {
             if (device.whiteLabel) {
                 for (const whiteLabel of device.whiteLabel) {
                     verifyKeys(['vendor', 'model'], Object.keys(whiteLabel), `whitelabel-of-${device.model}`);
-                    containsOnly(['vendor', 'model', 'description', 'fingerprint'], Object.keys(definition));
+                    containsOnly(['vendor', 'model', 'description', 'fingerprint'], Object.keys(whiteLabel));
                     if (whiteLabel.fingerprint && foundModels.includes(whiteLabel.model.toLowerCase())) {
                         throw new Error(`Duplicate whitelabel zigbee model ${whiteLabel.model}`)
                     }


### PR DESCRIPTION
**Problem**

Currently there is a lot of definition (code) duplication between different TuYa devices.

e.g. the Lidl HG06492B 
https://github.com/Koenkk/zigbee-herdsman-converters/blob/1413d092d8babf7f1f6fa6f9fd13afd7977b08da/devices/lidl.js#L788

is functionally the same as TuYa TS0502A

https://github.com/Koenkk/zigbee-herdsman-converters/blob/1413d092d8babf7f1f6fa6f9fd13afd7977b08da/devices/tuya.js#L1689

but with a different `vendor`/`description`/`model` value. This is done in order to generate a separate supported device page (zigbee2mqtt.io) and to show the correct vendor/description/model and picture (since that is based on the model) in the logging/discovery and frontend.

**Solution**
Override the definition model/vendor/description with the one from the whitelabel. To determine wether a whitelabel matches the device, the `fingerprint` property of the whitelabel is checked against the device. The `fingerprint` property is optional. This is because there are a lot of whitelabels already and we don't have all the information to define the missing fingerprints right now.