### PR TITLE
Adding AC frequency to Develco SPLZB-131

### DIFF
--- a/devices/develco.js
+++ b/devices/develco.js
@@ -292,7 +292,7 @@ module.exports = [
         description: 'Power plug',
         fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
         toZigbee: [tz.on_off],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
@@ -303,6 +303,7 @@ module.exports = [
             await reporting.rmsVoltage(endpoint);
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint);
+            await reporting.acFrequency(endpoint);
         },
         endpoint: (device) => {
             return {default: 2};


### PR DESCRIPTION
As a new contributor, I'm hoping that I'm in the right direction for creating a pull request. 

The SPLZB-131 does support Ac Frequency measurements. I've locally changed the device in the code. Hope that this will be sufficient to make the change persistent. 
```
{"ac_frequency":49960,"current":1.23,"energy":0.33,"linkquality":36,"power":207,"state":"ON","voltage":226.75}
```

If I'm not doing this correctly, please make me aware of that. 

- Ramon