### PR TITLE
Support Lidl / Parkside watering timer

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -2632,12 +2632,6 @@ const converters = {
             }
         },
     },
-    lidl_watering_timer: {
-        key: ['timer'],
-        convertSet: async (entity, key, value, meta) => {
-            await tuya.sendDataPointRaw(entity, tuya.dataPoints.lidlTimer, tuya.convertDecimalValueTo4ByteHexArray(value));
-        },
-    },
     matsee_garage_door_opener: {
         key: ['trigger'],
         convertSet: async (entity, key, value, meta) => {

--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -202,7 +202,6 @@ const fzLocal = {
                     // time slot execution is already completed
                     Date.now() > maximumEndTime ||
                     // scheduling was interrupted by turning watering on manually
-                    // TODO verify that this statement still works in this minimal converter
                     (reportedState === 'ON' && reportedState != meta.state.state && meta.state.time_left > 0)
                 ) {
                     // reporting is no longer necessary

--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -830,8 +830,15 @@ module.exports = [
         model: 'PSBZS A1',
         vendor: 'Lidl',
         description: 'Parkside smart watering timer',
-        fromZigbee: [fz.ignore_basic_report, fz.ignore_tuya_set_time, fz.ignore_onoff_report, tuya.fz.datapoints, fz.watering_time_left],
-        toZigbee: [tz.on_off, tz.lidl_watering_timer],
+        fromZigbee: [fz.ignore_basic_report, fz.ignore_tuya_set_time, fz.ignore_onoff_report, tuya.fz.datapoints, fzLocal.watering_time_left],
+        toZigbee: [
+            {
+                ...tuya.tz.datapoints,
+                key: ['state', 'timer', 'reset_frost_lock', 'schedule_periodic', 'schedule_weekday',
+                    ...[1, 2, 3, 4, 5, 6].map((timeSlotNumber) => `schedule_slot_${timeSlotNumber}`),
+                ],
+            },
+        ],
         onEvent: async (type, data, device) => {
             await tuya.onEventSetLocalTime(type, data, device);
 

--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -187,7 +187,7 @@ const fzLocal = {
                         timer: timeslot.timer,
                         pause: timeslot.pause,
                         iteration_duration: timeslot.timer + timeslot.pause,
-                        iterations: Math.max(timeslot.iterations, 1),
+                        iterations: timeslot.iterations,
                         iteration_report: false, // will be set in the next step
                         iteration_timestamp: 0, // will be set in the next step
                     });
@@ -605,11 +605,11 @@ const valueConverterLocal = {
         from: (buffer) => {
             return {
                 state: buffer.readUInt8(0) === 1 ? 'ON' : 'OFF',
-                start_hour: utils.numberWithinRange(buffer.readUInt8(1), 0, 23), // device reports 255 initially when timeslot was never used before
-                start_minute: utils.numberWithinRange(buffer.readUInt8(2), 0, 59), // device reports 255 initially when timeslot was never used before
-                timer: buffer.readUInt8(3) * 60 + buffer.readUInt8(4),
-                pause: buffer.readUInt8(6) * 60 + buffer.readUInt8(7),
-                iterations: buffer.readUInt8(9),
+                start_hour: utils.numberWithinRange(buffer.readUInt8(1), 0, 23), // device reports non-valid value 255 initially
+                start_minute: utils.numberWithinRange(buffer.readUInt8(2), 0, 59), // device reports non-valid value 255 initially
+                timer: utils.numberWithinRange(buffer.readUInt8(3) * 60 + buffer.readUInt8(4), 1, 599), // device reports non-valid value 0 initially
+                pause: utils.numberWithinRange(buffer.readUInt8(6) * 60 + buffer.readUInt8(7), 0, 599),
+                iterations: utils.numberWithinRange(buffer.readUInt8(9), 1, 9), // device reports non-valid value 0 initially
             };
         },
         to: (value, meta) => {
@@ -626,7 +626,7 @@ const valueConverterLocal = {
             if (!utils.isInRange(0, 23, startHour)) throw new Error(`Invalid start hour value ${startHour} (expected ${0} to ${23})`);
             if (!utils.isInRange(0, 59, startMinute)) throw new Error(`Invalid start minute value: ${startMinute} (expected ${0} to ${59})`);
             if (!utils.isInRange(1, 599, duratonInMin)) throw new Error(`Invalid timer value: ${duratonInMin} (expected ${1} to ${599})`);
-            if (!utils.isInRange(1, 599, iterations)) throw new Error(`Invalid iterations value: ${iterations} (expected ${1} to ${599})`);
+            if (!utils.isInRange(1, 9, iterations)) throw new Error(`Invalid iterations value: ${iterations} (expected ${1} to ${9})`);
             if (!utils.isInRange(0, 599, pauseInMin)) throw new Error(`Invalid pause value: ${pauseInMin} (expected ${0} to ${599})`);
             if (iterations > 1 && pauseInMin === 0) throw new Error(`Pause value must be at least 1 minute when using multiple iterations`);
 

--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -551,7 +551,7 @@ const tzLocal = {
 };
 
 const valueConverterLocal = {
-    resetFrostGuard: {
+    resetFrostLock: {
         to: (value) => {
             utils.validateValue(value, ['RESET']);
             return 0;
@@ -871,15 +871,15 @@ module.exports = [
                 .withUnit('min')
                 .withDescription('Remaining time until the watering turns off.'),
             exposes
-                .binary('frost_guard', ea.STATE, 'ON', 'OFF')
+                .binary('frost_lock', ea.STATE, 'ON', 'OFF')
                 .withDescription(
                     'Indicates if the frost guard is currently active. ' +
                     'If the temperature drops below 5° C, device activates frost guard and disables irrigation. ' +
                     'You need to reset the frost guard to activate irrigation again. Note: There is no way to enable frost guard manually.',
                 ),
             exposes
-                .enum('reset_frost_guard', ea.SET, ['RESET'])
-                .withDescription('Resets frost_guard to make the device workable again.'),
+                .enum('reset_frost_lock', ea.SET, ['RESET'])
+                .withDescription('Resets frost lock to make the device workable again.'),
             exposes
                 .enum('schedule_mode', ea.STATE, ['OFF', 'WEEKDAY', 'PERIODIC'])
                 .withDescription('Scheduling mode that is currently in use.'),
@@ -954,9 +954,9 @@ module.exports = [
                 [5, 'timer', tuya.valueConverter.raw],
                 [6, 'time_left', tuya.valueConverter.raw],
                 [11, 'battery', tuya.valueConverter.raw],
-                [108, 'frost_guard', tuya.valueConverter.onOff],
+                [108, 'frost_lock', tuya.valueConverter.onOff],
                 // there is no state reporting for reset
-                [109, 'reset_frost_guard', valueConverterLocal.resetFrostGuard, {optimistic: false}],
+                [109, 'reset_frost_lock', valueConverterLocal.resetFrostLock, {optimistic: false}],
                 [107, null, valueConverterLocal.scheduleMode],
                 [107, 'schedule_periodic', valueConverterLocal.schedulePeriodic],
                 [107, 'schedule_weekday', valueConverterLocal.scheduleWeekday],

--- a/devices/lidl.js
+++ b/devices/lidl.js
@@ -150,6 +150,7 @@ const fzLocal = {
             // Setup workaround for time_left reporting
             // Background: Device reports the real time_left value only on manual watering
             // for scheduled watering it will report just '0' in the beginning and at the end
+            // Note: this procedure relies on the continuous reporting every minute
             const result = {};
             let reportedState = undefined;
 
@@ -550,13 +551,13 @@ const tzLocal = {
 };
 
 const valueConverterLocal = {
-    resetFrostLock: {
+    wateringResetFrostLock: {
         to: (value) => {
             utils.validateValue(value, ['RESET']);
             return 0;
         },
     },
-    scheduleMode: {
+    wateringScheduleMode: {
         from: (value) => {
             const [scheduleMode, scheduleValue] = value;
             const isWeekday = scheduleMode === 0;
@@ -576,7 +577,7 @@ const valueConverterLocal = {
             };
         },
     },
-    schedulePeriodic: {
+    wateringSchedulePeriodic: {
         to: (value) => {
             if (!utils.isInRange(0, 7, value)) throw new Error(`Invalid value: ${value} (expected ${0} to ${7})`);
             // Note: mode value of 0 switches to disabled weekday scheduler
@@ -584,7 +585,7 @@ const valueConverterLocal = {
             return [scheduleMode, value];
         },
     },
-    scheduleWeekday: {
+    wateringScheduleWeekday: {
         to: (value, meta) => {
             // map each day to ON/OFF and use current state as default to allow partial updates
             const dayValues = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
@@ -600,7 +601,7 @@ const valueConverterLocal = {
             return [scheduleMode, scheduleValue];
         },
     },
-    scheduleSlot: (timeSlotNumber) => ({
+    wateringScheduleSlot: (timeSlotNumber) => ({
         from: (buffer) => {
             return {
                 state: buffer.readUInt8(0) === 1 ? 'ON' : 'OFF',
@@ -961,16 +962,16 @@ module.exports = [
                 [11, 'battery', tuya.valueConverter.raw],
                 [108, 'frost_lock', tuya.valueConverter.onOff],
                 // there is no state reporting for reset
-                [109, 'reset_frost_lock', valueConverterLocal.resetFrostLock, {optimistic: false}],
-                [107, null, valueConverterLocal.scheduleMode],
-                [107, 'schedule_periodic', valueConverterLocal.schedulePeriodic],
-                [107, 'schedule_weekday', valueConverterLocal.scheduleWeekday],
-                [101, 'schedule_slot_1', valueConverterLocal.scheduleSlot(1)],
-                [102, 'schedule_slot_2', valueConverterLocal.scheduleSlot(2)],
-                [103, 'schedule_slot_3', valueConverterLocal.scheduleSlot(3)],
-                [104, 'schedule_slot_4', valueConverterLocal.scheduleSlot(4)],
-                [105, 'schedule_slot_5', valueConverterLocal.scheduleSlot(5)],
-                [106, 'schedule_slot_6', valueConverterLocal.scheduleSlot(6)],
+                [109, 'reset_frost_lock', valueConverterLocal.wateringResetFrostLock, {optimistic: false}],
+                [107, null, valueConverterLocal.wateringScheduleMode],
+                [107, 'schedule_periodic', valueConverterLocal.wateringSchedulePeriodic],
+                [107, 'schedule_weekday', valueConverterLocal.wateringScheduleWeekday],
+                [101, 'schedule_slot_1', valueConverterLocal.wateringScheduleSlot(1)],
+                [102, 'schedule_slot_2', valueConverterLocal.wateringScheduleSlot(2)],
+                [103, 'schedule_slot_3', valueConverterLocal.wateringScheduleSlot(3)],
+                [104, 'schedule_slot_4', valueConverterLocal.wateringScheduleSlot(4)],
+                [105, 'schedule_slot_5', valueConverterLocal.wateringScheduleSlot(5)],
+                [106, 'schedule_slot_6', valueConverterLocal.wateringScheduleSlot(6)],
             ],
         },
     },

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -624,7 +624,6 @@ const dataPoints = {
     // Tuya CO (carbon monoxide) smart air box
     tuyaSabCOalarm: 1,
     tuyaSabCO: 2,
-    lidlTimer: 5,
     // Moes MS-105 Dimmer
     moes105DimmerState1: 1,
     moes105DimmerLevel1: 2,

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1251,6 +1251,12 @@ const valueConverter = {
     divideBy10: valueConverterBasic.divideBy(10),
     divideBy1000: valueConverterBasic.divideBy(1000),
     raw: valueConverterBasic.raw(),
+    range: (min, max) => {
+        return {
+            to: (v) => utils.numberWithinRange(v, min, max),
+            from: (v) => utils.numberWithinRange(v, min, max),
+        };
+    },
     setLimit: {
         to: (v) => {
             if (!v) throw new Error('Limit cannot be unset, use factory_reset');

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1686,6 +1686,9 @@ const tuyaTz = {
                 } else {
                     throw new Error(`Don't know how to send type '${typeof convertedValue}'`);
                 }
+
+                if (dpEntry[3] && dpEntry[3].optimistic === false) continue;
+
                 state[key] = value;
             }
             return {state};

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1253,8 +1253,11 @@ const valueConverter = {
     raw: valueConverterBasic.raw(),
     range: (min, max) => {
         return {
-            to: (v) => utils.numberWithinRange(v, min, max),
-            from: (v) => utils.numberWithinRange(v, min, max),
+            to: (v) => {
+                if (!utils.isInRange(min, max, v)) throw new Error(`Value of ${v} is outside of expected range from ${min} to ${max}`);
+                return v;
+            },
+            from: (v) => v,
         };
     },
     setLimit: {


### PR DESCRIPTION
This adds full support for the lidl watering timer as requested in Koenkk/zigbee2mqtt#7695. Tuya dp converter format is used when possible.

Tested locally with npm link against the latest zigbee2mqtt:
- [x] on/off
- [x] timer
- [x] reporting of time left (manual watering + scheduled watering)
- [x] battery
- [x] time sync
- [x] scheduling / time slot config (even partial configs are possible to simplify creation of custom mqtt entities in HA)
- [x] frost lock

Open tasks (won't fix):
- prevention of overlapping time slot configurations (e.g. due to iterations + pause) 
  - device skips/ignores overlapping time slots, only the first one wins
  - reporting will be correct for the active slot (on/off, time left) 


This it how it looks like:
![image](https://user-images.githubusercontent.com/8046231/235747237-93fb7220-638d-47f3-a7b2-1073a9d4028d.png)


Btw while testing I discovered that the initial reporting of the device was unreliable in my production setup, but worked pretty good in my new dev setup. In my previous converter I got around this with a delay of one second before sending the tuya magic, but this doesn't help always.
The only real difference in my setup between dev and production was the used firmware. Since I updated the firmware in my production environment as well, the initial reporting seems to be working pretty solid, too.
- bumped cc2652p coordinator from 20220103 to 20221226
- bumped cc2652p router from 20220125 to 20221102 


<details>
<summary>Info: data restrictions by the original gateway</summary>

**Note:** Device may accepts higher values or invalid for some of these, but the following are the officially used ones.

- Timer: 1 - 599 min
- Scheduler: weekday (monday to sunday), periodic (every 1 -7 days) or disabled
- Timeslot (1  - 6):
  - start hour: 0 - 23 (255 seems to be reported for never used slots, but it's technically invalid)
  - start minute: 0 - 59 (255 seems to be reported for never used slots, but it's technically invalid)
  - timer: 1 - 599 min (0 seems to be reported for never used slots, but it's technically invalid)
  - pause: 0 - 599
  - iterations: 1 - 9 (0 seems to be reported for never used slots, but it's technically invalid)



</details>