### PR TITLE
added manufacturerName for known device TZE204_xxx

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -2518,6 +2518,7 @@ module.exports = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_3ylew7b4'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_llm0epxg'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_n1aauwb4'},
+            {modelID: 'TS0601', manufacturerName: '_TZE204_sxm7l9xa'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_xu4a5rhj'},
             {modelID: 'TS0601', manufacturerName: '_TZE204_r0jdjrvi'},
         ],


### PR DESCRIPTION
This TuYa presence sensor comes with a variety of different `manufacturerName` entries. I have stumbled over another one and added it to the list. 