### PR TITLE
Develco SPLZB-131: power_reactive (VAR) reading

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -778,6 +778,7 @@ const converters = {
                 {key: 'activePowerPhB', name: 'power_phase_b', factor: 'acPower'},
                 {key: 'activePowerPhC', name: 'power_phase_c', factor: 'acPower'},
                 {key: 'apparentPower', name: 'power_apparent', factor: 'acPower'},
+                {key: 'reactivePower', name: 'power_reactive', factor: 'acPower'},
                 {key: 'rmsCurrent', name: 'current', factor: 'acCurrent'},
                 {key: 'rmsCurrentPhB', name: 'current_phase_b', factor: 'acCurrent'},
                 {key: 'rmsCurrentPhC', name: 'current_phase_c', factor: 'acCurrent'},

--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -1654,6 +1654,12 @@ const converters = {
             await entity.read('haElectricalMeasurement', ['acFrequency']);
         },
     },
+    electrical_measurement_power_reactive: {
+        key: ['power_reactive'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('haElectricalMeasurement', ['reactivePower']);
+        },
+    },
     powerfactor: {
         key: ['power_factor'],
         convertGet: async (entity, key, meta) => {

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -297,7 +297,7 @@ module.exports = [
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
-            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint, true);
             await reporting.activePower(endpoint);
             await reporting.rmsCurrent(endpoint);
             await reporting.rmsVoltage(endpoint);

--- a/devices/develco.js
+++ b/devices/develco.js
@@ -292,13 +292,14 @@ module.exports = [
         description: 'Power plug',
         fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
         toZigbee: [tz.on_off],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
+        exposes: [e.switch(), e.power(), e.power_reactive(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint, true);
             await reporting.activePower(endpoint);
+            await reporting.reactivePower(endpoint);
             await reporting.rmsCurrent(endpoint);
             await reporting.rmsVoltage(endpoint);
             await reporting.readMeteringMultiplierDivisor(endpoint);

--- a/lib/exposes.js
+++ b/lib/exposes.js
@@ -626,6 +626,7 @@ module.exports = {
         power_on_behavior: (values=['off', 'previous', 'on']) => new Enum('power_on_behavior', access.ALL, values).withDescription('Controls the behavior when the device is powered on after power loss'),
         power_outage_count: (resetsWhenPairing = true) => new Numeric('power_outage_count', access.STATE).withDescription('Number of power outages' + (resetsWhenPairing ? ' (since last pairing)' : '')),
         power_outage_memory: () => new Binary('power_outage_memory', access.ALL, true, false).withDescription('Enable/disable the power outage memory, this recovers the on/off mode after power failure'),
+        power_reactive: () => new Numeric('power_reactive', access.STATE).withUnit('VAR').withDescription('Instantaneous measured reactive power'),
         presence: () => new Binary('presence', access.STATE, true, false).withDescription('Indicates whether the device detected presence'),
         pressure: () => new Numeric('pressure', access.STATE).withUnit('hPa').withDescription('The measured atmospheric pressure'),
         programming_operation_mode: () => new Enum('programming_operation_mode', access.ALL, ['setpoint', 'schedule', 'schedule_with_preheat', 'eco']).withDescription('Controls how programming affects the thermostat. Possible values: setpoint (only use specified setpoint), schedule (follow programmed setpoint schedule), schedule_with_preheat (follow programmed setpoint schedule with pre-heating). Changing this value does not clear programmed schedules.'),

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -25,7 +25,7 @@ async function readEletricalMeasurementMultiplierDivisors(endpoint, readFrequenc
     // Split into three chunks, some devices fail to respond when reading too much attributes at once.
     await endpoint.read('haElectricalMeasurement', ['acVoltageMultiplier', 'acVoltageDivisor', 'acCurrentMultiplier']);
     await endpoint.read('haElectricalMeasurement', ['acCurrentDivisor', 'acPowerMultiplier', 'acPowerDivisor']);
-    // Only read frequency multiplier/devisor when enabled as not all devices support this.
+    // Only read frequency multiplier/divisor when enabled as not all devices support this.
     if (readFrequencyAttrs) {
         await endpoint.read('haElectricalMeasurement', ['acFrequencyDivisor', 'acFrequencyMultiplier']);
     }

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -203,6 +203,10 @@ module.exports = {
         const p = payload('activePower', 5, repInterval.HOUR, 1, overrides);
         await endpoint.configureReporting('haElectricalMeasurement', p);
     },
+    reactivePower: async (endpoint, overrides) => {
+        const p = payload('reactivePower', 5, repInterval.HOUR, 1, overrides);
+        await endpoint.configureReporting('haElectricalMeasurement', p);
+    },
     apparentPower: async (endpoint, overrides) => {
         const p = payload('apparentPower', 5, repInterval.HOUR, 1, overrides);
         await endpoint.configureReporting('haElectricalMeasurement', p);


### PR DESCRIPTION
Useful to distinguish between Capacitive and Inductive load (negative values are common for negative-energy).

Maybe other Develco SPLZB-13x could have same capability, but I don't have any of them.