### PR TITLE
Add more controls to Sinopé thermostats 2nd display and minor fix to SW2500ZB energy report

### DIFF
--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -249,7 +249,7 @@ const tzLocal = {
             await entity.read('hvacThermostat', ['SinopeAuxCycleOutput']);
         },
     },
-    enable_outdoor_temperature: { //DEPRECATED: Use Second Display Mode or control via the timeout
+    enable_outdoor_temperature: { // DEPRECATED: Use Second Display Mode or control via the timeout
         key: ['enable_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {
             if (value.toLowerCase() == 'on') {
@@ -609,7 +609,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['TH1124ZB'],
+        zigbeeModel: ['TH1124ZA'],
         model: 'TH1124ZB',
         vendor: 'Sinopé',
         description: 'Zigbee line volt thermostat',
@@ -1085,7 +1085,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['SW2500ZB'],
+        zigbeeModel: ['SW2500ZA'],
         model: 'SW2500ZB',
         vendor: 'Sinopé',
         description: 'Zigbee smart light switch',
@@ -1095,7 +1095,7 @@ module.exports = [
         exposes: [e.switch(),
             e.action(['up_single', 'up_double', 'up_hold', 'down_single', 'down_double', 'down_hold']),
             exposes.numeric('timer_seconds', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(65535)
-                .withPreset('Disabled',0).withDescription('Automatically turn off load after x seconds'),
+                .withPreset('Disabled', 0).withDescription('Automatically turn off load after x seconds'),
             exposes.numeric('led_intensity_on', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED intensity when load ON'),
             exposes.numeric('led_intensity_off', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
@@ -1145,7 +1145,7 @@ module.exports = [
             tzLocal.minimum_brightness, tzLocal.led_color_on, tzLocal.led_color_off],
         exposes: [e.light_brightness(),
             exposes.numeric('timer_seconds', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(65535)
-                .withPreset('Disabled',0).withDescription('Automatically turn off load after x seconds'),
+                .withPreset('Disabled', 0).withDescription('Automatically turn off load after x seconds'),
             exposes.numeric('led_intensity_on', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED intensity when load ON'),
             exposes.numeric('led_intensity_off', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
@@ -1181,7 +1181,7 @@ module.exports = [
             tzLocal.minimum_brightness, tzLocal.led_color_on, tzLocal.led_color_off],
         exposes: [e.light_brightness(),
             exposes.numeric('timer_seconds', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(65535)
-                .withPreset('Disabled',0).withDescription('Automatically turn off load after x seconds'),
+                .withPreset('Disabled', 0).withDescription('Automatically turn off load after x seconds'),
             exposes.numeric('led_intensity_on', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED intensity when load ON'),
             exposes.numeric('led_intensity_off', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -119,8 +119,17 @@ const fzLocal = {
                 const lookup = {0: 'off', 1: 'on'};
                 result.floor_limit_status = lookup[msg.data['floorLimitStatus']];
             }
+            if (msg.data.hasOwnProperty('secondScreenBehavior')) {
+                const lookup = {0: 'auto', 1: 'setpoint', 2: 'outdoor temp'};
+                result.second_display_mode = lookup[msg.data['secondScreenBehavior']];
+            }
             if (msg.data.hasOwnProperty('outdoorTempToDisplayTimeout')) {
-                result.enable_outdoor_temperature = msg.data['outdoorTempToDisplayTimeout'] == 10800 ? 'ON' : 'OFF';
+                result.outdoor_temperature_timeout = msg.data['outdoorTempToDisplayTimeout'];
+                // DEPRECATED: Use Second Display Mode or control via set outdoorTempToDisplayTimeout
+                result.enable_outdoor_temperature = msg.data['outdoorTempToDisplayTimeout'] === 12 ? 'OFF' : 'ON';
+            }
+            if (msg.data.hasOwnProperty('outdoorTempToDisplay')) {
+                result.thermostat_outdoor_temperature = precisionRound(msg.data['outdoorTempToDisplay'], 2) / 100;
             }
             if (msg.data.hasOwnProperty('currentTimeToDisplay')) {
                 result.current_time_to_display = msg.data['currentTimeToDisplay'];
@@ -240,7 +249,7 @@ const tzLocal = {
             await entity.read('hvacThermostat', ['SinopeAuxCycleOutput']);
         },
     },
-    enable_outdoor_temperature: {
+    enable_outdoor_temperature: { //DEPRECATED: Use Second Display Mode or control via the timeout
         key: ['enable_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {
             if (value.toLowerCase() == 'on') {
@@ -255,12 +264,39 @@ const tzLocal = {
             await entity.read('manuSpecificSinope', ['outdoorTempToDisplayTimeout'], manuSinope);
         },
     },
-    outdoor_temperature: {
+    second_display_mode: {
+        key: ['second_display_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            const lookup = {'auto': 0, 'setpoint': 1, 'outdoor temp': 2};
+            await entity.write('manuSpecificSinope', {secondScreenBehavior: lookup[value]});
+            return {state: {second_display_mode: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificSinope', ['secondScreenBehavior']);
+        },
+    },
+    thermostat_outdoor_temperature: {
         key: ['thermostat_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {
-            if (value > -100 && value < 100) {
+            if (value >= -99.5 && value <= 99.5) {
                 await entity.write('manuSpecificSinope', {outdoorTempToDisplay: value * 100}, manuSinope);
             }
+            return {state: {thermostat_outdoor_temperature: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificSinope', ['outdoorTempToDisplay'], manuSinope);
+        },
+    },
+    outdoor_temperature_timeout: {
+        key: ['outdoor_temperature_timeout'],
+        convertSet: async (entity, key, value, meta) => {
+            if (value >= 30 && value <= 64800) {
+                await entity.write('manuSpecificSinope', {outdoorTempToDisplayTimeout: value});
+                return {state: {outdoor_temperature_timeout: value}};
+            }
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificSinope', ['outdoorTempToDisplayTimeout']);
         },
     },
     thermostat_time: {
@@ -420,7 +456,7 @@ const tzLocal = {
         },
     },
     led_intensity_off: {
-        // DM2500ZB and SW2500ZB
+        // DM25x0ZB and SW2500ZB
         key: ['led_intensity_off'],
         convertSet: async (entity, key, value, meta) => {
             if (value >= 0 && value <= 100) {
@@ -457,7 +493,7 @@ const tzLocal = {
         },
     },
     minimum_brightness: {
-        // DM2x0ZB
+        // DM25x0ZB
         key: ['minimum_brightness'],
         convertSet: async (entity, key, value, meta) => {
             if (value >= 0 && value <= 3000) {
@@ -473,7 +509,7 @@ const tzLocal = {
         // DM25x0ZB and SW2500ZB
         key: ['timer_seconds'],
         convertSet: async (entity, key, value, meta) => {
-            if (value >= 0 && value <= 10800) {
+            if (value >= 0 && value <= 65535) {
                 await entity.write('manuSpecificSinope', {dimmerTimmer: value});
             }
             return {state: {timer_seconds: value}};
@@ -505,8 +541,9 @@ module.exports = [
             fz.electrical_measurement, fz.metering, fz.ignore_temperature_report],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
-            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
-            tzLocal.thermostat_occupancy, tzLocal.main_cycle_output, tz.electrical_measurement_power],
+            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.second_display_mode,
+            tzLocal.thermostat_outdoor_temperature, tzLocal.outdoor_temperature_timeout, tzLocal.thermostat_occupancy,
+            tzLocal.main_cycle_output, tz.electrical_measurement_power],
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
@@ -517,8 +554,16 @@ module.exports = [
                 .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.enum('thermostat_occupancy', ea.ALL, ['unoccupied', 'occupied'])
                 .withDescription('Occupancy state of the thermostat'),
+            exposes.enum('second_display_mode', ea.ALL, ['auto', 'setpoint', 'outdoor temp'])
+                .withDescription('Displays the outdoor temperature and then returns to the set point in "auto" mode, or clears ' +
+                    'in "outdoor temp" mode when expired.'),
+            exposes.numeric('thermostat_outdoor_temperature', ea.ALL).withUnit('°C').withValueMin(-99.5).withValueMax(99.5).withValueStep(0.5)
+                .withDescription('Outdoor temperature for the secondary display'),
+            exposes.numeric('outdoor_temperature_timeout', ea.ALL).withUnit('Seconds').withValueMin(30).withValueMax(64800)
+                .withPreset('15 min', 900).withPreset('30 min', 1800).withPreset('1 hour', 3600)
+                .withDescription('Time in seconds after which the outdoor temperature is considered to have expired'),
             exposes.binary('enable_outdoor_temperature', ea.ALL, 'ON', 'OFF')
-                .withDescription('Showing outdoor temperature on secondary display'),
+                .withDescription('DEPRECATED: Use second_display_mode or control via outdoor_temperature_timeout'),
             exposes.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
                 .withDescription('The temperature format displayed on the thermostat screen'),
             exposes.enum('time_format', ea.ALL, ['24h', '12h'])
@@ -572,8 +617,9 @@ module.exports = [
             fz.electrical_measurement, fz.metering, fz.ignore_temperature_report],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
-            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
-            tzLocal.thermostat_occupancy, tzLocal.main_cycle_output, tz.electrical_measurement_power],
+            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.second_display_mode,
+            tzLocal.thermostat_outdoor_temperature, tzLocal.outdoor_temperature_timeout, tzLocal.thermostat_occupancy,
+            tzLocal.main_cycle_output, tz.electrical_measurement_power],
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
@@ -584,8 +630,16 @@ module.exports = [
                 .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.enum('thermostat_occupancy', ea.ALL, ['unoccupied', 'occupied'])
                 .withDescription('Occupancy state of the thermostat'),
+            exposes.enum('second_display_mode', ea.ALL, ['auto', 'setpoint', 'outdoor temp'])
+                .withDescription('Displays the outdoor temperature and then returns to the set point in "auto" mode, or clears ' +
+                    'in "outdoor temp" mode when expired.'),
+            exposes.numeric('thermostat_outdoor_temperature', ea.ALL).withUnit('°C').withValueMin(-99.5).withValueMax(99.5).withValueStep(0.5)
+                .withDescription('Outdoor temperature for the secondary display'),
+            exposes.numeric('outdoor_temperature_timeout', ea.ALL).withUnit('Seconds').withValueMin(30).withValueMax(64800)
+                .withPreset('15 min', 900).withPreset('30 min', 1800).withPreset('1 hour', 3600)
+                .withDescription('Time in seconds after which the outdoor temperature is considered to have expired'),
             exposes.binary('enable_outdoor_temperature', ea.ALL, 'ON', 'OFF')
-                .withDescription('Showing outdoor temperature on secondary display'),
+                .withDescription('DEPRECATED: Use second_display_mode or control via outdoor_temperature_timeout'),
             exposes.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
                 .withDescription('The temperature format displayed on the thermostat screen'),
             exposes.enum('time_format', ea.ALL, ['24h', '12h'])
@@ -639,8 +693,9 @@ module.exports = [
             fz.electrical_measurement, fz.metering, fz.ignore_temperature_report],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
-            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
-            tzLocal.thermostat_occupancy, tzLocal.main_cycle_output, tz.electrical_measurement_power],
+            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.second_display_mode,
+            tzLocal.thermostat_outdoor_temperature, tzLocal.outdoor_temperature_timeout, tzLocal.thermostat_occupancy,
+            tzLocal.main_cycle_output, tz.electrical_measurement_power],
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
@@ -651,8 +706,16 @@ module.exports = [
                 .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.enum('thermostat_occupancy', ea.ALL, ['unoccupied', 'occupied'])
                 .withDescription('Occupancy state of the thermostat'),
+            exposes.enum('second_display_mode', ea.ALL, ['auto', 'setpoint', 'outdoor temp'])
+                .withDescription('Displays the outdoor temperature and then returns to the set point in "auto" mode, or clears ' +
+                    'in "outdoor temp" mode when expired.'),
+            exposes.numeric('thermostat_outdoor_temperature', ea.ALL).withUnit('°C').withValueMin(-99.5).withValueMax(99.5).withValueStep(0.5)
+                .withDescription('Outdoor temperature for the secondary display'),
+            exposes.numeric('outdoor_temperature_timeout', ea.ALL).withUnit('Seconds').withValueMin(30).withValueMax(64800)
+                .withPreset('15 min', 900).withPreset('30 min', 1800).withPreset('1 hour', 3600)
+                .withDescription('Time in seconds after which the outdoor temperature is considered to have expired'),
             exposes.binary('enable_outdoor_temperature', ea.ALL, 'ON', 'OFF')
-                .withDescription('Showing outdoor temperature on secondary display'),
+                .withDescription('DEPRECATED: Use second_display_mode or control via outdoor_temperature_timeout'),
             exposes.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
                 .withDescription('The temperature format displayed on the thermostat screen'),
             exposes.enum('time_format', ea.ALL, ['24h', '12h'])
@@ -712,8 +775,9 @@ module.exports = [
             fz.electrical_measurement, fz.metering, fz.ignore_temperature_report],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
-            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
-            tzLocal.thermostat_occupancy, tzLocal.main_cycle_output, tz.electrical_measurement_power],
+            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.second_display_mode,
+            tzLocal.thermostat_outdoor_temperature, tzLocal.outdoor_temperature_timeout, tzLocal.thermostat_occupancy,
+            tzLocal.main_cycle_output, tz.electrical_measurement_power],
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
@@ -724,8 +788,16 @@ module.exports = [
                 .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.enum('thermostat_occupancy', ea.ALL, ['unoccupied', 'occupied'])
                 .withDescription('Occupancy state of the thermostat'),
+            exposes.enum('second_display_mode', ea.ALL, ['auto', 'setpoint', 'outdoor temp'])
+                .withDescription('Displays the outdoor temperature and then returns to the set point in "auto" mode, or clears ' +
+                    'in "outdoor temp" mode when expired.'),
+            exposes.numeric('thermostat_outdoor_temperature', ea.ALL).withUnit('°C').withValueMin(-99.5).withValueMax(99.5).withValueStep(0.5)
+                .withDescription('Outdoor temperature for the secondary display'),
+            exposes.numeric('outdoor_temperature_timeout', ea.ALL).withUnit('Seconds').withValueMin(30).withValueMax(64800)
+                .withPreset('15 min', 900).withPreset('30 min', 1800).withPreset('1 hour', 3600)
+                .withDescription('Time in seconds after which the outdoor temperature is considered to have expired'),
             exposes.binary('enable_outdoor_temperature', ea.ALL, 'ON', 'OFF')
-                .withDescription('Showing outdoor temperature on secondary display'),
+                .withDescription('DEPRECATED: Use second_display_mode or control via outdoor_temperature_timeout'),
             exposes.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
                 .withDescription('The temperature format displayed on the thermostat screen'),
             exposes.enum('time_format', ea.ALL, ['24h', '12h'])
@@ -785,8 +857,9 @@ module.exports = [
             fz.electrical_measurement, fz.metering, fz.ignore_temperature_report],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
-            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
-            tzLocal.thermostat_occupancy, tzLocal.floor_control_mode, tzLocal.ambiant_max_heat_setpoint, tzLocal.floor_min_heat_setpoint,
+            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.second_display_mode,
+            tzLocal.thermostat_outdoor_temperature, tzLocal.outdoor_temperature_timeout, tzLocal.thermostat_occupancy,
+            tzLocal.floor_control_mode, tzLocal.ambiant_max_heat_setpoint, tzLocal.floor_min_heat_setpoint,
             tzLocal.floor_max_heat_setpoint, tzLocal.temperature_sensor, tz.electrical_measurement_power],
         exposes: [
             exposes.climate()
@@ -798,8 +871,16 @@ module.exports = [
                 .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.enum('thermostat_occupancy', ea.ALL, ['unoccupied', 'occupied'])
                 .withDescription('Occupancy state of the thermostat'),
+            exposes.enum('second_display_mode', ea.ALL, ['auto', 'setpoint', 'outdoor temp'])
+                .withDescription('Displays the outdoor temperature and then returns to the set point in "auto" mode, or clears ' +
+                    'in "outdoor temp" mode when expired.'),
+            exposes.numeric('thermostat_outdoor_temperature', ea.ALL).withUnit('°C').withValueMin(-99.5).withValueMax(99.5).withValueStep(0.5)
+                .withDescription('Outdoor temperature for the secondary display'),
+            exposes.numeric('outdoor_temperature_timeout', ea.ALL).withUnit('Seconds').withValueMin(30).withValueMax(64800)
+                .withPreset('15 min', 900).withPreset('30 min', 1800).withPreset('1 hour', 3600)
+                .withDescription('Time in seconds after which the outdoor temperature is considered to have expired'),
             exposes.binary('enable_outdoor_temperature', ea.ALL, 'ON', 'OFF')
-                .withDescription('Showing outdoor temperature on secondary display'),
+                .withDescription('DEPRECATED: Use second_display_mode or control via outdoor_temperature_timeout'),
             exposes.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
                 .withDescription('The temperature format displayed on the thermostat screen'),
             exposes.enum('time_format', ea.ALL, ['24h', '12h'])
@@ -861,8 +942,9 @@ module.exports = [
             fz.electrical_measurement, fz.metering, fz.ignore_temperature_report],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
-            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
-            tzLocal.thermostat_occupancy, tzLocal.floor_control_mode, tzLocal.ambiant_max_heat_setpoint, tzLocal.floor_min_heat_setpoint,
+            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.second_display_mode,
+            tzLocal.thermostat_outdoor_temperature, tzLocal.outdoor_temperature_timeout, tzLocal.thermostat_occupancy,
+            tzLocal.floor_control_mode, tzLocal.ambiant_max_heat_setpoint, tzLocal.floor_min_heat_setpoint,
             tzLocal.floor_max_heat_setpoint, tzLocal.temperature_sensor, tz.thermostat_min_heat_setpoint_limit,
             tz.thermostat_max_heat_setpoint_limit, tzLocal.connected_load, tzLocal.aux_connected_load, tzLocal.main_cycle_output,
             tzLocal.aux_cycle_output, tzLocal.pump_protection],
@@ -878,8 +960,16 @@ module.exports = [
             e.min_heat_setpoint_limit(5, 36, 0.5),
             exposes.enum('thermostat_occupancy', ea.ALL, ['unoccupied', 'occupied'])
                 .withDescription('Occupancy state of the thermostat'),
+            exposes.enum('second_display_mode', ea.ALL, ['auto', 'setpoint', 'outdoor temp'])
+                .withDescription('Displays the outdoor temperature and then returns to the set point in "auto" mode, or clears ' +
+                    'in "outdoor temp" mode when expired.'),
+            exposes.numeric('thermostat_outdoor_temperature', ea.ALL).withUnit('°C').withValueMin(-99.5).withValueMax(99.5).withValueStep(0.5)
+                .withDescription('Outdoor temperature for the secondary display'),
+            exposes.numeric('outdoor_temperature_timeout', ea.ALL).withUnit('Seconds').withValueMin(30).withValueMax(64800)
+                .withPreset('15 min', 900).withPreset('30 min', 1800).withPreset('1 hour', 3600)
+                .withDescription('Time in seconds after which the outdoor temperature is considered to have expired'),
             exposes.binary('enable_outdoor_temperature', ea.ALL, 'ON', 'OFF')
-                .withDescription('Showing outdoor temperature on secondary display'),
+                .withDescription('DEPRECATED: Use second_display_mode or control via outdoor_temperature_timeout'),
             exposes.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
                 .withDescription('The temperature format displayed on the thermostat screen'),
             exposes.enum('time_format', ea.ALL, ['24h', '12h'])
@@ -951,8 +1041,8 @@ module.exports = [
             fz.electrical_measurement, fz.metering, fz.ignore_temperature_report],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout, tz.thermostat_system_mode, tzLocal.backlight_autodim,
-            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.outdoor_temperature,
-            tzLocal.thermostat_occupancy],
+            tzLocal.thermostat_time, tzLocal.time_format, tzLocal.enable_outdoor_temperature, tzLocal.second_display_mode,
+            tzLocal.thermostat_outdoor_temperature, tzLocal.outdoor_temperature_timeout, tzLocal.thermostat_occupancy],
         exposes: [
             exposes.climate()
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
@@ -963,8 +1053,16 @@ module.exports = [
                 .withRunningState(['idle', 'heat'], ea.STATE),
             exposes.enum('thermostat_occupancy', ea.ALL, ['unoccupied', 'occupied'])
                 .withDescription('Occupancy state of the thermostat'),
+            exposes.enum('second_display_mode', ea.ALL, ['auto', 'setpoint', 'outdoor temp'])
+                .withDescription('Displays the outdoor temperature and then returns to the set point in "auto" mode, or clears ' +
+                    'in "outdoor temp" mode when expired.'),
+            exposes.numeric('thermostat_outdoor_temperature', ea.ALL).withUnit('°C').withValueMin(-99.5).withValueMax(99.5).withValueStep(0.5)
+                .withDescription('Outdoor temperature for the secondary display'),
+            exposes.numeric('outdoor_temperature_timeout', ea.ALL).withUnit('Seconds').withValueMin(30).withValueMax(64800)
+                .withPreset('15 min', 900).withPreset('30 min', 1800).withPreset('1 hour', 3600)
+                .withDescription('Time in seconds after which the outdoor temperature is considered to have expired'),
             exposes.binary('enable_outdoor_temperature', ea.ALL, 'ON', 'OFF')
-                .withDescription('Showing outdoor temperature on secondary display'),
+                .withDescription('DEPRECATED: Use second_display_mode or control via outdoor_temperature_timeout'),
             exposes.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
                 .withDescription('The temperature format displayed on the thermostat screen'),
             exposes.enum('time_format', ea.ALL, ['24h', '12h'])
@@ -996,8 +1094,8 @@ module.exports = [
             tzLocal.led_color_on, tzLocal.led_color_off, tzLocal.keypad_lockout, tzLocal.connected_load],
         exposes: [e.switch(),
             e.action(['up_single', 'up_double', 'up_hold', 'down_single', 'down_double', 'down_hold']),
-            exposes.numeric('timer_seconds', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(10800)
-                .withDescription('Automatically turn off load after x seconds'),
+            exposes.numeric('timer_seconds', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(65535)
+                .withPreset('Disabled',0).withDescription('Automatically turn off load after x seconds'),
             exposes.numeric('led_intensity_on', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED intensity when load ON'),
             exposes.numeric('led_intensity_off', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
@@ -1015,7 +1113,7 @@ module.exports = [
             exposes.enum('keypad_lockout', ea.ALL, ['unlock', 'lock'])
                 .withDescription('Enables or disables the device’s buttons'),
             exposes.numeric('connected_load', ea.ALL)
-                .withUnit('W').withValueMin(1).withValueMax(1800)
+                .withUnit('W').withValueMin(0).withValueMax(1800)
                 .withDescription('Load connected in watt'),
             e.energy(),
         ],
@@ -1025,6 +1123,7 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.onOff(endpoint);
             try {
+                await reporting.readMeteringMultiplierDivisor(endpoint);
                 await reporting.currentSummDelivered(endpoint, {min: 10, max: 300, change: [0, 10]});
             } catch (error) {/* Do nothing*/}
             const payload = [{
@@ -1045,11 +1144,11 @@ module.exports = [
         toZigbee: [tz.light_onoff_brightness, tzLocal.timer_seconds, tzLocal.led_intensity_on, tzLocal.led_intensity_off,
             tzLocal.minimum_brightness, tzLocal.led_color_on, tzLocal.led_color_off],
         exposes: [e.light_brightness(),
-            exposes.numeric('timer_seconds', ea.ALL).withValueMin(0).withValueMax(10800)
-                .withDescription('Automatically turn off load after x seconds'),
-            exposes.numeric('led_intensity_on', ea.ALL).withValueMin(0).withValueMax(100)
-                .withDescription('Control status LED when load ON'),
-            exposes.numeric('led_intensity_off', ea.ALL).withValueMin(0).withValueMax(100)
+            exposes.numeric('timer_seconds', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(65535)
+                .withPreset('Disabled',0).withDescription('Automatically turn off load after x seconds'),
+            exposes.numeric('led_intensity_on', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
+                .withDescription('Control status LED intensity when load ON'),
+            exposes.numeric('led_intensity_off', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED when load OFF'),
             exposes.numeric('minimum_brightness', ea.ALL).withValueMin(0).withValueMax(3000)
                 .withDescription('Control minimum dimmer brightness'),
@@ -1081,11 +1180,11 @@ module.exports = [
         toZigbee: [tz.light_onoff_brightness, tzLocal.timer_seconds, tzLocal.led_intensity_on, tzLocal.led_intensity_off,
             tzLocal.minimum_brightness, tzLocal.led_color_on, tzLocal.led_color_off],
         exposes: [e.light_brightness(),
-            exposes.numeric('timer_seconds', ea.ALL).withValueMin(0).withValueMax(10800)
-                .withDescription('Automatically turn off load after x seconds'),
-            exposes.numeric('led_intensity_on', ea.ALL).withValueMin(0).withValueMax(100)
-                .withDescription('Control status LED when load ON'),
-            exposes.numeric('led_intensity_off', ea.ALL).withValueMin(0).withValueMax(100)
+            exposes.numeric('timer_seconds', ea.ALL).withUnit('seconds').withValueMin(0).withValueMax(65535)
+                .withPreset('Disabled',0).withDescription('Automatically turn off load after x seconds'),
+            exposes.numeric('led_intensity_on', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
+                .withDescription('Control status LED intensity when load ON'),
+            exposes.numeric('led_intensity_off', ea.ALL).withUnit('%').withValueMin(0).withValueMax(100)
                 .withDescription('Control status LED when load OFF'),
             exposes.numeric('minimum_brightness', ea.ALL).withValueMin(0).withValueMax(3000)
                 .withDescription('Control minimum dimmer brightness'),

--- a/devices/sinope.js
+++ b/devices/sinope.js
@@ -609,7 +609,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['TH1124ZA'],
+        zigbeeModel: ['TH1124ZB'],
         model: 'TH1124ZB',
         vendor: 'Sinopé',
         description: 'Zigbee line volt thermostat',
@@ -1085,7 +1085,7 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['SW2500ZA'],
+        zigbeeModel: ['SW2500ZB'],
         model: 'SW2500ZB',
         vendor: 'Sinopé',
         description: 'Zigbee smart light switch',


### PR DESCRIPTION
Thermostat: TH1123ZB, TH1124ZB, TH1123ZB-G2, TH1124ZB-G2, TH11300ZB, TH1400ZB, TH1500ZB. 
_(Tested on TH1124ZB with older (2019) and latest firwmare)_ 
1) Add property `second_display_mode` for the thermostat Second display control, available with the latest thermostat firmware. There are 3 availables modes:  

 a) `auto`: The outdoor temperature (`thermostat_outdoor_temperature`) is displayed until considered expired by the thermostat.  The display then revert to the set point value.  The outdoor temp is considered expired when it has not been refreshed within `outdoor_temperature_timeout`.
b) `setpoint`: Display the set point value at all time.
c) `outdoor temp`: Same as auto, except the display blank when the outdoor temperature is expired. 

2) `thermostat_outdoor_temperature` is now exposed, along with `second_display_mode` and `outdoor_temperature_timeout`, converters were also added.

3) Property `enable_outdoor_temperature` is deprecated. It was emulating the function by controlling the `outdoor_temperature_timout`. Newer firmware should use the `second_display_mode` and older firmware without Second Display mode support should control the timeout directly instead.

Light Switch: SW2500ZB
1) Extended the `timer_seconds` range to 65536, as allowed by the light switch.  Added a preset named `Disabled` with the value 0.
2) Added the value 0 to the `connected_load` range. Starting at 1 was a typo.
3) Added `reporting.readMeteringMultiplierDivisor(endpoint)` required for the energy summation (`currentSummDelivered()`) to report a value.