### PR TITLE
Add CCT Zigbee model to Paulmann 50064

### DIFF
--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -73,7 +73,7 @@ module.exports = [
     },
     {
         fingerprint: [{modelID: 'CCT Light', manufacturerName: 'Paulmann lamp'}],
-        zigbeeModel: ['CCT light', 'CCT_light', 'CCT light '],
+        zigbeeModel: ['CCT light', 'CCT_light', 'CCT light ', 'CCT'],
         model: '50064',
         vendor: 'Paulmann',
         description: 'SmartHome led spot',

--- a/devices/paulmann.js
+++ b/devices/paulmann.js
@@ -72,8 +72,11 @@ module.exports = [
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
     },
     {
-        fingerprint: [{modelID: 'CCT Light', manufacturerName: 'Paulmann lamp'}],
-        zigbeeModel: ['CCT light', 'CCT_light', 'CCT light ', 'CCT'],
+        fingerprint: [
+            {modelID: 'CCT Light', manufacturerName: 'Paulmann lamp'},
+            {modelID: 'CCT', manufacturerName: 'Paulmann Licht GmbH'},
+        ],
+        zigbeeModel: ['CCT light', 'CCT_light', 'CCT light '],
         model: '50064',
         vendor: 'Paulmann',
         description: 'SmartHome led spot',


### PR DESCRIPTION
The new Paulmann 501.29 light I received today has a new Zigbee name (CCT) compared to my old ones (CCT_LIGHT). Adding the new name to the existing configuration allows me to control it. I tested this locally on my setup.

Note that I have 501.29 lights instead of 500.64. They appear to use the same Zigbee names.