### PR TITLE
Add support for Cleverio SS200 motion sensor

### DIFF
--- a/devices/cleverio.js
+++ b/devices/cleverio.js
@@ -37,7 +37,7 @@ module.exports = [
         fingerprint: [{modelID: 'SM0202', manufacturerName: '_TYZB01_z2umiwvq'}],
         model: 'SS200',
         vendor: 'Cleverio',
-        description: 'Cleverio Smart Motion Sensor',
+        description: 'Smart motion sensor',
         fromZigbee: [fz.ias_occupancy_alarm_1_with_timeout, fz.battery, fz.ignore_basic_report],
         toZigbee: [],
         exposes: [e.occupancy(), e.battery_low(), e.linkquality(), e.battery(), e.battery_voltage()],

--- a/devices/cleverio.js
+++ b/devices/cleverio.js
@@ -33,4 +33,18 @@ module.exports = [
         toZigbee: [],
         configure: tuya.configureMagicPacket,
     },
+    {
+        fingerprint: [{modelID: 'SM0202', manufacturerName: '_TYZB01_z2umiwvq'}],
+        model: 'SS200',
+        vendor: 'Cleverio',
+        description: 'Cleverio Smart Motion Sensor',
+        fromZigbee: [fz.ias_occupancy_alarm_1_with_timeout, fz.battery, fz.ignore_basic_report],
+        toZigbee: [],
+        exposes: [e.occupancy(), e.battery_low(), e.linkquality(), e.battery(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+    },
 ];


### PR DESCRIPTION
[Cleverio Smart Motion Sensor](https://www.kjell.com/se/produkter/smarta-hem/smarta-sensorer/smarta-rorelsevakter/cleverio-smart-rorelsesensor-med-zigbee-3.0-p51827)

Same configuration as for example 
https://github.com/Koenkk/zigbee-herdsman-converters/blob/1b89f7d2d57f9519287d79c9cd5e33d29c982497/devices/tuya.js#L1066

Should `modelID` and `manufacturerName` be added there instead with an additional whitelabel?

Image added in https://github.com/Koenkk/zigbee2mqtt.io/pull/2031