### PR TITLE
Add fingerprint to the Sonoff SNZB-02D

### DIFF
--- a/devices/sonoff.js
+++ b/devices/sonoff.js
@@ -164,6 +164,9 @@ module.exports = [
         },
     },
     {
+        fingerprint: [
+            {type: 'EndDevice', manufacturerName: 'SONOFF', modelID: 'SNZB-02D'}
+        ],
         zigbeeModel: ['SNZB-02D'],
         model: 'SNZB-02D',
         vendor: 'SONOFF',

--- a/devices/sonoff.js
+++ b/devices/sonoff.js
@@ -165,7 +165,7 @@ module.exports = [
     },
     {
         fingerprint: [
-            {type: 'EndDevice', manufacturerName: 'SONOFF', modelID: 'SNZB-02D'}
+            {type: 'EndDevice', manufacturerName: 'SONOFF', modelID: 'SNZB-02D'},
         ],
         zigbeeModel: ['SNZB-02D'],
         model: 'SNZB-02D',


### PR DESCRIPTION
Add fingerprint to the Sonoff SNZB-02D because without one the device isn't identified.

I recently bought 5 of these devices from AliExpress and they were not identified with the current Edge version. After adding the fingerprint they were detected and function without problem. Maybe this isn't correct and there is another underlying issue why a fingerprint is needed but this works well for me.