### PR TITLE
Support Philips Hue Phoenix LED Pendant light

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -3147,7 +3147,7 @@ module.exports = [
         zigbeeModel: ['LLM011'],
         model: '800094',
         vendor: 'Philips',
-        description: 'Hue Phoenix Dimmable LED Smart Pendant Light',
+        description: 'Hue Phoenix dimmable LED smart pendant light',
         extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
 ];

--- a/devices/philips.js
+++ b/devices/philips.js
@@ -3143,4 +3143,11 @@ module.exports = [
         description: 'Hue White Ambiance Devote',
         extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
+    {
+        zigbeeModel: ['LLM011'],
+        model: '800094',
+        vendor: 'Philips',
+        description: 'Hue Phoenix Dimmable LED Smart Pendant Light',
+        extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+    },
 ];


### PR DESCRIPTION
This light presents itself as two different lights. One is the upward-facing bulb and the other is the downward-facing bulb.