### PR TITLE
Fix false alerts in log for Aqara `RTCZCGQ11LM`

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -253,7 +253,6 @@ const fzLocal = {
 
             Object.entries(msg.data).forEach(([key, value]) => {
                 const eventKey = parseInt(key);
-                const eventKeyHex = printNumberAsHex(eventKey, 4);
 
                 switch (eventKey) {
                 case fp1.constants.region_event_key: {

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -10,7 +10,7 @@ const ea = exposes.access;
 const globalStore = require('../lib/store');
 const xiaomi = require('../lib/xiaomi');
 const utils = require('../lib/utils');
-const {printNumberAsHex, printNumbersAsHexSequence} = utils;
+const {printNumbersAsHexSequence} = utils;
 const {fp1, manufacturerCode, trv} = xiaomi;
 
 const xiaomiExtend = {

--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -287,21 +287,6 @@ const fzLocal = {
                     payload.action = `region_${regionId}_${eventTypeName}`;
                     break;
                 }
-                case 0xf7: {
-                    const valueHexSequence = printNumbersAsHexSequence(value, 2);
-                    log('debug', `Unhandled key ${eventKeyHex} = ${valueHexSequence}`);
-                    break;
-                }
-                case 0x0142:
-                case 0x0143:
-                case 0x0144:
-                case 0x0146: {
-                    log('debug', `Unhandled key ${eventKeyHex} = ${value}`);
-                    break;
-                }
-                default: {
-                    log('warn', `Unknown key ${eventKeyHex} = ${value}`);
-                }
                 }
             });
 


### PR DESCRIPTION
Fix https://github.com/Koenkk/zigbee2mqtt/issues/16628
Fix https://github.com/Koenkk/zigbee2mqtt/issues/16724

[This code](https://github.com/Koenkk/zigbee-herdsman-converters/blob/25bbf91b0a1d35b71e721ba54aa344be268fefa2/devices/xiaomi.js#L290-L304) generates alerts about unknown and unhandled keys in the log (_issues https://github.com/Koenkk/zigbee2mqtt/issues/16628, https://github.com/Koenkk/zigbee2mqtt/issues/16724, https://github.com/Koenkk/zigbee2mqtt/issues/17643_), which are false, because they are actually known and handled in [lib/xiaomi.js](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/lib/xiaomi.js) via [fz.aqara_opple](https://github.com/Koenkk/zigbee-herdsman-converters/blob/25bbf91b0a1d35b71e721ba54aa344be268fefa2/devices/xiaomi.js#L1822).