### PR TITLE
Fix rtcgq13lm OTA update

### DIFF
--- a/devices/xiaomi.js
+++ b/devices/xiaomi.js
@@ -1759,6 +1759,8 @@ module.exports = [
             await endpoint.read('genPowerCfg', ['batteryVoltage']);
             await endpoint.read('aqaraOpple', [0x0102], {manufacturerCode: 0x115f});
             await endpoint.read('aqaraOpple', [0x010c], {manufacturerCode: 0x115f});
+            // This cluster is not discovered automatically and needs to be explicitly attached to enable OTA
+            utils.attachOutputCluster(device, 'genOta');
         },
         ota: ota.zigbeeOTA,
     },


### PR DESCRIPTION
I have two rtcgq13lm devices that encountered the issue `Failed to find endpoint which support OTA cluster` during OTA  updates. I tried force remove, restarting z2m, and re-pairing, but the problem is still. I found that the method mentioned in #5316  worked for me. Thanks @protyposis method can solve my problem.