### PR TITLE
Fix unknown power source for WSP403

### DIFF
--- a/devices/owon.js
+++ b/devices/owon.js
@@ -109,6 +109,7 @@ module.exports = [
         zigbeeModel: ['WSP403-E'],
         model: 'WSP403',
         vendor: 'OWON',
+        whiteLabel: [{vendor: 'Oz Smart Things', model: 'WSP403'}],
         description: 'Smart plug',
         fromZigbee: [fz.on_off, fz.metering],
         toZigbee: [tz.on_off],
@@ -121,6 +122,11 @@ module.exports = [
             await reporting.instantaneousDemand(endpoint, {min: 5, max: constants.repInterval.MINUTES_5, change: 2}); // divider 1000: 2W
             await reporting.currentSummDelivered(endpoint, {min: 5, max: constants.repInterval.MINUTES_5,
                 change: [10, 10]}); // divider 1000: 0,01kWh
+
+            if (device.powerSource === 'Unknown') {
+                device.powerSource = 'Mains (single phase)';
+                device.save();
+            }
         },
     },
     {


### PR DESCRIPTION
The [Oz Smart Things whitelabel of WSP403](https://www.ozsmartthings.com.au/collections/zigbee/products/oz-zigbee-smart-plug) reports an unknown power source. The WSP403 is a smart plug that is always connected to mains so this PR adds a check for that, as well as adding a `whiteLabel` entry for good measure.