### PR TITLE
New 8 gang switch/relay

### DIFF
--- a/devices/tuya.js
+++ b/devices/tuya.js
@@ -5177,4 +5177,44 @@ module.exports = [
             ],
         },
     },
+    {
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_vmcgja59'},
+        ],
+        model: 'TS0601_switch_8',
+        vendor: 'TuYa',
+        description: '8 Gang switch',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            tuya.exposes.switch().withEndpoint('l1'),
+            tuya.exposes.switch().withEndpoint('l2'),
+            tuya.exposes.switch().withEndpoint('l3'),
+            tuya.exposes.switch().withEndpoint('l4'),
+            tuya.exposes.switch().withEndpoint('l5'),
+            tuya.exposes.switch().withEndpoint('l6'),
+            tuya.exposes.switch().withEndpoint('l7'),
+            tuya.exposes.switch().withEndpoint('l8'),
+        ],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1, 'l7': 1, 'l8': 1};
+        },
+        meta: {
+            multiEndpoint: true,
+            tuyaDatapoints: [
+                [1, 'state_l1', tuya.valueConverter.onOff],
+                [2, 'state_l2', tuya.valueConverter.onOff],
+                [3, 'state_l3', tuya.valueConverter.onOff],
+                [4, 'state_l4', tuya.valueConverter.onOff],
+                [5, 'state_l5', tuya.valueConverter.onOff],
+                [6, 'state_l6', tuya.valueConverter.onOff],
+                [0x65, 'state_l7', tuya.valueConverter.onOff],
+                [0x66, 'state_l8', tuya.valueConverter.onOff],
+            ],
+        },
+        whiteLabel: [
+            tuya.whitelabel('ZYXH', 'TS0601_switch_8', '8 Gang switch', ['_TZE200_vmcgja59']),
+        ],
+    },
 ];

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1664,7 +1664,8 @@ const tuyaTz = {
             const datapoints = utils.getMetaValue(entity, meta.mapped, 'tuyaDatapoints', undefined, undefined);
             if (!datapoints) throw new Error('No datapoints map defined');
             for (const [attr, value] of Object.entries(meta.message)) {
-                const convertedKey = meta.mapped.meta.multiEndpoint && meta.endpoint_name && !attr.startsWith(`${key}_`) ? `${attr}_${meta.endpoint_name}` : attr;
+                const convertedKey = meta.mapped.meta.multiEndpoint && meta.endpoint_name && !attr.startsWith(`${key}_`) ?
+                    `${attr}_${meta.endpoint_name}` : attr;
                 const dpEntry = datapoints.find((d) => d[1] === convertedKey);
                 if (!dpEntry || !dpEntry[1]) {
                     throw new Error(`No datapoint defined for '${attr}'`);

--- a/lib/tuya.js
+++ b/lib/tuya.js
@@ -1663,11 +1663,11 @@ const tuyaTz = {
             const state = {};
             const datapoints = utils.getMetaValue(entity, meta.mapped, 'tuyaDatapoints', undefined, undefined);
             if (!datapoints) throw new Error('No datapoints map defined');
-            for (const [key, value] of Object.entries(meta.message)) {
-                const convertedKey = meta.mapped.meta.multiEndpoint && meta.endpoint_name ? `${key}_${meta.endpoint_name}` : key;
+            for (const [attr, value] of Object.entries(meta.message)) {
+                const convertedKey = meta.mapped.meta.multiEndpoint && meta.endpoint_name && !attr.startsWith(`${key}_`) ? `${attr}_${meta.endpoint_name}` : attr;
                 const dpEntry = datapoints.find((d) => d[1] === convertedKey);
                 if (!dpEntry || !dpEntry[1]) {
-                    throw new Error(`No datapoint defined for '${key}'`);
+                    throw new Error(`No datapoint defined for '${attr}'`);
                 }
                 if (dpEntry[3] && dpEntry[3].skip && dpEntry[3].skip(meta)) continue;
                 const dpId = dpEntry[0];


### PR DESCRIPTION
https://aliexpress.ru/item/1005005453758738.html

Fixed getting convertedKey when endpoint_name comes already in an attribute name.

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/8360230/ded846ab-6a03-48cb-8ab9-d1f7399f8b43)

For some reason, several switches of one device have combined into a single block, accumulate and send changes as a single object.
If you switch the first switch, it will send:
`{"topic":"0xa4c1386e1e3d81cc/set","payload":{"state_l1":"ON"}}`
If you switch the second without going to another page, then it will send:
`{"topic":"0xa4c1386e1e3d81cc/set","payload":{"state_l1":"ON","state_l2":"ON"}}`
And so on, until you go to another page:
`{"topic":"0xa4c1386e1e3d81cc/set","payload":{"state_l1":"OFF","state_l2":"ON","state_l3":"OFF"}}`
If you do switching through the dashboard, this does not happen.

When the converter receives the object {"state_l1":"ON","state_l2":"ON"}, then the tuya-converter behaves inappropriately - an error occurs:
`Error: No datapoint defined for 'state_l2' at Object.convertSet (C:\Projects\zigbee2mqtt\node_modules\zigbee-herdsman-converters\lib\tuya.js:1671:27)`
I fixed it.

But! Several commands will be sent to the device at the same time, in my case 8. And not all will reach.

Seems to be related to the zigbee2mqtt-frontend.