### PR TITLE
Bosch ```BSP-FZ2```: Enable OTA updates

### DIFF
--- a/devices/bosch.js
+++ b/devices/bosch.js
@@ -812,6 +812,7 @@ const definition = [
         model: 'BSP-FZ2',
         vendor: 'Bosch',
         description: 'Plug compact EU',
+        ota: ota.zigbeeOTA,
         fromZigbee: [fz.on_off, fz.power_on_behavior, fz.electrical_measurement, fz.metering],
         toZigbee: [tz.on_off, tz.power_on_behavior],
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
Bosch released a firmware update for the ```BSP-FZ2``` today. To allow the update over Z2M, I had to modify the converter. This is for IT. 