### PR TITLE
add xiaomi_multistate_action converter for WS-USC03

### DIFF
--- a/src/devices/xiaomi.js
+++ b/src/devices/xiaomi.js
@@ -1026,7 +1026,7 @@ module.exports = [
         model: 'WS-USC03',
         vendor: 'Xiaomi',
         description: 'Aqara smart wall switch (neutral, single rocker)',
-        fromZigbee: [fz.on_off, fz.xiaomi_power, fz.aqara_opple],
+        fromZigbee: [fz.on_off, fz.xiaomi_power, fz.xiaomi_multistate_action, fz.aqara_opple],
         toZigbee: [tz.on_off, tz.xiaomi_power, tz.xiaomi_switch_operation_mode_opple, tz.xiaomi_switch_power_outage_memory,
             tz.xiaomi_flip_indicator_light],
         exposes: [e.switch(), e.action(['single', 'double']), e.flip_indicator_light(), e.power_outage_count(),


### PR DESCRIPTION
In my previous PR (https://github.com/Koenkk/zigbee-herdsman-converters/pull/5770), I added several supported features for Aqara WS-USC03. However, I realized that I did not specify the xiaomi_multistate_action converter for the device.

This simple commit will add the missing converter for the device.