### PR TITLE
Update Acova Taffetas2 features

### DIFF
--- a/src/devices/acova.js
+++ b/src/devices/acova.js
@@ -70,7 +70,7 @@ module.exports = [
         zigbeeModel: ['TAFFETAS2 D1.00P1.02Z1.00', 'TAFFETAS2 D1.00P1.01Z1.00'],
         model: 'TAFFETAS2',
         vendor: 'Acova',
-        description: 'Taffetas 2 heater (custom)',
+        description: 'Taffetas 2 heater',
         fromZigbee: [fz.thermostat, fz.hvac_user_interface, fz.occupancy],
         toZigbee: [
             tz.thermostat_local_temperature,

--- a/src/devices/acova.js
+++ b/src/devices/acova.js
@@ -67,19 +67,18 @@ module.exports = [
         },
     },
     {
-        zigbeeModel: ['TAFFETAS2 D1.00P1.02Z1.00\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
-            'TAFFETAS2 D1.00P1.01Z1.00\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
+        zigbeeModel: ['TAFFETAS2 D1.00P1.02Z1.00', 'TAFFETAS2 D1.00P1.01Z1.00'],
         model: 'TAFFETAS2',
         vendor: 'Acova',
-        description: 'Taffetas 2 heater',
-        fromZigbee: [fz.thermostat, fz.hvac_user_interface],
+        description: 'Taffetas 2 heater (custom)',
+        fromZigbee: [fz.thermostat, fz.hvac_user_interface, fz.occupancy],
         toZigbee: [
             tz.thermostat_local_temperature,
             tz.thermostat_system_mode,
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_occupied_cooling_setpoint,
             tz.thermostat_running_state,
+            tz.thermostat_local_temperature_calibration,
         ],
         exposes: [
             exposes.climate()
@@ -87,15 +86,21 @@ module.exports = [
                 .withSetpoint('unoccupied_heating_setpoint', 7, 28, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(['off', 'heat', 'auto'])
-                .withRunningState(['idle', 'heat']),
+                .withRunningState(['idle', 'heat'])
+                .withLocalTemperatureCalibration('local_temperature_calibration'),
+            e.occupancy(),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
+            const endpoint2 = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
+            await reporting.bind(endpoint2, coordinatorEndpoint, ['msOccupancySensing']);
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatRunningState(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatTemperatureCalibration(endpoint);
+            await reporting.occupancy(endpoint2)
         },
     },
 ];

--- a/src/devices/acova.js
+++ b/src/devices/acova.js
@@ -101,7 +101,7 @@ module.exports = [
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatTemperatureCalibration(endpoint);
-            await reporting.occupancy(endpoint2)
+            await reporting.occupancy(endpoint2);
         },
     },
 ];

--- a/src/devices/acova.js
+++ b/src/devices/acova.js
@@ -2,6 +2,7 @@ const exposes = require('../lib/exposes');
 const fz = require('../converters/fromZigbee');
 const tz = require('../converters/toZigbee');
 const reporting = require('../lib/reporting');
+const e = exposes.presets;
 
 module.exports = [
     {


### PR DESCRIPTION
added some features to Taffetas 2 heaters :
 - occupancy reporting using embedded motion sensor (stays on for 2 hours when triggered and is triggered by any change on the heater configuration : mode, set-point...)
 - unoccupied set-point control
 - temperature calibration control