### PR TITLE
ZNCLBL01LM: Added parsing for illuminance_lux

### DIFF
--- a/src/devices/xiaomi.js
+++ b/src/devices/xiaomi.js
@@ -2381,6 +2381,7 @@ module.exports = [
             e.battery().withAccess(ea.STATE_GET),
             e.battery_voltage().withAccess(ea.STATE_GET),
             e.device_temperature(),
+            e.illuminance_lux(),
             e.action(['manual_open', 'manual_close']),
             exposes.enum('motor_state', ea.STATE, ['stopped', 'opening', 'closing', 'pause']).withDescription('Motor state'),
             exposes.binary('running', ea.STATE, true, false).withDescription('Whether the motor is moving or not'),

--- a/src/lib/xiaomi.js
+++ b/src/lib/xiaomi.js
@@ -657,7 +657,7 @@ const numericAttributes2Payload = async (msg, meta, model, options, dataObject) 
             break;
         case '1065':
             if (['ZNCLBL01LM'].includes(model.model)) {
-                payload.illuminance_lux = +value * 50;
+                payload.illuminance_lux = value * 50;
             }
             break;
         case '1289':

--- a/src/lib/xiaomi.js
+++ b/src/lib/xiaomi.js
@@ -655,6 +655,11 @@ const numericAttributes2Payload = async (msg, meta, model, options, dataObject) 
                 payload.hooks_lock = {0: 'UNLOCK', 1: 'LOCK', 2: 'UNLOCK', 3: 'LOCK'}[value];
             }
             break;
+        case '1065':
+            if (['ZNCLBL01LM'].includes(model.model)) {
+                payload.illuminance_lux = +value * 50;
+            }
+            break;
         case '1289':
             payload.dimmer_mode = {3: 'rgbw', 1: 'dual_ct'}[value];
             break;


### PR DESCRIPTION
Added possibility to parse illuminance_lux provided from ZNCLBL01LM

founded hubitat example for Zigbee - Aqara E1 Smart Curtain Motor 
[link](https://github.com/yoyotogblo/Hubitat/blob/master/Drivers/Zigbee%20-%20Aqara%20E1%20Smart%20Curtain%20Motor) 376 line

Created custom converter with next code
[Gist](https://gist.github.com/desout/489f8f334dcf47f5b02deb92008dd4f5)

### How it works

In case of night it shows _0_ in _1065_ attribute

In case of day it shows _2_ in _1065_ attribute

Tested via closing light sensor manually

Message provided just in case of value change.

![Screenshot 2023-05-23 at 8 37 05 AM](https://github.com/Koenkk/zigbee-herdsman-converters/assets/35991006/cd41bbb7-0e91-4ac3-99c4-bf87a0fae5c0)
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/35991006/fc7102b1-8e95-41c7-9fe7-18f62a395bcf)
