### PR TITLE
Profalux covers: switch to using cluster 0x102, add MAI-ZTP20C remote

### DIFF
--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -46,7 +46,7 @@ const definitions: Definition[] = [
         // is the right thing to do.
         fingerprint: [{manufacturerID: 4368, endpoints: [{ID: 1, profileID: 260, deviceID: 512,
             inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544]}]}],
-        model: 'NSAV061 (old)',
+        model: 'NSAV061_old',
         vendor: 'Profalux',
         description: 'Cover',
         fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -46,7 +46,7 @@ const definitions: Definition[] = [
         // is the right thing to do.
         fingerprint: [{manufacturerID: 4368, endpoints: [{ID: 1, profileID: 260, deviceID: 512,
             inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544]}]}],
-        model: 'NSAV061_old',
+        model: 'NSAV061_v1',
         vendor: 'Profalux',
         description: 'Cover',
         fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -18,13 +18,23 @@ const definitions: Definition[] = [
         exposes: [],
     },
     {
-        // Recent covers are matched by Zigbee model. Their remotes communicate using cluster 0x102 "closuresWindowCovering", so use that.
+        // Recent covers are matched by Zigbee model. Their remotes communicate
+        // using cluster 0x102 "closuresWindowCovering", so use that.
+        // 06/10/20/30 is the torque in Nm. 20/30 have not been seen but
+        // extracted from Profalux documentation. C/F seems to be a version. D
+        // and E have not been seen in the while. I suspect A is the earlier
+        // model covered below, NSAV061_v1.
         zigbeeModel: [
             'MOT-C1Z06C\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
-            'MOT-C1Z10F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
+            'MOT-C1Z10C\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
+            'MOT-C1Z20C\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
+            'MOT-C1Z30C\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
             'MOT-C1Z06F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
+            'MOT-C1Z10F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
+            'MOT-C1Z20F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
+            'MOT-C1Z30F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
         ],
-        model: 'NSAV061',
+        model: 'MOT-C1ZxxC/F',
         vendor: 'Profalux',
         description: 'Cover',
         fromZigbee: [fz.command_cover_close, fz.command_cover_open, fz.cover_position_tilt],

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -29,7 +29,7 @@ const definitions: Definition[] = [
         description: 'Cover',
         fromZigbee: [fz.command_cover_close, fz.command_cover_open, fz.cover_position_tilt ],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        exposes: [e.cover_position().setAccess('state', ea.ALL)],
+        exposes: [e.cover_position() ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -23,7 +23,7 @@ const definitions: Definition[] = [
         // 06/10/20/30 is the torque in Nm. 20/30 have not been seen but
         // extracted from Profalux documentation. C/F seems to be a version. D
         // and E have not been seen in the while. I suspect A is the earlier
-        // model covered below, NSAV061_v1.
+        // model covered below, NSAV061.
         zigbeeModel: [
             'MOT-C1Z06C\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
             'MOT-C1Z10C\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
@@ -56,7 +56,7 @@ const definitions: Definition[] = [
         // is the right thing to do.
         fingerprint: [{manufacturerID: 4368, endpoints: [{ID: 1, profileID: 260, deviceID: 512,
             inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544]}]}],
-        model: 'NSAV061_v1',
+        model: 'NSAV061',
         vendor: 'Profalux',
         description: 'Cover',
         fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -18,28 +18,51 @@ const definitions: Definition[] = [
         exposes: [],
     },
     {
+        // Recent covers are matched by Zigbee model. Their remotes communicate using cluster 0x102 "closuresWindowCovering", so use that.
         zigbeeModel: [
             'MOT-C1Z06C\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
             'MOT-C1Z10F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
             'MOT-C1Z06F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
         ],
-        fingerprint: [{manufacturerID: 4368, endpoints: [{ID: 1, profileID: 260, deviceID: 512,
-            inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544]}]}],
         model: 'NSAV061',
         vendor: 'Profalux',
         description: 'Cover',
-        fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],
-        toZigbee: [tz.cover_via_brightness],
+        fromZigbee: [fz.command_cover_close, fz.command_cover_open, fz.cover_position_tilt ],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt],
         exposes: [e.cover_position().setAccess('state', ea.ALL)],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(2);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
+            await reporting.currentPositionLiftPercentage(endpoint);
+        },  
+            endpoint: (device) => {
+                    return { default: 2};
+            },
+    },
+    {
+        // Identify older covers based on their fingerprint. These do not
+        // expose closuresWindowCovering and need to use genLevelCtrl
+        // instead. Sniffing a remote would be welcome to confirm that this
+        // is the right thing to do.
+        fingerprint: [{ manufacturerID: 4368, endpoints: [{ ID: 1, profileID: 260, deviceID: 512,
+                        inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544] }] }],
+        model: 'NSAV061 (old)',
+        vendor: 'Profalux',
+        description: 'Cover',
+        fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff ],
+        toZigbee: [tz.cover_via_brightness ],
+        exposes: [e.cover_position().setAccess('state', ea.ALL)], 
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genLevelCtrl']);
-            await reporting.brightness(endpoint);
+            await reporting.currentPositionLiftPercentage(endpoint);
         },
     },
     {
-        zigbeeModel: ['MAI-ZTP20F'],
-        model: 'MAI-ZTP20F',
+        // Newer remotes. These expose a bunch of things but they are bound to                                                                                // the cover and don't seem to communicate with the coordinator, so
+        // nothing is likely to be doable in Z2M.
+        zigbeeModel: ['MAI-ZTP20F', 'MAI-ZTP20C'],
+        model: 'MAI-ZTP20',
         vendor: 'Profalux',
         description: 'Cover remote',
         fromZigbee: [],

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -27,24 +27,24 @@ const definitions: Definition[] = [
         model: 'NSAV061',
         vendor: 'Profalux',
         description: 'Cover',
-        fromZigbee: [fz.command_cover_close, fz.command_cover_open, fz.cover_position_tilt ],
+        fromZigbee: [fz.command_cover_close, fz.command_cover_open, fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        exposes: [e.cover_position() ],
+        exposes: [e.cover_position()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
             await reporting.currentPositionLiftPercentage(endpoint);
-        },  
-            endpoint: (device) => {
-                    return { default: 2};
-            },
+        }, 
+        endpoint: (device) => {
+                return {default: 2};
+        },
     },
     {
         // Identify older covers based on their fingerprint. These do not
         // expose closuresWindowCovering and need to use genLevelCtrl
         // instead. Sniffing a remote would be welcome to confirm that this
         // is the right thing to do.
-        fingerprint: [{ manufacturerID: 4368, endpoints: [{ ID: 1, profileID: 260, deviceID: 512,
+        fingerprint: [{manufacturerID: 4368, endpoints: [{ID: 1, profileID: 260, deviceID: 512,
                         inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544] }] }],
         model: 'NSAV061 (old)',
         vendor: 'Profalux',
@@ -59,7 +59,8 @@ const definitions: Definition[] = [
         },
     },
     {
-        // Newer remotes. These expose a bunch of things but they are bound to                                                                                // the cover and don't seem to communicate with the coordinator, so
+        // Newer remotes. These expose a bunch of things but they are bound to
+        // the cover and don't seem to communicate with the coordinator, so
         // nothing is likely to be doable in Z2M.
         zigbeeModel: ['MAI-ZTP20F', 'MAI-ZTP20C'],
         model: 'MAI-ZTP20',

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -34,9 +34,9 @@ const definitions: Definition[] = [
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
             await reporting.currentPositionLiftPercentage(endpoint);
-        }, 
+        },
         endpoint: (device) => {
-                return {default: 2};
+            return {default: 2};
         },
     },
     {
@@ -45,13 +45,13 @@ const definitions: Definition[] = [
         // instead. Sniffing a remote would be welcome to confirm that this
         // is the right thing to do.
         fingerprint: [{manufacturerID: 4368, endpoints: [{ID: 1, profileID: 260, deviceID: 512,
-                        inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544] }] }],
+            inputClusters: [0, 3, 4, 5, 6, 8, 10, 21, 256, 64544, 64545], outputClusters: [3, 64544]}]}],
         model: 'NSAV061 (old)',
         vendor: 'Profalux',
         description: 'Cover',
-        fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff ],
-        toZigbee: [tz.cover_via_brightness ],
-        exposes: [e.cover_position().setAccess('state', ea.ALL)], 
+        fromZigbee: [fz.cover_position_via_brightness, fz.cover_state_via_onoff],
+        toZigbee: [tz.cover_via_brightness],
+        exposes: [e.cover_position().setAccess('state', ea.ALL)],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genLevelCtrl']);


### PR DESCRIPTION
This change references remote model MAI-ZTP20C.
More importantly, it switches the control of covers to using the dedicated ClosuresWindowCovering (0x102) cluster. Sniffing Zigbee traffic of my remotes show that the remotes use this cluster to control the covers, and not 0x8 as currently implemented. The compliance document for the Profalux motors at https://csa-iot.org/csa_product/ac-motor-for-window-coverings/ also lists that cluster and does NOT list 0x6/0x8.

So I think the correct way to control these covers is 0x102, and certainly it's the way that seems to work with my shutters (all bought in 2023).

This change is likely to break existing setups if older revisions of these motors did not expose 0x102.

0x102 is on endpoint 2, while 0x6/0x8 are on endpoint 1. An ideal implementation would use 0x102 when it exists, and 0x8 the rest of the time, but I don't know how to implement that.

This change needs testing by other Profalux users!
Looking into https://github.com/Koenkk/zigbee2mqtt/issues/17674 is what prompted me to sniff traffic to figure out what was wrong.