### PR TITLE
fix trailing space in SNZB-02P description

### DIFF
--- a/src/devices/sonoff.js
+++ b/src/devices/sonoff.js
@@ -278,7 +278,7 @@ module.exports = [
         zigbeeModel: ['SNZB-02P'],
         model: 'SNZB-02P',
         vendor: 'SONOFF',
-        description: 'Temperature and humidity sensor ',
+        description: 'Temperature and humidity sensor',
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_low(), e.battery_voltage()],
         fromZigbee: [fz.temperature, fz.humidity, fz.battery],
         toZigbee: [],


### PR DESCRIPTION
Not sure what the pr subject should be with the changes... I don't think it's `feat: ...` ?

Anyway, the recent PR that added support for SNZB-02P had a training space in the description, this one removes it.