### PR TITLE
fix(ignore): fix SNZB-02D not showing power source correctly

### DIFF
--- a/src/devices/sonoff.js
+++ b/src/devices/sonoff.js
@@ -178,6 +178,8 @@ module.exports = [
             await reporting.temperature(endpoint, {min: 5, max: constants.repInterval.MINUTES_30, change: 20});
             await reporting.humidity(endpoint);
             await reporting.batteryPercentageRemaining(endpoint, {min: 3600, max: 7200});
+            device.powerSource = 'Battery';
+            device.save();
         },
     },
     {


### PR DESCRIPTION
This PR fixes incorrectly displayed power source for Sonoff SNZB-02D
