### PR TITLE
fix: IKEA FYRTUR and friends on fwVer >= 24 have wrong checkinInterval after OTA

### DIFF
--- a/src/devices/ikea.js
+++ b/src/devices/ikea.js
@@ -891,6 +891,14 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
             await reporting.batteryPercentageRemaining(endpoint);
             await reporting.currentPositionLiftPercentage(endpoint);
+
+            // NOTE: Firmware 24.4.11 introduce genPollCtrl
+            //       after OTA update the checkinInterval is 4 which spams the network a lot
+            //       removing + factory resetting has it set to 172800, we set the same value here
+            //       so people do not need to update.
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 24) {
+                await endpoint.write('genPollCtrl', {'checkinInterval': 172800});
+            }
         },
         exposes: [e.cover_position(), e.battery().withAccess(ea.STATE_GET)],
     },
@@ -907,6 +915,14 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
             await reporting.batteryPercentageRemaining(endpoint);
             await reporting.currentPositionLiftPercentage(endpoint);
+
+            // NOTE: Firmware 24.4.11 introduce genPollCtrl
+            //       after OTA update the checkinInterval is 4 which spams the network a lot
+            //       removing + factory resetting has it set to 172800, we set the same value here
+            //       so people do not need to update.
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 24) {
+                await endpoint.write('genPollCtrl', {'checkinInterval': 172800});
+            }
         },
         exposes: [e.cover_position(), e.battery().withAccess(ea.STATE_GET)],
     },
@@ -923,6 +939,14 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
             await reporting.batteryPercentageRemaining(endpoint);
             await reporting.currentPositionLiftPercentage(endpoint);
+
+            // NOTE: Firmware 24.4.11 introduce genPollCtrl
+            //       after OTA update the checkinInterval is 4 which spams the network a lot
+            //       removing + factory resetting has it set to 172800, we set the same value here
+            //       so people do not need to update.
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 24) {
+                await endpoint.write('genPollCtrl', {'checkinInterval': 172800});
+            }
         },
         exposes: [e.cover_position(), e.battery().withAccess(ea.STATE_GET)],
     },
@@ -940,6 +964,14 @@ module.exports = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);
             await reporting.batteryPercentageRemaining(endpoint);
             await reporting.currentPositionLiftPercentage(endpoint);
+
+            // NOTE: Firmware 24.4.11 introduce genPollCtrl
+            //       after OTA update the checkinInterval is 4 which spams the network a lot
+            //       removing + factory resetting has it set to 172800, we set the same value here
+            //       so people do not need to update.
+            if (device && device.softwareBuildID && device.softwareBuildID.split('.')[0] >= 24) {
+                await endpoint.write('genPollCtrl', {'checkinInterval': 172800});
+            }
         },
         exposes: [e.cover_position(), e.battery()],
     },


### PR DESCRIPTION
When doing an OTA update to 24.4.11 FYRTUR (and presumable other blinds as it's the same firmware) start spamming the network:

```
debug 2023-06-03 16:09:38: Received Zigbee message from 'cover/livingroom/side_front_window', type 'commandCheckIn', cluster 'genPollCtrl', data '{}' from endpoint 1 with groupID 0
debug 2023-06-03 16:09:38: Received Zigbee message from 'cover/livingroom/side_back_window', type 'commandCheckIn', cluster 'genPollCtrl', data '{}' from endpoint 1 with groupID 0
debug 2023-06-03 16:09:39: Received Zigbee message from 'cover/livingroom/side_front_window', type 'commandCheckIn', cluster 'genPollCtrl', data '{}' from endpoint 1 with groupID 0
debug 2023-06-03 16:09:39: Received Zigbee message from 'cover/livingroom/side_back_window', type 'commandCheckIn', cluster 'genPollCtrl', data '{}' from endpoint 1 with groupID 0
debug 2023-06-03 16:09:40: Received Zigbee message from 'cover/livingroom/side_front_window', type 'commandCheckIn', cluster 'genPollCtrl', data '{}' from endpoint 1 with groupID 0
debug 2023-06-03 16:09:40: Received Zigbee message from 'cover/livingroom/side_back_window', type 'commandCheckIn', cluster 'genPollCtrl', data '{}' from endpoint 1 with groupID 0
debug 2023-06-03 16:09:41: Received Zigbee message from 'cover/livingroom/side_front_window', type 'commandCheckIn', cluster 'genPollCtrl', data '{}' from endpoint 1 with groupID 0
```

For some reason the genPollCtrl.checkinInterval is set to `4`, the default after a full reset and (re)join seems to be `13200`, we simple set this in `configure()` so people do not need to reset their upgraded blinds.

This fixes #5836 

Tests done:

Set the genPollCtrl.checkinInterval back to `4`, hit the reconfigure button:
```
Zigbee2MQTT:info  2023-06-04 00:45:50: Configuring 'cover/livingroom/side_back_window'
Zigbee2MQTT:info  2023-06-04 00:45:52: Successfully configured 'cover/livingroom/side_back_window'
```

Verify configure still completes successfully. then read genPollCtrl.checkinInterval via the dev console to verify the valuye is now indeed `13200`.