### PR TITLE
disablePowerOnBehavior: true for Innr FL 130 C

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -59,7 +59,7 @@ const definitions: Definition[] = [
         model: 'FL 130 C',
         vendor: 'Innr',
         description: 'Color Flex LED strip',
-        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 555], supportsHueAndSaturation: true}),
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 555], supportsHueAndSaturation: true, disablePowerOnBehavior: true}),
         meta: {applyRedFix: true, turnsOffAtBrightness1: true},
     },
     {

--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -59,7 +59,9 @@ const definitions: Definition[] = [
         model: 'FL 130 C',
         vendor: 'Innr',
         description: 'Color Flex LED strip',
-        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 555], supportsHueAndSaturation: true, disablePowerOnBehavior: true}),
+        extend: extend.light_onoff_brightness_colortemp_color({
+            colorTempRange: [153, 555], supportsHueAndSaturation: true, disablePowerOnBehavior: true},
+        ),
         meta: {applyRedFix: true, turnsOffAtBrightness1: true},
     },
     {


### PR DESCRIPTION
Fixing 
Publish 'set' 'power_on_behavior' to 'xxx' failed: 'Error: Write 0x00158d0001c9e37e/1 genOnOff({"startUpOnOff":1}, {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'