### PR TITLE
fix: IKEA SYMFONISK gen2 does not need to divide the batteryPercentageRemaining

### DIFF
--- a/src/devices/ikea.js
+++ b/src/devices/ikea.js
@@ -1185,7 +1185,7 @@ module.exports = [
         model: 'E2123',
         vendor: 'IKEA',
         description: 'SYMFONISK sound remote gen2',
-        fromZigbee: [ikea.fz.battery, fz.legacy.E1744_play_pause, ikea.fz.ikea_track_click, ikea.fz.ikea_volume_click,
+        fromZigbee: [fz.battery, fz.legacy.E1744_play_pause, ikea.fz.ikea_track_click, ikea.fz.ikea_volume_click,
             ikea.fz.ikea_volume_hold, ikea.fz.ikea_dots_click_v1, ikea.fz.ikea_dots_click_v2],
         exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['toggle', 'track_previous', 'track_next', 'volume_up',
             'volume_down', 'volume_up_hold', 'volume_down_hold', 'dots_1_initial_press', 'dots_2_initial_press',


### PR DESCRIPTION
We have a `ikea.fz.battery` that tries to be smart based on the fwVersion if we need to divide or not, IKEA fixed there implementation to be in spec a while ago.

The SYMFONISK gen2 remote never had the problem and our fwVersion check checkes for a version that is high enough, but this remote has an good firmware even at major 1.

We can simply switch to the regular `fz.battery` to get the correct result here.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/17616