### PR TITLE
Add RDM003 to Philips hue smart button

### DIFF
--- a/src/devices/philips.js
+++ b/src/devices/philips.js
@@ -1931,7 +1931,7 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['ROM001'],
+        zigbeeModel: ['ROM001', 'RDM003'],
         model: '8718699693985',
         vendor: 'Philips',
         description: 'Hue smart button',


### PR DESCRIPTION
I live in AU, have purchased a new smart button that reports a different model from my old ones. I've created a custom converter which is literally the same as the existing one but with an updated model and that works for me on my own setup, so here's a PR to add it to master.

Not quite sure how best to 'prove' that this is correct aside "I have one, trust me", but here's a photo if anyone's curious: (old=left, new=right)

![PXL_20230605_213305104](https://github.com/Koenkk/zigbee-herdsman-converters/assets/119184/fa534112-b0fd-497e-a473-5921f10d6f18)
