### PR TITLE
add support for EGLO FUEVA-Z (ceiling light IP44)

### DIFF
--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -23,6 +23,13 @@ const definitions: Definition[] = [
         description: 'SALITERAS-Z ceiling light',
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
     },
+    {
+        zigbeeModel: ['EGLO_ZM_TW_CLP'],
+        model: '98847',
+        vendor: 'EGLO',
+        description: 'EGLO FUEVA-Z ceiling light IP44',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
+    },
 ];
 
 module.exports = definitions;

--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -27,7 +27,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['EGLO_ZM_TW_CLP'],
         model: '98847',
         vendor: 'EGLO',
-        description: 'EGLO FUEVA-Z ceiling light IP44',
+        description: 'FUEVA-Z ceiling light IP44',
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
     },
 ];


### PR DESCRIPTION
It seems to be working, however preset `warm` is missing for `color_temp` and `color_temp_startup` (where are only `coolest`, `cool`, `neutral` and `warmest` visible on GUI). Why? I also noticed that both `neutral` and `warmest` pressets are equal 370. It should be fixed, but how?