### PR TITLE
Add support for Lonsonho X702A

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "zigbee-herdsman-converters",
-      "version": "15.21.2",
+      "version": "15.24.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1936,7 +1936,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
-        meta: { multiEndpoint: true },
+        meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1932,9 +1932,9 @@ const definitions: Definition[] = [
         model: 'TS0002_switch_module_3',
         vendor: 'TuYa',
         description: '2-Gang switch with backlight',
-        extend: tuya.extend.switch({ powerOnBehavior2: true, indicatorMode: true, endpoints: ['l1', 'l2'] }),
+        extend: tuya.extend.switch({powerOnBehavior2: true, indicatorMode: true, endpoints: ['l1', 'l2']}),
         endpoint: (device) => {
-            return { 'l1': 1, 'l2': 2 };
+            return {'l1': 1, 'l2': 2};
         },
         meta: { multiEndpoint: true },
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -1952,16 +1952,16 @@ const definitions: Definition[] = [
         vendor: 'TuYa',
         description: '2 gang switch',
         whiteLabel: [
-            { vendor: 'Zemismart', model: 'ZM-CSW002-D_switch' },
-            { vendor: 'Lonsonho', model: 'X702' },
-            { vendor: 'Lonsonho', model: 'X702A' },
-            { vendor: 'Avatto', model: 'ZTS02' }],
+            {vendor: 'Zemismart', model: 'ZM-CSW002-D_switch'},
+            {vendor: 'Lonsonho', model: 'X702'},
+            {vendor: 'Lonsonho', model: 'X702A'},
+            {vendor: 'Avatto', model: 'ZTS02'}],
         extend: tuya.extend.switch(),
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],
         endpoint: (device) => {
-            return { 'l1': 1, 'l2': 2 };
+            return {'l1': 1, 'l2': 2};
         },
-        meta: { multiEndpoint: true },
+        meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1944,7 +1944,7 @@ const definitions: Definition[] = [
         },
         whiteLabel: [
             tuya.whitelabel('Lonsonho', 'X702A', '2 Gang switch with backlight', ['_TZ3000_54hjn4vs']),
-        ]
+        ],
     },
     {
         zigbeeModel: ['TS0002'],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1932,6 +1932,48 @@ const definitions: Definition[] = [
         model: 'TS0002',
         vendor: 'TuYa',
         description: '2 gang switch',
+        whiteLabel: [
+            { vendor: 'Zemismart', model: 'ZM-CSW002-D_switch' },
+            { vendor: 'Lonsonho', model: 'X702' },
+            { vendor: 'Lonsonho', model: 'X702A' },
+            { vendor: 'Avatto', model: 'ZTS02' }
+        ],
+        extend: tuya.extend.switch(),
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],
+        endpoint: (device) => {
+            return { 'l1': 1, 'l2': 2 };
+        },
+        meta: { multiEndpoint: true },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_54hjn4vs']),
+        model: 'TS0002',
+        vendor: 'TuYa',
+        description: '2-Gang switch with backlight',
+        extend: tuya.extend.switch({ powerOnBehavior2: true, indicatorMode: true, endpoints: ['l1', 'l2'] }),
+        endpoint: (device) => {
+            return { 'l1': 1, 'l2': 2 };
+        },
+        meta: { multiEndpoint: true },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+        },
+        whiteLabel: [
+            tuya.whitelabel('Lonsonho', 'X702A', '2 Gang switch with backlight', ['_TZ3000_54hjn4vs']),
+        ]
+    },
+    {
+        zigbeeModel: ['TS0002'],
+        model: 'TS0002',
+        vendor: 'TuYa',
+        description: '2 gang switch',
         whiteLabel: [{vendor: 'Zemismart', model: 'ZM-CSW002-D_switch'}, {vendor: 'Lonsonho', model: 'X702'},
             {vendor: 'Avatto', model: 'ZTS02'}],
         extend: tuya.extend.switch(),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1929,7 +1929,7 @@ const definitions: Definition[] = [
     },
     {
         fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_54hjn4vs']),
-        model: 'TS0002',
+        model: 'TS0002_switch_module_3',
         vendor: 'TuYa',
         description: '2-Gang switch with backlight',
         extend: tuya.extend.switch({ powerOnBehavior2: true, indicatorMode: true, endpoints: ['l1', 'l2'] }),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1954,7 +1954,6 @@ const definitions: Definition[] = [
         whiteLabel: [
             {vendor: 'Zemismart', model: 'ZM-CSW002-D_switch'},
             {vendor: 'Lonsonho', model: 'X702'},
-            {vendor: 'Lonsonho', model: 'X702A'},
             {vendor: 'Avatto', model: 'ZTS02'}],
         extend: tuya.extend.switch(),
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1928,29 +1928,6 @@ const definitions: Definition[] = [
         },
     },
     {
-        zigbeeModel: ['TS0002'],
-        model: 'TS0002',
-        vendor: 'TuYa',
-        description: '2 gang switch',
-        whiteLabel: [
-            { vendor: 'Zemismart', model: 'ZM-CSW002-D_switch' },
-            { vendor: 'Lonsonho', model: 'X702' },
-            { vendor: 'Lonsonho', model: 'X702A' },
-            { vendor: 'Avatto', model: 'ZTS02' }
-        ],
-        extend: tuya.extend.switch(),
-        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],
-        endpoint: (device) => {
-            return { 'l1': 1, 'l2': 2 };
-        },
-        meta: { multiEndpoint: true },
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-        },
-    },
-    {
         fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_54hjn4vs']),
         model: 'TS0002',
         vendor: 'TuYa',
@@ -1974,14 +1951,17 @@ const definitions: Definition[] = [
         model: 'TS0002',
         vendor: 'TuYa',
         description: '2 gang switch',
-        whiteLabel: [{vendor: 'Zemismart', model: 'ZM-CSW002-D_switch'}, {vendor: 'Lonsonho', model: 'X702'},
-            {vendor: 'Avatto', model: 'ZTS02'}],
+        whiteLabel: [
+            { vendor: 'Zemismart', model: 'ZM-CSW002-D_switch' },
+            { vendor: 'Lonsonho', model: 'X702' },
+            { vendor: 'Lonsonho', model: 'X702A' },
+            { vendor: 'Avatto', model: 'ZTS02' }],
         extend: tuya.extend.switch(),
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],
         endpoint: (device) => {
-            return {'l1': 1, 'l2': 2};
+            return { 'l1': 1, 'l2': 2 };
         },
-        meta: {multiEndpoint: true},
+        meta: { multiEndpoint: true },
         configure: async (device, coordinatorEndpoint, logger) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1931,7 +1931,7 @@ const definitions: Definition[] = [
         fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_54hjn4vs']),
         model: 'TS0002_switch_module_3',
         vendor: 'TuYa',
-        description: '2-Gang switch with backlight',
+        description: '2 gang switch with backlight',
         extend: tuya.extend.switch({powerOnBehavior2: true, indicatorMode: true, endpoints: ['l1', 'l2']}),
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
@@ -1943,7 +1943,7 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
         },
         whiteLabel: [
-            tuya.whitelabel('Lonsonho', 'X702A', '2 Gang switch with backlight', ['_TZ3000_54hjn4vs']),
+            tuya.whitelabel('Lonsonho', 'X702A', '2 gang switch with backlight', ['_TZ3000_54hjn4vs']),
         ],
     },
     {


### PR DESCRIPTION
Added support for [Lonsonho X702A](https://www.aliexpress.com/item/4001138076397.html) (2-gang with neutral).
Added LED backlight settings
Added power_on_behavior for each channel
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/40930080/d6fbbedc-6410-491e-b92c-dab348f2cdbe)
