### PR TITLE
Update hvacThermostat attributes + invalid value handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If any of those commands finish with an error your PR won't pass the tests and w
 - `disableActionGroup`: Prevents some converters adding the action_group to the payload (default: false)
 - `tuyaThermostatSystemMode`/`tuyaThermostatPreset`: TuYa specific thermostat options
 - `thermostat`: see e.g. HT-08 definition
-  - `{dontMapPIHeatingDemand: true}`: do not map piHeatingDemand from 0-255 -> 0-100, see fromZigbee.thermostat (default: false)
+  - `{dontMapPIHeatingDemand: true}`: do not map `pIHeatingDemand`/`pICoolingDemand` from 0-255 -> 0-100, see fromZigbee.thermostat (default: false)
 - `battery`:
   - `{dontDividePercentage: true}`: prevents batteryPercentageRemainig from being divided (ZCL 200=100%, but some report 100=100%) (default: false)
   - `{voltageToPercentage: '3V_2100'}`: convert voltage to percentage using specified option. See utils.batteryVoltageToPercentage() (default: null, no voltage to percentage conversion)

--- a/src/converters/fromZigbee.js
+++ b/src/converters/fromZigbee.js
@@ -43,7 +43,7 @@ const converters = {
             const dontMapPIHeatingDemand = model.meta && model.meta.thermostat && model.meta.thermostat.dontMapPIHeatingDemand;
             if (msg.data.hasOwnProperty('localTemp')) {
                 let value = precisionRound(msg.data['localTemp'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('local_temperature', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('localTemperatureCalibration')) {
@@ -52,7 +52,7 @@ const converters = {
             }
             if (msg.data.hasOwnProperty('outdoorTemp')) {
                 let value = precisionRound(msg.data['outdoorTemp'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('outdoor_temperature', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('occupancy')) {
@@ -61,7 +61,7 @@ const converters = {
             if (msg.data.hasOwnProperty('occupiedHeatingSetpoint')) {
                 let value = precisionRound(msg.data['occupiedHeatingSetpoint'], 2) / 100;
                 // Stelpro will return -325.65 when set to off, value is not realistic anyway
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('occupied_heating_setpoint', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('unoccupiedHeatingSetpoint')) {
@@ -134,37 +134,37 @@ const converters = {
             }
             if (msg.data.hasOwnProperty('minHeatSetpointLimit')) {
                 let value = precisionRound(msg.data['minHeatSetpointLimit'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('min_heat_setpoint_limit', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('maxHeatSetpointLimit')) {
                 let value = precisionRound(msg.data['maxHeatSetpointLimit'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('max_heat_setpoint_limit', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('absMinHeatSetpointLimit')) {
                 let value = precisionRound(msg.data['absMinHeatSetpointLimit'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('abs_min_heat_setpoint_limit', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('absMaxHeatSetpointLimit')) {
                 let value = precisionRound(msg.data['absMaxHeatSetpointLimit'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('abs_max_heat_setpoint_limit', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('absMinCoolSetpointLimit')) {
                 let value = precisionRound(msg.data['absMinCoolSetpointLimit'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('abs_min_cool_setpoint_limit', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('absMaxCoolSetpointLimit')) {
                 let value = precisionRound(msg.data['absMaxCoolSetpointLimit'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('abs_max_cool_setpoint_limit', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('minSetpointDeadBand')) {
                 let value = precisionRound(msg.data['minSetpointDeadBand'], 2) / 100;
-                value = value < -250 ? 0 : value;
+                value = value < -273.15 ? null : value;
                 result[postfixWithEndpointName('min_setpoint_dead_band', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('acLouverPosition')) {

--- a/src/converters/fromZigbee.js
+++ b/src/converters/fromZigbee.js
@@ -42,14 +42,18 @@ const converters = {
             const result = {};
             const dontMapPIHeatingDemand = model.meta && model.meta.thermostat && model.meta.thermostat.dontMapPIHeatingDemand;
             if (msg.data.hasOwnProperty('localTemp')) {
-                result[postfixWithEndpointName('local_temperature', msg, model, meta)] = precisionRound(msg.data['localTemp'], 2) / 100;
+                let value = precisionRound(msg.data['localTemp'], 2) / 100;
+                value = value < -250 ? 0 : value;
+                result[postfixWithEndpointName('local_temperature', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('localTemperatureCalibration')) {
                 result[postfixWithEndpointName('local_temperature_calibration', msg, model, meta)] =
                     precisionRound(msg.data['localTemperatureCalibration'], 2) / 10;
             }
             if (msg.data.hasOwnProperty('outdoorTemp')) {
-                result[postfixWithEndpointName('outdoor_temperature', msg, model, meta)] = precisionRound(msg.data['outdoorTemp'], 2) / 100;
+                let value = precisionRound(msg.data['outdoorTemp'], 2) / 100;
+                value = value < -250 ? 0 : value;
+                result[postfixWithEndpointName('outdoor_temperature', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('occupancy')) {
                 result[postfixWithEndpointName('occupancy', msg, model, meta)] = (msg.data.occupancy % 2) > 0;

--- a/src/converters/fromZigbee.js
+++ b/src/converters/fromZigbee.js
@@ -42,27 +42,30 @@ const converters = {
             const result = {};
             const dontMapPIHeatingDemand = model.meta && model.meta.thermostat && model.meta.thermostat.dontMapPIHeatingDemand;
             if (msg.data.hasOwnProperty('localTemp')) {
-                let value = precisionRound(msg.data['localTemp'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('local_temperature', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['localTemp'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('local_temperature', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('localTemperatureCalibration')) {
                 result[postfixWithEndpointName('local_temperature_calibration', msg, model, meta)] =
                     precisionRound(msg.data['localTemperatureCalibration'], 2) / 10;
             }
             if (msg.data.hasOwnProperty('outdoorTemp')) {
-                let value = precisionRound(msg.data['outdoorTemp'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('outdoor_temperature', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['outdoorTemp'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('outdoor_temperature', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('occupancy')) {
                 result[postfixWithEndpointName('occupancy', msg, model, meta)] = (msg.data.occupancy % 2) > 0;
             }
             if (msg.data.hasOwnProperty('occupiedHeatingSetpoint')) {
-                let value = precisionRound(msg.data['occupiedHeatingSetpoint'], 2) / 100;
+                const value = precisionRound(msg.data['occupiedHeatingSetpoint'], 2) / 100;
                 // Stelpro will return -325.65 when set to off, value is not realistic anyway
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('occupied_heating_setpoint', msg, model, meta)] = value;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('occupied_heating_setpoint', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('unoccupiedHeatingSetpoint')) {
                 result[postfixWithEndpointName('unoccupied_heating_setpoint', msg, model, meta)] =
@@ -133,39 +136,46 @@ const converters = {
                     msg.data['tempSetpointHoldDuration'];
             }
             if (msg.data.hasOwnProperty('minHeatSetpointLimit')) {
-                let value = precisionRound(msg.data['minHeatSetpointLimit'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('min_heat_setpoint_limit', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['minHeatSetpointLimit'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('min_heat_setpoint_limit', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('maxHeatSetpointLimit')) {
-                let value = precisionRound(msg.data['maxHeatSetpointLimit'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('max_heat_setpoint_limit', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['maxHeatSetpointLimit'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('max_heat_setpoint_limit', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('absMinHeatSetpointLimit')) {
-                let value = precisionRound(msg.data['absMinHeatSetpointLimit'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('abs_min_heat_setpoint_limit', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['absMinHeatSetpointLimit'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('abs_min_heat_setpoint_limit', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('absMaxHeatSetpointLimit')) {
-                let value = precisionRound(msg.data['absMaxHeatSetpointLimit'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('abs_max_heat_setpoint_limit', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['absMaxHeatSetpointLimit'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('abs_max_heat_setpoint_limit', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('absMinCoolSetpointLimit')) {
-                let value = precisionRound(msg.data['absMinCoolSetpointLimit'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('abs_min_cool_setpoint_limit', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['absMinCoolSetpointLimit'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('abs_min_cool_setpoint_limit', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('absMaxCoolSetpointLimit')) {
-                let value = precisionRound(msg.data['absMaxCoolSetpointLimit'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('abs_max_cool_setpoint_limit', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['absMaxCoolSetpointLimit'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('abs_max_cool_setpoint_limit', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('minSetpointDeadBand')) {
-                let value = precisionRound(msg.data['minSetpointDeadBand'], 2) / 100;
-                value = value < -273.15 ? null : value;
-                result[postfixWithEndpointName('min_setpoint_dead_band', msg, model, meta)] = value;
+                const value = precisionRound(msg.data['minSetpointDeadBand'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('min_setpoint_dead_band', msg, model, meta)] = value;
+                }
             }
             if (msg.data.hasOwnProperty('acLouverPosition')) {
                 result[postfixWithEndpointName('ac_louver_position', msg, model, meta)] =

--- a/src/converters/fromZigbee.js
+++ b/src/converters/fromZigbee.js
@@ -116,6 +116,11 @@ const converters = {
                 result[postfixWithEndpointName('pi_heating_demand', msg, model, meta)] =
                     mapNumberRange(msg.data['pIHeatingDemand'], 0, (dontMapPIHeatingDemand ? 100: 255), 0, 100);
             }
+            if (msg.data.hasOwnProperty('pICoolingDemand')) {
+                // we assume the behavior is consistent for pIHeatingDemand + pICoolingDemand for the same vendor
+                result[postfixWithEndpointName('pi_cooling_demand', msg, model, meta)] =
+                    mapNumberRange(msg.data['pICoolingDemand'], 0, (dontMapPIHeatingDemand ? 100: 255), 0, 100);
+            }
             if (msg.data.hasOwnProperty('tempSetpointHold')) {
                 result[postfixWithEndpointName('temperature_setpoint_hold', msg, model, meta)] = msg.data['tempSetpointHold'] == 1;
             }
@@ -142,6 +147,21 @@ const converters = {
                 let value = precisionRound(msg.data['absMaxHeatSetpointLimit'], 2) / 100;
                 value = value < -250 ? 0 : value;
                 result[postfixWithEndpointName('abs_max_heat_setpoint_limit', msg, model, meta)] = value;
+            }
+            if (msg.data.hasOwnProperty('absMinCoolSetpointLimit')) {
+                let value = precisionRound(msg.data['absMinCoolSetpointLimit'], 2) / 100;
+                value = value < -250 ? 0 : value;
+                result[postfixWithEndpointName('abs_min_cool_setpoint_limit', msg, model, meta)] = value;
+            }
+            if (msg.data.hasOwnProperty('absMaxCoolSetpointLimit')) {
+                let value = precisionRound(msg.data['absMaxCoolSetpointLimit'], 2) / 100;
+                value = value < -250 ? 0 : value;
+                result[postfixWithEndpointName('abs_max_cool_setpoint_limit', msg, model, meta)] = value;
+            }
+            if (msg.data.hasOwnProperty('minSetpointDeadBand')) {
+                let value = precisionRound(msg.data['minSetpointDeadBand'], 2) / 100;
+                value = value < -250 ? 0 : value;
+                result[postfixWithEndpointName('min_setpoint_dead_band', msg, model, meta)] = value;
             }
             if (msg.data.hasOwnProperty('acLouverPosition')) {
                 result[postfixWithEndpointName('ac_louver_position', msg, model, meta)] =


### PR DESCRIPTION
Please review per-commit.

- a5be5d64657c04fd5d1a9ed55d1b0a00e213663f likely won't raise any significant discussion.
- 32f3888fd22a7f71a35a2b6c5802ae2c658e84f3 can potentially cause some backwards compatibility issues, if someone has an automation based on "expected wrong" value reported by their thermostat. On the other hand – `localTemperature` is so common (ZCL mandatory) that hopefully no/very-little devices returns invalid values.
- ad5ceb7405fb27306bf596d8b9a664d63462fd78 should be fixed because `0` can easily be a valid value for these attributes and by converting invalid values to `0` we loose the information. *The subject of discussion is if `null` is the right value to return in this case.*

Your thoughts are welcome.