### PR TITLE
Added Soil Sensor - Tuya TS0601 _TZE200_ga1maeof

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3611,7 +3611,7 @@ const definitions: Definition[] = [
         onEvent: tuya.onEventSetTime,
     },
     {
-        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay', '_TZE200_ga1maeof']),
+        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay']),
         model: 'TS0222_temperature_humidity',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor',
@@ -3620,7 +3620,6 @@ const definitions: Definition[] = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance()],
         whiteLabel: [
             tuya.whitelabel('TuYa', 'QT-07S', 'Soil sensor', ['_TZ3000_kky16aay']),
-            tuya.whitelabel('TuYa', 'QT-07S', 'Soil sensor', ['_TZE200_ga1maeof']),
         ],
     },
     {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3611,7 +3611,7 @@ const definitions: Definition[] = [
         onEvent: tuya.onEventSetTime,
     },
     {
-        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay','_TZE200_ga1maeof']),
+        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay', '_TZE200_ga1maeof']),
         model: 'TS0222_temperature_humidity',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1148,7 +1148,7 @@ const definitions: Definition[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_myd45weu']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_myd45weu', '_TZE200_ga1maeof']),
         model: 'TS0601_soil',
         vendor: 'TuYa',
         description: 'Soil sensor',
@@ -3611,7 +3611,7 @@ const definitions: Definition[] = [
         onEvent: tuya.onEventSetTime,
     },
     {
-        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay']),
+        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay','_TZE200_ga1maeof']),
         model: 'TS0222_temperature_humidity',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor',
@@ -3620,6 +3620,7 @@ const definitions: Definition[] = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance()],
         whiteLabel: [
             tuya.whitelabel('TuYa', 'QT-07S', 'Soil sensor', ['_TZ3000_kky16aay']),
+            tuya.whitelabel('TuYa', 'QT-07S', 'Soil sensor', ['_TZE200_ga1maeof']),
         ],
     },
     {


### PR DESCRIPTION
First PR from my end - please review. 
I bought TS0601 Soil Sensor that is not supported (using by HomeAssistant). Could you help me and review it quickly + deploy new version so I can use it soon? @Koenkk