### PR TITLE
Added additional vent size

### DIFF
--- a/src/devices/keen_home.ts
+++ b/src/devices/keen_home.ts
@@ -24,7 +24,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['SV01-410-MP-1.0', 'SV01-410-MP-1.1', 'SV01-410-MP-1.4', 'SV01-410-MP-1.5', 'SV01-412-MP-1.0', 'SV01-412-MP-1.1',
             'SV01-412-MP-1.3', 'SV01-412-MP-1.4', 'SV01-610-MP-1.0', 'SV01-610-MP-1.1', 'SV01-612-MP-1.0', 'SV01-612-MP-1.1', 'SV01-612-MP-1.2',
-            'SV01-610-MP-1.4'],
+            'SV01-610-MP-1.4', 'SV01-612-MP-1.4'],
         model: 'SV01',
         vendor: 'Keen Home',
         description: 'Smart vent',


### PR DESCRIPTION
The model number follows the pattern SVxx-yzz-MP-w.w where: xx - 01 or 02 - denotes device series
y - vent's width (e.g. 6")
zz - vent's length (e.g. 12")
w.w - firmware version.