### PR TITLE
set min rep interval to 1 for Schneider Electric 545D6102 brightness

### DIFF
--- a/src/devices/schneider_electric.js
+++ b/src/devices/schneider_electric.js
@@ -611,7 +611,7 @@ module.exports = [
             const endpoint = device.getEndpoint(3);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
             await reporting.onOff(endpoint);
-            await reporting.brightness(endpoint);
+            await reporting.brightness(endpoint, {min: 1});
             // Configure the four front switches
             device.endpoints.forEach(async (ep) => {
                 if (21 <= ep.ID && ep.ID <= 22) {


### PR DESCRIPTION
Setting the min. rep internal for Schneider Electric LK FUGA wiser wireless dimmer (545D6102) reporting of brightness to 1. Having the min. set to 0 generates a lot of zigbee traffic that result in brightness values arriving at the endpoint out of order resulting in "jumpy" controls from the physical dimmer. Setting min. rep interval to 1 gives correct and smooth control.

Exactly the same issue as described for [Candeo Zigbee LED smart dimmer switch (C202)](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/candeo.ts#L36).