### PR TITLE
Add zonestatus value for pressed button for HS2SS-E_V03

### DIFF
--- a/src/converters/fromZigbee.js
+++ b/src/converters/fromZigbee.js
@@ -5915,7 +5915,10 @@ const converters = {
         type: 'commandStatusChangeNotification',
         convert: (model, msg, publish, options, meta) => {
             if (hasAlreadyProcessedMessage(msg, model)) return;
-            const lookup = {32768: 'pressed'};
+            const lookup = {
+                32768: 'pressed',
+                32772: 'pressed',
+            };
             const zoneStatus = msg.data.zonestatus;
             return {
                 action: lookup[zoneStatus],


### PR DESCRIPTION
Hi there!

Just bought a brand new `HS2SS-E_V03` and the `action` value is never propagated when the button is pressed.
While debugging the logs I noticed the value for the `zoneStatus` wasn't in the expected ones.

Here are the logs:

```
debug 2023-06-29 17:17:56Received Zigbee message from '0x8cf681fffed7d49e', type 'commandStatusChangeNotification', cluster 'ssIasZone', data '{"extendedstatus":0,"zonestatus":32772}' from endpoint 1 with groupID 0
info 2023-06-29 17:17:56MQTT publish: topic 'zigbee2mqtt/0x8cf681fffed7d49e', payload '{"battery":100,"battery_low":false,"linkquality":193,"tamper":true}'
```