### PR TITLE
Fix naming inconsistency for vendor LED-Trading

### DIFF
--- a/src/devices/enocean.ts
+++ b/src/devices/enocean.ts
@@ -18,7 +18,7 @@ const definitions: Definition[] = [
             {vendor: 'NodOn', description: 'Smart switch for Philips Hue', model: 'CWS-4-1-01_HUE'},
             {vendor: 'Vimar', description: 'Zigbee Friends of Hue RF switch', model: '03906'},
             {vendor: 'Sunricher', model: 'SR-ZGP2801K4-FOH-E'},
-            {vendor: 'LED Trading', model: '9125'},
+            {vendor: 'LED-Trading', model: '9125'},
             {vendor: 'Feller', description: 'Smart light control for Philips Hue', model: '4120.2.S.FMI.61'},
         ],
     },

--- a/src/devices/led_trading.ts
+++ b/src/devices/led_trading.ts
@@ -30,7 +30,7 @@ const definitions: Definition[] = [
     {
         fingerprint: [{modelID: 'GreenPower_2', ieeeAddr: /^0x00000000427.....$/}],
         model: '9133',
-        vendor: 'Led Trading',
+        vendor: 'LED-Trading',
         description: 'Pushbutton transmitter module',
         fromZigbee: [fzLocal.led_trading_9133],
         toZigbee: [],
@@ -39,7 +39,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['HK-LN-DIM-A'],
         model: 'HK-LN-DIM-A',
-        vendor: 'LED Trading',
+        vendor: 'LED-Trading',
         description: 'ZigBee AC phase-cut dimmer',
         extend: extend.light_onoff_brightness({noConfigure: true}),
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -52,7 +52,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['HK-LN-SOCKET-A'],
         model: '9134',
-        vendor: 'LED Trading',
+        vendor: 'LED-Trading',
         description: 'Powerstrip with 4 sockets and USB',
         extend: extend.switch(),
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
@@ -72,7 +72,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['HK-ZCC-ZLL-A'],
         model: '9135',
-        vendor: 'LED Trading',
+        vendor: 'LED-Trading',
         description: 'Curtain motor controller',
         fromZigbee: [fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -76,7 +76,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['ON/OFF(2CH)'],
         model: 'UP-SA-9127D',
         vendor: 'Sunricher',
-        description: 'LED-trading 2 channel AC switch',
+        description: 'LED-Trading 2 channel AC switch',
         extend: extend.switch(),
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2')],
         endpoint: (device) => {


### PR DESCRIPTION
Just stumbled upon two forms of capitalization on the zigbee2mqtt.io device search by vendor. As I understand it, the markdown files are auto-generated, so this should fix it on the next docgen run