### PR TITLE
Add polling to 'Din smart relay'

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3679,6 +3679,8 @@ const definitions: Definition[] = [
                 .withDescription('Recover state after power outage'),
             e.enum('indicator_mode', ea.STATE_SET, ['off', 'on_off', 'off_on'])
                 .withDescription('Relay LED indicator mode')],
+        options: [exposes.options.measurement_poll_interval()],
+        onEvent: tuya.onEventMeasurementPoll,
     },
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_7issjl2q'}],


### PR DESCRIPTION
The din smart relay _TZ3000_qeuvnohg needs polling to get metering data.