### PR TITLE
Missing poweroutagememory for SPP02G

### DIFF
--- a/src/devices/mercator.ts
+++ b/src/devices/mercator.ts
@@ -95,7 +95,7 @@ const definitions: Definition[] = [
         extend: tuya.extend.switch({powerOutageMemory: true, electricalMeasurements: true, endpoints: ['left', 'right']}),
         exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right'),
             e.power().withEndpoint('left'), e.current().withEndpoint('left'),
-            e.voltage().withEndpoint('left').withAccess(ea.STATE), e.energy()],
+            e.voltage().withEndpoint('left').withAccess(ea.STATE), e.energy(), tuya.exposes.powerOutageMemory()],
         endpoint: (device) => {
             return {left: 1, right: 2};
         },


### PR DESCRIPTION
the following tuya.exposes.powerOutageMemory() was missing from the SPP02G reference which is the same socket as the SPP04G but with 2 sockets