### PR TITLE
findByModel function. Useful in external converters 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -221,28 +221,14 @@ function isFingerprintMatch(fingerprint, device) {
 
 function findByModel(model){
     /*
-    Search device description by model name.
+    Search device description by definition model name.
     Useful when redefining, expanding device descriptions in external converters.
     */
-    const modelToFind = model.toLowerCase();
-    let candidate;
-    for (const definition of definitions) {
-        if (definition.model.toLowerCase() == modelToFind) {
-            candidate = definition;
-            break;
-        }
-        if (definition.whiteLabel) {
-            for (const whiteLabel of definition.whiteLabel) {
-                const {vendor, model, description} = whiteLabel;
-                if (model.toLowerCase() == modelToFind) {
-                    candidate = definition;
-                    break;
-                }
-            }
-            if (candidate) break;
-        }
-    }
-    return candidate;
+    model = model.toLowerCase();
+    return definitions.find((d) => {
+        const whiteLabelMatch = definition.whiteLabel && definition.whiteLabel.find((dd) => dd.model.toLowerCase() === modelToFind);
+        return d.model.toLowerCase() == model || whiteLabelMatch;
+    });
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -225,9 +225,9 @@ function findByModel(model){
     Useful when redefining, expanding device descriptions in external converters.
     */
     model = model.toLowerCase();
-    return definitions.find((d) => {
-        const whiteLabelMatch = definition.whiteLabel && definition.whiteLabel.find((dd) => dd.model.toLowerCase() === modelToFind);
-        return d.model.toLowerCase() == model || whiteLabelMatch;
+    return definitions.find((definition) => {
+        const whiteLabelMatch = definition.whiteLabel && definition.whiteLabel.find((dd) => dd.model.toLowerCase() === model);
+        return definition.model.toLowerCase() == model || whiteLabelMatch;
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -219,6 +219,34 @@ function isFingerprintMatch(fingerprint, device) {
     return match;
 }
 
+function findByModel(model){
+    /*
+    Search device description by model name.
+    Useful when redefining, expanding device descriptions in external converters.
+    */
+    const modelToFind = model.toLowerCase();
+    let candidate = findByZigbeeModel(modelToFind);
+    if (!candidate) {
+        for (const definition of definitions) {
+            if (definition.model.toLowerCase() == modelToFind) {
+                candidate = definition;
+                break;
+            }
+            if (definition.whiteLabel) {
+                for (const whiteLabel of definition.whiteLabel) {
+                    const {vendor, model, description} = whiteLabel;
+                    if (model.toLowerCase() == modelToFind) {
+                        candidate = definition;
+                        break;
+                    }
+                }
+                if (candidate) break;
+            }
+        }
+    }
+    return candidate;
+}
+
 module.exports = {
     getConfigureKey: configureKey.getConfigureKey,
     devices: definitions,
@@ -226,6 +254,7 @@ module.exports = {
     definitions,
     findByZigbeeModel, // Legacy method, use findByDevice instead.
     findByDevice,
+    findByModel,
     toZigbeeConverters: toZigbee,
     fromZigbeeConverters: fromZigbee,
     addDeviceDefinition: addDefinition,

--- a/src/index.js
+++ b/src/index.js
@@ -225,23 +225,21 @@ function findByModel(model){
     Useful when redefining, expanding device descriptions in external converters.
     */
     const modelToFind = model.toLowerCase();
-    let candidate = findByZigbeeModel(modelToFind);
-    if (!candidate) {
-        for (const definition of definitions) {
-            if (definition.model.toLowerCase() == modelToFind) {
-                candidate = definition;
-                break;
-            }
-            if (definition.whiteLabel) {
-                for (const whiteLabel of definition.whiteLabel) {
-                    const {vendor, model, description} = whiteLabel;
-                    if (model.toLowerCase() == modelToFind) {
-                        candidate = definition;
-                        break;
-                    }
+    let candidate;
+    for (const definition of definitions) {
+        if (definition.model.toLowerCase() == modelToFind) {
+            candidate = definition;
+            break;
+        }
+        if (definition.whiteLabel) {
+            for (const whiteLabel of definition.whiteLabel) {
+                const {vendor, model, description} = whiteLabel;
+                if (model.toLowerCase() == modelToFind) {
+                    candidate = definition;
+                    break;
                 }
-                if (candidate) break;
             }
+            if (candidate) break;
         }
     }
     return candidate;


### PR DESCRIPTION
it is easier to add new or similar devices in external converters without completely copying the description.
for example:
```
const findByModel = require('zigbee-herdsman-converters').findByModel;
const tuya = require('zigbee-herdsman-converters/lib/tuya');

const oldDefinition = findByModel('TS0001_fingerbot_1');
const definition = {
    ...oldDefinition,
    model: 'new_model',
    fingerprint: tuya.fingerprint('TS0001', ['_TZ3210_434534534'])
};

module.exports = definition;
```