### PR TITLE
Correct errors on Schneider NHPB Switches

### DIFF
--- a/src/devices/schneider_electric.js
+++ b/src/devices/schneider_electric.js
@@ -505,9 +505,9 @@ module.exports = [
         model: 'S520530W',
         vendor: 'Schneider Electric',
         description: 'Odace connectable relay switch 10A',
-        extend: extend.switch(),
+        extend: extend.switch({disablePowerOnBehavior: true}),
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(21);
+            const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
         },


### PR DESCRIPTION
Fixing the issue reported here; https://github.com/Koenkk/zigbee2mqtt/issues/18429 


Disable powerOnBehaviour as it is unsupported on this device.
Change endpoint to '1' which is the correct endpoint for OnOff reading.


