### PR TITLE
Add: Heatit zig dim250

### DIFF
--- a/src/devices/heatit.ts
+++ b/src/devices/heatit.ts
@@ -1,9 +1,8 @@
 import {Definition} from '../lib/types';
-import fz from '../converters/fromZigbee';
 import * as exposes from '../lib/exposes';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
-const e = exposes.presets;
+
 
 const definitions: Definition[] = [
     {

--- a/src/devices/heatit.ts
+++ b/src/devices/heatit.ts
@@ -6,7 +6,7 @@ const definitions: Definition[] = [
         fingerprint: [{type: 'Router', manufacturerName: 'Heatit Controls AB', modelID: 'Dimmer-Switch-ZB3.0'}],
         model: '1444420',
         vendor: 'Heatit',
-        description: 'Zigbee dimmer 250W',
+        description: 'Zig Dim 250W',
         extend: extend.light_onoff_brightness({disablePowerOnBehavior: true}),
     },
 ];

--- a/src/devices/heatit.ts
+++ b/src/devices/heatit.ts
@@ -4,7 +4,7 @@ import extend from '../lib/extend';
 const definitions: Definition[] = [
     {
         fingerprint: [{type: 'Router', manufacturerName: 'Heatit Controls AB', modelID: 'Dimmer-Switch-ZB3.0'}],
-        model: 'Zig Dim 250W',
+        model: '1444420',
         vendor: 'Heatit',
         description: 'Zigbee dimmer 250W',
         extend: extend.light_onoff_brightness({disablePowerOnBehavior: true}),

--- a/src/devices/heatit.ts
+++ b/src/devices/heatit.ts
@@ -1,8 +1,5 @@
 import {Definition} from '../lib/types';
-import * as exposes from '../lib/exposes';
-import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
-
 
 const definitions: Definition[] = [
     {

--- a/src/devices/heatit.ts
+++ b/src/devices/heatit.ts
@@ -1,0 +1,18 @@
+import {Definition} from '../lib/types';
+import fz from '../converters/fromZigbee';
+import * as exposes from '../lib/exposes';
+import * as reporting from '../lib/reporting';
+import extend from '../lib/extend';
+const e = exposes.presets;
+
+const definitions: Definition[] = [
+    {
+        fingerprint: [{type: 'Router', manufacturerName: 'Heatit Controls AB', modelID: 'Dimmer-Switch-ZB3.0'}],
+        model: 'Zig Dim 250W',
+        vendor: 'Heatit',
+        description: 'Zigbee dimmer 250W',
+        extend: extend.light_onoff_brightness({disablePowerOnBehavior: true}),
+    },
+];
+
+module.exports = definitions;


### PR DESCRIPTION
This adds support for the Heatit Zigbee dimmer 250W.

Seems like a oem of  Dimmer-Switch-ZB3.0, but the firmware has some differences.
PowerOnBehavior doesn´t seem to be supported, so have disabled this. 

Tried to keep the config as tiny as possible.

----
```Debug 2023-07-26 09:31:29Received MQTT message on 'zigbee2mqtt/0x3YYYYYYYYYYYY/set' with data '{"power_on_behavior":"previous"}'
Debug 2023-07-26 09:31:29Publishing 'set' 'power_on_behavior' to '0x3YYYYYYYYYYYY'
Error 2023-07-26 09:31:29Publish 'set' 'power_on_behavior' to '0x3YYYYYYYYYYYY' failed: 'Error: Write 0x3YYYYYYYYYYYY/1 genOnOff({"startUpOnOff":255}, {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'
Debug 2023-07-26 09:31:29Error: Write 0x3YYYYYYYYYYYY/1 genOnOff({"startUpOnOff":255}, {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE') at Endpoint.checkStatus (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:419:28) at Endpoint.write (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:488:22) at Object.convertSet (/app/node_modules/zigbee-herdsman-converters/src/converters/toZigbee.js:116:13) at Publish.onMQTTMessage (/app/lib/extension/publish.ts:248:36)