### PR TITLE
Update owon.js

### DIFF
--- a/src/devices/owon.js
+++ b/src/devices/owon.js
@@ -318,9 +318,7 @@ module.exports = [
             await reporting.fanMode(endpoint);
             await reporting.bind(endpoint, coordinatorEndpoint, ['hvacThermostat']);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatOccupiedCoolingSetpoint(endpoint);
-            await reporting.thermostatUnoccupiedCoolingSetpoint(endpoint);
             await reporting.thermostatTemperature(endpoint, {min: 60, max: 600, change: 0.1});
             await reporting.thermostatSystemMode(endpoint);
             await reporting.thermostatRunningMode(endpoint);


### PR DESCRIPTION
Hello,
issue for unsupported attribute error

Deleted lines : 
await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint); await reporting.thermostatUnoccupiedCoolingSetpoint(endpoint);

Check issue : https://github.com/Koenkk/zigbee2mqtt/issues/17211

This error stop the other reporting like occupancy and humidity.

Tested on my box.

Regards