### PR TITLE
Adding new manufacturerName for TuYa smoke sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2931,7 +2931,10 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_ntcy3xu1']),
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_ntcy3xu1'},
+            {modelID: 'TS0601', manufacturerName: '_TZE204_ntcy3xu1'},
+        ],
         model: 'TS0601_smoke_1',
         vendor: 'TuYa',
         description: 'Smoke sensor',


### PR DESCRIPTION
Just a very small change to support the new production line of Tuya smoke sensors.

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/3637190/9818387b-d6a4-43da-918e-4be4f8760650)

Old ones (that I own) have TZE200, new ones (just bought) have TZE204.