### PR TITLE
Add ZBEK-27 to adeo devices

### DIFF
--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -172,6 +172,13 @@ const definitions: Definition[] = [
         extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
     },
     {
+        zigbeeModel: ['ZBEK-27'],
+        model: '84845506',
+        vendor: 'ADEO',
+        description: 'ENKI LEXMAN Gdansk',
+        extend: extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 370]}),
+    },
+    {
         zigbeeModel: ['ZBEK-28'],
         model: 'PEZ1-042-1020-C1D1',
         vendor: 'ADEO',


### PR DESCRIPTION
Add the ZBEK-27 LED Panel 

https://www.leroymerlin.fr/produits/electricite-domotique/domotique-et-objets-connectes/eclairage-et-son-connectes/panneau-led-connecte/panneau-led-connecte-gdansk-enki-29-5-x29-5-cm-couleurs-et-blancs-blanc-inspire-84845506.html