### PR TITLE
Support Sercomm SZ-WTD03 leak sensor

### DIFF
--- a/src/devices/sercomm.js
+++ b/src/devices/sercomm.js
@@ -144,6 +144,6 @@ module.exports = [
         description: 'Water Leak Detector',
         fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
         toZigbee: [],
-        exposes: [e.water_leak(), e.battery_low()]
+        exposes: [e.water_leak(), e.battery_low()],
     },
 ];

--- a/src/devices/sercomm.js
+++ b/src/devices/sercomm.js
@@ -141,7 +141,7 @@ module.exports = [
         zigbeeModel: ['SZ-WTD03'],
         model: 'SZ-WTD03',
         vendor: 'Sercomm',
-        description: 'Water Leak Detector',
+        description: 'Water leak detector',
         fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
         toZigbee: [],
         exposes: [e.water_leak(), e.battery_low()],


### PR DESCRIPTION
Adds low battery and leak detection / alert for Sercomm SZ-WTD03 and SZ-WTD03N water sensors. 

Triggered device leak detector contacts and confirmed alarming occurs in zigbee2mqtt and Home Assistant