### PR TITLE
feat: Add OTA support for Bticino Shutter 4027C

### DIFF
--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -4,6 +4,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
+import * as ota from '../lib/ota';
 const e = exposes.presets;
 const ea = exposes.access;
 
@@ -76,6 +77,7 @@ const definitions: Definition[] = [
                 `to see the switch in the dark`),
             e.enum('identify', ea.SET, ['blink']).withDescription(`Blinks the built-in LED to make it easier to find the device`),
         ],
+        ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);


### PR DESCRIPTION
According to the [official documentation](https://static.developer.legrand.com/files/2023/02/Shutter-switch-with-neutral.xlsx), [Legrand shutter 067776](https://github.com/Koenkk/zigbee-herdsman-converters/blob/88f17a5c133e19e7dfd938b3c2fe035afdb37e63/src/devices/legrand.js#L140) and Bticino 4027C share the same NLV firmware.

Please be aware that I didn't personally test this with my K4027C device because I'm not really sure how I'm supposed to deploy those changes in a z2m docker container (if you have some pointers, it would be great).

/cc @SilentT-FR 