### PR TITLE
Add missing Bticino OTA support

### DIFF
--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -50,6 +50,7 @@ const definitions: Definition[] = [
             e.binary('led_if_on', ea.ALL, 'ON', 'OFF').withDescription('Enables the LED when the light is turned on'),
             e.enum('identify', ea.SET, ['blink']).withDescription(`Blinks the built-in LED to make it easier to find the device`),
         ],
+        ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);

--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -23,6 +23,7 @@ const definitions: Definition[] = [
             e.binary('led_if_on', ea.ALL, 'ON', 'OFF').withDescription('Enables the LED when the light is turned on'),
             e.enum('identify', ea.SET, ['blink']).withDescription(`Blinks the built-in LED to make it easier to find the device`),
         ],
+        ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genBinaryInput']);


### PR DESCRIPTION
Thanks to https://github.com/Koenkk/zigbee-OTA/pull/322, also the Bticino 4003C and 4411C should be marked as OTA supported.

The 4003C device uses the firmware NLL, while the 4411C the firmware NLFN.