### PR TITLE
Update philips.js with new-version Philips Filament ST19 bulb

### DIFF
--- a/src/devices/philips.js
+++ b/src/devices/philips.js
@@ -14,7 +14,7 @@ module.exports = [
         zigbeeModel: ['LWV006'],
         model: '9290030518',
         vendor: 'Philips',
-        description: 'Philips Filament E26 Hue Bulb',
+        description: 'Philips filament E26 bulb',
         extend: philips.extend.light_onoff_brightness({disableHueEffects: false}),
     },
     {

--- a/src/devices/philips.js
+++ b/src/devices/philips.js
@@ -11,6 +11,13 @@ const extend = {switch: require('../lib/extend').switch};
 
 module.exports = [
     {
+        zigbeeModel: ['LWV006'],
+        model: '9290030518',
+        vendor: 'Philips',
+        description: 'Philips Filament E26 Hue Bulb',
+        extend: philips.extend.light_onoff_brightness({disableHueEffects: false}),
+    },
+    {
         zigbeeModel: ['LWO005'],
         model: '9290030519',
         vendor: 'Philips',


### PR DESCRIPTION
From https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#done

Tested on my home's zigbee2mqtt instance, works fine on these new bulb skus.