### PR TITLE
Scene rename

### DIFF
--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -4530,6 +4530,36 @@ const converters = {
             meta.logger.info('Successfully removed all scenes');
         },
     },
+    scene_rename: {
+        key: ['scene_rename'],
+        convertSet: (entity, key, value, meta) => {
+            if (typeof value !== 'object') {
+                throw new Error('Payload should be object.');
+            }
+            const isGroup = entity.constructor.name === 'Group';
+            const sceneid = value.ID;
+            const scenename = value.name;
+            const groupid = isGroup ? entity.groupID : value.hasOwnProperty('group_id') ? value.group_id : 0;
+
+            if (isGroup) {
+                if (meta.membersState) {
+                    for (const member of entity.members) {
+                        const state = utils.getSceneState(member, sceneid, groupid);
+                        if (state) {
+                            utils.saveSceneState(member, sceneid, groupid, state, scenename);
+                        }
+                    }
+                }
+            } else {
+                const state = utils.getSceneState(entity, sceneid, groupid);
+                if (!state) {
+                    throw new Error(`No such scene in device meta data`);
+                }
+                utils.saveSceneState(entity, sceneid, groupid, state, scenename);
+            }
+            meta.logger.info('Successfully renamed scene');
+        },
+    },
     TS0003_curtain_switch: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ function addDefinition(definition) {
         };
     }
 
-    definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.read, tz.write,
+    definition.toZigbee.push(tz.scene_store, tz.scene_recall, tz.scene_add, tz.scene_remove, tz.scene_remove_all, tz.scene_rename, tz.read, tz.write,
         tz.command, tz.factory_reset);
 
     if (definition.exposes && Array.isArray(definition.exposes) && !definition.exposes.find((e) => e.name === 'linkquality')) {

--- a/src/lib/ota/common.ts
+++ b/src/lib/ota/common.ts
@@ -399,7 +399,7 @@ export async function updateToLatest(device: Zh.Device, logger: Logger, onProgre
                         logger.debug(`Update succeeded, waiting for device announce`);
                         onProgress(100, null);
 
-                        let timer: NodeJS.Timer = null;
+                        let timer: ReturnType<typeof setTimeout> = null;
                         const cb = () => {
                             logger.debug('Got device announce or timed out, call resolve');
                             clearInterval(timer);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -439,7 +439,7 @@ export function normalizeCelsiusVersionOfFahrenheit(value: number) {
 export function noOccupancySince(endpoint: Zh.Endpoint, options: KeyValueAny, publish: Publish, action: 'start' | 'stop') {
     if (options && options.no_occupancy_since) {
         if (action == 'start') {
-            globalStore.getValue(endpoint, 'no_occupancy_since_timers', []).forEach((t: NodeJS.Timer) => clearTimeout(t));
+            globalStore.getValue(endpoint, 'no_occupancy_since_timers', []).forEach((t: ReturnType<typeof setInterval>) => clearTimeout(t));
             globalStore.putValue(endpoint, 'no_occupancy_since_timers', []);
 
             options.no_occupancy_since.forEach((since: number) => {
@@ -449,7 +449,7 @@ export function noOccupancySince(endpoint: Zh.Endpoint, options: KeyValueAny, pu
                 globalStore.getValue(endpoint, 'no_occupancy_since_timers').push(timer);
             });
         } else if (action === 'stop') {
-            globalStore.getValue(endpoint, 'no_occupancy_since_timers', []).forEach((t: NodeJS.Timer) => clearTimeout(t));
+            globalStore.getValue(endpoint, 'no_occupancy_since_timers', []).forEach((t: ReturnType<typeof setInterval>) => clearTimeout(t));
             globalStore.putValue(endpoint, 'no_occupancy_since_timers', []);
         }
     }


### PR DESCRIPTION
As we can name scenes, I think we should also be able to *re*name them.

A tiny patch to zigbee2mqtt is also required, in order to call `emitScenesChanged()` when a rename happens.

This pull requests also contains an unrelated patch, without which I'm unable to build zigbee-herdsman-converters. I don't understand why building doesn't work for me, while it presumable does for others (I tried multiple nodejs versions), but this solution seems safe and may save other a headache.