### PR TITLE
Add converter for Halemeier HA-ZBM-MW2

### DIFF
--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -39,6 +39,20 @@ const definitions: Definition[] = [
             'color_temperature_step_up', 'color_temperature_step_down', 'brightness_step_up', 'brightness_step_down']),
         ],
     },
+    {
+        zigbeeModel: ['HA-ZBM-MW2'],
+        vendor: 'Halemeier',
+        description: 'S-Mitter Basic MultiWhite² 1-channel sender Zigbee ',
+        fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],
+        toZigbee: [tz.battery_percentage_remaining],
+        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off']), e.light_brightness_colortemp([0, 254])],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+}
 ];
 
 module.exports = definitions;

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -47,7 +47,7 @@ const definitions: Definition[] = [
         description: 'S-Mitter Basic MultiWhite² 1-channel sender Zigbee ',
         fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],
         toZigbee: [tz.battery_percentage_remaining],
-        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off', 'recall_1', 'recall_2', 'recall_3', 'recall_4', 
+        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off', 'recall_1', 'recall_2', 'recall_3', 'recall_4',
             'color_temperature_step_up', 'color_temperature_step_down', 'brightness_step_up', 'brightness_step_down'])],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -52,7 +52,6 @@ const definitions: Definition[] = [
             await reporting.batteryPercentageRemaining(endpoint);
         },
     },
-}
 ];
 
 module.exports = definitions;

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -47,7 +47,7 @@ const definitions: Definition[] = [
         description: 'S-Mitter Basic MultiWhite² 1-channel sender Zigbee ',
         fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],
         toZigbee: [tz.battery_percentage_remaining],
-        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off'])],
+        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off', 'recall_1', 'recall_2', 'recall_3', 'recall_4', 'color_temperature_step_up', 'color_temperature_step_down', 'brightness_step_up', 'brightness_step_down'])],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -3,6 +3,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import extend from '../lib/extend';
 import * as exposes from '../lib/exposes';
+import * as reporting from '../lib/reporting';
 const e = exposes.presets;
 const ea = exposes.access;
 

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -47,7 +47,7 @@ const definitions: Definition[] = [
         description: 'S-Mitter Basic MultiWhite² 1-channel sender Zigbee ',
         fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],
         toZigbee: [tz.battery_percentage_remaining],
-        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off']), e.light_brightness_colortemp([0, 254])],
+        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off'])],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -45,7 +45,7 @@ const definitions: Definition[] = [
         model: 'HA-ZBM-MW2',
         vendor: 'Halemeier',
         description: 'S-Mitter basic MultiWhite² 1-channel sender Zigbee ',
-        fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],
+        fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step, fz.battery],
         toZigbee: [tz.battery_percentage_remaining],
         exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off', 'recall_1', 'recall_2', 'recall_3', 'recall_4',
             'color_temperature_step_up', 'color_temperature_step_down', 'brightness_step_up', 'brightness_step_down'])],

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -42,6 +42,7 @@ const definitions: Definition[] = [
     },
     {
         zigbeeModel: ['HA-ZBM-MW2'],
+        model: 'HA-ZBM-MW2',
         vendor: 'Halemeier',
         description: 'S-Mitter Basic MultiWhite² 1-channel sender Zigbee ',
         fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -47,7 +47,8 @@ const definitions: Definition[] = [
         description: 'S-Mitter Basic MultiWhite² 1-channel sender Zigbee ',
         fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],
         toZigbee: [tz.battery_percentage_remaining],
-        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off', 'recall_1', 'recall_2', 'recall_3', 'recall_4', 'color_temperature_step_up', 'color_temperature_step_down', 'brightness_step_up', 'brightness_step_down'])],
+        exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off', 'recall_1', 'recall_2', 'recall_3', 'recall_4', 
+            'color_temperature_step_up', 'color_temperature_step_down', 'brightness_step_up', 'brightness_step_down'])],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);

--- a/src/devices/halemeier.ts
+++ b/src/devices/halemeier.ts
@@ -44,7 +44,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['HA-ZBM-MW2'],
         model: 'HA-ZBM-MW2',
         vendor: 'Halemeier',
-        description: 'S-Mitter Basic MultiWhite² 1-channel sender Zigbee ',
+        description: 'S-Mitter basic MultiWhite² 1-channel sender Zigbee ',
         fromZigbee: [fz.command_recall, fz.command_off, fz.command_on, fz.command_step_color_temperature, fz.command_step],
         toZigbee: [tz.battery_percentage_remaining],
         exposes: [e.battery().withAccess(ea.STATE_GET), e.action(['on', 'off', 'recall_1', 'recall_2', 'recall_3', 'recall_4',


### PR DESCRIPTION
Added first version for remote HA-ZBM-MW2
What's not yet working: Battery

Messages are converted and sent to MQTT fine, I don't know yet if they are in the right format. The other Halemeier remote seems to use different `expose` configurations.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/18670 