### PR TITLE
Update müller_licht.ts

### DIFF
--- a/src/devices/müller_licht.ts
+++ b/src/devices/müller_licht.ts
@@ -137,9 +137,9 @@ const definitions: Definition[] = [
         model: '404002',
         description: 'Tint dim remote control',
         vendor: 'Müller Licht',
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.command_recall],
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_step, fz.command_move, fz.command_stop, fz.command_recall, fz.command_store],
         exposes: [e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up', 'brightness_move_down',
-            'brightness_stop', 'recall_1'])],
+            'brightness_stop', 'recall_1', 'store_1'])],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Add 'Store Scene' to Müller Licht ZBT-DIMController-D0800

Currently no converter is in place for handling this:

````
Debug 2023-08-07 21:49:37 Received Zigbee message from 'DimController', type 'commandStore', cluster 'genScenes', data '{"groupid":16387,"sceneid":1}' from endpoint 1 with groupID 0
````

In case this PR will get merged
- also the documentation needs to be adapted.
- I will do an extra PR in this case then 