### PR TITLE
_TZE204_k7mfgaen should set volume middle instead medium

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5749,7 +5749,7 @@ const definitions: Definition[] = [
         exposes: [
             e.binary('alarm', ea.STATE_SET, 'ON', 'OFF').withDescription('Turn the light of the alarm ON/OFF'),
             e.enum('type', ea.STATE_SET, ['sound', 'light', 'sound+light', 'normal']).withDescription('Alarm type'),
-            e.enum('volume', ea.STATE_SET, ['mute', 'low', 'medium', 'high']).withDescription('Volume of the alarm'),
+            e.enum('volume', ea.STATE_SET, ['mute', 'low', 'middle', 'high']).withDescription('Volume of the alarm'),
             e.enum('ringtone', ea.STATE_SET, [
                 'melody1', 'melody2', 'melody3', 'melody4', 'melody5', 'melody6', 'melody7', 'melody8',
                 'door', 'water', 'temperature', 'entered', 'left',


### PR DESCRIPTION
Publish 'set' 'volume' to '0xa4c138650acbe986' failed: 'Error: Expected one of: low, middle, high, mute, got: 'medium''

https://ss.codeone.pl/ss-2023-08-30-08-37-38-1693377458-wzo6EnTJ.png