### PR TITLE
Add zigbeeModel 929003536001 variation for Philips Hue Iris Copper special edition

### DIFF
--- a/src/devices/philips.js
+++ b/src/devices/philips.js
@@ -249,6 +249,13 @@ module.exports = [
         extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
+        zigbeeModel: ['929003536001'],
+        model: '929003536001',
+        vendor: 'Philips',
+        description: 'Hue Iris copper special edition (generation 4)',
+        extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+    },
+    {
         zigbeeModel: ['929002401001'],
         model: '929002401001',
         vendor: 'Philips',


### PR DESCRIPTION
I picked up a Hue Iris lamp which came with a different zigbeeModel from the ones that were supported by zigbee2mqtt.  Tested this config with my Home Assistant and it seems to do the trick.