### PR TITLE
_TZE204_sooucan5 swap dp's

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5724,8 +5724,8 @@ const definitions: Definition[] = [
                 [0x03, 'minimum_range', tuya.valueConverter.divideBy100],
                 [0x04, 'maximum_range', tuya.valueConverter.divideBy100],
                 [0x65, 'illuminance_lux', tuya.valueConverter.raw],
-                [0x66, 'fading_time', tuya.valueConverter.divideBy10],
-                [0x67, 'detection_delay', tuya.valueConverter.divideBy10],
+                [0x66, 'detection_delay', tuya.valueConverter.divideBy10],
+                [0x67, 'fading_time', tuya.valueConverter.divideBy10],
                 [0x68, 'radar_scene', tuya.valueConverterBasic.lookup({
                     'default': tuya.enum(0),
                     'bathroom': tuya.enum(1),


### PR DESCRIPTION
Manufacturer set the dp names wrong, they need to be be swapped.

Despite having those names in the Tuya device properties it makes no sense for normal operation to have the fading time st to 0.2s while the detection delay is 100s with the default setting.

This PR swaps the names for those two dp's to look and behave correctly