### PR TITLE
 Feat(add): Support Ikea LED2104R3

### DIFF
--- a/src/devices/ikea.js
+++ b/src/devices/ikea.js
@@ -439,6 +439,13 @@ module.exports = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
+        zigbeeModel: ['\u001aTRADFRI bulb GU10 WW 345lm8'],
+        model: 'LED2104R3',
+        vendor: 'IKEA',
+        description: 'TRADFRI LED bulb GU10 WW 345 lumen, dimmable',
+        extend: tradfriExtend.light_onoff_brightness(),
+    },    
+    {
         zigbeeModel: ['TRADFRIbulbG125E27WSopal470lm', 'TRADFRIbulbG125E26WSopal450lm'],
         model: 'LED1936G5',
         vendor: 'IKEA',

--- a/src/devices/ikea.js
+++ b/src/devices/ikea.js
@@ -444,7 +444,7 @@ module.exports = [
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb GU10 WW 345 lumen, dimmable',
         extend: tradfriExtend.light_onoff_brightness(),
-    },    
+    },
     {
         zigbeeModel: ['TRADFRIbulbG125E27WSopal470lm', 'TRADFRIbulbG125E26WSopal450lm'],
         model: 'LED1936G5',


### PR DESCRIPTION
New shipped model. BEWARE: The \u001a AND the 8 are really needed, these are also sent from the bulb. This was quite a struggle to figure out since this character is not shown in the debug log but it is shown in the database luckly after pairing.