### PR TITLE
Update acuity_brands_lighting.ts

### DIFF
--- a/src/devices/acuity_brands_lighting.ts
+++ b/src/devices/acuity_brands_lighting.ts
@@ -15,7 +15,7 @@ const definitions: Definition[] = [
         vendor: 'Acuity Brands Lighting (ABL)',
         description: 'Juno Retrobasics 4" and 6" LED smart downlight',
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200, 370], disableColorTempStartup: true}),
-    },        
+    },
 ];
 
 module.exports = definitions;

--- a/src/devices/acuity_brands_lighting.ts
+++ b/src/devices/acuity_brands_lighting.ts
@@ -9,6 +9,13 @@ const definitions: Definition[] = [
         description: 'Juno 4" and 6" LED smart wafer downlight',
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200, 370], disableColorTempStartup: true}),
     },
+    {
+        zigbeeModel: ['ABL-LIGHT-Z-201'],
+        model: 'RB56SC',
+        vendor: 'Acuity Brands Lighting (ABL)',
+        description: 'Juno Retrobasics 4" and 6" LED smart downlight',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [200, 370], disableColorTempStartup: true}),
+    },        
 ];
 
 module.exports = definitions;


### PR DESCRIPTION
Add ABL-LIGHT-Z-201 zigbee model (RB56SC).  Functionality is identical to existing ABL-LIGHT-Z-001 model, different chassis.

https://www.amazon.com/gp/product/B0BQ1VJLPL/ref=ppx_yo_dt_b_search_asin_image?ie=UTF8&th=1