### PR TITLE
feat: add power outage memory to Mercator Ikuü SPP02GIP

### DIFF
--- a/src/devices/mercator.ts
+++ b/src/devices/mercator.ts
@@ -126,7 +126,7 @@ const definitions: Definition[] = [
         extend: tuya.extend.switch({powerOutageMemory: true, electricalMeasurements: true, endpoints: ['left', 'right']}),
         exposes: [e.switch().withEndpoint('left'), e.switch().withEndpoint('right'),
             e.power().withEndpoint('left'), e.current().withEndpoint('left'),
-            e.voltage().withEndpoint('left').withAccess(ea.STATE), e.energy()],
+            e.voltage().withEndpoint('left').withAccess(ea.STATE), e.energy(), tuya.exposes.powerOutageMemory()],
         endpoint: (device) => {
             return {left: 1, right: 2};
         },


### PR DESCRIPTION
The SPP02GIP is the exterior version of the SPP02G. Power outage memory was added to SPP02G in #5968