### PR TITLE
Detect TS000F / _TZ3000_skueekg3 as TuYa WHD02 Wall switch module

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -778,6 +778,7 @@ const definitions: Definition[] = [
         fingerprint: [{modelID: 'TS0001', manufacturerName: '_TZ3000_hktqahrq'}, {manufacturerName: '_TZ3000_hktqahrq'},
             {manufacturerName: '_TZ3000_q6a3tepg'}, {modelID: 'TS000F', manufacturerName: '_TZ3000_m9af2l6g'},
             {modelID: 'TS000F', manufacturerName: '_TZ3000_mx3vgyea'},
+            {modelID: 'TS000F', manufacturerName: '_TZ3000_skueekg3'},
             {modelID: 'TS0001', manufacturerName: '_TZ3000_npzfdcof'},
             {modelID: 'TS0001', manufacturerName: '_TZ3000_5ng23zjs'},
             {modelID: 'TS0001', manufacturerName: '_TZ3000_rmjr4ufz'},


### PR DESCRIPTION
Another one:
Same units WHD02 bought at the same time, one already suported, one unsupported with a different ModelID / ManufacturerName:

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/0d952b72-4a4f-4ba0-9730-5b87f15ae2b0)

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/3401f5e3-da54-4bb0-a97c-03038d99bcf0)

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/43bebcb2-ad4d-4276-be40-f7700ae31a59)

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/a5d5534b-9002-49bc-828e-4b015fd0a817)
