### PR TITLE
Restore power_on_behavior for Gledopto GL-C-006P and GL-LB-001P

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -276,7 +276,7 @@ const definitions: Definition[] = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee LED Controller RGB (pro)',
-        extend: gledoptoExtend.light_onoff_brightness_color({noConfigure: true}),
+        extend: gledoptoExtend.light_onoff_brightness_color({noConfigure: true, disablePowerOnBehavior: false}),
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness_color().configure(device, coordinatorEndpoint, logger);
             await configureReadModelID(device, coordinatorEndpoint, logger);
@@ -341,7 +341,7 @@ const definitions: Definition[] = [
         model: 'GL-LB-001P',
         vendor: 'Gledopto',
         description: 'Zigbee USB LED bar RGB+CCT (pro)',
-        extend: gledoptoExtend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495]}),
+        extend: gledoptoExtend.light_onoff_brightness_colortemp_color({colorTempRange: [158, 495], disablePowerOnBehavior: false}),
     },
     {
         zigbeeModel: ['GL-B-002P'],


### PR DESCRIPTION
Support for `power_on_behavior` was disabled in b0b91c724dea790816d4927b1050faf9256b9124 as a result of Koenkk/zigbee2mqtt#16873 for all the Gledopto devices, but from my tests it perfectly works on GL-C-006P and GL-LB-001P, at least.

This pull request restore it for these two devices, although I'd recommend to restore it for all the devices and only disable it for the device reported in Koenkk/zigbee2mqtt#16873.