### PR TITLE
Add LTG003

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3379,6 +3379,13 @@ const definitions: Definition[] = [
         description: 'Philips Hue white ambiance pillar double spot (2 spot) with Bluetooth',
         extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
+    {
+        zigbeeModel: ['LTG003'],
+        model: '8719514491342',
+        vendor: 'Philips',
+        description: 'Hue white ambiance MR16 with Bluetooth',
+        extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+    },
 ];
 
 module.exports = definitions;


### PR DESCRIPTION
Adds support for the new MR16WA bulb. 
https://www.philips-hue.com/en-gb/p/hue-white-ambiance-mr16---smart-spotlight/8719514491342
Pic added in zigbee2mqtt.io https://github.com/Koenkk/zigbee2mqtt.io/pull/2222

colorTempRange confirmed via dev console