### PR TITLE
Add support for new Festavia with 100 LEDs

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3207,7 +3207,10 @@ const definitions: Definition[] = [
         model: '9290036745',
         vendor: 'Philips',
         description: 'Hue Festavia gradient light string 100',
-        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle']}),
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({
+            colorTempRange: [153, 500],
+            extraEffects: ['sparkle', 'opal', 'glisten'],
+        }),
     },
     {
         zigbeeModel: ['915005987101'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3203,6 +3203,13 @@ const definitions: Definition[] = [
         extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle']}),
     },
     {
+        zigbeeModel: ['LCX016'],
+        model: '9290036745',
+        vendor: 'Philips',
+        description: 'Hue Festavia gradient light string 100',
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle']}),
+    },
+    {
         zigbeeModel: ['915005987101'],
         model: '915005987101',
         vendor: 'Philips',

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -47,6 +47,8 @@ const knownEffects = {
     '0380': 'colorloop',
     '0980': 'sunrise',
     '0a80': 'sparkle',
+    '0b80': 'opal',
+    '0c80': 'glisten',
 };
 
 export const extend = {
@@ -402,6 +404,8 @@ const hueEffects = {
     'colorloop': '21000103',
     'sunrise': '21000109',
     'sparkle': '2100010a',
+    'opal': '2100010b',
+    'glisten': '2100010c',
     'stop_hue_effect': '200000',
 };
 


### PR DESCRIPTION
This adds support for the new Festavia "V2" light string with 100 LEDs. There are also new variants with 250 LEDs and 400 LEDs. Unfortunately I don't know their model IDs and numbers. All of these should also support three new Hue effects (besides sparkle), namely `opal`, `glisten` and `prism`.

By trial and error I have found the settings for `opal` and `glisten`, but `prism` is apparently _not_ `2100010d`. Unfortunately I have no equipment for sniffing the traffic of the official Hue app.