### PR TITLE
Update lellki.ts

### DIFF
--- a/src/devices/lellki.ts
+++ b/src/devices/lellki.ts
@@ -12,7 +12,7 @@ const definitions: Definition[] = [
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_air9m6af'}, {modelID: 'TS011F', manufacturerName: '_TZ3000_9djocypn'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_bppxj3sf'}],
-        zigbeeModel: ['JZ-ZB-005'],
+        zigbeeModel: ['JZ-ZB-005', 'E220-KR5N0Z0-HA'],
         model: 'WP33-EU/WP34-EU',
         vendor: 'LELLKI',
         description: 'Multiprise with 4 AC outlets and 2 USB super charging ports (16A)',


### PR DESCRIPTION
Add zigbeeModel E220-KR5N0Z0-HA

I have purchased the Lellki WP33. When pairing it with Zigbee, it is recognized as E220-KR5N0Z0-HA, and it does not function properly. I have used an external converter to add E220-KR5N0Z0-HA, but it seems that simply adding the Zigbee model to the existing lellki.ts file would solve the issue.