### PR TITLE
Added missing feature ''Low water temp protection adjustment'' for RM3500ZB

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -233,6 +233,9 @@ const fzLocal = {
                 const lookup = {0: 'unlock', 1: 'lock'};
                 result.keypad_lockout = utils.getFromLookup(msg.data['keypadLockout'], lookup);
             }
+            if (msg.data.hasOwnProperty('drConfigWaterTempMin')) {
+                result.low_water_temp_protection = msg.data['drConfigWaterTempMin'];
+            }
             return result;
         },
     } as Fz.Converter,
@@ -372,7 +375,7 @@ const tzLocal = {
         },
     } as Tz.Converter,
     ambiant_max_heat_setpoint: {
-        // TH1300ZB and TH1400ZBspecific
+        // TH1300ZB and TH1400ZB specific
         key: ['ambiant_max_heat_setpoint'],
         convertSet: async (entity, key, value, meta) => {
             // @ts-expect-error
@@ -583,6 +586,17 @@ const tzLocal = {
             await entity.read('manuSpecificSinope', ['keypadLockout']);
         },
     } as Tz.Converter,
+       low_water_temp_protection: {
+        // RM3500ZB specific
+        key: ['low_water_temp_protection'],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write('manuSpecificSinope', {drConfigWaterTempMin: value});
+            return {state: {low_water_temp_protection: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificSinope', ['drConfigWaterTempMin']);
+        },
+    } as Tz.Converter, 
 };
 const definitions: Definition[] = [
     {
@@ -1425,8 +1439,11 @@ const definitions: Definition[] = [
         description: 'Calypso smart water heater controller',
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fzLocal.ias_water_leak_alarm,
             fzLocal.sinope, fz.temperature],
-        toZigbee: [tz.on_off],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.water_leak(), e.temperature()],
+        toZigbee: [tz.on_off, tzLocal.low_water_temp_protection],
+        exposes: [e.switch(), 
+            e.numeric('low_water_temp_protection', ea.ALL).withUnit('°C').withValueMin(0).withValueMax(65).withValueStep(1)
+                  .withDescription('Temperature at which water heating will resume automatically (default: 45°C)'),
+            e.power(), e.current(), e.voltage(), e.energy(), e.water_leak(), e.temperature()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             const binds = ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'msTemperatureMeasurement', 'ssIasZone',

--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -586,7 +586,7 @@ const tzLocal = {
             await entity.read('manuSpecificSinope', ['keypadLockout']);
         },
     } as Tz.Converter,
-       low_water_temp_protection: {
+    low_water_temp_protection: {
         // RM3500ZB specific
         key: ['low_water_temp_protection'],
         convertSet: async (entity, key, value, meta) => {
@@ -596,7 +596,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['drConfigWaterTempMin']);
         },
-    } as Tz.Converter, 
+    } as Tz.Converter,
 };
 const definitions: Definition[] = [
     {
@@ -1440,9 +1440,9 @@ const definitions: Definition[] = [
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fzLocal.ias_water_leak_alarm,
             fzLocal.sinope, fz.temperature],
         toZigbee: [tz.on_off, tzLocal.low_water_temp_protection],
-        exposes: [e.switch(), 
+        exposes: [e.switch(),
             e.numeric('low_water_temp_protection', ea.ALL).withUnit('°C').withValueMin(0).withValueMax(65).withValueStep(1)
-                  .withDescription('Temperature at which water heating will resume automatically (default: 45°C)'),
+                .withDescription('Temperature at which water heating will resume automatically (default: 45°C)'),
             e.power(), e.current(), e.voltage(), e.energy(), e.water_leak(), e.temperature()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Tested locally by editing /node_modules/zigbee-herdsman-converter/devices/sinope.js
Had to reformat for typescript (sinope.ts), might want to double check just in case.

Complete explanation at https://github.com/Koenkk/zigbee-herdsman-converters/issues/5627

![calypso](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/6ffe507a-6db2-43dc-a84f-c8bf08f55298)

From the manufacturer website:
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/5b51af7c-147f-4d2d-abdb-04ecc8886676)

