### PR TITLE
philips hue go 7602031N6 supports colours

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -507,7 +507,7 @@ const definitions: Definition[] = [
         model: '7602031N6',
         vendor: 'Philips',
         description: 'Hue Go portable light',
-        extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500]}),
+        extend: philips.extend.light_onoff_brightness_colortemp_color(),
     },
     {
         zigbeeModel: ['929003128501'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -507,7 +507,7 @@ const definitions: Definition[] = [
         model: '7602031N6',
         vendor: 'Philips',
         description: 'Hue Go portable light',
-        extend: philips.extend.light_onoff_brightness_colortemp_color(colorTempRange: [153, 500]),
+        extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['929003128501'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -507,7 +507,7 @@ const definitions: Definition[] = [
         model: '7602031N6',
         vendor: 'Philips',
         description: 'Hue Go portable light',
-        extend: philips.extend.light_onoff_brightness_colortemp_color(),
+        extend: philips.extend.light_onoff_brightness_colortemp_color(colorTempRange: [153, 500]),
     },
     {
         zigbeeModel: ['929003128501'],


### PR DESCRIPTION
The Philips Hue Go light (7602031N6) supports full RGB, minor tweak to enable colour changing support. Tested and working with my own 7602031N6 lights.