### PR TITLE
fix(detect): Detect (TS0001, _TZ3000_h8ngtlxy) as TuYa Smart water/gas valve

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -824,7 +824,7 @@ const definitions: Definition[] = [
             {modelID: 'TS0001', manufacturerName: '_TZ3000_o4cjetlm'}, {manufacturerName: '_TZ3000_o4cjetlm'},
             {modelID: 'TS0001', manufacturerName: '_TZ3000_iedbgyxt'}, {modelID: 'TS0001', manufacturerName: '_TZ3000_h3noz0a5'},
             {modelID: 'TS0001', manufacturerName: '_TYZB01_4tlksk8a'}, {modelID: 'TS0011', manufacturerName: '_TYZB01_rifa0wlb'},
-            {modelID: 'TS0001', manufacturerName: '_TZ3000_5ucujjts'},
+            {modelID: 'TS0001', manufacturerName: '_TZ3000_5ucujjts'}, {modelID: 'TS0001', manufacturerName: '_TZ3000_h8ngtlxy'},
         ],
         model: 'ZN231392',
         vendor: 'TuYa',


### PR DESCRIPTION
I added the smart valve to zigbee2mqtt and it was originally detected as a 1-gang-switch, which was wrong.

So I added the zigbee model and manufacturer (as seen in the attached photo) to the fingerprint list and now it's detected properly.


![description](https://github.com/Koenkk/zigbee-herdsman-converters/assets/146347091/d897fe4e-ccda-4936-b925-82f596edc9eb)
