### PR TITLE
fix: yookie cover position

### DIFF
--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -447,6 +447,16 @@ const converters = {
             await entity.read('closuresWindowCovering', [isPosition ? 'currentPositionLiftPercentage' : 'currentPositionTiltPercentage']);
         },
     },
+    cover_position_invert: {
+        key: ['position'],
+        options: [exposes.options.invert_cover()],
+        convertSet: async (entity, key, value, meta) => {
+            return await converters.cover_position_tilt.convertSet(entity, key, 100 - value, meta);
+        },
+        convertGet: async (entity, key, meta) => {
+            return converters.cover_position_tilt.convertGet(entity, key, meta);
+        },
+    },
     occupancy_timeout: {
         // Sets delay after motion detector changes from occupied to unoccupied
         key: ['occupancy_timeout'],

--- a/src/devices/yookee.ts
+++ b/src/devices/yookee.ts
@@ -12,7 +12,8 @@ const definitions: Definition[] = [
         vendor: 'Yookee',
         description: 'Smart blind controller',
         fromZigbee: [fz.cover_position_tilt, fz.battery],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt],
+        toZigbee: [tz.cover_state, tz.cover_position_invert],
+        meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);


### PR DESCRIPTION
This PR might be more of a conversation based on what I'm [reading in ZHA](https://github.com/zigpy/zha-device-handlers/pull/1664#issuecomment-1464998229). (I'm going to try ZHA in a bit and see if they've fixed this issue on my end).

From what I can tell over there, there's maybe some issues with firmware or issues with the cover roll being put on the front or back of the blind. 

This code works for all of my blinds, I have some with rolls in the front and some in the back. All of my blinds are "old" (I added the original converter for these a while ago) so firmware might be outdated, I don't think it's updatable.

Do you have any memory of why the inversion I added was reverted? I looked through the git history and I see it going back and forth which makes me think there's something funky going on. 