### PR TITLE
fix(docs): fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm run build
 If any of those commands finish with an error your PR won't pass the tests and will likely be rejected.
 
 ## Documentation of definition meta property
-- `multiEndpoint`: enables the multi endpoint functionallity in e.g. fromZigbee.on_off, example: normally this converter would return {"state": "OFF"}, when multiEndpoint is enabled the 'endpoint' method of the device definition will be called to determine the endpoint name which is then used as key e.g. {"state_left": "OFF"}. Only needed when device sends the same attribute from multiple endpoints. (default: false)
+- `multiEndpoint`: enables the multi endpoint functionality in e.g. fromZigbee.on_off, example: normally this converter would return {"state": "OFF"}, when multiEndpoint is enabled the 'endpoint' method of the device definition will be called to determine the endpoint name which is then used as key e.g. {"state_left": "OFF"}. Only needed when device sends the same attribute from multiple endpoints. (default: false)
 - `multiEndpointSkip`: array of attributes to not suffix with the endpoint name
 - `multiEndpointEnforce`: enforce a certain endpoint for an attribute, e.g. {"power": 4} see utils.enforceEndpoint()
 - `disableDefaultResponse`: used by toZigbee converters to disable the default response of some devices as they don't provide one. (default: false)
@@ -40,5 +40,5 @@ If any of those commands finish with an error your PR won't pass the tests and w
 - `thermostat`: see e.g. HT-08 definition
   - `{dontMapPIHeatingDemand: true}`: do not map `pIHeatingDemand`/`pICoolingDemand` from 0-255 -> 0-100, see fromZigbee.thermostat (default: false)
 - `battery`:
-  - `{dontDividePercentage: true}`: prevents batteryPercentageRemainig from being divided (ZCL 200=100%, but some report 100=100%) (default: false)
+  - `{dontDividePercentage: true}`: prevents batteryPercentageRemaining from being divided (ZCL 200=100%, but some report 100=100%) (default: false)
   - `{voltageToPercentage: '3V_2100'}`: convert voltage to percentage using specified option. See utils.batteryVoltageToPercentage() (default: null, no voltage to percentage conversion)


### PR DESCRIPTION
Credit to `codespell`.