### PR TITLE
Fix invalid device model for TRADFRI bulb GU10 WS 345lm

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1041,7 +1041,7 @@ const definitions: Definition[] = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
-        zigbeeModel: ['TRADFRIbulbGU10WS345lm', 'TRADFRI bulb GU10 WW 345lm', 'TRADFRIbulbGU10WS380lm'],
+        zigbeeModel: ['TRADFRIbulbGU10WS345lm', 'TRADFRI bulb GU10 WS 345lm', 'TRADFRIbulbGU10WS380lm'],
         model: 'LED2005R5',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb GU10 345/380 lumen, dimmable, white spectrum',


### PR DESCRIPTION
I'm suggesting that this was a typo.

There is already a corresponding definition for WW (albeit with some extra characters control characters at the beginning) here that looks as expected:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/dc17051ffcad9eeb2b8225e4900d98206f6d5a1f/src/devices/ikea.ts#L465-L471

It doesn't make sense to me that a WW light would expose color temp, so I'm suggesting that this is a typo for WS.

I ran locally with this definition:

```javascript
const definition = {
    zigbeeModel: ['TRADFRI bulb GU10 WS 345lm'], // The model ID from: Device with modelID 'lumi.sens' is not supported.
    model: 'LED2005R5', // Vendor model number, look on the device for a model number
    vendor: 'IKEA', // Vendor of the device (only used for documentation and startup logging)
    description: 'TRADFRI bulb GU10 WS 345lm', // Description of the device, copy from vendor site. (only used for documentation and startup logging)
    extend: {
        ...extend.light_onoff_brightness_colortemp({colorTempRange: [250, 454]}),
        exposes: [...extend.light_onoff_brightness_colortemp({colorTempRange: [250, 454]}).exposes],
        ota: ota.tradfri,
        // onEvent: bulbOnEvent,
    }};
```

and it seems to be working well so I'm expecting this change to work well.