### PR TITLE
Update battery for Wiser TRV

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -250,8 +250,9 @@ const definitions: Definition[] = [
         fromZigbee: [fz.ignore_basic_report, fz.ignore_haDiagnostic, fz.ignore_genOta, fz.ignore_zclversion_read,
             legacy.fz.wiser_thermostat, legacy.fz.wiser_itrv_battery, fz.hvac_user_interface, fz.wiser_device_info],
         toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_keypad_lockout],
+        meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
         exposes: [e.climate().withSetpoint('occupied_heating_setpoint', 7, 30, 1).withLocalTemperature(ea.STATE)
-            .withRunningState(['idle', 'heat'], ea.STATE).withPiHeatingDemand()],
+            .withRunningState(['idle', 'heat'], ea.STATE).withPiHeatingDemand(), e.battery(), e.battery_voltage()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const binds = ['genBasic', 'genPowerCfg', 'hvacThermostat', 'haDiagnostic'];


### PR DESCRIPTION
Battery was not exposed and was not calculated accurately.,

I wasn't sure whether to remove withRunningState as this does not appear to be supported by the device 
```
 2023-10-03 14:29:25Publish 'set' 'read' to 'Kitchen TRV' failed: 'Error: Read 0x50325ffffe7f5cd7/1 hvacThermostat(["runningMode"], {"sendWhen":"active","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'
```
but I wasn't sure if there are any considerations to just remove this.

It does appear to support systemMode 
```
2023-10-03 14:31:25Read result of 'hvacThermostat': {"systemMode":1}
```
but I wasn't sure about how to figure out which modes it actually supports ?

I figured the battery change should be simple and then I can update modes later