### PR TITLE
set MTG275-ZB-RL as whitelabel

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6054,7 +6054,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_sbyx0lm6', '_TZE204_clrdrnya']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_sbyx0lm6', '_TZE204_clrdrnya','_TZE204_dtzziy1e']),
         model: 'MTG075-ZB-RL',
         vendor: 'TuYa',
         description: '5.8G human presence sensor with relay',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6054,7 +6054,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_sbyx0lm6', '_TZE204_clrdrnya','_TZE204_dtzziy1e']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_sbyx0lm6', '_TZE204_clrdrnya', '_TZE204_dtzziy1e']),
         model: 'MTG075-ZB-RL',
         vendor: 'TuYa',
         description: '5.8G human presence sensor with relay',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6054,10 +6054,13 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_sbyx0lm6', '_TZE204_dtzziy1e', '_TZE204_clrdrnya']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_sbyx0lm6', '_TZE204_clrdrnya']),
         model: 'MTG075-ZB-RL',
         vendor: 'TuYa',
         description: '5.8G human presence sensor with relay',
+        whiteLabel: [
+            tuya.whitelabel('TuYa', 'MTG275-ZB-RL', '24G MmWave radar human presence motion sensor', ['_TZE204_dtzziy1e']),
+        ],
         configure: tuya.configureMagicPacket,
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],


### PR DESCRIPTION
I opened _TZE204_dtzziy1e to confirm it's a 24G sensor as advertised.
Works out of the box with the existing converter, just changed it as whitelabel to fix model and description.