### PR TITLE
Readability improvements: Legrand.ts + Bticino.ts

### DIFF
--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -14,16 +14,18 @@ const definitions: Definition[] = [
         model: 'K4003C/L4003C/N4003C/NT4003C',
         vendor: 'BTicino',
         description: 'Light switch with neutral',
+        ota: ota.zigbeeOTA,
         fromZigbee: [fz.identify, fz.on_off, fz.K4003C_binary_input, fz.legrand_cluster_fc01, fz.legrand_led_in_dark],
         toZigbee: [tz.on_off, tz.legrand_settingEnableLedInDark, tz.legrand_settingEnableLedIfOn, tz.legrand_identify],
         exposes: [
             e.switch(), e.action(['identify', 'on', 'off']),
-            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF').withDescription(`Enables the LED when the light is turned off, allowing ` +
-                `to see the switch in the dark`),
-            e.binary('led_if_on', ea.ALL, 'ON', 'OFF').withDescription('Enables the LED when the light is turned on'),
-            e.enum('identify', ea.SET, ['blink']).withDescription(`Blinks the built-in LED to make it easier to find the device`),
+            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF').
+                withDescription('Enables the LED when the light is turned off, allowing to see the switch in the dark'),
+            e.binary('led_if_on', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the LED when the light is turned on'),
+            e.enum('identify', ea.SET, ['blink'])
+                .withDescription('Blinks the built-in LED to make it easier to find the device'),
         ],
-        ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genBinaryInput']);
@@ -35,6 +37,7 @@ const definitions: Definition[] = [
         vendor: 'BTicino',
         description: 'Dimmer switch with neutral',
         extend: extend.light_onoff_brightness({noConfigure: true}),
+        ota: ota.zigbeeOTA,
         fromZigbee: [fz.brightness, fz.identify, fz.on_off, fz.lighting_ballast_configuration, fz.legrand_cluster_fc01, fz.legrand_led_in_dark],
         toZigbee: [tz.light_onoff_brightness, tz.legrand_settingEnableLedInDark, tz.legrand_settingEnableLedIfOn,
             tz.legrand_deviceMode, tz.legrand_identify, tz.ballast_config],
@@ -44,18 +47,19 @@ const definitions: Definition[] = [
                 .withDescription('Specifies the minimum brightness value'),
             e.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
                 .withDescription('Specifies the maximum brightness value'),
-            e.binary('device_mode', ea.ALL, 'dimmer_on', 'dimmer_off').withDescription('Allow the device to change brightness'),
-            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF').withDescription(`Enables the LED when the light is turned off, allowing ` +
-                `to see the switch in the dark`),
-            e.binary('led_if_on', ea.ALL, 'ON', 'OFF').withDescription('Enables the LED when the light is turned on'),
-            e.enum('identify', ea.SET, ['blink']).withDescription(`Blinks the built-in LED to make it easier to find the device`),
+            e.binary('device_mode', ea.ALL, 'dimmer_on', 'dimmer_off')
+                .withDescription('Allow the device to change brightness'),
+            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the LED when the light is turned off, allowing to see the switch in the dark'),
+            e.binary('led_if_on', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the LED when the light is turned on'),
+            e.enum('identify', ea.SET, ['blink'])
+                .withDescription('Blinks the built-in LED to make it easier to find the device'),
         ],
-        ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genLevelCtrl',
-                'genBinaryInput', 'lightingBallastCfg']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'genLevelCtrl', 'genBinaryInput', 'lightingBallastCfg']);
             await reporting.onOff(endpoint);
             await reporting.brightness(endpoint);
         },
@@ -69,17 +73,18 @@ const definitions: Definition[] = [
         model: 'K4027C/L4027C/N4027C/NT4027C',
         vendor: 'BTicino',
         description: 'Shutter SW with level control',
+        ota: ota.zigbeeOTA,
         fromZigbee: [fz.identify, fz.ignore_basic_report, fz.ignore_zclversion_read, fz.bticino_4027C_binary_input_moving,
             fz.cover_position_tilt, fz.legrand_led_in_dark],
         toZigbee: [tz.bticino_4027C_cover_state, tz.bticino_4027C_cover_position, tz.legrand_identify,
             tz.legrand_settingEnableLedInDark],
         exposes: [
             e.cover_position(), e.action(['moving', 'identify', '']),
-            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF').withDescription(`Enables the LED when the light is turned off, allowing ` +
-                `to see the switch in the dark`),
-            e.enum('identify', ea.SET, ['blink']).withDescription(`Blinks the built-in LED to make it easier to find the device`),
+            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the LED when the light is turned off, allowing to see the switch in the dark'),
+            e.enum('identify', ea.SET, ['blink'])
+                .withDescription('Blinks the built-in LED to make it easier to find the device'),
         ],
-        ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
@@ -94,9 +99,12 @@ const definitions: Definition[] = [
         extend: extend.switch(),
         fromZigbee: [fz.identify, fz.on_off, fz.electrical_measurement, fz.legrand_cluster_fc01, fz.ignore_basic_report, fz.ignore_genOta],
         toZigbee: [tz.legrand_deviceMode, tz.on_off, tz.legrand_identify, tz.electrical_measurement_power],
-        exposes: [e.switch().withState('state', true, 'On/off (works only if device is in "switch" mode)'),
-            e.power().withAccess(ea.STATE_GET), e.enum('device_mode', ea.ALL, ['switch', 'auto'])
-                .withDescription('switch: allow on/off, auto will use wired action via C1/C2 on contactor for example with HC/HP')],
+        exposes: [
+            e.switch().withState('state', true, 'On/off (works only if device is in "switch" mode)'),
+            e.power().withAccess(ea.STATE_GET),
+            e.enum('device_mode', ea.ALL, ['switch', 'auto'])
+                .withDescription('switch: allow on/off, auto will use wired action via C1/C2 on contactor for example with HC/HP'),
+        ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'haElectricalMeasurement']);
@@ -112,7 +120,13 @@ const definitions: Definition[] = [
         description: 'Power socket with power consumption monitoring',
         fromZigbee: [fz.identify, fz.on_off, fz.electrical_measurement, fz.legrand_led_in_dark],
         toZigbee: [tz.on_off, tz.legrand_settingEnableLedInDark, tz.legrand_identify],
-        exposes: [e.switch(), e.action(['identify']), e.power(), e.voltage(), e.current()],
+        exposes: [
+            e.switch(),
+            e.action(['identify']),
+            e.power(),
+            e.voltage(),
+            e.current(),
+        ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genIdentify', 'genOnOff', 'haElectricalMeasurement']);


### PR DESCRIPTION
1. Improved the readability by having:
        - Reordered definition attributes on all devices (see pattern)
        - Prettified the code

Pattern:
> zigbeeModel
> model
> vendor
> description
> whiteLabel
> extend
> ota
> meta
> fromZigbee
> toZigbee
> exposes
> onEvent
> configure
> endpoint

2. Also removed the definition for the 067776_inverted device due to:
        - the fact the Legrand OTA now works reliably
        - the cover can be inverted on the classic version
        
>  Caution: This may break backwards compat. !
>  Please cherry pick from that PR in case the latter commit is not acceptable
 
