### PR TITLE
Updated Legrand 067776 family switches

### DIFF
--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -75,17 +75,16 @@ const definitions: Definition[] = [
         vendor: 'BTicino',
         description: 'Shutter SW with level control',
         ota: ota.zigbeeOTA,
-        fromZigbee: [fz.identify, fz.ignore_basic_report, fz.ignore_zclversion_read, fz.bticino_4027C_binary_input_moving,
-            fz.cover_position_tilt, fz.legrand_led_in_dark],
-        toZigbee: [tz.bticino_4027C_cover_state, tz.bticino_4027C_cover_position, tz.legrand_identify,
-            tz.legrand_settingEnableLedInDark],
+        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.bticino_4027C_binary_input_moving,
+            fz.identify, fz.legrand_led_in_dark, fz.ignore_zclversion_read],
+        toZigbee: [tz.bticino_4027C_cover_state, tz.bticino_4027C_cover_position, tz.legrand_identify, tz.legrand_settingEnableLedInDark],
         exposes: [
             e.cover_position(),
             e.action(['moving', 'identify', '']),
-            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
-                .withDescription('Enables the LED when the light is turned off, allowing to see the switch in the dark'),
             e.enum('identify', ea.SET, ['blink'])
-                .withDescription('Blinks the built-in LED to make it easier to find the device'),
+                .withDescription('Blinks the built-in LED to make it easier to identify the device'),
+            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -18,9 +18,10 @@ const definitions: Definition[] = [
         fromZigbee: [fz.identify, fz.on_off, fz.K4003C_binary_input, fz.legrand_cluster_fc01, fz.legrand_led_in_dark],
         toZigbee: [tz.on_off, tz.legrand_settingEnableLedInDark, tz.legrand_settingEnableLedIfOn, tz.legrand_identify],
         exposes: [
-            e.switch(), e.action(['identify', 'on', 'off']),
-            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF').
-                withDescription('Enables the LED when the light is turned off, allowing to see the switch in the dark'),
+            e.switch(),
+            e.action(['identify', 'on', 'off']),
+            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the LED when the light is turned off, allowing to see the switch in the dark'),
             e.binary('led_if_on', ea.ALL, 'ON', 'OFF')
                 .withDescription('Enables the LED when the light is turned on'),
             e.enum('identify', ea.SET, ['blink'])
@@ -79,7 +80,8 @@ const definitions: Definition[] = [
         toZigbee: [tz.bticino_4027C_cover_state, tz.bticino_4027C_cover_position, tz.legrand_identify,
             tz.legrand_settingEnableLedInDark],
         exposes: [
-            e.cover_position(), e.action(['moving', 'identify', '']),
+            e.cover_position(),
+            e.action(['moving', 'identify', '']),
             e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
                 .withDescription('Enables the LED when the light is turned off, allowing to see the switch in the dark'),
             e.enum('identify', ea.SET, ['blink'])
@@ -100,8 +102,10 @@ const definitions: Definition[] = [
         fromZigbee: [fz.identify, fz.on_off, fz.electrical_measurement, fz.legrand_cluster_fc01, fz.ignore_basic_report, fz.ignore_genOta],
         toZigbee: [tz.legrand_deviceMode, tz.on_off, tz.legrand_identify, tz.electrical_measurement_power],
         exposes: [
-            e.switch().withState('state', true, 'On/off (works only if device is in "switch" mode)'),
-            e.power().withAccess(ea.STATE_GET),
+            e.switch()
+                .withState('state', true, 'On/off (works only if device is in "switch" mode)'),
+            e.power()
+                .withAccess(ea.STATE_GET),
             e.enum('device_mode', ea.ALL, ['switch', 'auto'])
                 .withDescription('switch: allow on/off, auto will use wired action via C1/C2 on contactor for example with HC/HP'),
         ],

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -170,12 +170,15 @@ const definitions: Definition[] = [
         vendor: 'Legrand',
         description: 'Netatmo wired shutter switch',
         ota: ota.zigbeeOTA,
-        fromZigbee: [fz.identify, fz.ignore_basic_report, fz.legrand_binary_input_moving, fz.cover_position_tilt, fz.legrand_led_in_dark],
+        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify, fz.legrand_led_in_dark],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingEnableLedInDark],
         exposes: [
             e.cover_position(),
+            e.action(['moving', 'identify']),
+            e.enum('identify', ea.SET, ['blink'])
+                .withDescription('Blinks the built-in LED to make it easier to identify the device'),
             e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
-                .withDescription('Enables the LED when the power socket is turned off, allowing to see it in the dark'),
+                .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -212,6 +212,31 @@ const definitions: Definition[] = [
         },
     },
     {
+        // Fingerprinting required due to conflict with potential whitelabel Bticino - K4027C/L4027C/N4027C/NT4027C
+        fingerprint: [
+            {modelID: ' Shutter SW with level control\u0000', manufacturerID: 4129},
+        ],
+        model: '067776A',
+        vendor: 'Legrand',
+        description: 'Netatmo wired shutter switch with level control (NLLV)',
+        ota: ota.zigbeeOTA,
+        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify, fz.legrand_led_in_dark],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingEnableLedInDark],
+        exposes: [
+            e.cover_position(),
+            e.action(['moving', 'identify']),
+            e.enum('identify', ea.SET, ['blink'])
+                .withDescription('Blinks the built-in LED to make it easier to identify the device'),
+            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
+            await reporting.currentPositionLiftPercentage(endpoint);
+        },
+    },
+    {
         // LED blinks RED when battery is low
         zigbeeModel: [' Remote switch\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
         model: '067773',


### PR DESCRIPTION
This PR updates Legrand 067776 family shutter switches:

### Legrand 067776
- Added 'Action'
- Added 'Identify'
- Updated 'LED in dark' description

### Legrand 067776A
- Added the new generation 067776A switch (with level control)

### K4027C/L4027C/N4027C/NT4027C
- Updated 'Identify' and 'LED in dark' description