### PR TITLE
Update philips.ts with model 1744230P7.

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -664,6 +664,13 @@ const definitions: Definition[] = [
         extend: philips.extend.light_onoff_brightness_colortemp_color(),
     },
     {
+        zigbeeModel: ['1744230P7'],
+        model: '1744230P7',
+        vendor: 'Philips',
+        description: 'Hue Econic outdoor Post Light',
+        extend: philips.extend.light_onoff_brightness_colortemp_color(),
+    },
+    {
         zigbeeModel: ['1745730V7'],
         model: '1745730V7',
         vendor: 'Philips',

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -667,7 +667,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['1744230P7'],
         model: '1744230P7',
         vendor: 'Philips',
-        description: 'Hue Econic outdoor Post Light',
+        description: 'Hue Econic outdoor post light',
         extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -661,14 +661,14 @@ const definitions: Definition[] = [
         model: '1744130P7',
         vendor: 'Philips',
         description: 'Hue Econic outdoor Pedestal',
-        extend: philips.extend.light_onoff_brightness_colortemp_color(),
+        extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['1744230P7'],
         model: '1744230P7',
         vendor: 'Philips',
         description: 'Hue Econic outdoor Post Light',
-        extend: philips.extend.light_onoff_brightness_colortemp_color(),
+        extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['1745730V7'],


### PR DESCRIPTION
Add support for the Phillips Hue Econic outdoor Post Light 1744230P7.

Its the same Light as the 1744130P7 but with a higher Post.