### PR TITLE
Add Philips Hue PAR38 Outdoor Spotlight bulb support

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2507,6 +2507,13 @@ const definitions: Definition[] = [
         extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {
+        zigbeeModel: ['LCS002'],
+        model: '577262',
+        vendor: 'Philips',
+        description: 'Hue White and Color Ambiance PAR38 Outdoor Spotlight',
+        extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
+    },
+    {
         zigbeeModel: ['1742730P7', '1742830P7'],
         model: '1742830P7',
         vendor: 'Philips',

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2508,7 +2508,7 @@ const definitions: Definition[] = [
     },
     {
         zigbeeModel: ['LCS002'],
-        model: '577262',
+        model: '9290031508',
         vendor: 'Philips',
         description: 'Hue White and Color Ambiance PAR38 outdoor spotlight',
         extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2510,7 +2510,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['LCS002'],
         model: '577262',
         vendor: 'Philips',
-        description: 'Hue White and Color Ambiance PAR38 Outdoor Spotlight',
+        description: 'Hue White and Color Ambiance PAR38 outdoor spotlight',
         extend: philips.extend.light_onoff_brightness_colortemp_color({colorTempRange: [153, 500]}),
     },
     {


### PR DESCRIPTION
Add support for the new Philips Hue White and Color PAR38 Outdoor Spotlight bulb