### PR TITLE
fix: Re-enable incremental TSC builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint .",
     "test": "ZHC_TEST=true jest test",
     "test-watch": "ZHC_TEST=true jest test --watch",
-    "clean": "rimraf index* devices lib converters",
+    "clean": "rimraf index* devices lib converters tsconfig.tsbuildinfo",
     "build": "tsc",
     "prepack": "npm run clean && npm run build"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
       "outDir": ".",
       "baseUrl": ".",
       "resolveJsonModule": true,
-      "allowJs": true
+      "allowJs": true,
+      "incremental": true
     },
     "include": ["./src/"],
     "exclude": []


### PR DESCRIPTION
With ref. to the last comment in [PR#6267](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6267), this PR contains a fix to (re)enable incremental TSC builds.



