### PR TITLE
feat: Add support for multiple MiBoxer FUT089Z remotes

### DIFF
--- a/src/devices/miboxer.ts
+++ b/src/devices/miboxer.ts
@@ -23,16 +23,18 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
-            await endpoint.command('genGroups', 'miboxerSetZones', {zones: [
-                {zoneNum: 1, groupId: 101},
-                {zoneNum: 2, groupId: 102},
-                {zoneNum: 3, groupId: 103},
-                {zoneNum: 4, groupId: 104},
-                {zoneNum: 5, groupId: 105},
-                {zoneNum: 6, groupId: 106},
-                {zoneNum: 7, groupId: 107},
-                {zoneNum: 8, groupId: 108},
-            ]});
+
+            // Get unique identifier for the remote and convert it from hex-string to integer
+            const devId = parseInt(device.ieeeAddr, 16);
+
+            // Generate 8 globally unique (but reproducable) Zigbee group IDs
+            const groupIds = [devId+1, devId+2, devId+3, devId+4, devId+5, devId+6, devId+7, devId+8];
+
+            // Generate the zone mapping, which tells the remote to use the 8 unique group IDs for its 8 zones
+            const zoneToGroupMappings = groupIds.map((groupId, i) => ({zoneNum: i+1, groupId: groupId}));
+
+            // Send the zone mapping to the remote
+            await endpoint.command('genGroups', 'miboxerSetZones', {zones: zoneToGroupMappings});
             await endpoint.command('genBasic', 'tuyaSetup', {}, {disableDefaultResponse: true});
         },
     },


### PR DESCRIPTION
This commit changes MiBoxer FUT089Z remotes to send their commands to unique groups, allowing multiple remotes of this type to be configured individually.

BREAKING CHANGE: The group IDs for all MiBoxer FUT089Z remotes are changed, meaning that the remote won't send its commands to the old static groups (101-108) anymore.

This fixes #6274 . 

Unfortunately, I don't know how to test my code in Zigbee2MQTT in Home Assistant. Any guidance would be appreciated (in case there even is any interest in getting this merged). Unfortunately I can't see any way to do all of this without breaking backwards compatibility to some degree. (Users that have configured groups 101-108 for this remote, will have to update the IDs of those groups if they still want their remote to send commands to these groups.)