### PR TITLE
Add additional zigbee id for Philips Play Lightbar

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1171,7 +1171,7 @@ const definitions: Definition[] = [
         extend: philips.extend.light_onoff_brightness_colortemp_color(),
     },
     {
-        zigbeeModel: ['LCT024', '440400982841', '440400982842'],
+        zigbeeModel: ['LCT024', '440400982841', '440400982842', 'PCM002'],
         model: '915005733701',
         vendor: 'Philips',
         description: 'Hue White and color ambiance Play Lightbar',


### PR DESCRIPTION
I found that one of my three Play Lightbars reports a different Zigbee id, PCM002.  Endpoints are all the same.