### PR TITLE
Revert "fix: yookie cover position"

### DIFF
--- a/src/devices/yookee.ts
+++ b/src/devices/yookee.ts
@@ -1,22 +1,9 @@
-import {Definition, Tz} from '../lib/types';
+import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
-import * as utils from '../lib/utils';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 const e = exposes.presets;
-
-const tzLocal = {
-    D10110_position: {
-        ...tz.cover_position_tilt,
-        convertSet: async (entity, key, value, meta) => {
-            utils.assertNumber(value, key);
-            // Requires coverInverted for fromZigbee but not for toZigbee
-            // https://github.com/Koenkk/zigbee-herdsman-converters/pull/6211/files#r1344424726
-            return await tz.cover_position_tilt.convertSet(entity, key, 100 - value, meta);
-        },
-    } as Tz.Converter,
-};
 
 const definitions: Definition[] = [
     {
@@ -25,8 +12,7 @@ const definitions: Definition[] = [
         vendor: 'Yookee',
         description: 'Smart blind controller',
         fromZigbee: [fz.cover_position_tilt, fz.battery],
-        toZigbee: [tz.cover_state, tzLocal.D10110_position],
-        meta: {coverInverted: true},
+        toZigbee: [tz.cover_state, tz.cover_position_tilt],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'closuresWindowCovering']);


### PR DESCRIPTION
Reverts Koenkk/zigbee-herdsman-converters#6211

Sorry, after using this for longer and still seeing some bizarre behavior I started looking into this more and reading more through this thread https://github.com/zigpy/zha-device-handlers/issues/1306

My _guess_ is that I happen to have old firmware that is particularly buggy and newer firmware likely doesn't have my problem.

Leaving this change as is, from what I can tell, is the correct thing for newer devices and I'll need to write a custom converter. 