### PR TITLE
feat(detect): detect TRADFRI bulb E26 CWS 810lm as LED1924G9

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -612,10 +612,10 @@ const definitions: Definition[] = [
         meta: {supportsHueAndSaturation: false},
     },
     {
-        zigbeeModel: ['TRADFRI bulb E26 CWS 800lm', 'TRADFRI bulb E27 CWS 806lm', 'TRADFRI bulb E26 CWS 806lm'],
+        zigbeeModel: ['TRADFRI bulb E26 CWS 800lm', 'TRADFRI bulb E27 CWS 806lm', 'TRADFRI bulb E26 CWS 806lm', 'TRADFRI bulb E26 CWS 810lm'],
         model: 'LED1924G9',
         vendor: 'IKEA',
-        description: 'TRADFRI bulb E26/E27 CWS 800/806 lumen, dimmable, color, opal white',
+        description: 'TRADFRI bulb E26/E27 CWS 800/806/810 lumen, dimmable, color, opal white',
         extend: tradfriExtend.light_onoff_brightness_colortemp_color(),
         meta: {turnsOffAtBrightness1: true},
     },


### PR DESCRIPTION
This works for me to add support for the new Ikea 810 lumen color bulb.

It's small, so I hope it will be accepted, but if i made mistakes, please let me know so I can correct it.

https://github.com/Koenkk/zigbee2mqtt/issues/19306