### PR TITLE
Add support for Philips Hue Play Gradient Light strip (PC version)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2741,7 +2741,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['LXC006'],
         model: '929003498601',
         vendor: 'Philips',
-        description: 'Play Gradient Lightstrip for PC (32-34)',
+        description: 'Play gradient lightstrip for PC (32-34)',
         extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
     },
     {

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2736,6 +2736,13 @@ const definitions: Definition[] = [
         vendor: 'Philips',
         description: 'Hue Adore white ambiance bathroom mirror',
         extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+    }, 
+    {
+        zigbeeModel: ['LXC006'],
+        model: '929003498601',
+        vendor: 'Philips',
+        description: 'Play Gradient Lightstrip for PC (32-34)',
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500]}),
     },
     {
         zigbeeModel: ['LCX001'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2736,7 +2736,7 @@ const definitions: Definition[] = [
         vendor: 'Philips',
         description: 'Hue Adore white ambiance bathroom mirror',
         extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
-    }, 
+    },
     {
         zigbeeModel: ['LXC006'],
         model: '929003498601',


### PR DESCRIPTION
https://www.philips-hue.com/en-gb/p/lightstrips-play-gradient-lightstrip-for-pc/8719514434530

This is for the 32-34" model, not sure if it would be different on the 24"-27"

The file I have as an external converter:

```js
const ota = require('zigbee-herdsman-converters/lib/ota');
const { extend } = require('zigbee-herdsman-converters/lib/philips');

module.exports = [{
    zigbeeModel: ['LCX006'],
    model: '929003498601',
    vendor: 'Philips',
    description: 'Hue gradient lightstrip',
    meta: { turnsOffAtBrightness1: true },
    extend: extend.light_onoff_brightness_colortemp_color_gradient({ colorTempRange: [153, 500] }),
    ota: ota.zigbeeOTA,
}];
```