### PR TITLE
Add Wenzhi WZ-M100-Z as whitelabel for TuYa ZY-M100-S_1

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4446,6 +4446,9 @@ const definitions: Definition[] = [
         description: 'Mini human breathe sensor',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
+        whiteLabel: [
+            tuya.whitelabel('Wenzhi', 'WZ-M100-W', 'Human presence sensor', ['_TZE204_e5m9c5hl']),
+        ],
         exposes: [
             e.illuminance_lux(), e.presence(),
             e.numeric('target_distance', ea.STATE).withDescription('Distance to target').withUnit('m'),


### PR DESCRIPTION
Add Wenzhi WZ-M100-Z as whitelabel of the TuYa ZY-M100 as this is a clone and implement the same features.

By opening the device and looking at the PCB and the chip used, the device use the same sensor and the same ARM controller of the Tuya ZY-M100.

Only the fingerprint reported is different.