### PR TITLE
Add additional model number for Hue Enrave L

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -230,7 +230,7 @@ const definitions: Definition[] = [
         extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
     },
     {
-        zigbeeModel: ['915005996801', '915005996901', '929003574401'],
+        zigbeeModel: ['915005996801', '915005996901', '929003574401', '929003531602'],
         model: '915005996901',
         vendor: 'Philips',
         description: 'Hue white ambiance ceiling light Enrave L with Bluetooth',


### PR DESCRIPTION
I bought two [Hue White Ambiance Enrave Large Ceiling Lamps](https://www.philips-hue.com/en-us/p/hue-white-ambiance-enrave-large-ceiling-lamp/046677579814). This device already has a converter, but the specific model number of my units doesn't seem included.  

I have been running this locally using an external converter in zigbee2mqtt without any issues:
```
const definition = {
    zigbeeModel: ['929003531602'], // The model ID from: Device with modelID 'lumi.sens' is not supported.
    model: '929003531602', // Vendor model number, look on the device for a model number
    vendor: 'Phillips', // Vendor of the device (only used for documentation and startup logging)
    description: 'Hue white ambiance ceiling light Enrave L with Bluetooth', // Description of the device, copy from vendor site. (only used for documentation and startup logging)
    extend: philips.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]})
};
```

I have also confirmed the color temp min/max values.

**Full disclosure:** while I have built, linted, and tested my change without errors (which differs from just using an external converter), I don't know how to sideload a local build to my Home Assistant server. So I'm just assuming from code inspection that this is the correct way to implement what has been working in my zigbee2mqtt external converter above.