### PR TITLE
Add support for another whitelabel of Tuya TS0201 Temp & Humidity Sensor with display.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1845,11 +1845,8 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [
-            {modelID: 'TS0201', manufacturerName: '_TZ2000_a476raq2'},
-            {modelID: 'SNTZ003', manufacturerName: '_TZ2000_a476raq2'},
-            {modelID: 'TY0201', manufacturerName: '_TZ3000_bjawzodf'},
-        ],
+        fingerprint: [{manufacturerName: '_TZ2000_a476raq2'}],
+        zigbeeModel: ['TS0201', 'SNTZ003', 'TY0201'],
         model: 'TS0201',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor with display',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1845,8 +1845,11 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{manufacturerName: '_TZ2000_a476raq2'}],
-        zigbeeModel: ['TS0201', 'SNTZ003'],
+        fingerprint: [
+            {modelID: 'TS0201', manufacturerName: '_TZ2000_a476raq2'},
+            {modelID: 'SNTZ003', manufacturerName: '_TZ2000_a476raq2'},
+            {modelID: 'TY0201', manufacturerName: '_TZ3000_bjawzodf'},
+        ],
         model: 'TS0201',
         vendor: 'TuYa',
         description: 'Temperature & humidity sensor with display',


### PR DESCRIPTION
I bought these https://www.aliexpress.com/item/1005005951859787.html the other day, and they didn't work immediately -- fiddled around with the fingerprints of the converter for this https://www.zigbee2mqtt.io/devices/TS0201.html as they look physically identical.

Temperature, Humidity and Battery % work as does calibration (only in reported values not values displayed on screen)

Values update automatically, if a little slowly but I think that's just the nature of battery powered zig temp sensors really.

Only things I'm not sure of is that with my device I'm seeing the mV of the battery at "Null" and I wasn't entirely sure what to put as the modelID for the fingerprint as there was two zigbeeModel entries, so I just put both for now.