### PR TITLE
Legrand 067776(A): Support calibration + Venetian mode

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -6,7 +6,7 @@ import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
 import * as ota from '../lib/ota';
-import {tzLegrand, fzLegrand, readInitialBatteryState} from '../lib/legrand';
+import {tzLegrand, fzLegrand, readInitialBatteryState, _067776} from '../lib/legrand';
 const e = exposes.presets;
 const ea = exposes.access;
 
@@ -133,20 +133,23 @@ const definitions: Definition[] = [
         vendor: 'Legrand',
         description: 'Netatmo wired shutter switch',
         ota: ota.zigbeeOTA,
-        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify, fz.legrand_led_in_dark],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingEnableLedInDark],
+        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify,
+            fz.legrand_led_in_dark, fzLegrand.calibration_mode(false)],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingEnableLedInDark, tzLegrand.calibration_mode(false)],
         exposes: [
-            e.cover_position(),
+            _067776.getCover(),
             e.action(['moving', 'identify']),
             e.enum('identify', ea.SET, ['blink'])
                 .withDescription('Blinks the built-in LED to make it easier to identify the device'),
             e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
                 .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
+            _067776.getCalibrationModes(false),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
-            await reporting.currentPositionLiftPercentage(endpoint);
+            await reporting.currentPositionLiftPercentage(endpoint, {max: 120});
+            await reporting.currentPositionTiltPercentage(endpoint, {max: 120});
         },
     },
     {
@@ -183,20 +186,23 @@ const definitions: Definition[] = [
         vendor: 'Legrand',
         description: 'Netatmo wired shutter switch with level control (NLLV)',
         ota: ota.zigbeeOTA,
-        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify, fz.legrand_led_in_dark],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingEnableLedInDark],
+        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify,
+            fz.legrand_led_in_dark, fzLegrand.calibration_mode(true)],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_settingEnableLedInDark, tzLegrand.calibration_mode(true)],
         exposes: [
-            e.cover_position(),
+            _067776.getCover(),
             e.action(['moving', 'identify']),
             e.enum('identify', ea.SET, ['blink'])
                 .withDescription('Blinks the built-in LED to make it easier to identify the device'),
             e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
                 .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
+            _067776.getCalibrationModes(true),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
-            await reporting.currentPositionLiftPercentage(endpoint);
+            await reporting.currentPositionLiftPercentage(endpoint, {max: 120});
+            await reporting.currentPositionTiltPercentage(endpoint, {max: 120});
         },
     },
     {

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -148,8 +148,11 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
-            await reporting.currentPositionLiftPercentage(endpoint, {max: 120});
-            await reporting.currentPositionTiltPercentage(endpoint, {max: 120});
+            let p = reporting.payload('currentPositionLiftPercentage', 1, 120, 1);
+            await endpoint.configureReporting('closuresWindowCovering', p, {manufacturerCode: 4129});
+
+            p = reporting.payload('currentPositionTiltPercentage', 1, 120, 1);
+            await endpoint.configureReporting('closuresWindowCovering', p, {manufacturerCode: 4129});
         },
     },
     {
@@ -201,8 +204,11 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
-            await reporting.currentPositionLiftPercentage(endpoint, {max: 120});
-            await reporting.currentPositionTiltPercentage(endpoint, {max: 120});
+            let p = reporting.payload('currentPositionLiftPercentage', 1, 120, 1);
+            await endpoint.configureReporting('closuresWindowCovering', p, {manufacturerCode: 4129});
+
+            p = reporting.payload('currentPositionTiltPercentage', 1, 120, 1);
+            await endpoint.configureReporting('closuresWindowCovering', p, {manufacturerCode: 4129});
         },
     },
     {

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -7,11 +7,11 @@ const ea = exposes.access;
 const legrandOptions = {manufacturerCode: 4129, disableDefaultResponse: true};
 
 const shutterCalibrationModes: {[k: number]: {description: string, onlyNLLV: boolean}} = {
-    0: {description: 'Classic (NLLV)', onlyNLLV: true},
-    1: {description: 'Specific (NLLV)', onlyNLLV: true},
-    2: {description: 'Up/Down/Stop', onlyNLLV: false},
-    3: {description: 'Temporal', onlyNLLV: false},
-    4: {description: 'Venetian (BSO)', onlyNLLV: false},
+    0: {description: 'classic_nllv', onlyNLLV: true},
+    1: {description: 'specific_nllv', onlyNLLV: true},
+    2: {description: 'up_down_stop', onlyNLLV: false},
+    3: {description: 'temporal', onlyNLLV: false},
+    4: {description: 'venetian_bso', onlyNLLV: false},
 };
 
 const getApplicableCalibrationModes = (isNLLVSwitch: boolean): KeyValueString => {

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -1,5 +1,22 @@
-import {Fz, OnEvent, Tz} from '../lib/types';
+import {Fz, Tz, OnEvent} from '../lib/types';
+import * as exposes from './exposes';
 import * as utils from '../lib/utils';
+const e = exposes.presets;
+const ea = exposes.access;
+
+const shutterCalibrationModes = {
+    'Classic (NLLV)': {ID: 0, onlyNLLV: true},
+    'Specific (NLLV)': {ID: 1, onlyNLLV: true},
+    'Up/Down/Stop': {ID: 2, onlyNLLV: false},
+    'Temporal': {ID: 3, onlyNLLV: false},
+    'Venetian (BSO)': {ID: 4, onlyNLLV: false},
+};
+
+const getApplicableCalibrationModes = (isNLLVSwitch: boolean) => {
+    return Object.fromEntries(Object.entries(shutterCalibrationModes)
+        .filter((e) => isNLLVSwitch ? true : e[1].onlyNLLV === false)
+        .map((e) => [e[0], e[1].ID]));
+};
 
 export const readInitialBatteryState: OnEvent = async (type, data, device, options) => {
     if (['deviceAnnounce'].includes(type)) {
@@ -19,6 +36,20 @@ export const tzLegrand = {
             return {state: {'auto_mode': value}};
         },
     } as Tz.Converter,
+    calibration_mode: (isNLLVSwitch: boolean) => {
+        return {
+            key: ['calibration_mode'],
+            convertSet: async (entity, key, value, meta) => {
+                const applicableModes = getApplicableCalibrationModes(isNLLVSwitch);
+                utils.validateValue(value, Object.keys(applicableModes));
+                const idx = applicableModes[value as string];
+                await entity.write('closuresWindowCovering', {'tuyaMotorReversal': idx});
+            },
+            convertGet: async (entity, key, meta) => {
+                await entity.read('closuresWindowCovering', [0xf002]);
+            },
+        } as Tz.Converter;
+    },
 };
 
 export const fzLegrand = {
@@ -36,4 +67,44 @@ export const fzLegrand = {
             }
         },
     } as Fz.Converter,
+    calibration_mode: (isNLLVSwitch: boolean) => {
+        return {
+            cluster: 'closuresWindowCovering',
+            type: ['attributeReport', 'readResponse'],
+            convert: (model, msg, publish, options, meta) => {
+                const attr = 'tuyaMotorReversal';
+                if (msg.data.hasOwnProperty(attr)) {
+                    const idx = msg.data[attr];
+                    const applicableModes = getApplicableCalibrationModes(isNLLVSwitch);
+                    utils.validateValue(idx, Object.values(applicableModes));
+                    const calMode = utils.getKey(applicableModes, idx);
+                    return {calibration_mode: calMode};
+                }
+            },
+        } as Fz.Converter;
+    },
+};
+
+export const _067776 = {
+    getCover: () => {
+        const c = e.cover_position();
+        if (c.hasOwnProperty('features')) {
+            c.features.push(new exposes.Numeric('tilt', ea.ALL)
+                .withValueMin(0).withValueMax(100)
+                .withValueStep(25)
+                .withPreset('Closed', 0, 'Vertical')
+                .withPreset('25 %', 25, '25%')
+                .withPreset('50 %', 50, '50%')
+                .withPreset('75 %', 75, '75%')
+                .withPreset('Open', 100, 'Horizontal')
+                .withUnit('%')
+                .withDescription('Tilt percentage of that cover'));
+        }
+        return c;
+    },
+    getCalibrationModes: (isNLLVSwitch: boolean) => {
+        const modes = getApplicableCalibrationModes(isNLLVSwitch);
+        return e.enum('calibration_mode', ea.ALL, Object.keys(modes))
+            .withDescription('Defines the calibration mode of the switch. (Caution: Changing modes requires a recalibration of the shutter switch!)');
+    },
 };

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -4,6 +4,8 @@ import * as utils from '../lib/utils';
 const e = exposes.presets;
 const ea = exposes.access;
 
+const legrandOptions = {manufacturerCode: 4129, disableDefaultResponse: true};
+
 const shutterCalibrationModes = {
     'Classic (NLLV)': {ID: 0, onlyNLLV: true},
     'Specific (NLLV)': {ID: 1, onlyNLLV: true},
@@ -43,10 +45,10 @@ export const tzLegrand = {
                 const applicableModes = getApplicableCalibrationModes(isNLLVSwitch);
                 utils.validateValue(value, Object.keys(applicableModes));
                 const idx = applicableModes[value as string];
-                await entity.write('closuresWindowCovering', {'tuyaMotorReversal': idx});
+                await entity.write('closuresWindowCovering', {'calibrationMode': idx}, legrandOptions);
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read('closuresWindowCovering', [0xf002]);
+                await entity.read('closuresWindowCovering', ['calibrationMode'], legrandOptions);
             },
         } as Tz.Converter;
     },
@@ -72,7 +74,7 @@ export const fzLegrand = {
             cluster: 'closuresWindowCovering',
             type: ['attributeReport', 'readResponse'],
             convert: (model, msg, publish, options, meta) => {
-                const attr = 'tuyaMotorReversal';
+                const attr = 'calibrationMode';
                 if (msg.data.hasOwnProperty(attr)) {
                     const idx = msg.data[attr];
                     const applicableModes = getApplicableCalibrationModes(isNLLVSwitch);

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -1,0 +1,39 @@
+import {Fz, OnEvent, Tz} from '../lib/types';
+import * as utils from '../lib/utils';
+
+export const readInitialBatteryState: OnEvent = async (type, data, device, options) => {
+    if (['deviceAnnounce'].includes(type)) {
+        const endpoint = device.getEndpoint(1);
+        const options = {manufacturerCode: 0x1021, disableDefaultResponse: true};
+        await endpoint.read('genPowerCfg', ['batteryVoltage'], options);
+    }
+};
+
+export const tzLegrand = {
+    auto_mode: {
+        key: ['auto_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            const mode = utils.getFromLookup(value, {'off': 0x00, 'auto': 0x02, 'on_override': 0x03});
+            const payload = {data: Buffer.from([mode])};
+            await entity.command('manuSpecificLegrandDevices3', 'command0', payload);
+            return {state: {'auto_mode': value}};
+        },
+    } as Tz.Converter,
+};
+
+export const fzLegrand = {
+    legrand_600087l: {
+        cluster: 'greenPower',
+        type: ['commandNotification'],
+        convert: (model, msg, publish, options, meta) => {
+            const commandID = msg.data.commandID;
+            const lookup: {[s: number]: string} = {0x34: 'stop', 0x35: 'up', 0x36: 'down'};
+            if (commandID === 224) return;
+            if (!lookup.hasOwnProperty(commandID)) {
+                meta.logger.error(`GreenPower_3 error: missing command '${commandID}'`);
+            } else {
+                return {action: lookup[commandID]};
+            }
+        },
+    } as Fz.Converter,
+};


### PR DESCRIPTION
This PR:
- includes a small refactoring of Legrand related devices / libraries
- enables calibration on 067776 / 067776A devices
- adds support for Venetian (BSO) mode

@Koenkk: A couple of questions / remarks:
1.) The reporting does not work reliably yet. I am somewhat puzzled with the reporting of attributes. Can you give me pointers as how to fix this or where to look for potential issues ?
- The device seems to report attributes regardless of the configured reporting. (I assume there is not much we can do about that, unless we explicitly disregard those reports)
- While the manufacturer code is honoured for readAttribute requests, it is ignored for attribute reports.
As an example, this is an excerpt from database.db for one of the devices:
```
{
  "61444": 25,
  "currentPositionLiftPercentage": 100,
  "currentPositionTiltPercentage": 0,
  "tuyaMotorReversal": 4,
  "moesCalibrationTime": 0,
  "tuyaMovingState": 100,
  "tuyaCalibration" :1
  }
```
Attribute 61444 (0xF004) should read "calibrationMode" following [zigbee-herdsman PR#784](https://github.com/Koenkk/zigbee-herdsman/pull/784), which as mentioned, works for readAttributes but not for reports.

2.) In order to avoid code duplication, i wanted to merge 067776 / 067776A devices in the device definition.
Shouldn't the following work ?
```
  {
        zigbeeModel: [' Shutter switch with neutral\u0000\u0000\u0000'],
        model: '067776',
        vendor: 'Legrand',
        description: 'Netatmo wired shutter switch',
        whiteLabel: [
            {model: '067776A',
            vendor: 'Legrand',
            description: 'Netatmo wired shutter switch with level control (NLLV)',
            meta: {supportsLevelDetection: false},
            fingerprint: [{modelID: ' Shutter SW with level control\u0000', manufacturerID: 4129}]},
        ],
        ota: ota.zigbeeOTA,
        meta: {supportsLevelDetection: false},
```
Thanks a lot.

P.S: I'll take a look at the failing test shortly. Looks like:
- ~my new Meta definition~
- ~and including a function in "exposes"~
causes troubles.