### PR TITLE
Add set limit and battery for ZM25RX-08/30

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2500,46 +2500,6 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [
-            {modelID: 'TS0601', manufacturerName: '_TZE200_7eue9vhc'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_bv1jcqqu'},
-        ],
-        whiteLabel: [
-            tuya.whitelabel('Zemismart', 'ZM25RX-08/30', 'Tubular motor', ['_TZE200_bv1jcqqu', '_TZE200_7eue9vhc']),
-        ],
-        model: 'TS0601_cover_8',
-        vendor: 'TuYa',
-        description: 'Cover motor',
-        onEvent: tuya.onEvent(),
-        configure: tuya.configureMagicPacket,
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
-        options: [exposes.options.invert_cover()],
-        exposes: [
-            e.text('work_state', ea.STATE),
-            e.cover_position().setAccess('position', ea.STATE_SET),
-            e.battery(),
-            e.enum('program', ea.SET, ['SET BOTTOM', 'SET UPPER', 'RESET']).withDescription('Set the upper/bottom limit'),
-            e.enum('program', ea.SET, ['UPPER', 'UPPER MICRO', 'LOWER', 'LOWER MICRO']).withDescription('Steps control (ignores set limit)'),
-            e.enum('motor_direction', ea.STATE_SET, ['NORMAL', 'REVERSED']).withDescription('Motor direction'),
-        ],
-        meta: {
-            tuyaDatapoints: [
-                [1, 'state', tuya.valueConverterBasic.lookup({'OPEN': tuya.enum(2), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(0)})],
-                [2, 'position', tuya.valueConverter.coverPosition],
-                [3, 'position', tuya.valueConverter.coverPosition],
-                [5, 'motor_direction', tuya.valueConverterBasic.lookup({'NORMAL': tuya.enum(0), 'REVERSED': tuya.enum(1)})],
-                [7, 'work_state', tuya.valueConverterBasic.lookup({'standby': tuya.enum(0), 'success': tuya.enum(1), 'learning': tuya.enum(2)})],
-                [13, 'battery', tuya.valueConverter.raw],
-                [101, 'program', tuya.valueConverterBasic.lookup({
-                    'SET BOTTOM': tuya.enum(0), 'SET UPPER': tuya.enum(1), 'RESET': tuya.enum(4),
-                    'LOWER': tuya.enum(2), 'UPPER': tuya.enum(3),
-                    'LOWER MICRO': tuya.enum(5), 'UPPER MICRO': tuya.enum(6),
-                })],
-            ],
-        },
-    },
-    {
         zigbeeModel: ['kud7u2l'],
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE200_ckud7u2l'},

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2470,7 +2470,7 @@ const definitions: Definition[] = [
                 [2, 'position', tuya.valueConverter.coverPositionInverted],
                 [3, 'position', tuya.valueConverter.coverPositionInverted],
                 [4, 'opening_mode', tuya.valueConverterBasic.lookup({'tilt': tuya.enum(0), 'lift': tuya.enum(1)})],
-                [7, 'work_state', tuya.valueConverter.tubularMotorWorkState],
+                [7, 'work_state', tuya.valueConverterBasic.lookup({'standby': tuya.enum(0), 'success': tuya.enum(1), 'learning': tuya.enum(2)})],
                 [13, 'battery', tuya.valueConverter.raw],
                 [101, 'motor_direction', tuya.valueConverterBasic.lookup({'left': tuya.enum(0), 'right': tuya.enum(1)})],
                 [102, 'set_upper_limit', tuya.valueConverterBasic.lookup({'start': tuya.enum(1), 'stop': tuya.enum(0)})],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2519,8 +2519,8 @@ const definitions: Definition[] = [
             e.text('work_state', ea.STATE),
             e.cover_position().setAccess('position', ea.STATE_SET),
             e.battery(),
-            // it's also has `UPPER [MICRO]`/`LOWER [MICRO]` command that can be used to move motor over set limit, but it's not clear why :)
-            e.enum('program', ea.SET, ['SET BOTTOM', 'SET UPPER', 'RESET'/* , 'UPPER', 'LOWER' */]).withDescription('Set the upper/bottom limit'),
+            e.enum('program', ea.SET, ['SET BOTTOM', 'SET UPPER', 'RESET']).withDescription('Set the upper/bottom limit'),
+            e.enum('program', ea.SET, ['UPPER', 'UPPER MICRO', 'LOWER', 'LOWER MICRO']).withDescription('Steps control (ignores set limit)'),
             e.enum('motor_direction', ea.STATE_SET, ['NORMAL', 'REVERSED']).withDescription('Motor direction'),
         ],
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2519,7 +2519,7 @@ const definitions: Definition[] = [
             e.text('work_state', ea.STATE),
             e.cover_position().setAccess('position', ea.STATE_SET),
             e.battery(),
-            // it also has `UPPER`/`LOWER` command that can be used to move motor over set limit, but it's not clear why :)
+            // it's also has `UPPER [MICRO]`/`LOWER [MICRO]` command that can be used to move motor over set limit, but it's not clear why :)
             e.enum('program', ea.SET, ['SET BOTTOM', 'SET UPPER', 'RESET'/* , 'UPPER', 'LOWER' */]).withDescription('Set the upper/bottom limit'),
             e.enum('motor_direction', ea.STATE_SET, ['NORMAL', 'REVERSED']).withDescription('Motor direction'),
         ],
@@ -2534,6 +2534,7 @@ const definitions: Definition[] = [
                 [101, 'program', tuya.valueConverterBasic.lookup({
                     'SET BOTTOM': tuya.enum(0), 'SET UPPER': tuya.enum(1), 'RESET': tuya.enum(4),
                     'LOWER': tuya.enum(2), 'UPPER': tuya.enum(3),
+                    'LOWER MICRO': tuya.enum(5), 'UPPER MICRO': tuya.enum(6),
                 })],
             ],
         },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2525,7 +2525,7 @@ const definitions: Definition[] = [
         ],
         meta: {
             tuyaDatapoints: [
-                [1, 'state', tuya.valueConverterBasic.lookup({'OPEN': tuya.enum(0), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(2)})],
+                [1, 'state', tuya.valueConverterBasic.lookup({'OPEN': tuya.enum(2), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(0)})],
                 [2, 'position', tuya.valueConverter.coverPosition],
                 [3, 'position', tuya.valueConverter.coverPosition],
                 [5, 'motor_direction', tuya.valueConverterBasic.lookup({'NORMAL': tuya.enum(0), 'REVERSED': tuya.enum(1)})],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2391,8 +2391,6 @@ const definitions: Definition[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE204_r0jdjrvi'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_bjzrowv2'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_axgvo9jh'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_bv1jcqqu'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_7eue9vhc'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_gaj531w3'},
         ],
         model: 'TS0601_cover_1',
@@ -2418,7 +2416,6 @@ const definitions: Definition[] = [
             tuya.whitelabel('Shenzhen Golden Security Technology', 'GM46', 'Curtain motor', ['_TZE204_guvc7pdy']),
             {vendor: 'Quoya', model: 'AT8510-TY'},
             tuya.whitelabel('Somgoms', 'ZSTY-SM-1DMZG-US-W_1', 'Curtain switch', ['_TZE200_axgvo9jh']),
-            tuya.whitelabel('Zemismart', 'ZM25RX-08/30', 'Tubular motor', ['_TZE200_bv1jcqqu', '_TZE200_7eue9vhc']),
             tuya.whitelabel('HUARUI', 'CMD900LE', 'Lithium battery intelligent curtain opening and closing motor', ['_TZE200_zxxfv8wi']),
         ],
         fromZigbee: [legacy.fromZigbee.tuya_cover, fz.ignore_basic_report],
@@ -2499,6 +2496,45 @@ const definitions: Definition[] = [
                 // motor_direction doesn't work: https://github.com/Koenkk/zigbee2mqtt/issues/18103
                 // [5, 'motor_direction', tuya.valueConverterBasic.lookup({'normal': tuya.enum(0), 'reversed': tuya.enum(1)})],
                 [101, 'battery', tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_7eue9vhc'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_bv1jcqqu'},
+        ],
+        whiteLabel: [
+            tuya.whitelabel('Zemismart', 'ZM25RX-08/30', 'Tubular motor', ['_TZE200_bv1jcqqu', '_TZE200_7eue9vhc']),
+        ],
+        model: 'TS0601_cover_8',
+        vendor: 'TuYa',
+        description: 'Cover motor',
+        onEvent: tuya.onEvent(),
+        configure: tuya.configureMagicPacket,
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        options: [exposes.options.invert_cover()],
+        exposes: [
+            e.text('work_state', ea.STATE),
+            e.cover_position().setAccess('position', ea.STATE_SET),
+            e.battery(),
+            // it also has `UPPER`/`LOWER` command that can be used to move motor over set limit, but it's not clear why :)
+            e.enum('program', ea.SET, ['SET BOTTOM', 'SET UPPER', 'RESET'/* , 'UPPER', 'LOWER' */]).withDescription('Set the upper/bottom limit'),
+            e.enum('motor_direction', ea.STATE_SET, ['NORMAL', 'REVERSED']).withDescription('Motor direction'),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'state', tuya.valueConverterBasic.lookup({'OPEN': tuya.enum(0), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(2)})],
+                [2, 'position', tuya.valueConverter.coverPosition],
+                [3, 'position', tuya.valueConverter.coverPosition],
+                [5, 'motor_direction', tuya.valueConverterBasic.lookup({'NORMAL': tuya.enum(0), 'REVERSED': tuya.enum(1)})],
+                [7, 'work_state', tuya.valueConverterBasic.lookup({'standby': tuya.enum(0), 'success': tuya.enum(1), 'learning': tuya.enum(2)})],
+                [13, 'battery', tuya.valueConverter.raw],
+                [101, 'program', tuya.valueConverterBasic.lookup({
+                    'SET BOTTOM': tuya.enum(0), 'SET UPPER': tuya.enum(1), 'RESET': tuya.enum(4),
+                    'LOWER': tuya.enum(2), 'UPPER': tuya.enum(3),
+                })],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2470,7 +2470,7 @@ const definitions: Definition[] = [
                 [2, 'position', tuya.valueConverter.coverPositionInverted],
                 [3, 'position', tuya.valueConverter.coverPositionInverted],
                 [4, 'opening_mode', tuya.valueConverterBasic.lookup({'tilt': tuya.enum(0), 'lift': tuya.enum(1)})],
-                [7, 'work_state', tuya.valueConverterBasic.lookup({'standby': tuya.enum(0), 'success': tuya.enum(1), 'learning': tuya.enum(2)})],
+                [7, 'work_state', tuya.valueConverter.tubularMotorWorkState],
                 [13, 'battery', tuya.valueConverter.raw],
                 [101, 'motor_direction', tuya.valueConverterBasic.lookup({'left': tuya.enum(0), 'right': tuya.enum(1)})],
                 [102, 'set_upper_limit', tuya.valueConverterBasic.lookup({'start': tuya.enum(1), 'stop': tuya.enum(0)})],
@@ -2622,7 +2622,7 @@ const definitions: Definition[] = [
                 [1, 'state', tuya.valueConverterBasic.lookup({'OPEN': tuya.enum(0), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(2)})],
                 [2, 'position', tuya.valueConverter.coverPosition],
                 [3, 'position', tuya.valueConverter.raw],
-                [5, 'motor_direction', tuya.valueConverterBasic.lookup({'normal': tuya.enum(0), 'reversed': tuya.enum(1)})],
+                [5, 'motor_direction', tuya.valueConverter.tubularMotorDirection],
                 [7, null, null], // work_state, not useful, ignore
                 [101, 'opening_mode', tuya.valueConverterBasic.lookup({'tilt': tuya.enum(0), 'lift': tuya.enum(1)})],
                 [102, 'factory_reset', tuya.valueConverter.raw],

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -1,4 +1,111 @@
-{
+import * as exposes from '../lib/exposes';
+import fz from '../converters/fromZigbee';
+import * as legacy from '../lib/legacy';
+import tz from '../converters/toZigbee';
+import * as reporting from '../lib/reporting';
+import extend from '../lib/extend';
+import {Definition} from '../lib/types';
+const e = exposes.presets;
+import * as tuya from '../lib/tuya';
+const ea = exposes.access;
+
+const definitions: Definition[] = [
+    {
+        zigbeeModel: ['NUET56-DL27LX1.1'],
+        model: 'LXZB-12A',
+        vendor: 'Zemismart',
+        description: 'RGB LED downlight',
+        extend: extend.light_onoff_brightness_colortemp_color(),
+    },
+    {
+        zigbeeModel: ['LXT56-LS27LX1.6'],
+        model: 'HGZB-DLC4-N15B',
+        vendor: 'Zemismart',
+        description: 'RGB LED downlight',
+        extend: extend.light_onoff_brightness_colortemp_color(),
+    },
+    {
+        zigbeeModel: ['TS0302'],
+        model: 'ZM-CSW032-D',
+        vendor: 'Zemismart',
+        description: 'Curtain/roller blind switch',
+        fromZigbee: [fz.ignore_basic_report, fz.ZMCSW032D_cover_position],
+        toZigbee: [tz.cover_state, tz.ZMCSW032D_cover_position],
+        exposes: [e.cover_position()],
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
+            // Configure reporting of currentPositionLiftPercentage always fails.
+            // https://github.com/Koenkk/zigbee2mqtt/issues/3216
+        },
+    },
+    {
+        fingerprint: [{modelID: 'TS0003', manufacturerName: '_TZ3000_vjhcenzo'}, {modelID: 'TS0003', manufacturerName: '_TZ3000_f09j9qjb'}],
+        model: 'TB25',
+        vendor: 'Zemismart',
+        description: 'Smart light switch and socket - 2 gang with neutral wire',
+        extend: tuya.extend.switch({endpoints: ['left', 'center', 'right']}),
+        meta: {multiEndpoint: true},
+        endpoint: () => {
+            return {'left': 1, 'center': 2, 'right': 3};
+        },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            for (const endpointID of [1, 2, 3]) {
+                const endpoint = device.getEndpoint(endpointID);
+                await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+                await reporting.onOff(endpoint);
+            }
+        },
+    },
+    {
+        zigbeeModel: ['LXN56-SS27LX1.1'],
+        model: 'LXN56-SS27LX1.1',
+        vendor: 'Zemismart',
+        description: 'Smart light switch - 2 gang with neutral wire',
+        extend: extend.switch(),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(10);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        },
+    },
+    {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_zqtiam4u'}],
+        model: 'ZM-RM02',
+        vendor: 'Zemismart',
+        description: 'Smart 6 key scene switch',
+        fromZigbee: [legacy.fromZigbee.ZMRM02],
+        toZigbee: [],
+        onEvent: tuya.onEventSetTime,
+        exposes: [e.battery(), e.action([
+            'button_1_hold', 'button_1_single', 'button_1_double',
+            'button_2_hold', 'button_2_single', 'button_2_double',
+            'button_3_hold', 'button_3_single', 'button_3_double',
+            'button_4_hold', 'button_4_single', 'button_4_double',
+            'button_5_hold', 'button_5_single', 'button_5_double',
+            'button_6_hold', 'button_6_single', 'button_6_double'])],
+    },
+    {
+        fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_zigisuyh', '_TZ3000_v4mevirn', '_TZ3000_mlswgkc3']),
+        model: 'ZIGBEE-B09-UK',
+        vendor: 'Zemismart',
+        description: 'Zigbee smart outlet universal socket with USB port',
+        extend: tuya.extend.switch({powerOutageMemory: true, endpoints: ['l1', 'l2']}),
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(device.getEndpoint(1));
+            await reporting.onOff(device.getEndpoint(2));
+        },
+    },
+    {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_7eue9vhc', '_TZE200_bv1jcqqu']),
         model: 'ZM25RX-08/30',
         vendor: 'Zemismart',
@@ -32,3 +139,107 @@
             ],
         },
     },
+    {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_iossyxra', '_TZE200_cxu0jkjk']),
+        model: 'ZM-AM02_cover',
+        vendor: 'Zemismart',
+        description: 'Zigbee/RF curtain converter',
+        fromZigbee: [legacy.fz.ZMAM02_cover],
+        toZigbee: [legacy.tz.ZMAM02_cover],
+        exposes: [e.cover_position().setAccess('position', ea.STATE_SET),
+            e.composite('options', 'options', ea.STATE)
+                .withFeature(e.numeric('motor_speed', ea.STATE)
+                    .withValueMin(0)
+                    .withValueMax(255)
+                    .withDescription('Motor speed')),
+            e.enum('motor_working_mode', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02MotorWorkingMode)),
+            e.numeric('percent_state', ea.STATE).withValueMin(0).withValueMax(100).withValueStep(1).withUnit('%'),
+            e.enum('mode', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Mode)),
+            e.enum('motor_direction', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Direction)),
+            e.enum('border', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Border)),
+        // ---------------------------------------------------------------------------------
+        // DP exists, but not used at the moment
+        // e.numeric('percent_control', ea.STATE_SET).withValueMin(0).withValueMax(100).withValueStep(1).withUnit('%'),
+        // exposes.enum('work_state', ea.STATE, Object.values(tuya.ZMAM02.AM02WorkState)),
+        // e.numeric('countdown_left', ea.STATE).withUnit('s'),
+        // e.numeric('time_total', ea.STATE).withUnit('ms'),
+        // exposes.enum('situation_set', ea.STATE, Object.values(tuya.ZMAM02.AM02Situation)),
+        ],
+    },
+    {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_gubdgai2'}],
+        model: 'M515EGBZTN',
+        vendor: 'Zemismart',
+        description: 'Roller shade driver',
+        fromZigbee: [legacy.fz.ZMAM02_cover],
+        toZigbee: [legacy.tz.ZMAM02_cover],
+        exposes: [e.cover_position().setAccess('position', ea.STATE_SET),
+            e.enum('motor_direction', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Direction)),
+            e.enum('border', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Border)),
+        ],
+    },
+    {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'}],
+        model: 'ZM25TQ',
+        vendor: 'Zemismart',
+        description: 'Tubular motor',
+        fromZigbee: [legacy.fz.tuya_cover, fz.ignore_basic_report],
+        toZigbee: [legacy.tz.tuya_cover_control, legacy.tz.tuya_cover_options, legacy.tz.tuya_data_point_test],
+        exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],
+    },
+    {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_1n2kyphz'}, {modelID: 'TS0601', manufacturerName: '_TZE200_shkxsgis'}],
+        model: 'TB26-4',
+        vendor: 'Zemismart',
+        description: '4-gang smart wall switch',
+        exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l4').setAccess('state', ea.STATE_SET)],
+        fromZigbee: [fz.ignore_basic_report, legacy.fz.tuya_switch],
+        toZigbee: [legacy.tz.tuya_switch_state],
+        meta: {multiEndpoint: true},
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1};
+        },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(3)) await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(4)) await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+            device.powerSource = 'Mains (single phase)';
+            device.save();
+        },
+    },
+    {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_9mahtqtg'}, {modelID: 'TS0601', manufacturerName: '_TZE200_r731zlxk'}],
+        model: 'TB26-6',
+        vendor: 'Zemismart',
+        description: '6-gang smart wall switch',
+        exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l4').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l5').setAccess('state', ea.STATE_SET),
+            e.switch().withEndpoint('l6').setAccess('state', ea.STATE_SET)],
+        fromZigbee: [fz.ignore_basic_report, legacy.fz.tuya_switch],
+        toZigbee: [legacy.tz.tuya_switch_state],
+        meta: {multiEndpoint: true},
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1};
+        },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(3)) await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(4)) await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(5)) await reporting.bind(device.getEndpoint(5), coordinatorEndpoint, ['genOnOff']);
+            if (device.getEndpoint(6)) await reporting.bind(device.getEndpoint(6), coordinatorEndpoint, ['genOnOff']);
+            // Reports itself as battery which is not correct: https://github.com/Koenkk/zigbee2mqtt/issues/6190
+            device.powerSource = 'Mains (single phase)';
+            device.save();
+        },
+    },
+];
+
+module.exports = definitions;

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -128,16 +128,16 @@ const definitions: Definition[] = [
                 [1, 'state', tuya.valueConverterBasic.lookup({'OPEN': tuya.enum(2), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(0)})],
                 [2, 'position', tuya.valueConverter.coverPosition],
                 [3, 'position', tuya.valueConverter.coverPosition],
-                [5, 'motor_direction', tuya.valueConverterBasic.lookup({'NORMAL': tuya.enum(0), 'REVERSED': tuya.enum(1)})],
-                [7, 'work_state', tuya.valueConverterBasic.lookup({'standby': tuya.enum(0), 'success': tuya.enum(1), 'learning': tuya.enum(2)})],
+                [5, 'motor_direction', tuya.valueConverter.tubularMotorDirection],
+                [7, 'work_state', tuya.valueConverter.tubularMotorWorkState],
                 [13, 'battery', tuya.valueConverter.raw],
                 [101, 'program', tuya.valueConverterBasic.lookup({
                     'set_bottom': tuya.enum(0), 'set_upper': tuya.enum(1), 'reset': tuya.enum(4)
-                  }, null)],
-                  [101, 'click_control', tuya.valueConverterBasic.lookup({
+                }, null)],
+                [101, 'click_control', tuya.valueConverterBasic.lookup({
                     'lower': tuya.enum(2), 'upper': tuya.enum(3),
                     'lower_micro': tuya.enum(5), 'upper_micro': tuya.enum(6),
-                  }, null)],
+                }, null)],
             ],
         },
     },

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -129,7 +129,7 @@ const definitions: Definition[] = [
                 [2, 'position', tuya.valueConverter.coverPosition],
                 [3, 'position', tuya.valueConverter.coverPosition],
                 [5, 'motor_direction', tuya.valueConverter.tubularMotorDirection],
-                [7, 'work_state', tuya.valueConverter.tubularMotorWorkState],
+                [7, 'work_state', tuya.valueConverterBasic.lookup({ 'moved_down': tuya.enum(0), 'moved_up': tuya.enum(1) })],
                 [13, 'battery', tuya.valueConverter.raw],
                 [101, 'program', tuya.valueConverterBasic.lookup({
                     'set_bottom': tuya.enum(0), 'set_upper': tuya.enum(1), 'reset': tuya.enum(4)

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -121,7 +121,7 @@ const definitions: Definition[] = [
             e.battery(),
             e.enum('program', ea.SET, ['set_bottom', 'set_upper', 'reset']).withDescription('Set the upper/bottom limit'),
             e.enum('click_control', ea.SET, ['upper', 'upper_micro', 'lower', 'lower_micro'])
-                .withDescription('Control motor in steps (ingores set limits; micro = small movement)'),
+                .withDescription('Control motor in steps (ingores set limits; normal/micro = 120deg/5deg movement)'),
             e.enum('motor_direction', ea.STATE_SET, ['normal', 'reversed']).withDescription('Motor direction'),
         ],
         meta: {

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -130,7 +130,7 @@ const definitions: Definition[] = [
                 [2, 'position', tuya.valueConverter.coverPosition],
                 [3, 'position', tuya.valueConverter.coverPosition],
                 [5, 'motor_direction', tuya.valueConverter.tubularMotorDirection],
-                [7, 'work_state', tuya.valueConverterBasic.lookup({'moved_down': tuya.enum(0), 'moved_up': tuya.enum(1)})],
+                [7, 'work_state', tuya.valueConverterBasic.lookup({'closing': tuya.enum(0), 'opening': tuya.enum(1)})],
                 [13, 'battery', tuya.valueConverter.raw],
                 [101, 'program', tuya.valueConverterBasic.lookup({
                     'set_bottom': tuya.enum(0), 'set_upper': tuya.enum(1), 'reset': tuya.enum(4),

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -1,211 +1,34 @@
-import * as exposes from '../lib/exposes';
-import fz from '../converters/fromZigbee';
-import * as legacy from '../lib/legacy';
-import tz from '../converters/toZigbee';
-import * as reporting from '../lib/reporting';
-import extend from '../lib/extend';
-import {Definition} from '../lib/types';
-const e = exposes.presets;
-import * as tuya from '../lib/tuya';
-const ea = exposes.access;
-
-const definitions: Definition[] = [
-    {
-        zigbeeModel: ['NUET56-DL27LX1.1'],
-        model: 'LXZB-12A',
-        vendor: 'Zemismart',
-        description: 'RGB LED downlight',
-        extend: extend.light_onoff_brightness_colortemp_color(),
-    },
-    {
-        zigbeeModel: ['LXT56-LS27LX1.6'],
-        model: 'HGZB-DLC4-N15B',
-        vendor: 'Zemismart',
-        description: 'RGB LED downlight',
-        extend: extend.light_onoff_brightness_colortemp_color(),
-    },
-    {
-        zigbeeModel: ['TS0302'],
-        model: 'ZM-CSW032-D',
-        vendor: 'Zemismart',
-        description: 'Curtain/roller blind switch',
-        fromZigbee: [fz.ignore_basic_report, fz.ZMCSW032D_cover_position],
-        toZigbee: [tz.cover_state, tz.ZMCSW032D_cover_position],
-        exposes: [e.cover_position()],
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
-            // Configure reporting of currentPositionLiftPercentage always fails.
-            // https://github.com/Koenkk/zigbee2mqtt/issues/3216
-        },
-    },
-    {
-        fingerprint: [{modelID: 'TS0003', manufacturerName: '_TZ3000_vjhcenzo'}, {modelID: 'TS0003', manufacturerName: '_TZ3000_f09j9qjb'}],
-        model: 'TB25',
-        vendor: 'Zemismart',
-        description: 'Smart light switch and socket - 2 gang with neutral wire',
-        extend: tuya.extend.switch({endpoints: ['left', 'center', 'right']}),
-        meta: {multiEndpoint: true},
-        endpoint: () => {
-            return {'left': 1, 'center': 2, 'right': 3};
-        },
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
-            for (const endpointID of [1, 2, 3]) {
-                const endpoint = device.getEndpoint(endpointID);
-                await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
-                await reporting.onOff(endpoint);
-            }
-        },
-    },
-    {
-        zigbeeModel: ['LXN56-SS27LX1.1'],
-        model: 'LXN56-SS27LX1.1',
-        vendor: 'Zemismart',
-        description: 'Smart light switch - 2 gang with neutral wire',
-        extend: extend.switch(),
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(10);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
-            await reporting.onOff(endpoint);
-        },
-    },
-    {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_zqtiam4u'}],
-        model: 'ZM-RM02',
-        vendor: 'Zemismart',
-        description: 'Smart 6 key scene switch',
-        fromZigbee: [legacy.fromZigbee.ZMRM02],
-        toZigbee: [],
-        onEvent: tuya.onEventSetTime,
-        exposes: [e.battery(), e.action([
-            'button_1_hold', 'button_1_single', 'button_1_double',
-            'button_2_hold', 'button_2_single', 'button_2_double',
-            'button_3_hold', 'button_3_single', 'button_3_double',
-            'button_4_hold', 'button_4_single', 'button_4_double',
-            'button_5_hold', 'button_5_single', 'button_5_double',
-            'button_6_hold', 'button_6_single', 'button_6_double'])],
-    },
-    {
-        fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_zigisuyh', '_TZ3000_v4mevirn', '_TZ3000_mlswgkc3']),
-        model: 'ZIGBEE-B09-UK',
-        vendor: 'Zemismart',
-        description: 'Zigbee smart outlet universal socket with USB port',
-        extend: tuya.extend.switch({powerOutageMemory: true, endpoints: ['l1', 'l2']}),
-        endpoint: (device) => {
-            return {'l1': 1, 'l2': 2};
-        },
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-            await reporting.onOff(device.getEndpoint(1));
-            await reporting.onOff(device.getEndpoint(2));
-        },
-    },
-    {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_iossyxra', '_TZE200_cxu0jkjk']),
-        model: 'ZM-AM02_cover',
-        vendor: 'Zemismart',
-        description: 'Zigbee/RF curtain converter',
-        fromZigbee: [legacy.fz.ZMAM02_cover],
-        toZigbee: [legacy.tz.ZMAM02_cover],
-        exposes: [e.cover_position().setAccess('position', ea.STATE_SET),
-            e.composite('options', 'options', ea.STATE)
-                .withFeature(e.numeric('motor_speed', ea.STATE)
-                    .withValueMin(0)
-                    .withValueMax(255)
-                    .withDescription('Motor speed')),
-            e.enum('motor_working_mode', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02MotorWorkingMode)),
-            e.numeric('percent_state', ea.STATE).withValueMin(0).withValueMax(100).withValueStep(1).withUnit('%'),
-            e.enum('mode', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Mode)),
-            e.enum('motor_direction', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Direction)),
-            e.enum('border', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Border)),
-        // ---------------------------------------------------------------------------------
-        // DP exists, but not used at the moment
-        // e.numeric('percent_control', ea.STATE_SET).withValueMin(0).withValueMax(100).withValueStep(1).withUnit('%'),
-        // exposes.enum('work_state', ea.STATE, Object.values(tuya.ZMAM02.AM02WorkState)),
-        // e.numeric('countdown_left', ea.STATE).withUnit('s'),
-        // e.numeric('time_total', ea.STATE).withUnit('ms'),
-        // exposes.enum('situation_set', ea.STATE, Object.values(tuya.ZMAM02.AM02Situation)),
-        ],
-    },
-    {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_gubdgai2'}],
-        model: 'M515EGBZTN',
-        vendor: 'Zemismart',
-        description: 'Roller shade driver',
-        fromZigbee: [legacy.fz.ZMAM02_cover],
-        toZigbee: [legacy.tz.ZMAM02_cover],
-        exposes: [e.cover_position().setAccess('position', ea.STATE_SET),
-            e.enum('motor_direction', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Direction)),
-            e.enum('border', ea.STATE_SET, Object.values(legacy.ZMLookups.AM02Border)),
-        ],
-    },
-    {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_fzo2pocs'}],
-        model: 'ZM25TQ',
+{
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_7eue9vhc', '_TZE200_bv1jcqqu']),
+        model: 'ZM25RX-08/30',
         vendor: 'Zemismart',
         description: 'Tubular motor',
-        fromZigbee: [legacy.fz.tuya_cover, fz.ignore_basic_report],
-        toZigbee: [legacy.tz.tuya_cover_control, legacy.tz.tuya_cover_options, legacy.tz.tuya_data_point_test],
-        exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],
-    },
-    {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_1n2kyphz'}, {modelID: 'TS0601', manufacturerName: '_TZE200_shkxsgis'}],
-        model: 'TB26-4',
-        vendor: 'Zemismart',
-        description: '4-gang smart wall switch',
-        exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l4').setAccess('state', ea.STATE_SET)],
-        fromZigbee: [fz.ignore_basic_report, legacy.fz.tuya_switch],
-        toZigbee: [legacy.tz.tuya_switch_state],
-        meta: {multiEndpoint: true},
-        endpoint: (device) => {
-            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1};
-        },
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(3)) await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(4)) await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
-            device.powerSource = 'Mains (single phase)';
-            device.save();
-        },
-    },
-    {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_9mahtqtg'}, {modelID: 'TS0601', manufacturerName: '_TZE200_r731zlxk'}],
-        model: 'TB26-6',
-        vendor: 'Zemismart',
-        description: '6-gang smart wall switch',
-        exposes: [e.switch().withEndpoint('l1').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l2').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l3').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l4').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l5').setAccess('state', ea.STATE_SET),
-            e.switch().withEndpoint('l6').setAccess('state', ea.STATE_SET)],
-        fromZigbee: [fz.ignore_basic_report, legacy.fz.tuya_switch],
-        toZigbee: [legacy.tz.tuya_switch_state],
-        meta: {multiEndpoint: true},
-        endpoint: (device) => {
-            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1};
-        },
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(2)) await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(3)) await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(4)) await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(5)) await reporting.bind(device.getEndpoint(5), coordinatorEndpoint, ['genOnOff']);
-            if (device.getEndpoint(6)) await reporting.bind(device.getEndpoint(6), coordinatorEndpoint, ['genOnOff']);
-            // Reports itself as battery which is not correct: https://github.com/Koenkk/zigbee2mqtt/issues/6190
-            device.powerSource = 'Mains (single phase)';
-            device.save();
+        onEvent: tuya.onEvent(),
+        configure: tuya.configureMagicPacket,
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        options: [exposes.options.invert_cover()],
+        exposes: [
+            e.text('work_state', ea.STATE),
+            e.cover_position().setAccess('position', ea.STATE_SET),
+            e.battery(),
+            e.enum('program', ea.SET, ['SET BOTTOM', 'SET UPPER', 'RESET']).withDescription('Set the upper/bottom limit'),
+            e.enum('program', ea.SET, ['UPPER', 'UPPER MICRO', 'LOWER', 'LOWER MICRO']).withDescription('Steps control (ignores set limit)'),
+            e.enum('motor_direction', ea.STATE_SET, ['NORMAL', 'REVERSED']).withDescription('Motor direction'),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'state', tuya.valueConverterBasic.lookup({'OPEN': tuya.enum(2), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(0)})],
+                [2, 'position', tuya.valueConverter.coverPosition],
+                [3, 'position', tuya.valueConverter.coverPosition],
+                [5, 'motor_direction', tuya.valueConverterBasic.lookup({'NORMAL': tuya.enum(0), 'REVERSED': tuya.enum(1)})],
+                [7, 'work_state', tuya.valueConverterBasic.lookup({'standby': tuya.enum(0), 'success': tuya.enum(1), 'learning': tuya.enum(2)})],
+                [13, 'battery', tuya.valueConverter.raw],
+                [101, 'program', tuya.valueConverterBasic.lookup({
+                    'SET BOTTOM': tuya.enum(0), 'SET UPPER': tuya.enum(1), 'RESET': tuya.enum(4),
+                    'LOWER': tuya.enum(2), 'UPPER': tuya.enum(3),
+                    'LOWER MICRO': tuya.enum(5), 'UPPER MICRO': tuya.enum(6),
+                })],
+            ],
         },
     },
-];
-
-module.exports = definitions;

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -119,9 +119,9 @@ const definitions: Definition[] = [
             e.text('work_state', ea.STATE),
             e.cover_position().setAccess('position', ea.STATE_SET),
             e.battery(),
-            e.enum('program', ea.SET, ['SET BOTTOM', 'SET UPPER', 'RESET']).withDescription('Set the upper/bottom limit'),
-            e.enum('program', ea.SET, ['UPPER', 'UPPER MICRO', 'LOWER', 'LOWER MICRO']).withDescription('Steps control (ignores set limit)'),
-            e.enum('motor_direction', ea.STATE_SET, ['NORMAL', 'REVERSED']).withDescription('Motor direction'),
+            e.enum('program', ea.SET, ['set_bottom', 'set_upper', 'reset']).withDescription('Set the upper/bottom limit'),
+            e.enum('click_control', ea.SET, ['upper', 'upper_micro', 'lower', 'lower_micro']).withDescription('Control motor in steps (ingores set limits; micro = small movement)'),
+            e.enum('motor_direction', ea.STATE_SET, ['normal', 'reversed']).withDescription('Motor direction'),
         ],
         meta: {
             tuyaDatapoints: [
@@ -132,10 +132,12 @@ const definitions: Definition[] = [
                 [7, 'work_state', tuya.valueConverterBasic.lookup({'standby': tuya.enum(0), 'success': tuya.enum(1), 'learning': tuya.enum(2)})],
                 [13, 'battery', tuya.valueConverter.raw],
                 [101, 'program', tuya.valueConverterBasic.lookup({
-                    'SET BOTTOM': tuya.enum(0), 'SET UPPER': tuya.enum(1), 'RESET': tuya.enum(4),
-                    'LOWER': tuya.enum(2), 'UPPER': tuya.enum(3),
-                    'LOWER MICRO': tuya.enum(5), 'UPPER MICRO': tuya.enum(6),
-                })],
+                    'set_bottom': tuya.enum(0), 'set_upper': tuya.enum(1), 'reset': tuya.enum(4)
+                  }, null)],
+                  [101, 'click_control', tuya.valueConverterBasic.lookup({
+                    'lower': tuya.enum(2), 'upper': tuya.enum(3),
+                    'lower_micro': tuya.enum(5), 'upper_micro': tuya.enum(6),
+                  }, null)],
             ],
         },
     },

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -120,7 +120,8 @@ const definitions: Definition[] = [
             e.cover_position().setAccess('position', ea.STATE_SET),
             e.battery(),
             e.enum('program', ea.SET, ['set_bottom', 'set_upper', 'reset']).withDescription('Set the upper/bottom limit'),
-            e.enum('click_control', ea.SET, ['upper', 'upper_micro', 'lower', 'lower_micro']).withDescription('Control motor in steps (ingores set limits; micro = small movement)'),
+            e.enum('click_control', ea.SET, ['upper', 'upper_micro', 'lower', 'lower_micro'])
+                .withDescription('Control motor in steps (ingores set limits; micro = small movement)'),
             e.enum('motor_direction', ea.STATE_SET, ['normal', 'reversed']).withDescription('Motor direction'),
         ],
         meta: {
@@ -129,10 +130,10 @@ const definitions: Definition[] = [
                 [2, 'position', tuya.valueConverter.coverPosition],
                 [3, 'position', tuya.valueConverter.coverPosition],
                 [5, 'motor_direction', tuya.valueConverter.tubularMotorDirection],
-                [7, 'work_state', tuya.valueConverterBasic.lookup({ 'moved_down': tuya.enum(0), 'moved_up': tuya.enum(1) })],
+                [7, 'work_state', tuya.valueConverterBasic.lookup({'moved_down': tuya.enum(0), 'moved_up': tuya.enum(1)})],
                 [13, 'battery', tuya.valueConverter.raw],
                 [101, 'program', tuya.valueConverterBasic.lookup({
-                    'set_bottom': tuya.enum(0), 'set_upper': tuya.enum(1), 'reset': tuya.enum(4)
+                    'set_bottom': tuya.enum(0), 'set_upper': tuya.enum(1), 'reset': tuya.enum(4),
                 }, null)],
                 [101, 'click_control', tuya.valueConverterBasic.lookup({
                     'lower': tuya.enum(2), 'upper': tuya.enum(3),

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -485,7 +485,6 @@ export const valueConverter = {
         },
     },
     tubularMotorDirection: valueConverterBasic.lookup({'normal': new Enum(0), 'reversed': new Enum(1)}),
-    tubularMotorWorkState: valueConverterBasic.lookup({'standby': new Enum(0), 'success': new Enum(1), 'learning': new Enum(2)}),
     plus1: {
         from: (v: number) => v + 1,
         to: (v: number) => v - 1,

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -484,6 +484,8 @@ export const valueConverter = {
             return options.invert_cover ? v : 100 - v;
         },
     },
+    tubularMotorDirection: valueConverterBasic.lookup({'normal': new Enum(0), 'reversed': new Enum(1)}),
+    tubularMotorWorkState: valueConverterBasic.lookup({'standby': new Enum(0), 'success': new Enum(1), 'learning': new Enum(2)}),
     plus1: {
         from: (v: number) => v + 1,
         to: (v: number) => v - 1,

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -400,12 +400,15 @@ export class Bitmap extends Base {
 }
 
 export const valueConverterBasic = {
-    lookup: (map: {[s: (string)]: number | boolean | Enum | string}) => {
+    lookup: (map: {[s: (string)]: number | boolean | Enum | string}, fallbackValue?: number | boolean | KeyValue | string | null) => {
         return {
             to: (v: string) => utils.getFromLookup(v, map),
             from: (v: number) => {
                 const value = Object.entries(map).find((i) => i[1].valueOf() === v);
-                if (!value) throw new Error(`Value '${v}' is not allowed, expected one of ${Object.values(map)}`);
+                if (!value) {
+                    if (fallbackValue !== undefined) return fallbackValue;
+                    throw new Error(`Value '${v}' is not allowed, expected one of ${Object.values(map)}`);
+                }
                 return value[0];
             },
         };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -148,7 +148,7 @@ export namespace Tuya {
     export interface DpValue {dp: number, datatype: number, data: Buffer | number[]}
     export interface ValueConverterSingle {
         to?: (value: unknown, meta?: Tz.Meta) => unknown,
-        from?: (value: unknown, meta?: Fz.Meta, options?: KeyValue, publish?: Publish) => number|string|boolean|KeyValue,
+        from?: (value: unknown, meta?: Fz.Meta, options?: KeyValue, publish?: Publish) => number|string|boolean|KeyValue|null,
     }
     export interface ValueConverterMulti {
         to?: (value: unknown, meta?: Tz.Meta) => unknown,


### PR DESCRIPTION
Added set limit/motor direction functionality (tested) for _TZE200_bv1jcqqu.

Also added battery: asked to test [here](https://github.com/Koenkk/zigbee2mqtt/issues/18685). My _TZE200_bv1jcqqu never sends it; at least when i use buttons on motor (up/down)/zigbee commands. According to https://github.com/Koenkk/zigbee2mqtt/issues/11251 some motors send battery data only when remote buttons are used