### PR TITLE
fix: Sonoff TRV child lock status incorrectly set to UNLOCKED

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -4,7 +4,7 @@ import tz from '../converters/toZigbee';
 import * as constants from '../lib/constants';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
-import {Definition, Fz, KeyValue, Tz} from '../lib/types';
+import {Definition, Fz, KeyValue, KeyValueAny, Tz} from '../lib/types';
 const e = exposes.presets;
 const ea = exposes.access;
 import * as ota from '../lib/ota';
@@ -24,10 +24,14 @@ const fzLocal = {
         cluster: '64529',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
-            const isLocked = msg.data['0'];
-            return {
-                child_lock: isLocked ? 'LOCK' : 'UNLOCK',
-            };
+            const result: KeyValueAny = {};
+            const data = msg.data;
+
+            if (data.hasOwnProperty(0x0000)) {
+                result.child_lock = data[0x0000] ? 'LOCK' : 'UNLOCK';
+            }
+
+            return result;
         },
     } as Fz.Converter,
 };


### PR DESCRIPTION
I discovered a minor bug with the Sonoff TRV child lock functionality I recently exposed. 

When the TRV sends an attribute report for the same cluster ID, the child lock attribute is not always be present in the payload. My previous code set the child lock to 'UNLOCK' if the attribute was not truthy. As a result, when the TRV sent an attribute report for the cluster without the child lock attribute (e.g. when the temperature is remotely set), the child lock state was incorrectly set to UNLOCK, despite it actually being LOCK.

This PR fixes the issue by checking for the presence of the attribute.

