### PR TITLE
Consolidate Legrand TZ led handling

### DIFF
--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -3913,35 +3913,6 @@ const converters = {
             }
         },
     },
-    legrand_led_in_dark: {
-        // connected power outlet is on attribute 2 and not 1
-        key: ['led_in_dark'],
-        convertSet: async (entity, key, value, meta) => {
-            // enable or disable the LED (blue) when permitJoin=false (LED off)
-            const enableLedIfOn = value === 'ON' || (value === 'OFF' ? false : !!value);
-            const payload = {1: {value: enableLedIfOn, type: 16}};
-            await entity.write('manuSpecificLegrandDevices', payload, manufacturerOptions.legrand);
-            return {state: {'led_in_dark': value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('manuSpecificLegrandDevices', [0x0001], manufacturerOptions.legrand);
-        },
-    },
-    legrand_led_if_on: {
-        key: ['led_if_on'],
-        convertSet: async (entity, key, value, meta) => {
-            // enable the LED when the light object is "doing something"
-            // on the light switch, the LED is on when the light is on,
-            // on the shutter switch, the LED is on when the shutter is moving
-            const enableLedIfOn = value === 'ON' || (value === 'OFF' ? false : !!value);
-            const payload = {2: {value: enableLedIfOn, type: 16}};
-            await entity.write('manuSpecificLegrandDevices', payload, manufacturerOptions.legrand);
-            return {state: {'led_if_on': value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('manuSpecificLegrandDevices', [0x0002], manufacturerOptions.legrand);
-        },
-    },
     legrand_device_mode: {
         key: ['device_mode'],
         convertSet: async (entity, key, value, meta) => {

--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -5,7 +5,7 @@ import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
 import * as ota from '../lib/ota';
-import {fzLegrand} from '../lib/legrand';
+import {fzLegrand, tzLegrand} from '../lib/legrand';
 const e = exposes.presets;
 const ea = exposes.access;
 
@@ -17,7 +17,7 @@ const definitions: Definition[] = [
         description: 'Light switch with neutral',
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.identify, fz.on_off, fz.K4003C_binary_input, fzLegrand.cluster_fc01],
-        toZigbee: [tz.on_off, tz.legrand_led_in_dark, tz.legrand_led_if_on, tz.legrand_identify],
+        toZigbee: [tz.on_off, tzLegrand.led_mode, tz.legrand_identify],
         exposes: [
             e.switch(),
             e.action(['identify', 'on', 'off']),
@@ -41,8 +41,7 @@ const definitions: Definition[] = [
         extend: extend.light_onoff_brightness({noConfigure: true}),
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.brightness, fz.identify, fz.on_off, fz.lighting_ballast_configuration, fzLegrand.cluster_fc01],
-        toZigbee: [tz.light_onoff_brightness, tz.legrand_led_in_dark, tz.legrand_led_if_on,
-            tz.legrand_device_mode, tz.legrand_identify, tz.ballast_config],
+        toZigbee: [tz.light_onoff_brightness, tzLegrand.led_mode, tz.legrand_device_mode, tz.legrand_identify, tz.ballast_config],
         exposes: [
             e.light_brightness(),
             e.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
@@ -78,7 +77,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.bticino_4027C_binary_input_moving,
             fz.identify, fzLegrand.cluster_fc01, fz.ignore_zclversion_read],
-        toZigbee: [tz.bticino_4027C_cover_state, tz.bticino_4027C_cover_position, tz.legrand_identify, tz.legrand_led_in_dark],
+        toZigbee: [tz.bticino_4027C_cover_state, tz.bticino_4027C_cover_position, tz.legrand_identify, tzLegrand.led_mode],
         exposes: [
             e.cover_position(),
             e.action(['moving', 'identify', '']),
@@ -123,7 +122,7 @@ const definitions: Definition[] = [
         vendor: 'BTicino',
         description: 'Power socket with power consumption monitoring',
         fromZigbee: [fz.identify, fz.on_off, fz.electrical_measurement, fzLegrand.cluster_fc01],
-        toZigbee: [tz.on_off, tz.legrand_led_in_dark, tz.legrand_identify],
+        toZigbee: [tz.on_off, tzLegrand.led_mode, tz.legrand_identify],
         exposes: [
             e.switch(),
             e.action(['identify']),

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -135,7 +135,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify,
             fzLegrand.cluster_fc01, fzLegrand.calibration_mode(false)],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_led_in_dark, tzLegrand.calibration_mode(false)],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tzLegrand.led_mode, tzLegrand.calibration_mode(false)],
         exposes: [
             _067776.getCover(),
             e.action(['moving', 'identify']),
@@ -172,7 +172,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         meta: {coverInverted: true},
         fromZigbee: [fz.identify, fz.ignore_basic_report, fz.legrand_binary_input_moving, fz.cover_position_tilt, fzLegrand.cluster_fc01],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_led_in_dark],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tzLegrand.led_mode],
         exposes: [e.cover_position()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -191,7 +191,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify,
             fzLegrand.cluster_fc01, fzLegrand.calibration_mode(true)],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tz.legrand_led_in_dark, tzLegrand.calibration_mode(true)],
+        toZigbee: [tz.cover_state, tz.cover_position_tilt, tz.legrand_identify, tzLegrand.led_mode, tzLegrand.calibration_mode(true)],
         exposes: [
             _067776.getCover(),
             e.action(['moving', 'identify']),
@@ -282,7 +282,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.brightness, fz.identify, fz.on_off, fz.lighting_ballast_configuration, fzLegrand.cluster_fc01,
             fz.power_on_behavior],
-        toZigbee: [tz.light_onoff_brightness, tz.legrand_led_in_dark, tz.legrand_led_if_on, tz.legrand_device_mode,
+        toZigbee: [tz.light_onoff_brightness, tzLegrand.led_mode, tz.legrand_device_mode,
             tz.legrand_identify, tz.ballast_config, tz.power_on_behavior],
         exposes: [
             e.light_brightness(),
@@ -315,7 +315,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.brightness, fz.identify, fz.on_off, fz.lighting_ballast_configuration, fzLegrand.cluster_fc01,
             fz.power_on_behavior],
-        toZigbee: [tz.light_onoff_brightness, tz.legrand_led_in_dark, tz.legrand_led_if_on, tz.legrand_device_mode,
+        toZigbee: [tz.light_onoff_brightness, tzLegrand.led_mode, tz.legrand_device_mode,
             tz.legrand_identify, tz.ballast_config, tz.power_on_behavior],
         exposes: [
             e.light_brightness(),
@@ -346,7 +346,7 @@ const definitions: Definition[] = [
         description: 'Power socket with power consumption monitoring',
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.identify, fz.on_off, fz.electrical_measurement, fz.power_on_behavior, fzLegrand.cluster_fc01],
-        toZigbee: [tz.on_off, tz.legrand_led_in_dark, tz.legrand_identify, tz.legrand_led_if_on, tz.power_on_behavior],
+        toZigbee: [tz.on_off, tzLegrand.led_mode, tz.legrand_identify, tz.power_on_behavior],
         exposes: [
             e.switch(),
             e.action(['identify']),
@@ -427,7 +427,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.identify, fz.metering, fz.electrical_measurement, fz.ignore_basic_report, fz.ignore_genOta,
             fz.legrand_power_alarm, fzLegrand.cluster_fc01],
-        toZigbee: [tz.legrand_led_in_dark, tz.legrand_identify, tz.electrical_measurement_power, tz.legrand_power_alarm],
+        toZigbee: [tzLegrand.led_mode, tz.legrand_identify, tz.electrical_measurement_power, tz.legrand_power_alarm],
         exposes: [
             e.power().withAccess(ea.STATE_GET),
             e.power_apparent(),
@@ -554,8 +554,8 @@ const definitions: Definition[] = [
         meta: {multiEndpoint: true},
         fromZigbee: [fz.brightness, fz.identify, fz.on_off, fz.legrand_binary_input_on_off, fz.lighting_ballast_configuration,
             fzLegrand.cluster_fc01, fz.power_on_behavior],
-        toZigbee: [tz.light_onoff_brightness, tz.legrand_identify, tz.legrand_device_mode, tz.on_off, tz.legrand_led_in_dark,
-            tz.legrand_led_if_on, tz.ballast_config, tz.power_on_behavior],
+        toZigbee: [tz.light_onoff_brightness, tz.legrand_identify, tz.legrand_device_mode, tz.on_off, tzLegrand.led_mode,
+            tz.ballast_config, tz.power_on_behavior],
         exposes: [
             e.light_brightness().withEndpoint('left'),
             e.light_brightness().withEndpoint('right'),
@@ -599,7 +599,7 @@ const definitions: Definition[] = [
         description: 'Outlet with power consumption monitoring',
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.identify, fz.on_off, fz.electrical_measurement, fzLegrand.cluster_fc01],
-        toZigbee: [tz.on_off, tz.legrand_led_in_dark, tz.legrand_identify],
+        toZigbee: [tz.on_off, tzLegrand.led_mode, tz.legrand_identify],
         exposes: [
             e.switch(),
             e.action(['identify']),
@@ -619,7 +619,7 @@ const definitions: Definition[] = [
         vendor: 'Legrand',
         description: 'Smart switch with Netatmo',
         fromZigbee: [fz.on_off, fz.legrand_binary_input_on_off, fzLegrand.cluster_fc01],
-        toZigbee: [tz.on_off, tz.legrand_led_in_dark, tz.legrand_led_if_on],
+        toZigbee: [tz.on_off, tzLegrand.led_mode],
         exposes: [
             e.switch(),
             e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
@@ -641,8 +641,8 @@ const definitions: Definition[] = [
         extend: extend.light_onoff_brightness({noConfigure: true}),
         fromZigbee: [fz.brightness, fz.identify, fz.on_off, fz.lighting_ballast_configuration, fzLegrand.cluster_fc01,
             fz.power_on_behavior],
-        toZigbee: [tz.light_onoff_brightness, tz.legrand_led_in_dark, tz.legrand_led_if_on,
-            tz.legrand_device_mode, tz.legrand_identify, tz.ballast_config, tz.power_on_behavior],
+        toZigbee: [tz.light_onoff_brightness, tzLegrand.led_mode, tz.legrand_device_mode, tz.legrand_identify,
+            tz.ballast_config, tz.power_on_behavior],
         exposes: [
             e.light_brightness(),
             e.numeric('ballast_minimum_level', ea.ALL).withValueMin(1).withValueMax(254)
@@ -693,7 +693,7 @@ const definitions: Definition[] = [
         vendor: 'Legrand',
         description: 'Centralized ventilation switch',
         fromZigbee: [fz.identify, fz.on_off, fz.power_on_behavior, fzLegrand.cluster_fc01],
-        toZigbee: [tz.on_off, tz.legrand_led_in_dark, tz.legrand_identify, tz.legrand_led_if_on, tz.power_on_behavior],
+        toZigbee: [tz.on_off, tzLegrand.led_mode, tz.legrand_identify, tz.power_on_behavior],
         exposes: [
             e.switch(),
             e.action(['identify']),

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -143,6 +143,8 @@ const definitions: Definition[] = [
                 .withDescription('Blinks the built-in LED to make it easier to identify the device'),
             e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
                 .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
+            e.binary('led_if_on', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the LED on activity'),
             _067776.getCalibrationModes(false),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -199,6 +201,8 @@ const definitions: Definition[] = [
                 .withDescription('Blinks the built-in LED to make it easier to identify the device'),
             e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
                 .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
+            e.binary('led_if_on', ea.ALL, 'ON', 'OFF')
+                .withDescription('Enables the LED on activity'),
             _067776.getCalibrationModes(true),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -131,7 +131,7 @@ export const fzLegrand = {
                 else if (option0 === 0x0100) payload.device_mode = 'dimmer_off';
                 else if (option0 === 0x0101) payload.device_mode = 'dimmer_on';
                 else {
-                    meta.logger.warn(`device_mode ${option0} not recognized, please fix me`);
+                    meta.logger.warn(`Device_mode ${option0} not recognized, please fix me!`);
                     payload.device_mode = 'unknown';
                 }
             }

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -14,6 +14,11 @@ const shutterCalibrationModes: {[k: number]: {description: string, onlyNLLV: boo
     4: {description: 'venetian_bso', onlyNLLV: false},
 };
 
+const ledModes:{[k: number]: string} = {
+    1: 'led_in_dark',
+    2: 'led_if_on',
+};
+
 const getApplicableCalibrationModes = (isNLLVSwitch: boolean): KeyValueString => {
     return Object.fromEntries(Object.entries(shutterCalibrationModes)
         .filter((e) => isNLLVSwitch ? true : e[1].onlyNLLV === false)
@@ -75,6 +80,22 @@ export const tzLegrand = {
             },
         } as Tz.Converter;
     },
+    led_mode: {
+        key: ['led_in_dark', 'led_if_on'],
+        convertSet: async (entity, key, value, meta) => {
+            utils.validateValue(key, Object.values(ledModes));
+            const idx = utils.getKey(ledModes, key);
+            const state = value === 'ON' || (value === 'OFF' ? false : !!value);
+            const payload = {[idx]: {value: state, type: 16}};
+            await entity.write('manuSpecificLegrandDevices', payload, legrandOptions);
+            return {state: {[key]: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            utils.validateValue(key, Object.values(ledModes));
+            const idx = utils.getKey(ledModes, key);
+            await entity.read('manuSpecificLegrandDevices', [Number(idx)], legrandOptions);
+        },
+    } as Tz.Converter,
 };
 
 export const fzLegrand = {


### PR DESCRIPTION
This PR:
- Consolidates the Legrand led_in_dark and led_if_on FZ handlers in a single manufacturer specific led_mode FZ converter.
- Adds the "Led If On" feature to the 067776 / 067776A switches