### PR TITLE
Fix Bticino K4027C family detection 

### DIFF
--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -66,33 +66,6 @@ const definitions: Definition[] = [
         },
     },
     {
-        // Newer firmwares (e.g. 001f) Does support partial position reporting
-        // Old firmware of this device provides only three values: 0, 100 and 50, 50 means an indefinite position between 1 and 99.
-        // If you have an old Firmware set no_position_support to true
-        // https://github.com/Koenkk/zigbee-herdsman-converters/pull/2214 - 1st very basic support
-        zigbeeModel: [' Shutter SW with level control\u0000'],
-        model: 'K4027C/L4027C/N4027C/NT4027C',
-        vendor: 'BTicino',
-        description: 'Shutter SW with level control',
-        ota: ota.zigbeeOTA,
-        fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.bticino_4027C_binary_input_moving,
-            fz.identify, fzLegrand.cluster_fc01, fz.ignore_zclversion_read],
-        toZigbee: [tz.bticino_4027C_cover_state, tz.bticino_4027C_cover_position, tz.legrand_identify, tzLegrand.led_mode],
-        exposes: [
-            e.cover_position(),
-            e.action(['moving', 'identify', '']),
-            e.enum('identify', ea.SET, ['blink'])
-                .withDescription('Blinks the built-in LED to make it easier to identify the device'),
-            e.binary('led_in_dark', ea.ALL, 'ON', 'OFF')
-                .withDescription('Enables the built-in LED allowing to see the switch in the dark'),
-        ],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
-            await reporting.currentPositionLiftPercentage(endpoint);
-        },
-    },
-    {
         zigbeeModel: ['Bticino Din power consumption module '],
         model: 'F20T60A',
         description: 'DIN power consumption module (same as Legrand 412015)',

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -183,13 +183,16 @@ const definitions: Definition[] = [
         },
     },
     {
-        // Fingerprinting required due to conflict with potential whitelabel Bticino - K4027C/L4027C/N4027C/NT4027C
-        fingerprint: [
-            {modelID: ' Shutter SW with level control\u0000', manufacturerID: 4129},
-        ],
+        zigbeeModel: [' Shutter SW with level control\u0000'],
         model: '067776A',
         vendor: 'Legrand',
         description: 'Netatmo wired shutter switch with level control (NLLV)',
+        whiteLabel: [
+            {
+                model: 'K4027C/L4027C/N4027C/NT4027C', vendor: 'BTicino', description: 'Shutter SW with level control',
+                fingerprint: [{hardwareVersion: 13}],
+            },
+        ],
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify,
             fzLegrand.cluster_fc01, fzLegrand.calibration_mode(true)],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,8 +32,9 @@ export type Expose = exposes.Numeric | exposes.Binary | exposes.Enum | exposes.C
     exposes.Lock | exposes.Cover | exposes.Climate | exposes.Text;
 export type Option = exposes.Numeric | exposes.Binary | exposes.Composite | exposes.Enum | exposes.List | exposes.Text;
 export interface Fingerprint {
-    modelID?: string, manufacturerName?: string, type?: 'EndDevice' | 'Router', manufacturerID?: number, applicationVersion?: number,
-    powerSource?: 'Battery' | 'Mains (single phase)', softwareBuildID?: string, ieeeAddr?: RegExp,
+    applicationVersion?: number, manufacturerID?: number, type?: 'EndDevice' | 'Router', dateCode?: number,
+    hardwareVersion?: number, manufacturerName?: string, modelID?: string, powerSource?: 'Battery' | 'Mains (single phase)',
+    softwareBuildID?: string, stackVersion?: number, zclVersion?: number, ieeeAddr?: RegExp,
     endpoints?: {ID?: number, profileID?: number, deviceID?: number, inputClusters?: number[], outputClusters?: number[]}[],
 }
 export type WhiteLabel =


### PR DESCRIPTION
Various users reported that Bticino K4027C/L4027C/N4027C/NT4027C switches get reported as Legrand 067776A.
Unfortunately, Bticino shutter switches expose the very same attribues than the Legrand switches.
Databases of the affected users show that Bticino devices "seem" to expose HW Version 13 however.

This PR:
- Consolidates the Fingerprint interface and enables the 'hardwareVersion' attribute to be used as fingerprinting attribute
- Adds the Bticino family switches as whitelabels to the 067776A

References:
https://github.com/Koenkk/zigbee2mqtt/issues/19509
https://github.com/Koenkk/zigbee2mqtt/issues/19108

Hardware IDs:
067776A (NLLVs) -> HW version 1
??? -> HW version 4
Bticino 4027C ->  HW version 13
