### PR TITLE
Update vesternet VES-ZB-SWI-015

### DIFF
--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -102,7 +102,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.5.3_r2'}, {modelID: 'ON/OFF(2CH)', softwareBuildID: '2.9.2_r3'}],
+        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.5.3_r2'}],
         model: 'VES-ZB-SWI-015',
         vendor: 'Vesternet',
         description: 'Zigbee 2 channel switch',
@@ -128,6 +128,37 @@ const definitions: Definition[] = [
             await reporting.rmsVoltage(endpoint1, {min: 10});
             await reporting.readMeteringMultiplierDivisor(endpoint1);
             await reporting.currentSummDelivered(endpoint1);
+        },
+    },
+    {
+        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.9.2_r3'}],
+        model: 'VES-ZB-SWI-015',
+        vendor: 'Vesternet',
+        description: 'Zigbee 2 channel switch',
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.power_on_behavior, fz.ignore_genOta],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.power(), e.current(),
+            e.voltage(), e.energy(), e.power_on_behavior(['off', 'on', 'previous'])],
+        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9101SAC-HP-SWITCH-2CH'}],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint1 = device.getEndpoint(1);
+            const endpoint2 = device.getEndpoint(2);
+            const endpoint11 = device.getEndpoint(11);
+            await reporting.bind(endpoint1, coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(endpoint2, coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(endpoint11, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
+            await reporting.onOff(endpoint1);
+            await reporting.onOff(endpoint2);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint11);
+            await reporting.activePower(endpoint11);
+            await reporting.rmsCurrent(endpoint11, {min: 10, change: 10});
+            await reporting.rmsVoltage(endpoint11, {min: 10});
+            await reporting.readMeteringMultiplierDivisor(endpoint11);
+            await reporting.currentSummDelivered(endpoint11);
         },
     },
     {

--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -102,36 +102,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.5.3_r2'}],
-        model: 'VES-ZB-SWI-015',
-        vendor: 'Vesternet',
-        description: 'Zigbee 2 channel switch',
-        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.power_on_behavior, fz.ignore_genOta],
-        toZigbee: [tz.on_off, tz.power_on_behavior],
-        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.power(), e.current(),
-            e.voltage(), e.energy(), e.power_on_behavior(['off', 'on', 'previous'])],
-        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9101SAC-HP-SWITCH-2CH'}],
-        endpoint: (device) => {
-            return {'l1': 1, 'l2': 2};
-        },
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint1 = device.getEndpoint(1);
-            const endpoint2 = device.getEndpoint(2);
-            await reporting.bind(endpoint1, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ['genOnOff']);
-            await reporting.onOff(endpoint1);
-            await reporting.onOff(endpoint2);
-            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint1);
-            await reporting.activePower(endpoint1);
-            await reporting.rmsCurrent(endpoint1, {min: 10, change: 10});
-            await reporting.rmsVoltage(endpoint1, {min: 10});
-            await reporting.readMeteringMultiplierDivisor(endpoint1);
-            await reporting.currentSummDelivered(endpoint1);
-        },
-    },
-    {
-        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.9.2_r3'}],
+        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.5.3_r2'}, {modelID: 'ON/OFF(2CH)', softwareBuildID: '2.9.2_r3'}],
         model: 'VES-ZB-SWI-015',
         vendor: 'Vesternet',
         description: 'Zigbee 2 channel switch',


### PR DESCRIPTION
i separate the VES-ZB-SWI-015 in 2 configuration, because the software version 2.9.2_r3 have measurment on endpoint 11 not 1
i don't have the device with software version  under 2.9.2_r3, that why i split

information in my local documentation with the device :

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/8700106/d245bfd4-c36e-458b-9301-acb3f46298df)


and the result after change with external file on Z2M, the measurment are correct :

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/8700106/016e2826-7e31-43db-9440-c35fb7505c63)
