### PR TITLE
Update philips.ts for Festavia Effects

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3305,14 +3305,14 @@ const definitions: Definition[] = [
         model: '929003535301',
         vendor: 'Philips',
         description: 'Hue Festavia gradient light string 250',
-        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle']}),
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle', 'opal', 'glisten']}),
     },
     {
         zigbeeModel: ['LCX017'],
         model: '929003674601',
         vendor: 'Philips',
         description: 'Hue Festavia gradient light string 500',
-        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle']}),
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle', 'opal', 'glisten']}),
     },
     {
         zigbeeModel: ['LCX016'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3305,14 +3305,20 @@ const definitions: Definition[] = [
         model: '929003535301',
         vendor: 'Philips',
         description: 'Hue Festavia gradient light string 250',
-        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle', 'opal', 'glisten']}),
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({
+            colorTempRange: [153, 500],
+            extraEffects: ['sparkle', 'opal', 'glisten'],
+        }),
     },
     {
         zigbeeModel: ['LCX017'],
         model: '929003674601',
         vendor: 'Philips',
         description: 'Hue Festavia gradient light string 500',
-        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({colorTempRange: [153, 500], extraEffects: ['sparkle', 'opal', 'glisten']}),
+        extend: philips.extend.light_onoff_brightness_colortemp_color_gradient({
+            colorTempRange: [153, 500],
+            extraEffects: ['sparkle', 'opal', 'glisten'],
+        }),
     },
     {
         zigbeeModel: ['LCX016'],


### PR DESCRIPTION
Added in supported extraEffects Glisten and Opal to the Festavia 250 and 500 count string lights.