### PR TITLE
feat: add support for Sonoff TRV local temperature calibration

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -403,6 +403,7 @@ const definitions: Definition[] = [
             e.climate()
                 .withSetpoint('occupied_heating_setpoint', 4, 35, 0.5)
                 .withLocalTemperature()
+                .withLocalTemperatureCalibration(-7.0, 7.0, 0.2)
                 .withSystemMode(['off', 'auto', 'heat'], ea.ALL, 'Mode of the thermostat')
                 .withRunningState(['idle', 'heat'], ea.STATE_GET),
             e.battery(),
@@ -423,6 +424,7 @@ const definitions: Definition[] = [
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
             await reporting.thermostatSystemMode(endpoint);
+            await endpoint.read('hvacThermostat', ['localTemperatureCalibration']);
             await endpoint.read(64529, [0x0000, 0x6000]);
         },
     },

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -439,7 +439,7 @@ export class Climate extends Base {
         // For devices following the ZCL local_temperature_calibration is an int8, so min = -12.8 and max 12.7
         assert(!this.endpoint, 'Cannot add feature after adding endpoint');
         this.features.push(new Numeric('local_temperature_calibration', access)
-            .withValueMin(min).withValueMax(max).withValueStep(step).withUnit('°C').withDescription('Offset to be used in the local_temperature'));
+            .withValueMin(min).withValueMax(max).withValueStep(step).withUnit('°C').withDescription('Offset to add/subtract to the local temperature'));
         return this;
     }
 


### PR DESCRIPTION
Adds support for Sonoff TRV local temperature calibration.

Also reworded the local temperature calibration description to make it slightly friendlier (in my opinion).

Issue being tracked here: https://github.com/Koenkk/zigbee2mqtt/issues/19269