### PR TITLE
fix(ignore): Fixed BTicino K4027C family detection

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -190,7 +190,7 @@ const definitions: Definition[] = [
         whiteLabel: [
             {
                 model: 'K4027C/L4027C/N4027C/NT4027C', vendor: 'BTicino', description: 'Shutter SW with level control',
-                fingerprint: [{hardwareVersion: 13}],
+                fingerprint: [{hardwareVersion: 9}, {hardwareVersion: 13}],
             },
         ],
         ota: ota.zigbeeOTA,


### PR DESCRIPTION
* 067776A: added additional HW version for BTicino whitelabels

Reference:
https://github.com/Koenkk/zigbee2mqtt/issues/19509#issuecomment-1794455410

Hi @Koenkk,
One more use report for that shutter switch.

I am starting to question the approach. Only Legrand can actually tell how those switches can be identified properly in the end. I am okay to maintain a list of hardware Version in the fingerprint for now, but cannot tell 100% if that doesn't break things for other users.
What do you think ?