### PR TITLE
fix - Inovelli VZW35\VZM31 lookup values for aux switch button presses

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -23,6 +23,9 @@ const buttonLookup: { [key: number]: string } = {
     1: 'down',
     2: 'up',
     3: 'config',
+    4: 'aux_down',
+    5: 'aux_up',
+    6: 'aux_config',
 };
 
 const ledEffects: { [key: string]: number } = {


### PR DESCRIPTION
This fixes an issue where a button press from an aux switch would show up as unknown because the lookup wasn't defined.