### PR TITLE
fix: :bug: fixed converters for LEL and CO values

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6500,9 +6500,9 @@ const definitions: Definition[] = [
         meta: {
             tuyaDatapoints: [
                 [1, 'gas', tuya.valueConverter.trueFalseEnum0],
-                [2, 'gas_value', tuya.valueConverter.raw],
+                [2, 'gas_value', tuya.valueConverter.divideBy1000],
                 [18, 'carbon_monoxide', tuya.valueConverter.trueFalseEnum0],
-                [19, 'co', tuya.valueConverter.raw],
+                [19, 'co', tuya.valueConverter.divideBy100],
             ],
         },
     },


### PR DESCRIPTION
After receiving TuYa gateway and attaching device I found a difference in the way the values were reported. I have made adjustments to fix these values. See application screenshot below. 

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/341606/dde662e2-ab46-41f9-aa36-6ac83ff58f0f)

Ran

- [x] `npm lint`  
- [x] `npm run build`  
- [x] `npm test`  