### PR TITLE
Edit SIN-4-FP-21_EQU configuration to choose mode

### DIFF
--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -3939,6 +3939,25 @@ const converters = {
             await entity.read('manuSpecificLegrandDevices', [0x0000, 0x0001, 0x0002], manufacturerOptions.legrand);
         },
     },
+    equation_cable_outlet_mode: {
+        key: ['cable_outlet_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            const mode = {
+                'comfort': 0x01,
+                'comfort-1': 0x04,
+                'comfort-2': 0x05,
+                'eco': 0x02,
+                'frost_protection': 0x03,
+                'off': 0x00,
+            };
+            const payload = {data: Buffer.from([mode[value]])};
+            await entity.command(0xfc00, 'command0', payload);
+            return {state: {'cable_outlet_mode': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read(0xfc00, [0x0000], {manufacturerCode: 0x128b});
+        },
+    },
     legrand_cable_outlet_mode: {
         key: ['cable_outlet_mode'],
         convertSet: async (entity, key, value, meta) => {

--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -21,6 +21,7 @@ const manufacturerOptions = {
     tint: {manufacturerCode: herdsman.Zcl.ManufacturerCode.MUELLER_LICHT_INT},
     legrand: {manufacturerCode: herdsman.Zcl.ManufacturerCode.VANTAGE, disableDefaultResponse: true},
     viessmann: {manufacturerCode: herdsman.Zcl.ManufacturerCode.VIESSMAN_ELEKTRO},
+    nodon: {manufacturerCode: herdsman.Zcl.ManufacturerCode.NODON}
 };
 
 const converters = {
@@ -3939,25 +3940,6 @@ const converters = {
             await entity.read('manuSpecificLegrandDevices', [0x0000, 0x0001, 0x0002], manufacturerOptions.legrand);
         },
     },
-    equation_cable_outlet_mode: {
-        key: ['cable_outlet_mode'],
-        convertSet: async (entity, key, value, meta) => {
-            const mode = {
-                'comfort': 0x01,
-                'comfort-1': 0x04,
-                'comfort-2': 0x05,
-                'eco': 0x02,
-                'frost_protection': 0x03,
-                'off': 0x00,
-            };
-            const payload = {data: Buffer.from([mode[value]])};
-            await entity.command('manuSpecificUbisysDeviceSetup', 'command0', payload);
-            return {state: {'cable_outlet_mode': value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('manuSpecificUbisysDeviceSetup', [0x0000], {manufacturerCode: 0x128b});
-        },
-    },
     legrand_cable_outlet_mode: {
         key: ['cable_outlet_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -5150,6 +5132,25 @@ const converters = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('ssIasZone', [0x4000], {manufacturerCode: 4919});
+        },
+    },
+    equation_cable_outlet_mode: {
+        key: ['cable_outlet_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            const mode = {
+                'comfort': 0x01,
+                'comfort-1': 0x04,
+                'comfort-2': 0x05,
+                'eco': 0x02,
+                'frost_protection': 0x03,
+                'off': 0x00,
+            };
+            const payload = {data: Buffer.from([mode[value]])};
+            await entity.command('manuSpecificUbisysDeviceSetup2', 'command0', payload);
+            return {state: {'cable_outlet_mode': value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificUbisysDeviceSetup2', [0x0000], manufacturerOptions.nodon);
         },
     },
     // #endregion

--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -3951,11 +3951,11 @@ const converters = {
                 'off': 0x00,
             };
             const payload = {data: Buffer.from([mode[value]])};
-            await entity.command(0xfc00, 'command0', payload);
+            await entity.command('manuSpecificUbisysDeviceSetup', 'command0', payload);
             return {state: {'cable_outlet_mode': value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read(0xfc00, [0x0000], {manufacturerCode: 0x128b});
+            await entity.read('manuSpecificUbisysDeviceSetup', [0x0000], {manufacturerCode: 0x128b});
         },
     },
     legrand_cable_outlet_mode: {

--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -359,16 +359,22 @@ const definitions: Definition[] = [
         vendor: 'ADEO',
         description: 'Equation pilot wire heating module',
         ota: ota.zigbeeOTA,
-        fromZigbee: [fz.on_off, fz.metering],
-        toZigbee: [tz.on_off],
-        exposes: [e.switch(), e.power(), e.energy()],
+        fromZigbee: [fz.on_off, fz.metering, fz.power_on_behavior],
+        toZigbee: [tz.on_off, tz.currentsummdelivered, tz.metering_power, tz.power_on_behavior, tz.equation_cable_outlet_mode],
+        exposes: [
+            e.enum('cable_outlet_mode', ea.ALL, ['comfort', 'comfort-1', 'comfort-2', 'eco', 'frost_protection', 'off']),
+	        e.switch().withState('state', true, 'Works only when the pilot wire is deactivated'),
+            e.energy().withAccess(ea.STATE_GET),
+	        e.power().withAccess(ea.STATE_GET),
+	        e.power_on_behavior().withDescription('Controls the behavior when the device is powered on. Works only when the pilot wire is deactivated'),
+        ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const ep = device.getEndpoint(1);
             await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering']);
             await reporting.onOff(ep, {min: 1, max: 3600, change: 0});
             await reporting.readMeteringMultiplierDivisor(ep);
-            await reporting.instantaneousDemand(ep);
             await reporting.currentSummDelivered(ep);
+            await reporting.readMeteringMultiplierDivisor(ep);
         },
     },
 ];


### PR DESCRIPTION
Following the issue https://github.com/Koenkk/zigbee2mqtt/issues/19169 and PR https://github.com/Koenkk/zigbee-herdsman/pull/796

SIN_4_FP_21_EQU is a module to pilot heater from pilot wire and check consumption measurement. We can choose between 4 or 6 mode depending of the heater (off, frost protection, eco, confort + confort -1 and confort -2).

The new tz converter si similar to `legrand_cable_outlet_mode`.

The `command0` on cluster `manuSpecificLegrandDevices2` come from [a pending PR on Zigbee-herdsman](https://github.com/Koenkk/zigbee-herdsman/pull/796).

PS : The module is build by `Adeo`, Sell by `NodOn` with brand `equation`. I'm not sure about the name that I have to use so don't hesitate to give me feedback !

Thanks