### PR TITLE
lywsd03mc: add toggle for temperature degrees selection

### DIFF
--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -1268,8 +1268,8 @@ const definitions: Definition[] = [
         model: 'LYWSD03MMC',
         vendor: 'Custom devices (DiY)',
         description: 'Xiaomi temperature & humidity sensor with custom firmware',
-        fromZigbee: [fz.temperature, fz.humidity, fz.battery],
-        toZigbee: [],
+        fromZigbee: [fz.temperature, fz.humidity, fz.battery, fz.hvac_user_interface],
+        toZigbee: [tz.thermostat_temperature_display_mode],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             const bindClusters = ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg'];
@@ -1279,7 +1279,11 @@ const definitions: Definition[] = [
             await reporting.batteryVoltage(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.temperature(), e.humidity(), e.battery()],
+        exposes: [
+            e.temperature(), e.humidity(), e.battery(),
+            e.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
+                .withDescription('The temperature format displayed on the screen'),
+        ],
         ota: ota.zigbeeOTA,
     },
     {


### PR DESCRIPTION
Add a toggle for Fahrenheit degrees on the screen


Related PR to move temperature_display_mode to config category: https://github.com/Koenkk/zigbee2mqtt/pull/19631