### PR TITLE
fix: nodon pilot mode payload

### DIFF
--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -5145,7 +5145,7 @@ const converters = {
                 'comfort_-1': 0x04,
                 'comfort_-2': 0x05,
             });
-            const payload = {data: Buffer.from([mode])};
+            const payload = {mode: Buffer.from([mode])};
             await entity.command('manuSpecificNodOnFilPilote', 'setMode', payload);
             return {state: {'mode': value}};
         },


### PR DESCRIPTION
Hello

Following [the PR](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6429)

It seem that payload sent by `tz.nodon_fil_pilote_mode` can't work because [`setMode` command need `mode` in the payload](https://github.com/Koenkk/zigbee-herdsman/blob/81ec998d2b5493564c5633f2f9f1e872a0784fed/src/zcl/definition/cluster.ts#L5608) (actually `data` is sent)

Thanks
