### PR TITLE
Add support for AduroSmart 81814

### DIFF
--- a/src/devices/adurosmart.ts
+++ b/src/devices/adurosmart.ts
@@ -136,6 +136,13 @@ const definitions: Definition[] = [
         description: 'Eria tunable white A19 smart bulb',
         extend: extend.light_onoff_brightness_colortemp_color({supportsHueAndSaturation: true, colorTempRange: [153, 500]}),
     },
+    {
+        zigbeeModel: ['AD-ColorTemperature3001'],
+        model: '81814',
+        vendor: 'AduroSmart',
+        description: 'ERIA Tunable White BR30 light bulb',
+        extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500]}),
+    },
 ];
 
 module.exports = definitions;


### PR DESCRIPTION
added support for AduroSmart 81814
model ID displays as AD-ColorTemperature3001

pull request for image: Koenkk/zigbee2mqtt.io#2320