### PR TITLE
fix Aqara L1-350 (ZNXDD01LM) support

### DIFF
--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -2283,7 +2283,7 @@ const converters = {
             if (['SP-EUC01', 'ZNCZ04LM', 'ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM', 'SSM-U01', 'SSM-U02', 'DLKZMK11LM', 'DLKZMK12LM',
                 'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG18LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM', 'QBKG29LM',
                 'QBKG31LM', 'QBKG32LM', 'QBKG34LM', 'QBKG38LM', 'QBKG39LM', 'QBKG40LM', 'QBKG41LM', 'ZNDDMK11LM', 'ZNLDP13LM', 'ZNQBKG31LM',
-                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM',
+                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM', 'ZNXDD01LM',
             ].includes(meta.mapped.model)) {
                 await entity.write('aqaraOpple', {0x0201: {value: value ? 1 : 0, type: 0x10}}, manufacturerOptions.xiaomi);
             } else if (['ZNCZ02LM', 'QBCZ11LM', 'LLKZMK11LM'].includes(meta.mapped.model)) {
@@ -2308,7 +2308,7 @@ const converters = {
             if (['SP-EUC01', 'ZNCZ04LM', 'ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM', 'SSM-U01', 'SSM-U02', 'DLKZMK11LM', 'DLKZMK12LM',
                 'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG18LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM', 'QBKG29LM',
                 'QBKG31LM', 'QBKG32LM', 'QBKG34LM', 'QBKG38LM', 'QBKG39LM', 'QBKG40LM', 'QBKG41LM', 'ZNDDMK11LM', 'ZNLDP13LM', 'ZNQBKG31LM',
-                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM',
+                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM', 'ZNXDD01LM',
             ].includes(meta.mapped.model)) {
                 await entity.read('aqaraOpple', [0x0201]);
             } else if (['ZNCZ02LM', 'QBCZ11LM', 'ZNCZ11LM', 'ZNCZ12LM'].includes(meta.mapped.model)) {

--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -2283,7 +2283,8 @@ const converters = {
             if (['SP-EUC01', 'ZNCZ04LM', 'ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM', 'SSM-U01', 'SSM-U02', 'DLKZMK11LM', 'DLKZMK12LM',
                 'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG18LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM', 'QBKG29LM',
                 'QBKG31LM', 'QBKG32LM', 'QBKG34LM', 'QBKG38LM', 'QBKG39LM', 'QBKG40LM', 'QBKG41LM', 'ZNDDMK11LM', 'ZNLDP13LM', 'ZNQBKG31LM',
-                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM', 'ZNXDD01LM',
+                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM', 'JWDL001A', 'JWSP001A', 'SSWQD02LM', 'SSWQD03LM', 'XDD11LM',
+                'XDD12LM', 'XDD13LM', 'ZNLDP12LM', 'ZNLDP13LM', 'ZNXDD01LM',
             ].includes(meta.mapped.model)) {
                 await entity.write('aqaraOpple', {0x0201: {value: value ? 1 : 0, type: 0x10}}, manufacturerOptions.xiaomi);
             } else if (['ZNCZ02LM', 'QBCZ11LM', 'LLKZMK11LM'].includes(meta.mapped.model)) {
@@ -2308,7 +2309,8 @@ const converters = {
             if (['SP-EUC01', 'ZNCZ04LM', 'ZNCZ15LM', 'QBCZ14LM', 'QBCZ15LM', 'SSM-U01', 'SSM-U02', 'DLKZMK11LM', 'DLKZMK12LM',
                 'WS-EUK01', 'WS-EUK02', 'WS-EUK03', 'WS-EUK04', 'QBKG19LM', 'QBKG18LM', 'QBKG20LM', 'QBKG25LM', 'QBKG26LM', 'QBKG28LM', 'QBKG29LM',
                 'QBKG31LM', 'QBKG32LM', 'QBKG34LM', 'QBKG38LM', 'QBKG39LM', 'QBKG40LM', 'QBKG41LM', 'ZNDDMK11LM', 'ZNLDP13LM', 'ZNQBKG31LM',
-                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM', 'ZNXDD01LM',
+                'WS-USC02', 'WS-USC03', 'WS-USC04', 'ZNQBKG24LM', 'ZNQBKG25LM', 'JWDL001A', 'JWSP001A', 'SSWQD02LM', 'SSWQD03LM', 'XDD11LM',
+                'XDD12LM', 'XDD13LM', 'ZNLDP12LM', 'ZNLDP13LM', 'ZNXDD01LM',
             ].includes(meta.mapped.model)) {
                 await entity.read('aqaraOpple', [0x0201]);
             } else if (['ZNCZ02LM', 'QBCZ11LM', 'ZNCZ11LM', 'ZNCZ12LM'].includes(meta.mapped.model)) {

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -15,14 +15,36 @@ import {Definition, OnEvent, Fz, KeyValue, Tz, Extend} from '../lib/types';
 const {printNumbersAsHexSequence} = utils;
 const {fp1, manufacturerCode, trv} = xiaomi;
 
+interface xiaomi_options_light_onoff_brightness_colortemp extends Extend.options_light_onoff_brightness_colortemp {
+    disableAqaraOpple?: boolean, disableSwitchPowerOutageMemory?: boolean,
+}
+
 const xiaomiExtend = {
-    light_onoff_brightness_colortemp: (options:Extend.options_light_onoff_brightness_colortemp={disableColorTempStartup: true}): Extend => ({
-        ...extend.light_onoff_brightness_colortemp(options),
-        fromZigbee: extend.light_onoff_brightness_colortemp(options).fromZigbee.concat([
-            fz.xiaomi_bulb_interval, fz.ignore_occupancy_report, fz.ignore_humidity_report,
-            fz.ignore_pressure_report, fz.ignore_temperature_report,
-        ]),
-    }),
+    light_onoff_brightness_colortemp: (options: xiaomi_options_light_onoff_brightness_colortemp = {}): Extend => {
+        options = {
+            disableEffect: true, disableColorTempStartup: true, disablePowerOnBehavior: true,
+            colorTempRange: [153, 370], toZigbee: [], fromZigbee: [], exposes: [], ...options,
+        };
+        const fromZigbee = [
+            ...extend.light_onoff_brightness_colortemp(options).fromZigbee, ...options.fromZigbee];
+        const toZigbee = [
+            ...extend.light_onoff_brightness_colortemp(options).toZigbee, ...options.toZigbee];
+        const exposes = [
+            ...extend.light_onoff_brightness_colortemp(options).exposes, ...options.exposes];
+
+        if (!options.disableSwitchPowerOutageMemory) {
+            toZigbee.push(tz.xiaomi_switch_power_outage_memory);
+            exposes.push(e.power_outage_memory());
+        }
+
+        if (!options.disableAqaraOpple) {
+            fromZigbee.push(fz.aqara_opple);
+            exposes.push(e.device_temperature());
+            exposes.push(e.power_outage_count());
+        }
+
+        return {fromZigbee, toZigbee, exposes};
+    },
 };
 
 const preventReset: OnEvent = async (type, data, device) => {
@@ -801,11 +823,12 @@ const definitions: Definition[] = [
         model: 'ZNLDP12LM',
         vendor: 'Xiaomi',
         description: 'Aqara smart LED bulb',
-        toZigbee: xiaomiExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 370], disablePowerOnBehavior: true})
+        toZigbee: xiaomiExtend.light_onoff_brightness_colortemp({disableSwitchPowerOutageMemory: true})
             .toZigbee.concat([tz.xiaomi_light_power_outage_memory]),
-        fromZigbee: xiaomiExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 370], disablePowerOnBehavior: true}).fromZigbee,
+        fromZigbee: xiaomiExtend.light_onoff_brightness_colortemp({disableSwitchPowerOutageMemory: true})
+            .fromZigbee,
         // power_on_behavior 'toggle' does not seem to be supported
-        exposes: xiaomiExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 370], disablePowerOnBehavior: true})
+        exposes: xiaomiExtend.light_onoff_brightness_colortemp({disableSwitchPowerOutageMemory: true})
             .exposes.concat([e.power_outage_memory().withAccess(ea.STATE_SET)]),
         ota: ota.zigbeeOTA,
     },
@@ -814,37 +837,15 @@ const definitions: Definition[] = [
         model: 'ZNXDD01LM',
         vendor: 'Xiaomi',
         description: 'Aqara ceiling light L1-350',
-        toZigbee: xiaomiExtend.light_onoff_brightness_colortemp({
-            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true,
-        }).toZigbee.concat([tz.xiaomi_switch_power_outage_memory]),
-        fromZigbee: xiaomiExtend.light_onoff_brightness_colortemp({
-            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true,
-        }).fromZigbee.concat([fz.aqara_opple]),
-        exposes: xiaomiExtend.light_onoff_brightness_colortemp({
-            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true,
-            colorTempRange: [153, 370],
-        }).exposes.concat([e.power_outage_memory(), e.device_temperature(), e.power_outage_count()]),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
+        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['lumi.light.cwac02', 'lumi.light.acn014'],
         model: 'ZNLDP13LM',
         vendor: 'Xiaomi',
         description: 'Aqara T1 smart LED bulb',
-        toZigbee: xiaomiExtend.light_onoff_brightness_colortemp({disableEffect: true, disablePowerOnBehavior: true}).toZigbee.concat([
-            tz.xiaomi_switch_power_outage_memory,
-        ]),
-        fromZigbee: xiaomiExtend.light_onoff_brightness_colortemp({disableEffect: true, disablePowerOnBehavior: true}).fromZigbee.concat([
-            fz.aqara_opple,
-        ]),
-        exposes: xiaomiExtend.light_onoff_brightness_colortemp({
-            disableEffect: true,
-            disablePowerOnBehavior: true,
-            colorTempRange: [153, 370],
-        }).exposes.concat([
-            e.power_outage_memory(),
-            e.device_temperature(),
-            e.power_outage_count(),
-        ]),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             device.type = 'Router';
@@ -858,8 +859,7 @@ const definitions: Definition[] = [
         vendor: 'Xiaomi',
         description: 'Aqara Opple MX960',
         meta: {turnsOffAtBrightness1: true},
-        extend: xiaomiExtend.light_onoff_brightness_colortemp({disableEffect: true, disableColorTempStartup: true,
-            colorTempRange: [175, 370]}),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
     },
     {
@@ -868,8 +868,7 @@ const definitions: Definition[] = [
         vendor: 'Xiaomi',
         description: 'Aqara Opple MX650',
         meta: {turnsOffAtBrightness1: true},
-        extend: xiaomiExtend.light_onoff_brightness_colortemp({disableEffect: true, disableColorTempStartup: true,
-            colorTempRange: [175, 370]}),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
     },
     {
@@ -878,8 +877,7 @@ const definitions: Definition[] = [
         vendor: 'Xiaomi',
         description: 'Aqara Opple MX480',
         meta: {turnsOffAtBrightness1: true},
-        extend: xiaomiExtend.light_onoff_brightness_colortemp({disableEffect: true, disableColorTempStartup: true,
-            colorTempRange: [175, 370]}),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
     },
     {
@@ -887,15 +885,14 @@ const definitions: Definition[] = [
         model: 'JWSP001A',
         vendor: 'Xiaomi',
         description: 'Jiawen LED Driver & Dimmer',
-        extend: xiaomiExtend.light_onoff_brightness_colortemp({disableEffect: true, disableColorTempStartup: true,
-            colorTempRange: [153, 370]}),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
     },
     {
         zigbeeModel: ['lumi.light.cwjwcn02'],
         model: 'JWDL001A',
         vendor: 'Xiaomi',
         description: 'Aqara embedded spot led light',
-        extend: xiaomiExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 370]}),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
     },
     {
         zigbeeModel: ['lumi.sensor_switch'],
@@ -2716,8 +2713,7 @@ const definitions: Definition[] = [
         model: 'SSWQD02LM',
         vendor: 'Xiaomi',
         description: 'Aqara smart dimmer controller t1 pro',
-        extend: extend.light_onoff_brightness_colortemp({
-            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true, colorTempRange: [153, 370]}),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
     },
     {
@@ -2725,8 +2721,7 @@ const definitions: Definition[] = [
         model: 'SSWQD03LM',
         vendor: 'Xiaomi',
         description: 'Aqara spotlight T2',
-        extend: extend.light_onoff_brightness_colortemp({
-            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true, colorTempRange: [153, 370]}),
+        extend: xiaomiExtend.light_onoff_brightness_colortemp(),
         ota: ota.zigbeeOTA,
     },
     {

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -814,8 +814,16 @@ const definitions: Definition[] = [
         model: 'ZNXDD01LM',
         vendor: 'Xiaomi',
         description: 'Aqara ceiling light L1-350',
-        extend: xiaomiExtend.light_onoff_brightness_colortemp({disableEffect: true, colorTempRange: [153, 370]}),
-        ota: ota.zigbeeOTA,
+        toZigbee: xiaomiExtend.light_onoff_brightness_colortemp({
+            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true,
+        }).toZigbee.concat([tz.xiaomi_switch_power_outage_memory]),
+        fromZigbee: xiaomiExtend.light_onoff_brightness_colortemp({
+            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true,
+        }).fromZigbee.concat([fz.aqara_opple]),
+        exposes: xiaomiExtend.light_onoff_brightness_colortemp({
+            disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true,
+            colorTempRange: [153, 370],
+        }).exposes.concat([e.power_outage_memory(), e.device_temperature(), e.power_outage_count()]),
     },
     {
         zigbeeModel: ['lumi.light.cwac02', 'lumi.light.acn014'],

--- a/src/lib/xiaomi.ts
+++ b/src/lib/xiaomi.ts
@@ -204,7 +204,7 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             }
             break;
         case '9':
-            if (['ZNLDP13LM'].includes(model.model)) {
+            if (['ZNLDP13LM', 'ZNXDD01LM'].includes(model.model)) {
                 // We don't know what the value means for these devices.
             }
             break;
@@ -224,7 +224,17 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             }
             break;
         case '12':
-            if (['ZNLDP13LM'].includes(model.model)) {
+            if (['ZNLDP13LM', 'ZNXDD01LM'].includes(model.model)) {
+                // We don't know what the value means for these devices.
+            }
+            break;
+        case '13':
+            if (['ZNXDD01LM'].includes(model.model)) {
+                // We don't know what the value means for these devices.
+            }
+            break;
+        case '17':
+            if (['ZNXDD01LM'].includes(model.model)) {
                 // We don't know what the value means for these devices.
             }
             break;
@@ -321,6 +331,8 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
                 payload.battery = precisionRound(battery, 2);
             } else if (['RTCZCGQ11LM'].includes(model.model)) {
                 payload.presence = getFromLookup(value, {0: false, 1: true, 255: null});
+            } else if (['ZNXDD01LM'].includes(model.model)) {
+                payload.brightness = value;
             }
             break;
         case '102':
@@ -339,11 +351,17 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
                 } else {
                     payload.motion_sensitivity = getFromLookup(value, {1: 'low', 2: 'medium', 3: 'high'});
                 }
+            } else if (['ZNXDD01LM'].includes(model.model)) {
+                payload.color_temp = value;
             }
             break;
         case '103':
             if (['RTCZCGQ11LM'].includes(model.model)) {
                 payload.monitoring_mode = getFromLookup(value, {0: 'undirected', 1: 'left_right'});
+            } else if (['ZNXDD01LM'].includes(model.model)) {
+                assertNumber(value);
+                // const color_temp_min = (value & 0xffff); // 2700
+                // const color_temp_max = (value >> 16) & 0xffff; // 6500
             }
             break;
         case '105':
@@ -400,7 +418,7 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             }
             break;
         case '154':
-            if (['ZNLDP13LM'].includes(model.model)) {
+            if (['ZNLDP13LM', 'ZNXDD01LM'].includes(model.model)) {
                 // We don't know what the value means for these devices.
             }
             break;
@@ -452,6 +470,11 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
         case '166':
             if (['JT-BZ-01AQ/A'].includes(model.model)) {
                 payload.linkage_alarm = value === 1;
+            }
+            break;
+        case '238':
+            if (['ZNXDD01LM'].includes(model.model)) {
+                // We don't know what the value means for these devices.
             }
             break;
         case '240':
@@ -698,6 +721,18 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             break;
         case '1289':
             payload.dimmer_mode = getFromLookup(value, {3: 'rgbw', 1: 'dual_ct'});
+            break;
+        case '1299':
+            if (['ZNXDD01LM'].includes(model.model)) {
+                assertNumber(value);
+                // maximum color temp (6500)
+            }
+            break;
+        case '1300':
+            if (['ZNXDD01LM'].includes(model.model)) {
+                assertNumber(value);
+                // minimum color temp (2700)
+            }
             break;
         case '65281':
             {

--- a/src/lib/xiaomi.ts
+++ b/src/lib/xiaomi.ts
@@ -359,7 +359,6 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             if (['RTCZCGQ11LM'].includes(model.model)) {
                 payload.monitoring_mode = getFromLookup(value, {0: 'undirected', 1: 'left_right'});
             } else if (['ZNXDD01LM'].includes(model.model)) {
-                assertNumber(value);
                 // const color_temp_min = (value & 0xffff); // 2700
                 // const color_temp_max = (value >> 16) & 0xffff; // 6500
             }

--- a/src/lib/xiaomi.ts
+++ b/src/lib/xiaomi.ts
@@ -723,13 +723,11 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             break;
         case '1299':
             if (['ZNXDD01LM'].includes(model.model)) {
-                assertNumber(value);
                 // maximum color temp (6500)
             }
             break;
         case '1300':
             if (['ZNXDD01LM'].includes(model.model)) {
-                assertNumber(value);
                 // minimum color temp (2700)
             }
             break;


### PR DESCRIPTION
Fix Aqara L1-350 ceiling light support. Current version has broken support of power on behaviour and color temperature restore at startup (report unsupported attributes).

 `aqaraOpple` cluster is added to support additional attributes. After this, 'device temperature' and 'power outage count' seems to have the correct values. 'power_outage_memory' is also operated via `aqaraOpple` cluster.

The following data was observed from `aqaraOpple` cluster:

```
{
    "3": 33,          <- device temperature
    "5": 106,         <- outage count
    "9": 256,         <- ?
    "10": 0,          <- ?
    "12": 10,         <- ?
    "13": 28,         <- ?
    "17": 1,          <- ?
    "100": 0,         <- current state
    "101": 254,       <- brightness
    "102": 153,       <- color temperature
    "103": 425986700, <- = 0x19640A8C 0x1964 - 6500, 0x0A8C - 2700, min and max color temp
    "154": 0,         <- ?
}
```

`{"1299":6500,"1300":2700}`

`{"238":0}`