### PR TITLE
Add support for ID Lock 202 Multi

### DIFF
--- a/src/devices/datek.ts
+++ b/src/devices/datek.ts
@@ -116,10 +116,10 @@ const definitions: Definition[] = [
             e.numeric('occupancy_timeout', ea.ALL).withUnit('s').withValueMin(0).withValueMax(65535)],
     },
     {
-        zigbeeModel: ['ID Lock 150'],
+        zigbeeModel: ['ID Lock 150', 'ID Lock 202'],
         model: '0402946',
         vendor: 'Datek',
-        description: 'Zigbee module for ID lock 150',
+        description: 'Zigbee module for ID lock',
         fromZigbee: [fz.lock, fz.battery, fz.lock_operation_event, fz.lock_programming_event,
             fz.idlock, fz.idlock_fw, fz.lock_pin_code_response],
         toZigbee: [tz.lock, tz.lock_sound_volume, tz.idlock_master_pin_mode, tz.idlock_rfid_enable,


### PR DESCRIPTION
ID Lock has released a new lock called "202 Multi". It uses the same zigbee module as the existing ID Lock 150 model which is already supported.

I was able to get it to work for my lock with an external converter that simply copied the existing converter for the 150 and changed the model name. As I have understood it that means I can just add the new model to the `zigbeeModel` array, but this is my first contribution in this repo so please let me know if that's wrong.