### PR TITLE
tuya.ts: Supoort Immax Neo Lite 07732L TRV

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2528,6 +2528,7 @@ const definitions: Definition[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_8whxpsiw'}, // EVOLVEO
             {modelID: 'TS0601', manufacturerName: '_TZE200_xby0s3ta'}, // Sandy Beach HY367
             {modelID: 'TS0601', manufacturerName: '_TZE200_7fqkphoq'}, // AFINTEK
+            {modelID: 'TS0601', manufacturerName: '_TZE200_rufdtfyv'}, // Immax 07732L
         ],
         model: 'TS0601_thermostat',
         vendor: 'TuYa',
@@ -2538,6 +2539,7 @@ const definitions: Definition[] = [
             {vendor: 'SHOJZJ', model: '378RT'},
             {vendor: 'Silvercrest', model: 'TVR01'},
             {vendor: 'Immax', model: '07732B'},
+            {vendor: 'Immax', model: '07732L'},
             {vendor: 'Evolveo', model: 'Heat M30'},
         ],
         meta: {tuyaThermostatPreset: legacy.thermostatPresets, tuyaThermostatSystemMode: legacy.thermostatSystemModes3},

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2528,7 +2528,7 @@ const definitions: Definition[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_8whxpsiw'}, // EVOLVEO
             {modelID: 'TS0601', manufacturerName: '_TZE200_xby0s3ta'}, // Sandy Beach HY367
             {modelID: 'TS0601', manufacturerName: '_TZE200_7fqkphoq'}, // AFINTEK
-            {modelID: 'TS0601', manufacturerName: '_TZE200_rufdtfyv'}, // Immax 07732L
+            {modelID: 'TS0601', manufacturerName: '_TZE200_rufdtfyv'},
         ],
         model: 'TS0601_thermostat',
         vendor: 'TuYa',
@@ -2539,7 +2539,7 @@ const definitions: Definition[] = [
             {vendor: 'SHOJZJ', model: '378RT'},
             {vendor: 'Silvercrest', model: 'TVR01'},
             {vendor: 'Immax', model: '07732B'},
-            {vendor: 'Immax', model: '07732L'},
+            tuya.whitelabel('Immax', '07732L', 'Radiator valve with thermostat', ['_TZE200_rufdtfyv']),
             {vendor: 'Evolveo', model: 'Heat M30'},
         ],
         meta: {tuyaThermostatPreset: legacy.thermostatPresets, tuyaThermostatSystemMode: legacy.thermostatSystemModes3},


### PR DESCRIPTION
I have Immax 07732B and wanted to buy a new one, but got under the same label and a similar appearance another type _TZE200_rufdtfyv. Just adding it to the same section as 07732B makes it work with zigbee2mqtt, only the calendar schedules are empty, so they might be different in this model.

So far I tested that the values are read correctly, boost mode, manual mode and, force open/close mode work as expected. So I guess as a first approximation this can be merged as is.