### PR TITLE
Add tilt to Profalux covers supporting it

### DIFF
--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -40,11 +40,19 @@ const definitions: Definition[] = [
         description: 'Cover',
         fromZigbee: [fz.command_cover_close, fz.command_cover_open, fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
-        exposes: [e.cover_position()],
+        options: [e.binary('has_tilt', ea.SET, true, false).withDescription('Cover configured with tilt mode (BSO)')],
+        exposes: (device,options) => {
+            if (options == null || (options.hasOwnProperty('has_tilt') && options['has_tilt'])) {
+                return [ e.cover_position_tilt().setAccess('state', ea.ALL)]
+            } else {
+                return [ e.cover_position().setAccess('state', ea.ALL)]
+            }
+        },
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresWindowCovering']);
             await reporting.currentPositionLiftPercentage(endpoint);
+            await reporting.currentPositionTiltPercentage(endpoint);
         },
         endpoint: (device) => {
             return {default: 2};
@@ -73,7 +81,7 @@ const definitions: Definition[] = [
         // Newer remotes. These expose a bunch of things but they are bound to
         // the cover and don't seem to communicate with the coordinator, so
         // nothing is likely to be doable in Z2M.
-        zigbeeModel: ['MAI-ZTP20F', 'MAI-ZTP20C'],
+        zigbeeModel: ['MAI-ZTP20F', 'MAI-ZTP20C', 'MAI-ZTS'],
         model: 'MAI-ZTP20',
         vendor: 'Profalux',
         description: 'Cover remote',


### PR DESCRIPTION
Profalux cover motors can be configured by the remote to act as 3 sort of covers : regular lifting covers, lift and tilt cover, and "soft" fabric covers using the associated remote.
Sniffing the remote during setup shows that the configuration is stored on the cover in attribute 0 of cluster 0xFC21 and thus requires an update to zigbee-herdsman cluster list.
PR : https://github.com/Koenkk/zigbee-herdsman/pull/800

| config | mode | setup on the remote |
| - | - | - |
| 0 | default hard cover (aka Volet)  | 2xF Up + Down | 
| 1 | cover using tilt (aka BSO) | 2xF Stop + Up |
| 2 | soft cover (aka store)     | 2xF Stop + Down |

This PR allows to retrieve at configure time the type of cover and exposes the lift feature if configured on the cover

The configuration itself is not  exposed as I don't think it would make sense for normal use