### PR TITLE
bad cast in toZibee nodon converter, take into account the device button, reverse stop/anti-freeze 

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -6330,10 +6330,10 @@ const converters2 = {
             const payload: KeyValueAny = {};
             const mode = msg.data['mode'];
 
-            if (mode === 0x00) payload.mode = 'stop';
+            if (mode === 0x00) payload.mode = 'anti-freeze';
             else if (mode === 0x01) payload.mode = 'comfort';
             else if (mode === 0x02) payload.mode = 'eco';
-            else if (mode === 0x03) payload.mode = 'anti-freeze';
+            else if (mode === 0x03) payload.mode = 'stop';
             else if (mode === 0x04) payload.mode = 'comfort_-1';
             else if (mode === 0x05) payload.mode = 'comfort_-2';
             else {

--- a/src/converters/toZigbee.js
+++ b/src/converters/toZigbee.js
@@ -5142,12 +5142,12 @@ const converters = {
             const mode = utils.getFromLookup(value, {
                 'comfort': 0x01,
                 'eco': 0x02,
-                'anti-freeze': 0x03,
-                'stop': 0x00,
+                'anti-freeze': 0x00,
+                'stop': 0x03,
                 'comfort_-1': 0x04,
                 'comfort_-2': 0x05,
             });
-            const payload = {mode: Buffer.from([mode])};
+            const payload = {'mode': mode};
             await entity.command('manuSpecificNodOnFilPilote', 'setMode', payload);
             return {state: {'mode': value}};
         },

--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -374,12 +374,13 @@ const definitions: Definition[] = [
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const ep = device.getEndpoint(1);
-            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering']);
+            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering', 'manuSpecificNodOnFilPilote']);
             await reporting.onOff(ep, {min: 1, max: 3600, change: 0});
             await reporting.readMeteringMultiplierDivisor(ep);
             await reporting.instantaneousDemand(ep);
             await reporting.currentSummDelivered(ep);
-            await ep.read('manuSpecificNodOnFilPilote', ['mode']);
+            const p = reporting.payload('mode', 0, 120, 0, {min: 1, max: 3600, change: 0});
+            await ep.configureReporting('manuSpecificNodOnFilPilote', p);
         },
     },
 ];


### PR DESCRIPTION
Following "Update SIN-4-FP-21 and SIN-4-FP-20 from NodOn #6429" topic

I found 2 bugs and a missing feature

Bugs;
1- anti-freeze and stop values must be reversed
2- the toZibee for nodon use a buffer instead of a uint8 making the command not effective

Missing feature:
The device can be forced to a mode when using the dedicated button
The current implem does not take this into account