### PR TITLE
fix(detect): Detect `TRADFRI bulb E26 WW G95 CL 440lm` as IKEA LED2102G3

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -463,10 +463,10 @@ const definitions: Definition[] = [
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {
-        zigbeeModel: ['TRADFRI bulb E27 WW G95 CL 470lm', 'TRADFRI bulb E26 WW G95 CL 450lm'],
+        zigbeeModel: ['TRADFRI bulb E27 WW G95 CL 470lm', 'TRADFRI bulb E26 WW G95 CL 450lm', 'TRADFRI bulb E26 WW G95 CL 440lm'],
         model: 'LED2102G3',
         vendor: 'IKEA',
-        description: 'TRADFRI bulb E26/E27 WW 450/470 lumen, wireless dimmable warm white/globe clear',
+        description: 'TRADFRI bulb E26/E27 WW 440/450/470 lumen, wireless dimmable warm white/globe clear',
         extend: tradfriExtend.light_onoff_brightness(),
     },
     {


### PR DESCRIPTION
Japanese or maybe 100V version of the bulb is sold as 440lm.