### PR TITLE
fix(detect): detect `_TZ3000_saiqcn0y` as WSD500A

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1880,6 +1880,7 @@ const definitions: Definition[] = [
             {modelID: 'TS0201', manufacturerName: '_TZ3000_6uzkisv2'},
             {modelID: 'TS0201', manufacturerName: '_TZ3000_xr3htd96'},
             {modelID: 'TS0201', manufacturerName: '_TZ3000_fllyghyj'},
+            {modelID: 'TS0201', manufacturerName: '_TZ3000_saiqcn0y'},
         ],
         model: 'WSD500A',
         vendor: 'TuYa',


### PR DESCRIPTION
Hello, I picked up a couple of TuYa temperature/humidity sensors from [aliexpress](https://www.aliexpress.com/item/1005003707857013.html) and they're being misdetected by zigbee2mqtt as a TuYa temperature sensor with display.