### PR TITLE
Update yale.ts

### DIFF
--- a/src/devices/yale.ts
+++ b/src/devices/yale.ts
@@ -86,6 +86,13 @@ const definitions: Definition[] = [
         extend: lockExtend(),
     },
     {
+        zigbeeModel: ['YRD652 TSDB', 'YRD652L TSDB'],
+        model: 'YRD652HA20BP',
+        vendor: 'Yale',
+        description: 'Assure lock SL',
+        extend: lockExtend(),
+    },
+    {
         zigbeeModel: ['0600000001'],
         model: 'YMF30',
         vendor: 'Yale',


### PR DESCRIPTION
Added the YRD652 Assure Lock SL which replaces the YRD256 Assure Lock.  The locks have the same functionality but the 652 is the upgraded version.