### PR TITLE
Namron thermostat Window open check min value

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -493,7 +493,7 @@ const definitions: Definition[] = [
                 .withDescription('The temperature on the display.  Default: Room Temperature.'),
             e.numeric('window_open_check', ea.ALL)
                 .withUnit('°C')
-                .withValueMin(1.5).withValueMax(4).withValueStep(0.5)
+                .withValueMin(0).withValueMax(4).withValueStep(0.5)
                 .withDescription('The threshold to detect window open, between 1.5 and 4 in 0.5 °C.  Default: 0 (disabled).'),
             e.numeric('hysterersis', ea.ALL)
                 .withUnit('°C')


### PR DESCRIPTION
Window open check min value should be 0 (disabled)

I'm not 100% sure this is the correct way to solve these error messages in Home Assistant?

Logger: homeassistant.components.mqtt.number
Source: components/mqtt/number.py:194
Integration: MQTT ([documentation](https://www.home-assistant.io/integrations/mqtt), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+mqtt%22))
First occurred: 10:41:58 (76 occurrences)
Last logged: 11:11:42

Invalid value for number.badrum_golvvarme_window_open_check: 0 (range 1.5 - 4.0)