### PR TITLE
feat: Extend generators

### DIFF
--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -10,6 +10,7 @@ const e = exposes.presets;
 const ea = exposes.access;
 import * as globalStore from '../lib/store';
 import * as xiaomi from '../lib/xiaomi';
+import xiaomiExtend2 from '../lib/extend/xiaomi';
 import * as utils from '../lib/utils';
 import {Definition, OnEvent, Fz, KeyValue, Tz, Extend} from '../lib/types';
 const {printNumbersAsHexSequence} = utils;
@@ -2559,6 +2560,7 @@ const definitions: Definition[] = [
         exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'),
             e.power(), e.current(), e.energy(), e.voltage(), e.device_temperature(),
         ],
+        extend: [xiaomiExtend2.switchType],
         ota: ota.zigbeeOTA,
     },
     {

--- a/src/lib/extend/xiaomi.ts
+++ b/src/lib/extend/xiaomi.ts
@@ -1,0 +1,17 @@
+import extend from '../extend';
+
+const manufacturerCode = 0x115f;
+
+const xiaomi = {
+    switchType: extend.enumLookup({
+        name: 'switch_type',
+        lookup: {'toggle': 1, 'momentary': 2, 'none': 3},
+        cluster: 'aqaraOpple',
+        attribute: {id: 0x000a, type: 0x20},
+        description: 'External switch type',
+        zigbeeOptions: {manufacturerCode},
+    }),
+};
+
+export default xiaomi;
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,7 +100,7 @@ export type Definition = {
         updateToLatest: (device: Zh.Device, logger: Logger, onProgress: Ota.OnProgress) => Promise<number>;
     }
 } & ({ zigbeeModel: string[] } | { fingerprint: Fingerprint[] })
-    & ({ extend: Extend, fromZigbee?: Fz.Converter[], toZigbee?: Tz.Converter[],
+    & ({ extend: Extend | Extend[], fromZigbee?: Fz.Converter[], toZigbee?: Tz.Converter[],
         exposes?: (Expose[] | ((device: Zh.Device, options: KeyValue) => Expose[])) } |
     { fromZigbee: Fz.Converter[], toZigbee: Tz.Converter[], exposes: (Expose[] | ((device: Zh.Device, options: KeyValue) => Expose[])) });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -556,6 +556,18 @@ export function getFromLookup<V>(value: unknown, lookup: {[s: number | string]: 
     return result ?? defaultValue;
 }
 
+export function getFromLookupByValue(value: unknown, lookup: {[s: string]: unknown}, defaultValue: string=undefined): string {
+    for (const entry of Object.entries(lookup)) {
+        if (entry[1] === value) {
+            return entry[0];
+        }
+    }
+    if (defaultValue === undefined) {
+        throw new Error(`Expected one of: ${Object.values(lookup).join(', ')}, got: '${value}'`);
+    }
+    return defaultValue;
+}
+
 export function assertEndpoint(obj: unknown): asserts obj is Zh.Endpoint {
     if (obj?.constructor?.name?.toLowerCase() !== 'endpoint') throw new Error('Not an endpoint');
 }


### PR DESCRIPTION
**Problem**
Currently when e.g. adding support for a new attribute a new `toZigbee`, `fromZigbee` and `exposes` has to be created and added to the definition. When a lookup is used, it's values are also duplicate in `toZigbee`, `fromZigbee` and `exposes`. This creates a lot of code like https://github.com/Koenkk/zigbee-herdsman-converters/pull/6457 and https://github.com/Koenkk/zigbee-herdsman-converters/pull/6469.

**Solution**
Make extend more generic by adding extend generators, the extend generator generates the `toZigbee`, `fromZigbee` and `exposes` code. I've added an example for the Xiaomi switch type. Later we can also add a function which dynamically determines the extend for a certain device (e.g. an unsupported bulb).


Please review: @kirovilya @photomoose @sjorge @nurikk