### PR TITLE
innr RB 279 T lights not responding

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -209,6 +209,9 @@ const definitions: Definition[] = [
         extend: extend.light_onoff_brightness_colortemp({colorTempRange: [153, 555]}),
         meta: {applyRedFix: true, turnsOffAtBrightness1: true},
         ota: ota.zigbeeOTA,
+        endpoint: (device) => {
+            return {default: 1};
+        },
     },
     {
         zigbeeModel: ['RB 285 C'],


### PR DESCRIPTION
The innr RB 279 T lights seem to have an issue similar to BY 266 and RB 266 (see https://github.com/Koenkk/zigbee-herdsman-converters/commit/91a47a8d0b09f1317f47e10042f433929b70737b  )