### PR TITLE
update `as` assertions to `satisfies`

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -6164,7 +6164,7 @@ const converters2 = {
             // also trigger movement, because there is no illuminance without movement
             // https://github.com/Koenkk/zigbee-herdsman-converters/issues/1925
             msg.data.occupancy = 1;
-            const payload = await converters1.occupancy_with_timeout.convert(model, msg, publish, options, meta);
+            const payload = await converters1.occupancy_with_timeout.convert(model, msg, publish, options, meta) as KeyValueAny;
             if (payload) {
                 // DEPRECATED: remove illuminance_lux here.
                 const illuminance = msg.data['measuredValue'];
@@ -6209,7 +6209,7 @@ const converters2 = {
                 const sidelookup: KeyValueAny = {5: 'right', 7: 'right', 40: 'left', 56: 'left'};
                 if (sidelookup[value]) {
                     msg.data.occupancy = 1;
-                    const payload = await converters1.occupancy_with_timeout.convert(model, msg, publish, options, meta);
+                    const payload = await converters1.occupancy_with_timeout.convert(model, msg, publish, options, meta) as KeyValueAny;
                     if (payload) {
                         payload.action_side = sidelookup[value];
                         payload.side = sidelookup[value]; /* legacy: remove this line (replaced by action_side) */

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3,7 +3,7 @@ import {
     calibrateAndPrecisionRoundOptions, addActionGroup, postfixWithEndpointName, getKey,
     batteryVoltageToPercentage,
 } from '../lib/utils';
-import {Fz, KeyValueAny, KeyValueNumberString} from '../lib/types';
+import {Fz, KeyValueAny, KeyValueNumberString, Option} from '../lib/types';
 import * as globalStore from '../lib/store';
 import * as constants from '../lib/constants';
 import * as libColor from '../lib/color';
@@ -26,7 +26,7 @@ const converters1 = {
                 return {fan_mode: key, fan_state: key === 'off' ? 'OFF' : 'ON'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -175,7 +175,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thermostat_weekly_schedule: {
         cluster: 'hvacThermostat',
         type: ['commandGetWeeklyScheduleRsp'],
@@ -201,7 +201,7 @@ const converters1 = {
 
             return {[postfixWithEndpointName('weekly_schedule', msg, model, meta)]: {days, transitions}};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hvac_user_interface: {
         cluster: 'hvacUserInterfaceCfg',
         type: ['attributeReport', 'readResponse'],
@@ -217,7 +217,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lock_operation_event: {
         cluster: 'closuresDoorLock',
         type: 'commandOperationEventNotification',
@@ -248,7 +248,7 @@ const converters1 = {
                 action_source_name: constants.lockSourceName[msg.data['opereventsrc']],
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lock_programming_event: {
         cluster: 'closuresDoorLock',
         type: 'commandProgrammingEventNotification',
@@ -269,7 +269,7 @@ const converters1 = {
                 action_source_name: constants.lockSourceName[msg.data['programeventsrc']],
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lock: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],
@@ -296,7 +296,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lock_pin_code_response: {
         cluster: 'closuresDoorLock',
         type: ['commandGetPinCodeRsp'],
@@ -317,7 +317,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lock_user_status_response: {
         cluster: 'closuresDoorLock',
         type: ['commandGetUserStatusRsp'],
@@ -338,14 +338,14 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     linkquality_from_basic: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {linkquality: msg.linkquality};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -393,7 +393,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     temperature: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -405,7 +405,7 @@ const converters1 = {
                 return {[property]: calibrateAndPrecisionRoundOptions(temperature, options, 'temperature')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     device_temperature: {
         cluster: 'genDeviceTempCfg',
         type: ['attributeReport', 'readResponse'],
@@ -416,7 +416,7 @@ const converters1 = {
                 return {device_temperature: calibrateAndPrecisionRoundOptions(value, options, 'device_temperature')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     humidity: {
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
@@ -432,7 +432,7 @@ const converters1 = {
                 return {[property]: calibrateAndPrecisionRoundOptions(humidity, options, 'humidity')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     pm25: {
         cluster: 'pm25Measurement',
         type: ['attributeReport', 'readResponse'],
@@ -441,7 +441,7 @@ const converters1 = {
                 return {pm25: msg.data['measuredValue']};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     soil_moisture: {
         cluster: 'msSoilMoisture',
         type: ['attributeReport', 'readResponse'],
@@ -450,7 +450,7 @@ const converters1 = {
             const soilMoisture = parseFloat(msg.data['measuredValue']) / 100.0;
             return {soil_moisture: calibrateAndPrecisionRoundOptions(soilMoisture, options, 'soil_moisture')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     illuminance: {
         cluster: 'msIlluminanceMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -464,7 +464,7 @@ const converters1 = {
                 illuminance_lux: calibrateAndPrecisionRoundOptions(illuminanceLux, options, 'illuminance_lux'),
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     pressure: {
         cluster: 'msPressureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -479,14 +479,14 @@ const converters1 = {
             }
             return {pressure: calibrateAndPrecisionRoundOptions(pressure, options, 'pressure')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     co2: {
         cluster: 'msCO2',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {co2: Math.floor(msg.data.measuredValue * 1000000)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     occupancy: {
         // This is for occupancy sensor that send motion start AND stop messages
         cluster: 'msOccupancySensing',
@@ -499,7 +499,7 @@ const converters1 = {
                 return payload;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     occupancy_with_timeout: {
         // This is for occupancy sensor that only send a message when motion detected,
         // but do not send a motion stop.
@@ -534,7 +534,7 @@ const converters1 = {
             utils.noOccupancySince(msg.endpoint, options, publish, 'start');
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     occupancy_timeout: {
         cluster: 'msOccupancySensing',
         type: ['attributeReport', 'readResponse'],
@@ -543,7 +543,7 @@ const converters1 = {
                 return {occupancy_timeout: msg.data.pirOToUDelay};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     brightness: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -553,7 +553,7 @@ const converters1 = {
                 return {[property]: msg.data['currentLevel']};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     level_config: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -618,7 +618,7 @@ const converters1 = {
                 return result;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     color_colortemp: {
         cluster: 'lightingColorCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -678,7 +678,7 @@ const converters1 = {
             //       we use assign here so we do not lose other attributes.
             return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, meta.logger));
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     meter_identification: {
         cluster: 'haMeterIdentification',
         type: ['readResponse'],
@@ -697,7 +697,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     metering: {
         /**
          * When using this converter also add the following to the configure method of the device:
@@ -705,8 +705,9 @@ const converters1 = {
          */
         cluster: 'seMetering',
         type: ['attributeReport', 'readResponse'],
+        // FIXME: Why are we expecting errors here? Sounds like a codesmell
         options: (definition) => {
-            const result: KeyValueAny = [];
+            const result: Option[] = [];
             // @ts-expect-error
             if (definition.exposes.find((e) => e.name === 'power')) {
                 result.push(exposes.options.precision('power'), exposes.options.calibration('power', 'percentual'));
@@ -751,7 +752,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     electrical_measurement: {
         /**
          * When using this converter also add the following to the configure method of the device:
@@ -802,7 +803,7 @@ const converters1 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     on_off: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -819,7 +820,7 @@ const converters1 = {
                 return payload;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     on_off_force_multiendpoint: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -840,7 +841,7 @@ const converters1 = {
                 return payload;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     on_off_skip_duplicate_transaction: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -860,7 +861,7 @@ const converters1 = {
                 return payload;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     power_on_behavior: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -871,7 +872,7 @@ const converters1 = {
                 return {[property]: lookup[msg.data['startUpOnOff']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_no_alarm: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'commandStatusChangeNotification'],
@@ -882,7 +883,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_siren: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -898,7 +899,7 @@ const converters1 = {
                 test: (zoneStatus & 1<<8) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_water_leak_alarm_1: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -910,7 +911,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_water_leak_alarm_1_report: {
         cluster: 'ssIasZone',
         type: 'attributeReport',
@@ -922,7 +923,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_vibration_alarm_1: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -934,7 +935,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_vibration_alarm_1_with_timeout: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -963,7 +964,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_gas_alarm_1: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -975,7 +976,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_gas_alarm_2: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -987,7 +988,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_smoke_alarm_1: {
         cluster: 'ssIasZone',
         type: ['commandStatusChangeNotification', 'attributeReport', 'readResponse'],
@@ -1005,7 +1006,7 @@ const converters1 = {
                 battery_defect: (zoneStatus & 1<<9) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_contact_alarm_1: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1021,7 +1022,7 @@ const converters1 = {
                 [batteryLowProperty]: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_contact_alarm_1_report: {
         cluster: 'ssIasZone',
         type: 'attributeReport',
@@ -1033,7 +1034,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_carbon_monoxide_alarm_1: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1045,7 +1046,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_carbon_monoxide_alarm_1_gas_alarm_2: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1062,7 +1063,7 @@ const converters1 = {
                 battery_defect: (zoneStatus & 1 << 9) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_sos_alarm_2: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1074,7 +1075,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_occupancy_alarm_1: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1086,7 +1087,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_occupancy_alarm_1_report: {
         cluster: 'ssIasZone',
         type: 'attributeReport',
@@ -1098,7 +1099,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_occupancy_alarm_2: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1110,7 +1111,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_alarm_only_alarm_1: {
         cluster: 'ssIasZone',
         type: 'attributeReport',
@@ -1120,7 +1121,7 @@ const converters1 = {
                 alarm: (zoneStatus & 1) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_occupancy_only_alarm_2: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1130,7 +1131,7 @@ const converters1 = {
                 occupancy: (zoneStatus & 1<<1) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_occupancy_alarm_1_with_timeout: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1153,7 +1154,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_store: {
         cluster: 'genScenes',
         type: 'commandStore',
@@ -1163,7 +1164,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_recall: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -1173,7 +1174,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_panic: {
         cluster: 'ssIasAce',
         type: 'commandPanic',
@@ -1183,7 +1184,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_arm: {
         cluster: 'ssIasAce',
         type: 'commandArm',
@@ -1197,7 +1198,7 @@ const converters1 = {
             if (msg.groupID) payload.action_group = msg.groupID;
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_cover_stop: {
         cluster: 'closuresWindowCovering',
         type: 'commandStop',
@@ -1207,7 +1208,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_cover_open: {
         cluster: 'closuresWindowCovering',
         type: 'commandUpOpen',
@@ -1217,7 +1218,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_cover_close: {
         cluster: 'closuresWindowCovering',
         type: 'commandDownClose',
@@ -1227,7 +1228,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_on: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -1237,7 +1238,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_off: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -1247,7 +1248,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_off_with_effect: {
         cluster: 'genOnOff',
         type: 'commandOffWithEffect',
@@ -1257,7 +1258,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_toggle: {
         cluster: 'genOnOff',
         type: 'commandToggle',
@@ -1267,7 +1268,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move_to_level: {
         cluster: 'genLevelCtrl',
         type: ['commandMoveToLevel', 'commandMoveToLevelWithOnOff'],
@@ -1292,7 +1293,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move: {
         cluster: 'genLevelCtrl',
         type: ['commandMove', 'commandMoveWithOnOff'],
@@ -1329,7 +1330,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_step: {
         cluster: 'genLevelCtrl',
         type: ['commandStep', 'commandStepWithOnOff'],
@@ -1358,7 +1359,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_stop: {
         cluster: 'genLevelCtrl',
         type: ['commandStop', 'commandStopWithOnOff'],
@@ -1374,7 +1375,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move_color_temperature: {
         cluster: 'lightingColorCtrl',
         type: ['commandMoveColorTemp'],
@@ -1386,7 +1387,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_step_color_temperature: {
         cluster: 'lightingColorCtrl',
         type: 'commandStepColorTemp',
@@ -1405,7 +1406,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_ehanced_move_to_hue_and_saturation: {
         cluster: 'lightingColorCtrl',
         type: 'commandEnhancedMoveToHueAndSaturation',
@@ -1422,7 +1423,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_step_hue: {
         cluster: 'lightingColorCtrl',
         type: ['commandStepHue'],
@@ -1437,7 +1438,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_step_saturation: {
         cluster: 'lightingColorCtrl',
         type: ['commandStepSaturation'],
@@ -1452,7 +1453,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_color_loop_set: {
         cluster: 'lightingColorCtrl',
         type: 'commandColorLoopSet',
@@ -1482,7 +1483,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move_to_color_temp: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToColorTemp',
@@ -1496,7 +1497,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move_to_color: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToColor',
@@ -1513,7 +1514,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move_hue: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
@@ -1525,7 +1526,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move_to_saturation: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToSaturation',
@@ -1539,7 +1540,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_move_to_hue: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToHue',
@@ -1554,7 +1555,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_emergency: {
         cluster: 'ssIasAce',
         type: 'commandEmergency',
@@ -1564,7 +1565,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_on_state: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -1573,7 +1574,7 @@ const converters1 = {
             const property = postfixWithEndpointName('state', msg, model, meta);
             return {[property]: 'ON'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_off_state: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -1582,14 +1583,14 @@ const converters1 = {
             const property = postfixWithEndpointName('state', msg, model, meta);
             return {[property]: 'OFF'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     identify: {
         cluster: 'genIdentify',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {action: postfixWithEndpointName(`identify`, msg, model, meta)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cover_position_tilt: {
         cluster: 'closuresWindowCovering',
         type: ['attributeReport', 'readResponse'],
@@ -1621,7 +1622,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cover_position_via_brightness: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -1633,7 +1634,7 @@ const converters1 = {
             const state = options.invert_cover ? (position > 0 ? 'CLOSE' : 'OPEN') : (position > 0 ? 'OPEN' : 'CLOSE');
             return {state: state, position: position};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cover_state_via_onoff: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1642,7 +1643,7 @@ const converters1 = {
                 return {state: msg.data['onOff'] === 1 ? 'OPEN' : 'CLOSE'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     curtain_position_analog_output: {
         cluster: 'genAnalogOutput',
         type: ['attributeReport', 'readResponse'],
@@ -1652,7 +1653,7 @@ const converters1 = {
             position = options.invert_cover ? 100 - position : position;
             return {position};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lighting_ballast_configuration: {
         cluster: 'lightingBallastCfg',
         type: ['attributeReport', 'readResponse'],
@@ -1705,7 +1706,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     checkin_presence: {
         cluster: 'genPollCtrl',
         type: ['commandCheckIn'],
@@ -1722,7 +1723,7 @@ const converters1 = {
 
             return {presence: true};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_enroll: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],
@@ -1736,7 +1737,7 @@ const converters1 = {
                 zone_id: zoneId,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_wd: {
         cluster: 'ssIasWd',
         type: ['attributeReport', 'readResponse'],
@@ -1745,7 +1746,7 @@ const converters1 = {
             if (msg.data.hasOwnProperty('maxDuration')) result['max_duration'] = msg.data.maxDuration;
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     power_source: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -1773,7 +1774,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     // #endregion
 
     // #region Non-generic converters
@@ -1835,7 +1836,7 @@ const converters1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     namron_hvac_user_interface: {
         cluster: 'hvacUserInterfaceCfg',
         type: ['attributeReport', 'readResponse'],
@@ -1846,7 +1847,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     elko_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -1913,7 +1914,7 @@ const converters1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_smoke_alarm_1_develco: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -1927,7 +1928,7 @@ const converters1 = {
                 test: (zoneStatus & 1<<8) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ts0201_temperature_humidity_alarm: {
         cluster: 'manuSpecificTuya_2',
         type: ['attributeReport', 'readResponse'],
@@ -1956,7 +1957,7 @@ const converters1 = {
             return result;
         },
 
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_led_controller: {
         cluster: 'lightingColorCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -1995,7 +1996,7 @@ const converters1 = {
 
             return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, meta.logger));
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wiser_device_info: {
         cluster: 'wiserDeviceInfo',
         type: 'attributeReport',
@@ -2029,7 +2030,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_doorbell_button: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -2043,7 +2044,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     terncy_knob: {
         cluster: 'manuSpecificClusterAduroSmart',
         type: ['attributeReport', 'readResponse'],
@@ -2054,7 +2055,7 @@ const converters1 = {
                 return {action: 'rotate', action_direction: direction, action_number: number};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     DTB190502A1: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -2072,7 +2073,7 @@ const converters1 = {
                 led_state: lookupLED[msg.data['41363']],
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZNMS12LM_low_battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -2081,7 +2082,7 @@ const converters1 = {
                 return {battery_low: msg.data['batteryAlarmMask'] === 1};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_lock_report: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -2115,7 +2116,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZigUP: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -2145,14 +2146,14 @@ const converters1 = {
                 [`${ds18b20Id}`]: ds18b20Value,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     terncy_contact: {
         cluster: 'genBinaryInput',
         type: 'attributeReport',
         convert: (model, msg, publish, options, meta) => {
             return {contact: (msg.data['presentValue']==0)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     terncy_temperature: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -2161,7 +2162,7 @@ const converters1 = {
             const temperature = parseFloat(msg.data['measuredValue']) / 10.0;
             return {temperature: calibrateAndPrecisionRoundOptions(temperature, options, 'temperature')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ts0216_siren: {
         cluster: 'ssIasWd',
         type: ['attributeReport', 'readResponse'],
@@ -2176,7 +2177,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_cover_options_2: {
         cluster: 'closuresWindowCovering',
         type: ['attributeReport', 'readResponse'],
@@ -2193,7 +2194,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_cover_options: {
         cluster: 'closuresWindowCovering',
         type: ['attributeReport', 'readResponse'],
@@ -2220,7 +2221,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     WSZ01_on_off_action: {
         cluster: 65029,
         type: 'raw',
@@ -2228,7 +2229,7 @@ const converters1 = {
             const clickMapping: KeyValueNumberString = {0: 'release', 1: 'single', 2: 'double', 3: 'hold'};
             return {action: `${clickMapping[msg.data[6]]}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_on_off_action: {
         cluster: 'genOnOff',
         type: 'raw',
@@ -2252,7 +2253,7 @@ const converters1 = {
             msg.endpoint.defaultResponse(0xfd, 0, 6, msg.data[1]).catch((error) => {});
             return {action: `${button}${clickMapping[msg.data[3]]}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_switch_scene: {
         cluster: 'genOnOff',
         type: 'raw',
@@ -2264,7 +2265,7 @@ const converters1 = {
             msg.endpoint.defaultResponse(0xfd, 0, 6, msg.data[1]).catch((error) => {});
             return {action: 'switch_scene', action_scene: msg.data[3]};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_switch_state: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -2275,7 +2276,7 @@ const converters1 = {
                 state_right: status & 2 ? 'ON' : 'OFF',
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_socket_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2286,7 +2287,7 @@ const converters1 = {
                 return {state: status & 1 ? 'ON' : 'OFF'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_new_switch_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2297,7 +2298,7 @@ const converters1 = {
                 return {state: status & 1 ? 'ON' : 'OFF'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_new_switch_state_2gang: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2313,7 +2314,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_new_switch_state_4gang: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2340,7 +2341,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_curtain_switch_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2356,7 +2357,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_dimmer_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2379,7 +2380,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_cover_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2424,7 +2425,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_pir_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2439,7 +2440,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     easycode_action: {
         cluster: 'closuresDoorLock',
         type: 'raw',
@@ -2457,7 +2458,7 @@ const converters1 = {
                 return {action: lookup[msg.data[3]]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     easycodetouch_action: {
         cluster: 'closuresDoorLock',
         type: 'raw',
@@ -2469,7 +2470,7 @@ const converters1 = {
                 meta.logger.warn('Unknown lock status with source ' + msg.data[3] + ' and event code ' + msg.data[4]);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     livolo_switch_state_raw: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2554,7 +2555,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ptvo_switch_uart: {
         cluster: 'genMultistateValue',
         type: ['attributeReport', 'readResponse'],
@@ -2579,7 +2580,7 @@ const converters1 = {
             }
             return {'action': data};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ptvo_switch_analog_input: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
@@ -2650,7 +2651,7 @@ const converters1 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     keypad20states: {
         cluster: 'genOnOff',
         type: ['readResponse', 'attributeReport'],
@@ -2661,7 +2662,7 @@ const converters1 = {
                 return {[button]: state};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     keypad20_battery: {
         cluster: 'genPowerCfg',
         type: ['readResponse', 'attributeReport'],
@@ -2673,7 +2674,7 @@ const converters1 = {
                 // voltage: voltage / 1000.0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     plaid_battery: {
         cluster: 'genPowerCfg',
         type: ['readResponse', 'attributeReport'],
@@ -2688,7 +2689,7 @@ const converters1 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     heiman_ir_remote: {
         cluster: 'heimanSpecificInfraRedRemote',
         type: ['commandStudyKeyRsp', 'commandCreateIdRsp', 'commandGetIdAndKeyCodeListRsp'],
@@ -2741,7 +2742,7 @@ const converters1 = {
             }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     meazon_meter: {
         cluster: 'seMetering',
         type: ['attributeReport', 'readResponse'],
@@ -2810,7 +2811,7 @@ const converters1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     danfoss_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -2919,7 +2920,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     danfoss_thermostat_setpoint_scheduled: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -2931,7 +2932,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     danfoss_icon_battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -2948,7 +2949,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     danfoss_icon_regulator: {
         cluster: 'haDiagnostic',
         type: ['attributeReport', 'readResponse'],
@@ -2974,7 +2975,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     orvibo_raw_1: {
         cluster: 23,
         type: 'raw',
@@ -3010,7 +3011,7 @@ const converters1 = {
                 return {action: `${button}_${action}`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     orvibo_raw_2: {
         cluster: 23,
         type: 'raw',
@@ -3036,7 +3037,7 @@ const converters1 = {
                 return {action: `${button}_${action}`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tint_scene: {
         cluster: 'genBasic',
         type: 'write',
@@ -3045,7 +3046,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tint404011_move_to_color_temp: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToColorTemp',
@@ -3079,7 +3080,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZNMS11LM_closuresDoorLock_report: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],
@@ -3146,7 +3147,7 @@ const converters1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZNMS12LM_ZNMS13LM_closuresDoorLock_report: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],
@@ -3281,7 +3282,7 @@ const converters1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     restorable_brightness: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -3294,14 +3295,14 @@ const converters1 = {
                 return {};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1524_E1810_toggle: {
         cluster: 'genOnOff',
         type: 'commandToggle',
         convert: (model, msg, publish, options, meta) => {
             return {action: postfixWithEndpointName('toggle', msg, model, meta)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_arrow_click: {
         cluster: 'genScenes',
         type: 'commandTradfriArrowSingle',
@@ -3315,7 +3316,7 @@ const converters1 = {
             const direction = msg.data.value === 257 ? 'left' : 'right';
             return {action: `arrow_${direction}_click`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_arrow_hold: {
         cluster: 'genScenes',
         type: 'commandTradfriArrowHold',
@@ -3325,7 +3326,7 @@ const converters1 = {
             globalStore.putValue(msg.endpoint, 'direction', direction);
             return {action: `arrow_${direction}_hold`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_arrow_release: {
         cluster: 'genScenes',
         type: 'commandTradfriArrowRelease',
@@ -3341,7 +3342,7 @@ const converters1 = {
                 return result;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1524_E1810_levelctrl: {
         cluster: 'genLevelCtrl',
         type: [
@@ -3360,7 +3361,7 @@ const converters1 = {
             };
             return {action: lookup[msg.type]};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ewelink_action: {
         cluster: 'genOnOff',
         type: ['commandOn', 'commandOff', 'commandToggle'],
@@ -3368,14 +3369,14 @@ const converters1 = {
             const lookup: KeyValueAny = {'commandToggle': 'single', 'commandOn': 'double', 'commandOff': 'long'};
             return {action: lookup[msg.type]};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_contact: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {contact: msg.data['onOff'] !== 0};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_rspm: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -3389,14 +3390,14 @@ const converters1 = {
                 action: msg.data['41367'] === 1 ? 'hold' : 'release',
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     K4003C_binary_input: {
         cluster: 'genBinaryInput',
         type: 'attributeReport',
         convert: (model, msg, publish, options, meta) => {
             return {action: msg.data.presentValue === 1 ? 'off' : 'on'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     enocean_ptm215z: {
         cluster: 'greenPower',
         type: ['commandNotification', 'commandCommissioningNotification'],
@@ -3418,7 +3419,7 @@ const converters1 = {
             const action = lookup.hasOwnProperty(commandID) ? lookup[commandID] : `unknown_${commandID}`;
             return {action};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     enocean_ptm215ze: {
         cluster: 'greenPower',
         type: ['commandNotification', 'commandCommissioningNotification'],
@@ -3446,7 +3447,7 @@ const converters1 = {
                 return {action: lookup[commandID]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     enocean_ptm216z: {
         cluster: 'greenPower',
         type: ['commandNotification', 'commandCommissioningNotification'],
@@ -3473,7 +3474,7 @@ const converters1 = {
                 return {action: lookup[ID]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lifecontrolVoc: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -3490,7 +3491,7 @@ const converters1 = {
                 eco2, voc,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     _8840100H_water_leak_alarm: {
         cluster: 'haApplianceEventsAlerts',
         type: 'commandAlertsNotification',
@@ -3500,7 +3501,7 @@ const converters1 = {
                 water_leak: (alertStatus & 1<<12) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1E_G7F_action: {
         cluster: 64528,
         type: ['raw'],
@@ -3527,7 +3528,7 @@ const converters1 = {
                 return {action: lookup[msg.data[5]]}; // Just output the data from the above lookup list
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_freepad_clicks: {
         cluster: 'genMultistateInput',
         type: ['readResponse', 'attributeReport'],
@@ -3538,21 +3539,21 @@ const converters1 = {
             const action = lookup[clicks] ? lookup[clicks] : `many_${clicks}`;
             return {action: `${button}_${action}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     kmpcil_res005_occupancy: {
         cluster: 'genBinaryInput',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {occupancy: (msg.data['presentValue']===1)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     kmpcil_res005_on_off: {
         cluster: 'genBinaryOutput',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {state: (msg.data['presentValue']==0) ? 'OFF' : 'ON'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     _3310_humidity: {
         cluster: 'manuSpecificCentraliteHumidity',
         type: ['attributeReport', 'readResponse'],
@@ -3561,7 +3562,7 @@ const converters1 = {
             const humidity = parseFloat(msg.data['measuredValue']) / 100.0;
             return {humidity: calibrateAndPrecisionRoundOptions(humidity, options, 'humidity')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     smartthings_acceleration: {
         cluster: 'manuSpecificSamsungAccelerometer',
         type: ['attributeReport', 'readResponse'],
@@ -3584,7 +3585,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     byun_smoke_false: {
         cluster: 'pHMeasurement',
         type: ['attributeReport'],
@@ -3593,7 +3594,7 @@ const converters1 = {
                 return {smoke: false};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     byun_smoke_true: {
         cluster: 'ssIasZone',
         type: ['commandStatusChangeNotification'],
@@ -3602,7 +3603,7 @@ const converters1 = {
                 return {smoke: true};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     byun_gas_false: {
         cluster: 1034,
         type: ['raw'],
@@ -3611,7 +3612,7 @@ const converters1 = {
                 return {gas: false};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     byun_gas_true: {
         cluster: 'ssIasZone',
         type: ['commandStatusChangeNotification'],
@@ -3620,7 +3621,7 @@ const converters1 = {
                 return {gas: true};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_smart_button_event: {
         cluster: 'manuSpecificPhilips',
         type: 'commandHueNotification',
@@ -3629,14 +3630,14 @@ const converters1 = {
             const lookup: KeyValueAny = {0: 'press', 1: 'hold', 2: 'release', 3: 'release'};
             return {action: lookup[msg.data['type']]};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     legrand_binary_input_moving: {
         cluster: 'genBinaryInput',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {action: msg.data.presentValue ? 'moving' : 'stopped'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     legrand_binary_input_on_off: {
         cluster: 'genBinaryInput',
         type: ['attributeReport', 'readResponse'],
@@ -3645,7 +3646,7 @@ const converters1 = {
             const property = multiEndpoint ? postfixWithEndpointName('state', msg, model, meta) : 'state';
             return {[property]: msg.data.presentValue ? 'ON' : 'OFF'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bticino_4027C_binary_input_moving: {
         cluster: 'genBinaryInput',
         type: ['attributeReport', 'readResponse'],
@@ -3655,7 +3656,7 @@ const converters1 = {
                 {action: msg.data.presentValue ? 'stopped' : 'moving', position: 50} :
                 {action: msg.data.presentValue ? 'stopped' : 'moving'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     legrand_scenes: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -3663,7 +3664,7 @@ const converters1 = {
             const lookup: KeyValueAny = {0xfff7: 'enter', 0xfff6: 'leave', 0xfff4: 'sleep', 0xfff5: 'wakeup'};
             return {action: lookup[msg.data.groupid] ? lookup[msg.data.groupid] : 'default'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     legrand_master_switch_center: {
         cluster: 'manuSpecificLegrandDevices',
         type: 'raw',
@@ -3673,7 +3674,7 @@ const converters1 = {
                 return {action: 'center'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     legrand_cable_outlet_mode: {
         cluster: 'manuSpecificLegrandDevices2',
         type: ['readResponse'],
@@ -3693,7 +3694,7 @@ const converters1 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     legrand_power_alarm: {
         cluster: 'haElectricalMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -3716,7 +3717,7 @@ const converters1 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     legrand_greenpower: {
         cluster: 'greenPower',
         type: ['commandNotification', 'commandCommissioningNotification'],
@@ -3737,7 +3738,7 @@ const converters1 = {
                 return {action: lookup[commandID]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_power: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
@@ -3745,7 +3746,7 @@ const converters1 = {
         convert: (model, msg, publish, options, meta) => {
             return {power: calibrateAndPrecisionRoundOptions(msg.data['presentValue'], options, 'power')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_basic: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -3753,7 +3754,7 @@ const converters1 = {
         convert: async (model, msg, publish, options, meta) => {
             return await xiaomi.numericAttributes2Payload(msg, meta, model, options, msg.data);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_basic_raw: {
         cluster: 'genBasic',
         type: ['raw'],
@@ -3766,7 +3767,7 @@ const converters1 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -3774,7 +3775,7 @@ const converters1 = {
         convert: async (model, msg, publish, options, meta) => {
             return await xiaomi.numericAttributes2Payload(msg, meta, model, options, msg.data);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_on_off_action: {
         cluster: 'genOnOff',
         type: ['attributeReport'],
@@ -3805,7 +3806,7 @@ const converters1 = {
 
             return {action: `${action}${button}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_multistate_action: {
         cluster: 'genMultistateInput',
         type: ['attributeReport'],
@@ -3845,7 +3846,7 @@ const converters1 = {
                 return {action};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_occupancy_illuminance: {
         // This is for occupancy sensor that only send a message when motion detected,
         // but do not send a motion stop.
@@ -3883,7 +3884,7 @@ const converters1 = {
                 return payload;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     RTCGQ13LM_occupancy: {
         // This is for occupancy sensor that only send a message when motion detected,
         // but do not send a motion stop.
@@ -3920,7 +3921,7 @@ const converters1 = {
             utils.noOccupancySince(msg.endpoint, options, publish, 'start');
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_WXKG01LM_action: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -3969,14 +3970,14 @@ const converters1 = {
                 publish({action: payload});
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_contact: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {contact: msg.data['onOff'] === 0};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     W2_module_carbon_monoxide: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -3986,7 +3987,7 @@ const converters1 = {
                 carbon_monoxide: (zoneStatus & 1<<8) > 8,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_temperature: {
         cluster: 'msTemperatureMeasurement',
         options: [exposes.options.precision('temperature'), exposes.options.calibration('temperature')],
@@ -4000,7 +4001,7 @@ const converters1 = {
                 return {temperature: calibrateAndPrecisionRoundOptions(temperature, options, 'temperature')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_WXKG11LM_action: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -4017,7 +4018,7 @@ const converters1 = {
                 return {action: actionLookup[clicks]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_status_change_notification_action: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -4025,7 +4026,7 @@ const converters1 = {
             const lookup: KeyValueAny = {0: 'off', 1: 'single', 2: 'double', 3: 'hold'};
             return {action: lookup[msg.data.zonestatus]};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ptvo_multistate_action: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -4035,7 +4036,7 @@ const converters1 = {
             const action = actionLookup[value];
             return {action: postfixWithEndpointName(action, msg, model, meta)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     konke_action: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -4044,7 +4045,7 @@ const converters1 = {
             const lookup: KeyValueAny = {128: 'single', 129: 'double', 130: 'hold'};
             return lookup[value] ? {action: lookup[value]} : null;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_curtain_position: {
         cluster: 'genAnalogOutput',
         type: ['attributeReport', 'readResponse'],
@@ -4061,7 +4062,7 @@ const converters1 = {
             position = options.invert_cover ? 100 - position : position;
             return {position};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_curtain_position_tilt: {
         cluster: 'closuresWindowCovering',
         type: ['attributeReport', 'readResponse'],
@@ -4082,7 +4083,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_curtain_hagl04_status: {
         cluster: 'genMultistateOutput',
         type: ['attributeReport'],
@@ -4105,7 +4106,7 @@ const converters1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_curtain_hagl07_status: {
         cluster: 'genMultistateOutput',
         type: ['attributeReport'],
@@ -4128,7 +4129,7 @@ const converters1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_curtain_acn002_status: {
         cluster: 'genMultistateOutput',
         type: ['attributeReport'],
@@ -4152,7 +4153,7 @@ const converters1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_operation_mode_basic: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -4177,7 +4178,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     qlwz_letv8key_switch: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -4190,7 +4191,7 @@ const converters1 = {
                 return {action: `${action}_${button}`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_multistate: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -4213,7 +4214,7 @@ const converters1 = {
                 return {action: `button_${button}_${actionLookup[value]}`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_on: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -4221,7 +4222,7 @@ const converters1 = {
             if (hasAlreadyProcessedMessage(msg, model)) return;
             return {action: 'button_2_single'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_off: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -4229,7 +4230,7 @@ const converters1 = {
             if (hasAlreadyProcessedMessage(msg, model)) return;
             return {action: 'button_1_single'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_step: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -4238,7 +4239,7 @@ const converters1 = {
             const button = msg.data.stepmode === 0 ? '4' : '3';
             return {action: `button_${button}_single`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -4253,7 +4254,7 @@ const converters1 = {
                 return payload;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_move: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -4263,7 +4264,7 @@ const converters1 = {
             globalStore.putValue(msg.endpoint, 'button', {button, start: Date.now()});
             return {action: `button_${button}_hold`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_step_color_temp: {
         cluster: 'lightingColorCtrl',
         type: 'commandStepColorTemp',
@@ -4279,7 +4280,7 @@ const converters1 = {
             }
             return {action: `button_${action}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_opple_move_color_temp: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveColorTemp',
@@ -4300,7 +4301,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     keen_home_smart_vent_pressure: {
         cluster: 'msPressureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -4309,7 +4310,7 @@ const converters1 = {
             const pressure = msg.data.hasOwnProperty('measuredValue') ? msg.data.measuredValue : parseFloat(msg.data['32']) / 1000.0;
             return {pressure: calibrateAndPrecisionRoundOptions(pressure, options, 'pressure')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     U02I007C01_contact: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -4320,7 +4321,7 @@ const converters1 = {
                 contact: !((zoneStatus & 1) > 0),
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     U02I007C01_water_leak: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -4331,7 +4332,7 @@ const converters1 = {
                 water_leak: (zoneStatus & 1) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     heiman_hcho: {
         cluster: 'heimanSpecificFormaldehydeMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -4340,7 +4341,7 @@ const converters1 = {
                 return {hcho: parseFloat(msg.data['measuredValue']) / 100.0};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     heiman_air_quality: {
         cluster: 'heimanSpecificAirQuality',
         type: ['attributeReport', 'readResponse'],
@@ -4359,14 +4360,14 @@ const converters1 = {
             if (msg.data['pm10measuredValue']) result['pm10'] = msg.data['pm10measuredValue'];
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     scenes_recall_scene_65024: {
         cluster: 65024,
         type: ['raw'],
         convert: (model, msg, publish, options, meta) => {
             return {action: `scene_${msg.data[msg.data.length - 2] - 9}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     color_stop_raw: {
         cluster: 'lightingColorCtrl',
         type: ['raw'],
@@ -4375,7 +4376,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     MFKZQ01LM_action_multistate: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -4425,7 +4426,7 @@ const converters1 = {
 
             return result ? result : null;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     MFKZQ01LM_action_analog: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
@@ -4445,7 +4446,7 @@ const converters1 = {
             if (!isLegacyEnabled(options)) delete result.angle;
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tradfri_occupancy: {
         cluster: 'genOnOff',
         type: 'commandOnWithTimedOff',
@@ -4474,7 +4475,7 @@ const converters1 = {
 
             return {occupancy: true, illuminance_above_threshold: onlyWhenOnFlag};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     almond_click: {
         cluster: 'ssIasAce',
         type: ['commandArm'],
@@ -4497,7 +4498,7 @@ const converters1 = {
                 return {action: lookup[action]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     SAGE206612_state: {
         cluster: 'genOnOff',
         type: ['commandOn', 'commandOff'],
@@ -4519,7 +4520,7 @@ const converters1 = {
                 list.push(timer);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZMCSW032D_cover_position: {
         cluster: 'closuresWindowCovering',
         type: ['attributeReport', 'readResponse'],
@@ -4601,7 +4602,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     PGC410EU_presence: {
         cluster: 'manuSpecificSmartThingsArrivalSensor',
         type: 'commandArrivalSensorNotify',
@@ -4618,7 +4619,7 @@ const converters1 = {
 
             return {presence: true};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     STS_PRS_251_presence: {
         cluster: 'genBinaryInput',
         type: ['attributeReport', 'readResponse'],
@@ -4635,7 +4636,7 @@ const converters1 = {
 
             return {presence: true};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1745_requested_brightness: {
         // Possible values are 76 (30%) or 254 (100%)
         cluster: 'genLevelCtrl',
@@ -4646,7 +4647,7 @@ const converters1 = {
                 requested_brightness_percent: mapNumberRange(msg.data.level, 0, 254, 0, 100),
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_bulb_interval: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -4660,7 +4661,7 @@ const converters1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     heiman_scenes: {
         cluster: 'heimanSpecificScenes',
         type: ['commandAtHome', 'commandGoOut', 'commandCinema', 'commandRepast', 'commandSleep'],
@@ -4674,7 +4675,7 @@ const converters1 = {
             };
             if (lookup.hasOwnProperty(msg.type)) return {action: lookup[msg.type]};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     javis_lock_report: {
         cluster: 'genBasic',
         type: 'attributeReport',
@@ -4711,7 +4712,7 @@ const converters1 = {
                 action_source_name: lookup[data[5]],
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_freepad_config: {
         cluster: 'genOnOffSwitchCfg',
         type: ['readResponse'],
@@ -4725,7 +4726,7 @@ const converters1 = {
                 [`switch_actions_${button}`]: switchActionsLookup[switchActions],
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_geiger: {
         cluster: 'msIlluminanceMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -4735,7 +4736,7 @@ const converters1 = {
                 radiation_dose_per_hour: msg.data['61442'],
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_geiger_config: {
         cluster: 'msIlluminanceLevelSensing',
         type: 'readResponse',
@@ -4761,7 +4762,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_airsense_config_co2: {
         cluster: 'msCO2',
         type: 'readResponse',
@@ -4781,7 +4782,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_airsense_config_temp: {
         cluster: 'msTemperatureMeasurement',
         type: 'readResponse',
@@ -4792,7 +4793,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_airsense_config_pres: {
         cluster: 'msPressureMeasurement',
         type: 'readResponse',
@@ -4804,7 +4805,7 @@ const converters1 = {
             return result;
         },
 
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_airsense_config_hum: {
         cluster: 'msRelativeHumidity',
         type: 'readResponse',
@@ -4815,7 +4816,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     diyruz_zintercom_config: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],
@@ -4847,7 +4848,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     JTQJBF01LMBW_gas_density: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -4860,7 +4861,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     JTQJBF01LMBW_sensitivity: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],
@@ -4877,7 +4878,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     DJT11LM_vibration: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],
@@ -4950,21 +4951,21 @@ const converters1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     DJT12LM_vibration: {
         cluster: 'genOnOff',
         type: 'commandOn',
         convert: (model, msg, publish, options, meta) => {
             return {action: 'vibration'};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CC2530ROUTER_led: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {led: msg.data['onOff'] === 1};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CC2530ROUTER_meta: {
         cluster: 'genBinaryValue',
         type: ['attributeReport', 'readResponse'],
@@ -4976,14 +4977,14 @@ const converters1 = {
                 rssi: data['presentValue'],
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     KAMI_contact: {
         cluster: 'ssIasZone',
         type: ['raw'],
         convert: (model, msg, publish, options, meta) => {
             return {contact: msg.data[7] === 0};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     KAMI_occupancy: {
         cluster: 'msOccupancySensing',
         type: ['raw'],
@@ -4992,7 +4993,7 @@ const converters1 = {
                 return {action: 'motion'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     DNCKAT_S00X_buttons: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -5008,7 +5009,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_on_off_ignore_endpoint_4_5_6: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -5019,7 +5020,7 @@ const converters1 = {
                 return {[property]: msg.data['onOff'] === 1 ? 'ON' : 'OFF'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_motion_sensitivity: {
         cluster: 'msOccupancySensing',
         type: ['attributeReport', 'readResponse'],
@@ -5029,7 +5030,7 @@ const converters1 = {
                 return {motion_sensitivity: lookup[msg.data['48']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_motion_led_indication: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -5038,7 +5039,7 @@ const converters1 = {
                 return {led_indication: msg.data['51'] === 1};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_wall_switch_device_mode: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -5048,7 +5049,7 @@ const converters1 = {
                 return {device_mode: values[msg.data['52']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CCTSwitch_D0001_levelctrl: {
         cluster: 'genLevelCtrl',
         options: [exposes.options.legacy()],
@@ -5120,7 +5121,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CCTSwitch_D0001_lighting: {
         cluster: 'lightingColorCtrl',
         type: ['commandMoveToColorTemp', 'commandMoveColorTemp'],
@@ -5205,7 +5206,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_wall_switch: {
         cluster: 'manuSpecificPhilips',
         type: 'commandHueNotification',
@@ -5216,7 +5217,7 @@ const converters1 = {
             const type = typeLookup[msg.data['type']];
             return {action: `${button}_${type}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_dimmer_switch: {
         cluster: 'manuSpecificPhilips',
         type: 'commandHueNotification',
@@ -5247,7 +5248,7 @@ const converters1 = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_tap: {
         cluster: 'greenPower',
         type: ['commandNotification', 'commandCommissioningNotification'],
@@ -5267,7 +5268,7 @@ const converters1 = {
                 return {action: lookup[commandID]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_relay_din_led_indicator: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -5283,7 +5284,7 @@ const converters1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_keypad: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -5295,7 +5296,7 @@ const converters1 = {
                 restore_reports: (zoneStatus & 1<<5) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     itcmdr_clicks: {
         cluster: 'genMultistateInput',
         type: ['readResponse', 'attributeReport'],
@@ -5306,7 +5307,7 @@ const converters1 = {
             const action = lookup[clicks] ? lookup[clicks] : `many`;
             return {action};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZB003X_attr: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],
@@ -5323,7 +5324,7 @@ const converters1 = {
                 return {keep_time: keeptimelookup[value]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZB003X_occupancy: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -5331,7 +5332,7 @@ const converters1 = {
             const zoneStatus = msg.data.zonestatus;
             return {occupancy: (zoneStatus & 1) > 0, tamper: (zoneStatus & 4) > 0};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     idlock: {
         cluster: 'closuresDoorLock',
         type: ['attributeReport', 'readResponse'],
@@ -5357,7 +5358,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     idlock_fw: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -5368,7 +5369,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     schneider_pilot_mode: {
         cluster: 'schneiderSpecificPilotMode',
         type: ['attributeReport', 'readResponse'],
@@ -5380,7 +5381,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     schneider_ui_action: {
         cluster: 'wiserDeviceInfo',
         type: 'attributeReport',
@@ -5418,7 +5419,7 @@ const converters1 = {
                 return result;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     schneider_temperature: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -5428,7 +5429,7 @@ const converters1 = {
             const property = postfixWithEndpointName('local_temperature', msg, model, meta);
             return {[property]: calibrateAndPrecisionRoundOptions(temperature, options, 'temperature')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wiser_smart_thermostat_client: {
         cluster: 'hvacThermostat',
         type: 'read',
@@ -5442,7 +5443,7 @@ const converters1 = {
                 await msg.endpoint.readResponse(msg.cluster, msg.meta.zclTransactionSequenceNumber, response, {srcEndpoint: 11});
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wiser_smart_setpoint_command_client: {
         cluster: 'hvacThermostat',
         type: ['command', 'commandWiserSmartSetSetpoint'],
@@ -5460,7 +5461,7 @@ const converters1 = {
             meta.logger.debug(`received wiser setpoint command with value: '${msg.data['setpoint']}'`);
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZNCJMB14LM: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -5532,7 +5533,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     rc_110_level_to_scene: {
         cluster: 'genLevelCtrl',
         type: ['commandMoveToLevel', 'commandMoveToLevelWithOnOff'],
@@ -5540,14 +5541,14 @@ const converters1 = {
             const scenes: KeyValueAny = {2: '1', 52: '2', 102: '3', 153: '4', 194: '5', 254: '6'};
             return {action: `scene_${scenes[msg.data.level]}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_tvoc: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             return {voc: msg.data.presentValue};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     heiman_doorbell_button: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -5564,7 +5565,7 @@ const converters1 = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_knob_rotation: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -5581,7 +5582,7 @@ const converters1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     sihas_people_cnt: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
@@ -5595,7 +5596,7 @@ const converters1 = {
                 return result;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     sihas_action: {
         cluster: 'genOnOff',
         type: ['commandOn', 'commandOff', 'commandToggle'],
@@ -5620,7 +5621,7 @@ const converters1 = {
             const button = buttonMapping ? `${buttonMapping[msg.endpoint.ID]}_` : '';
             return {action: `${button}${lookup[msg.type]}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_operation_mode: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -5631,7 +5632,7 @@ const converters1 = {
                 return {operation_mode: lookup[value]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     sunricher_switch2801K2: {
         cluster: 'greenPower',
         type: ['commandNotification', 'commandCommissioningNotification'],
@@ -5646,7 +5647,7 @@ const converters1 = {
                 return {action: lookup[commandID]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     sunricher_switch2801K4: {
         cluster: 'greenPower',
         type: ['commandNotification', 'commandCommissioningNotification'],
@@ -5669,7 +5670,7 @@ const converters1 = {
                 return {action: lookup[commandID]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_stop_move_raw: {
         cluster: 'lightingColorCtrl',
         type: 'raw',
@@ -5683,7 +5684,7 @@ const converters1 = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_multi_action: {
         cluster: 'genOnOff',
         type: 'raw',
@@ -5706,7 +5707,7 @@ const converters1 = {
 
             return {action};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     led_on_motion: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],
@@ -5717,7 +5718,7 @@ const converters1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hw_version: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
@@ -5726,7 +5727,7 @@ const converters1 = {
             if (msg.data.hasOwnProperty('hwVersion')) result['hw_version'] = msg.data.hwVersion;
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     SNZB02_temperature: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -5741,7 +5742,7 @@ const converters1 = {
                 return {[property]: calibrateAndPrecisionRoundOptions(temperature, options, 'temperature')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     SNZB02_humidity: {
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
@@ -5755,7 +5756,7 @@ const converters1 = {
                 return {humidity: calibrateAndPrecisionRoundOptions(humidity, options, 'humidity')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     awox_colors: {
         cluster: 'lightingColorCtrl',
         type: ['raw'],
@@ -5777,7 +5778,7 @@ const converters1 = {
                 return {action: color};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     awox_refreshColored: {
         cluster: 'lightingColorCtrl',
         type: ['commandMoveHue'],
@@ -5788,7 +5789,7 @@ const converters1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     awox_refresh: {
         cluster: 'genLevelCtrl',
         type: ['raw'],
@@ -5802,7 +5803,7 @@ const converters1 = {
                 return {action: 'refresh_long'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     // #endregion
 
     // #region Ignore converters (these message dont need parsing).
@@ -5810,167 +5811,167 @@ const converters1 = {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_basic_report: {
         cluster: 'genBasic',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_illuminance_report: {
         cluster: 'msIlluminanceMeasurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_occupancy_report: {
         cluster: 'msOccupancySensing',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_temperature_report: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_humidity_report: {
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_pressure_report: {
         cluster: 'msPressureMeasurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_analog_report: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_multistate_report: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_power_report: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_light_brightness_report: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_light_color_colortemp_report: {
         cluster: 'lightingColorCtrl',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_closuresWindowCovering_report: {
         cluster: 'closuresWindowCovering',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_thermostat_report: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_iaszone_attreport: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_iaszone_statuschange: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_iaszone_report: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_iasace_commandgetpanelstatus: {
         cluster: 'ssIasAce',
         type: ['commandGetPanelStatus'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_genIdentify: {
         cluster: 'genIdentify',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_command_on: {
         cluster: 'genOnOff',
         type: 'commandOn',
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_command_off: {
         cluster: 'genOnOff',
         type: 'commandOffWithEffect',
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_command_step: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_command_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_poll_ctrl: {
         cluster: 'genPollCtrl',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_genLevelCtrl_report: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_genOta: {
         cluster: 'genOta',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_haDiagnostic: {
         cluster: 'haDiagnostic',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_zclversion_read: {
         cluster: 'genBasic',
         type: 'read',
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_time_read: {
         cluster: 'genTime',
         type: 'read',
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_tuya_set_time: {
         cluster: 'manuSpecificTuya',
         type: ['commandMcuSyncTime'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_tuya_raw: {
         cluster: 'manuSpecificTuya',
         type: ['raw'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_metering: {
         cluster: 'seMetering',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ignore_electrical_measurement: {
         cluster: 'haElectricalMeasurement',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => null,
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     // #endregion
 };
 
@@ -5984,7 +5985,7 @@ const converters2 = {
             payload.action_transaction = msg.meta.zclTransactionSequenceNumber;
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     metering_datek: {
         cluster: 'seMetering',
         type: ['attributeReport', 'readResponse'],
@@ -5997,7 +5998,7 @@ const converters2 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     JTYJGD01LMBW_smoke: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -6007,7 +6008,7 @@ const converters2 = {
             if (result) result.test = (zoneStatus & 1<<1) > 0;
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     EKO09738_metering: {
         /**
          * Elko EKO09738 and EKO09716 reports power in mW, scale to W
@@ -6021,7 +6022,7 @@ const converters2 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     command_on_presence: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -6030,7 +6031,7 @@ const converters2 = {
             const payload2 = await converters1.command_on.convert(model, msg, publish, options, meta);
             return {...payload1, ...payload2};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ias_ace_occupancy_with_timeout: {
         cluster: 'ssIasAce',
         type: 'commandGetPanelStatus',
@@ -6039,7 +6040,7 @@ const converters2 = {
             msg.data.occupancy = 1;
             return converters1.occupancy_with_timeout.convert(model, msg, publish, options, meta);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     SP600_power: {
         cluster: 'seMetering',
         type: ['attributeReport', 'readResponse'],
@@ -6064,7 +6065,7 @@ const converters2 = {
                 return converters1.metering.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     stelpro_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -6079,7 +6080,7 @@ const converters2 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     viessmann_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -6116,7 +6117,7 @@ const converters2 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     eurotronic_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -6154,7 +6155,7 @@ const converters2 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     RTCGQ11LM_illuminance: {
         cluster: 'msIlluminanceMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -6172,7 +6173,7 @@ const converters2 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     terncy_raw: {
         cluster: 'manuSpecificClusterAduroSmart',
         type: 'raw',
@@ -6218,7 +6219,7 @@ const converters2 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZM35HQ_attr: {
         cluster: 'ssIasZone',
         type: ['attributeReport', 'readResponse'],
@@ -6239,7 +6240,7 @@ const converters2 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     schneider_lighting_ballast_configuration: {
         cluster: 'lightingBallastCfg',
         type: ['attributeReport', 'readResponse'],
@@ -6251,7 +6252,7 @@ const converters2 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wiser_lighting_ballast_configuration: {
         cluster: 'lightingBallastCfg',
         type: ['attributeReport', 'readResponse'],
@@ -6262,7 +6263,7 @@ const converters2 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wiser_smart_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -6322,7 +6323,7 @@ const converters2 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     nodon_fil_pilote_mode: {
         cluster: 'manuSpecificNodOnFilPilote',
         type: ['attributeReport', 'readResponse'],
@@ -6342,7 +6343,7 @@ const converters2 = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const converters = {...converters1, ...converters2};

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -56,7 +56,7 @@ const converters1 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['onOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_color: {
         key: ['color'],
         options: [exposes.options.color_sync(), exposes.options.transition()],
@@ -151,7 +151,7 @@ const converters1 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', light.readColorAttributes(entity, meta));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_colortemp: {
         key: ['color_temp', 'color_temp_percent'],
         options: [exposes.options.color_sync(), exposes.options.transition()],
@@ -187,7 +187,7 @@ const converters1 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', ['colorMode', 'colorTemperature']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const converters2 = {
@@ -202,7 +202,7 @@ const converters2 = {
                 return {state: {[value.state_property]: result}};
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     write: {
         key: ['write'],
         convertSet: async (entity, key, value, meta) => {
@@ -214,7 +214,7 @@ const converters2 = {
             await entity.write(value.cluster, value.payload, options);
             meta.logger.info(`Wrote '${JSON.stringify(value.payload)}' to '${value.cluster}'`);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     command: {
         key: ['command'],
         convertSet: async (entity, key, value, meta) => {
@@ -223,19 +223,19 @@ const converters2 = {
             await entity.command(value.cluster, value.command, (value.hasOwnProperty('payload') ? value.payload : {}), options);
             meta.logger.info(`Invoked '${value.cluster}.${value.command}' with payload '${JSON.stringify(value.payload)}'`);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     factory_reset: {
         key: ['reset'],
         convertSet: async (entity, key, value, meta) => {
             await entity.command('genBasic', 'resetFactDefault', {}, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     identify: {
         key: ['identify'],
         convertSet: async (entity, key, value, meta) => {
             await entity.command('genIdentify', 'identify', {identifytime: value}, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     arm_mode: {
         key: ['arm_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -266,19 +266,19 @@ const converters2 = {
             const payload = {panelstatus: panelStatus, secondsremain: 0, audiblenotif: 0, alarmstatus: 0};
             await entity.commandResponse('ssIasAce', 'panelStatusChanged', payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     battery_percentage_remaining: {
         key: ['battery'],
         convertGet: async (entity, key, meta) => {
             await entity.read('genPowerCfg', ['batteryPercentageRemaining']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     battery_voltage: {
         key: ['battery', 'voltage'],
         convertGet: async (entity, key, meta) => {
             await entity.read('genPowerCfg', ['batteryVoltage']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     power_on_behavior: {
         key: ['power_on_behavior'],
         convertSet: async (entity, key, value, meta) => {
@@ -291,13 +291,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['startUpOnOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_color_mode: {
         key: ['color_mode'],
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', ['colorMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_color_options: {
         key: ['color_options'],
         convertSet: async (entity, key, value, meta) => {
@@ -309,7 +309,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', ['options']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     lock: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -326,7 +326,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', ['lockState']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     lock_auto_relock_time: {
         key: ['auto_relock_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -336,7 +336,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', ['autoRelockTime']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     lock_sound_volume: {
         key: ['sound_volume'],
         convertSet: async (entity, key, value, meta) => {
@@ -349,7 +349,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', ['soundVolume']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     pincode_lock: {
         key: ['pin_code'],
         convertSet: async (entity, key, value, meta) => {
@@ -396,7 +396,7 @@ const converters2 = {
                 await entity.command('closuresDoorLock', 'getPinCode', {userid: user}, utils.getOptions(meta.mapped, entity));
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     lock_userstatus: {
         key: ['user_status'],
         convertSet: async (entity, key, value, meta) => {
@@ -447,7 +447,7 @@ const converters2 = {
                 await entity.command('closuresDoorLock', 'getUserStatus', {userid: user}, utils.getOptions(meta.mapped, entity));
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     cover_via_brightness: {
         key: ['position', 'state'],
         options: [exposes.options.invert_cover()],
@@ -479,7 +479,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genLevelCtrl', ['currentLevel']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     warning: {
         key: ['warning'],
         convertSet: async (entity, key, value, meta) => {
@@ -518,7 +518,7 @@ const converters2 = {
                 utils.getOptions(meta.mapped, entity),
             );
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ias_max_duration: {
         key: ['max_duration'],
         convertSet: async (entity, key, value, meta) => {
@@ -528,7 +528,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('ssIasWd', ['maxDuration']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     warning_simple: {
         key: ['alarm'],
         convertSet: async (entity, key, value, meta) => {
@@ -549,7 +549,7 @@ const converters2 = {
                 utils.getOptions(meta.mapped, entity),
             );
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     squawk: {
         key: ['squawk'],
         convertSet: async (entity, key, value, meta) => {
@@ -565,7 +565,7 @@ const converters2 = {
                 (utils.getFromLookup(values.level, level) << 6);
             await entity.command('ssIasWd', 'squawk', {squawkinfo: info}, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     cover_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -574,7 +574,7 @@ const converters2 = {
             value = value.toLowerCase();
             await entity.command('closuresWindowCovering', utils.getFromLookup(value, lookup), {}, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     cover_position_tilt: {
         key: ['position', 'tilt'],
         options: [exposes.options.invert_cover()],
@@ -601,7 +601,7 @@ const converters2 = {
             const isPosition = (key === 'position');
             await entity.read('closuresWindowCovering', [isPosition ? 'currentPositionLiftPercentage' : 'currentPositionTiltPercentage']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     occupancy_timeout: {
         // Sets delay after motion detector changes from occupied to unoccupied
         key: ['occupancy_timeout'],
@@ -614,7 +614,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('msOccupancySensing', ['pirOToUDelay']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     level_config: {
         key: ['level_config'],
         convertSet: async (entity, key, value, meta) => {
@@ -751,7 +751,7 @@ const converters2 = {
                 }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ballast_config: {
         key: ['ballast_config',
             'ballast_minimum_level',
@@ -806,7 +806,7 @@ const converters2 = {
                 meta.logger.warn(`ballast_config attribute results received: ${JSON.stringify(utils.toSnakeCase(result))}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_brightness_step: {
         key: ['brightness_step', 'brightness_step_onoff'],
         options: [exposes.options.transition()],
@@ -845,7 +845,7 @@ const converters2 = {
                 return {state: {brightness, state: brightness === 0 ? 'OFF' : 'ON'}};
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_brightness_move: {
         key: ['brightness_move', 'brightness_move_onoff'],
         convertSet: async (entity, key, value, meta) => {
@@ -866,7 +866,7 @@ const converters2 = {
                 await entity.command('genLevelCtrl', command, payload, utils.getOptions(meta.mapped, entity));
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_colortemp_step: {
         key: ['color_temp_step'],
         options: [exposes.options.transition()],
@@ -888,7 +888,7 @@ const converters2 = {
                 await entityToRead.read('lightingColorCtrl', ['colorTemperature']);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_colortemp_move: {
         key: ['colortemp_move', 'color_temp_move'],
         convertSet: async (entity, key, value, meta) => {
@@ -931,7 +931,7 @@ const converters2 = {
                 await entity.command('lightingColorCtrl', 'moveColorTemp', payload, utils.getOptions(meta.mapped, entity));
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_color_and_colortemp_via_color: {
         key: ['color', 'color_temp', 'color_temp_percent'],
         options: [exposes.options.color_sync(), exposes.options.transition()],
@@ -956,7 +956,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', light.readColorAttributes(entity, meta));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_hue_saturation_step: {
         key: ['hue_step', 'saturation_step'],
         options: [exposes.options.transition()],
@@ -979,7 +979,7 @@ const converters2 = {
                 await entityToRead.read('lightingColorCtrl', [attribute, 'colorMode']);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_hue_saturation_move: {
         key: ['hue_move', 'saturation_move'],
         convertSet: async (entity, key, value, meta) => {
@@ -1010,7 +1010,7 @@ const converters2 = {
                 }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_onoff_brightness: {
         key: ['state', 'brightness', 'brightness_percent', 'on_time'],
         options: [exposes.options.transition()],
@@ -1107,7 +1107,8 @@ const converters2 = {
             }
 
             if (brightness === undefined) {
-                const result = await converters1.on_off.convertSet(entity, 'state', state, meta);
+                // Converting the type to a generic one so we can set readAfterWriteTime and state.brightness without errors
+                const result = await converters1.on_off.convertSet(entity, 'state', state, meta) as KeyValueAny;
                 if (result) {
                     result.readAfterWriteTime = 0;
                     if (result.state && result.state.state === 'ON' && meta.state.brightness === 0) {
@@ -1151,7 +1152,7 @@ const converters2 = {
                 await converters1.on_off.convertGet(entity, key, meta);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_colortemp_startup: {
         key: ['color_temp_startup'],
         convertSet: async (entity, key, value, meta) => {
@@ -1177,7 +1178,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', ['startUpColorTemperature']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     light_color_colortemp: {
         /**
          * This converter is a combination of light_color and light_colortemp and
@@ -1205,7 +1206,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', light.readColorAttributes(entity, meta, ['colorTemperature']));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     effect: {
         key: ['effect', 'alert', 'flash'], // alert and flash are deprecated.
         convertSet: async (entity, key, value, meta) => {
@@ -1231,7 +1232,7 @@ const converters2 = {
                 await entity.command('genIdentify', 'triggerEffect', payload, utils.getOptions(meta.mapped, entity));
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_remote_sensing: {
         key: ['remote_sensing'],
         convertSet: async (entity, key, value, meta) => {
@@ -1240,7 +1241,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['remoteSensing']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_weekly_schedule: {
         key: ['weekly_schedule'],
         convertSet: async (entity, key, value, meta) => {
@@ -1389,7 +1390,7 @@ const converters2 = {
             };
             await entity.command('hvacThermostat', 'getWeeklySchedule', payload, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -1403,7 +1404,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['systemMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_control_sequence_of_operation: {
         key: ['control_sequence_of_operation'],
         convertSet: async (entity, key, value, meta) => {
@@ -1422,7 +1423,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['ctrlSeqeOfOper']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_programming_operation_mode: {
         key: ['programming_operation_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -1437,7 +1438,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['programingOperMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_temperature_display_mode: {
         key: ['temperature_display_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -1448,7 +1449,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacUserInterfaceCfg', ['tempDisplayMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_keypad_lockout: {
         key: ['keypad_lockout'],
         convertSet: async (entity, key, value, meta) => {
@@ -1459,7 +1460,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacUserInterfaceCfg', ['keypadLockout']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_temperature_setpoint_hold: {
         key: ['temperature_setpoint_hold'],
         convertSet: async (entity, key, value, meta) => {
@@ -1469,7 +1470,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['tempSetpointHold']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_temperature_setpoint_hold_duration: {
         key: ['temperature_setpoint_hold_duration'],
         convertSet: async (entity, key, value, meta) => {
@@ -1479,7 +1480,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['tempSetpointHoldDuration']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     fan_mode: {
         key: ['fan_mode', 'fan_state'],
         convertSet: async (entity, key, value, meta) => {
@@ -1491,19 +1492,19 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacFanCtrl', ['fanMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_local_temperature: {
         key: ['local_temperature'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['localTemp']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_outdoor_temperature: {
         key: ['outdoor_temperature'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['outdoorTemp']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_local_temperature_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value, meta) => {
@@ -1514,31 +1515,31 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['localTemperatureCalibration']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_occupancy: {
         key: ['occupancy'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['occupancy']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_clear_weekly_schedule: {
         key: ['clear_weekly_schedule'],
         convertSet: async (entity, key, value, meta) => {
             await entity.command('hvacThermostat', 'clearWeeklySchedule', {}, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_pi_heating_demand: {
         key: ['pi_heating_demand'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['pIHeatingDemand']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_running_state: {
         key: ['running_state'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['runningState']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_occupied_heating_setpoint: {
         key: ['occupied_heating_setpoint'],
         options: [exposes.options.thermostat_unit()],
@@ -1557,7 +1558,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['occupiedHeatingSetpoint']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_unoccupied_heating_setpoint: {
         key: ['unoccupied_heating_setpoint'],
         options: [exposes.options.thermostat_unit()],
@@ -1576,7 +1577,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['unoccupiedHeatingSetpoint']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_occupied_cooling_setpoint: {
         key: ['occupied_cooling_setpoint'],
         options: [exposes.options.thermostat_unit()],
@@ -1595,7 +1596,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['occupiedCoolingSetpoint']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_unoccupied_cooling_setpoint: {
         key: ['unoccupied_cooling_setpoint'],
         options: [exposes.options.thermostat_unit()],
@@ -1614,7 +1615,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['unoccupiedCoolingSetpoint']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_setpoint_raise_lower: {
         key: ['setpoint_raise_lower'],
         convertSet: async (entity, key, value, meta) => {
@@ -1622,19 +1623,19 @@ const converters2 = {
             const payload = {mode: value.mode, amount: Math.round(value.amount) * 100};
             await entity.command('hvacThermostat', 'setpointRaiseLower', payload, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_relay_status_log: {
         key: ['relay_status_log'],
         convertGet: async (entity, key, meta) => {
             await entity.command('hvacThermostat', 'getRelayStatusLog', {}, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_running_mode: {
         key: ['running_mode'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['runningMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_min_heat_setpoint_limit: {
         key: ['min_heat_setpoint_limit'],
         convertSet: async (entity, key, value, meta) => {
@@ -1652,7 +1653,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['minHeatSetpointLimit']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_max_heat_setpoint_limit: {
         key: ['max_heat_setpoint_limit'],
         convertSet: async (entity, key, value, meta) => {
@@ -1670,7 +1671,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['maxHeatSetpointLimit']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_min_cool_setpoint_limit: {
         key: ['min_cool_setpoint_limit'],
         convertSet: async (entity, key, value, meta) => {
@@ -1688,7 +1689,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['minCoolSetpointLimit']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_max_cool_setpoint_limit: {
         key: ['max_cool_setpoint_limit'],
         convertSet: async (entity, key, value, meta) => {
@@ -1706,7 +1707,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['maxCoolSetpointLimit']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_ac_louver_position: {
         key: ['ac_louver_position'],
         convertSet: async (entity, key, value, meta) => {
@@ -1720,69 +1721,69 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['acLouverPosition']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     electrical_measurement_power: {
         key: ['power'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', ['activePower']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     metering_power: {
         key: ['power'],
         convertGet: async (entity, key, meta) => {
             utils.assertEndpoint(entity);
             await utils.enforceEndpoint(entity, key, meta).read('seMetering', ['instantaneousDemand']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     currentsummdelivered: {
         key: ['energy'],
         convertGet: async (entity, key, meta) => {
             utils.assertEndpoint(entity);
             await utils.enforceEndpoint(entity, key, meta).read('seMetering', ['currentSummDelivered']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     frequency: {
         key: ['ac_frequency'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', ['acFrequency']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     electrical_measurement_power_reactive: {
         key: ['power_reactive'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', ['reactivePower']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     powerfactor: {
         key: ['power_factor'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', ['powerFactor']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     acvoltage: {
         key: ['voltage'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', ['rmsVoltage']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     accurrent: {
         key: ['current'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', ['rmsCurrent']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     temperature: {
         key: ['temperature'],
         convertGet: async (entity, key, meta) => {
             await entity.read('msTemperatureMeasurement', ['measuredValue']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     illuminance: {
         key: ['illuminance', 'illuminance_lux'],
         convertGet: async (entity, key, meta) => {
             await entity.read('msIlluminanceMeasurement', ['measuredValue']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     // #endregion
 
     // #region Non-generic converters
@@ -1795,7 +1796,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoLoad']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_display_text: {
         key: ['display_text'],
         convertSet: async (entity, key, value, meta) => {
@@ -1810,7 +1811,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoDisplayText']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_power_status: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -1820,19 +1821,19 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoPowerStatus']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_external_temp: {
         key: ['floor_temp'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoExternalTemp']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_mean_power: {
         key: ['mean_power'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoMeanPower']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
@@ -1842,7 +1843,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoChildLock']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_frost_guard: {
         key: ['frost_guard'],
         convertSet: async (entity, key, value, meta) => {
@@ -1852,7 +1853,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoFrostGuard']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_night_switching: {
         key: ['night_switching'],
         convertSet: async (entity, key, value, meta) => {
@@ -1862,20 +1863,20 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoNightSwitching']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_relay_state: {
         key: ['running_state'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoRelayState']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_sensor_mode: {
         key: ['sensor'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('hvacThermostat', {'elkoSensor': utils.getFromLookup(value, {'air': '0', 'floor': '1', 'supervisor_floor': '3'})});
             return {state: {sensor: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_regulator_time: {
         key: ['regulator_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -1885,7 +1886,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoRegulatorTime']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_regulator_mode: {
         key: ['regulator_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -1895,7 +1896,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoRegulatorMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_local_temperature_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value, meta) => {
@@ -1906,7 +1907,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoCalibration']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     elko_max_floor_temp: {
         key: ['max_floor_temp'],
         convertSet: async (entity, key, value, meta) => {
@@ -1919,7 +1920,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoMaxFloorTemp']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     livolo_socket_switch_on_off: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -1980,7 +1981,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     livolo_switch_on_off: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -2003,7 +2004,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     livolo_dimmer_level: {
         key: ['brightness', 'brightness_percent', 'level'],
         convertSet: async (entity, key, value, meta) => {
@@ -2045,7 +2046,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.command('genOnOff', 'toggle', {}, {transactionSequenceNumber: 0});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     livolo_cover_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -2080,7 +2081,7 @@ const converters2 = {
                 readAfterWriteTime: 250,
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     livolo_cover_position: {
         key: ['position'],
         convertSet: async (entity, key, value, meta) => {
@@ -2101,7 +2102,7 @@ const converters2 = {
                 readAfterWriteTime: 250,
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     livolo_cover_options: {
         key: ['options'],
         convertSet: async (entity, key, value, meta) => {
@@ -2140,7 +2141,7 @@ const converters2 = {
                 await entity.write('genPowerCfg', payload, options);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_motion_sensitivity: {
         key: ['motion_sensitivity'],
         convertSet: async (entity, key, value, meta) => {
@@ -2153,13 +2154,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x010c], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RTCZCGQ11LM_presence: {
         key: ['presence'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0142], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RTCZCGQ11LM_monitoring_mode: {
         key: ['monitoring_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -2172,7 +2173,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0144], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RTCZCGQ11LM_approach_distance: {
         key: ['approach_distance'],
         convertSet: async (entity, key, value, meta) => {
@@ -2185,20 +2186,20 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0146], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RTCZCGQ11LM_reset_nopresence_status: {
         key: ['reset_nopresence_status'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('aqaraOpple', {0x0157: {value: 1, type: 0x20}}, manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZigUP_lock: {
         key: ['led'],
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'off': 'lockDoor', 'on': 'unlockDoor', 'toggle': 'toggleDoor'};
             await entity.command('closuresDoorLock', utils.getFromLookup(value, lookup), {'pincodevalue': ''});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     LS21001_alert_behaviour: {
         key: ['alert_behaviour'],
         convertSet: async (entity, key, value, meta) => {
@@ -2207,7 +2208,7 @@ const converters2 = {
                 {manufacturerCode: 0x1168, disableDefaultResponse: true, sendWhen: 'active'});
             return {state: {alert_behaviour: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_switch_type: {
         key: ['switch_type'],
         convertSet: async (entity, key, value, meta) => {
@@ -2220,7 +2221,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x000A], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_switch_power_outage_memory: {
         key: ['power_outage_memory'],
         convertSet: async (entity, key, value, meta) => {
@@ -2263,21 +2264,21 @@ const converters2 = {
                 throw new Error('Not supported');
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_light_power_outage_memory: {
         key: ['power_outage_memory'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('genBasic', {0xFF19: {value: value ? 1 : 0, type: 0x10}}, manufacturerOptions.xiaomi);
             return {state: {power_outage_memory: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_power: {
         key: ['power'],
         convertGet: async (entity, key, meta) => {
             const endpoint = meta.device.endpoints.find((e) => e.supportsInputCluster('genAnalogInput'));
             await endpoint.read('genAnalogInput', ['presentValue']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_auto_off: {
         key: ['auto_off'],
         convertSet: async (entity, key, value, meta) => {
@@ -2301,7 +2302,7 @@ const converters2 = {
                 throw new Error('Not supported');
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     GZCGQ11LM_detection_period: {
         key: ['detection_period'],
         convertSet: async (entity, key, value, meta) => {
@@ -2313,7 +2314,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0000], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_detection_interval: {
         key: ['detection_interval'],
         convertSet: async (entity, key, value, meta) => {
@@ -2325,7 +2326,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0102], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_overload_protection: {
         key: ['overload_protection'],
         convertSet: async (entity, key, value, meta) => {
@@ -2337,7 +2338,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x020b], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_switch_mode_switch: {
         key: ['mode_switch'],
         convertSet: async (entity, key, value, meta) => {
@@ -2348,7 +2349,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0004], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_button_switch_mode: {
         key: ['button_switch_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -2359,7 +2360,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0226], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_socket_button_lock: {
         key: ['button_lock'],
         convertSet: async (entity, key, value, meta) => {
@@ -2370,7 +2371,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0200], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_led_disabled_night: {
         key: ['led_disabled_night'],
         convertSet: async (entity, key, value, meta) => {
@@ -2398,7 +2399,7 @@ const converters2 = {
                 throw new Error('Not supported');
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_flip_indicator_light: {
         key: ['flip_indicator_light'],
         convertSet: async (entity, key, value, meta) => {
@@ -2409,7 +2410,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x00F0], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_dimmer_mode: {
         key: ['dimmer_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -2430,7 +2431,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0509], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_switch_operation_mode_basic: {
         key: ['operation_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -2480,7 +2481,7 @@ const converters2 = {
             }
             await entity.read('genBasic', [attrId], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_switch_operation_mode_opple: {
         key: ['operation_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -2495,20 +2496,20 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0200], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_switch_do_not_disturb: {
         key: ['do_not_disturb'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('aqaraOpple', {0x0203: {value: value ? 1 : 0, type: 0x10}}, manufacturerOptions.xiaomi);
             return {state: {do_not_disturb: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     STS_PRS_251_beep: {
         key: ['beep'],
         convertSet: async (entity, key, value, meta) => {
             await entity.command('genIdentify', 'identify', {identifytime: value}, utils.getOptions(meta.mapped, entity));
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_curtain_options: {
         key: ['options'],
         convertSet: async (entity, key, value, meta) => {
@@ -2557,7 +2558,7 @@ const converters2 = {
                 throw new Error(`xiaomi_curtain_options get called for not supported model: ${meta.mapped.model}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_curtain_position_state: {
         key: ['state', 'position'],
         options: [exposes.options.invert_cover()],
@@ -2611,7 +2612,7 @@ const converters2 = {
                 await entity.read('genAnalogOutput', [0x0055]);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_curtain_battery_voltage: {
         key: ['voltage'],
         convertGet: async (entity, key, meta) => {
@@ -2623,19 +2624,19 @@ const converters2 = {
                 throw new Error(`xiaomi_curtain_battery_voltage - unsupported model: ${meta.mapped.model}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_curtain_acn002_charging_status: {
         key: ['charging_status'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0409], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_curtain_acn002_battery: {
         key: ['battery'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x040a], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ledvance_commands: {
         /* deprecated osram_*/
         key: ['set_transition', 'remember_state', 'osram_set_transition', 'osram_remember_state'],
@@ -2655,14 +2656,14 @@ const converters2 = {
                 }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     SPZ01_power_outage_memory: {
         key: ['power_outage_memory'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('genOnOff', {0x2000: {value: value ? 0x01 : 0x00, type: 0x20}});
             return {state: {power_outage_memory: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 
     tuya_relay_din_led_indicator: {
         key: ['indicator_mode'],
@@ -2674,7 +2675,7 @@ const converters2 = {
             await entity.write('genOnOff', {0x8001: {value: payload, type: 0x30}});
             return {state: {indicator_mode: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     kmpcil_res005_on_off: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -2700,7 +2701,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genBinaryOutput', ['presentValue']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     JTQJBF01LMBW_JTYJGD01LMBW_sensitivity: {
         key: ['sensitivity'],
         convertSet: async (entity, key, value, meta) => {
@@ -2713,7 +2714,7 @@ const converters2 = {
             await entity.write('ssIasZone', {0xFFF1: {value: utils.getFromLookup(value, lookup), type: 0x23}}, options);
             return {state: {sensitivity: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     JTQJBF01LMBW_JTYJGD01LMBW_selfest: {
         key: ['selftest'],
         convertSet: async (entity, key, value, meta) => {
@@ -2721,19 +2722,19 @@ const converters2 = {
             const options = {...manufacturerOptions.xiaomi, timeout: 35000};
             await entity.write('ssIasZone', {0xFFF1: {value: 0x03010000, type: 0x23}}, options);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_alarm: {
         key: ['gas', 'smoke'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x013a], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_density: {
         key: ['gas_density', 'smoke_density', 'smoke_density_dbm'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x013b], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     JTBZ01AQA_gas_sensitivity: {
         key: ['gas_sensitivity'],
         convertSet: async (entity, key, value, meta) => {
@@ -2746,13 +2747,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x010c], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_selftest: {
         key: ['selftest'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('aqaraOpple', {0x0127: {value: true, type: 0x10}}, manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_buzzer: {
         key: ['buzzer'],
         convertSet: async (entity, key, value, meta) => {
@@ -2763,7 +2764,7 @@ const converters2 = {
             value = (value === 15361) ? 0 : 1;
             await entity.write('aqaraOpple', {0x0126: {value: [`${value}`], type: 0x20}}, manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_buzzer_manual: {
         key: ['buzzer_manual_alarm', 'buzzer_manual_mute'],
         convertGet: async (entity, key, meta) => {
@@ -2773,7 +2774,7 @@ const converters2 = {
                 await entity.read('aqaraOpple', [0x013d], manufacturerOptions.xiaomi);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     JYGZ01AQ_heartbeat_indicator: {
         key: ['heartbeat_indicator'],
         convertSet: async (entity, key, value, meta) => {
@@ -2784,7 +2785,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x013c], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_linkage_alarm: {
         key: ['linkage_alarm'],
         convertSet: async (entity, key, value, meta) => {
@@ -2795,19 +2796,19 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x014b], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     JTBZ01AQA_state: {
         key: ['state'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0139], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_power_outage_count: {
         key: ['power_outage_count'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0002], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RTCGQ14LM_trigger_indicator: {
         key: ['trigger_indicator'],
         convertSet: async (entity, key, value, meta) => {
@@ -2818,14 +2819,14 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0152], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     LLKZMK11LM_interlock: {
         key: ['interlock'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('genBinaryOutput', {0xff06: {value: value ? 0x01 : 0x00, type: 0x10}}, manufacturerOptions.xiaomi);
             return {state: {interlock: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     DJT11LM_vibration_sensitivity: {
         key: ['sensitivity'],
         convertSet: async (entity, key, value, meta) => {
@@ -2837,7 +2838,7 @@ const converters2 = {
             await entity.write('genBasic', {0xFF0D: {value: utils.getFromLookup(value, lookup), type: 0x20}}, options);
             return {state: {sensitivity: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hue_wall_switch_device_mode: {
         key: ['device_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -2849,7 +2850,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genBasic', [0x0034], manufacturerOptions.hue);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_thermostat_occupied_heating_setpoint: {
         key: ['occupied_heating_setpoint'],
         convertSet: async (entity, key, value, meta) => {
@@ -2865,7 +2866,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['occupiedHeatingSetpoint']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_thermostat_occupied_heating_setpoint_scheduled: {
         key: ['occupied_heating_setpoint_scheduled'],
         convertSet: async (entity, key, value, meta) => {
@@ -2881,13 +2882,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['occupiedHeatingSetpoint']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_mounted_mode_active: {
         key: ['mounted_mode_active'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossMountedModeActive'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_mounted_mode_control: {
         key: ['mounted_mode_control'],
         convertSet: async (entity, key, value, meta) => {
@@ -2897,7 +2898,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossMountedModeControl'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_thermostat_vertical_orientation: {
         key: ['thermostat_vertical_orientation'],
         convertSet: async (entity, key, value, meta) => {
@@ -2907,7 +2908,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossThermostatOrientation'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_external_measured_room_sensor: {
         key: ['external_measured_room_sensor'],
         convertSet: async (entity, key, value, meta) => {
@@ -2917,7 +2918,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossExternalMeasuredRoomSensor'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_radiator_covered: {
         key: ['radiator_covered'],
         convertSet: async (entity, key, value, meta) => {
@@ -2927,7 +2928,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossRadiatorCovered'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_viewing_direction: {
         key: ['viewing_direction'],
         convertSet: async (entity, key, value, meta) => {
@@ -2937,7 +2938,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacUserInterfaceCfg', ['danfossViewingDirection'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_algorithm_scale_factor: {
         key: ['algorithm_scale_factor'],
         convertSet: async (entity, key, value, meta) => {
@@ -2947,7 +2948,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossAlgorithmScaleFactor'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_heat_available: {
         key: ['heat_available'],
         convertSet: async (entity, key, value, meta) => {
@@ -2957,13 +2958,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossHeatAvailable'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_heat_required: {
         key: ['heat_required'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossHeatRequired'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_day_of_week: {
         key: ['day_of_week'],
         convertSet: async (entity, key, value, meta) => {
@@ -2974,7 +2975,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossDayOfWeek'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_trigger_time: {
         key: ['trigger_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -2984,7 +2985,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossTriggerTime'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_window_open_feature: {
         key: ['window_open_feature'],
         convertSet: async (entity, key, value, meta) => {
@@ -2994,13 +2995,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossWindowOpenFeatureEnable'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_window_open_internal: {
         key: ['window_open_internal'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossWindowOpenInternal'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_window_open_external: {
         key: ['window_open_external'],
         convertSet: async (entity, key, value, meta) => {
@@ -3010,7 +3011,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossWindowOpenExternal'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_load_balancing_enable: {
         key: ['load_balancing_enable'],
         convertSet: async (entity, key, value, meta) => {
@@ -3020,7 +3021,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossLoadBalancingEnable'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_load_room_mean: {
         key: ['load_room_mean'],
         convertSet: async (entity, key, value, meta) => {
@@ -3030,25 +3031,25 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossLoadRoomMean'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_load_estimate: {
         key: ['load_estimate'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossLoadEstimate'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_preheat_status: {
         key: ['preheat_status'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossPreheatStatus'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_adaptation_status: {
         key: ['adaptation_run_status'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossAdaptionRunStatus'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_adaptation_settings: {
         key: ['adaptation_run_settings'],
         convertSet: async (entity, key, value, meta) => {
@@ -3059,7 +3060,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossAdaptionRunSettings'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_adaptation_control: {
         key: ['adaptation_run_control'],
         convertSet: async (entity, key, value, meta) => {
@@ -3071,7 +3072,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossAdaptionRunControl'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_regulation_setpoint_offset: {
         key: ['regulation_setpoint_offset'],
         convertSet: async (entity, key, value, meta) => {
@@ -3083,37 +3084,37 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossRegulationSetpointOffset'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_output_status: {
         key: ['output_status'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossOutputStatus'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_room_status_code: {
         key: ['room_status_code'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['danfossRoomStatusCode'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_system_status_code: {
         key: ['system_status_code'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haDiagnostic', ['danfossSystemStatusCode'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_system_status_water: {
         key: ['system_status_water'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haDiagnostic', ['danfossSystemStatusWater'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     danfoss_multimaster_role: {
         key: ['multimaster_role'],
         convertGet: async (entity, key, meta) => {
             await entity.read('haDiagnostic', ['danfossMultimasterRole'], manufacturerOptions.danfoss);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZMCSW032D_cover_position: {
         key: ['position', 'tilt'],
         convertSet: async (entity, key, value, meta) => {
@@ -3155,7 +3156,7 @@ const converters2 = {
             const isPosition = (key === 'position');
             await entity.read('closuresWindowCovering', [isPosition ? 'currentPositionLiftPercentage' : 'currentPositionTiltPercentage']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     namron_thermostat: {
         key: [
             'lcd_brightness', 'button_vibration_level', 'floor_sensor_type', 'sensor', 'powerup_status', 'floor_sensor_calibration',
@@ -3268,7 +3269,7 @@ const converters2 = {
             }
         },
 
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     namron_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
@@ -3279,14 +3280,14 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacUserInterfaceCfg', ['keypadLockout']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     easycode_auto_relock: {
         key: ['auto_relock'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('closuresDoorLock', {autoRelockTime: value ? 1 : 0}, utils.getOptions(meta.mapped, entity));
             return {state: {auto_relock: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_led_control: {
         key: ['brightness', 'color', 'color_temp'],
         options: [exposes.options.color_sync()],
@@ -3416,7 +3417,7 @@ const converters2 = {
                 'currentHue', 'currentSaturation', 'tuyaBrightness', 'tuyaRgbMode', 'colorTemperature',
             ]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_led_controller: {
         key: ['state', 'color'],
         convertSet: async (entity, key, value, meta) => {
@@ -3453,7 +3454,7 @@ const converters2 = {
                 await entity.read('lightingColorCtrl', ['currentHue', 'currentSaturation']);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_opple_operation_mode: {
         key: ['operation_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -3470,7 +3471,7 @@ const converters2 = {
             const endpoint = meta.device.getEndpoint(1);
             await endpoint.read('aqaraOpple', ['mode'], {manufacturerCode: 0x115f});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     EMIZB_132_mode: {
         key: ['interface_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -3498,7 +3499,7 @@ const converters2 = {
 
             return {state: {interface_mode: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     eurotronic_host_flags: {
         key: ['eurotronic_host_flags', 'eurotronic_system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -3538,13 +3539,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4008], manufacturerOptions.eurotronic);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     eurotronic_error_status: {
         key: ['eurotronic_error_status'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4002], manufacturerOptions.eurotronic);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     eurotronic_current_heating_setpoint: {
         key: ['current_heating_setpoint'],
         convertSet: async (entity, key, value, meta) => {
@@ -3556,7 +3557,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4003], manufacturerOptions.eurotronic);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     eurotronic_valve_position: {
         key: ['eurotronic_valve_position', 'valve_position'],
         convertSet: async (entity, key, value, meta) => {
@@ -3567,7 +3568,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4001], manufacturerOptions.eurotronic);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     eurotronic_trv_mode: {
         key: ['eurotronic_trv_mode', 'trv_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -3578,7 +3579,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4000], manufacturerOptions.eurotronic);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     stelpro_thermostat_outdoor_temperature: {
         key: ['thermostat_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {
@@ -3587,7 +3588,7 @@ const converters2 = {
                 await entity.write('hvacThermostat', {StelproOutdoorTemp: value * 100});
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     DTB190502A1_LED: {
         key: ['LED'],
         convertSet: async (entity, key, value, meta) => {
@@ -3612,7 +3613,7 @@ const converters2 = {
 
             await entity.write('genBasic', payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ptvo_switch_trigger: {
         key: ['trigger', 'interval'],
         convertSet: async (entity, key, value, meta) => {
@@ -3629,7 +3630,7 @@ const converters2 = {
                 }]);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ptvo_switch_uart: {
         key: ['action'],
         convertSet: async (entity, key, value, meta) => {
@@ -3646,7 +3647,7 @@ const converters2 = {
             }
             await entity.write('genMultistateValue', payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ptvo_switch_analog_input: {
         key: ['l1', 'l2', 'l3', 'l4', 'l5', 'l6', 'l7', 'l8', 'l9', 'l10', 'l11', 'l12', 'l13', 'l14', 'l15', 'l16'],
         convertGet: async (entity, key, meta) => {
@@ -3684,13 +3685,13 @@ const converters2 = {
             }
             return;
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tint_scene: {
         key: ['tint_scene'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('genBasic', {0x4005: {value, type: 0x20}}, manufacturerOptions.tint);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     bticino_4027C_cover_state: {
         key: ['state'],
         options: [exposes.options.invert_cover()],
@@ -3714,7 +3715,7 @@ const converters2 = {
             await entity.command('closuresWindowCovering', utils.getFromLookup(value, lookup), {}, utils.getOptions(meta.mapped, entity));
             return {state: {position}, readAfterWriteTime: 0};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     bticino_4027C_cover_position: {
         key: ['position'],
         options: [exposes.options.invert_cover(), exposes.options.no_position_support()],
@@ -3737,7 +3738,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresWindowCovering', ['currentPositionLiftPercentage']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     legrand_identify: {
         key: ['identify'],
         convertSet: async (entity, key, value, meta) => {
@@ -3770,7 +3771,7 @@ const converters2 = {
                 await entity.command('genIdentify', 'identify', {identifytime: 10}, {});
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     legrand_device_mode: {
         key: ['device_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -3797,7 +3798,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificLegrandDevices', [0x0000, 0x0001, 0x0002], manufacturerOptions.legrand);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     legrand_cable_outlet_mode: {
         key: ['cable_outlet_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -3816,7 +3817,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificLegrandDevices2', [0x0000], manufacturerOptions.legrand);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     legrand_power_alarm: {
         key: ['power_alarm'],
         convertSet: async (entity, key, value, meta) => {
@@ -3831,7 +3832,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('haElectricalMeasurement', [0xf000, 0xf001, 0xf002]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     diyruz_freepad_on_off_config: {
         key: ['switch_type', 'switch_actions'],
         convertGet: async (entity, key, meta) => {
@@ -3860,7 +3861,7 @@ const converters2 = {
 
             return {state: {[`${key}`]: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TYZB01_on_off: {
         key: ['state', 'time_in_seconds'],
         convertSet: async (entity, key, value, meta) => {
@@ -3903,7 +3904,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['onOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     diyruz_geiger_config: {
         key: ['sensitivity', 'led_feedback', 'buzzer_feedback', 'sensors_count', 'sensors_type', 'alert_threshold'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -3949,7 +3950,7 @@ const converters2 = {
             };
             await entity.read(payloads[key][0], [payloads[key][1]]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     diyruz_airsense_config: {
         key: ['led_feedback', 'enable_abc', 'threshold1', 'threshold2', 'temperature_offset', 'pressure_offset', 'humidity_offset'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -3981,7 +3982,7 @@ const converters2 = {
             };
             await entity.read(payloads[key][0], [payloads[key][1]]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     diyruz_zintercom_config: {
         key: ['mode', 'sound', 'time_ring', 'time_talk', 'time_open', 'time_bell', 'time_report'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -4020,13 +4021,13 @@ const converters2 = {
             // @ts-expect-error
             await entity.read(v[0], [v[1]]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     power_source: {
         key: ['power_source', 'charging'],
         convertGet: async (entity, key, meta) => {
             await entity.read('genBasic', ['powerSource']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ts0201_temperature_humidity_alarm: {
         key: ['alarm_humidity_max', 'alarm_humidity_min', 'alarm_temperature_max', 'alarm_temperature_min'],
         convertSet: async (entity, key, value, meta) => {
@@ -4048,7 +4049,7 @@ const converters2 = {
                 meta.logger.warn(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     heiman_ir_remote: {
         key: ['send_key', 'create', 'learn', 'delete', 'get_list'],
         convertSet: async (entity, key, value, meta) => {
@@ -4083,7 +4084,7 @@ const converters2 = {
                 throw new Error(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     scene_store: {
         key: ['scene_store'],
         convertSet: async (entity, key, value: KeyValueAny, meta) => {
@@ -4117,7 +4118,7 @@ const converters2 = {
             meta.logger.info('Successfully stored scene');
             return {state: {}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     scene_recall: {
         key: ['scene_recall'],
         convertSet: async (entity, key, value, meta) => {
@@ -4176,7 +4177,7 @@ const converters2 = {
                 }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     scene_add: {
         key: ['scene_add'],
         convertSet: async (entity, key, value, meta) => {
@@ -4323,7 +4324,7 @@ const converters2 = {
             meta.logger.info('Successfully added scene');
             return {state: {}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     scene_remove: {
         key: ['scene_remove'],
         convertSet: async (entity, key, value, meta) => {
@@ -4349,7 +4350,7 @@ const converters2 = {
             }
             meta.logger.info('Successfully removed scene');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     scene_remove_all: {
         key: ['scene_remove_all'],
         convertSet: async (entity, key, value, meta) => {
@@ -4371,10 +4372,10 @@ const converters2 = {
             }
             meta.logger.info('Successfully removed all scenes');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     scene_rename: {
         key: ['scene_rename'],
-        convertSet: (entity, key, value, meta) => {
+        convertSet: async (entity, key, value, meta) => {
             utils.assertObject(value);
             const isGroup = utils.isGroup(entity);
             const sceneid = value.ID;
@@ -4399,7 +4400,7 @@ const converters2 = {
             }
             meta.logger.info('Successfully renamed scene');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS0003_curtain_switch: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -4415,7 +4416,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['onOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ts0216_duration: {
         key: ['duration'],
         convertSet: async (entity, key, value, meta) => {
@@ -4424,7 +4425,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('ssIasWd', ['maxDuration']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ts0216_volume: {
         key: ['volume'],
         convertSet: async (entity, key, value, meta) => {
@@ -4434,7 +4435,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('ssIasWd', [0x0002]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ts0216_alarm: {
         key: ['alarm'],
         convertSet: async (entity, key, value, meta) => {
@@ -4447,7 +4448,7 @@ const converters2 = {
                 utils.getOptions(meta.mapped, entity),
             );
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_cover_calibration: {
         key: ['calibration'],
         convertSet: async (entity, key, value, meta) => {
@@ -4461,7 +4462,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresWindowCovering', ['tuyaCalibration']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_cover_reversal: {
         key: ['motor_reversal'],
         convertSet: async (entity, key, value, meta) => {
@@ -4475,7 +4476,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresWindowCovering', ['tuyaMotorReversal']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_cover_calibration: {
         key: ['calibration_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -4487,7 +4488,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresWindowCovering', ['moesCalibrationTime']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZM35HQ_attr: {
         key: [
             'sensitivity', 'keep_time',
@@ -4512,7 +4513,7 @@ const converters2 = {
             // @ts-expect-error
             await entity.read('ssIasZone', ['currentZoneSensitivityLevel', 61441, 'zoneStatus'], {sendWhen: 'active'});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS0210_sensitivity: {
         key: ['sensitivity'],
         convertSet: async (entity, key, value, meta) => {
@@ -4520,13 +4521,13 @@ const converters2 = {
             await entity.write('ssIasZone', {currentZoneSensitivityLevel: value});
             return {state: {sensitivity: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     viessmann_window_open: {
         key: ['window_open'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['viessmannWindowOpenInternal'], manufacturerOptions.viessmann);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     viessmann_window_open_force: {
         key: ['window_open_force'],
         convertSet: async (entity, key, value, meta) => {
@@ -4540,13 +4541,13 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['viessmannWindowOpenForce'], manufacturerOptions.viessmann);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     viessmann_assembly_mode: {
         key: ['assembly_mode'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['viessmannAssemblyMode'], manufacturerOptions.viessmann);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     dawondns_only_off: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -4559,7 +4560,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['onOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     idlock_master_pin_mode: {
         key: ['master_pin_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4570,7 +4571,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', [0x4000], {manufacturerCode: 4919});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     idlock_rfid_enable: {
         key: ['rfid_enable'],
         convertSet: async (entity, key, value, meta) => {
@@ -4581,7 +4582,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', [0x4001], {manufacturerCode: 4919});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     idlock_service_mode: {
         key: ['service_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4593,7 +4594,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', [0x4003], {manufacturerCode: 4919});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     idlock_lock_mode: {
         key: ['lock_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4605,7 +4606,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', [0x4004], {manufacturerCode: 4919});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     idlock_relock_enabled: {
         key: ['relock_enabled'],
         convertSet: async (entity, key, value, meta) => {
@@ -4616,7 +4617,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', [0x4005], {manufacturerCode: 4919});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_pilot_mode: {
         key: ['schneider_pilot_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4630,7 +4631,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('schneiderSpecificPilotMode', ['pilotMode'], {manufacturerCode: 0x105e});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_dimmer_mode: {
         key: ['dimmer_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4642,7 +4643,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingBallastCfg', [0xe000], {manufacturerCode: 0x105e});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_dimmer_mode: {
         key: ['dimmer_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4654,7 +4655,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingBallastCfg', ['wiserControlMode'], {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_temperature_measured_value: {
         key: ['temperature_measured_value'],
         convertSet: async (entity, key, value, meta) => {
@@ -4662,7 +4663,7 @@ const converters2 = {
             utils.assertEndpoint(entity);
             await entity.report('msTemperatureMeasurement', {'measuredValue': Math.round(value * 100)});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4671,7 +4672,7 @@ const converters2 = {
             entity.saveClusterAttributeKeyValue('hvacThermostat', {systemMode: systemMode});
             return {state: {system_mode: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_thermostat_occupied_heating_setpoint: {
         key: ['occupied_heating_setpoint'],
         convertSet: async (entity, key, value, meta) => {
@@ -4681,7 +4682,7 @@ const converters2 = {
             entity.saveClusterAttributeKeyValue('hvacThermostat', {occupiedHeatingSetpoint: occupiedHeatingSetpoint});
             return {state: {occupied_heating_setpoint: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_thermostat_control_sequence_of_operation: {
         key: ['control_sequence_of_operation'],
         convertSet: async (entity, key, value, meta) => {
@@ -4690,7 +4691,7 @@ const converters2 = {
             entity.saveClusterAttributeKeyValue('hvacThermostat', {ctrlSeqeOfOper: val});
             return {state: {control_sequence_of_operation: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_thermostat_pi_heating_demand: {
         key: ['pi_heating_demand'],
         convertSet: async (entity, key, value, meta) => {
@@ -4698,7 +4699,7 @@ const converters2 = {
             entity.saveClusterAttributeKeyValue('hvacThermostat', {pIHeatingDemand: value});
             return {state: {pi_heating_demand: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     schneider_thermostat_keypad_lockout: {
         key: ['keypad_lockout'],
         convertSet: async (entity, key, value, meta) => {
@@ -4708,7 +4709,7 @@ const converters2 = {
             entity.saveClusterAttributeKeyValue('hvacUserInterfaceCfg', {keypadLockout});
             return {state: {keypad_lockout: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZNCJMB14LM: {
         key: ['theme',
             'standby_enabled',
@@ -4844,7 +4845,7 @@ const converters2 = {
                 throw new Error(`Not supported: '${key}'`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZNCLBL01LM_hooks_lock: {
         key: ['hooks_lock'],
         convertSet: async (entity, key, value, meta) => {
@@ -4852,13 +4853,13 @@ const converters2 = {
             await entity.write('aqaraOpple', {0x0427: {value: utils.getFromLookup(value, lookup), type: 0x20}}, manufacturerOptions.xiaomi);
             return {state: {[key]: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZNCLBL01LM_hooks_state: {
         key: ['hooks_state'],
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0428], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZNCLBL01LM_hand_open: {
         key: ['hand_open'],
         convertSet: async (entity, key, value, meta) => {
@@ -4867,7 +4868,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0401], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZNCLBL01LM_limits_calibration: {
         key: ['limits_calibration'],
         convertSet: async (entity, key, value, meta) => {
@@ -4884,7 +4885,7 @@ const converters2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_fip_setting: {
         key: ['fip_setting'],
         convertSet: async (entity, key, value, meta) => {
@@ -4911,7 +4912,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0xe020]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_hact_config: {
         key: ['hact_config'],
         convertSet: async (entity, key, value, meta) => {
@@ -4925,7 +4926,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0xe011]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_zone_mode: {
         key: ['zone_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -4937,7 +4938,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0xe010]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_vact_calibrate_valve: {
         key: ['calibrate_valve'],
         convertSet: async (entity, key, value, meta) => {
@@ -4945,13 +4946,13 @@ const converters2 = {
                 {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
             return {state: {'calibrate_valve': value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_sed_zone_mode: {
         key: ['zone_mode'],
         convertSet: async (entity, key, value, meta) => {
             return {state: {'zone_mode': value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_sed_occupied_heating_setpoint: {
         key: ['occupied_heating_setpoint'],
         convertSet: async (entity, key, value, meta) => {
@@ -4961,7 +4962,7 @@ const converters2 = {
             entity.saveClusterAttributeKeyValue('hvacThermostat', {occupiedHeatingSetpoint});
             return {state: {'occupied_heating_setpoint': value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_sed_thermostat_local_temperature_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value, meta) => {
@@ -4970,7 +4971,7 @@ const converters2 = {
                 {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
             return {state: {local_temperature_calibration: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     wiser_sed_thermostat_keypad_lockout: {
         key: ['keypad_lockout'],
         convertSet: async (entity, key, value, meta) => {
@@ -4979,7 +4980,7 @@ const converters2 = {
                 {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
             return {state: {keypad_lockout: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     sihas_set_people: {
         key: ['people'],
         convertSet: async (entity, key, value, meta) => {
@@ -4991,7 +4992,7 @@ const converters2 = {
             const endpoint = meta.device.endpoints.find((e) => e.supportsInputCluster('genAnalogInput'));
             await endpoint.read('genAnalogInput', ['presentValue']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_operation_mode: {
         key: ['operation_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -5007,7 +5008,7 @@ const converters2 = {
             const endpoint = meta.device.getEndpoint(1);
             await endpoint.read('genOnOff', ['tuyaOperationMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     xiaomi_switch_click_mode: {
         key: ['click_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -5018,7 +5019,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x125], manufacturerOptions.xiaomi);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     led_on_motion: {
         key: ['led_on_motion'],
         convertSet: async (entity, key, value, meta) => {
@@ -5029,7 +5030,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('ssIasZone', [0x4000], {manufacturerCode: 4919});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     nodon_fil_pilote_mode: {
         key: ['mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -5048,22 +5049,20 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificNodOnFilPilote', [0x0000], manufacturerOptions.nodon);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     // #endregion
 
     // #region Ignore converters
     ignore_transition: {
         key: ['transition'],
-        attr: [],
         convertSet: async (entity, key, value, meta) => {
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ignore_rate: {
         key: ['rate'],
-        attr: [],
         convertSet: async (entity, key, value, meta) => {
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     // #endregion
 
     // Not a converter, can be used by tests to clear the store.
@@ -5096,7 +5095,7 @@ const converters3 = {
         convertGet: async (entity, key, meta) => {
             return await converters2.light_onoff_brightness.convertGet(entity, key, meta);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RM01_light_onoff_brightness: {
         key: ['state', 'brightness', 'brightness_percent'],
         options: [exposes.options.transition()],
@@ -5116,7 +5115,7 @@ const converters3 = {
                 throw new Error('OnOff and LevelControl not supported on this RM01 device.');
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RM01_light_brightness_step: {
         options: [exposes.options.transition()],
         key: ['brightness_step', 'brightness_step_onoff'],
@@ -5128,7 +5127,7 @@ const converters3 = {
                 throw new Error('LevelControl not supported on this RM01 device.');
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     RM01_light_brightness_move: {
         key: ['brightness_move', 'brightness_move_onoff'],
         convertSet: async (entity, key, value, meta) => {
@@ -5139,7 +5138,7 @@ const converters3 = {
                 throw new Error('LevelControl not supported on this RM01 device.');
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ptvo_switch_light_brightness: {
         key: ['brightness', 'brightness_percent', 'transition'],
         options: [exposes.options.transition()],
@@ -5175,7 +5174,7 @@ const converters3 = {
                 throw new Error('LevelControl not supported on this endpoint.');
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     eurotronic_thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -5200,7 +5199,7 @@ const converters3 = {
         convertGet: async (entity, key, meta) => {
             await converters2.eurotronic_host_flags.convertGet(entity, 'eurotronic_host_flags', meta);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const converters = {...converters1, ...converters2, ...converters3};

--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -20,7 +20,7 @@ const fzLocal = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -30,7 +30,7 @@ const tzLocal = {
             await entity.write('ssIasZone', {0x0013: {value, type: 0x20}});
             return {state: {sensitivity: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/atlantic.ts
+++ b/src/devices/atlantic.ts
@@ -24,7 +24,7 @@ const tzLocal = {
             await entity.write('hvacFanCtrl', {0x1000: {value: value ? 1 : 0, type: 0x10}}, {manufacturerCode: 0x125b});
             return {state: {quiet_fan: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ac_louver_position: {
         key: ['ac_louver_position'],
         convertSet: async (entity, key, value, meta) => {
@@ -34,7 +34,7 @@ const tzLocal = {
             await entity.write('hvacThermostat', {0x4273: {value: index, type: 0x30}}, {manufacturerCode: 0x125b});
             return {state: {ac_louver_position: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     preset: {
         key: ['preset'],
         convertSet: async (entity, key, value, meta) => {
@@ -51,7 +51,7 @@ const tzLocal = {
 
             return {state: {preset: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     swingMode: {
         key: ['swing_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -61,7 +61,7 @@ const tzLocal = {
             await entity.write('hvacThermostat', {0x4274: {value: value === 'on' ? 1 : 0, type: 0x10}}, {manufacturerCode: 0x125b});
             return {state: {swing_mode: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/aurora_lighting.ts
+++ b/src/devices/aurora_lighting.ts
@@ -19,7 +19,7 @@ const tzLocal = {
             await endpoint.command('genOnOff', state, {});
             return {state: {backlight_led: state.toUpperCase()}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     backlight_brightness: {
         key: ['brightness'],
         options: [exposes.options.transition()],
@@ -30,7 +30,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genLevelCtrl', ['currentLevel']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const disableBatteryRotaryDimmerReporting = async (endpoint: Zh.Endpoint) => {
@@ -42,8 +42,8 @@ const disableBatteryRotaryDimmerReporting = async (endpoint: Zh.Endpoint) => {
 };
 
 const batteryRotaryDimmer = (...endpointsIds: number[]) => ({
-    fromZigbee: [fz.battery, fz.command_on, fz.command_off, fz.command_step, fz.command_step_color_temperature] as Fz.Converter[],
-    toZigbee: [] as Tz.Converter[],
+    fromZigbee: [fz.battery, fz.command_on, fz.command_off, fz.command_step, fz.command_step_color_temperature] satisfies Fz.Converter[],
+    toZigbee: [] as Tz.Converter[], // TODO: Needs documented reasoning for asserting this as a type it isn't
     exposes: [e.battery(), e.action([
         'on', 'off', 'brightness_step_up', 'brightness_step_down', 'color_temperature_step_up', 'color_temperature_step_down'])],
     configure: (async (device, coordinatorEndpoint, logger) => {
@@ -58,7 +58,7 @@ const batteryRotaryDimmer = (...endpointsIds: number[]) => ({
 
             await disableBatteryRotaryDimmerReporting(endpoint);
         }
-    }) as Configure,
+    }) satisfies Configure,
     onEvent: (async (type, data, device) => {
         // The rotary dimmer devices appear to lose the configured reportings when they
         // re-announce themselves which they do roughly every 6 hours.
@@ -77,7 +77,7 @@ const batteryRotaryDimmer = (...endpointsIds: number[]) => ({
                 }
             }
         }
-    }) as OnEvent,
+    }) satisfies OnEvent,
 });
 
 const definitions: Definition[] = [

--- a/src/devices/bitron.ts
+++ b/src/devices/bitron.ts
@@ -31,7 +31,7 @@ const bitron = {
 
                 return result;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
     },
     tz: {
         thermostat_hysteresis: {
@@ -53,7 +53,7 @@ const bitron = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('hvacThermostat', ['fourNoksHysteresisHigh', 'fourNoksHysteresisLow'], manufacturerOptions);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
     },
 };
 
@@ -250,11 +250,13 @@ const definitions: Definition[] = [
         ],
         exposes: (device, options) => {
             const dynExposes = [];
-            let ctrlSeqeOfOper = (device?.getEndpoint(1).getClusterAttributeValue('hvacThermostat', 'ctrlSeqeOfOper') ?? null) as number;
+            let ctrlSeqeOfOper = (device?.getEndpoint(1).getClusterAttributeValue('hvacThermostat', 'ctrlSeqeOfOper') ?? null);
             const modes = [];
 
+            if (typeof ctrlSeqeOfOper === 'string') ctrlSeqeOfOper = parseInt(ctrlSeqeOfOper) ?? null;
+
             // NOTE: ctrlSeqeOfOper defaults to 2 for this device (according to the manual)
-            if (ctrlSeqeOfOper == null) ctrlSeqeOfOper = 2;
+            if (ctrlSeqeOfOper === null || isNaN(ctrlSeqeOfOper)) ctrlSeqeOfOper = 2;
 
             // NOTE: set cool and/or heat support based on ctrlSeqeOfOper (see lib/constants -> thermostatControlSequenceOfOperations)
             // WARN: a restart of zigbee2mqtt is required after changing ctrlSeqeOfOper for expose data to be re-calculated

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -175,7 +175,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key toZigbee.rbshoszbeu.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     bmct: {
         key: [
             'device_type',
@@ -254,7 +254,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key toZigbee.bcmt.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     bwa1: {
         key: ['alarm_on_motion', 'test'],
         convertSet: async (entity, key, value, meta) => {
@@ -273,7 +273,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key toZigbee.bosch_twinguard.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     bosch_thermostat: {
         key: ['window_open', 'boost', 'system_mode', 'pi_heating_demand', 'remote_temperature'],
         convertSet: async (entity, key, value, meta) => {
@@ -338,7 +338,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key toZigbee.bosch_thermostat.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     bosch_userInterface: {
         key: ['display_orientation', 'display_ontime', 'display_brightness', 'child_lock', 'displayed_temperature'],
         convertSet: async (entity, key, value, meta) => {
@@ -387,7 +387,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key toZigbee.bosch_userInterface.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     bosch_twinguard: {
         key: ['sensitivity', 'pre_alarm', 'self_test', 'alarm', 'heartbeat'],
         convertSet: async (entity, key, value, meta) => {
@@ -446,7 +446,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key toZigbee.bosch_twinguard.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 
@@ -454,7 +454,6 @@ const fzLocal = {
     bmct: {
         cluster: '64672',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
             const data = msg.data;
@@ -471,11 +470,10 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bwa1_alarm_on_motion: {
         cluster: '64684',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
             const data = msg.data;
@@ -484,7 +482,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_contact: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -500,7 +498,7 @@ const fzLocal = {
             if (result.action === 'none') delete result.action;
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_ignore_dst: {
         cluster: 'genTime',
         type: 'read',
@@ -515,7 +513,7 @@ const fzLocal = {
                 await msg.endpoint.readResponse(msg.cluster, msg.meta.zclTransactionSequenceNumber, response);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -543,7 +541,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_userInterface: {
         cluster: 'hvacUserInterfaceCfg',
         type: ['attributeReport', 'readResponse'],
@@ -568,11 +566,10 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_twinguard_sensitivity: {
         cluster: 'manuSpecificBosch',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
             if (msg.data.hasOwnProperty(0x4003)) {
@@ -580,7 +577,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_twinguard_measurements: {
         cluster: 'manuSpecificBosch3',
         type: ['attributeReport', 'readResponse'],
@@ -607,11 +604,10 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_twinguard_pre_alarm: {
         cluster: 'manuSpecificBosch5',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
             if (msg.data.hasOwnProperty('pre_alarm')) {
@@ -619,11 +615,10 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_twinguard_heartbeat: {
         cluster: 'manuSpecificBosch7',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
             if (msg.data.hasOwnProperty('heartbeat')) {
@@ -631,11 +626,10 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_twinguard_alarm_state: {
         cluster: 'manuSpecificBosch8',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
             const lookup: KeyValue = {
@@ -654,11 +648,10 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bosch_twinguard_smoke_alarm_state: {
         cluster: 'genAlarms',
         type: ['commandAlarm', 'readResponse'],
-        options: [],
         convert: async (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
             const lookup: KeyValue = {
@@ -674,7 +667,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/centralite.ts
+++ b/src/devices/centralite.ts
@@ -32,7 +32,7 @@ const fzLocal = {
             }
             return fz.thermostat.convert(model, msg, publish, options, meta);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/ctm.ts
+++ b/src/devices/ctm.ts
@@ -32,7 +32,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_device_mode: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -46,7 +46,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_device_enabled: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -59,7 +59,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_child_lock: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -72,7 +72,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_current_flag: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -85,7 +85,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_relay_state: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -98,7 +98,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_temperature_offset: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -111,7 +111,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -234,7 +234,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_group_config: {
         cluster: '65191', // 0xFEA7 ctmGroupConfig
         type: ['attributeReport', 'readResponse'],
@@ -247,7 +247,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_sove_guard: {
         cluster: '65481', // 0xFFC9 ctmSoveGuard
         type: ['attributeReport', 'readResponse'],
@@ -329,7 +329,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ctm_water_leak_alarm: {
         cluster: 'ssIasZone',
         type: ['commandStatusChangeNotification', 'attributeReport'],
@@ -341,7 +341,7 @@ const fzLocal = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 
@@ -355,13 +355,13 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['onOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_device_mode: {
         key: ['device_mode'],
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', [0x2200]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_device_enabled: {
         key: ['device_enabled'],
         convertSet: async (entity, key, value, meta) => {
@@ -370,19 +370,19 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', [0x2201]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_child_lock: {
         key: ['child_lock'],
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', [0x2202]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_current_flag: {
         key: ['current_flag'],
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', [0x5000], {manufacturerCode: 0x1337});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_relay_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
@@ -392,7 +392,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', [0x5001], {manufacturerCode: 0x1337});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_temperature_offset: {
         key: ['temperature_offset'],
         convertSet: async (entity, key, value, meta) => {
@@ -403,7 +403,7 @@ const tzLocal = {
             await entity.read('msTemperatureMeasurement', [0x0400], {manufacturerCode: 0x1337, sendWhen: 'active'});
             await entity.read('msTemperatureMeasurement', ['measuredValue'], {sendWhen: 'active'});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_thermostat: {
         key: ['load', 'display_text', 'sensor', 'regulator_mode', 'power_status', 'system_mode', 'night_switching', 'frost_guard',
             'max_floor_temp', 'regulator_setpoint', 'regulation_mode', 'max_floor_guard', 'weekly_timer', 'exteral_sensor_source',
@@ -516,20 +516,20 @@ const tzLocal = {
                 throw new Error(`Unhandled key tzLocal.ctm_thermostat.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_thermostat_preset: {
         key: ['preset'],
         convertSet: async (entity, key, value, meta) => {
             const presetLookup = {'off': 0, 'away': 1, 'sleep': 2, 'home': 3};
             await entity.write('hvacThermostat', {0x0422: {value: utils.getFromLookup(value, presetLookup), type: dataType.uint8}});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('hvacThermostat', {0x0413: {value: utils.getFromLookup(value, {'UNLOCK': 0, 'LOCK': 1}), type: dataType.boolean}});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_thermostat_gets: {
         key: ['mean_power', 'floor_temp', 'running_state', 'frost_guard_setpoint', 'external_temp',
             'air_temp', 'floor_sensor_error', 'exteral_sensor_error',
@@ -565,13 +565,13 @@ const tzLocal = {
                 throw new Error(`Unhandled key tzLocal.ctm_thermostat.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_group_config: {
         key: ['group_id'],
         convertGet: async (entity, key, meta) => {
             await entity.read(0xFEA7, [0x0000], {manufacturerCode: 0x1337, sendWhen: 'active'});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ctm_sove_guard: {
         key: [
             'alarm_status', 'change_battery', 'stove_temperature', 'ambient_temperature', 'active', 'runtime', 'runtime_timeout',
@@ -645,7 +645,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key tzLocal.ctm_sove_guard.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -26,7 +26,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genBasic', [0x1337]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     node_config: {
         key: ['report_delay'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -41,7 +41,7 @@ const tzLocal = {
                 state: {[key]: rawValue},
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     local_time: {
         key: ['local_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -51,7 +51,7 @@ const tzLocal = {
             await firstEndpoint.write('genTime', {time: time});
             return {state: {local_time: time}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     co2_config: {
         key: ['auto_brightness', 'forced_recalibration', 'factory_reset_co2', 'long_chart_period', 'set_altitude',
             'manual_forced_recalibration', 'light_indicator', 'light_indicator_level'],
@@ -74,7 +74,7 @@ const tzLocal = {
                 state: {[key]: rawValue},
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     temperature_config: {
         key: ['temperature_offset'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -88,7 +88,7 @@ const tzLocal = {
                 state: {[key]: rawValue},
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     humidity_config: {
         key: ['humidity_offset'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -102,7 +102,7 @@ const tzLocal = {
                 state: {[key]: rawValue},
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_config: {
         key: ['high_temperature', 'low_temperature', 'enable_temperature'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -119,7 +119,7 @@ const tzLocal = {
                 state: {[key]: rawValue},
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hydrostat_config: {
         key: ['high_humidity', 'low_humidity', 'enable_humidity'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -136,7 +136,7 @@ const tzLocal = {
                 state: {[key]: rawValue},
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     co2_gasstat_config: {
         key: ['high_gas', 'low_gas', 'enable_gas'],
         convertSet: async (entity, key, rawValue, meta) => {
@@ -153,7 +153,7 @@ const tzLocal = {
                 state: {[key]: rawValue},
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     multi_zig_sw_switch_type: {
         key: ['switch_type_1', 'switch_type_2', 'switch_type_3', 'switch_type_4'],
         convertGet: async (entity, key, meta) => {
@@ -165,7 +165,7 @@ const tzLocal = {
             await entity.write('genOnOffSwitchCfg', payload);
             return {state: {[`${key}`]: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -177,7 +177,7 @@ const fzLocal = {
             if (msg.data['4919']) result['transmit_power'] = msg.data['4919'];
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     node_config: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -188,7 +188,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     co2: {
         cluster: 'msCO2',
         type: ['attributeReport', 'readResponse'],
@@ -198,7 +198,7 @@ const fzLocal = {
                 return {co2: calibrateAndPrecisionRoundOptions(co2, options, 'co2')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     co2_config: {
         cluster: 'msCO2',
         type: ['attributeReport', 'readResponse'],
@@ -230,7 +230,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     temperature_config: {
         cluster: 'msTemperatureMeasurement',
         type: 'readResponse',
@@ -241,7 +241,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     humidity_config: {
         cluster: 'msRelativeHumidity',
         type: 'readResponse',
@@ -252,7 +252,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thermostat_config: {
         cluster: 'msTemperatureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -269,7 +269,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hydrostat_config: {
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
@@ -286,7 +286,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     co2_gasstat_config: {
         cluster: 'msCO2',
         type: ['attributeReport', 'readResponse'],
@@ -303,7 +303,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     humidity2: {
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
@@ -321,7 +321,7 @@ const fzLocal = {
                 return {[property]: calibrateAndPrecisionRoundOptions(humidity, options, 'humidity')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     illuminance2: {
         cluster: 'msIlluminanceMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -339,7 +339,7 @@ const fzLocal = {
                 [property2]: calibrateAndPrecisionRoundOptions(illuminanceLux, options, 'illuminance_lux'),
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     pressure2: {
         cluster: 'msPressureMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -357,7 +357,7 @@ const fzLocal = {
             const property = (multiEndpoint)? postfixWithEndpointName('pressure', msg, model, meta): 'pressure';
             return {[property]: calibrateAndPrecisionRoundOptions(pressure, options, 'pressure')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     multi_zig_sw_battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -366,7 +366,7 @@ const fzLocal = {
             const battery = (voltage - 2200) / 8;
             return {battery: battery > 100 ? 100 : battery, voltage: voltage};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     multi_zig_sw_switch_buttons: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -377,7 +377,7 @@ const fzLocal = {
             const action = actionLookup[value];
             return {action: button + '_' + action};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     multi_zig_sw_switch_config: {
         cluster: 'genOnOffSwitchCfg',
         type: ['readResponse', 'attributeReport'],
@@ -386,7 +386,7 @@ const fzLocal = {
             const {switchType} = msg.data;
             return {[`switch_type_${channel}`]: getKey(switchTypesList, switchType)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 function ptvoGetMetaOption(device: Zh.Device, key: string, defaultValue: unknown) {

--- a/src/devices/databyte.ts
+++ b/src/devices/databyte.ts
@@ -18,7 +18,7 @@ const fzLocal = {
                 key_4: msg.data['41364'] === 1 ? 'ON' : 'OFF',
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/dawon_dns.ts
+++ b/src/devices/dawon_dns.ts
@@ -18,7 +18,7 @@ const fzLocal = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 
@@ -28,7 +28,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('ssIasZone', ['zoneState']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -59,7 +59,7 @@ const develco = {
                     return fz.electrical_measurement.convert(model, msg, publish, options, meta);
                 }
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         device_temperature: {
             ...fz.device_temperature,
             convert: (model, msg, publish, options, meta) => {
@@ -67,7 +67,7 @@ const develco = {
                     return fz.device_temperature.convert(model, msg, publish, options, meta);
                 }
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         temperature: {
             ...fz.temperature,
             convert: (model, msg, publish, options, meta) => {
@@ -75,7 +75,7 @@ const develco = {
                     return fz.temperature.convert(model, msg, publish, options, meta);
                 }
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         metering: {
             ...fz.metering,
             convert: (model, msg, publish, options, meta) => {
@@ -83,7 +83,7 @@ const develco = {
                     return fz.metering.convert(model, msg, publish, options, meta);
                 }
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         pulse_configuration: {
             cluster: 'seMetering',
             type: ['attributeReport', 'readResponse'],
@@ -96,7 +96,7 @@ const develco = {
 
                 return result;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         interface_mode: {
             cluster: 'seMetering',
             type: ['attributeReport', 'readResponse'],
@@ -115,7 +115,7 @@ const develco = {
 
                 return result;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         fault_status: {
             cluster: 'genBinaryInput',
             type: ['attributeReport', 'readResponse'],
@@ -130,7 +130,7 @@ const develco = {
                 }
                 return result;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         voc: {
             cluster: 'develcoSpecificAirQuality',
             type: ['attributeReport', 'readResponse'],
@@ -164,7 +164,7 @@ const develco = {
                 }
                 return {[vocProperty]: utils.calibrateAndPrecisionRoundOptions(voc, options, 'voc'), [airQualityProperty]: airQuality};
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         voc_battery: {
             cluster: 'genPowerCfg',
             type: ['attributeReport', 'readResponse'],
@@ -179,11 +179,10 @@ const develco = {
                 if (result) result.battery_low = (result.voltage <= 2500);
                 return result;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         led_control: {
             cluster: 'genBasic',
             type: ['attributeReport', 'readResponse'],
-            options: [],
             convert: (model, msg, publish, options, meta) => {
                 const state: KeyValue = {};
 
@@ -193,11 +192,10 @@ const develco = {
 
                 return state;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         ias_occupancy_timeout: {
             cluster: 'ssIasZone',
             type: ['attributeReport', 'readResponse'],
-            options: [],
             convert: (model, msg, publish, options, meta) => {
                 const state: KeyValue = {};
 
@@ -207,7 +205,7 @@ const develco = {
 
                 return state;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         input: {
             cluster: 'genBinaryInput',
             type: ['attributeReport', 'readResponse'],
@@ -219,7 +217,7 @@ const develco = {
                 }
                 return result;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
     },
     tz: {
         pulse_configuration: {
@@ -231,7 +229,7 @@ const develco = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('seMetering', ['develcoPulseConfiguration'], manufacturerOptions);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         interface_mode: {
             key: ['interface_mode'],
             convertSet: async (entity, key, value, meta) => {
@@ -242,14 +240,14 @@ const develco = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('seMetering', ['develcoInterfaceMode'], manufacturerOptions);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         current_summation: {
             key: ['current_summation'],
             convertSet: async (entity, key, value, meta) => {
                 await entity.write('seMetering', {'develcoCurrentSummation': value}, manufacturerOptions);
                 return {state: {'current_summation': value}};
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         led_control: {
             key: ['led_control'],
             convertSet: async (entity, key, value, meta) => {
@@ -260,7 +258,7 @@ const develco = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('genBasic', ['develcoLedControl'], manufacturerOptions);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         ias_occupancy_timeout: {
             key: ['occupancy_timeout'],
             convertSet: async (entity, key, value, meta) => {
@@ -275,13 +273,13 @@ const develco = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         input: {
             key: ['input'],
             convertGet: async (entity, key, meta) => {
                 await entity.read('genBinaryInput', ['presentValue']);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
     },
 };
 

--- a/src/devices/dlink.ts
+++ b/src/devices/dlink.ts
@@ -17,7 +17,7 @@ const fzLocal = {
                 battery_low: (zoneStatus & 1<<3) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -14,7 +14,7 @@ const fzLocal = {
             if (msg.endpoint.ID != 1) return;
             return {rain: (zoneStatus & 1) > 0};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -32,7 +32,7 @@ const tzLocal1 = {
         convertGet: async (entity, key, meta) => {
             return await tz.light_onoff_brightness.convertGet(entity, key, meta);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     gledopto_light_colortemp: {
         key: ['color_temp', 'color_temp_percent'],
         options: [exposes.options.color_sync(), exposes.options.transition()],
@@ -54,7 +54,7 @@ const tzLocal1 = {
         convertGet: async (entity, key, meta) => {
             return await tz.light_colortemp.convertGet(entity, key, meta);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     gledopto_light_color: {
         key: ['color'],
         options: [exposes.options.color_sync(), exposes.options.transition()],
@@ -81,7 +81,7 @@ const tzLocal1 = {
         convertGet: async (entity, key, meta) => {
             return await tz.light_color.convertGet(entity, key, meta);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const tzLocal = {
@@ -94,7 +94,6 @@ const tzLocal = {
                 const result = await tzLocal1.gledopto_light_color.convertSet(entity, key, value, meta);
                 utils.assertObject(result);
                 if (result.state && result.state.color.hasOwnProperty('x') && result.state.color.hasOwnProperty('y')) {
-                    // @ts-expect-error
                     result.state.color_temp = Math.round(libColor.ColorXY.fromObject(result.state.color).toMireds());
                 }
 
@@ -102,7 +101,6 @@ const tzLocal = {
             } else if (key == 'color_temp' || key == 'color_temp_percent') {
                 const result = await tzLocal1.gledopto_light_colortemp.convertSet(entity, key, value, meta);
                 utils.assertObject(result);
-                // @ts-expect-error
                 result.state.color = libColor.ColorXY.fromMireds(result.state.color_temp).rounded(4).toObject();
                 return result;
             }
@@ -110,7 +108,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             return await tz.light_color_colortemp.convertGet(entity, key, meta);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const gledoptoExtend = {

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -197,7 +197,7 @@ const fzLocal = {
 
             return state;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_voc_index: {
         cluster: 'msIkeaVocIndexMeasurement',
         type: ['attributeReport', 'readResponse'],
@@ -206,7 +206,7 @@ const fzLocal = {
                 return {voc_index: msg.data['measuredValue']};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -231,7 +231,7 @@ const fzLocal = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     // The STYRBAR sends an on +- 500ms after the arrow release. We don't want to send the ON action in this case.
     // https://github.com/Koenkk/zigbee2mqtt/issues/13335
     styrbar_on: {
@@ -244,7 +244,7 @@ const fzLocal = {
                 return {action: 'on'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     styrbar_arrow_release: {
         cluster: 'genScenes',
         type: 'commandTradfriArrowRelease',
@@ -261,7 +261,7 @@ const fzLocal = {
                 return result;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_dots_click_v1: {
         // For remotes with firmware 1.0.012 (20211214)
         cluster: 64639,
@@ -278,7 +278,7 @@ const fzLocal = {
 
             return {action: `dots_${button}_${action}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_dots_click_v2: {
         // For remotes with firmware 1.0.32 (20221219)
         cluster: 'heimanSpecificScenes',
@@ -301,7 +301,7 @@ const fzLocal = {
 
             return {action: `dots_${button}_${action}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_volume_click: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
@@ -309,7 +309,7 @@ const fzLocal = {
             const direction = msg.data.movemode === 1 ? 'down' : 'up';
             return {action: `volume_${direction}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_volume_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -317,7 +317,7 @@ const fzLocal = {
             const direction = msg.data.movemode === 1 ? 'down_hold' : 'up_hold';
             return {action: `volume_${direction}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ikea_track_click: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -326,7 +326,7 @@ const fzLocal = {
             const direction = msg.data.stepmode === 1 ? 'previous' : 'next';
             return {action: `track_${direction}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -357,25 +357,25 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificIkeaAirPurifier', ['fanMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     air_purifier_fan_speed: {
         key: ['fan_speed'],
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificIkeaAirPurifier', ['fanSpeed']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     air_purifier_pm25: {
         key: ['pm25', 'air_quality'],
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificIkeaAirPurifier', ['particulateMatter25Measurement']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     air_purifier_replace_filter: {
         key: ['replace_filter', 'filter_age'],
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificIkeaAirPurifier', ['filterRunTime']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     air_purifier_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
@@ -387,7 +387,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificIkeaAirPurifier', ['childLock']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     air_purifier_led_enable: {
         key: ['led_enable'],
         convertSet: async (entity, key, value, meta) => {
@@ -397,7 +397,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificIkeaAirPurifier', ['controlPanelLight']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -892,7 +892,7 @@ const tzLocal = {
                 manufacturerCode: INOVELLI,
             });
         },
-    }) as Tz.Converter,
+    }) satisfies Tz.Converter,
     inovelli_parameters_readOnly: (ATTRIBUTES: {[s: string]: Attribute})=>({
         key: Object.keys(ATTRIBUTES).filter((a) => ATTRIBUTES[a].readOnly),
         convertGet: async (entity, key, meta) => {
@@ -900,8 +900,7 @@ const tzLocal = {
                 manufacturerCode: INOVELLI,
             });
         },
-        convertSet: undefined,
-    }) as Tz.Converter,
+    }) satisfies Tz.Converter,
     inovelli_led_effect: {
         key: ['led_effect'],
         convertSet: async (entity, key, values, meta) => {
@@ -922,7 +921,7 @@ const tzLocal = {
             );
             return {state: {[key]: values}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     inovelli_individual_led_effect: {
         key: ['individual_led_effect'],
         convertSet: async (entity, key, values, meta) => {
@@ -945,7 +944,7 @@ const tzLocal = {
             );
             return {state: {[key]: values}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     /**
      * Inovelli VZM31SN has a default transition property that the device should
      * fallback to if a transition is not specified by passing 0xffff
@@ -1151,7 +1150,7 @@ const tzLocal = {
                 await tz.on_off.convertGet(entity, key, meta);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     fan_mode: {
         key: ['fan_mode'],
         convertSet: async (entity, key, value :string, meta) => {
@@ -1174,7 +1173,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genLevelCtrl', ['currentLevel']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     fan_state: {
         key: ['fan_state'],
         convertSet: async (entity, key, value, meta) => {
@@ -1204,7 +1203,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['onOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 /*
@@ -1309,7 +1308,7 @@ const fzLocal = {
                 }, {});
             }
         },
-    }) as Fz.Converter,
+    }) satisfies Fz.Converter,
     fan_mode: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -1328,7 +1327,7 @@ const fzLocal = {
             }
             return msg.data;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     fan_state: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1338,7 +1337,7 @@ const fzLocal = {
             }
             return msg.data;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const exposesList: Expose[] = [

--- a/src/devices/jethome.ts
+++ b/src/devices/jethome.ts
@@ -16,7 +16,7 @@ const jetHome = {
                 const action = utils.getFromLookup(value, actionLookup);
                 return {action: utils.postfixWithEndpointName(action, msg, model, meta)};
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
     },
 };
 

--- a/src/devices/kmpcil.ts
+++ b/src/devices/kmpcil.ts
@@ -52,7 +52,7 @@ const kmpcilConverters = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     presence_power: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -68,7 +68,7 @@ const kmpcilConverters = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/konke.ts
+++ b/src/devices/konke.ts
@@ -20,7 +20,7 @@ const fzLocal = {
             };
             return {action: utils.getFromLookup(msg.data.sceneid, payload)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/kurvia.ts
+++ b/src/devices/kurvia.ts
@@ -1,4 +1,4 @@
-import {Definition, Tz} from '../lib/types';
+import {Definition} from '../lib/types';
 import tz from '../converters/toZigbee';
 import extend from '../lib/extend';
 
@@ -11,8 +11,7 @@ const definitions: Definition[] = [
         vendor: 'KURVIA',
         description: 'GU10 GRBWC built from AliExpress',
         extend: extendData,
-        // FIXME: This doesn't satisfy the constraints of Tz.Converter[] and may be an unsafe assertion
-        toZigbee: ([tz.on_off] as Tz.Converter[]).concat(extendData.toZigbee),
+        toZigbee: [tz.on_off, ...extendData.toZigbee],
         meta: {applyRedFix: true, supportsEnhancedHue: false},
     },
 ];

--- a/src/devices/kurvia.ts
+++ b/src/devices/kurvia.ts
@@ -11,6 +11,7 @@ const definitions: Definition[] = [
         vendor: 'KURVIA',
         description: 'GU10 GRBWC built from AliExpress',
         extend: extendData,
+        // FIXME: This doesn't satisfy the constraints of Tz.Converter[] and may be an unsafe assertion
         toZigbee: ([tz.on_off] as Tz.Converter[]).concat(extendData.toZigbee),
         meta: {applyRedFix: true, supportsEnhancedHue: false},
     },

--- a/src/devices/led_trading.ts
+++ b/src/devices/led_trading.ts
@@ -23,7 +23,7 @@ const fzLocal = {
                 return {action: utils.getFromLookup(commandID, lookup)};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/leviton.ts
+++ b/src/devices/leviton.ts
@@ -20,7 +20,7 @@ const fzLocal = {
                 return {[property]: currentLevel > 0 ? 'ON' : 'OFF'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/linptech.ts
+++ b/src/devices/linptech.ts
@@ -29,7 +29,7 @@ const tzLocal = {
             }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -40,7 +40,7 @@ const fzLocal = {
             const buffer = msg.data;
             return {illuminance: Math.round(0.0001 * Math.pow(Number(buffer[7]), 3.413))};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS0225: {
         cluster: 'manuSpecificTuya_2',
         type: ['attributeReport'],
@@ -63,7 +63,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -121,7 +121,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lixee_private_fz: {
         cluster: 'liXeePrivate', // 0xFF66
         type: ['attributeReport', 'readResponse'],
@@ -197,7 +197,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     lixee_metering: {
         cluster: 'seMetering', // 0x0702
         type: ['attributeReport', 'readResponse'],
@@ -261,7 +261,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 

--- a/src/devices/lytko.ts
+++ b/src/devices/lytko.ts
@@ -37,7 +37,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thermostat_ui: {
         cluster: 'hvacUserInterfaceCfg',
         type: ['attributeReport', 'readResponse'],
@@ -55,7 +55,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -101,7 +101,7 @@ const tzLocal = {
             }
             return {state: {[key]: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_ui: {
         key: ['brightness', 'brightness_standby'],
         convertGet: async (entity, key, meta) => {
@@ -137,7 +137,7 @@ const tzLocal = {
             }
             return {state: {[key]: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -19,7 +19,7 @@ const fzLocal = {
                 return {[`state_${endpointName}`]: msg.data['onOff'] === 1 ? 'ON' : 'OFF'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -41,7 +41,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -93,7 +93,7 @@ const tzLocal = {
                 throw new Error(`Unhandled key toZigbee.namron_panelheater.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/niko.ts
+++ b/src/devices/niko.ts
@@ -20,7 +20,7 @@ const local = {
                 }
                 return state;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         switch_action: {
             cluster: 'manuSpecificNiko2',
             type: ['attributeReport', 'readResponse'],
@@ -62,7 +62,7 @@ const local = {
                 }
                 return state;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         switch_status_led: {
             cluster: 'manuSpecificNiko1',
             type: ['attributeReport', 'readResponse'],
@@ -76,7 +76,7 @@ const local = {
                 }
                 return state;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         outlet: {
             cluster: 'manuSpecificNiko1',
             type: ['attributeReport', 'readResponse'],
@@ -90,7 +90,7 @@ const local = {
                 }
                 return state;
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
     },
     tz: {
         switch_operation_mode: {
@@ -120,7 +120,7 @@ const local = {
                     ['switchOperationMode'],
                 );
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         switch_led_enable: {
             key: ['led_enable'],
             convertSet: async (entity, key, value, meta) => {
@@ -131,7 +131,7 @@ const local = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificNiko1', ['outletLedState']);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         switch_led_state: {
             key: ['led_state'],
             convertSet: async (entity, key, value, meta) => {
@@ -142,7 +142,7 @@ const local = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificNiko1', ['outletLedColor']);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         outlet_child_lock: {
             key: ['child_lock'],
             convertSet: async (entity, key, value, meta) => {
@@ -153,7 +153,7 @@ const local = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificNiko1', ['outletChildLock']);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         outlet_led_enable: {
             key: ['led_enable'],
             convertSet: async (entity, key, value, meta) => {
@@ -163,7 +163,7 @@ const local = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificNiko1', ['outletLedState']);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
     },
 };
 

--- a/src/devices/nue_3a.ts
+++ b/src/devices/nue_3a.ts
@@ -22,7 +22,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     LXN59_cover_state_via_onoff: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -31,7 +31,7 @@ const fzLocal = {
                 return {state: msg.data['onOff'] === 1 ? 'CLOSE' : 'OPEN'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/onesti.ts
+++ b/src/devices/onesti.ts
@@ -52,7 +52,7 @@ const fzLocal = {
                 return attributes;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 

--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -18,7 +18,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genLevelCtrl', ['currentLevel']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/osram.ts
+++ b/src/devices/osram.ts
@@ -21,7 +21,7 @@ const fzLocal = {
             };
             return {[utils.postfixWithEndpointName('action', msg, model, meta)]: lookup[msg.type]};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -17,7 +17,7 @@ const fzLocal = {
                 return fz.temperature.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     PC321_metering: {
         cluster: 'seMetering',
         type: ['attributeReport', 'readResponse'],
@@ -85,7 +85,7 @@ const fzLocal = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/perenio.ts
+++ b/src/devices/perenio.ts
@@ -36,7 +36,7 @@ const fzPerenio = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     switch_type: {
         cluster: 'genMultistateValue',
         type: ['attributeReport', 'readResponse'],
@@ -55,7 +55,7 @@ const fzPerenio = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     smart_plug: {
         cluster: '64635',
         type: ['attributeReport', 'readResponse'],
@@ -120,7 +120,7 @@ const fzPerenio = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzPerenio = {
@@ -141,7 +141,7 @@ const tzPerenio = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genMultistateValue', ['presentValue']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     default_state: {
         key: ['default_on_off_state'],
         convertSet: async (entity, key, val, meta) => {
@@ -157,7 +157,7 @@ const tzPerenio = {
         convertGet: async (entity, key, meta) => {
             await entity.read(64635, [0]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     alarms_reset: {
         key: ['alarm_voltage_min', 'alarm_voltage_max', 'alarm_power_max', 'alarm_consumed_energy'],
         convertSet: async (entity, key, val, meta) => {
@@ -167,7 +167,7 @@ const tzPerenio = {
         convertGet: async (entity, key, meta) => {
             await entity.read(64635, [1]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     alarms_limits: {
         key: ['voltage_min', 'voltage_max', 'power_max', 'consumed_energy_limit'],
         convertSet: async (entity, key, val, meta) => {
@@ -203,7 +203,7 @@ const tzPerenio = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     on_off_mod: {
         key: ['state', 'on_time', 'off_wait_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -242,7 +242,7 @@ const tzPerenio = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genOnOff', ['onOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -21,7 +21,7 @@ const fzLocal = {
                 return {contact: msg.data['onOff'] === 0};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/plugwise.ts
+++ b/src/devices/plugwise.ts
@@ -47,7 +47,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -58,7 +58,7 @@ const tzLocal = {
                 {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
             return {state: {'calibrate_valve': value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     plugwise_valve_position: {
         key: ['plugwise_valve_position', 'valve_position'],
         convertSet: async (entity, key, value, meta) => {
@@ -70,7 +70,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4001], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     plugwise_push_force: {
         key: ['plugwise_push_force', 'force'],
         convertSet: async (entity, key, value, meta) => {
@@ -81,7 +81,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4012], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     plugwise_radio_strength: {
         key: ['plugwise_radio_strength', 'radio_strength'],
         convertSet: async (entity, key, value, meta) => {
@@ -92,7 +92,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', [0x4014], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/rgb_genie.ts
+++ b/src/devices/rgb_genie.ts
@@ -17,7 +17,7 @@ const fzLocal = {
             utils.addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZB1026_command_off: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -26,7 +26,7 @@ const fzLocal = {
             utils.addActionGroup(payload, msg, model);
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -23,7 +23,7 @@ const tzLocal = {
             await entity.write(0x0102, {0xe000: {value, type: 0x21}}, {manufacturerCode: 0x105e});
             return {state: {lift_duration: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     indicator_mode: {
         key: ['indicator_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -40,7 +40,7 @@ const tzLocal = {
             const endpoint = entity.getDevice().getEndpoint(21);
             await endpoint.read(0xFF17, [0x0000], {manufacturerCode: 0x105e});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -194,7 +194,7 @@ const fzLocal = {
 
             return ret;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     indicator_mode: {
         cluster: 'clipsalWiserSwitchConfigurationClusterServer',
         type: ['attributeReport', 'readResponse'],
@@ -206,7 +206,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -26,7 +26,7 @@ const fzLocal = {
                 occupancy_and: (occupancyAnd & 1) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     DMS300_OUT: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -41,7 +41,7 @@ const fzLocal = {
                 occupancy_and: (occupancyAnd & 1) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ISM300Z3_on_off: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -55,7 +55,7 @@ const fzLocal = {
                 return {operation_mode: utils.getFromLookup(value, lookup)};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -157,7 +157,7 @@ const tzLocal = {
             }
             await endpoint.write('genAnalogInput', payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ISM300Z3_on_off: {
         key: ['state', 'operation_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -188,7 +188,7 @@ const tzLocal = {
                 await entity.read('genOnOff', ['onOff']);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ISM300Z3_rf_pairing: {
         key: ['rf_pairing'],
         convertSet: async (entity, key, value, meta) => {
@@ -196,7 +196,7 @@ const tzLocal = {
             const payload = {0x9001: {value: utils.getFromLookup(value, lookup), type: 0x20}}; // INT8U
             await entity.write('genOnOff', payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -25,7 +25,7 @@ const fzLocal = {
                 tamper: (zoneStatus & 1<<2) > 0,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -108,7 +108,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tank_level: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
@@ -139,7 +139,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     sinope: {
         cluster: 'manuSpecificSinope',
         type: ['attributeReport', 'readResponse'],
@@ -236,7 +236,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 const tzLocal = {
     thermostat_occupancy: {
@@ -250,7 +250,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['SinopeOccupancy'], manuSinope);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     backlight_autodim: {
         key: ['backlight_auto_dim'],
         convertSet: async (entity, key, value, meta) => {
@@ -262,7 +262,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['SinopeBacklight'], manuSinope);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     main_cycle_output: {
         key: ['main_cycle_output'],
         convertSet: async (entity, key, value, meta) => {
@@ -273,7 +273,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['SinopeMainCycleOutput'], manuSinope);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aux_cycle_output: {
         // TH1400ZB specific
         key: ['aux_cycle_output'],
@@ -285,7 +285,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['SinopeAuxCycleOutput']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     enable_outdoor_temperature: { // DEPRECATED: Use Second Display Mode or control via the timeout
         key: ['enable_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {
@@ -301,7 +301,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['outdoorTempToDisplayTimeout'], manuSinope);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     second_display_mode: {
         key: ['second_display_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -312,7 +312,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['secondScreenBehavior']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_outdoor_temperature: {
         key: ['thermostat_outdoor_temperature'],
         convertSet: async (entity, key, value, meta) => {
@@ -325,7 +325,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['outdoorTempToDisplay'], manuSinope);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     outdoor_temperature_timeout: {
         key: ['outdoor_temperature_timeout'],
         convertSet: async (entity, key, value, meta) => {
@@ -338,7 +338,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['outdoorTempToDisplayTimeout']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     thermostat_time: {
         key: ['thermostat_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -352,7 +352,7 @@ const tzLocal = {
                 await entity.write('manuSpecificSinope', {currentTimeToDisplay: value}, manuSinope);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     floor_control_mode: {
         // TH1300ZB and TH1400ZB specific
         key: ['floor_control_mode'],
@@ -371,7 +371,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['floorControlMode']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ambiant_max_heat_setpoint: {
         // TH1300ZB and TH1400ZB specific
         key: ['ambiant_max_heat_setpoint'],
@@ -386,7 +386,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['ambiantMaxHeatSetpointLimit']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     floor_min_heat_setpoint: {
         // TH1300ZB and TH1400ZB specific
         key: ['floor_min_heat_setpoint'],
@@ -401,7 +401,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['floorMinHeatSetpointLimit']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     floor_max_heat_setpoint: {
         // TH1300ZB and TH1400ZB specific
         key: ['floor_max_heat_setpoint'],
@@ -416,7 +416,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['floorMaxHeatSetpointLimit']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     temperature_sensor: {
         // TH1300ZB and TH1400ZB specific
         key: ['floor_temperature_sensor'],
@@ -435,7 +435,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['temperatureSensor']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     time_format: {
         key: ['time_format'],
         convertSet: async (entity, key, value, meta) => {
@@ -453,7 +453,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['timeFormatToDisplay'], manuSinope);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     connected_load: {
         // TH1400ZB and SW2500ZB
         key: ['connected_load'],
@@ -464,7 +464,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['connectedLoad']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aux_connected_load: {
         // TH1400ZB specific
         key: ['aux_connected_load'],
@@ -475,7 +475,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['auxConnectedLoad']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     pump_protection: {
         // TH1400ZB specific
         key: ['pump_protection'],
@@ -491,7 +491,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['pumpProtection']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     led_intensity_on: {
         // DM25x0ZB and SW2500ZB
         key: ['led_intensity_on'],
@@ -505,7 +505,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['ledIntensityOn']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     led_intensity_off: {
         // DM25x0ZB and SW2500ZB
         key: ['led_intensity_off'],
@@ -519,7 +519,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['ledIntensityOff']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     led_color_on: {
         // DM25x0ZB and SW2500ZB
         key: ['led_color_on'],
@@ -531,7 +531,7 @@ const tzLocal = {
             const valueHex = r + g * 256 + (b * 256 ** 2);
             await entity.write('manuSpecificSinope', {ledColorOn: valueHex});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     led_color_off: {
         // DM25x0ZB and SW2500ZB
         key: ['led_color_off'],
@@ -543,7 +543,7 @@ const tzLocal = {
             const valueHex = r + g * 256 + b * 256 ** 2;
             await entity.write('manuSpecificSinope', {ledColorOff: valueHex});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     minimum_brightness: {
         // DM25x0ZB
         key: ['minimum_brightness'],
@@ -557,7 +557,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['minimumBrightness']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     timer_seconds: {
         // DM25x0ZB and SW2500ZB
         key: ['timer_seconds'],
@@ -571,7 +571,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['dimmerTimmer']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     keypad_lockout: {
         // SW2500ZB
         key: ['keypad_lockout'],
@@ -583,7 +583,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['keypadLockout']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     low_water_temp_protection: {
         // RM3500ZB specific
         key: ['low_water_temp_protection'],
@@ -594,7 +594,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificSinope', ['drConfigWaterTempMin']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 const definitions: Definition[] = [
     {

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -22,7 +22,7 @@ const fzLocal = {
                 result.light_indicator_level = msg.data['currentLevel'];
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     child_lock: {
         cluster: '64529',
         type: ['attributeReport', 'readResponse'],
@@ -36,7 +36,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     open_window: {
         cluster: '64529',
         type: ['attributeReport', 'readResponse'],
@@ -50,7 +50,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     frost_protection_temperature: {
         cluster: '64529',
         type: ['attributeReport', 'readResponse'],
@@ -64,7 +64,7 @@ const fzLocal = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -81,7 +81,7 @@ const tzLocal = {
                 },
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     open_window: {
         key: ['open_window'],
         convertGet: async (entity, key, meta) => {
@@ -95,7 +95,7 @@ const tzLocal = {
                 },
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     frost_protection_temperature: {
         key: ['frost_protection_temperature'],
         convertGet: async (entity, key, meta) => {
@@ -109,7 +109,7 @@ const tzLocal = {
                 },
             };
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/sprut.ts
+++ b/src/devices/sprut.ts
@@ -93,9 +93,6 @@ const fzLocal = {
         },
     } satisfies Fz.Converter,
     co2_mh_z19b_config: {
-        // FIXME: There is no "key" on type Converter
-        // @ts-expect-error
-        key: ['co2_autocalibration', 'co2_manual_calibration'],
         cluster: 'msCO2',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
@@ -108,9 +105,6 @@ const fzLocal = {
         },
     } satisfies Fz.Converter,
     th_heater: {
-        // FIXME: There is no "key" on type Converter
-        // @ts-expect-error
-        key: ['th_heater'],
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {

--- a/src/devices/sprut.ts
+++ b/src/devices/sprut.ts
@@ -27,7 +27,7 @@ const fzLocal = {
             const temperature = parseFloat(msg.data['measuredValue']) / 100.0;
             return {temperature: calibrateAndPrecisionRoundOptions(temperature, options, 'temperature')};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     occupancy_level: {
         cluster: 'msOccupancySensing',
         type: ['readResponse', 'attributeReport'],
@@ -36,7 +36,7 @@ const fzLocal = {
                 return {occupancy_level: msg.data['sprutOccupancyLevel']};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     voc: {
         cluster: 'sprutVoc',
         type: ['readResponse', 'attributeReport'],
@@ -45,7 +45,7 @@ const fzLocal = {
                 return {voc: msg.data['voc']};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     noise: {
         cluster: 'sprutNoise',
         type: ['readResponse', 'attributeReport'],
@@ -54,7 +54,7 @@ const fzLocal = {
                 return {noise: msg.data['noise'].toFixed(2)};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     noise_detected: {
         cluster: 'sprutNoise',
         type: ['readResponse', 'attributeReport'],
@@ -63,36 +63,38 @@ const fzLocal = {
                 return {noise_detected: msg.data['noiseDetected'] === 1};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     occupancy_timeout: {
         cluster: 'msOccupancySensing',
         type: ['readResponse', 'attributeReport'],
         convert: (model, msg, publish, options, meta) => {
             return {occupancy_timeout: msg.data['pirOToUDelay']};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     noise_timeout: {
         cluster: 'sprutNoise',
         type: ['readResponse', 'attributeReport'],
         convert: (model, msg, publish, options, meta) => {
             return {noise_timeout: msg.data['noiseAfterDetectDelay']};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     occupancy_sensitivity: {
         cluster: 'msOccupancySensing',
         type: ['readResponse', 'attributeReport'],
         convert: (model, msg, publish, options, meta) => {
             return {occupancy_sensitivity: msg.data['sprutOccupancySensitivity']};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     noise_detect_level: {
         cluster: 'sprutNoise',
         type: ['readResponse', 'attributeReport'],
         convert: (model, msg, publish, options, meta) => {
             return {noise_detect_level: msg.data['noiseDetectLevel']};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     co2_mh_z19b_config: {
+        // FIXME: There is no "key" on type Converter
+        // @ts-expect-error
         key: ['co2_autocalibration', 'co2_manual_calibration'],
         cluster: 'msCO2',
         type: ['attributeReport', 'readResponse'],
@@ -104,8 +106,10 @@ const fzLocal = {
                 return {co2_manual_calibration: switchActionValues[msg.data['sprutCO2Calibration']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     th_heater: {
+        // FIXME: There is no "key" on type Converter
+        // @ts-expect-error
         key: ['th_heater'],
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
@@ -114,7 +118,7 @@ const fzLocal = {
                 return {th_heater: switchActionValues[msg.data['sprutHeater']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -159,7 +163,7 @@ const tzLocal = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     occupancy_timeout: {
         key: ['occupancy_timeout'],
         convertSet: async (entity, key, value, meta) => {
@@ -170,7 +174,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('msOccupancySensing', ['pirOToUDelay']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     noise_timeout: {
         key: ['noise_timeout'],
         convertSet: async (entity, key, value, meta) => {
@@ -182,7 +186,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('sprutNoise', ['noiseAfterDetectDelay']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     occupancy_sensitivity: {
         key: ['occupancy_sensitivity'],
         convertSet: async (entity, key, value, meta) => {
@@ -195,7 +199,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('msOccupancySensing', ['sprutOccupancySensitivity'], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     noise_detect_level: {
         key: ['noise_detect_level'],
         convertSet: async (entity, key, value, meta) => {
@@ -208,7 +212,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('sprutNoise', ['noiseDetectLevel'], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     temperature_offset: {
         key: ['temperature_offset'],
         convertSet: async (entity, key, value, meta) => {
@@ -219,7 +223,7 @@ const tzLocal = {
             await entity.write('msTemperatureMeasurement', {'sprutTemperatureOffset': newValue}, options);
             return {state: {[key]: number}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     co2_mh_z19b_config: {
         key: ['co2_autocalibration', 'co2_manual_calibration'],
         convertSet: async (entity, key, value, meta) => {
@@ -235,7 +239,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('msCO2', [getFromLookup(key, co2Lookup)], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     th_heater: {
         key: ['th_heater'],
         convertSet: async (entity, key, value, meta) => {
@@ -250,7 +254,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('msRelativeHumidity', ['sprutHeater'], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/stelpro.ts
+++ b/src/devices/stelpro.ts
@@ -16,7 +16,7 @@ const fzLocal = {
                 return {power: msg.data['16392']};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     energy: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -25,7 +25,7 @@ const fzLocal = {
                 return {energy: parseFloat(msg.data['16393']) / 1000};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -40,7 +40,7 @@ const fzLocal = {
                 return {action: utils.getFromLookup(commandID, lookup)};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 async function syncTime(endpoint: Zh.Endpoint) {

--- a/src/devices/third_reality.ts
+++ b/src/devices/third_reality.ts
@@ -18,7 +18,7 @@ const fzLocal = {
             if (msg.data['3']) payload.z_axis = msg.data['3'];
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thirdreality_private_motion_sensor: {
         cluster: 'manuSpecificUbisysDeviceSetup',
         type: 'attributeReport',
@@ -26,7 +26,7 @@ const fzLocal = {
             const zoneStatus = msg.data[2];
             return {occupancy: (zoneStatus & 1) > 0};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -28,14 +28,14 @@ const tzLocal = {
             const lookup = {up: 0, down: 1, up_delete: 2, down_delete: 3};
             await entity.write(0xe001, {0xe001: {value: utils.getFromLookup(value, lookup), type: 0x30}});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS0726_switch_mode: {
         key: ['switch_mode'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write(0xe001, {0xd020: {value: utils.getFromLookup(value, {switch: 0, scene: 1}), type: 0x30}});
             return {state: {switch_mode: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     led_control: {
         key: ['brightness', 'color', 'color_temp', 'transition'],
         options: [exposes.options.color_sync()],
@@ -137,7 +137,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('lightingColorCtrl', ['currentHue', 'currentSaturation', 'currentLevel', 'tuyaRgbMode', 'colorTemperature']);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS110E_options: {
         key: ['min_brightness', 'max_brightness', 'light_type', 'switch_type'],
         convertSet: async (entity, key, value, meta) => {
@@ -160,10 +160,9 @@ const tzLocal = {
             if (key === 'light_type' || key === 'switch_type') id = 64514;
             await entity.read('genLevelCtrl', [id]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS110E_onoff_brightness: {
         key: ['state', 'brightness'],
-        options: [],
         convertSet: async (entity, key, value, meta) => {
             const {message, state} = meta;
             if (message.state === 'OFF' || (message.hasOwnProperty('state') && !message.hasOwnProperty('brightness'))) {
@@ -184,7 +183,7 @@ const tzLocal = {
             if (key === 'state') await tz.on_off.convertGet(entity, key, meta);
             if (key === 'brightness') await entity.read('genLevelCtrl', [61440]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS110E_light_onoff_brightness: {
         ...tz.light_onoff_brightness,
         convertSet: async (entity, key, value, meta) => {
@@ -196,7 +195,7 @@ const tzLocal = {
             }
             return tz.light_onoff_brightness.convertSet(entity, key, value, meta);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS0504B_color: {
         key: ['color'],
         convertSet: async (entity, key, value, meta) => {
@@ -221,7 +220,7 @@ const tzLocal = {
                 return await tz.light_color.convertSet(entity, key, value, meta);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS0224: {
         key: ['light', 'duration', 'volume'],
         convertSet: async (entity, key, value, meta) => {
@@ -240,7 +239,7 @@ const tzLocal = {
             }
             return {state: {[key]: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     temperature_unit: {
         key: ['temperature_unit'],
         convertSet: async (entity, key, value, meta) => {
@@ -254,7 +253,7 @@ const tzLocal = {
                 meta.logger.warn(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     TS011F_threshold: {
         key: [
             'temperature_threshold', 'temperature_breaker', 'power_threshold', 'power_breaker',
@@ -333,7 +332,7 @@ const tzLocal = {
                 meta.logger.warn(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -343,7 +342,7 @@ const fzLocal = {
         convert: (model, msg, publish, options, meta) => {
             return {action: `scene_${msg.endpoint.ID}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS0222_humidity: {
         ...fz.humidity,
         convert: async (model, msg, publish, options, meta) => {
@@ -351,7 +350,7 @@ const fzLocal = {
             if (result) result.humidity *= 10;
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS110E: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -368,7 +367,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS110E_light_type: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -380,7 +379,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS110E_switch_type: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -393,7 +392,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     scenes_recall_scene_65029: {
         cluster: '65029',
         type: ['raw', 'attributeReport'],
@@ -401,7 +400,7 @@ const fzLocal = {
             const id = meta.device.modelID === '005f0c3b' ? msg.data[0] : msg.data[msg.data.length - 1];
             return {action: `scene_${id}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS0201_battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -410,7 +409,7 @@ const fzLocal = {
             if (msg.data.batteryPercentageRemaining == 200 && msg.data.batteryVoltage < 30) return;
             return fz.battery.convert(model, msg, publish, options, meta);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS0201_humidity: {
         ...fz.humidity,
         convert: (model, msg, publish, options, meta) => {
@@ -419,7 +418,7 @@ const fzLocal = {
             }
             return fz.humidity.convert(model, msg, publish, options, meta);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     humidity10: {
         cluster: 'msRelativeHumidity',
         type: ['attributeReport', 'readResponse'],
@@ -430,7 +429,7 @@ const fzLocal = {
                 return {humidity: utils.calibrateAndPrecisionRoundOptions(humidity, options, 'humidity')};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     temperature_unit: {
         cluster: 'manuSpecificTuya_2',
         type: ['attributeReport', 'readResponse'],
@@ -441,7 +440,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS011F_electrical_measurement: {
         ...fz.electrical_measurement,
         convert: async (model, msg, publish, options, meta) => {
@@ -467,7 +466,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS011F_threshold: {
         cluster: 'manuSpecificTuya_3',
         type: 'raw',
@@ -507,7 +506,7 @@ const fzLocal = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -75,7 +75,7 @@ const ubisys = {
                     };
                 }
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         dimmer_setup_genLevelCtrl: {
             cluster: 'genLevelCtrl',
             type: ['attributeReport', 'readResponse'],
@@ -84,7 +84,7 @@ const ubisys = {
                     return {minimum_on_level: msg.data.ubisysMinimumOnLevel};
                 }
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         configure_device_setup: {
             cluster: 'manuSpecificUbisysDeviceSetup',
             type: ['attributeReport', 'readResponse'],
@@ -100,7 +100,7 @@ const ubisys = {
                 }
                 return {configure_device_setup: result};
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
         thermostat_vacation_mode: {
             cluster: 'hvacThermostat',
             type: ['attributeReport', 'readResponse'],
@@ -109,7 +109,7 @@ const ubisys = {
                     return {vacation_mode: msg.data.occupancy === 0};
                 }
             },
-        } as Fz.Converter,
+        } satisfies Fz.Converter,
     },
     tz: {
         configure_j1: {
@@ -269,7 +269,7 @@ const ubisys = {
                     'ubisysStartupSteps',
                 ], manufacturerOptions.ubisys));
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         dimmer_setup: {
             key: ['capabilities_forward_phase_control',
                 'capabilities_reverse_phase_control',
@@ -298,7 +298,7 @@ const ubisys = {
                 await entity.read('manuSpecificUbisysDimmerSetup', ['status'], manufacturerOptions.ubisysNull);
                 await entity.read('manuSpecificUbisysDimmerSetup', ['mode'], manufacturerOptions.ubisysNull);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         dimmer_setup_genLevelCtrl: {
             key: ['minimum_on_level'],
             convertSet: async (entity, key, value, meta) => {
@@ -310,7 +310,7 @@ const ubisys = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('genLevelCtrl', ['ubisysMinimumOnLevel'], manufacturerOptions.ubisys);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         configure_device_setup: {
             key: ['configure_device_setup'],
             convertSet: async (entity, key, value: KeyValueAny, meta) => {
@@ -531,7 +531,7 @@ const ubisys = {
                 await devMgmtEp.read('manuSpecificUbisysDeviceSetup', ['inputActions'],
                     manufacturerOptions.ubisysNull);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
         thermostat_vacation_mode: {
             key: ['vacation_mode'],
             convertSet: async (entity, key, value, meta) => {
@@ -548,7 +548,7 @@ const ubisys = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('hvacThermostat', ['occupancy']);
             },
-        } as Tz.Converter,
+        } satisfies Tz.Converter,
     },
 };
 

--- a/src/devices/woolley.ts
+++ b/src/devices/woolley.ts
@@ -31,7 +31,7 @@ const fzLocal = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -91,7 +91,7 @@ const fzLocal = {
         convert: (model, msg, publish, options, meta) => {
             return {co2: Math.floor(msg.data.measuredValue)};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_s1_pm25: {
         cluster: 'pm25Measurement',
         type: ['attributeReport', 'readResponse'],
@@ -100,7 +100,7 @@ const fzLocal = {
                 return {pm25: msg.data['measuredValue'] / 1000};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_trv: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -189,7 +189,7 @@ const fzLocal = {
             });
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_feeder: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -273,7 +273,7 @@ const fzLocal = {
             });
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     aqara_fp1_region_events: {
         cluster: 'aqaraOpple',
         type: ['attributeReport', 'readResponse'],
@@ -326,11 +326,10 @@ const fzLocal = {
 
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CTPR01_action_multistate: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const value = msg.data['presentValue'];
             let payload;
@@ -357,11 +356,10 @@ const fzLocal = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CTPR01_action_analog: {
         cluster: 'genAnalogInput',
         type: ['attributeReport', 'readResponse'],
-        options: [],
         convert: (model, msg, publish, options, meta) => {
             const value = msg.data['presentValue'];
             return {
@@ -369,7 +367,7 @@ const fzLocal = {
                 action_angle: Math.floor(value * 100) / 100,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -385,7 +383,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x010C], {manufacturerCode});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_trv: {
         key: ['system_mode', 'preset', 'window_detection', 'valve_detection', 'child_lock', 'away_preset_temperature',
             'calibrate', 'sensor', 'sensor_temp', 'identify', 'schedule', 'schedule_settings'],
@@ -524,7 +522,7 @@ const tzLocal = {
                 await entity.read('aqaraOpple', [utils.getFromLookup(key, dict)], {manufacturerCode: 0x115F});
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     VOCKQJK11LM_display_unit: {
         key: ['display_unit'],
         convertSet: async (entity, key, value, meta) => {
@@ -535,7 +533,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0114], {manufacturerCode: 0x115F, disableDefaultResponse: true});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_feeder: {
         key: ['feed', 'schedule', 'led_indicator', 'child_lock', 'mode', 'serving_size', 'portion_weight'],
         convertSet: async (entity, key, value, meta) => {
@@ -610,7 +608,7 @@ const tzLocal = {
             }
             return {state: {[key]: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_fp1_region_upsert: {
         key: ['region_upsert'],
         convertSet: async (entity, key, value, meta) => {
@@ -674,7 +672,7 @@ const tzLocal = {
 
             await entity.write('aqaraOpple', payload, {manufacturerCode});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     aqara_fp1_region_delete: {
         key: ['region_delete'],
         convertSet: async (entity, key, value, meta) => {
@@ -720,7 +718,7 @@ const tzLocal = {
 
             await entity.write('aqaraOpple', payload, {manufacturerCode});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     CTPR01_operation_mode: {
         key: ['operation_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -739,7 +737,7 @@ const tzLocal = {
             globalStore.putValue(meta.device, 'opModeSwitchTask', {callback, newMode: value});
             meta.logger.info('Now give your cube a forceful throw motion (Careful not to drop it)!');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/devices/yale.ts
+++ b/src/devices/yale.ts
@@ -60,7 +60,7 @@ const fzLocal = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const definitions: Definition[] = [

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -1283,7 +1283,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     watering_timer: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport'],
@@ -1332,7 +1332,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZM35HQ_battery: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport'],
@@ -1345,7 +1345,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`zigbee-herdsman-converters:ZM35HQ: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZMRM02: {
         cluster: 'manuSpecificTuya',
         type: ['commandGetData', 'commandSetDataResponse', 'commandDataResponse'],
@@ -1361,7 +1361,7 @@ const fromZigbee1 = {
                 return {action: `button_${button}_${action}`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     SA12IZL: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -1392,7 +1392,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     R7049_status: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -1437,7 +1437,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     woox_R7060: {
         cluster: 'manuSpecificTuya',
         type: ['commandActiveStatusReport'],
@@ -1456,7 +1456,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hpsz: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -1484,7 +1484,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     zb_sm_cover: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -1554,7 +1554,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     x5h_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -1662,7 +1662,7 @@ const fromZigbee1 = {
             }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     zs_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -1766,7 +1766,7 @@ const fromZigbee1 = {
                 meta.logger.warn(`zigbee-herdsman-converters:zsThermostat: Unrecognized DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     giexWaterValve: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -1804,7 +1804,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_alecto_smoke: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -1839,7 +1839,7 @@ const fromZigbee1 = {
                     `DP #${ dp} with data ${JSON.stringify(msg.data)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     WXKG11LM_click: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1861,7 +1861,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     SmartButton_skip: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -1878,7 +1878,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     konke_click: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1895,7 +1895,7 @@ const fromZigbee1 = {
                 return lookup[value] ? lookup[value] : null;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_action_click_multistate: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -1911,7 +1911,7 @@ const fromZigbee1 = {
                 return lookup[value] ? lookup[value] : null;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     WXKG12LM_action_click_multistate: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -1927,7 +1927,7 @@ const fromZigbee1 = {
                 return lookup[value] ? lookup[value] : null;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     terncy_raw: {
         cluster: 'manuSpecificClusterAduroSmart',
         type: 'raw',
@@ -1963,7 +1963,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CCTSwitch_D0001_on_off: {
         cluster: 'genOnOff',
         type: ['commandOn', 'commandOff'],
@@ -1973,7 +1973,7 @@ const fromZigbee1 = {
                 return {click: 'power'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ptvo_switch_buttons: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -1998,7 +1998,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZGRC013_brightness_onoff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
@@ -2012,7 +2012,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZGRC013_brightness_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStopWithOnOff',
@@ -2025,7 +2025,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZGRC013_scene: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -2035,7 +2035,7 @@ const fromZigbee1 = {
                 return {click: `scene_${msg.data.groupid}_${msg.data.sceneid}`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZGRC013_cmdOn: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -2048,7 +2048,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZGRC013_cmdOff: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -2061,7 +2061,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZGRC013_brightness: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -2075,7 +2075,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CTR_U_scene: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -2085,7 +2085,7 @@ const fromZigbee1 = {
                 return {click: `scene_${msg.data.groupid}_${msg.data.sceneid}`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     st_button_state: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
@@ -2108,7 +2108,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     QBKG11LM_click: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -2121,7 +2121,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     QBKG12LM_click: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -2136,7 +2136,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     QBKG03LM_QBKG12LM_click: {
         cluster: 'genOnOff',
         type: ['attributeReport'],
@@ -2150,7 +2150,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     QBKG04LM_QBKG11LM_click: {
         cluster: 'genOnOff',
         type: ['attributeReport'],
@@ -2162,7 +2162,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cover_stop: {
         cluster: 'closuresWindowCovering',
         type: 'commandStop',
@@ -2172,7 +2172,7 @@ const fromZigbee1 = {
                 return {click: 'release'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cover_open: {
         cluster: 'closuresWindowCovering',
         type: 'commandUpOpen',
@@ -2182,7 +2182,7 @@ const fromZigbee1 = {
                 return {click: 'open'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cover_close: {
         cluster: 'closuresWindowCovering',
         type: 'commandDownClose',
@@ -2192,7 +2192,7 @@ const fromZigbee1 = {
                 return {click: 'close'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     WXKG03LM_click: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -2202,7 +2202,7 @@ const fromZigbee1 = {
                 return {click: 'single'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     TS0218_click: {
         cluster: 'ssIasAce',
         type: 'commandEmergency',
@@ -2214,7 +2214,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_emergency.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_on_off_action: {
         cluster: 'genOnOff',
         type: ['attributeReport'],
@@ -2226,7 +2226,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.xiaomi_on_off_action.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     WXKG02LM_click: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -2237,7 +2237,7 @@ const fromZigbee1 = {
                 return {click: lookup[msg.endpoint.ID]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     WXKG02LM_click_multistate: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -2267,7 +2267,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     WXKG01LM_click: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -2317,7 +2317,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     scenes_recall_click: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -2327,7 +2327,7 @@ const fromZigbee1 = {
                 return {click: msg.data.sceneid};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     AV2010_34_click: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -2337,7 +2337,7 @@ const fromZigbee1 = {
                 return {click: msg.data.groupid};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1743_brightness_down: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -2347,7 +2347,7 @@ const fromZigbee1 = {
                 return {click: 'brightness_down'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1743_brightness_up: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
@@ -2357,7 +2357,7 @@ const fromZigbee1 = {
                 return {click: 'brightness_up'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1743_brightness_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStopWithOnOff',
@@ -2367,7 +2367,7 @@ const fromZigbee1 = {
                 return {click: 'brightness_stop'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     genOnOff_cmdOn: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -2377,7 +2377,7 @@ const fromZigbee1 = {
                 return {click: 'on'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     genOnOff_cmdOff: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -2387,7 +2387,7 @@ const fromZigbee1 = {
                 return {click: 'off'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     RM01_on_click: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -2400,7 +2400,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_on.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     RM01_off_click: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -2413,7 +2413,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_off.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     RM01_down_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -2431,7 +2431,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     RM01_up_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandStepWithOnOff',
@@ -2449,7 +2449,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     RM01_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -2462,7 +2462,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     xiaomi_multistate_action: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -2482,7 +2482,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.xiaomi_multistate_action.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1744_play_pause: {
         cluster: 'genOnOff',
         type: 'commandToggle',
@@ -2495,7 +2495,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_toggle.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     E1744_skip: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -2513,7 +2513,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cmd_move: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -2528,7 +2528,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cmd_move_with_onoff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
@@ -2542,7 +2542,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cmd_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -2556,7 +2556,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cmd_stop_with_onoff: {
         cluster: 'genLevelCtrl',
         type: 'commandStopWithOnOff',
@@ -2569,7 +2569,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     cmd_move_to_level_with_onoff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveToLevelWithOnOff',
@@ -2583,7 +2583,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_level.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     immax_07046L_arm: {
         cluster: 'ssIasAce',
         type: 'commandArm',
@@ -2602,7 +2602,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_arm.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     KEF1PA_arm: {
         cluster: 'ssIasAce',
         type: 'commandArm',
@@ -2621,7 +2621,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_arm.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     QBKG25LM_click: {
         cluster: 'genMultistateInput',
         type: ['attributeReport', 'readResponse'],
@@ -2638,7 +2638,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.xiaomi_multistate_action.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     QBKG03LM_buttons: {
         cluster: 'genOnOff',
         type: ['attributeReport'],
@@ -2654,7 +2654,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CTR_U_brightness_updown_click: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -2679,7 +2679,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CTR_U_brightness_updown_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -2703,7 +2703,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     CTR_U_brightness_updown_release: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -2723,7 +2723,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdOn: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -2735,7 +2735,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_on.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdOff: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -2747,7 +2747,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_off.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdMoveWithOnOff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
@@ -2764,7 +2764,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AC0251100NJ_cmdStop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -2781,7 +2781,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdMove: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -2798,7 +2798,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdMoveHue: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
@@ -2812,7 +2812,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_hue.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdMoveToSaturation: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToSaturation',
@@ -2824,7 +2824,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_saturation.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdMoveToLevelWithOnOff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveToLevelWithOnOff',
@@ -2836,7 +2836,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_level.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_cmdMoveToColorTemp: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToColorTemp',
@@ -2848,7 +2848,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_color_temp.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_73743_cmdStop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -2868,7 +2868,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdOn: {
         cluster: 'genOnOff',
         type: 'commandOn',
@@ -2880,7 +2880,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_on.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdOff: {
         cluster: 'genOnOff',
         type: 'commandOff',
@@ -2892,7 +2892,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_off.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdStepColorTemp: {
         cluster: 'lightingColorCtrl',
         type: 'commandStepColorTemp',
@@ -2905,7 +2905,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step_color_temperature.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdMoveWithOnOff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
@@ -2917,7 +2917,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdMove: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -2929,7 +2929,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdStop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -2942,7 +2942,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdMoveHue: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveHue',
@@ -2956,7 +2956,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_hue.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     osram_lightify_switch_AB371860355_cmdMoveSat: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToSaturation',
@@ -2969,7 +2969,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_saturation.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     insta_scene_click: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -2983,7 +2983,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_recall.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     insta_down_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -3000,7 +3000,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     insta_up_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandStepWithOnOff',
@@ -3017,7 +3017,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     insta_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -3031,7 +3031,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tint404011_brightness_updown_click: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -3050,7 +3050,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tint404011_brightness_updown_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -3076,7 +3076,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tint404011_brightness_updown_release: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -3096,7 +3096,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tint404011_move_to_color_temp: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToColorTemp',
@@ -3114,7 +3114,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.tint404011_move_to_color_temp.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tint404011_move_to_color: {
         cluster: 'lightingColorCtrl',
         type: 'commandMoveToColor',
@@ -3135,7 +3135,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_color.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     heiman_smart_controller_armmode: {
         cluster: 'ssIasAce',
         type: 'commandArm',
@@ -3156,7 +3156,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_arm.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     LZL4B_onoff: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveToLevelWithOnOff',
@@ -3171,7 +3171,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_level.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     eria_81825_updown: {
         cluster: 'genLevelCtrl',
         type: 'commandStep',
@@ -3184,7 +3184,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_step.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZYCT202_stop: {
         cluster: 'genLevelCtrl',
         type: 'commandStop',
@@ -3196,7 +3196,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_stop.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZYCT202_up_down: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
@@ -3212,7 +3212,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     STS_PRS_251_beeping: {
         cluster: 'genIdentify',
         type: ['attributeReport', 'readResponse'],
@@ -3224,7 +3224,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.identify.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     dimmer_passthru_brightness: {
         cluster: 'genLevelCtrl',
         type: 'commandMoveToLevelWithOnOff',
@@ -3236,7 +3236,7 @@ const fromZigbee1 = {
                 return fromZigbeeConverters.command_move_to_level.convert(model, msg, publish, options, meta);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     bitron_thermostat_att_report: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -3266,7 +3266,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thermostat_att_report: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -3355,7 +3355,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     stelpro_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -3384,7 +3384,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     viessmann_thermostat_att_report: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -3406,7 +3406,7 @@ const fromZigbee1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     eurotronic_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -3468,7 +3468,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wiser_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -3491,7 +3491,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hvac_user_interface: {
         cluster: 'hvacUserInterfaceCfg',
         type: ['attributeReport', 'readResponse'],
@@ -3508,7 +3508,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     thermostat_weekly_schedule_rsp: {
         cluster: 'hvacThermostat',
         type: ['commandGetWeeklyScheduleRsp'],
@@ -3534,7 +3534,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     terncy_knob: {
         cluster: 'manuSpecificClusterAduroSmart',
         type: ['attributeReport', 'readResponse'],
@@ -3551,7 +3551,7 @@ const fromZigbee1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wiser_itrv_battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],
@@ -3578,7 +3578,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ubisys_c4_scenes: {
         cluster: 'genScenes',
         type: 'commandRecall',
@@ -3589,7 +3589,7 @@ const fromZigbee1 = {
             }
             return {action: `${msg.endpoint.ID}_scene_${msg.data.groupid}_${msg.data.sceneid}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ubisys_c4_onoff: {
         cluster: 'genOnOff',
         type: ['commandOn', 'commandOff', 'commandToggle'],
@@ -3606,7 +3606,7 @@ const fromZigbee1 = {
             }
             return {action: `${msg.endpoint.ID}_${msg.type.substr(7).toLowerCase()}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ubisys_c4_level: {
         cluster: 'genLevelCtrl',
         type: ['commandMoveWithOnOff', 'commandStopWithOnOff'],
@@ -3627,7 +3627,7 @@ const fromZigbee1 = {
                 return {action: `${msg.endpoint.ID}_level_stop`};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ubisys_c4_cover: {
         cluster: 'closuresWindowCovering',
         type: ['commandUpOpen', 'commandDownClose', 'commandStop'],
@@ -3650,7 +3650,7 @@ const fromZigbee1 = {
             };
             return {action: `${msg.endpoint.ID}_cover_${lookup[msg.type]}`};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hue_dimmer_switch: {
         cluster: 'manuSpecificPhilips',
         type: 'commandHueNotification',
@@ -3769,7 +3769,7 @@ const fromZigbee1 = {
 
             return {};
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     blitzwolf_occupancy_with_timeout: {
         cluster: 'manuSpecificTuya',
         type: 'commandDataResponse',
@@ -3778,7 +3778,7 @@ const fromZigbee1 = {
             msg.data.occupancy = dpValue.dp === dataPoints.occupancy ? 1 : 0;
             return fromZigbeeConverters.occupancy_with_timeout.convert(model, msg, publish, options, meta) as KeyValueAny;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     moes_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -3908,7 +3908,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     moesS_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -3978,7 +3978,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_air_quality: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -4035,7 +4035,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_CO: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -4054,7 +4054,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     connecte_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4104,7 +4104,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     saswell_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4229,7 +4229,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     evanell_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4274,7 +4274,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     etop_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4324,7 +4324,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4433,7 +4433,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_dimmer: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4475,7 +4475,7 @@ const fromZigbee1 = {
                 }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_motion_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse'],
@@ -4526,7 +4526,7 @@ const fromZigbee1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_smart_vibration_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandGetData', 'commandDataResponse', 'raw'],
@@ -4551,7 +4551,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     matsee_garage_door_opener: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'raw'],
@@ -4576,7 +4576,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     moes_thermostat_tv: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'raw'],
@@ -4665,7 +4665,7 @@ const fromZigbee1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hoch_din: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4780,7 +4780,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_light_wz5: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4814,7 +4814,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZMAM02_cover: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -4902,7 +4902,7 @@ const fromZigbee1 = {
                     ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tm081: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport'],
@@ -4916,7 +4916,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`zigbee-herdsman-converters:TM081: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_remote: {
         cluster: 'manuSpecificTuya',
         type: ['commandGetData', 'commandDataResponse'],
@@ -4935,7 +4935,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_smart_human_presense_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -4982,7 +4982,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZG204ZL_lms: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -5016,7 +5016,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     moes_cover: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -5055,7 +5055,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_temperature_humidity_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5085,7 +5085,7 @@ const fromZigbee1 = {
                     `DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     nous_lcd_temperature_humidity_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -5149,7 +5149,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_illuminance_temperature_humidity_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5173,7 +5173,7 @@ const fromZigbee1 = {
                     `DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_illuminance_sensor: {
         cluster: `manuSpecificTuya`,
         type: [`commandDataReport`, `commandDataResponse`],
@@ -5203,7 +5203,7 @@ const fromZigbee1 = {
                 }
             };
         })(),
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     hy_thermostat: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5289,7 +5289,7 @@ const fromZigbee1 = {
                     dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     neo_nas_pd07: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5336,7 +5336,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`fz.neo_nas_pd07: Unhandled DP #${dp}: ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     neo_t_h_alarm: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5386,7 +5386,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`fz.neo_t_h_alarm: Unhandled DP #${dp}: ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     neo_alarm: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5411,7 +5411,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`Unhandled DP #${dp}: ${JSON.stringify(msg.data)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZB006X_settings: {
         cluster: 'manuSpecificTuya',
         type: ['commandActiveStatusReport', 'commandActiveStatusReportAlt'],
@@ -5449,7 +5449,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`fz.ZB006X_settings: Unhandled DP|Value [${dp}|${value}][${JSON.stringify(dpValue)}]`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_cover: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5512,7 +5512,7 @@ const fromZigbee1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     moes_switch: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -5538,7 +5538,7 @@ const fromZigbee1 = {
                 break;
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_water_leak: {
         cluster: 'manuSpecificTuya',
         type: 'commandDataReport',
@@ -5548,7 +5548,7 @@ const fromZigbee1 = {
                 return {water_leak: getDataValue(dpValue)};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     wls100z_water_leak: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -5570,7 +5570,7 @@ const fromZigbee1 = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     silvercrest_smart_led_string: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -5620,7 +5620,7 @@ const fromZigbee1 = {
 
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     frankever_valve: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'commandActiveStatusReport'],
@@ -5644,7 +5644,7 @@ const fromZigbee1 = {
             }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_woox_smoke: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse'],
@@ -5663,7 +5663,7 @@ const fromZigbee1 = {
                 meta.logger.warn(`zigbee-herdsman-converters:tuya_smoke: Unrecognized DP #${ dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_switch: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse', 'commandActiveStatusReport'],
@@ -5684,7 +5684,7 @@ const fromZigbee1 = {
             }
             return null;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_dinrail_switch: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse', 'commandActiveStatusReport'],
@@ -5712,7 +5712,7 @@ const fromZigbee1 = {
 
             return null;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZVG1: {
         cluster: 'manuSpecificTuya',
         type: 'commandDataResponse',
@@ -5798,7 +5798,7 @@ const fromZigbee1 = {
             }
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     ZB003X: {
         cluster: 'manuSpecificTuya',
         type: ['commandActiveStatusReport'],
@@ -5838,7 +5838,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`fz.ZB003X: Unhandled DP #${dp}: ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_thermostat_weekly_schedule_2: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -5889,7 +5889,7 @@ const fromZigbee1 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     tuya_data_point_dump: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'commandActiveStatusReport', 'commandActiveStatusReportAlt'],
@@ -5924,7 +5924,7 @@ const fromZigbee1 = {
                 if (err) throw err;
             });
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     javis_microwave_sensor: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataReport', 'commandDataResponse'],
@@ -5996,7 +5996,7 @@ const fromZigbee1 = {
                     `DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     SLUXZB: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport'],
@@ -6016,7 +6016,7 @@ const fromZigbee1 = {
                 meta.logger.debug(`s_lux_zb_illuminance: NOT RECOGNIZED DP #${dp} with data ${JSON.stringify(dpValue)}`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const fromZigbee2 = {
@@ -6079,7 +6079,7 @@ const fromZigbee2 = {
                 };
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 const toZigbee1 = {
@@ -6088,57 +6088,57 @@ const toZigbee1 = {
         convertSet: async (entity, key, value: any, meta) => {
             await sendDataPointBool(entity, 16, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     SA12IZL_alarm: {
         key: ['alarm'],
         convertSet: async (entity, key, value: any, meta) => {
             // @ts-ignore
             await sendDataPointEnum(entity, 20, {true: 0, false: 1}[value]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     R7049_silenceSiren: {
         key: ['silence_siren'],
         convertSet: async (entity, key, value: any, meta) => {
             await sendDataPointBool(entity, 16, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     R7049_testAlarm: {
         key: ['test_alarm'],
         convertSet: async (entity, key, value: any, meta) => {
             await sendDataPointBool(entity, 8, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     R7049_alarm: {
         key: ['alarm'],
         convertSet: async (entity, key, value: any, meta) => {
             const linkAlarm: KeyValueAny = {true: 0, false: 1};
             await sendDataPointEnum(entity, 20, linkAlarm[value]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     valve_state: {
         key: ['valve_state'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.wateringTimer.valve_state, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     shutdown_timer: {
         key: ['shutdown_timer'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.wateringTimer.shutdown_timer, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     valve_state_auto_shutdown: {
         key: ['valve_state_auto_shutdown'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.wateringTimer.valve_state_auto_shutdown, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hpsz: {
         key: ['led_state'],
         convertSet: async (entity, key, value: any, meta) => {
             await sendDataPointBool(entity, dataPoints.HPSZLEDState, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_cover_control: {
         key: ['state', 'position'],
         options: [exposes.options.invert_cover()],
@@ -6177,7 +6177,7 @@ const toZigbee1 = {
                 }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const toZigbee2 = {
@@ -6249,7 +6249,7 @@ const toZigbee2 = {
             }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     x5h_thermostat: {
         key: ['system_mode', 'current_heating_setpoint', 'sensor', 'brightness_state', 'sound', 'frost_protection', 'week', 'factory_reset',
             'local_temperature_calibration', 'heating_temp_limit', 'deadzone_temperature', 'upper_temp', 'preset', 'child_lock',
@@ -6374,25 +6374,25 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.zsChildLock, value === 'LOCK');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_binary_one: {
         key: ['binary_one'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.zsBinaryOne, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_binary_two: {
         key: ['binary_two'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.zsBinaryTwo, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_current_heating_setpoint: {
         key: ['current_heating_setpoint'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -6401,7 +6401,7 @@ const toZigbee2 = {
             if (temp>=60) temp = 59;
             await sendDataPointValue(entity, dataPoints.zsHeatingSetpoint, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_current_heating_setpoint_auto: {
         key: ['current_heating_setpoint_auto'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -6410,7 +6410,7 @@ const toZigbee2 = {
             if (temp>=60) temp = 59;
             await sendDataPointValue(entity, dataPoints.zsHeatingSetpointAuto, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_comfort_temp: {
         key: ['comfort_temperature'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -6418,7 +6418,7 @@ const toZigbee2 = {
             const temp = Math.round(value * 2);
             await sendDataPointValue(entity, dataPoints.zsComfortTemp, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_openwindow_temp: {
         key: ['detectwindow_temperature'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -6427,20 +6427,20 @@ const toZigbee2 = {
             if (temp>=60) temp = 59;
             await sendDataPointValue(entity, dataPoints.zsOpenwindowTemp, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_openwindow_time: {
         key: ['detectwindow_timeminute'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.zsOpenwindowTime, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_eco_temp: {
         key: ['eco_temperature'],
         convertSet: async (entity, key, value: number, meta) => {
             const temp = Math.round(value * 2);
             await sendDataPointValue(entity, dataPoints.zsEcoTemp, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_preset_mode: {
         key: ['preset'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6456,7 +6456,7 @@ const toZigbee2 = {
                 }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -6472,7 +6472,7 @@ const toZigbee2 = {
                 await sendDataPointValue(entity, dataPoints.zsHeatingSetpoint, temp ? Math.round(temp * 2) : 43 );
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_local_temperature_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -6480,7 +6480,7 @@ const toZigbee2 = {
             if (value < 0) value = value*10 + 0x100000000;
             await sendDataPointValue(entity, dataPoints.zsTempCalibration, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_away_setting: {
         key: ['away_setting'],
         convertSet: async (entity, key, value: KeyValueAny, meta) => {
@@ -6540,7 +6540,7 @@ const toZigbee2 = {
 
             await sendDataPointRaw(entity, dataPoints.zsAwaySetting, result);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zs_thermostat_local_schedule: {
         key: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6592,7 +6592,7 @@ const toZigbee2 = {
             if (value < 0) value = value*10 + 0x100000000;
             await sendDataPointRaw(entity, (109+day-1), results);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     giexWaterValve:
     {
         key: [
@@ -6627,7 +6627,7 @@ const toZigbee2 = {
                 meta.logger.warn(`tzLocal.giexWaterValve: Unhandled KEY ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_alecto_smoke: {
         key: ['self_checking', 'silence'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6642,7 +6642,7 @@ const toZigbee2 = {
                 throw new Error(`zigbee-herdsman-converters:tuya_alecto_smoke: Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     matsee_garage_door_opener: {
         key: ['trigger'],
         convertSet: async (entity, key, value, meta) => {
@@ -6651,7 +6651,7 @@ const toZigbee2 = {
             await sendDataPointBool(entity, dataPoints.garageDoorTrigger, state);
             return {state: {trigger: state}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     connecte_thermostat: {
         key: [
             'child_lock', 'current_heating_setpoint', 'local_temperature_calibration', 'max_temperature_protection', 'window_detection',
@@ -6715,14 +6715,14 @@ const toZigbee2 = {
                 throw new Error(`Unhandled key toZigbee.connecte_thermostat ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 
     moes_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.moesChildLock, value === 'LOCK');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_current_heating_setpoint: {
         key: ['current_heating_setpoint'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6732,7 +6732,7 @@ const toZigbee2 = {
                 await sendDataPointValue(entity, dataPoints.moesHeatingSetpoint, value);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_deadzone_temperature: {
         key: ['deadzone_temperature'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6742,14 +6742,14 @@ const toZigbee2 = {
                 await sendDataPointValue(entity, dataPoints.moesDeadZoneTemp, value);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value: any, meta) => {
             if (value < 0) value = 4096 + value;
             await sendDataPointValue(entity, dataPoints.moesTempCalibration, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_min_temperature_limit: {
         key: ['min_temperature_limit'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6759,7 +6759,7 @@ const toZigbee2 = {
                 await sendDataPointValue(entity, dataPoints.moesMinTempLimit, value);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_max_temperature_limit: {
         key: ['max_temperature_limit'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6769,7 +6769,7 @@ const toZigbee2 = {
                 await sendDataPointValue(entity, dataPoints.moesMaxTempLimit, value);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_mode: {
         key: ['preset'],
         convertSet: async (entity, key, value, meta) => {
@@ -6778,13 +6778,13 @@ const toZigbee2 = {
             await sendDataPointEnum(entity, dataPoints.moesHold, hold);
             await sendDataPointEnum(entity, dataPoints.moesScheduleEnable, schedule);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_standby: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.state, value === 'heat');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_program_schedule: {
         key: ['program'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6840,51 +6840,51 @@ const toZigbee2 = {
             ];
             await sendDataPointRaw(entity, dataPoints.moesSchedule, payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
             return {state: {system_mode: 'heat'}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_preset: {
         key: ['preset'],
         convertSet: async (entity, key, value: any, meta) => {
             const lookup: KeyValueAny = {'programming': 0, 'manual': 1, 'temporary_manual': 2, 'holiday': 3};
             await sendDataPointEnum(entity, dataPoints.moesSsystemMode, lookup[value]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_current_heating_setpoint: {
         key: ['current_heating_setpoint'],
         convertSet: async (entity, key, value: number, meta) => {
             const temp = Math.round(value);
             await sendDataPointValue(entity, dataPoints.moesSheatingSetpoint, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_boost_heating: {
         key: ['boost_heating'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.moesSboostHeating, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_window_detection: {
         key: ['window_detection'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.moesSwindowDetectionFunktion_A2, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.moesSchildLock, value === 'LOCK');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_boostHeatingCountdownTimeSet: {
         key: ['boost_heating_countdown_time_set'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.moesSboostHeatingCountdownTimeSet, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_temperature_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -6894,34 +6894,34 @@ const toZigbee2 = {
             }
             await sendDataPointValue(entity, dataPoints.moesScompensationTempSet, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_moesSecoMode: {
         key: ['eco_mode'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.moesSecoMode, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_eco_temperature: {
         key: ['eco_temperature'],
         convertSet: async (entity, key, value: any, meta) => {
             const temp = Math.round(value);
             await sendDataPointValue(entity, dataPoints.moesSecoModeTempSet, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_max_temperature: {
         key: ['max_temperature'],
         convertSet: async (entity, key, value: any, meta) => {
             const temp = Math.round(value);
             await sendDataPointValue(entity, dataPoints.moesSmaxTempSet, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_min_temperature: {
         key: ['min_temperature'],
         convertSet: async (entity, key, value: any, meta) => {
             const temp = Math.round(value);
             await sendDataPointValue(entity, dataPoints.moesSminTempSet, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moesS_thermostat_schedule_programming: {
         key: ['programming_mode'],
         convertSet: async (entity, key, value: string, meta) => {
@@ -6940,13 +6940,13 @@ const toZigbee2 = {
             }
             await sendDataPointRaw(entity, dataPoints.moesSschedule, payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hgkg_thermostat_standby: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.state, value === 'cool');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_switch: {
         key: ['power_on_behavior', 'indicate_light'],
         convertSet: async (entity, key, value, meta) => {
@@ -6972,7 +6972,7 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_sensor: {
         key: ['sensor'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -6988,14 +6988,14 @@ const toZigbee2 = {
                 throw new Error(`Unsupported value: ${value}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_dimmer_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
             // Always use same transid as tuya_dimmer_level (https://github.com/Koenkk/zigbee2mqtt/issues/6366)
             await sendDataPointBool(entity, dataPoints.state, value === 'ON', 'dataRequest', 1);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_dimmer_level: {
         key: ['brightness_min', 'min_brightness', 'max_brightness', 'brightness', 'brightness_percent', 'level'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -7048,7 +7048,7 @@ const toZigbee2 = {
             // Always use same transid as tuya_dimmer_state (https://github.com/Koenkk/zigbee2mqtt/issues/6366)
             await sendDataPointValue(entity, dp, newValue, 'dataRequest', 1);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_switch_state: {
         key: ['state'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -7058,7 +7058,7 @@ const toZigbee2 = {
             await sendDataPointBool(entity, keyid, value === 'ON');
             return {state: {state: value.toUpperCase()}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     frankever_threshold: {
         key: ['threshold'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -7067,7 +7067,7 @@ const toZigbee2 = {
             await sendDataPointValue(entity, dataPoints.frankEverTreshold, thresh, 'dataRequest', 1);
             return {state: {threshold: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     frankever_timer: {
         key: ['timer'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -7077,7 +7077,7 @@ const toZigbee2 = {
             await sendDataPointValue(entity, dataPoints.frankEverTimer, timer, 'dataRequest', 1);
             return {state: {timer: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZVG1_timer: {
         key: ['timer'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -7087,14 +7087,14 @@ const toZigbee2 = {
             await sendDataPointValue(entity, 11, timer, 'dataRequest', 1);
             return {state: {timer: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZVG1_weather_delay: {
         key: ['weather_delay'],
         convertSet: async (entity, key, value: string, meta) => {
             const lookup: KeyValueAny = {'disabled': 0, '24h': 1, '48h': 2, '72h': 3};
             await sendDataPointEnum(entity, 10, lookup[value]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZVG1_cycle_timer: {
         key: ['cycle_timer_1', 'cycle_timer_2', 'cycle_timer_3', 'cycle_timer_4'],
         convertSet: async (entity, key, value: string, meta) => {
@@ -7157,7 +7157,7 @@ const toZigbee2 = {
             ret['state'][key] = value;
             return ret;
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZVG1_normal_schedule_timer: {
         key: ['normal_schedule_timer_1', 'normal_schedule_timer_2', 'normal_schedule_timer_3', 'normal_schedule_timer_4'],
         convertSet: async (entity, key, value: string, meta) => {
@@ -7215,7 +7215,7 @@ const toZigbee2 = {
             ret['state'][key] = value;
             return ret;
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     etop_thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7235,7 +7235,7 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     etop_thermostat_away_mode: {
         key: ['away_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7250,7 +7250,7 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_weekly_schedule: {
         key: ['weekly_schedule'],
         convertSet: async (entity, key, value, meta) => {
@@ -7337,13 +7337,13 @@ const toZigbee2 = {
                 }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.childLock, value === 'LOCK');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_window_detection: {
         key: ['window_detection'],
         convertSet: async (entity, key, value, meta) => {
@@ -7352,7 +7352,7 @@ const toZigbee2 = {
                 dataPoints.windowDetection,
                 [value === 'ON' ? 1 : 0]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     siterwell_thermostat_window_detection: {
         key: ['window_detection'],
         convertSet: async (entity, key, value, meta) => {
@@ -7361,20 +7361,20 @@ const toZigbee2 = {
                 dataPoints.siterwellWindowDetection,
                 value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_valve_detection: {
         key: ['valve_detection'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.valveDetection, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_current_heating_setpoint: {
         key: ['current_heating_setpoint'],
         convertSet: async (entity, key, value: number, meta) => {
             const temp = Math.round(value * 10);
             await sendDataPointValue(entity, dataPoints.heatingSetpoint, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7386,7 +7386,7 @@ const toZigbee2 = {
                 throw new Error(`TRV system mode ${value} is not recognized.`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_preset: {
         key: ['preset'],
         convertSet: async (entity, key, value, meta) => {
@@ -7398,7 +7398,7 @@ const toZigbee2 = {
                 throw new Error(`TRV preset ${value} is not recognized.`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_away_mode: {
         key: ['away_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7420,7 +7420,7 @@ const toZigbee2 = {
                 throw new Error(`TRV preset ${value} is not recognized.`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_fan_mode: {
         key: ['fan_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7432,7 +7432,7 @@ const toZigbee2 = {
                 throw new Error(`TRV fan mode ${value} is not recognized.`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_bac_fan_mode: {
         key: ['fan_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7444,13 +7444,13 @@ const toZigbee2 = {
                 throw new Error(`TRV fan mode ${value} is not recognized.`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_auto_lock: {
         key: ['auto_lock'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.autoLock, value === 'AUTO');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value: number, meta) => {
@@ -7460,37 +7460,37 @@ const toZigbee2 = {
             }
             await sendDataPointValue(entity, dataPoints.tempCalibration, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_min_temp: {
         key: ['min_temperature'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.minTemp, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_max_temp: {
         key: ['max_temperature'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.maxTemp, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_boost_time: {
         key: ['boost_time'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.boostTime, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_comfort_temp: {
         key: ['comfort_temperature'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.comfortTemp, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_eco_temp: {
         key: ['eco_temperature'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointValue(entity, dataPoints.ecoTemp, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_force: {
         key: ['force'],
         convertSet: async (entity, key, value, meta) => {
@@ -7502,7 +7502,7 @@ const toZigbee2 = {
                 throw new Error(`TRV force mode ${value} is not recognized.`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_force_to_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7514,7 +7514,7 @@ const toZigbee2 = {
                 throw new Error(`TRV system mode ${value} is not recognized.`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_away_preset: {
         key: ['away_preset_temperature', 'away_preset_days'],
         convertSet: async (entity, key, value, meta) => {
@@ -7527,14 +7527,14 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_window_detect: { // payload example { "detect":"OFF", "temperature":5, "minutes":8}
         key: ['window_detect'],
         convertSet: async (entity, key, value: KeyValueAny, meta) => {
             const detect = value.detect.toUpperCase() === 'ON' ? 1 : 0;
             await sendDataPointRaw(entity, dataPoints.windowDetection, [detect, value.temperature, value.minutes]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_schedule: { // payload example {"holidays":[{"hour":6,"minute":0,"temperature":20},{"hour":8,"minute":0,....  6x
         key: ['schedule'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -7559,7 +7559,7 @@ const toZigbee2 = {
                 await sendDataPointRaw(entity, dpId, payload);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_schedule_programming_mode: { // payload example "00:20/5°C 01:20/5°C 6:59/15°C 18:00/5°C 20:00/5°C 23:30/5°C"
         key: ['workdays_schedule', 'holidays_schedule'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -7587,7 +7587,7 @@ const toZigbee2 = {
             }
             await sendDataPointRaw(entity, dpId, payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_thermostat_week: {
         key: ['week'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -7596,7 +7596,7 @@ const toZigbee2 = {
             await sendDataPointEnum(entity, dataPoints.weekFormat, week);
             return {state: {week: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_cover_options: {
         key: ['options'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -7619,7 +7619,7 @@ const toZigbee2 = {
                 await sendDataPointValue(entity, dataPoints.coverSpeed, value.motor_speed);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     neo_nas_pd07: {
         key: ['temperature_max', 'temperature_min', 'humidity_max', 'humidity_min', 'temperature_scale', 'unknown_111', 'unknown_112'],
         convertSet: async (entity, key, value, meta) => {
@@ -7649,7 +7649,7 @@ const toZigbee2 = {
                 throw new Error(`tz.neo_nas_pd07: Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     neo_t_h_alarm: {
         key: [
             'alarm', 'melody', 'volume', 'duration',
@@ -7696,7 +7696,7 @@ const toZigbee2 = {
                 throw new Error(`tz.neo_t_h_alarm: Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     neo_alarm: {
         key: [
             'alarm', 'melody', 'volume', 'duration',
@@ -7723,7 +7723,7 @@ const toZigbee2 = {
                 throw new Error(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     nous_lcd_temperature_humidity_sensor: {
         key: [
             'min_temperature', 'max_temperature', 'temperature_sensitivity', 'temperature_unit_convert', 'temperature_report_interval',
@@ -7762,14 +7762,14 @@ const toZigbee2 = {
                 meta.logger.warn(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_current_heating_setpoint: {
         key: ['current_heating_setpoint'],
         convertSet: async (entity, key, value: any, meta) => {
             const temp = Math.round(value * 10);
             await sendDataPointValue(entity, dataPoints.saswellHeatingSetpoint, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7780,7 +7780,7 @@ const toZigbee2 = {
             await utils.sleep(3000);
             await sendDataPointBool(entity, dataPoints.saswellScheduleEnable, schedule);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_away: {
         key: ['away_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7790,7 +7790,7 @@ const toZigbee2 = {
                 await sendDataPointBool(entity, dataPoints.saswellAwayMode, false);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
@@ -7798,39 +7798,39 @@ const toZigbee2 = {
             // but it's not entering lock state
             await sendDataPointBool(entity, dataPoints.saswellChildLock, value === 'LOCK');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_window_detection: {
         key: ['window_detection'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.saswellWindowDetection, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_frost_detection: {
         key: ['frost_detection'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.saswellFrostDetection, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_anti_scaling: {
         key: ['anti_scaling'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.saswellAntiScaling, value === 'ON');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     saswell_thermostat_calibration: {
         key: ['local_temperature_calibration'],
         convertSet: async (entity, key, value: any, meta) => {
             if (value < 0) value = 0xFFFFFFFF + value + 1;
             await sendDataPointValue(entity, dataPoints.saswellTempCalibration, value);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     evanell_thermostat_current_heating_setpoint: {
         key: ['current_heating_setpoint'],
         convertSet: async (entity, key, value: any, meta) => {
             const temp = Math.round(value * 10);
             await sendDataPointValue(entity, dataPoints.evanellHeatingSetpoint, temp);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     evanell_thermostat_system_mode: {
         key: ['system_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -7846,13 +7846,13 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     evanell_thermostat_child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
             await sendDataPointBool(entity, dataPoints.evanellChildLock, value === 'LOCK');
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     silvercrest_smart_led_string: {
         key: ['color', 'brightness', 'effect'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -8007,7 +8007,7 @@ const toZigbee2 = {
                 await sendDataPointStringBuffer(entity, dataPoints.silvercrestSetColor, data);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_data_point_test: {
         key: ['tuya_data_point_test'],
         convertSet: async (entity, key, value: string, meta) => {
@@ -8040,7 +8040,7 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hy_thermostat: {
         key: [
             'child_lock', 'current_heating_setpoint', 'local_temperature_calibration',
@@ -8130,7 +8130,7 @@ const toZigbee2 = {
                 throw new Error(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZB003X: {
         key: [
             'reporting_time', 'temperature_calibration', 'humidity_calibration',
@@ -8177,7 +8177,7 @@ const toZigbee2 = {
                 throw new Error(`tz.ZB003X: Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZB006X_settings: {
         key: ['switch_type', 'load_detection_mode', 'control_mode'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -8201,7 +8201,7 @@ const toZigbee2 = {
                 throw new Error(`tz.ZB006X_settings: Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_motion_sensor: {
         key: ['o_sensitivity', 'v_sensitivity', 'led_status', 'vacancy_delay',
             'light_on_luminance_prefer', 'light_off_luminance_prefer', 'mode'],
@@ -8233,7 +8233,7 @@ const toZigbee2 = {
                 meta.logger.warn(`toZigbee.tuya_motion_sensor: Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     javis_microwave_sensor: {
         key: [
             'illuminance_calibration', 'led_enable',
@@ -8273,7 +8273,7 @@ const toZigbee2 = {
                 throw new Error(`Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_thermostat_tv: {
         key: [
             'system_mode', 'window_detection', 'frost_detection', 'child_lock',
@@ -8351,7 +8351,7 @@ const toZigbee2 = {
                 meta.logger.warn(`toZigbee.moes_thermostat_tv: Unhandled key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_light_wz5: {
         key: ['color', 'color_temp', 'brightness', 'white_brightness'],
         convertSet: async (entity, key, value: any, meta) => {
@@ -8479,7 +8479,7 @@ const toZigbee2 = {
                 return {state: newState};
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZMAM02_cover: {
         key: ['state', 'position', 'mode', 'motor_direction', 'border', 'motor_working_mode'],
         options: [exposes.options.invert_cover()],
@@ -8532,7 +8532,7 @@ const toZigbee2 = {
                 break;
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     tuya_smart_human_presense_sensor: {
         key: ['radar_sensitivity', 'minimum_range', 'maximum_range', 'detection_delay', 'fading_time'],
         convertSet: async (entity, key, value:any, meta) => {
@@ -8556,7 +8556,7 @@ const toZigbee2 = {
                 meta.logger.warn(`toZigbee.tuya_smart_human_presense_sensor: Unhandled Key ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     ZG204ZL_lms: {
         key: ['sensitivity', 'keep_time'],
         convertSet: async (entity, key, value, meta) => {
@@ -8585,7 +8585,7 @@ const toZigbee2 = {
                 meta.logger.warn(`Unhandled key toZigbee.ZG204ZL_lms.convertGet ${key}`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     moes_cover: {
         key: ['backlight', 'calibration', 'motor_reversal', 'state', 'position'],
         options: [exposes.options.invert_cover()],
@@ -8623,7 +8623,7 @@ const toZigbee2 = {
             }
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hoch_din: {
         key: ['state',
             'child_lock',
@@ -8676,7 +8676,7 @@ const toZigbee2 = {
                 throw new Error(`Not supported: '${key}'`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 const thermostatControlSequenceOfOperations = {

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -65,7 +65,7 @@ export const tzLegrand = {
             await entity.command('manuSpecificLegrandDevices3', 'command0', payload);
             return {state: {'auto_mode': value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     calibration_mode: (isNLLVSwitch: boolean) => {
         return {
             key: ['calibration_mode'],
@@ -78,7 +78,7 @@ export const tzLegrand = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('closuresWindowCovering', ['calibrationMode'], legrandOptions);
             },
-        } as Tz.Converter;
+        } satisfies Tz.Converter;
     },
     led_mode: {
         key: ['led_in_dark', 'led_if_on'],
@@ -95,7 +95,7 @@ export const tzLegrand = {
             const idx = utils.getKey(ledModes, key);
             await entity.read('manuSpecificLegrandDevices', [Number(idx)], legrandOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 export const fzLegrand = {
@@ -113,7 +113,7 @@ export const fzLegrand = {
                     return {calibration_mode: calMode};
                 }
             },
-        } as Fz.Converter;
+        } satisfies Fz.Converter;
     },
     cluster_fc01: {
         cluster: 'manuSpecificLegrandDevices',
@@ -139,5 +139,5 @@ export const fzLegrand = {
             if (msg.data.hasOwnProperty('2')) payload.led_if_on = msg.data['2'] === 0x00 ? 'OFF' : 'ON';
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -169,7 +169,7 @@ const philipsTz = {
             const payload = {data: Buffer.from(scene, 'hex')};
             await entity.command('manuSpecificPhilips2', 'multiColor', payload);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     gradient: (opts = {reverse: false}) => {
         return {
             key: ['gradient'],
@@ -182,7 +182,7 @@ const philipsTz = {
             convertGet: async (entity, key, meta) => {
                 await entity.read('manuSpecificPhilips2', ['state']);
             },
-        } as Tz.Converter;
+        } satisfies Tz.Converter;
     },
     effect: {
         key: ['effect'],
@@ -194,7 +194,7 @@ const philipsTz = {
                 return await tz.effect.convertSet(entity, key, value, meta);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hue_power_on_behavior: {
         key: ['hue_power_on_behavior'],
         convertSet: async (entity, key, value, meta) => {
@@ -281,7 +281,7 @@ const philipsTz = {
 
             return {state: {hue_power_on_behavior: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hue_power_on_error: {
         key: ['hue_power_on_brightness', 'hue_power_on_color_temperature', 'hue_power_on_color'],
         convertSet: async (entity, key, value, meta) => {
@@ -289,7 +289,7 @@ const philipsTz = {
                 throw new Error(`Provide a value for 'hue_power_on_behavior'`);
             }
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hue_motion_sensitivity: {
         // motion detect sensitivity, philips specific
         key: ['motion_sensitivity'],
@@ -303,7 +303,7 @@ const philipsTz = {
         convertGet: async (entity, key, meta) => {
             await entity.read('msOccupancySensing', [48], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     hue_motion_led_indication: {
         key: ['led_indication'],
         convertSet: async (entity, key, value, meta) => {
@@ -314,7 +314,7 @@ const philipsTz = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genBasic', [0x0033], manufacturerOptions);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 export {philipsTz as tz};
 
@@ -456,7 +456,7 @@ export const philipsFz = {
             }
             return payload;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     gradient: (opts = {reverse: false}) => {
         return {
             cluster: 'manuSpecificPhilips2',
@@ -471,7 +471,7 @@ export const philipsFz = {
                 }
                 return {};
             },
-        } as Fz.Converter;
+        } satisfies Fz.Converter;
     },
 };
 

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -782,8 +782,10 @@ const tuyaTz = {
             await entity.write('genOnOff', {moesStartUpOnOff});
             return {state: {[key]: value}};
         },
-        convertGet: async (entity, key, meta) => await entity.read('genOnOff', ['moesStartUpOnOff']),
-    } as Tz.Converter,
+        convertGet: async (entity, key, meta) => {
+            await entity.read('genOnOff', ['moesStartUpOnOff']);
+        },
+    } satisfies Tz.Converter,
     power_on_behavior_2: {
         key: ['power_on_behavior'],
         convertSet: async (entity, key, value, meta) => {
@@ -791,8 +793,10 @@ const tuyaTz = {
             await entity.write('manuSpecificTuya_3', {powerOnBehavior});
             return {state: {[key]: value}};
         },
-        convertGet: async (entity, key, meta) => await entity.read('manuSpecificTuya_3', ['powerOnBehavior']),
-    } as Tz.Converter,
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificTuya_3', ['powerOnBehavior']);
+        },
+    } satisfies Tz.Converter,
     switch_type: {
         key: ['switch_type'],
         convertSet: async (entity, key, value, meta) => {
@@ -800,8 +804,10 @@ const tuyaTz = {
             await entity.write('manuSpecificTuya_3', {switchType}, {disableDefaultResponse: true});
             return {state: {[key]: value}};
         },
-        convertGet: async (entity, key, meta) => await entity.read('manuSpecificTuya_3', ['switchType']),
-    } as Tz.Converter,
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificTuya_3', ['switchType']);
+        },
+    } satisfies Tz.Converter,
     backlight_indicator_mode_1: {
         key: ['backlight_mode', 'indicator_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -811,8 +817,10 @@ const tuyaTz = {
             await entity.write('genOnOff', {tuyaBacklightMode});
             return {state: {[key]: value}};
         },
-        convertGet: async (entity, key, meta) => await entity.read('genOnOff', ['tuyaBacklightMode']),
-    } as Tz.Converter,
+        convertGet: async (entity, key, meta) => {
+            await entity.read('genOnOff', ['tuyaBacklightMode']);
+        },
+    } satisfies Tz.Converter,
     backlight_indicator_mode_2: {
         key: ['backlight_mode'],
         convertSet: async (entity, key, value, meta) => {
@@ -820,15 +828,17 @@ const tuyaTz = {
             await entity.write('genOnOff', {tuyaBacklightSwitch});
             return {state: {[key]: value}};
         },
-        convertGet: async (entity, key, meta) => await entity.read('genOnOff', ['tuyaBacklightSwitch']),
-    } as Tz.Converter,
+        convertGet: async (entity, key, meta) => {
+            await entity.read('genOnOff', ['tuyaBacklightSwitch']);
+        },
+    } satisfies Tz.Converter,
     child_lock: {
         key: ['child_lock'],
         convertSet: async (entity, key, value, meta) => {
             const v = utils.getFromLookup(value, {'lock': true, 'unlock': false});
             await entity.write('genOnOff', {0x8000: {value: v, type: 0x10}});
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     min_brightness: {
         key: ['min_brightness'],
         convertSet: async (entity, key, value, meta) => {
@@ -843,7 +853,7 @@ const tuyaTz = {
         convertGet: async (entity, key, meta) => {
             await entity.read('genLevelCtrl', [0xfc00]);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     color_power_on_behavior: {
         key: ['color_power_on_behavior'],
         convertSet: async (entity, key, value, meta) => {
@@ -851,7 +861,7 @@ const tuyaTz = {
             await entity.command('lightingColorCtrl', 'tuyaOnStartUp', {mode: v*256, data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]});
             return {state: {color_power_on_behavior: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     datapoints: {
         key: [
             'temperature_unit', 'temperature_calibration', 'humidity_calibration', 'alarm_switch', 'tamper_alarm_switch',
@@ -920,14 +930,14 @@ const tuyaTz = {
             }
             return {state};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     do_not_disturb: {
         key: ['do_not_disturb'],
         convertSet: async (entity, key, value, meta) => {
             await entity.command('lightingColorCtrl', 'tuyaDoNotDisturb', {enable: value ? 1 : 0});
             return {state: {do_not_disturb: value}};
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 export {tuyaTz as tz};
 
@@ -943,7 +953,7 @@ const tuyaFz = {
             const payload = {payloadSize: 1, payload: 1};
             await msg.endpoint.command('manuSpecificTuya', 'mcuGatewayConnectionStatus', payload, {});
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     power_on_behavior_1: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -954,7 +964,7 @@ const tuyaFz = {
                 return {[property]: lookup[msg.data['moesStartUpOnOff']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     power_on_behavior_2: {
         cluster: 'manuSpecificTuya_3',
         type: ['attributeReport', 'readResponse'],
@@ -966,7 +976,7 @@ const tuyaFz = {
                 return {[property]: lookup[msg.data[attribute]]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     power_outage_memory: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -977,7 +987,7 @@ const tuyaFz = {
                 return {[property]: lookup[msg.data['moesStartUpOnOff']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     switch_type: {
         cluster: 'manuSpecificTuya_3',
         type: ['attributeReport', 'readResponse'],
@@ -987,7 +997,7 @@ const tuyaFz = {
                 return {switch_type: lookup[msg.data['switchType']]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     backlight_mode_low_medium_high: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -998,7 +1008,7 @@ const tuyaFz = {
                 return {backlight_mode: backlightLookup[value]};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     backlight_mode_off_normal_inverted: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1007,7 +1017,7 @@ const tuyaFz = {
                 return {backlight_mode: utils.getFromLookup(msg.data['tuyaBacklightMode'], {0: 'off', 1: 'normal', 2: 'inverted'})};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     backlight_mode_off_on: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1016,7 +1026,7 @@ const tuyaFz = {
                 return {backlight_mode: utils.getFromLookup(msg.data['tuyaBacklightSwitch'], {0: 'OFF', 1: 'ON'})};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     indicator_mode: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1025,7 +1035,7 @@ const tuyaFz = {
                 return {indicator_mode: utils.getFromLookup(msg.data['tuyaBacklightMode'], {0: 'off', 1: 'off/on', 2: 'on/off', 3: 'on'})};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     child_lock: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
@@ -1035,7 +1045,7 @@ const tuyaFz = {
                 return {child_lock: value ? 'LOCK' : 'UNLOCK'};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     min_brightness: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],
@@ -1046,7 +1056,7 @@ const tuyaFz = {
                 return {[property]: value};
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     datapoints: {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'commandActiveStatusReport', 'commandActiveStatusReportAlt'],
@@ -1091,7 +1101,7 @@ const tuyaFz = {
             }
             return result;
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 export {tuyaFz as fz};
 

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -48,7 +48,7 @@ export const fzZosung = {
             const irMsg = messagesGet(msg.endpoint, seq);
             meta.logger.debug(`IRCode to send: ${JSON.stringify(irMsg)} (seq:${seq})`);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     zosung_send_ir_code_02: {
         cluster: 'zosungIRTransmit',
         type: ['commandZosungSendIRCode02'],
@@ -70,7 +70,7 @@ export const fzZosung = {
                 {disableDefaultResponse: true});
             meta.logger.debug(`Sent IRCode part: ${part} (sum: ${sum}, seq:${seq})`);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     zosung_send_ir_code_04: {
         cluster: 'zosungIRTransmit',
         type: ['commandZosungSendIRCode04'],
@@ -86,7 +86,7 @@ export const fzZosung = {
             messagesClear(msg.endpoint, seq);
             meta.logger.debug(`IRCode has been successfully sent. (seq:${seq})`);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     zosung_send_ir_code_00: {
         cluster: 'zosungIRTransmit',
         type: ['commandZosungSendIRCode00'],
@@ -117,7 +117,7 @@ export const fzZosung = {
                 {disableDefaultResponse: true});
             meta.logger.debug(`"IR-Message-Code00" transfer started.`);
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     zosung_send_ir_code_03: {
         cluster: 'zosungIRTransmit',
         type: ['zosungSendIRCode03Resp'],
@@ -157,7 +157,7 @@ export const fzZosung = {
                 meta.logger.error(`Unexpected IR code position: ${JSON.stringify(msg.data)}, expecting: ${rcv.position}.`);
             }
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
     zosung_send_ir_code_05: {
         cluster: 'zosungIRTransmit',
         type: ['zosungSendIRCode05Resp'],
@@ -177,7 +177,7 @@ export const fzZosung = {
                 learned_ir_code: learnedIRCode,
             };
         },
-    } as Fz.Converter,
+    } satisfies Fz.Converter,
 };
 
 export const tzZosung = {
@@ -214,7 +214,7 @@ export const tzZosung = {
                 {disableDefaultResponse: true});
             meta.logger.debug(`Sending IR code initiated.`);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
     zosung_learn_ir_code: {
         key: ['learn_ir_code'],
         convertSet: async (entity, key, value, meta) => {
@@ -226,7 +226,7 @@ export const tzZosung = {
                 {disableDefaultResponse: true});
             meta.logger.debug(`IR Code Learning started.`);
         },
-    } as Tz.Converter,
+    } satisfies Tz.Converter,
 };
 
 


### PR DESCRIPTION
The `as` keyword in TypeScript asserts that "hey, I know that this type actually is what I'm saying it is. You can skip this and assume I'm right". However, this is usually a bad idea to do, as you can do unsafe assumptions leading to bugs. This is why the `satisfies` keyword was introduced. It makes sure that the object or array actually satisfies the type you want it to be.

In this PR, I'm changing all instances of the keyword `as` to `satisifies` where it makes sense to do so.

Beware, that while the first commit only includes uncontroversial changes (ergo, only type-level changes), some of the types I've changed locally don't actually satisfy the type it's asserted to, and in those cases, we have to figure out what needs changed. Those could be indicators of bugs.