### PR TITLE
Update namron.ts - Added Namron 4512767

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -923,7 +923,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        zigbeeModel: ['4512766'],
+        zigbeeModel: ['4512766', '4512767'],
         model: '4512766',
         vendor: 'Namron',
         description: 'Zigbee smart plug 16A',


### PR DESCRIPTION
This adds support for the Namron Zigbee Smart Plug 16A sort 4512767, the black version of 4512766.

There is no difference feature wise to the white model so I don't think there's a need to create a whole new device for it.

The model number shown will be wrong in the Z2M Devices list but in the about device page it shows the correct model.

