### PR TITLE
Fix Tuya TS0001 _TZ3000_skueekg3 detected as TS0001

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -799,6 +799,7 @@ const definitions: Definition[] = [
             {manufacturerName: '_TZ3000_q6a3tepg'}, {modelID: 'TS000F', manufacturerName: '_TZ3000_m9af2l6g'},
             {modelID: 'TS000F', manufacturerName: '_TZ3000_mx3vgyea'},
             {modelID: 'TS000F', manufacturerName: '_TZ3000_skueekg3'},
+            {modelID: 'TS0001', manufacturerName: '_TZ3000_skueekg3'},
             {modelID: 'TS0001', manufacturerName: '_TZ3000_npzfdcof'},
             {modelID: 'TS0001', manufacturerName: '_TZ3000_5ng23zjs'},
             {modelID: 'TS0001', manufacturerName: '_TZ3000_rmjr4ufz'},


### PR DESCRIPTION
TS000F with this manufacturerName was already in the WHD02 list. I've just encountered another one with TS0001 as model. Ref: https://github.com/Koenkk/zigbee2mqtt/issues/12005#issuecomment-1824541797