### PR TITLE
fix: Update configuration for Vesternet Zigbee devices

### DIFF
--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -69,7 +69,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'ZGRC-KEY-013', softwareBuildID: '2.5.3_r20'}, {modelID: 'ZGRC-KEY-013', softwareBuildID: '2.7.6_r25'}],
+        fingerprint: [{modelID: 'ZGRC-KEY-013', softwareBuildID: '2.5.3_r20'}],
         model: 'VES-ZB-REM-013',
         vendor: 'Vesternet',
         description: 'Zigbee remote control - 12 button',
@@ -78,6 +78,25 @@ const definitions: Definition[] = [
             e.action(['on_*', 'off_*', 'stop_*', 'brightness_move_up_*', 'brightness_move_down_*', 'brightness_stop_*', 'recall_*'])],
         toZigbee: [],
         meta: {multiEndpoint: true, battery: {dontDividePercentage: true}, publishDuplicateTransaction: true},
+        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K12-DIM-Z4'}],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genScenes', 'genPowerCfg']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genScenes']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genScenes']);
+            await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genScenes']);
+            await reporting.batteryPercentageRemaining(device.getEndpoint(1));
+        },
+    },
+    {
+        fingerprint: [{modelID: 'ZGRC-KEY-013', softwareBuildID: '2.7.6_r25'}],
+        model: 'VES-ZB-REM-013',
+        vendor: 'Vesternet',
+        description: 'Zigbee remote control - 12 button',
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.command_recall, fz.battery, fz.ignore_genOta],
+        exposes: [e.battery(),
+            e.action(['on_*', 'off_*', 'stop_*', 'brightness_move_up_*', 'brightness_move_down_*', 'brightness_stop_*', 'recall_*'])],
+        toZigbee: [],
+        meta: {multiEndpoint: true, battery: {dontDividePercentage: false}, publishDuplicateTransaction: true},
         whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K12-DIM-Z4'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genScenes', 'genPowerCfg']);
@@ -103,7 +122,36 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.5.3_r2'}, {modelID: 'ON/OFF(2CH)', softwareBuildID: '2.9.2_r3'}],
+        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.5.3_r2'}],
+        model: 'VES-ZB-SWI-015',
+        vendor: 'Vesternet',
+        description: 'Zigbee 2 channel switch',
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, fz.power_on_behavior, fz.ignore_genOta],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
+        exposes: [e.switch().withEndpoint('l1'), e.switch().withEndpoint('l2'), e.power(), e.current(),
+            e.voltage(), e.energy(), e.power_on_behavior(['off', 'on', 'previous'])],
+        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9101SAC-HP-SWITCH-2CH'}],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint1 = device.getEndpoint(1);
+            const endpoint2 = device.getEndpoint(2);
+            await reporting.bind(endpoint1, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.bind(endpoint2, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint1);
+            await reporting.onOff(endpoint2);
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint1);
+            await reporting.activePower(endpoint1);
+            await reporting.rmsCurrent(endpoint1, {min: 10, change: 10});
+            await reporting.rmsVoltage(endpoint1, {min: 10});
+            await reporting.readMeteringMultiplierDivisor(endpoint1);
+            await reporting.currentSummDelivered(endpoint1);
+        },
+    },
+    {
+        fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.9.2_r3'}],
         model: 'VES-ZB-SWI-015',
         vendor: 'Vesternet',
         description: 'Zigbee 2 channel switch',
@@ -134,7 +182,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'ZG2833K2_EU07', softwareBuildID: '2.5.3_r20'}, {modelID: 'ZG2833K2_EU07', softwareBuildID: '2.7.6_r25'}],
+        fingerprint: [{modelID: 'ZG2833K2_EU07', softwareBuildID: '2.5.3_r20'}],
         model: 'VES-ZB-WAL-006',
         vendor: 'Vesternet',
         description: 'Zigbee wall controller - 2 button',
@@ -150,7 +198,23 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'ZG2833K4_EU06', softwareBuildID: '2.5.3_r20'}, {modelID: 'ZG2833K4_EU06', softwareBuildID: '2.7.6_r25'}],
+        fingerprint: [{modelID: 'ZG2833K2_EU07', softwareBuildID: '2.7.6_r25'}],
+        model: 'VES-ZB-WAL-006',
+        vendor: 'Vesternet',
+        description: 'Zigbee wall controller - 2 button',
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.battery, fz.ignore_genOta],
+        exposes: [e.battery(), e.action([
+            'on_1', 'off_1', 'stop_1', 'brightness_move_up_1', 'brightness_move_down_1', 'brightness_stop_1'])],
+        toZigbee: [],
+        meta: {multiEndpoint: true, battery: {dontDividePercentage: false}},
+        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K2-DIM2'}],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genPowerCfg']);
+            await reporting.batteryPercentageRemaining(device.getEndpoint(1));
+        },
+    },
+    {
+        fingerprint: [{modelID: 'ZG2833K4_EU06', softwareBuildID: '2.5.3_r20'}],
         model: 'VES-ZB-WAL-011',
         vendor: 'Vesternet',
         description: 'Zigbee wall controller - 4 button',
@@ -168,7 +232,25 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'ZG2833K8_EU05', softwareBuildID: '2.5.3_r20'}, {modelID: 'ZG2833K8_EU05', softwareBuildID: '2.7.6_r25'}],
+        fingerprint: [{modelID: 'ZG2833K4_EU06', softwareBuildID: '2.7.6_r25'}],
+        model: 'VES-ZB-WAL-011',
+        vendor: 'Vesternet',
+        description: 'Zigbee wall controller - 4 button',
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.battery, fz.ignore_genOta],
+        exposes: [e.battery(), e.action([
+            'on_1', 'off_1', 'stop_1', 'brightness_move_up_1', 'brightness_move_down_1', 'brightness_stop_1',
+            'on_2', 'off_2', 'stop_2', 'brightness_move_up_2', 'brightness_move_down_2', 'brightness_stop_2'])],
+        toZigbee: [],
+        meta: {multiEndpoint: true, battery: {dontDividePercentage: false}},
+        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K4-DIM2'}],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genPowerCfg']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.batteryPercentageRemaining(device.getEndpoint(1));
+        },
+    },
+    {
+        fingerprint: [{modelID: 'ZG2833K8_EU05', softwareBuildID: '2.5.3_r20'}],
         model: 'VES-ZB-WAL-012',
         vendor: 'Vesternet',
         description: 'Zigbee wall controller - 8 button',
@@ -180,6 +262,28 @@ const definitions: Definition[] = [
             'on_4', 'off_4', 'stop_4', 'brightness_move_up_4', 'brightness_move_down_4', 'brightness_stop_4'])],
         toZigbee: [],
         meta: {multiEndpoint: true, battery: {dontDividePercentage: true}},
+        whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K8-DIM'}],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genPowerCfg']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.batteryPercentageRemaining(device.getEndpoint(1));
+        },
+    },
+    {
+        fingerprint: [{modelID: 'ZG2833K8_EU05', softwareBuildID: '2.7.6_r25'}],
+        model: 'VES-ZB-WAL-012',
+        vendor: 'Vesternet',
+        description: 'Zigbee wall controller - 8 button',
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move, fz.command_stop, fz.battery, fz.ignore_genOta],
+        exposes: [e.battery(), e.action([
+            'on_1', 'off_1', 'stop_1', 'brightness_move_up_1', 'brightness_move_down_1', 'brightness_stop_1',
+            'on_2', 'off_2', 'stop_2', 'brightness_move_up_2', 'brightness_move_down_2', 'brightness_stop_2',
+            'on_3', 'off_3', 'stop_3', 'brightness_move_up_3', 'brightness_move_down_3', 'brightness_stop_3',
+            'on_4', 'off_4', 'stop_4', 'brightness_move_up_4', 'brightness_move_down_4', 'brightness_stop_4'])],
+        toZigbee: [],
+        meta: {multiEndpoint: true, battery: {dontDividePercentage: false}},
         whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K8-DIM'}],
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'genPowerCfg']);


### PR DESCRIPTION
Split configuration based on firmware versions for battery powered devices, since later versions report 0 - 200 rather than 0 - 100 for battery percentage.

Split configuration based on firmware versions for 2 channel switch device, since later version report measurements on a different endpoint to the earlier version.