### PR TITLE
Support for new TuYa DY-RQ500A Gas sensor clone

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -760,7 +760,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_yojqa8xn', '_TZE204_zougpkpy']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_yojqa8xn', '_TZE204_zougpkpy', '_TZE204_chbyv06x']),
         model: 'TS0601_gas_sensor_2',
         vendor: 'TuYa',
         description: 'Gas sensor',
@@ -778,6 +778,7 @@ const definitions: Definition[] = [
         ],
         whiteLabel: [
             tuya.whitelabel('DYGSM', 'DY-RQ500A', 'Gas sensor', ['_TZE204_zougpkpy']),
+            tuya.whitelabel('DYGSM', 'DY-RQ500A', 'Gas sensor', ['_TZE204_chbyv06x']),
         ],
         meta: {
             tuyaDatapoints: [


### PR DESCRIPTION
Hello, this is my first PR for this project (and any ZigBee device support actually) so please be patient...:)

I've got a new ZigBee Gas sensor which is reported as unsupported in the latest koenkk/zigbee2mqtt:latest-dev Docker's image (#87523a1350e8) however looks pretty same as already supported [TuYa DY-RQ500A](https://www.zigbee2mqtt.io/devices/DY-RQ500A.html). The only difference is different Zigbee Manufacturer field. I've verified all features exported by the former one and it seems it is really the same kind of hardware but another HW clone only, everything working as I expected.

Feel free to ask me for more testing or some deeper debug info to better prove my assumption stated above but I have no  idea how better/deeper I can test the definition in case all features exposed in 'Exposes' tab (z2m front-end GUI) are working like a charm.