### PR TITLE
Actually use the modern extend scaled value

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -76,7 +76,7 @@ const extend = {
                     let value = msg.data[attributeKey];
                     assertNumber(value);
                     if (scale !== undefined) value = value / scale;
-                    return {[expose.property]: msg.data[attributeKey]};
+                    return {[expose.property]: value};
                 }
             },
         }];


### PR DESCRIPTION
When `scale` is applied to the value received from zigbee, the result is not actually used and the original value is reported in the UI. This fixes it.