### PR TITLE
Second try, something went wrong on the first:Added New Avatto ZWT198 updat including scedule, reset and brightness…

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -511,121 +511,6 @@ const fzLocal = {
 
 const definitions: Definition[] = [
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_viy9ihs7']),
-
-        model: 'ZWT198 Avatto',
-        vendor: 'TuYa',
-        description: 'Avatto ZWT198 Wall Thermostat',
-        onEvent: tuya.onEvent({timeStart: '1970'}),
-
-        fromZigbee: [
-            tuya.fz.datapoints,
-        ],
-        toZigbee: [
-            tuya.tz.datapoints,
-        ],
-        configure: tuya.configureMagicPacket,
-        exposes: [
-            e.binary('factory_reset', ea.STATE_SET, 'ON', 'OFF')
-                .withDescription('Full factory reset, use with caution !'),
-            e.child_lock(),
-            // e.battery(), // device seems not to give battery-info ..??
-            e.climate()
-                .withSystemMode(['off', 'heat'], ea.STATE_SET)
-                .withPreset(['auto', 'manual', 'temporary_manual'])
-                .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET)
-                .withRunningState(['idle', 'heat'], ea.STATE)
-                .withLocalTemperature(ea.STATE)
-                .withLocalTemperatureCalibration(-9.9, 9.9, 0.1, ea.STATE_SET),
-
-            e.binary('frost_protection', ea.STATE_SET, 'ON', 'OFF')
-                .withDescription('Antifreeze function'),
-
-            e.max_temperature_limit()
-                .withUnit('°C')
-                .withValueMin(15)
-                .withValueMax(90)
-                .withValueStep(0.5)
-                .withPreset('default', 60, 'Default value')
-                .withDescription('Maximum upper temperature'),
-
-            e.numeric('deadzone_temperature', ea.STATE_SET)
-                .withUnit('°C')
-                .withValueMax(10)
-                .withValueMin(0.5)
-                .withValueStep(0.5)
-                .withPreset('default', 1, 'Default value')
-                .withDescription('The delta between local_temperature (5<t<35)and current_heating_setpoint to trigger Heat'),
-
-            e.zwt198_workdaySetting(),
-            e.zwt198_backlightModeOffLowMediumHigh(),
-
-            e.text('schedule_weekday', ea.STATE_SET).withDescription('Workdays (6 times `hh:mm/cc.c°C`)'),
-            e.text('schedule_holiday', ea.STATE_SET).withDescription('Holidays (2 times `hh:mm/cc.c°C)`'),
-
-            // ============== exposes for found, but not functional datapoints:
-            /*
-            e.min_temperature_limit() // dp 16
-                .withValueMin(5)
-                .withValueMax(15)
-                .withValueStep(0.5)
-                .withPreset('default', 10, 'Default value')
-                .withDescription('dp16 is listed in Tuya, but no communication from device'),
-
-            e.binary('dp105', ea.STATE_SET, 'ON', 'OFF')
-                .withDescription('dp105 is not listed in Tuya, but device sends datapoint, binary: true/false'),
-
-            e.binary('dp111', ea.STATE_SET, 'ON', 'OFF')
-                .withDescription('dp111 is not listed in Tuya, but device sends datapoint, binary: true/false'),
-            */
-        ],
-        meta: {
-            // All datapoints go in here
-            tuyaDatapoints: [
-                [1, 'system_mode', tuya.valueConverterBasic.lookup({'heat': true, 'off': false})],
-                [2, 'current_heating_setpoint', tuya.valueConverter.divideBy10],
-                [3, 'local_temperature', tuya.valueConverter.divideBy10],
-                [4, 'preset', tuya.valueConverterBasic.lookup({'auto': tuya.enum(0), 'manual': tuya.enum(1), 'temporary_manual': tuya.enum(2)})],
-                [9, 'child_lock', tuya.valueConverter.lockUnlock],
-                [11, 'faultalarm', tuya.valueConverter.raw],
-                [15, 'max_temperature_limit', tuya.valueConverter.divideBy10],
-                [19, 'local_temperature_calibration', tuya.valueConverter.ZWT198_localTempCalibration],
-
-                [101, 'running_state', tuya.valueConverterBasic.lookup({'heat': tuya.enum(1), 'idle': tuya.enum(0)})],
-                [102, 'frost_protection', tuya.valueConverter.onOff],
-                [103, 'factory_reset', tuya.valueConverter.onOff],
-                [104, 'working_day', tuya.valueConverter.ZWT198_workdaySetting],
-                [107, 'deadzone_temperature', tuya.valueConverter.divideBy10],
-
-                [109, null, tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
-                [109, 'schedule_weekday', tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
-                [109, 'schedule_holiday', tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
-
-                [110, 'backlight_mode', tuya.valueConverter.ZWT198_backlightMode],
-
-                // ============== found but not functional datapoints:
-
-                // [16, 'min_temperature_limit', tuya.valueConverter.divideBy10],  // datapoint listed in Tuya, but no communication from device
-                // [105, 'dp105', tuya.valueConverter.onOff],                      // not listed in Tuya, but device sends datapoint
-                // [111, 'dp111', tuya.valueConverter.onOff],                      // not listed in Tuya, but device sends datapoint
-
-                // These are the schedule values in bytes, 8 periods in total (4 bytes per period).
-                // For each period:
-                // 1st byte: hour
-                // 2nd byte: minute
-                // 3rd, 4th bytes: temperature multiplied by 10
-                // On the device last 2 periods are ignored if schedule_mode is 7day. When schedule_mode is disabled,
-                // scheduling can't be configured at all on the device.
-                // For example, if schedule_mode is weekday/sat+sun and this byte array is received:
-                // [6,10,1,144,8,10,0,170,11,40,0,170,12,40,0,170,17,10,0,230,22,10,0,170,8,5,0,200,23,0,0,160]
-                // Then the schedule is:
-                // Mon-Fri: 6:10 --> 40C, 8:10 --> 17C, 11:40 --> 17C, 12:40 --> 17C, 17:10 --> 23C, 22:10 --> 17C
-                // Sat-Sun: 8:05 --> 20C, 23:00 --> 16C
-            ],
-        },
-    },
-
-    {
         zigbeeModel: ['TS0204'],
         model: 'TS0204',
         vendor: 'TuYa',
@@ -1413,7 +1298,7 @@ const definitions: Definition[] = [
                 [5, 'max_brightness', tuya.valueConverter.scale0_254to0_1000],
                 [6, 'countdown', tuya.valueConverter.countdown],
                 [14, 'power_on_behavior', tuya.valueConverter.powerOnBehavior],
-                [21, 'backlight_mode', tuya.valueConverter.backlightMode],
+                [21, 'backlight_mode', tuya.valueConverter.backlightModeOffNormalInverted],
             ],
         },
         whiteLabel: [
@@ -1453,7 +1338,7 @@ const definitions: Definition[] = [
                 [11, 'max_brightness_l2', tuya.valueConverter.scale0_254to0_1000],
                 [12, 'countdown_l2', tuya.valueConverter.countdown],
                 [14, 'power_on_behavior', tuya.valueConverter.powerOnBehaviorEnum],
-                [21, 'backlight_mode', tuya.valueConverter.backlightMode],
+                [21, 'backlight_mode', tuya.valueConverter.backlightModeOffNormalInverted],
             ],
         },
         endpoint: (device) => {
@@ -1501,7 +1386,7 @@ const definitions: Definition[] = [
                 [19, 'max_brightness_l3', tuya.valueConverter.scale0_254to0_1000],
                 [20, 'countdown_l3', tuya.valueConverter.countdown],
                 [14, 'power_on_behavior', tuya.valueConverter.powerOnBehaviorEnum],
-                [21, 'backlight_mode', tuya.valueConverter.backlightMode],
+                [21, 'backlight_mode', tuya.valueConverter.backlightModeOffNormalInverted],
             ],
         },
         endpoint: (device) => {
@@ -4277,6 +4162,104 @@ const definitions: Definition[] = [
                 .withValueMin(35).withValueStep(1).withPreset('default', 60, 'Default value'),
         ],
         onEvent: tuya.onEventSetTime,
+    },
+    {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_viy9ihs7']),
+        model: 'ZWT198',
+        vendor: 'TuYa',
+        description: 'Avatto wall thermostat',
+        onEvent: tuya.onEvent({timeStart: '1970'}),
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.binary('factory_reset', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('Full factory reset, use with caution!'),
+            e.child_lock(),
+            e.climate()
+                .withSystemMode(['off', 'heat'], ea.STATE_SET)
+                .withPreset(['auto', 'manual', 'temporary_manual'])
+                .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET)
+                .withRunningState(['idle', 'heat'], ea.STATE)
+                .withLocalTemperature(ea.STATE)
+                .withLocalTemperatureCalibration(-9.9, 9.9, 0.1, ea.STATE_SET),
+            e.binary('frost_protection', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('Antifreeze function'),
+            e.max_temperature_limit()
+                .withUnit('°C')
+                .withValueMin(15)
+                .withValueMax(90)
+                .withValueStep(0.5)
+                .withPreset('default', 60, 'Default value')
+                .withDescription('Maximum upper temperature'),
+            e.numeric('deadzone_temperature', ea.STATE_SET)
+                .withUnit('°C')
+                .withValueMax(10)
+                .withValueMin(0.5)
+                .withValueStep(0.5)
+                .withPreset('default', 1, 'Default value')
+                .withDescription('The delta between local_temperature (5<t<35)and current_heating_setpoint to trigger Heat'),
+            e.enum('backlight_mode', ea.STATE_SET, ['off', 'low', 'medium', 'high'])
+                .withDescription('Intensity of the backlight'),
+            e.enum('working_day', ea.STATE_SET, ['disabled', '6-1', '5-2', '7'])
+                .withDescription('Workday setting'),
+            e.text('schedule_weekday', ea.STATE_SET).withDescription('Workdays (6 times `hh:mm/cc.c°C`)'),
+            e.text('schedule_holiday', ea.STATE_SET).withDescription('Holidays (2 times `hh:mm/cc.c°C)`'),
+            // ============== exposes for found, but not functional datapoints:
+            /*
+            e.min_temperature_limit() // dp 16
+                .withValueMin(5)
+                .withValueMax(15)
+                .withValueStep(0.5)
+                .withPreset('default', 10, 'Default value')
+                .withDescription('dp16 is listed in Tuya, but no communication from device'),
+
+            e.binary('dp105', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('dp105 is not listed in Tuya, but device sends datapoint, binary: true/false'),
+
+            e.binary('dp111', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('dp111 is not listed in Tuya, but device sends datapoint, binary: true/false'),
+            */
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'system_mode', tuya.valueConverterBasic.lookup({'heat': true, 'off': false})],
+                [2, 'current_heating_setpoint', tuya.valueConverter.divideBy10],
+                [3, 'local_temperature', tuya.valueConverter.divideBy10],
+                [4, 'preset', tuya.valueConverterBasic.lookup({'auto': tuya.enum(0), 'manual': tuya.enum(1), 'temporary_manual': tuya.enum(2)})],
+                [9, 'child_lock', tuya.valueConverter.lockUnlock],
+                [11, 'faultalarm', tuya.valueConverter.raw],
+                [15, 'max_temperature_limit', tuya.valueConverter.divideBy10],
+                [19, 'local_temperature_calibration', tuya.valueConverter.localTempCalibration3],
+                [101, 'running_state', tuya.valueConverterBasic.lookup({'heat': tuya.enum(1), 'idle': tuya.enum(0)})],
+                [102, 'frost_protection', tuya.valueConverter.onOff],
+                [103, 'factory_reset', tuya.valueConverter.onOff],
+                [104, 'working_day', tuya.valueConverter.workingDay],
+                [107, 'deadzone_temperature', tuya.valueConverter.divideBy10],
+                [109, null, tuya.valueConverter.ZWT198_schedule],
+                [109, 'schedule_weekday', tuya.valueConverter.ZWT198_schedule],
+                [109, 'schedule_holiday', tuya.valueConverter.ZWT198_schedule],
+                [110, 'backlight_mode', tuya.valueConverter.backlightModeOffLowMediumHigh],
+                // ============== found but not functional datapoints:
+
+                // [16, 'min_temperature_limit', tuya.valueConverter.divideBy10],  // datapoint listed in Tuya, but no communication from device
+                // [105, 'dp105', tuya.valueConverter.onOff],                      // not listed in Tuya, but device sends datapoint
+                // [111, 'dp111', tuya.valueConverter.onOff],                      // not listed in Tuya, but device sends datapoint
+
+                // These are the schedule values in bytes, 8 periods in total (4 bytes per period).
+                // For each period:
+                // 1st byte: hour
+                // 2nd byte: minute
+                // 3rd, 4th bytes: temperature multiplied by 10
+                // On the device last 2 periods are ignored if schedule_mode is 7day. When schedule_mode is disabled,
+                // scheduling can't be configured at all on the device.
+                // For example, if schedule_mode is weekday/sat+sun and this byte array is received:
+                // [6,10,1,144,8,10,0,170,11,40,0,170,12,40,0,170,17,10,0,230,22,10,0,170,8,5,0,200,23,0,0,160]
+                // Then the schedule is:
+                // Mon-Fri: 6:10 --> 40C, 8:10 --> 17C, 11:40 --> 17C, 12:40 --> 17C, 17:10 --> 23C, 22:10 --> 17C
+                // Sat-Sun: 8:05 --> 20C, 23:00 --> 16C
+            ],
+        },
     },
     {
         fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay']),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -511,6 +511,126 @@ const fzLocal = {
 
 const definitions: Definition[] = [
     {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_viy9ihs7']),
+
+        model: 'ZWT198 Avatto',
+        vendor: 'TuYa',
+        description: 'Avatto ZWT198 Wall Thermostat',
+        onEvent: tuya.onEvent({timeStart: '1970'}),
+
+        fromZigbee: [
+            tuya.fz.datapoints,
+        ],
+        toZigbee: [
+            tuya.tz.datapoints,
+        ],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.binary('factory_reset', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('Full factory reset, use with caution !'),
+            e.child_lock(),
+            // e.battery(), // device seems not to give battery-info ..??
+            e.climate()
+                .withSystemMode(['off', 'heat'], ea.STATE_SET)
+                .withPreset(['auto', 'manual', 'temporary_manual'])
+                .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET)
+                .withRunningState(['idle', 'heat'], ea.STATE)
+                .withLocalTemperature(ea.STATE)
+                .withLocalTemperatureCalibration(-9.9, 9.9, 0.1, ea.STATE_SET),
+
+            e.binary('frost_protection', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('Antifreeze function'),
+
+            e.max_temperature_limit()
+                .withUnit('°C')
+                .withValueMin(15)
+                .withValueMax(90)
+                .withValueStep(0.5)
+                .withPreset('default', 60, 'Default value')
+                .withDescription('Maximum upper temperature'),
+
+            e.numeric('deadzone_temperature', ea.STATE_SET)
+                .withUnit('°C')
+                .withValueMax(10)
+                .withValueMin(0.5)
+                .withValueStep(0.5)
+                .withPreset('default', 1, 'Default value')
+                .withDescription('The delta between local_temperature (5<t<35)and current_heating_setpoint to trigger Heat'),
+
+            e.zwt198_workdaySetting(),
+            e.zwt198_backlightModeOffLowMediumHigh(),
+
+            e.composite('schedule', 'schedule', ea.STATE_SET)
+                .withDescription('Schedule split into 2 parts, includes error check')
+                .withFeature(
+                    e.text('schedule_weekday', ea.STATE_SET).withDescription('Workdays (6 times `hh:mm/cc.c°C`)'))
+                .withFeature(
+                    e.text('message_weekday', ea.STATE).withDescription('Messages from the schedule format'))
+                .withFeature(
+                    e.text('schedule_holiday', ea.STATE_SET).withDescription('Holidays (2 times `hh:mm/cc.c°C)`'))
+                .withFeature(
+                    e.text('message_holiday', ea.STATE).withDescription('Messages from the schedule format')),
+
+            // ============== exposes for found, but not functional datapoints:
+            /*
+            e.min_temperature_limit() // dp 16
+                .withValueMin(5)
+                .withValueMax(15)
+                .withValueStep(0.5)
+                .withPreset('default', 10, 'Default value')
+                .withDescription('dp16 is listed in Tuya, but no communication from device'),
+
+            e.binary('dp105', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('dp105 is not listed in Tuya, but device sends datapoint, binary: true/false'),
+
+            e.binary('dp111', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('dp111 is not listed in Tuya, but device sends datapoint, binary: true/false'),
+            */
+        ],
+        meta: {
+            // All datapoints go in here
+            tuyaDatapoints: [
+                [1, 'system_mode', tuya.valueConverterBasic.lookup({'heat': true, 'off': false})],
+                [2, 'current_heating_setpoint', tuya.valueConverter.divideBy10],
+                [3, 'local_temperature', tuya.valueConverter.divideBy10],
+                [4, 'preset', tuya.valueConverterBasic.lookup({'auto': tuya.enum(0), 'manual': tuya.enum(1), 'temporary_manual': tuya.enum(2)})],
+                [9, 'child_lock', tuya.valueConverter.lockUnlock],
+                [11, 'faultalarm', tuya.valueConverter.raw],
+                [15, 'max_temperature_limit', tuya.valueConverter.divideBy10],
+                [19, 'local_temperature_calibration', tuya.valueConverter.ZWT198_localTempCalibration],
+
+                [101, 'running_state', tuya.valueConverterBasic.lookup({'heat': tuya.enum(1), 'idle': tuya.enum(0)})],
+                [102, 'frost_protection', tuya.valueConverter.onOff],
+                [103, 'factory_reset', tuya.valueConverter.onOff],
+                [104, 'working_day', tuya.valueConverter.ZWT198_workdaySetting],
+
+                [107, 'deadzone_temperature', tuya.valueConverter.divideBy10],
+                [109, 'schedule', tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
+                [110, 'backlight_mode', tuya.valueConverter.ZWT198_backlightMode],
+
+                // ============== found but not functional datapoints:
+
+                // [16, 'min_temperature_limit', tuya.valueConverter.divideBy10],  // datapoint listed in Tuya, but no communication from device
+                // [105, 'dp105', tuya.valueConverter.onOff],                      // not listed in Tuya, but device sends datapoint
+                // [111, 'dp111', tuya.valueConverter.onOff],                      // not listed in Tuya, but device sends datapoint
+
+                // These are the schedule values in bytes, 8 periods in total (4 bytes per period).
+                // For each period:
+                // 1st byte: hour
+                // 2nd byte: minute
+                // 3rd, 4th bytes: temperature multiplied by 10
+                // On the device last 2 periods are ignored if schedule_mode is 7day. When schedule_mode is disabled,
+                // scheduling can't be configured at all on the device.
+                // For example, if schedule_mode is weekday/sat+sun and this byte array is received:
+                // [6,10,1,144,8,10,0,170,11,40,0,170,12,40,0,170,17,10,0,230,22,10,0,170,8,5,0,200,23,0,0,160]
+                // Then the schedule is:
+                // Mon-Fri: 6:10 --> 40C, 8:10 --> 17C, 11:40 --> 17C, 12:40 --> 17C, 17:10 --> 23C, 22:10 --> 17C
+                // Sat-Sun: 8:05 --> 20C, 23:00 --> 16C
+            ],
+        },
+    },
+
+    {
         zigbeeModel: ['TS0204'],
         model: 'TS0204',
         vendor: 'TuYa',
@@ -4162,72 +4282,6 @@ const definitions: Definition[] = [
                 .withValueMin(35).withValueStep(1).withPreset('default', 60, 'Default value'),
         ],
         onEvent: tuya.onEventSetTime,
-    },
-    {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_viy9ihs7']),
-        model: 'ZWT198',
-        vendor: 'TuYa',
-        description: 'AVATTO battery wall-mount thermostat',
-        fromZigbee: [tuya.fz.datapoints, fz.ignore_tuya_set_time],
-        toZigbee: [tuya.tz.datapoints],
-        onEvent: tuya.onEvent({timeStart: '1970'}),
-        configure: tuya.configureMagicPacket,
-        exposes: [
-            e.child_lock(),
-            e.climate()
-                .withSystemMode(['off', 'heat'], ea.STATE_SET)
-                .withPreset(['auto', 'manual', 'temporary program'])
-                .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET)
-                .withRunningState(['idle', 'heat'], ea.STATE)
-                .withLocalTemperature(ea.STATE)
-                .withLocalTemperatureCalibration(-9.9, 9.9, 0.1, ea.STATE_SET),
-            e.binary('frost_protection', ea.STATE_SET, 'ON', 'OFF')
-                .withDescription('Antifreeze function'),
-            e.numeric('upper_temp', ea.STATE_SET).withUnit('°C').withValueMax(95)
-                .withValueMin(15).withValueStep(1).withPreset('default', 60, 'Default value')
-                .withDescription('Maximum upper temperature'),
-            e.numeric('deadzone_temperature', ea.STATE_SET).withUnit('°C').withValueMax(10)
-                .withValueMin(0.5).withValueStep(0.5).withPreset('default', 1, 'Default value')
-                .withDescription('The delta between local_temperature and current_heating_setpoint to trigger Heat'),
-            // Not working yet:
-            // e.enum('schedule_mode', ea.STATE_SET, ['disabled','weekday/sat+sun','weekday+sat/sun','7day'])
-            //     .withDescription('Schedule mode')
-        ],
-        meta: {
-            tuyaDatapoints: [
-                [1, 'system_mode', tuya.valueConverterBasic.lookup({'heat': true, 'off': false})],
-                [2, 'current_heating_setpoint', tuya.valueConverter.divideBy10],
-                [3, 'local_temperature', tuya.valueConverter.divideBy10],
-                [4, 'preset', tuya.valueConverterBasic.lookup({'auto': tuya.enum(0), 'manual': tuya.enum(1), 'temporary program': tuya.enum(2)})],
-                [9, 'child_lock', tuya.valueConverter.lockUnlock],
-                [15, 'upper_temp', tuya.valueConverter.divideBy10],
-                [19, 'local_temperature_calibration', tuya.valueConverter.divideBy10],
-                [101, 'running_state', tuya.valueConverterBasic.lookup({'heat': tuya.enum(1), 'idle': tuya.enum(0)})],
-                [102, 'frost_protection', tuya.valueConverter.onOff],
-                [104, 'schedule_mode', tuya.valueConverterBasic.lookup({'disabled': 0, 'weekday/sat+sun': 1, 'weekday+sat/sun': 2, '7day': 3})],
-                [107, 'deadzone_temperature', tuya.valueConverter.divideBy10],
-                // These are the schedule values in bytes, 8 periods in total (4 bytes per period).
-                // For each period:
-                // 1st byte: hour
-                // 2nd byte: minute
-                // 3rd, 4th bytes: temperature multiplied by 10
-                // Last 2 periods are ignored if schedule_mode is 7day. When schedule_mode is disabled,
-                // scheduling can't be configured at all.
-                // For example, if schedule_mode is weekday/sat+sun and this byte array is received:
-                // [6,10,1,144,8,10,0,170,11,40,0,170,12,40,0,170,17,10,0,230,22,10,0,170,8,5,0,200,23,0,0,160]
-                // Then the schedule is:
-                // Mon-Fri: 6:10 --> 40C, 8:10 --> 17C, 11:40 --> 17C, 12:40 --> 17C, 17:10 --> 23C, 22:10 --> 17C
-                // Sat-Sun: 8:05 --> 20C, 23:00 --> 16C
-                // I wasn't able to find a proper converter or to create one, so i commented it out
-                // [109, 'dp109', tuya.valueConverter.raw],
-
-                // unmapped DPs, still need to figure out what they do
-                // [103, 'dp103', tuya.valueConverter.trueFalse1],
-                // [105, 'dp105', tuya.valueConverter.trueFalse1],
-                // [110, 'dp110', tuya.valueConverter.raw],
-                // [111, 'dp111', tuya.valueConverter.trueFalse1]
-            ],
-        },
     },
     {
         fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay']),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -560,16 +560,8 @@ const definitions: Definition[] = [
             e.zwt198_workdaySetting(),
             e.zwt198_backlightModeOffLowMediumHigh(),
 
-            e.composite('schedule', 'schedule', ea.STATE_SET)
-                .withDescription('Schedule split into 2 parts, includes error check')
-                .withFeature(
-                    e.text('schedule_weekday', ea.STATE_SET).withDescription('Workdays (6 times `hh:mm/cc.c°C`)'))
-                .withFeature(
-                    e.text('message_weekday', ea.STATE).withDescription('Messages from the schedule format'))
-                .withFeature(
-                    e.text('schedule_holiday', ea.STATE_SET).withDescription('Holidays (2 times `hh:mm/cc.c°C)`'))
-                .withFeature(
-                    e.text('message_holiday', ea.STATE).withDescription('Messages from the schedule format')),
+            e.text('schedule_weekday', ea.STATE_SET).withDescription('Workdays (6 times `hh:mm/cc.c°C`)'),
+            e.text('schedule_holiday', ea.STATE_SET).withDescription('Holidays (2 times `hh:mm/cc.c°C)`'),
 
             // ============== exposes for found, but not functional datapoints:
             /*
@@ -603,9 +595,12 @@ const definitions: Definition[] = [
                 [102, 'frost_protection', tuya.valueConverter.onOff],
                 [103, 'factory_reset', tuya.valueConverter.onOff],
                 [104, 'working_day', tuya.valueConverter.ZWT198_workdaySetting],
-
                 [107, 'deadzone_temperature', tuya.valueConverter.divideBy10],
-                [109, 'schedule', tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
+
+                [109, null, tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
+                [109, 'schedule_weekday', tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
+                [109, 'schedule_holiday', tuya.valueConverter.ZWT198_tuya_thermostat_schedule],
+
                 [110, 'backlight_mode', tuya.valueConverter.ZWT198_backlightMode],
 
                 // ============== found but not functional datapoints:

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -768,10 +768,6 @@ export const presets = {
         .withFeature(new Enum('state', access.SET, ['system_is_armed', 'system_is_disarmed']).withDescription('Set Squawk state'))
         .withFeature(new Enum('level', access.SET, ['low', 'medium', 'high', 'very_high']).withDescription('Sound level'))
         .withFeature(new Binary('strobe', access.SET, true, false).withDescription('Turn on/off the strobe (light) for Squawk')),
-    zwt198_backlightModeOffLowMediumHigh: () => new Enum('backlight_mode', access.STATE_SET, ['off', 'low', 'medium', 'high'])
-        .withDescription('Intensity of the backlight'),
-    zwt198_workdaySetting: () => new Enum('working_day', access.STATE_SET, ['disabled', '6-1', '5-2', '7'])
-        .withDescription('Workday setting'),
 };
 
 exports.binary = (name: string, access: number, valueOn: string, valueOff: string) => new Binary(name, access, valueOn, valueOff);

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -768,6 +768,10 @@ export const presets = {
         .withFeature(new Enum('state', access.SET, ['system_is_armed', 'system_is_disarmed']).withDescription('Set Squawk state'))
         .withFeature(new Enum('level', access.SET, ['low', 'medium', 'high', 'very_high']).withDescription('Sound level'))
         .withFeature(new Binary('strobe', access.SET, true, false).withDescription('Turn on/off the strobe (light) for Squawk')),
+    zwt198_backlightModeOffLowMediumHigh: () => new Enum('backlight_mode', access.STATE_SET, ['off', 'low', 'medium', 'high'])
+        .withDescription('Intensity of the backlight'),
+    zwt198_workdaySetting: () => new Enum('working_day', access.STATE_SET, ['disabled', '6-1', '5-2', '7'])
+        .withDescription('Workday setting'),
 };
 
 exports.binary = (name: string, access: number, valueOn: string, valueOff: string) => new Binary(name, access, valueOn, valueOff);


### PR DESCRIPTION
Added New Avatto ZWT198 updat including scedule, reset and brightness in devices/tuya.ts;  lib/exposes.ts end lib.tuya.ts

Hello,

Here my second try with a PR for a further improvement of the Avatto ZWT198 thermostat. 
The first one went wrong in one or another way....

So here is my new try.
All code is in the right place as you asked.
And I got the format message-option running within the tuya.tz.datapoints.

Just 2 remarks:

1) 
I used `composite `for the `schedule`, (combining `schedule_weekday`, `schedule_holiday`, `message_weekday` and `message_holiday`) and I noticed that the text fields (`schedule_weekday `and `schedule_holiday`) are not directly updated after the device send the info back on a change. In the `state.json` file the info from the device is correctly displayed. Just after a page renew, the returned data is shown correctly. Before, without the `composite ` it was OK. So I think `composite `components are not well updated on screen. Should I create a issue for this?

2)
Having it all working within Zigbee2mqtt, the data is not well handled Home Assistant:
(see below the `state.json` file from zigbee2mqtt)
```
{
    "child_lock": "UNLOCK",
    "linkquality": 150,
    "local_temperature": 20.5,
    "factory_reset": "OFF",
    "system_mode": "off",
    "current_heating_setpoint": 22,
    "preset": "manual",
    "max_temperature_limit": 60,
    "local_temperature_calibration": 0,
    "running_state": "idle",
    "frost_protection": "ON",
    "working_day": "6-1",
    "deadzone_temperature": 1,
    "schedule": {
        "message_holiday": "Holidays schedule format OK",
        "message_weekday": "Workdays schedule format OK",
        "schedule_holiday": "08:00/22.0°C 23:00/16.0°C",
        "schedule_weekday": "06:00/20.0°C 08:00/16.0°C 11:30/16.0°C 12:30/16.0°C 17:00/22.0°C 22:00/16.0°C"
    },
    "backlight_mode": "high"
}
```
The `schedule `part in Home Assistant is shown as a json-string with the four items. Can that be converted into the four separate items? 
If yes, how do I manage that?

regards