### PR TITLE
JetHome: first step to add JetHome OTA updates

### DIFF
--- a/src/devices/jethome.ts
+++ b/src/devices/jethome.ts
@@ -32,7 +32,7 @@ const definitions: Definition[] = [
         description: '3-ch battery discrete input module',
         fromZigbee: [fz.battery, jetHome.fz.multiStateAction],
         toZigbee: [],
-        ota: ota.zigbeeOTA,
+        ota: ota.jethome,
         exposes: [
             e.battery(), e.battery_voltage(), e.action(
                 ['release_in1', 'single_in1', 'double_in1', 'hold_in1',

--- a/src/lib/ota/common.ts
+++ b/src/lib/ota/common.ts
@@ -4,6 +4,7 @@ import {Zh, Ota, Logger, KeyValueAny, KeyValue, KeyValueNumberString} from '../t
 import assert from 'assert';
 import crc32 from 'buffer-crc32';
 import axios from 'axios';
+import * as URI from 'uri-js';
 import {Zcl} from 'zigbee-herdsman';
 const maxTimeout = 2147483647; // +- 24 days
 const imageBlockResponseDelay = 250;
@@ -38,6 +39,16 @@ const eblImageSignature = 0xe350;
 
 const gblTagHeader = 0xeb17a603;
 const gblTagEnd = 0xfc0404fc;
+
+export function isValidUrl(url: string) {
+    let parsed;
+    try {
+        parsed = URI.parse(url);
+    } catch (_) {
+        return false;
+    }
+    return parsed.scheme === 'http' || parsed.scheme === 'https';
+}
 
 function getOTAEndpoint(device: Zh.Device) {
     return device.endpoints.find((e) => e.supportsOutputCluster('genOta'));
@@ -546,3 +557,4 @@ exports.isNewImageAvailable = isNewImageAvailable;
 exports.updateToLatest = updateToLatest;
 exports.getNewImage = getNewImage;
 exports.getAxios = getAxios;
+exports.isValidUrl = isValidUrl;

--- a/src/lib/ota/index.ts
+++ b/src/lib/ota/index.ts
@@ -6,6 +6,7 @@ import * as securifi from './securifi';
 import * as tradfri from './tradfri';
 import * as ubisys from './ubisys';
 import * as zigbeeOTA from './zigbeeOTA';
+import * as jethome from './jethome';
 import {Ota} from '../types';
 
 export {
@@ -17,7 +18,7 @@ export {
     tradfri,
     ubisys,
     zigbeeOTA,
+    jethome,
 };
 
 export type ImageInfo = Ota.ImageInfo;
-

--- a/src/lib/ota/jethome.ts
+++ b/src/lib/ota/jethome.ts
@@ -1,0 +1,108 @@
+const baseurl = 'https://fw.jethome.ru';
+const deviceurl = baseurl + '/api/devices/';
+import * as common from './common';
+import {Logger, Zh, Ota, KeyValueAny} from '../types';
+const axios = common.getAxios();
+import fs from 'fs';
+import path from 'path';
+
+let overrideIndexFileName: string = null;
+let dataDir: string = null;
+
+/**
+ * Helper functions
+ */
+
+
+function isValidUrl(url: string) {
+    let parsed;
+    try {
+        parsed = URI.parse(url);
+    } catch (_) {
+        return false;
+    }
+    return parsed.scheme === 'http' || parsed.scheme === 'https';
+}
+
+function readLocalFile(fileName: string, logger: Logger) {
+    logger.debug(`JetHomeOTA: call readLocalFile`);
+    // If the file name is not a full path, then treat it as a relative to the data directory
+    if (!path.isAbsolute(fileName) && dataDir) {
+        fileName = path.join(dataDir, fileName);
+    }
+
+    logger.debug(`JetHomeOTA: getting local firmware file ${fileName}`);
+    return fs.readFileSync(fileName);
+}
+
+async function getFirmwareFile(image: KeyValueAny, logger: Logger) {
+    const urlOrName = image.url;
+
+    // First try to download firmware file with the URL provided
+    if (isValidUrl(urlOrName)) {
+        logger.debug(`JetHomeOTA: downloading firmware image from ${urlOrName}`);
+        return await axios.get(urlOrName, {responseType: 'arraybuffer'});
+    }
+
+    return {data: readLocalFile(urlOrName, logger)};
+}
+
+async function getIndex(logger: Logger, modelId: string) {
+    if (overrideIndexFileName) {
+        logger.debug(`JetHomeOTA: Loading override index ${overrideIndexFileName}`);
+        if (isValidUrl(overrideIndexFileName)) {
+            const index = (await axios.get(overrideIndexFileName)).data;
+            return index;
+        }
+        const index = JSON.parse(fs.readFileSync(overrideIndexFileName, 'utf-8'));
+        return index;
+    } else {
+        const index = (await axios.get(deviceurl + modelId + '/info')).data;
+        logger.debug(`JetHomeOTA: downloaded index for ${modelId}`);
+        return index;
+    }
+}
+
+export async function getImageMeta(current: Ota.ImageInfo, logger: Logger, device: Zh.Device): Promise<Ota.ImageMeta> {
+    const modelId = device.modelID;
+    const imageType = current.imageType;
+    logger.debug(`JetHomeOTA: call getImageMeta for ${modelId}`);
+    const images = await getIndex(logger, modelId);
+    // we need to return the latest_firmware.release.urls.zigbee.ota
+    const jetimage = images.latest_firmware.release.images['zigbee.ota'];
+
+    if (!jetimage) {
+        throw new Error(`No image available for imageType '${imageType}'`);
+    }
+    logger.debug('JetHomeOTA: ver: ' + images.latest_firmware.release.version + ' size: ' + jetimage.filesize + ' url: ' + baseurl + jetimage.url);
+    return {
+        fileVersion: Number(images.latest_firmware.release.version),
+        fileSize: jetimage.filesize,
+        url: baseurl + jetimage.url,
+    };
+}
+
+/**
+ * Interface implementation
+ */
+
+export async function isUpdateAvailable(device: Zh.Device, logger: Logger, requestPayload:Ota.ImageInfo=null) {
+    return common.isUpdateAvailable(device, logger, common.isNewImageAvailable, requestPayload, getImageMeta);
+}
+
+export async function updateToLatest(device: Zh.Device, logger: Logger, onProgress: Ota.OnProgress) {
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta, getFirmwareFile);
+}
+
+export const useIndexOverride = (indexFileName: string) => {
+    overrideIndexFileName = indexFileName;
+};
+export const setDataDir = (dir: string) => {
+    dataDir = dir;
+};
+
+exports.getImageMeta = getImageMeta;
+exports.isUpdateAvailable = isUpdateAvailable;
+exports.updateToLatest = updateToLatest;
+exports.useIndexOverride = useIndexOverride;
+exports.setDataDir = setDataDir;

--- a/src/lib/ota/jethome.ts
+++ b/src/lib/ota/jethome.ts
@@ -4,33 +4,12 @@ import * as common from './common';
 import {Logger, Zh, Ota, KeyValueAny} from '../types';
 const axios = common.getAxios();
 import fs from 'fs';
-import path from 'path';
 
 let overrideIndexFileName: string = null;
-let dataDir: string = null;
 
 /**
  * Helper functions
  */
-
-async function getFirmwareFile(image: KeyValueAny, logger: Logger) {
-    let urlOrName = image.url;
-
-    // First try to download firmware file with the URL provided
-    if (common.isValidUrl(urlOrName)) {
-        logger.debug(`JetHomeOTA: downloading firmware image from ${urlOrName}`);
-        return await axios.get(urlOrName, {responseType: 'arraybuffer'});
-    }
-
-    logger.debug(`JetHomeOTA: call readLocalFile`);
-    // If the file name is not a full path, then treat it as a relative to the data directory
-    if (!path.isAbsolute(urlOrName) && dataDir) {
-        urlOrName = path.join(dataDir, urlOrName);
-    }
-
-    logger.debug(`JetHomeOTA: getting local firmware file ${urlOrName}`);
-    return {data: fs.readFileSync(urlOrName)};
-}
 
 async function getIndex(logger: Logger, modelId: string) {
     if (overrideIndexFileName) {
@@ -76,18 +55,14 @@ export async function isUpdateAvailable(device: Zh.Device, logger: Logger, reque
 }
 
 export async function updateToLatest(device: Zh.Device, logger: Logger, onProgress: Ota.OnProgress) {
-    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta, getFirmwareFile);
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta, common.getFirmwareFile);
 }
 
 export const useIndexOverride = (indexFileName: string) => {
     overrideIndexFileName = indexFileName;
-};
-export const setDataDir = (dir: string) => {
-    dataDir = dir;
 };
 
 exports.getImageMeta = getImageMeta;
 exports.isUpdateAvailable = isUpdateAvailable;
 exports.updateToLatest = updateToLatest;
 exports.useIndexOverride = useIndexOverride;
-exports.setDataDir = setDataDir;

--- a/src/lib/ota/jethome.ts
+++ b/src/lib/ota/jethome.ts
@@ -1,7 +1,7 @@
 const baseurl = 'https://fw.jethome.ru';
 const deviceurl = baseurl + '/api/devices/';
 import * as common from './common';
-import {Logger, Zh, Ota, KeyValueAny} from '../types';
+import {Logger, Zh, Ota} from '../types';
 const axios = common.getAxios();
 import fs from 'fs';
 

--- a/src/lib/ota/zigbeeOTA.ts
+++ b/src/lib/ota/zigbeeOTA.ts
@@ -3,7 +3,6 @@ import * as common from './common';
 import {Logger, Zh, Ota, KeyValueAny} from '../types';
 const axios = common.getAxios();
 import fs from 'fs';
-import * as URI from 'uri-js';
 import path from 'path';
 
 let overrideIndexFileName: string = null;
@@ -14,18 +13,8 @@ let dataDir: string = null;
  */
 
 
-function isValidUrl(url: string) {
-    let parsed;
-    try {
-        parsed = URI.parse(url);
-    } catch (_) {
-        return false;
-    }
-    return parsed.scheme === 'http' || parsed.scheme === 'https';
-}
-
 async function getIndexFile(urlOrName: string) {
-    if (isValidUrl(urlOrName)) {
+    if (common.isValidUrl(urlOrName)) {
         return (await axios.get(urlOrName)).data;
     }
 
@@ -46,7 +35,7 @@ async function getFirmwareFile(image: KeyValueAny, logger: Logger) {
     const urlOrName = image.url;
 
     // First try to download firmware file with the URL provided
-    if (isValidUrl(urlOrName)) {
+    if (common.isValidUrl(urlOrName)) {
         logger.debug(`ZigbeeOTA: downloading firmware image from ${urlOrName}`);
         return await axios.get(urlOrName, {responseType: 'arraybuffer'});
     }
@@ -56,7 +45,7 @@ async function getFirmwareFile(image: KeyValueAny, logger: Logger) {
 
 function fillImageInfo(meta: KeyValueAny, logger: Logger) {
     // Web-hosted images must come with all fields filled already
-    if (isValidUrl(meta.url)) {
+    if (common.isValidUrl(meta.url)) {
         return meta;
     }
 
@@ -89,7 +78,7 @@ async function getIndex(logger: Logger) {
         const localIndex = await getIndexFile(overrideIndexFileName);
 
         // Resulting index will have overridden items first
-        return localIndex.concat(index).map((item: KeyValueAny) => isValidUrl(item.url) ? item : fillImageInfo(item, logger));
+        return localIndex.concat(index).map((item: KeyValueAny) => common.isValidUrl(item.url) ? item : fillImageInfo(item, logger));
     }
 
     return index;

--- a/src/lib/ota/zigbeeOTA.ts
+++ b/src/lib/ota/zigbeeOTA.ts
@@ -3,10 +3,8 @@ import * as common from './common';
 import {Logger, Zh, Ota, KeyValueAny} from '../types';
 const axios = common.getAxios();
 import fs from 'fs';
-import path from 'path';
 
 let overrideIndexFileName: string = null;
-let dataDir: string = null;
 
 /**
  * Helper functions
@@ -19,28 +17,6 @@ async function getIndexFile(urlOrName: string) {
     }
 
     return JSON.parse(fs.readFileSync(urlOrName, 'utf-8'));
-}
-
-function readLocalFile(fileName: string, logger: Logger) {
-    // If the file name is not a full path, then treat it as a relative to the data directory
-    if (!path.isAbsolute(fileName) && dataDir) {
-        fileName = path.join(dataDir, fileName);
-    }
-
-    logger.debug(`ZigbeeOTA: getting local firmware file ${fileName}`);
-    return fs.readFileSync(fileName);
-}
-
-async function getFirmwareFile(image: KeyValueAny, logger: Logger) {
-    const urlOrName = image.url;
-
-    // First try to download firmware file with the URL provided
-    if (common.isValidUrl(urlOrName)) {
-        logger.debug(`ZigbeeOTA: downloading firmware image from ${urlOrName}`);
-        return await axios.get(urlOrName, {responseType: 'arraybuffer'});
-    }
-
-    return {data: readLocalFile(urlOrName, logger)};
 }
 
 function fillImageInfo(meta: KeyValueAny, logger: Logger) {
@@ -57,7 +33,7 @@ function fillImageInfo(meta: KeyValueAny, logger: Logger) {
     }
 
     // If no fields provided - get them from the image file
-    const buffer = readLocalFile(meta.url, logger);
+    const buffer = common.readLocalFile(meta.url, logger);
     const start = buffer.indexOf(common.upgradeFileIdentifier);
     const image = common.parseImage(buffer.slice(start));
 
@@ -135,18 +111,14 @@ export async function isUpdateAvailable(device: Zh.Device, logger: Logger, reque
 }
 
 export async function updateToLatest(device: Zh.Device, logger: Logger, onProgress: Ota.OnProgress) {
-    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta, getFirmwareFile);
+    return common.updateToLatest(device, logger, onProgress, common.getNewImage, getImageMeta, common.getFirmwareFile);
 }
 
 export const useIndexOverride = (indexFileName: string) => {
     overrideIndexFileName = indexFileName;
-};
-export const setDataDir = (dir: string) => {
-    dataDir = dir;
 };
 
 exports.getImageMeta = getImageMeta;
 exports.isUpdateAvailable = isUpdateAvailable;
 exports.updateToLatest = updateToLatest;
 exports.useIndexOverride = useIndexOverride;
-exports.setDataDir = setDataDir;


### PR DESCRIPTION
Add JetHome OTA firmware links to own github repositories.

Planed later: move to own firmware storage and re-write ota module.