### PR TITLE
Add ota to namron 4512750 and 4512751

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -914,6 +914,7 @@ const definitions: Definition[] = [
         vendor: 'Namron',
         description: 'Zigbee dimmer 2.0',
         extend: extend.light_onoff_brightness({noConfigure: true}),
+        ota: ota.zigbeeOTA,
         whiteLabel: [{vendor: 'Namron', model: '4512751', description: 'Zigbee dimmer 2.0', fingerprint: [{modelID: '4512751'}]}],
         configure: async (device, coordinatorEndpoint, logger) => {
             await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);


### PR DESCRIPTION
Seems like ota support was left out for this device, added.

Example of device checking for OTA
```
Zigbee2MQTT:debug 2023-11-27 14:45:03: Device '0xxxxxxx' requested OTA
Zigbee2MQTT:debug 2023-11-27 14:45:03: Responded to OTA request of '0xxxxxxx with 'NO_IMAGE_AVAILABLE'