### PR TITLE
Support for frient Electricity Meter Interface 2

### DIFF
--- a/src/devices/frient.ts
+++ b/src/devices/frient.ts
@@ -1,0 +1,25 @@
+import {Definition} from '../lib/types';
+import * as exposes from '../lib/exposes';
+import fz from '../converters/fromZigbee';
+import * as reporting from '../lib/reporting';
+const e = exposes.presets;
+
+const definitions: Definition[] = [
+    {
+        zigbeeModel: ['EMIZB-141'],
+        model: 'EMIZB-141',
+        vendor: 'frient',
+        description: 'Smart Powermeter Zigbee Bridge',
+        fromZigbee: [fz.metering, fz.battery],
+        toZigbee: [],
+        exposes: [e.battery(), e.power(), e.energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(2);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering', 'genPowerCfg']);
+        },
+    },
+];
+
+export default definitions;
+module.exports = definitions;
+


### PR DESCRIPTION
This PR provides support for the Electric Meter Interface v2 by Frient:
 https://frient.com/products/electricity-meter-interface-2-led/