### PR TITLE
Develco SPLZB-131: support for device_temperature attr

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -289,14 +289,15 @@ const definitions: Definition[] = [
         model: 'SPLZB-131',
         vendor: 'Develco',
         description: 'Power plug',
-        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
+        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering, develco.fz.device_temperature],
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
-        exposes: [e.switch(), e.power(), e.power_reactive(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
+        exposes: [e.switch(), e.power(), e.power_reactive(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(2);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
             await reporting.onOff(endpoint);
+            await reporting.deviceTemperature(endpoint);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint, true);
             await reporting.activePower(endpoint);
             await reporting.reactivePower(endpoint);


### PR DESCRIPTION
I have 4 Develco SPLZB-131 but few of them seems don't have this value.
This behaviour seems firmware indipendant (it uses dates and not version numbers) as following table:

Firmware date = HAS_TEMPERATURE?
=======================

- 2018-01-16 16:06 = YES
- 2018-01-16 23:19 = NO!!
- 2021-06-08 03:51 = NO!!
- 2022-03-11 19:21 = YES

Eventually the "device_temperature" will be "null" when not supported........