### PR TITLE
Update orvibo.ts to support ZL1-EN

### DIFF
--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -310,7 +310,7 @@ const definitions: Definition[] = [
         exposes: [e.water_leak(), e.battery_low(), e.tamper()],
     },
     {
-        zigbeeModel: ['b7e305eb329f497384e966fe3fb0ac69', '52debf035a1b4a66af56415474646c02', 'MultIR'],
+        zigbeeModel: ['b7e305eb329f497384e966fe3fb0ac69', '52debf035a1b4a66af56415474646c02', 'MultIR', 'ZL1-EN'],
         model: 'SW30',
         vendor: 'ORVIBO',
         description: 'Water leakage sensor',


### PR DESCRIPTION
The [Orvibo SW30](https://www.zigbee2mqtt.io/devices/SW30.html) is also sold as `ZL1-EN` by IMOU and still manufactured by `Hangzhou Huacheng Network Technology Co.,Ltd.`

It looks exactly the same as the SW30, except that the label `Orvibo` is replaced by `IMOU`.
It works perfectly with the exact same device definition as the SW30.

It advertises itself as zigbeeModel `ZL1-EN` by manufacturer `MultIR`, and interestingly `MultiIR`was already listed as a possible zigbeeModel for the device.