### PR TITLE
Set power source for Xiaomi QBKG21LM

### DIFF
--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -1592,6 +1592,7 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             // Device advertises itself as Router but is an EndDevice
             device.type = 'EndDevice';
+            device.powerSource = 'Mains (single phase)';
             device.save();
         },
     },


### PR DESCRIPTION
Power is showing up as DC but this is a main powered switch.
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/1040621/da40662c-6e14-4391-a219-8adf485067b7)
but device is most definitely mains powered