### PR TITLE
M elec ml st r200

### DIFF
--- a/src/devices/m_elec.ts
+++ b/src/devices/m_elec.ts
@@ -28,7 +28,7 @@ const definitions: Definition[] = [
         model: 'ML-ST-R200',
         vendor: 'M-ELEC',
         description: 'Stitchy switchable wall module',
-        extend: extend.switch,
+        extend: extend.switch(),
     },
 ];
 

--- a/src/devices/m_elec.ts
+++ b/src/devices/m_elec.ts
@@ -1,6 +1,12 @@
 import {Definition} from '../lib/types';
 import extend from '../lib/extend';
 
+const exposes = require('../lib/exposes');
+const fz = require('../converters/fromZigbee');
+const tz = require('../converters/toZigbee');
+const reporting = require('../lib/reporting');
+const e = exposes.presets;
+
 const definitions: Definition[] = [
     {
         zigbeeModel: ['ML-ST-D200'],
@@ -28,7 +34,14 @@ const definitions: Definition[] = [
         model: 'ML-ST-R200',
         vendor: 'M-ELEC',
         description: 'Stitchy switchable wall module',
-        extend: extend.switch(),
+        fromZigbee: [fz.on_off],
+        toZigbee: [tz.on_off],
+        exposes: [e.light()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+            await reporting.onOff(endpoint);
+        },
     },
 ];
 

--- a/src/devices/m_elec.ts
+++ b/src/devices/m_elec.ts
@@ -23,6 +23,13 @@ const definitions: Definition[] = [
         description: 'Stitchy dim mechanism',
         extend: extend.light_onoff_brightness({disableEffect: true}),
     },
+    {
+        zigbeeModel: ['ML-ST-R200'],
+        model: 'ML-ST-R200',
+        vendor: 'M-ELEC',
+        description: 'Stitchy switchable wall module',
+        extend: extend.switch,
+    },
 ];
 
 export default definitions;


### PR DESCRIPTION
Updated code so that ML-ST-R200 is seen as a Light entity / device, instead of a switch within HA.

Also included code, so that the light switch position is reported is toggled manually.