### PR TITLE
Add support for ADEO ZB-Remote-D0001

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -4338,6 +4338,14 @@ const converters1 = {
             return {action: `scene_${msg.data[msg.data.length - 2] - 9}`};
         },
     } satisfies Fz.Converter,
+    adeo_button_65024: {
+        cluster: 65024,
+        type: ['raw'],
+        convert: (model, msg, publish, options, meta) => {
+            const clickMapping: KeyValueNumberString = {1: 'single', 2: 'double', 3: 'hold'};
+            return {action: `${clickMapping[msg.data[6]]}`};
+        },
+    } satisfies Fz.Converter,
     color_stop_raw: {
         cluster: 'lightingColorCtrl',
         type: ['raw'],

--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -383,6 +383,20 @@ const definitions: Definition[] = [
             await ep.configureReporting('manuSpecificNodOnFilPilote', p);
         },
     },
+    {
+        zigbeeModel: ['ZB-Remote-D0001'],
+        model: 'ZB-Remote-D0001',
+        vendor: 'ADEO',
+        description: '1-key remote control',
+        fromZigbee: [fz.adeo_button_65024, fz.battery],
+        exposes: [e.action(['single', 'double', 'hold']), e.battery()],
+        toZigbee: [],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+    },
 ];
 
 export default definitions;


### PR DESCRIPTION
This is a device I bought at Leroy Merlin in Spain

https://www.leroymerlin.es/productos/electricidad-y-domotica/alarmas-camaras-ip-y-detectores/alarmas-para-casa/boton-magnetico-conectado-para-escenarios-lexman-enki-83633204.html

https://www.leroymerlin.fr/produits/electricite-domotique/alarme-telesurveillance/alarme-maison/clavier-a-code-badge-et-telecommande/bouton-connecte-3-fonctions-lexman-83633204.html

It seems simmilar to [this](https://www.zigbee2mqtt.io/devices/ZS232000178.html), but is not exactly the same as this button supports single, double and hold presses.

I aso had to create a converter, as I haven't seen any that fits.