### PR TITLE
feat: Extend temperature range to 153-500 mireds

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1022,7 +1022,15 @@ const definitions: Definition[] = [
         model: 'LED1923R5/LED1925G6',
         vendor: 'IKEA',
         description: 'TRADFRI LED bulb GU10 345 lumen, dimmable, white spectrum, color spectrum',
-        extend: tradfriExtend.light_onoff_brightness_colortemp_color({colorTempRange: [250, 454]}),
+        extend: tradfriExtend.light_onoff_brightness_colortemp_color({
+            disableColorTempStartup: true,
+            colorTempRange: [153, 500],
+        }),
+        toZigbee: utils.replaceInArray(
+            tradfriExtend.light_onoff_brightness_colortemp_color().toZigbee,
+            [tz.light_color_colortemp],
+            [tz.light_color_and_colortemp_via_color],
+        ),
     },
     {
         zigbeeModel: ['TRADFRI bulb E27 WS globe 1055lm'],


### PR DESCRIPTION
LED1923R5/LED1925G6 lights seem to be pure RGB without white LEDs. After a lot of experimentation involving dozens of different color temperature values, and trying to set the same color via XY values, it was not possible to see the slightest shift in color. It looks like the light is actually working in XY mode all the time, and the firmware is simply converting color temperatures into XY internally.

This makes this light similar to the older LED1624G9, except that the firmware of this newer one emulates the color temperature functionality, while the older one doesn't.

Since the color temperature functionality is actually emulated by the firmware, this commit changes it to use the Z2M emulation implementation. This allows expanding the advertised color temperature range to 2000-6500K, an improvement over the firmware implementation which artificially clamps the values to the 2200K-4000K range.

See: https://github.com/Koenkk/zigbee-herdsman-converters/pull/6640
