### PR TITLE
Added RSH-HS06 _TZ3000_zl1kmjqx TUYA device - temperature and humidity sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1976,8 +1976,7 @@ const definitions: Definition[] = [
     {
         fingerprint: [
             ...tuya.fingerprint('TS0201', ['_TZ3000_dowj6gyi', '_TZ3000_8ybe88nf']),
-            ...tuya.fingerprint('TY0201', ['_TZ3000_zl1kmjqx']),
-            ...tuya.fingerprint('', ['_TZ3000_zl1kmjqx']),
+            {manufacturerName: '_TZ3000_zl1kmjqx'},
         ],
         model: 'IH-K009',
         vendor: 'TuYa',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1977,6 +1977,7 @@ const definitions: Definition[] = [
         fingerprint: [
             ...tuya.fingerprint('TS0201', ['_TZ3000_dowj6gyi', '_TZ3000_8ybe88nf']),
             ...tuya.fingerprint('TY0201', ['_TZ3000_zl1kmjqx']),
+            ...tuya.fingerprint('', ['_TZ3000_zl1kmjqx']),
         ],
         model: 'IH-K009',
         vendor: 'TuYa',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1985,6 +1985,9 @@ const definitions: Definition[] = [
         toZigbee: [],
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
         configure: tuya.configureMagicPacket,
+        whiteLabel: [
+            tuya.whitelabel('TuYa', 'RSH-HS06', 'Temperature & humidity sensor', ['_TZ3000_zl1kmjqx']),
+        ],
     },
     {
         fingerprint: tuya.fingerprint('SM0201', ['_TYZB01_cbiezpds', '_TYZB01_zqvwka4k']),


### PR DESCRIPTION
Added support for RSH-HS06 _TZ3000_zl1kmjqx TUYA device - temperature and humidity sensor

It wont show the modelID so I'll leave it blank. External converter is working. When I trust the package the modelID is RSH-HS06.

Maybe there is a way to get the modelID but my z2mqtt wont show the devices as supported (with external converter) if I type in RSH-HS06 as modelID. It will work without the modelID