### PR TITLE
Removes unsupported tamper from TS0203 contact sensor _TZ3000_bpkijo14

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -568,7 +568,7 @@ const definitions: Definition[] = [
         ],
         exposes: (device, options) => {
             const exps: Expose[] = [e.contact(), e.battery_low(), e.battery(), e.battery_voltage()];
-            if (!device || !['_TZ3000_2mbfxlzr', '_TZ3000_n2egfsli', '_TZ3000_yfekcy3n'].includes(device.manufacturerName)) {
+            if (!device || !['_TZ3000_2mbfxlzr', '_TZ3000_n2egfsli', '_TZ3000_yfekcy3n', '_TZ3000_bpkijo14'].includes(device.manufacturerName)) {
                 exps.push(e.tamper());
             }
             exps.push(e.linkquality());


### PR DESCRIPTION
This for one of the generic Tuya contact sensors, powered by AA batteries and no tamper detection