### PR TITLE
Support scene transition times with a resolution of 100ms instead of 1 second

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -4315,8 +4315,11 @@ const converters2 = {
             );
 
             if (isGroup || (utils.isObject(removeresp) && (removeresp.status === 0 || removeresp.status == 133 || removeresp.status == 139))) {
+                const addSceneCommand = Number.isInteger(transtime) ? 'add' : 'enhancedAdd';
+                const commandTransitionTime = addSceneCommand === 'enhancedAdd' ? Math.floor(transtime * 10) : transtime;
+
                 const response = await entity.command(
-                    'genScenes', 'add', {groupid, sceneid, scenename: '', transtime, extensionfieldsets},
+                    'genScenes', addSceneCommand, {groupid, sceneid, scenename: '', commandTransitionTime, extensionfieldsets},
                     utils.getOptions(meta.mapped, entity),
                 );
 


### PR DESCRIPTION
`enhancedAdd` for scenes is able to use a transition time with a resolution of 100ms, instead of 1 second for `add`.

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/296540/cfd34e82-aec2-414d-828b-bae4b47ead93)

In this PR, the code for `scene_add` will first check if the specified `transition` is an integer. If it is, it continues to use `add`, but if it is a decimal number, it will try to use `enhancedAdd` instead. `enhancedAdd` is already supported in [zigbee-herdsman](https://github.com/Koenkk/zigbee-herdsman/blob/0513221288463a37a92c623e28a9d0b2074940e3/src/zcl/definition/cluster.ts#L325C27-L325C27).

**Potentially breaking change:**

With this change, if someone uses `scene_add` with a decimal transition time, with a device that doesn't support `enhancedAdd` (as it is optional), the operation will fail. The current behaviour is that it will successfully store the scene but will round down the transition time.

The workaround is to make sure you specify an integer for transition time if a device doesn't support `enhancedAdd`.