### PR TITLE
Random tidying

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -152,7 +152,7 @@ const fzLocal = {
                 // calibrate and round pm25 unless invalid
                 pm25 = (pm25 == 65535) ? -1 : calibrateAndPrecisionRoundOptions(pm25, options, 'pm25');
 
-                state[pm25Property] = calibrateAndPrecisionRoundOptions(pm25, options, 'pm25');
+                state[pm25Property] = pm25;
                 state[airQualityProperty] = airQuality;
             }
 

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -936,9 +936,9 @@ const definitions: Definition[] = [
         description: 'Zigbee RGB+CCT light',
         whiteLabel: [
             tuya.whitelabel('Lidl', '14149505L/14149506L_2', 'Livarno Lux light bar RGB+CCT (black/white)', ['_TZ3210_iystcadi']),
-            tuya.whitelabel('Tuya', 'TS0505B_1_1', 'Zigbee 3.0 18W led light bulb E27 RGBCW',
+            tuya.whitelabel('TuYa', 'TS0505B_1_1', 'Zigbee 3.0 18W led light bulb E27 RGBCW',
                 ['_TZ3210_mja6r5ix', '_TZ3210_jd3z4yig', '_TZ3210_r5afgmkl']),
-            tuya.whitelabel('Tuya', 'TS0505B_1_2', 'Zigbee GU10/E14 5W smart bulb', ['_TZ3210_it1u8ahz']),
+            tuya.whitelabel('TuYa', 'TS0505B_1_2', 'Zigbee GU10/E14 5W smart bulb', ['_TZ3210_it1u8ahz']),
         ],
         toZigbee: [tz.on_off, tzLocal.led_control],
         fromZigbee: [fz.on_off, fz.tuya_led_controller, fz.brightness, fz.ignore_basic_report],

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -793,7 +793,7 @@ const definitions: Definition[] = [
         toZigbee: [tzLocal.aqara_detection_distance],
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         exposes: [e.contact(), e.battery(), e.battery_voltage(),
-            e.binary('battery_cover', ea.STATE, 'OPEN', 'CLOSE'),
+            e.tamper(),
             e.enum('detection_distance', ea.ALL, ['10mm', '20mm', '30mm'])
                 .withDescription('The sensor will be considered "off" within the set distance. Please press the device button before setting'),
         ],

--- a/src/lib/xiaomi.ts
+++ b/src/lib/xiaomi.ts
@@ -565,7 +565,7 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             break;
         case '320':
             if (['MCCGQ13LM'].includes(model.model)) {
-                payload.battery_cover = getFromLookup(value, {0: 'CLOSE', 1: 'OPEN'});
+                payload.tamper = getFromLookup(value, {0: false, 1: true});
             }
             break;
         case '322':


### PR DESCRIPTION
While browsing the source, some random oddities :
* 2 devices use `Tuya` as vendor name rather than `TuYa`
* Xiaomi MCCGQ13LM contact sensor using `battery_cover` rather than the much more common `tamper`
* a double calibration of  pm25 of STARKVIND Air purifier