### PR TITLE
Add support for Innr SP240 Smart Plug

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -573,6 +573,17 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['SP 240'],
+        model: 'SP 240',
+        vendor: 'Innr',
+        description: 'Smart plug',
+        extend: [
+            onOff(),
+            electricityMeter({current: {divisor: 1000}, voltage: {divisor: 1}, power: {divisor: 1}, energy: {divisor: 100}}),
+        ],
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['OSP 210'],
         model: 'OSP 210',
         vendor: 'Innr',


### PR DESCRIPTION
Support for new Innr SP240 Smart Plug with Power Meter.
This is more or less an exact copy of the SP 234 Plug.

Tested as external converter with
```
const definition = {
    zigbeeModel: ['SP 240'], // The model ID from: Device with modelID 'lumi.sens' is not supported.
    model: 'SP 240', // Vendor model number, look on the device for a model number
    vendor: 'Innr', // Vendor of the device (only used for documentation and startup logging)
    description: 'Smart Plug with power metering', // Description of the device, copy from vendor site. (only used for documentation and startup logging)
    fromZigbee: [fz.on_off, fz.metering, fz.electrical_measurement], // We will add this later
    toZigbee: [tz.on_off], // Should be empty, unless device can be controlled (e.g. lights, switches).
    exposes: [e.switch(), e.energy(), e.power(), e.current(), e.voltage()], // Defines what this device exposes, used for e.g. Home Assistant discovery and in the frontend
    configure: async (device, coordinatorEndpoint, logger) => {
        const endpoint = device.getEndpoint(1);
        await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
        await reporting.onOff(endpoint);
        endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
            acCurrentDivisor: 1000,
            acCurrentMultiplier: 1,
        });

        await reporting.activePower(endpoint);
        await reporting.rmsCurrent(endpoint);
        await reporting.rmsVoltage(endpoint);
        // Gives UNSUPPORTED_ATTRIBUTE on reporting.readMeteringMultiplierDivisor.
        endpoint.saveClusterAttributeKeyValue('seMetering', { multiplier: 1, divisor: 100 });
        await reporting.currentSummDelivered(endpoint);
    },
};
```