### PR TITLE
IKEA Symfonisk Remote outdated events

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -301,20 +301,18 @@ const fzLocal = {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
         convert: (model, msg, publish, options, meta) => {
-            if (!hasAlreadyProcessedMessage(msg, model)) {
-                const direction = msg.data.movemode === 1 ? 'down' : 'up';
-                return {action: `volume_${direction}`};
-            }
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            const direction = msg.data.movemode === 1 ? 'down' : 'up';
+            return {action: `volume_${direction}`};
         },
     } satisfies Fz.Converter,
     ikea_volume_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
         convert: (model, msg, publish, options, meta) => {
-            if (!hasAlreadyProcessedMessage(msg, model)) {
-                const direction = msg.data.movemode === 1 ? 'down_hold' : 'up_hold';
-                return {action: `volume_${direction}`};
-            }
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            const direction = msg.data.movemode === 1 ? 'down_hold' : 'up_hold';
+            return {action: `volume_${direction}`};
         },
     } satisfies Fz.Converter,
     ikea_track_click: {

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -301,16 +301,20 @@ const fzLocal = {
         cluster: 'genLevelCtrl',
         type: 'commandMoveWithOnOff',
         convert: (model, msg, publish, options, meta) => {
-            const direction = msg.data.movemode === 1 ? 'down' : 'up';
-            return {action: `volume_${direction}`};
+            if (!hasAlreadyProcessedMessage(msg, model)) {
+                const direction = msg.data.movemode === 1 ? 'down' : 'up';
+                return {action: `volume_${direction}`};
+            }
         },
     } satisfies Fz.Converter,
     ikea_volume_hold: {
         cluster: 'genLevelCtrl',
         type: 'commandMove',
         convert: (model, msg, publish, options, meta) => {
-            const direction = msg.data.movemode === 1 ? 'down_hold' : 'up_hold';
-            return {action: `volume_${direction}`};
+            if (!hasAlreadyProcessedMessage(msg, model)) {
+                const direction = msg.data.movemode === 1 ? 'down_hold' : 'up_hold';
+                return {action: `volume_${direction}`};
+            }
         },
     } satisfies Fz.Converter,
     ikea_track_click: {


### PR DESCRIPTION
This should probably fix the issue https://github.com/Koenkk/zigbee2mqtt/issues/17195

Implemented `hasAlreadyProcessedMessage` to the `volume_click` and `volume_hold` converters to prevent outdated messages to be published. 

Here is a herdsman log of pressing the button once and getting three published actions (without the changes of this MR):

```
2023-12-10T12:18:13.918Z zigbee-herdsman:adapter:ezsp:uart <-- [4310b1a97d312a15b658]
2023-12-10T12:18:13.919Z zigbee-herdsman:adapter:ezsp:uart <-- [9c4a24ab1593499c03d817e1919874f8d7528cfd8154b97e]
2023-12-10T12:18:13.919Z zigbee-herdsman:adapter:ezsp:uart <-- DATA (4,3,0): 4310b1a9112a15b6589c4a24ab1593499c03d817e1919874f8d7528cfd8154b97e
2023-12-10T12:18:13.919Z zigbee-herdsman:adapter:ezsp:uart --> ACK  (5)
2023-12-10T12:18:13.919Z zigbee-herdsman:adapter:ezsp:uart --> [8520dd7e]
2023-12-10T12:18:13.920Z zigbee-herdsman:adapter:ezsp:ezsp <== Frame: 529001450000040108000101400100004dffbc0c5fffff0511310501ff
2023-12-10T12:18:13.920Z zigbee-herdsman:adapter:ezsp:ezsp <== 0x45: {"_cls_":"incomingMessageHandler","_id_":69,"_isRequest_":false,"type":0,"apsFrame":{"profileId":260,"clusterId":8,"sourceEndpoint":1,"destinationEndpoint":1,"options":320,"groupId":0,"sequence":77},"lastHopLqi":255,"lastHopRssi":-68,"sender":24332,"bindingIndex":255,"addressIndex":255,"message":{"type":"Buffer","data":[17,49,5,1,255]}}
2023-12-10T12:18:13.921Z zigbee-herdsman:adapter:ezsp:debg processMessage: {"messageType":0,"apsFrame":{"profileId":260,"clusterId":8,"sourceEndpoint":1,"destinationEndpoint":1,"options":320,"groupId":0,"sequence":77},"lqi":255,"rssi":-68,"sender":24332,"bindingIndex":255,"addressIndex":255,"message":{"type":"Buffer","data":[17,49,5,1,255]}}
2023-12-10T12:18:13.924Z zigbee-herdsman:controller:log Received 'zcl' data '{"frame":{"Header":{"frameControl":{"frameType":1,"manufacturerSpecific":false,"direction":0,"disableDefaultResponse":true,"reservedBits":0},"transactionSequenceNumber":49,"manufacturerCode":null,"commandIdentifier":5},"Payload":{"movemode":1,"rate":255},"Command":{"ID":5,"parameters":[{"name":"movemode","type":32},{"name":"rate","type":32}],"name":"moveWithOnOff"}},"address":24332,"endpoint":1,"linkquality":255,"groupID":0,"wasBroadcast":false,"destinationEndpoint":1}'
Zigbee2MQTT:debug 2023-12-10 13:18:13: Received Zigbee message from 'Sonos Fernbedienung Wohnzimmer', type 'commandMoveWithOnOff', cluster 'genLevelCtrl', data '{"movemode":1,"rate":255}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2023-12-10 13:18:13: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer', payload '{"action":"volume_down","battery":100,"last_seen":"2023-12-10T12:18:13.924Z","linkquality":255,"update":{"installed_version":16777269,"latest_version":16777269,"state":"idle"},"update_available":null,"voltage":2800}'
Zigbee2MQTT:info  2023-12-10 13:18:13: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer', payload '{"action":"","battery":100,"last_seen":"2023-12-10T12:18:13.924Z","linkquality":255,"update":{"installed_version":16777269,"latest_version":16777269,"state":"idle"},"update_available":null,"voltage":2800}'
Zigbee2MQTT:info  2023-12-10 13:18:13: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer/action', payload 'volume_down'
2023-12-10T12:18:16.487Z zigbee-herdsman:adapter:ezsp:ezsp Time to watchdog ... 0
2023-12-10T12:18:16.487Z zigbee-herdsman:adapter:ezsp:ezsp ==> nop: null
2023-12-10T12:18:16.488Z zigbee-herdsman:adapter:ezsp:ezsp ==> {"_cls_":"nop","_id_":5,"_isRequest_":true}
2023-12-10T12:18:16.488Z zigbee-herdsman:adapter:ezsp:uart --> DATA (3,5,0): 5300010500
2023-12-10T12:18:16.488Z zigbee-herdsman:adapter:ezsp:uart --> [357d3121a9512a16c77e]
2023-12-10T12:18:16.489Z zigbee-herdsman:adapter:ezsp:uart -?- waiting (4)
2023-12-10T12:18:16.490Z zigbee-herdsman:adapter:ezsp:uart <-- [547d31a1a9512a]
2023-12-10T12:18:16.491Z zigbee-herdsman:adapter:ezsp:uart <-- [d1477e]
2023-12-10T12:18:16.491Z zigbee-herdsman:adapter:ezsp:uart <-- DATA (5,4,0): 5411a1a9512ad1477e
2023-12-10T12:18:16.492Z zigbee-herdsman:adapter:ezsp:uart --> ACK  (6)
2023-12-10T12:18:16.492Z zigbee-herdsman:adapter:ezsp:uart --> [8610be7e]
2023-12-10T12:18:16.494Z zigbee-herdsman:adapter:ezsp:ezsp <== Frame: 5380010500
2023-12-10T12:18:16.495Z zigbee-herdsman:adapter:ezsp:ezsp <== 0x5: {"_cls_":"nop","_id_":5,"_isRequest_":false}
2023-12-10T12:18:16.496Z zigbee-herdsman:adapter:ezsp:uart -+- waiting (4) success
2023-12-10T12:18:20.720Z zigbee-herdsman:adapter:ezsp:uart <-- [647d31b1a9]
2023-12-10T12:18:20.721Z zigbee-herdsman:adapter:ezsp:uart <-- [7d312a15b6589c4a24ab1593499c03]
2023-12-10T12:18:20.721Z zigbee-herdsman:adapter:ezsp:uart <-- [d86fe1919874f8d7528cfd81b1df7e]
2023-12-10T12:18:20.722Z zigbee-herdsman:adapter:ezsp:uart <-- DATA (6,4,0): 6411b1a9112a15b6589c4a24ab1593499c03d86fe1919874f8d7528cfd81b1df7e
2023-12-10T12:18:20.722Z zigbee-herdsman:adapter:ezsp:uart --> ACK  (7)
2023-12-10T12:18:20.722Z zigbee-herdsman:adapter:ezsp:uart --> [87009f7e]
2023-12-10T12:18:20.723Z zigbee-herdsman:adapter:ezsp:ezsp <== Frame: 539001450000040108000101400100004dffc40c5fffff0511310501ff
2023-12-10T12:18:20.723Z zigbee-herdsman:adapter:ezsp:ezsp <== 0x45: {"_cls_":"incomingMessageHandler","_id_":69,"_isRequest_":false,"type":0,"apsFrame":{"profileId":260,"clusterId":8,"sourceEndpoint":1,"destinationEndpoint":1,"options":320,"groupId":0,"sequence":77},"lastHopLqi":255,"lastHopRssi":-68,"sender":24332,"bindingIndex":255,"addressIndex":255,"message":{"type":"Buffer","data":[17,49,5,1,255]}}
2023-12-10T12:18:20.724Z zigbee-herdsman:adapter:ezsp:debg processMessage: {"messageType":0,"apsFrame":{"profileId":260,"clusterId":8,"sourceEndpoint":1,"destinationEndpoint":1,"options":320,"groupId":0,"sequence":77},"lqi":255,"rssi":-60,"sender":24332,"bindingIndex":255,"addressIndex":255,"message":{"type":"Buffer","data":[17,49,5,1,255]}}
2023-12-10T12:18:20.727Z zigbee-herdsman:controller:log Received 'zcl' data '{"frame":{"Header":{"frameControl":{"frameType":1,"manufacturerSpecific":false,"direction":0,"disableDefaultResponse":true,"reservedBits":0},"transactionSequenceNumber":49,"manufacturerCode":null,"commandIdentifier":5},"Payload":{"movemode":1,"rate":255},"Command":{"ID":5,"parameters":[{"name":"movemode","type":32},{"name":"rate","type":32}],"name":"moveWithOnOff"}},"address":24332,"endpoint":1,"linkquality":255,"groupID":0,"wasBroadcast":false,"destinationEndpoint":1}'
Zigbee2MQTT:debug 2023-12-10 13:18:20: Received Zigbee message from 'Sonos Fernbedienung Wohnzimmer', type 'commandMoveWithOnOff', cluster 'genLevelCtrl', data '{"movemode":1,"rate":255}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2023-12-10 13:18:20: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer', payload '{"action":"volume_down","battery":100,"last_seen":"2023-12-10T12:18:20.727Z","linkquality":255,"update":{"installed_version":16777269,"latest_version":16777269,"state":"idle"},"update_available":null,"voltage":2800}'
Zigbee2MQTT:info  2023-12-10 13:18:20: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer', payload '{"action":"","battery":100,"last_seen":"2023-12-10T12:18:20.727Z","linkquality":255,"update":{"installed_version":16777269,"latest_version":16777269,"state":"idle"},"update_available":null,"voltage":2800}'
Zigbee2MQTT:info  2023-12-10 13:18:20: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer/action', payload 'volume_down'
2023-12-10T12:18:26.493Z zigbee-herdsman:adapter:ezsp:ezsp Time to watchdog ... 0
2023-12-10T12:18:26.493Z zigbee-herdsman:adapter:ezsp:ezsp ==> nop: null
2023-12-10T12:18:26.493Z zigbee-herdsman:adapter:ezsp:ezsp ==> {"_cls_":"nop","_id_":5,"_isRequest_":true}
2023-12-10T12:18:26.494Z zigbee-herdsman:adapter:ezsp:uart --> DATA (4,7,0): 5400010500
2023-12-10T12:18:26.494Z zigbee-herdsman:adapter:ezsp:uart --> [471621a9512abfcf7e]
2023-12-10T12:18:26.495Z zigbee-herdsman:adapter:ezsp:uart -?- waiting (5)
2023-12-10T12:18:26.497Z zigbee-herdsman:adapter:ezsp:uart <-- [7516a1]
2023-12-10T12:18:26.498Z zigbee-herdsman:adapter:ezsp:uart <-- [a9512ac63b7e]
2023-12-10T12:18:26.499Z zigbee-herdsman:adapter:ezsp:uart <-- DATA (7,5,0): 7516a1a9512ac63b7e
2023-12-10T12:18:26.499Z zigbee-herdsman:adapter:ezsp:uart --> ACK  (0)
2023-12-10T12:18:26.501Z zigbee-herdsman:adapter:ezsp:uart --> [8070787e]
2023-12-10T12:18:26.502Z zigbee-herdsman:adapter:ezsp:ezsp <== Frame: 5480010500
2023-12-10T12:18:26.503Z zigbee-herdsman:adapter:ezsp:ezsp <== 0x5: {"_cls_":"nop","_id_":5,"_isRequest_":false}
2023-12-10T12:18:26.503Z zigbee-herdsman:adapter:ezsp:uart -+- waiting (5) success
2023-12-10T12:18:27.687Z zigbee-herdsman:adapter:ezsp:uart <-- [0516b1a97d312a15b658]
2023-12-10T12:18:27.688Z zigbee-herdsman:adapter:ezsp:uart <-- [9c4a24ab1593499c03d86ee1919874f8d7528cfd81c63a7e]
2023-12-10T12:18:27.688Z zigbee-herdsman:adapter:ezsp:uart <-- DATA (0,5,0): 0516b1a9112a15b6589c4a24ab1593499c03d86ee1919874f8d7528cfd81c63a7e
2023-12-10T12:18:27.688Z zigbee-herdsman:adapter:ezsp:uart --> ACK  (1)
2023-12-10T12:18:27.689Z zigbee-herdsman:adapter:ezsp:uart --> [8160597e]
2023-12-10T12:18:27.689Z zigbee-herdsman:adapter:ezsp:ezsp <== Frame: 549001450000040108000101400100004dffc50c5fffff0511310501ff
2023-12-10T12:18:27.690Z zigbee-herdsman:adapter:ezsp:ezsp <== 0x45: {"_cls_":"incomingMessageHandler","_id_":69,"_isRequest_":false,"type":0,"apsFrame":{"profileId":260,"clusterId":8,"sourceEndpoint":1,"destinationEndpoint":1,"options":320,"groupId":0,"sequence":77},"lastHopLqi":255,"lastHopRssi":-68,"sender":24332,"bindingIndex":255,"addressIndex":255,"message":{"type":"Buffer","data":[17,49,5,1,255]}}
2023-12-10T12:18:27.691Z zigbee-herdsman:adapter:ezsp:debg processMessage: {"messageType":0,"apsFrame":{"profileId":260,"clusterId":8,"sourceEndpoint":1,"destinationEndpoint":1,"options":320,"groupId":0,"sequence":77},"lqi":255,"rssi":-59,"sender":24332,"bindingIndex":255,"addressIndex":255,"message":{"type":"Buffer","data":[17,49,5,1,255]}}
2023-12-10T12:18:27.694Z zigbee-herdsman:controller:log Received 'zcl' data '{"frame":{"Header":{"frameControl":{"frameType":1,"manufacturerSpecific":false,"direction":0,"disableDefaultResponse":true,"reservedBits":0},"transactionSequenceNumber":49,"manufacturerCode":null,"commandIdentifier":5},"Payload":{"movemode":1,"rate":255},"Command":{"ID":5,"parameters":[{"name":"movemode","type":32},{"name":"rate","type":32}],"name":"moveWithOnOff"}},"address":24332,"endpoint":1,"linkquality":255,"groupID":0,"wasBroadcast":false,"destinationEndpoint":1}'
Zigbee2MQTT:debug 2023-12-10 13:18:27: Received Zigbee message from 'Sonos Fernbedienung Wohnzimmer', type 'commandMoveWithOnOff', cluster 'genLevelCtrl', data '{"movemode":1,"rate":255}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2023-12-10 13:18:27: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer', payload '{"action":"volume_down","battery":100,"last_seen":"2023-12-10T12:18:27.694Z","linkquality":255,"update":{"installed_version":16777269,"latest_version":16777269,"state":"idle"},"update_available":null,"voltage":2800}'
Zigbee2MQTT:info  2023-12-10 13:18:27: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer', payload '{"action":"","battery":100,"last_seen":"2023-12-10T12:18:27.694Z","linkquality":255,"update":{"installed_version":16777269,"latest_version":16777269,"state":"idle"},"update_available":null,"voltage":2800}'
Zigbee2MQTT:info  2023-12-10 13:18:27: MQTT publish: topic 'zigbee2mqtt/Sonos Fernbedienung Wohnzimmer/action', payload 'volume_down'
```

The `transactionSequenceNumber` stays the same for this one button click, so I guess `hasAlreadyProcessedMessage` should be enough here.