### PR TITLE
fix: add color for Philips 929003598001

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -16,7 +16,7 @@ const definitions: Definition[] = [
         model: '929003598001',
         vendor: 'Philips',
         description: 'Hue White & Color Ambiance Surimu square panel 30x30',
-        extend: [philipsLight({colorTemp: {range: [153, 500]}})],
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
         zigbeeModel: ['929003597601'],


### PR DESCRIPTION
Color option is currently missing.
See: https://www.philips-hue.com/de-de/p/hue-white---color-ambiance-surimu-quadratisches-panel-30x30-weiss/8720169159136