### PR TITLE
Update robb.ts

### DIFF
--- a/src/devices/robb.ts
+++ b/src/devices/robb.ts
@@ -152,7 +152,7 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
         },
-    },	
+    },
     {
         zigbeeModel: ['ROB_200-025-0'],
         model: 'ROB_200-025-0',

--- a/src/devices/robb.ts
+++ b/src/devices/robb.ts
@@ -1,7 +1,6 @@
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
-import * as legacy from '../lib/legacy';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
@@ -140,11 +139,9 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['ROB_200-024-0'],
         model: 'ROB_200-024-0',
-        vendor: 'ROBB smarrt',
+        vendor: 'ROBB',
         description: 'Zigbee 3.0 4 channel remote control',
-        fromZigbee: [fz.battery, fz.command_move, legacy.fz.ZGRC013_brightness_onoff,
-            legacy.fz.ZGRC013_brightness, fz.command_stop, legacy.fz.ZGRC013_brightness_stop, fz.command_on,
-            legacy.fz.ZGRC013_cmdOn, fz.command_off, legacy.fz.ZGRC013_cmdOff, fz.command_recall],
+        fromZigbee: [fz.battery, fz.command_move, fz.command_stop, fz.command_on, fz.command_off, fz.command_recall],
         exposes: [e.battery(), e.action(['brightness_move_up', 'brightness_move_down', 'brightness_stop', 'on', 'off', 'recall_*'])],
         toZigbee: [],
         whiteLabel: [{vendor: 'RGB Genie', model: 'ZGRC-KEY-013'}],

--- a/src/devices/robb.ts
+++ b/src/devices/robb.ts
@@ -1,6 +1,7 @@
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
+import * as legacy from '../lib/legacy';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
@@ -136,6 +137,25 @@ const definitions: Definition[] = [
         meta: {multiEndpoint: true},
         whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9001K8-DIM'}],
     },
+    {
+        zigbeeModel: ['ROB_200-024-0'],
+        model: 'ROB_200-024-0',
+        vendor: 'ROBB smarrt',
+        description: 'Zigbee 3.0 4 channel remote control',
+        fromZigbee: [fz.battery, fz.command_move, legacy.fz.ZGRC013_brightness_onoff,
+            legacy.fz.ZGRC013_brightness, fz.command_stop, legacy.fz.ZGRC013_brightness_stop, fz.command_on,
+            legacy.fz.ZGRC013_cmdOn, fz.command_off, legacy.fz.ZGRC013_cmdOff, fz.command_recall],
+        exposes: [e.battery(), e.action(['brightness_move_up', 'brightness_move_down', 'brightness_stop', 'on', 'off', 'recall_*'])],
+        toZigbee: [],
+        whiteLabel: [{vendor: 'RGB Genie', model: 'ZGRC-KEY-013'}],
+        meta: {multiEndpoint: true, battery: {dontDividePercentage: true}},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genScenes']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+        },
+    },	
     {
         zigbeeModel: ['ROB_200-025-0'],
         model: 'ROB_200-025-0',


### PR DESCRIPTION
Update robb.ts, added ROB_200-24-0. 

ROB_200-24-0 is a 4 channel Zigbee 3.0 remote control by vendor Robb smarrt.
(https://www.robbshop.nl/robb-smarrt-afstandsbediening-4-kanaals-zwart-zigbee).

The remote looks like a variant to the Sunricher SR-ZG9001K12-DIM-Z4 model.
Other comparable devices are RGBgenie ZB-5004, iCasa ICZB-RM11S.

The Sunricher config is slightly different compared to the others (using a legacy lib reference) and appears the only version with all buttons functioning (on/off tested, no dimming lightbulb at hand). 