### PR TITLE
add Wireless switch with 6 buttons, 'TS004F', ['_TZ3000_r0o2dahu']

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2253,6 +2253,21 @@ const converters1 = {
             return {action: `${button}${clickMapping[msg.data[3]]}`};
         },
     } satisfies Fz.Converter,
+    tuya_on_off_action_8: {
+        cluster: 'genOnOff',
+        type: 'raw',
+        convert: (model, msg, publish, options, meta) => {
+            if (hasAlreadyProcessedMessage(msg, model, msg.data[1])) return;
+            const clickMapping: KeyValueNumberString = {0: 'single', 1: 'double', 2: 'hold'};
+            const buttonMapping: KeyValueNumberString = {1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6', 7: '7', 8: '8'};
+            const button = buttonMapping ? `${buttonMapping[msg.endpoint.ID]}_` : '';
+            // Since it is a non standard ZCL command, no default response is send from zigbee-herdsman
+            // Send the defaultResponse here, otherwise the second button click delays.
+            // https://github.com/Koenkk/zigbee2mqtt/issues/8149
+            msg.endpoint.defaultResponse(0xfd, 0, 6, msg.data[1]).catch((error) => {});
+            return {action: `${button}${clickMapping[msg.data[3]]}`};
+        },
+    } satisfies Fz.Converter,
     tuya_switch_scene: {
         cluster: 'genOnOff',
         type: 'raw',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2144,6 +2144,42 @@ const definitions: Definition[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint('TS004F', ['_TZ3000_r0o2dahu']),
+        model: 'TS004F',
+        vendor: 'TuYa',
+        description: 'Wireless switch with 6 buttons',
+        exposes: [
+            e.battery(),
+            e.enum('operation_mode', ea.ALL, ['command', 'event']).withDescription(
+                'Operation mode: "command" - for group control, "event" - for clicks'),
+            e.action(['on', 'off', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up',
+                'brightness_move_down', '1_single', '1_double', '1_hold', '2_single', '2_double', '2_hold',
+                '3_single', '3_double', '3_hold', '4_single', '4_double', '4_hold',
+                '5_single', '5_double', '5_hold', '6_single', '6_double', '6_hold'])],
+        fromZigbee: [fz.battery, fz.tuya_on_off_action_8, fz.tuya_operation_mode,
+            fz.command_on, fz.command_off, fz.command_step, fz.command_move],
+        toZigbee: [tz.tuya_operation_mode],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read('genBasic', [0x0004, 0x000, 0x0001, 0x0005, 0x0007, 0xfffe]);
+            await endpoint.write('genOnOff', {'tuyaOperationMode': 1});
+            await endpoint.read('genOnOff', ['tuyaOperationMode']);
+            try {
+                await endpoint.read(0xE001, [0xD011]);
+            } catch (err) {/* do nothing */}
+            await endpoint.read('genPowerCfg', ['batteryVoltage', 'batteryPercentageRemaining']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            for (const ep of [1, 2, 3, 4, 5, 6]) {
+                // Not all variants have all endpoints
+                // https://github.com/Koenkk/zigbee2mqtt/issues/15730#issuecomment-1364498358
+                if (device.getEndpoint(ep)) {
+                    await reporting.bind(device.getEndpoint(ep), coordinatorEndpoint, ['genOnOff']);
+                }
+            }
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+    {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_qq9mpfhw'}],
         model: 'TS0601_water_sensor',
         vendor: 'TuYa',


### PR DESCRIPTION
It is a 6 buttons wireless panel, but the model ID is TS004F, that suppose to be a 4 buttons panel in the definition of fz.tuya_on_off_action.  So I created another function fz.tuya_on_off_action_8 for this.  Actually I dunno why fz.tuya_on_off_action need to do the modelID check because it is just a simple int -> string conversion.