### PR TITLE
Add missing color temp values

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1169,7 +1169,7 @@ const definitions: Definition[] = [
         model: 'L2208',
         vendor: 'IKEA',
         description: 'JETSTRÖM LED ceiling light panel, smart dimmable/white spectrum, 100x40 cm',
-        extend: tradfriExtend.light_onoff_brightness_colortemp(),
+        extend: tradfriExtend.light_onoff_brightness_colortemp({colorTempRange: [250, 454]}),
     },
     {
         zigbeeModel: ['TRADFRIbulbPAR38WS900lm'],


### PR DESCRIPTION
Add missing color temp values as requested in a comment in previous PR

Dev console output:

`info 2023-12-13 01:05:29Read result of 'lightingColorCtrl': {"colorTempPhysicalMin":250,"colorTempPhysicalMax":454}`

PR #6687 