### PR TITLE
fix: HS2AQ correct HCHO value to match what is on the display

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -4308,7 +4308,7 @@ const converters1 = {
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
             if (msg.data['measuredValue']) {
-                return {hcho: parseFloat(msg.data['measuredValue']) / 100.0};
+                return {hcho: parseFloat(msg.data['measuredValue']) / 1000.0};
             }
         },
     } satisfies Fz.Converter,


### PR DESCRIPTION
[Reported](https://github.com/Koenkk/zigbee-herdsman-converters/pull/5547#issuecomment-1854187611) by @RobLeighton67 that we seem to be off by a factor of 10.

Display shows 0.01 but z2m shows 0.1, update the convertor to device by 1000.0 instead of 100.0 to align these.