### PR TITLE
Added missing on/off for Namron outlet switch

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -141,9 +141,9 @@ const definitions: Definition[] = [
         model: '4512767',
         vendor: 'Namron',
         description: 'Zigbee smart plug 16A',
-        fromZigbee: [fz.metering, fz.electrical_measurement],
+        fromZigbee: [fz.on_off, fz.metering, fz.electrical_measurement],
+        toZigbee: [tz.on_off],
         exposes: [e.power(), e.current(), e.voltage(), e.energy(), e.switch()],
-        extend: extend.switch(),
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1) || device.getEndpoint(3);
             const binds = [


### PR DESCRIPTION
Namron Switch 4512767 presented no on/off under "exposes" in the GUI.