### PR TITLE
Add device support for: Innr SP-242 Smart Plug

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -669,6 +669,16 @@ const definitions: Definition[] = [
             electricityMeter({current: {divisor: 1000}, voltage: {divisor: 1}, power: {divisor: 1}, energy: {divisor: 100}}),
         ],
     },
+    {
+        zigbeeModel: ['SP 242'],
+        model: 'SP 242',
+        vendor: 'Innr',
+        description: 'Smart plug',
+        extend: [
+            onOff(),
+            electricityMeter({current: {divisor: 1000}, voltage: {divisor: 1}, power: {divisor: 1}, energy: {divisor: 100}}),
+        ],
+    }
 ];
 
 export default definitions;

--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -678,7 +678,7 @@ const definitions: Definition[] = [
             onOff(),
             electricityMeter({current: {divisor: 1000}, voltage: {divisor: 1}, power: {divisor: 1}, energy: {divisor: 100}}),
         ],
-    }
+    },
 ];
 
 export default definitions;


### PR DESCRIPTION
### Device
Innr has released an updated version of their smart plug for the UK:
https://www.amazon.co.uk/Innr-Zigbee-Philips-Google-Required/dp/B0CFVLK4FL

### Related Image PR
https://github.com/Koenkk/zigbee2mqtt.io/pull/2405

### Tested using external converter:
```
const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const reporting = require('zigbee-herdsman-converters/lib/reporting');
const extend = require('zigbee-herdsman-converters/lib/extend');
const e = exposes.presets;
const ea = exposes.access;
const ota = require('zigbee-herdsman-converters/lib/ota');
const { onOff, electricityMeter } = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['SP 242'], // The model ID from: Device with modelID 'lumi.sens' is not supported.
    model: 'SP 242', // Vendor model number, look on the device for a model number
    vendor: 'Innr', // Vendor of the device (only used for documentation and startup logging)
    description: 'Smart plug', // Description of the device, copy from vendor site. (only used for documentation and startup logging)
    extend: [
        onOff(),
        electricityMeter({current: {divisor: 1000}, voltage: {divisor: 1}, power: {divisor: 1}, energy: {divisor: 100}})
    ],
    ota: ota.zigbeeOTA
};

module.exports = definition;
```