### PR TITLE
feat: VOCKQJK11LM allow reading and improve reporting

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -5535,13 +5535,6 @@ const converters1 = {
             return {action: `scene_${scenes[msg.data.level]}`};
         },
     } satisfies Fz.Converter,
-    xiaomi_tvoc: {
-        cluster: 'genAnalogInput',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            return {voc: msg.data.presentValue};
-        },
-    } satisfies Fz.Converter,
     heiman_doorbell_button: {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1783,6 +1783,12 @@ const converters2 = {
             await entity.read('msTemperatureMeasurement', ['measuredValue']);
         },
     } satisfies Tz.Converter,
+    humidity: {
+        key: ['humidity'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('msRelativeHumidity', ['measuredValue']);
+        },
+    } satisfies Tz.Converter,
     illuminance: {
         key: ['illuminance', 'illuminance_lux'],
         convertGet: async (entity, key, meta) => {

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -3132,6 +3132,7 @@ const definitions: Definition[] = [
             const payload = reporting.payload('presentValue', 10, constants.repInterval.HOUR, 5);
             await endpoint.configureReporting('genAnalogInput', payload);
             await endpoint.read('genPowerCfg', ['batteryVoltage']);
+            await endpoint.read('aqaraOpple', [0x0114], {manufacturerCode: 0x115F, disableDefaultResponse: true});
         },
         ota: ota.zigbeeOTA,
     },

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -370,13 +370,6 @@ const fzLocal = {
             };
         },
     } satisfies Fz.Converter,
-    VOCKQJK11LM_tvoc: {
-        cluster: 'genAnalogInput',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            return {voc: msg.data.presentValue};
-        },
-    } satisfies Fz.Converter,
 };
 
 const tzLocal = {
@@ -541,12 +534,6 @@ const tzLocal = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('aqaraOpple', [0x0114], {manufacturerCode: 0x115F, disableDefaultResponse: true});
-        },
-    } satisfies Tz.Converter,
-    VOCKQJK11LM_tvoc: {
-        key: ['voc'],
-        convertGet: async (entity, key, meta) => {
-            await entity.read('genAnalogInput', ['presentValue']);
         },
     } satisfies Tz.Converter,
     VOCKQJK11LM_air_quality: {
@@ -3136,17 +3123,27 @@ const definitions: Definition[] = [
         vendor: 'Xiaomi',
         whiteLabel: [{vendor: 'Xiaomi', model: 'AAQS-S01'}],
         description: 'Aqara TVOC air quality monitor',
-        fromZigbee: [fzLocal.VOCKQJK11LM_tvoc, fz.battery, fz.temperature, fz.humidity, xiaomi.fromZigbee.aqara_opple],
-        toZigbee: [tzLocal.VOCKQJK11LM_tvoc, tzLocal.VOCKQJK11LM_air_quality, tz.temperature, tz.humidity, tz.battery_voltage,
+        fromZigbee: [fz.battery, fz.temperature, fz.humidity, xiaomi.fromZigbee.aqara_opple],
+        toZigbee: [tzLocal.VOCKQJK11LM_air_quality, tz.temperature, tz.humidity, tz.battery_voltage,
             tzLocal.VOCKQJK11LM_display_unit],
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         exposes: [e.temperature().withAccess(ea.STATE_GET), e.humidity().withAccess(ea.STATE_GET),
-            e.voc().withUnit('ppb').withAccess(ea.STATE_GET), e.device_temperature(),
+            e.device_temperature(),
             e.battery().withAccess(ea.STATE_GET), e.battery_voltage().withAccess(ea.STATE_GET),
             e.enum('display_unit', ea.ALL, ['mgm3_celsius', 'ppb_celsius', 'mgm3_fahrenheit', 'ppb_fahrenheit'])
                 .withDescription('Units to show on the display'),
             e.enum('air_quality', ea.STATE_GET, ['excellent', 'good', 'moderate', 'poor', 'unhealthy'])
                 .withDescription('Measured air quality'),
+        ],
+        extend: [
+            numeric({
+                name: 'voc',
+                cluster: 'genAnalogInput',
+                attribute: 'presentValue',
+                description: 'Measured VOC value',
+                unit: 'ppb',
+                readOnly: true,
+            }),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -3118,9 +3118,10 @@ const definitions: Definition[] = [
         whiteLabel: [{vendor: 'Xiaomi', model: 'AAQS-S01'}],
         description: 'Aqara TVOC air quality monitor',
         fromZigbee: [fz.xiaomi_tvoc, fz.battery, fz.temperature, fz.humidity, xiaomi.fromZigbee.aqara_opple],
-        toZigbee: [tzLocal.VOCKQJK11LM_display_unit],
+        toZigbee: [tz.temperature, tz.humidity, tz.battery_voltage, tzLocal.VOCKQJK11LM_display_unit],
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
-        exposes: [e.temperature(), e.humidity(), e.voc().withUnit('ppb'), e.device_temperature(), e.battery(), e.battery_voltage(),
+        exposes: [e.temperature().withAccess(ea.STATE_GET), e.humidity().withAccess(ea.STATE_GET), e.voc().withUnit('ppb'),
+            e.device_temperature(), e.battery().withAccess(ea.STATE_GET), e.battery_voltage().withAccess(ea.STATE_GET),
             e.enum('display_unit', ea.ALL, ['mgm3_celsius', 'ppb_celsius', 'mgm3_fahrenheit', 'ppb_fahrenheit'])
                 .withDescription('Units to show on the display')],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -536,6 +536,12 @@ const tzLocal = {
             await entity.read('aqaraOpple', [0x0114], {manufacturerCode: 0x115F, disableDefaultResponse: true});
         },
     } satisfies Tz.Converter,
+    xiaomi_tvoc: {
+        key: ['voc'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('genAnalogInput', ['presentValue']);
+        },
+    } satisfies Tz.Converter,
     aqara_feeder: {
         key: ['feed', 'schedule', 'led_indicator', 'child_lock', 'mode', 'serving_size', 'portion_weight'],
         convertSet: async (entity, key, value, meta) => {
@@ -3118,10 +3124,11 @@ const definitions: Definition[] = [
         whiteLabel: [{vendor: 'Xiaomi', model: 'AAQS-S01'}],
         description: 'Aqara TVOC air quality monitor',
         fromZigbee: [fz.xiaomi_tvoc, fz.battery, fz.temperature, fz.humidity, xiaomi.fromZigbee.aqara_opple],
-        toZigbee: [tz.temperature, tz.humidity, tz.battery_voltage, tzLocal.VOCKQJK11LM_display_unit],
+        toZigbee: [tz.temperature, tz.humidity, tz.battery_voltage, tzLocal.VOCKQJK11LM_display_unit, tzLocal.xiaomi_tvoc],
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
-        exposes: [e.temperature().withAccess(ea.STATE_GET), e.humidity().withAccess(ea.STATE_GET), e.voc().withUnit('ppb'),
-            e.device_temperature(), e.battery().withAccess(ea.STATE_GET), e.battery_voltage().withAccess(ea.STATE_GET),
+        exposes: [e.temperature().withAccess(ea.STATE_GET), e.humidity().withAccess(ea.STATE_GET),
+            e.voc().withUnit('ppb').withAccess(ea.STATE_GET), e.device_temperature(),
+            e.battery().withAccess(ea.STATE_GET), e.battery_voltage().withAccess(ea.STATE_GET),
             e.enum('display_unit', ea.ALL, ['mgm3_celsius', 'ppb_celsius', 'mgm3_fahrenheit', 'ppb_fahrenheit'])
                 .withDescription('Units to show on the display')],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -3132,7 +3132,8 @@ const definitions: Definition[] = [
             await reporting.temperature(endpoint);
             const payload = reporting.payload('presentValue', 10, constants.repInterval.HOUR, 5);
             await endpoint.configureReporting('genAnalogInput', payload);
-            await endpoint.read('genPowerCfg', ['batteryVoltage']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryVoltage(endpoint);
             await endpoint.read('aqaraOpple', [0x0114], {manufacturerCode: 0x115F, disableDefaultResponse: true});
         },
         ota: ota.zigbeeOTA,

--- a/src/lib/xiaomi.ts
+++ b/src/lib/xiaomi.ts
@@ -532,6 +532,11 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
                 payload.test = value === 1;
             }
             break;
+        case '297':
+            if (['VOCKQJK11LM'].includes(model.model)) {
+                payload.air_quality = getKey(VOCKQJK11LMAirQuality, value);
+            }
+            break;
         case '313':
             if (['JT-BZ-01AQ/A'].includes(model.model)) {
                 payload.state = getFromLookup(value, {0: 'work', 1: 'preparation'});
@@ -781,6 +786,15 @@ export const VOCKQJK11LMDisplayUnit = {
     'ppb_celsius': 0x01, // ppb, °C
     'mgm3_fahrenheit': 0x10, // mg/m³, °F
     'ppb_fahrenheit': 0x11, // ppb, °F
+};
+
+// Using German IAQ labels to match the Develco Air Quality Sensor
+export const VOCKQJK11LMAirQuality = {
+    'excellent': 1,
+    'good': 2,
+    'moderate': 3,
+    'poor': 4,
+    'unhealthy': 5,
 };
 
 export const numericAttributes2Options = (definition: Definition) => {


### PR DESCRIPTION
I got myself a VOCKQJK11LM after another one of my Develco VOC sensors died :(, so here are some improvements:

- support air_quality
- read display_unit and air_quality attribute during configure so the value is populated
- allow reading of temperature, humidity, voc, air_quality and battery.  (this is of course done after the next checkin)
- configure batteryVoltage reporting

Something I still haven't found is how to convert the ppb voc to ug/mg3, the display has the option to chose and the their hub also has it as ug/mg3 which makes sense to compare it to other sensors. 
<img width="729" alt="image" src="https://github.com/Koenkk/zigbee-herdsman-converters/assets/379665/cd070ac6-4963-4f9a-b9bf-c8cb619b10c2">

So far I haven't really found any info on the sensor which is a shame. Also not really sure this should be in the Xiaomi vendor file as the actual vendor is lumi and sold under the aqara brand. But that's not a can of worms I want to deal with.

If I do manage to find a spec-sheet for the chip I'll see about converting the value to ug/mg3 (and maybe see if I can somehow have it follow whatever is configured for the display_unit value.