### PR TITLE
Update philips.ts - added colorTemp range to Centris 2 spots white

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1952,7 +1952,7 @@ const definitions: Definition[] = [
         model: '5061031P7',
         vendor: 'Philips',
         description: 'Hue White & Color ambience Centris ceiling light (2 spots) (white)',
-        extend: [philipsLight({colorTemp: {range: undefined}, color: true})],
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
         zigbeeModel: ['5061030P7_01', '5061030P7_02', '5061030P7_03'],


### PR DESCRIPTION
Philips Hue Centris with 2 spots white was missing the colorTemp range. I have this product and already checked (it is the same as most of the philips hue products)