### PR TITLE
Add Avatto ZWSM16 

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2384,11 +2384,11 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_fisb3ajo', '_TZ3000_5gey1ohx']),
+        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_fisb3ajo', '_TZ3000_5gey1ohx','_TZ3000_mtnpt6ws']),
         model: 'TS0002_switch_module_2',
         vendor: 'TuYa',
         description: '2 gang switch module',
-        extend: tuya.extend.switch({endpoints: ['l1', 'l2']}),
+        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2']}),
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
@@ -2398,13 +2398,16 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
         },
+	whiteLabel: [
+		tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch module', ['_TZ3000_mtnpt6ws']),
+        ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_4o16jdca', '_TZ3000_odzoiovu']),
+        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_4o16jdca', '_TZ3000_odzoiovu','_TZ3000_hbic3ka3']),
         model: 'TS0003_switch_module_2',
         vendor: 'TuYa',
         description: '3 gang switch module',
-        extend: tuya.extend.switch({switchType: true, endpoints: ['l1', 'l2', 'l3']}),
+        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2', 'l3']}),
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2, 'l3': 3};
         },
@@ -2415,6 +2418,9 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
         },
+	whiteLabel: [
+		tuya.whitelabel('AVATTO', 'ZWSM16-3-Zigbee', '3 gang switch module', ['_TZ3000_hbic3ka3']),
+        ],
     },
     {
         fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_vsasbzkf', '_TZ3000_nnwehhst']),
@@ -7044,45 +7050,6 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_mtnpt6ws']),
-        model: 'TS0002_switch_module_2',
-        vendor: 'TuYa',
-        description: '2 gang switch module',
-        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2']}),
-        endpoint: (device) => {
-            return {'l1': 1, 'l2': 2};
-        },
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-        },
-		whiteLabel: [
-		tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch module', ['_TZ3000_mtnpt6ws']),
-        ],
-    },
-    {
-        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_hbic3ka3']),
-        model: 'TS0003_switch_module_2',
-        vendor: 'TuYa',
-        description: '3 gang switch module',
-        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2', 'l3']}),
-        endpoint: (device) => {
-            return {'l1': 1, 'l2': 2, 'l3': 3};
-        },
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
-            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
-            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
-        },
-		whiteLabel: [
-		tuya.whitelabel('AVATTO', 'ZWSM16-3-Zigbee', '3 gang switch module', ['_TZ3000_hbic3ka3']),
-        ],
-    },
-    {
         fingerprint: tuya.fingerprint('TS0004', ['_TZ3000_5ajpkyq6']),
         model: 'TS0004_switch_module_2',
         vendor: 'TuYa',
@@ -7099,7 +7066,7 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
 			await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
         },
-		whiteLabel: [
+	whiteLabel: [
 		tuya.whitelabel('AVATTO', 'ZWSM16-4-Zigbee', '4 gang switch module', ['_TZ3000_5ajpkyq6']),
         ],
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7046,8 +7046,8 @@ const definitions: Definition[] = [
                 [101, 'indicator', tuya.valueConverter.onOff],
                 [102, null, null], // toggle to enable presence notifications in app is ignored
                 [103, 'fading_time', tuya.valueConverter.raw],
-            ], 
-        }, 
+            ],
+        },
     },
     {
         fingerprint: tuya.fingerprint('TS0004', ['_TZ3000_5ajpkyq6']),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2399,7 +2399,7 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
         },
         whiteLabel: [
-        tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch module', ['_TZ3000_mtnpt6ws']),
+            tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch module', ['_TZ3000_mtnpt6ws']),
         ],
     },
     {
@@ -2418,8 +2418,8 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
         },
-    whiteLabel: [
-        tuya.whitelabel('AVATTO', 'ZWSM16-3-Zigbee', '3 gang switch module', ['_TZ3000_hbic3ka3']),
+        whiteLabel: [
+            tuya.whitelabel('AVATTO', 'ZWSM16-3-Zigbee', '3 gang switch module', ['_TZ3000_hbic3ka3']),
         ],
     },
     {
@@ -7046,8 +7046,8 @@ const definitions: Definition[] = [
                 [101, 'indicator', tuya.valueConverter.onOff],
                 [102, null, null], // toggle to enable presence notifications in app is ignored
                 [103, 'fading_time', tuya.valueConverter.raw],
-            ],
-        },
+            ], 
+        }, 
     },
     {
         fingerprint: tuya.fingerprint('TS0004', ['_TZ3000_5ajpkyq6']),
@@ -7066,8 +7066,8 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
         },
-    whiteLabel: [
-        tuya.whitelabel('AVATTO', 'ZWSM16-4-Zigbee', '4 gang switch module', ['_TZ3000_5ajpkyq6']),
+        whiteLabel: [
+            tuya.whitelabel('AVATTO', 'ZWSM16-4-Zigbee', '4 gang switch module', ['_TZ3000_5ajpkyq6']),
         ],
     },
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2362,7 +2362,7 @@ const definitions: Definition[] = [
     },
     {
         fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_01gpyda5', '_TZ3000_bvrlqyj7', '_TZ3000_7ed9cqgi',
-            '_TZ3000_zmy4lslw', '_TZ3000_ruxexjfz', '_TZ3000_4xfqlgqo', '_TZ3000_eei0ubpy', '_TZ3000_mtnpt6ws', '_TZ3000_qaa59zqd']),
+            '_TZ3000_zmy4lslw', '_TZ3000_ruxexjfz', '_TZ3000_4xfqlgqo', '_TZ3000_eei0ubpy', '_TZ3000_qaa59zqd']),
         model: 'TS0002_switch_module',
         vendor: 'TuYa',
         description: '2 gang switch module',
@@ -2371,7 +2371,6 @@ const definitions: Definition[] = [
             {vendor: 'MOES', model: 'ZM-104B-M'},
             tuya.whitelabel('pcblab.io', 'RR620ZB', '2 gang Zigbee switch module', ['_TZ3000_4xfqlgqo']),
             tuya.whitelabel('Nous', 'L13Z', '2 gang switch', ['_TZ3000_ruxexjfz']),
-            tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch', ['_TZ3000_mtnpt6ws']),
         ],
         extend: tuya.extend.switch({switchType: true, endpoints: ['l1', 'l2']}),
         endpoint: (device) => {
@@ -7043,6 +7042,66 @@ const definitions: Definition[] = [
                 [103, 'fading_time', tuya.valueConverter.raw],
             ],
         },
+    },
+    {
+        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_mtnpt6ws']),
+        model: 'TS0002_switch_module_2',
+        vendor: 'TuYa',
+        description: '2 gang switch module',
+        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2']}),
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+        },
+		whiteLabel: [
+		tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch module', ['_TZ3000_mtnpt6ws']),
+        ],
+    },
+    {
+        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_hbic3ka3']),
+        model: 'TS0003_switch_module_2',
+        vendor: 'TuYa',
+        description: '3 gang switch module',
+        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2', 'l3']}),
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2, 'l3': 3};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+        },
+		whiteLabel: [
+		tuya.whitelabel('AVATTO', 'ZWSM16-3-Zigbee', '3 gang switch module', ['_TZ3000_hbic3ka3']),
+        ],
+    },
+    {
+        fingerprint: tuya.fingerprint('TS0004', ['_TZ3000_5ajpkyq6']),
+        model: 'TS0004_switch_module_2',
+        vendor: 'TuYa',
+        description: '4 gang switch module',
+        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2', 'l3','l4']}),
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
+			await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+        },
+		whiteLabel: [
+		tuya.whitelabel('AVATTO', 'ZWSM16-4-Zigbee', '4 gang switch module', ['_TZ3000_5ajpkyq6']),
+        ],
     },
 ];
 

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2384,11 +2384,11 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_fisb3ajo', '_TZ3000_5gey1ohx','_TZ3000_mtnpt6ws']),
+        fingerprint: tuya.fingerprint('TS0002', ['_TZ3000_fisb3ajo', '_TZ3000_5gey1ohx', '_TZ3000_mtnpt6ws']),
         model: 'TS0002_switch_module_2',
         vendor: 'TuYa',
         description: '2 gang switch module',
-        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2']}),
+        extend: tuya.extend.switch({switchType: true, indicatorMode: true, endpoints: ['l1', 'l2']}),
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2};
         },
@@ -2398,16 +2398,16 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
         },
-	whiteLabel: [
-		tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch module', ['_TZ3000_mtnpt6ws']),
+        whiteLabel: [
+        tuya.whitelabel('AVATTO', 'ZWSM16-2-Zigbee', '2 gang switch module', ['_TZ3000_mtnpt6ws']),
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_4o16jdca', '_TZ3000_odzoiovu','_TZ3000_hbic3ka3']),
+        fingerprint: tuya.fingerprint('TS0003', ['_TZ3000_4o16jdca', '_TZ3000_odzoiovu', '_TZ3000_hbic3ka3']),
         model: 'TS0003_switch_module_2',
         vendor: 'TuYa',
         description: '3 gang switch module',
-        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2', 'l3']}),
+        extend: tuya.extend.switch({switchType: true, indicatorMode: true, endpoints: ['l1', 'l2', 'l3']}),
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2, 'l3': 3};
         },
@@ -2418,8 +2418,8 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
         },
-	whiteLabel: [
-		tuya.whitelabel('AVATTO', 'ZWSM16-3-Zigbee', '3 gang switch module', ['_TZ3000_hbic3ka3']),
+    whiteLabel: [
+        tuya.whitelabel('AVATTO', 'ZWSM16-3-Zigbee', '3 gang switch module', ['_TZ3000_hbic3ka3']),
         ],
     },
     {
@@ -7064,10 +7064,10 @@ const definitions: Definition[] = [
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
-			await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(4), coordinatorEndpoint, ['genOnOff']);
         },
-	whiteLabel: [
-		tuya.whitelabel('AVATTO', 'ZWSM16-4-Zigbee', '4 gang switch module', ['_TZ3000_5ajpkyq6']),
+    whiteLabel: [
+        tuya.whitelabel('AVATTO', 'ZWSM16-4-Zigbee', '4 gang switch module', ['_TZ3000_5ajpkyq6']),
         ],
     },
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7054,7 +7054,7 @@ const definitions: Definition[] = [
         model: 'TS0004_switch_module_2',
         vendor: 'TuYa',
         description: '4 gang switch module',
-        extend: tuya.extend.switch({switchType: true,indicatorMode: true, endpoints: ['l1', 'l2', 'l3','l4']}),
+        extend: tuya.extend.switch({switchType: true, indicatorMode: true, endpoints: ['l1', 'l2', 'l3', 'l4']}),
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4};
         },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2435,7 +2435,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0004', ['_TZ3000_ltt60asa', '_TZ3000_5ajpkyq6']),
+        fingerprint: tuya.fingerprint('TS0004', ['_TZ3000_ltt60asa']),
         model: 'TS0004_switch_module',
         vendor: 'TuYa',
         description: '4 gang switch module',


### PR DESCRIPTION
Add ZWSM16 devices and extra functionality. I got these three devices and after some testing with converters I managed to configure extra things such as last state and indicator mode.
Here is the db entry for each:

2 switches: 
`{"id":18,"type":"Router","ieeeAddr":"0xa4c1389385502507","nwkAddr":3663,"manufId":4417,"manufName":"_TZ3000_mtnpt6ws","powerSource":"Mains (single phase)","modelId":"TS0002","epList":[1,2,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":256,"inClusterList":[3,4,5,6,1794,2820,57344,57345,0],"outClusterList":[25,10],"clusters":{"genBasic":{"attributes":{"65503":"\u0000\u0000\u0000\u0012","65506":56,"65508":0,"65534":0,"modelId":"TS0002","manufacturerName":"_TZ3000_mtnpt6ws","powerSource":1,"zclVersion":3,"appVersion":72,"stackVersion":0,"hwVersion":1,"dateCode":""}},"manuSpecificBosch":{"attributes":{"53251":"AAAAAgAA"}},"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0,"moesStartUpOnOff":0}},"manuSpecificTuya_3":{"attributes":{"53248":0,"53249":0,"53250":0,"53251":0,"53252":0,"53253":0,"switchType":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"2":{"profId":260,"epId":2,"devId":256,"inClusterList":[4,5,6],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":72,"stackVersion":0,"hwVersion":1,"dateCode":"","zclVersion":3,"interviewCompleted":true,"meta":{"configured":-1030697865},"lastSeen":1702919597391,"defaultSendRequestWhen":"immediate"}`

3 switches:
`{"id":23,"type":"Router","ieeeAddr":"0xa4c138f780730ab5","nwkAddr":22935,"manufId":4417,"manufName":"_TZ3000_hbic3ka3","powerSource":"Mains (single phase)","modelId":"TS0003","epList":[1,2,3,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":256,"inClusterList":[3,4,5,6,1794,2820,57344,57345,0],"outClusterList":[25,10],"clusters":{"genBasic":{"attributes":{"65503":"Ց\f-\u0012","65506":56,"65508":0,"65534":0,"stackVersion":0,"dateCode":"","manufacturerName":"_TZ3000_hbic3ka3","zclVersion":3,"appVersion":72,"modelId":"TS0003","powerSource":1}},"manuSpecificBosch":{"attributes":{"53251":"AAAAAgAABAAA"}},"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0,"moesStartUpOnOff":0}},"manuSpecificTuya_3":{"attributes":{"53248":0,"53249":0,"53250":0,"53251":0,"53252":0,"53253":0,"switchType":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"2":{"profId":260,"epId":2,"devId":256,"inClusterList":[4,5,6],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"3":{"profId":260,"epId":3,"devId":256,"inClusterList":[4,5,6],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":72,"stackVersion":0,"hwVersion":1,"dateCode":"","zclVersion":3,"interviewCompleted":true,"meta":{"configured":-150731130},"lastSeen":1702919647846,"defaultSendRequestWhen":"immediate"}`

4 switches:

`{"id":19,"type":"Router","ieeeAddr":"0xa4c138a830afb472","nwkAddr":8603,"manufId":4417,"manufName":"_TZ3000_5ajpkyq6","powerSource":"Mains (single phase)","modelId":"TS0004","epList":[1,2,3,4,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":256,"inClusterList":[3,4,5,6,1794,2820,57344,57345,0],"outClusterList":[25,10],"clusters":{"genBasic":{"attributes":{"65503":"\u000e\u0000\u0000\u0000\u0012","65506":56,"65508":0,"65534":0,"modelId":"TS0004","manufacturerName":"_TZ3000_5ajpkyq6","powerSource":1,"zclVersion":3,"appVersion":72,"stackVersion":0,"hwVersion":1,"dateCode":""}},"manuSpecificBosch":{"attributes":{"53251":"AAAAAgAABAAABgAA"}},"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0,"moesStartUpOnOff":0}},"manuSpecificTuya_3":{"attributes":{"53248":0,"53249":0,"53250":0,"53251":0,"53252":0,"53253":0,"switchType":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"2":{"profId":260,"epId":2,"devId":256,"inClusterList":[4,5,6],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":1,"onTime":0,"offWaitTime":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"3":{"profId":260,"epId":3,"devId":256,"inClusterList":[4,5,6],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"4":{"profId":260,"epId":4,"devId":256,"inClusterList":[4,5,6],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":1,"onTime":0,"offWaitTime":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b0026b6a112","endpointID":1}],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":72,"stackVersion":0,"hwVersion":1,"dateCode":"","zclVersion":3,"interviewCompleted":true,"meta":{"configured":889996980},"lastSeen":1702919679755,"defaultSendRequestWhen":"immediate"}`

If this is right, I'll add the images soon, thanks!