### PR TITLE
Update Paulmann RGBWW maximum colorTemp

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -198,7 +198,7 @@ const definitions: Definition[] = [
         model: '291.52',
         vendor: 'Paulmann',
         description: 'Smart Home Zigbee LED bulb 4,9W Matt E14 RGBW',
-        extend: [light({colorTemp: {range: [153, 370]}, color: {modes: ['xy', 'hs']}})],
+        extend: [light({colorTemp: {range: [153, 454]}, color: {modes: ['xy', 'hs']}})],
     },
 ];
 


### PR DESCRIPTION
Recently new [E14 Paulmann bulbs](https://en.paulmann.com/p/230-v-standard-smart-home-zigbee-3.0-led-candle-e14-3x470lm-3x5w-rgbw-dimmable-matt/29152) were added (#6613) that report as Zigbee model {{RGBWW}}.

I own [Paulmann GU10 reflectors](https://en.paulmann.com/p/230-v-standard-smart-home-zigbee-3.0-led-reflector-gu10-3x350lm-3x4-8w-rgbw-dimmable-black-matt/29153) that also reports as Zigbee model {{RGBWW}}.

My lamps report a colorTemp range of 153 to 454. Comparing the two models on Paulmann's website, they have same characteristics and should therefore have the same reported colorTemp.

<img width="1074" alt="Screenshot 2023-12-20 at 18 05 59" src="https://github.com/Koenkk/zigbee-herdsman-converters/assets/6395243/4e0a81e1-6b91-4e15-9d5c-44a1bd807157">
