### PR TITLE
Bosch BTH-RA: Possible workaround for OTA problems and adding remote valve calibration

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -970,6 +970,13 @@ const definitions: Definition[] = [
             await reporting.thermostatKeypadLockMode(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
 
+            // Report setpoint_change_source
+            await endpoint.configureReporting('hvacThermostat', [{
+                attribute: {ID: 0x0030, type: Zcl.DataType.enum8},
+                minimumReportInterval: 0,
+                maximumReportInterval: constants.repInterval.HOUR * 12,
+                reportableChange: 1,
+            }]);
             // report operating_mode (system_mode)
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4007, type: Zcl.DataType.enum8},
@@ -999,7 +1006,7 @@ const definitions: Definition[] = [
                 reportableChange: 1,
             }], manufacturerOptions);
 
-            await endpoint.read('hvacThermostat', ['localTemperatureCalibration']);
+            await endpoint.read('hvacThermostat', ['localTemperatureCalibration', 0x0030]);
             await endpoint.read('hvacThermostat', [0x4007, 0x4020, 0x4040, 0x4042, 0x4043], manufacturerOptions);
 
             await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -96,6 +96,12 @@ const displayedTemperature = {
     'measured': 1,
 };
 
+const setpointSource = {
+    'manual': 0,
+    'schedule': 1,
+    'external': 2,
+};
+
 const adaptationStatus = {
     'none': 0,
     'ready_to_calibrate': 1,
@@ -996,7 +1002,7 @@ const definitions: Definition[] = [
                 .withDescription('Temperature displayed on the thermostat'),
             e.child_lock().setAccess('state', ea.ALL),
             e.battery(),
-            e.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
+            e.enum('setpoint_change_source', ea.STATE, Object.keys(setpointSource))
                 .withDescription('States where the current setpoint originated.'),
             e.enum('valve_adapt_status', ea.STATE, Object.keys(adaptationStatus))
                 .withLabel('Adaptation status')

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -403,6 +403,10 @@ const tzLocal = {
             case 'remote_temperature':
                 await entity.read('hvacThermostat', [0x4040], manufacturerOptions);
                 break;
+            case 'valve_adapt_process':
+                // Reads the current valve adaptation status as it depends solely on it
+                await entity.read('hvacThermostat', [0x4022], manufacturerOptions);
+                break;
 
             default: // Unknown key
                 throw new Error(`Unhandled key toZigbee.bosch_thermostat.convertGet ${key}`);
@@ -1007,7 +1011,7 @@ const definitions: Definition[] = [
             e.enum('valve_adapt_status', ea.STATE, Object.keys(adaptationStatus))
                 .withLabel('Adaptation status')
                 .withDescription('Specifies the current status of the valve adaptation'),
-            e.binary('valve_adapt_process', ea.SET, true, false)
+            e.binary('valve_adapt_process', ea.ALL, true, false)
                 .withLabel('Trigger adaptation process')
                 .withDescription('Trigger the valve adaptation process. Only possible when adaptation status ' +
                     'is "ready_to_calibrate" or "error".'),

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -635,11 +635,9 @@ const fzLocal = {
             if (data.hasOwnProperty(0x4022)) {
                 result.valve_adapt_status = utils.getFromLookupByValue(data[0x4022], adaptationStatus);
 
-                switch (data[0x4022]) {
-                case adaptationStatus.calibration_in_progress:
+                if (data[0x4022] === adaptationStatus.calibration_in_progress) {
                     result.valve_adapt_process = true;
-                    break;
-                default:
+                } else {
                     result.valve_adapt_process = false;
                 }
             }

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -978,7 +978,7 @@ const definitions: Definition[] = [
                 .withPiHeatingDemand(ea.ALL)
                 .withRunningState(['idle', 'heat'], ea.STATE),
             e.binary('boost', ea.ALL, 'ON', 'OFF')
-                .withDescription('Activate Boost heating'),
+                .withDescription('Activate boost heating'),
             e.binary('window_open', ea.ALL, 'ON', 'OFF')
                 .withDescription('Window open'),
             e.enum('display_orientation', ea.ALL, Object.keys(displayOrientation))
@@ -993,7 +993,7 @@ const definitions: Definition[] = [
             e.numeric('display_ontime', ea.ALL)
                 .withValueMin(5)
                 .withValueMax(30)
-                .withDescription('Specifies the display On-time'),
+                .withDescription('Specifies the display on-time'),
             e.numeric('display_brightness', ea.ALL)
                 .withValueMin(0)
                 .withValueMax(10)
@@ -1003,10 +1003,10 @@ const definitions: Definition[] = [
             e.child_lock().setAccess('state', ea.ALL),
             e.battery(),
             e.enum('setpoint_change_source', ea.STATE, Object.keys(setpointSource))
-                .withDescription('States where the current setpoint originated.'),
+                .withDescription('States where the current setpoint originated'),
             e.enum('valve_adapt_status', ea.STATE, Object.keys(adaptationStatus))
                 .withLabel('Adaptation status')
-                .withDescription('Specifies the current status of the valve adaptation.'),
+                .withDescription('Specifies the current status of the valve adaptation'),
             e.binary('valve_adapt_process', ea.SET, true, false)
                 .withLabel('Trigger adaptation process')
                 .withDescription('Trigger the valve adaptation process. Only possible when adaptation status ' +
@@ -1015,9 +1015,9 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat', 'hvacUserInterfaceCfg']);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await reporting.thermostatTemperature(endpoint);
-            await reporting.thermostatKeypadLockMode(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.HOUR * 12, change: 1});
+            await reporting.thermostatTemperature(endpoint, {min: 30, max: 900, change: 20});
+            await reporting.thermostatKeypadLockMode(endpoint, {min: 0, max: constants.repInterval.HOUR * 12, change: null});
             await reporting.batteryPercentageRemaining(endpoint);
 
             // Report setpoint_change_source
@@ -1025,42 +1025,42 @@ const definitions: Definition[] = [
                 attribute: {ID: 0x0030, type: Zcl.DataType.enum8},
                 minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.HOUR * 12,
-                reportableChange: 1,
+                reportableChange: null,
             }]);
             // report operating_mode (system_mode)
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4007, type: Zcl.DataType.enum8},
                 minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 1,
+                maximumReportInterval: constants.repInterval.HOUR * 12,
+                reportableChange: null,
             }], manufacturerOptions);
             // report pi_heating_demand (valve opening)
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4020, type: Zcl.DataType.enum8},
                 minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 1,
+                maximumReportInterval: constants.repInterval.HOUR * 12,
+                reportableChange: null,
             }], manufacturerOptions);
             // Report valve_adapt_status (adaptation status)
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4022, type: Zcl.DataType.enum8},
                 minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.HOUR * 12,
-                reportableChange: 1,
+                reportableChange: null,
             }], manufacturerOptions);
             // report window_open
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4042, type: Zcl.DataType.enum8},
                 minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 1,
+                maximumReportInterval: constants.repInterval.HOUR * 12,
+                reportableChange: null,
             }], manufacturerOptions);
             // report boost as it's disabled by thermostat after 5 minutes
             await endpoint.configureReporting('hvacThermostat', [{
                 attribute: {ID: 0x4043, type: Zcl.DataType.enum8},
                 minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 1,
+                maximumReportInterval: constants.repInterval.HOUR * 12,
+                reportableChange: null,
             }], manufacturerOptions);
 
             await endpoint.read('hvacThermostat', ['localTemperatureCalibration', 0x0030]);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -961,6 +961,8 @@ const definitions: Definition[] = [
                 .withDescription('Temperature displayed on the thermostat'),
             e.child_lock().setAccess('state', ea.ALL),
             e.battery(),
+            e.enum('setpoint_change_source', ea.STATE, ['manual', 'schedule', 'externally'])
+                .withDescription('States where the current setpoint originated.'),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -96,12 +96,14 @@ const displayedTemperature = {
     'measured': 1,
 };
 
+// Radiator Thermostat II
 const setpointSource = {
     'manual': 0,
     'schedule': 1,
     'external': 2,
 };
 
+// Radiator Thermostat II
 const adaptationStatus = {
     'none': 0,
     'ready_to_calibrate': 1,

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1011,7 +1011,7 @@ const definitions: Definition[] = [
             e.enum('valve_adapt_status', ea.STATE, Object.keys(adaptationStatus))
                 .withLabel('Adaptation status')
                 .withDescription('Specifies the current status of the valve adaptation'),
-            e.binary('valve_adapt_process', ea.ALL, true, false)
+            e.binary('valve_adapt_process', ea.SET, true, false)
                 .withLabel('Trigger adaptation process')
                 .withDescription('Trigger the valve adaptation process. Only possible when adaptation status ' +
                     'is "ready_to_calibrate" or "error".'),

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1011,7 +1011,7 @@ const definitions: Definition[] = [
             e.enum('valve_adapt_status', ea.STATE, Object.keys(adaptationStatus))
                 .withLabel('Adaptation status')
                 .withDescription('Specifies the current status of the valve adaptation'),
-            e.binary('valve_adapt_process', ea.SET, true, false)
+            e.binary('valve_adapt_process', ea.ALL, true, false)
                 .withLabel('Trigger adaptation process')
                 .withDescription('Trigger the valve adaptation process. Only possible when adaptation status ' +
                     'is "ready_to_calibrate" or "error".'),

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1022,7 +1022,7 @@ const definitions: Definition[] = [
 
             // Report setpoint_change_source
             await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x0030, type: Zcl.DataType.enum8},
+                attribute: 'setpointChangeSource',
                 minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.HOUR * 12,
                 reportableChange: null,
@@ -1063,7 +1063,7 @@ const definitions: Definition[] = [
                 reportableChange: null,
             }], manufacturerOptions);
 
-            await endpoint.read('hvacThermostat', ['localTemperatureCalibration', 0x0030]);
+            await endpoint.read('hvacThermostat', ['localTemperatureCalibration', 'setpointChangeSource']);
             await endpoint.read('hvacThermostat', [0x4007, 0x4020, 0x4022, 0x4040, 0x4042, 0x4043], manufacturerOptions);
 
             await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);

--- a/src/lib/ota/common.ts
+++ b/src/lib/ota/common.ts
@@ -4,7 +4,7 @@ import {Zh, Ota, Logger, KeyValueAny, KeyValue, KeyValueNumberString} from '../t
 import assert from 'assert';
 import crc32 from 'buffer-crc32';
 import axios from 'axios';
-import {Zcl} from "zigbee-herdsman";
+import {Zcl} from 'zigbee-herdsman';
 const maxTimeout = 2147483647; // +- 24 days
 const imageBlockResponseDelay = 250;
 const endRequestCodeLookup: KeyValueNumberString = {

--- a/src/lib/ota/common.ts
+++ b/src/lib/ota/common.ts
@@ -4,6 +4,7 @@ import {Zh, Ota, Logger, KeyValueAny, KeyValue, KeyValueNumberString} from '../t
 import assert from 'assert';
 import crc32 from 'buffer-crc32';
 import axios from 'axios';
+import {Zcl} from "zigbee-herdsman";
 const maxTimeout = 2147483647; // +- 24 days
 const imageBlockResponseDelay = 250;
 const endRequestCodeLookup: KeyValueNumberString = {
@@ -329,6 +330,13 @@ export async function updateToLatest(device: Zh.Device, logger: Logger, onProgre
             // (https://github.com/Koenkk/zigbee-herdsman-converters/issues/6657)
             if ( request.payload.manufacturerCode == 4742 && request.payload.imageType == 8199 ) {
                 imageBlockOrPageRequestTimeoutMs = 3600000;
+            }
+
+            // Bosch transmits the firmware updates in the background in their native implementation.
+            // According to the app, this can take up to 2 days. Therefore, we assume to get at least
+            // one package request per hour from the device here.
+            if (request.payload.manufacturerCode == Zcl.ManufacturerCode.ROBERT_BOSCH_GMBH) {
+                imageBlockOrPageRequestTimeoutMs = 60 * 60 * 1000;
             }
 
             const imageBlockRequest = endpoint.waitForCommand('genOta', 'imageBlockRequest', null, imageBlockOrPageRequestTimeoutMs);


### PR DESCRIPTION
In the last few months, there were several people with problems during/after the OTA process (see i.e. https://github.com/Koenkk/zigbee2mqtt/issues/17740). The thing is, that the native Bosch implementation works totally different then Z2M. With the native system, the new firmware gets uploaded to the device automatically within 2 days and will only be executed when triggered manually via the app. This is the same for all devices in the Bosch eco-system.

After the logfiles from https://github.com/Koenkk/zigbee-herdsman-converters/issues/6752 (which seems to be affected as the displayed firmware version in Z2M doesn't match the actual firmware version), I suspect some kind of timeout issue in heavily congested networks as the device never got an `upgradeEndRequestResponse`. To mitigate this, I advanced the timeout to 1 hour and will continue to monitor the situation.

Additionally, I added support for remote valve calibration (`valve_adapt_process`). This is necessary after an update - so, the possibility to do that from Z2M itself instead of walking from device to device is quite handy. It's required to have https://github.com/Koenkk/zigbee-herdsman/pull/836 merged. I hope this false/true implementation is okay as there is no pure "one button triggers something" in the UI. Since a calibration is only possible when the device requests for it, I've added a value to see if that is the case or not (`valve_adapt_status`). In the future, I'm thinking about triggering the calibration process automatically after an update. In the meantime, an automation in i.e. HA should be sufficient in case someone is missing this feature. 

Other changes:
- Adjusted the default reporting settings to match the default Bosch values. I only changed the already supported attributes. Bosch itself sets up quite more attributes no-one identified yet. Those are not added with this PR - just to avoid any confusion.
- Added support for monitoring the setpoint source (`setpoint_change_source`)