### PR TITLE
Added device id for Kojima Home door sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5097,7 +5097,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_pay2byax']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_pay2byax', '_TZE200_ijey4q29']),
         model: 'ZG-102ZL',
         vendor: 'TuYa',
         description: 'Luminance door sensor',


### PR DESCRIPTION
Hi there!

This PR addresses issue https://github.com/Koenkk/zigbee2mqtt/issues/19939
Nothing new, just added device id which is already supported https://www.zigbee2mqtt.io/devices/ZG-102ZL.html