### PR TITLE
Fix avatto wall socket identification

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2026,7 +2026,7 @@ const definitions: Definition[] = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
     },
     {
-        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_3zofvcaa'}],
+        fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_3zofvcaa', '_TZ3000_pvlvoxvt']),
         model: 'TS011F_2_gang_2_usb_wall',
         vendor: 'TuYa',
         description: '2 gang 2 usb wall outlet',


### PR DESCRIPTION
Avatto wall socket was been identified as smart plug. So, Manufacture Model "_TZ3000_pvlvoxvt" was added in tuya.ts at definitions array for device model 'TS011F_2_gang_2_usb_wall'. Before that, the device was being identified as 'TS011F_plug_1'