### PR TITLE
Fix: Disable powerOnBehavior for Sunricher ZG9101SAC-HP-Switch

### DIFF
--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -207,7 +207,7 @@ const definitions: Definition[] = [
         model: 'ZG9101SAC-HP-Switch',
         vendor: 'Sunricher',
         description: 'Zigbee AC in wall switch',
-        extend: [onOff()],
+        extend: [onOff({powerOnBehavior: false})],
     },
     {
         zigbeeModel: ['Micro Smart Dimmer', 'SM311', 'HK-SL-RDIM-A', 'HK-SL-DIM-EU-A'],


### PR DESCRIPTION
Configuration of the Sunricher ZG9101SAC-HP-Switch fails with error
`Failed to configure 'Light1', attempt 1 (Error: Read 0x000xxxxxxxxxxx/1 genOnOff(["startUpOnOff"], {"sendWhen":"immediate","timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')`, so I disabled powerOnBehavior.


