### PR TITLE
Ubisys J1: Adapt exposes according to CoveringType

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -819,24 +819,24 @@ const definitions: Definition[] = [
             const coverExpose = e.cover();
             if (device) {
                 const coverType = device.getEndpoint(1).getClusterAttributeValue('closuresWindowCovering', 'windowCoveringType');
-                switch(coverType) { //cf. Ubisys J1 Technical Reference Manual, chapter 7.2.5.1 Calibration
-                    case 0: // Roller Shade, Lift only
-                    case 1: // Roller Shade two motors, Lift only
-                    case 2: // Roller Shade exterior, Lift only
-                    case 3: // Roller Shade two motors exterior, Lift only
-                    case 4: // Drapery, Lift only
-                    case 5: // Awning, Lift only
-                    case 9: // Projector Screen, Lift only
-                        coverExpose.withPosition();
-                        break;
-                    case 6: // Shutter, Tilt only
-                    case 7: // Tilt Blind, Tilt only
-                        coverExpose.withTilt();
-                        break;
-                    case 8: // Tilt Blind, Lift & Tilt
-                    default:
-                        coverExpose.withPosition().withTilt();
-                        break;
+                switch (coverType) { // cf. Ubisys J1 Technical Reference Manual, chapter 7.2.5.1 Calibration
+                case 0: // Roller Shade, Lift only
+                case 1: // Roller Shade two motors, Lift only
+                case 2: // Roller Shade exterior, Lift only
+                case 3: // Roller Shade two motors exterior, Lift only
+                case 4: // Drapery, Lift only
+                case 5: // Awning, Lift only
+                case 9: // Projector Screen, Lift only
+                    coverExpose.withPosition();
+                    break;
+                case 6: // Shutter, Tilt only
+                case 7: // Tilt Blind, Tilt only
+                    coverExpose.withTilt();
+                    break;
+                case 8: // Tilt Blind, Lift & Tilt
+                default:
+                    coverExpose.withPosition().withTilt();
+                    break;
                 }
             } else {
                 coverExpose.withPosition().withTilt();

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -845,7 +845,8 @@ const definitions: Definition[] = [
                 coverExpose,
                 e.power().withAccess(ea.STATE_GET),
                 e.energy().withAccess(ea.STATE_GET),
-                e.linkquality()];
+                e.linkquality()
+            ];
         },
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint1 = device.getEndpoint(1);

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -845,7 +845,7 @@ const definitions: Definition[] = [
                 coverExpose,
                 e.power().withAccess(ea.STATE_GET),
                 e.energy().withAccess(ea.STATE_GET),
-                e.linkquality()
+                e.linkquality(),
             ];
         },
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
I have a little bit of spare time to fix some of the issues in my setup wichich are only mildly annoying: one is that the Ubisys J1 is exposing lift and tilt, even if it is configured as roller shutter with lift only.

This PR fixes this by adapting the exposes dynamically according to the `windowCoveringType`.

Note: I believe this could be useful for other devices as well since `windowCoveringType` is a standard ZCL type. Therefore it might be good to add it directly to the `cover()` expose. But I don't want to break things for other devices without testing