### PR TITLE
feat: add new featurees to Ubisys H1

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -818,29 +818,25 @@ const definitions: Definition[] = [
             tz.currentsummdelivered],
         exposes: (device, options) => {
             const coverExpose = e.cover();
-            if (device) {
-                const coverType = device?.getEndpoint(1).getClusterAttributeValue('closuresWindowCovering', 'windowCoveringType') ?? null;
-                switch (coverType) { // cf. Ubisys J1 Technical Reference Manual, chapter 7.2.5.1 Calibration
-                case 0: // Roller Shade, Lift only
-                case 1: // Roller Shade two motors, Lift only
-                case 2: // Roller Shade exterior, Lift only
-                case 3: // Roller Shade two motors exterior, Lift only
-                case 4: // Drapery, Lift only
-                case 5: // Awning, Lift only
-                case 9: // Projector Screen, Lift only
-                    coverExpose.withPosition();
-                    break;
-                case 6: // Shutter, Tilt only
-                case 7: // Tilt Blind, Tilt only
-                    coverExpose.withTilt();
-                    break;
-                case 8: // Tilt Blind, Lift & Tilt
-                default:
-                    coverExpose.withPosition().withTilt();
-                    break;
-                }
-            } else {
+            const coverType = (device?.getEndpoint(1).getClusterAttributeValue('closuresWindowCovering', 'windowCoveringType') ?? undefined);
+            switch (coverType) { // cf. Ubisys J1 Technical Reference Manual, chapter 7.2.5.1 Calibration
+            case 0: // Roller Shade, Lift only
+            case 1: // Roller Shade two motors, Lift only
+            case 2: // Roller Shade exterior, Lift only
+            case 3: // Roller Shade two motors exterior, Lift only
+            case 4: // Drapery, Lift only
+            case 5: // Awning, Lift only
+            case 9: // Projector Screen, Lift only
+                coverExpose.withPosition();
+                break;
+            case 6: // Shutter, Tilt only
+            case 7: // Tilt Blind, Tilt only
+                coverExpose.withTilt();
+                break;
+            case 8: // Tilt Blind, Lift & Tilt
+            default:
                 coverExpose.withPosition().withTilt();
+                break;
             }
             return [
                 coverExpose,

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -949,6 +949,18 @@ const definitions: Definition[] = [
                 valueStep: 0.5, // device seems to step in 0.5 ºC - XXX: does this need to be 0.5 or 50 given the scale ?
                 unit: 'ºC',
             }),
+            numeric({
+                name: 'occupied_heating_setpoint_default',
+                cluster: 'hvacThermostat',
+                attribute: 'ubisysDefaultOccupiedHeatingSetpoint',
+                description: 'Specifies the default heating setpoint during occupancy, ' +
+                    'representing the targeted temperature when a recurring weekly schedule ends without a follow-up schedule.',
+                scale: 100,
+                valueStep: 0.5, // device seems to step in 0.5 ºC - XXX: does this need to be 0.5 or 50 given the scale ?
+                valueMin: 7,
+                valueMax: 30,
+                unit: 'ºC',
+            }),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -961,6 +961,16 @@ const definitions: Definition[] = [
                 valueMax: 30,
                 unit: 'ºC',
             }),
+            numeric({
+                name: 'remote_temperature',
+                cluster: 'hvacThermostat',
+                attribute: 'ubisysRemoteTemperature',
+                description: 'Indicates the remotely measured temperature value, accessible through attribute reports. ' +
+                    'For heating regulation, a received remote temperature value, as long as valid, takes precedence over the locally measured one.',
+                scale: 100,
+                unit: 'ºC',
+                readOnly: true,
+            }),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -819,7 +819,7 @@ const definitions: Definition[] = [
         exposes: (device, options) => {
             const coverExpose = e.cover();
             if (device) {
-                const coverType = device.getEndpoint(1).getClusterAttributeValue('closuresWindowCovering', 'windowCoveringType');
+                const coverType = device?.getEndpoint(1).getClusterAttributeValue('closuresWindowCovering', 'windowCoveringType') ?? null;
                 switch (coverType) { // cf. Ubisys J1 Technical Reference Manual, chapter 7.2.5.1 Calibration
                 case 0: // Roller Shade, Lift only
                 case 1: // Roller Shade two motors, Lift only

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -8,6 +8,7 @@ import * as reporting from '../lib/reporting';
 import * as constants from '../lib/constants';
 import {Zcl} from 'zigbee-herdsman';
 import {Definition, Fz, OnEventType, Tz, OnEventData, Zh, KeyValue, KeyValueAny} from '../lib/types';
+import {numeric} from '../lib/modernExtend';
 const e = exposes.presets;
 const ea = exposes.access;
 
@@ -937,6 +938,17 @@ const definitions: Definition[] = [
                 .withWeeklySchedule(['heat']),
             e.binary('vacation_mode', ea.ALL, true, false)
                 .withDescription('When Vacation Mode is active the schedule is disabled and unoccupied_heating_setpoint is used.'),
+        ],
+        extend: [
+            numeric({
+                name: 'local_temperature_offset',
+                cluster: 'hvacThermostat',
+                attribute: 'ubisysTemperatureOffset',
+                description: 'Specifies the temperature offset for the locally measured temperature value.',
+                scale: 100,
+                valueStep: 0.5, // device seems to step in 0.5 ºC - XXX: does this need to be 0.5 or 50 given the scale ?
+                unit: 'ºC',
+            }),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -8,7 +8,7 @@ import * as reporting from '../lib/reporting';
 import * as constants from '../lib/constants';
 import {Zcl} from 'zigbee-herdsman';
 import {Definition, Fz, OnEventType, Tz, OnEventData, Zh, KeyValue, KeyValueAny} from '../lib/types';
-import {numeric} from '../lib/modernExtend';
+import { ubisysModernExtend } from '../lib/ubisys';
 const e = exposes.presets;
 const ea = exposes.access;
 
@@ -940,45 +940,10 @@ const definitions: Definition[] = [
                 .withDescription('When Vacation Mode is active the schedule is disabled and unoccupied_heating_setpoint is used.'),
         ],
         extend: [
-            numeric({
-                name: 'local_temperature_offset',
-                cluster: 'hvacThermostat',
-                attribute: 'ubisysTemperatureOffset',
-                description: 'Specifies the temperature offset for the locally measured temperature value.',
-                scale: 100,
-                valueStep: 0.5, // device seems to step in 0.5 ºC - XXX: does this need to be 0.5 or 50 given the scale ?
-                unit: 'ºC',
-            }),
-            numeric({
-                name: 'occupied_heating_setpoint_default',
-                cluster: 'hvacThermostat',
-                attribute: 'ubisysDefaultOccupiedHeatingSetpoint',
-                description: 'Specifies the default heating setpoint during occupancy, ' +
-                    'representing the targeted temperature when a recurring weekly schedule ends without a follow-up schedule.',
-                scale: 100,
-                valueStep: 0.5, // device seems to step in 0.5 ºC - XXX: does this need to be 0.5 or 50 given the scale ?
-                valueMin: 7,
-                valueMax: 30,
-                unit: 'ºC',
-            }),
-            numeric({
-                name: 'remote_temperature',
-                cluster: 'hvacThermostat',
-                attribute: 'ubisysRemoteTemperature',
-                description: 'Indicates the remotely measured temperature value, accessible through attribute reports. ' +
-                    'For heating regulation, a received remote temperature value, as long as valid, takes precedence over the locally measured one.',
-                scale: 100,
-                unit: 'ºC',
-                readOnly: true,
-            }),
-            numeric({
-                name: 'remote_temperature_duration',
-                cluster: 'hvacThermostat',
-                attribute: 'ubisysRemoteTemperatureValidDuration',
-                description: 'Specifies the duration period in seconds, during which a remotely measured temperature value ' +
-                    'remains valid since its reception as attribute report.',
-                unit: 's',
-            }),
+            ubisysModernExtend.localTemperatureOffset(),
+            ubisysModernExtend.occupiedHeatingSetpointDefault(),
+            ubisysModernExtend.remoteTemperature(),
+            ubisysModernExtend.remoteTemperatureDuration(),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -8,7 +8,7 @@ import * as reporting from '../lib/reporting';
 import * as constants from '../lib/constants';
 import {Zcl} from 'zigbee-herdsman';
 import {Definition, Fz, OnEventType, Tz, OnEventData, Zh, KeyValue, KeyValueAny} from '../lib/types';
-import { ubisysModernExtend } from '../lib/ubisys';
+import {ubisysModernExtend} from '../lib/ubisys';
 const e = exposes.presets;
 const ea = exposes.access;
 

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -971,6 +971,14 @@ const definitions: Definition[] = [
                 unit: 'ºC',
                 readOnly: true,
             }),
+            numeric({
+                name: 'remote_temperature_duration',
+                cluster: 'hvacThermostat',
+                attribute: 'ubisysRemoteTemperatureValidDuration',
+                description: 'Specifies the duration period in seconds, during which a remotely measured temperature value ' +
+                    'remains valid since its reception as attribute report.',
+                unit: 's',
+            }),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -30,7 +30,7 @@ const reportingConfigTimeLookup = {
 type ReportingConfigTime = number | keyof typeof reportingConfigTimeLookup;
 type ReportingConfigAttribute = string | number | {ID: number, type: number};
 type ReportingConfig = {min: ReportingConfigTime, max: ReportingConfigTime, change: number | [number, number], attribute: ReportingConfigAttribute}
-type ReportingConfigWithoutAttribute = Omit<ReportingConfig, 'attribute'>;
+export type ReportingConfigWithoutAttribute = Omit<ReportingConfig, 'attribute'>;
 
 function convertReportingConfigTime(time: ReportingConfigTime): number {
     if (isString(time)) {

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -1,0 +1,51 @@
+import { numeric, NumericArgs } from './modernExtend';
+
+export const ubisysModernExtend = {
+    localTemperatureOffset: (args?: Partial<NumericArgs>) => numeric({
+        name: 'local_temperature_offset',
+        cluster: 'hvacThermostat',
+        attribute: 'ubisysTemperatureOffset',
+        description: 'Specifies the temperature offset for the locally measured temperature value.',
+        scale: 100,
+        valueStep: 0.5, // H1 interface uses 0.5 step
+	valueMin: -10,
+	valueMax: 10,
+        unit: 'ºC',
+        ...args,
+    }),
+    occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs>) => numeric({
+        name: 'occupied_heating_setpoint_default',
+        cluster: 'hvacThermostat',
+        attribute: 'ubisysDefaultOccupiedHeatingSetpoint',
+        description: 'Specifies the default heating setpoint during occupancy, ' +
+            'representing the targeted temperature when a recurring weekly schedule ends without a follow-up schedule.',
+        scale: 100,
+        valueStep: 0.5, // H1 interface uses 0.5 step
+        valueMin: 7,
+        valueMax: 30,
+        unit: 'ºC',
+        ...args,
+    }),
+    remoteTemperature: (args?: Partial<NumericArgs>) => numeric({
+        name: 'remote_temperature',
+        cluster: 'hvacThermostat',
+        attribute: 'ubisysRemoteTemperature',
+        description: 'Indicates the remotely measured temperature value, accessible through attribute reports. ' +
+            'For heating regulation, a received remote temperature value, as long as valid, takes precedence over the locally measured one.',
+        scale: 100,
+        unit: 'ºC',
+        readOnly: true,
+        ...args,
+    }),
+    remoteTemperatureDuration: (args?: Partial<NumericArgs>) => numeric({
+        name: 'remote_temperature_duration',
+        cluster: 'hvacThermostat',
+        attribute: 'ubisysRemoteTemperatureValidDuration',
+        description: 'Specifies the duration period in seconds, during which a remotely measured temperature value ' +
+            'remains valid since its reception as attribute report.',
+        valueMin: 0,
+        valueMax: 86400,
+        unit: 's',
+        ...args,
+    }),
+};

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -1,4 +1,4 @@
-import { numeric, NumericArgs } from './modernExtend';
+import {numeric, NumericArgs} from './modernExtend';
 
 export const ubisysModernExtend = {
     localTemperatureOffset: (args?: Partial<NumericArgs>) => numeric({
@@ -8,8 +8,8 @@ export const ubisysModernExtend = {
         description: 'Specifies the temperature offset for the locally measured temperature value.',
         scale: 100,
         valueStep: 0.5, // H1 interface uses 0.5 step
-	valueMin: -10,
-	valueMax: 10,
+        valueMin: -10,
+        valueMax: 10,
         unit: 'ºC',
         ...args,
     }),

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -14,7 +14,7 @@ export const ubisysModernExtend = {
         ...args,
     }),
     occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs>) => numeric({
-        name: 'occupied_heating_setpoint_default',
+        name: 'occupied_heating_default_setpoint',
         cluster: 'hvacThermostat',
         attribute: 'ubisysDefaultOccupiedHeatingSetpoint',
         description: 'Specifies the default heating setpoint during occupancy, ' +


### PR DESCRIPTION
@Koenkk there is still something weird going on wrt to attribute picking.

e.g. when sending a simple read request for `occupied_heating_setpoint_default`:

```
debug 2024-01-02 15:17:10: Received MQTT message on 'zigbee2mqtt/trv/kitchen/get' with data '{"occupied_heating_setpoint_default":""}'
debug 2024-01-02 15:17:10: Publishing get 'get' 'occupied_heating_setpoint' to 'trv/kitchen'
debug 2024-01-02 15:17:15: Received Zigbee message from 'trv/kitchen', type 'readResponse', cluster 'hvacThermostat', data '{"occupiedHeatingSetpoint":1800}' from endpoint 1 with groupID 0
info  2024-01-02 15:17:15: MQTT publish: topic 'zigbee2mqtt/trv/kitchen', payload '{"battery":100,"last_seen":"2024-01-02T14:17:15.144Z","linkquality":109,"local_temperature":20,"local_temperature_calibration":null,"local_temperature_offset":0,"occupancy":false,"occupied_heating_setpoint":18,"pi_heating_demand":0,"remote_temperature":-327.68,"remote_temperature_duration":3600,"running_mode":"off","system_mode":"heat","unoccupied_heating_setpoint":7,"update":{"installed_version":22086704,"latest_version":22086704,"state":"idle"},"vacation_mode":true,"voltage":3400}'
```

I'm not sure `occupied_heating_setpoint_default` somehow becomes `occupied_heating_setpoint` but it seems it happens before it hits endpoint.ts in herdsman. The value that ends up getting read is indeed the normal hvacThermostat.occupiedHeatingSetpoint.

Perhaps in z2m, but it seems even the read from the numeric() during configure is effected. Non overlapping attributes seem to work fine though. 

```
debug 2024-01-02 15:15:27: Received MQTT message on 'zigbee2mqtt/trv/kitchen/get' with data '{"remote_temperature":""}'
debug 2024-01-02 15:15:27: Publishing get 'get' 'remote_temperature' to 'trv/kitchen'
debug 2024-01-02 15:15:29: Received Zigbee message from 'trv/kitchen', type 'readResponse', cluster 'hvacThermostat', data '{"ubisysRemoteTemperature":-32768}' from endpoint 1 with groupID 0
info  2024-01-02 15:15:29: MQTT publish: topic 'zigbee2mqtt/trv/kitchen', payload '{"battery":100,"last_seen":"2024-01-02T14:15:29.006Z","linkquality":131,"local_temperature":20,"local_temperature_calibration":null,"local_temperature_offset":0,"occupancy":false,"occupied_heating_setpoint":18,"pi_heating_demand":0,"remote_temperature":-327.68,"remote_temperature_duration":3600,"running_mode":"off","system_mode":"heat","unoccupied_heating_setpoint":7,"update":{"installed_version":22086704,"latest_version":22086704,"state":"idle"},"vacation_mode":true,"voltage":3400}'
```