### PR TITLE
Add support for Namron Touch Termostat 2.0

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -10,6 +10,7 @@ import * as ota from '../lib/ota';
 import * as utils from '../lib/utils';
 import extend from '../lib/extend';
 import {forcePowerSource, light, onOff} from '../lib/modernExtend';
+import * as tuya from '../lib/tuya';
 
 const ea = exposes.access;
 const e = exposes.presets;
@@ -990,6 +991,99 @@ const definitions: Definition[] = [
             await reporting.bind(endpoint3, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.bind(endpoint4, coordinatorEndpoint, ['msRelativeHumidity']);
             await reporting.bind(endpoint5, coordinatorEndpoint, ['msIlluminanceMeasurement']);
+        },
+    },
+    {
+        fingerprint: [
+            {
+                modelID: 'TS0601',
+                manufacturerName: '_TZE204_p3lqqy2r',
+            },
+        ],
+        model: '4512752/4512753',
+        vendor: 'Namron',
+        description: 'Touch Thermostat 16A 2.0',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        onEvent: tuya.onEventSetTime,
+        configure: tuya.configureMagicPacket,
+        options: [],
+        exposes: [
+            e.enum('mode', ea.STATE_SET, ['regulator', 'thermostat'])
+                .withDescription(
+                    'Controls how the operating mode of the device. Possible values:' +
+                    ' regulator (open-loop controller), thermostat (control with target temperature)',
+                ),
+            e.enum('regulator_period', ea.STATE_SET, ['15min', '30min', '45min', '60min', '90min'])
+                .withLabel('Regulator cycle duration')
+                .withDescription('Regulator cycle duration. Not applicable when in thermostat mode.'),
+            e.numeric('regulator_set_point', ea.STATE_SET)
+                .withUnit('%')
+                .withDescription('Desired heating set point (%) when in regulator mode.')
+                .withValueMin(0)
+                .withValueMax(95),
+            e.climate()
+                .withSystemMode(['off', 'heat'], ea.STATE_SET, 'Whether the thermostat is turned on or off')
+                .withPreset(['manual', 'home', 'away'])
+                .withLocalTemperature(ea.STATE)
+                .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
+                .withRunningState(['idle', 'heat'], ea.STATE)
+                .withSetpoint('current_heating_setpoint', 5, 35, 1, ea.STATE_SET),
+            e.current(),
+            e.power(),
+            e.energy(),
+            e.voltage(),
+            e.temperature_sensor_select(['air_sensor', 'floor_sensor', 'both']),
+            e.numeric('local_temperature', ea.STATE)
+                .withUnit('°C')
+                .withDescription('Current temperature measured with internal sensor')
+                .withValueStep(1),
+            e.numeric('local_temperature_floor', ea.STATE)
+                .withUnit('°C')
+                .withDescription('Current temperature measured on the external sensor (floor)')
+                .withValueStep(1),
+            e.child_lock(),
+            e.window_detection()
+                .withLabel('Open window detection'),
+            e.numeric('hysteresis', ea.STATE_SET)
+                .withUnit('°C')
+                .withDescription('The offset from the target temperature in which the temperature has to ' +
+                    'change for the heating state to change. This is to prevent erratically turning on/off ' +
+                    'when the temperature is close to the target.')
+                .withValueMin(1)
+                .withValueMax(9)
+                .withValueStep(1),
+            e.numeric('max_temperature_protection', ea.STATE_SET)
+                .withUnit('°C')
+                .withDescription('Max guarding temperature')
+                .withValueMin(20)
+                .withValueMax(95)
+                .withValueStep(1),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'system_mode', tuya.valueConverterBasic.lookup({off: false, heat: true})],
+                [2, 'preset', tuya.valueConverterBasic.lookup({manual: tuya.enum(0), home: tuya.enum(1), away: tuya.enum(2)})],
+                [16, 'current_heating_setpoint', tuya.valueConverter.raw],
+                [24, 'local_temperature', tuya.valueConverter.raw],
+                [28, 'local_temperature_calibration', tuya.valueConverter.localTempCalibration2],
+                [30, 'child_lock', tuya.valueConverter.lockUnlock],
+                [101, 'local_temperature_floor', tuya.valueConverter.raw],
+                [102, 'sensor', tuya.valueConverterBasic.lookup(
+                    {air_sensor: tuya.enum(0), floor_sensor: tuya.enum(1), both: tuya.enum(2)})],
+                [103, 'hysteresis', tuya.valueConverter.raw],
+                [104, 'running_state', tuya.valueConverterBasic.lookup({idle: false, heat: true})],
+                [106, 'window_detection', tuya.valueConverter.onOff],
+                [107, 'max_temperature_protection', tuya.valueConverter.raw],
+                [108, 'mode', tuya.valueConverterBasic.lookup({'regulator': tuya.enum(0), 'thermostat': tuya.enum(1)})],
+                [109, 'regulator_period', tuya.valueConverterBasic.lookup({
+                    '15min': tuya.enum(0), '30min': tuya.enum(1), '45min': tuya.enum(2), '60min': tuya.enum(3), '90min': tuya.enum(4)})],
+                [110, 'regulator_set_point', tuya.valueConverter.raw],
+                [120, 'current', tuya.valueConverter.divideBy10],
+                [121, 'voltage', tuya.valueConverter.raw],
+                [122, 'power', tuya.valueConverter.raw],
+                [123, 'energy', tuya.valueConverter.divideBy100],
+            ],
         },
     },
 ];

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -994,15 +994,10 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [
-            {
-                modelID: 'TS0601',
-                manufacturerName: '_TZE204_p3lqqy2r',
-            },
-        ],
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_p3lqqy2r']),
         model: '4512752/4512753',
         vendor: 'Namron',
-        description: 'Touch Thermostat 16A 2.0',
+        description: 'Touch thermostat 16A 2.0',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         onEvent: tuya.onEventSetTime,

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1092,7 +1092,7 @@ const tuyaTz = {
             'ph_max', 'ph_min', 'ec_max', 'ec_min', 'orp_max', 'orp_min', 'free_chlorine_max', 'free_chlorine_min', 'target_distance',
             'illuminance_treshold_max', 'illuminance_treshold_min', 'presence_illuminance_switch', 'light_switch', 'light_linkage',
             'indicator_light', 'find_switch', 'detection_method', 'sensor', 'hysteresis', 'max_temperature_protection', 'display_brightness',
-            'screen_orientation',
+            'screen_orientation', 'regulator_period', 'regulator_set_point',
         ],
         convertSet: async (entity, key, value, meta) => {
             // A set converter is only called once; therefore we need to loop


### PR DESCRIPTION
Implemented config for tuya thermostat Namron Zigbee Touch Termostat 16A (Issue: https://github.com/Koenkk/zigbee2mqtt/issues/20428).

Device page: https://www.namron.com/products/namron-zigbee-touch-termostat-16a-sort-760/

I have mapped all tuya datapoints I could find through z2m logs as I do not have a TuYa gateway. The thermostat has a few more features that I was unable to find datapoints for (such as screen brightness, floor sensor type (10K, 12K, etc.), but this config should still go a long way to support the basic functions of the device.

Had to add new keys for a few datapoints in `tuyaTz` as I couldn't find any similar keys that would fit. I dont know if this is how I'm supposed to do it, but it seems to work!