### PR TITLE
fix: LGYCDD01LM color supported again

### DIFF
--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -977,7 +977,7 @@ const definitions: Definition[] = [
         whiteLabel: [{vendor: 'Xiaomi', model: 'RLS-K01D'}],
         description: 'Aqara Zigbee 3.0 LED strip T1',
         extend: [
-            light({effect: false, powerOnBehaviour: false, colorTemp: {startup: false, range: [153, 370]}, color: {modes: ['xy']}}),
+            light({effect: false, powerOnBehaviour: false, colorTemp: {startup: false, range: [153, 370]}, color: true}),
             xiaomiPowerOnBehavior(),
             numeric({
                 name: 'length',

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -977,7 +977,7 @@ const definitions: Definition[] = [
         whiteLabel: [{vendor: 'Xiaomi', model: 'RLS-K01D'}],
         description: 'Aqara Zigbee 3.0 LED strip T1',
         extend: [
-            light({effect: false, powerOnBehaviour: false, colorTemp: {startup: false, range: [153, 370]}}),
+            light({effect: false, powerOnBehaviour: false, colorTemp: {startup: false, range: [153, 370]}, color: {modes: ['xy']}}),
             xiaomiPowerOnBehavior(),
             numeric({
                 name: 'length',


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/20497

Introduced in 3db5698a6b34d92bce5069862fcb8f735fd9a557 (Nov 27), subsequent updates never restored 'color'.

```diff
-        extend: extend.light_onoff_brightness_colortemp_color(
-            {disableEffect: true, disablePowerOnBehavior: true, disableColorTempStartup: true, colorTempRange: [153, 370]}),
+        extend: [
+            modernExtend.light({effect: false, powerOnBehaviour: false, colorTemp: {startup: false, range: [153, 370]}}),
```