### PR TITLE
QV-RGBCCT does not support power restore state.

### DIFF
--- a/src/devices/quotra.ts
+++ b/src/devices/quotra.ts
@@ -14,7 +14,7 @@ const definitions: Definition[] = [
         model: 'B07JHL6DRV',
         vendor: 'Quotra',
         description: 'RGB WW LED strip',
-        extend: [light({colorTemp: {range: [150, 500]}, color: true})],
+        extend: [light({colorTemp: {range: [150, 500]}, color: true, powerOnBehaviour: false})],
     },
 ];
 


### PR DESCRIPTION
Disable power on restore state and color temp startup for Quotra QV-RGBCCT, they are not actually supported.

In my bid to try and resolve https://github.com/Koenkk/zigbee-herdsman-converters/issues/6585 I noticed these were enabled but they are not actually supported.