### PR TITLE
Fix: Disable powerOnBehavior for RM3500ZB

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -1436,7 +1436,7 @@ const definitions: Definition[] = [
         model: 'RM3500ZB',
         vendor: 'Sinopé',
         description: 'Calypso smart water heater controller',
-        extend: [onOff(), electricityMeter()],
+        extend: [onOff({powerOnBehavior: false}), electricityMeter()],
         fromZigbee: [fzLocal.ias_water_leak_alarm, fzLocal.sinope, fz.temperature],
         toZigbee: [tzLocal.low_water_temp_protection],
         exposes: [


### PR DESCRIPTION
Disable powerOnBehavior (unsupported) for RM3500ZB introduced in #6727 when switching to extend.
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/acada376-e6dd-471e-8453-04b4e83f7db3)
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/115857857/b75b73ee-1f87-4061-a1f5-310f9151663e)
