### PR TITLE
fix: powerOnBehavior unsupported by Enbrighten 43082

### DIFF
--- a/src/devices/enbrighten.ts
+++ b/src/devices/enbrighten.ts
@@ -51,7 +51,7 @@ const definitions: Definition[] = [
         model: '43082',
         vendor: 'Enbrighten',
         description: 'Zigbee in-wall smart dimmer',
-        extend: [light({configureReporting: true, effect: false}), electricityMeter({cluster: 'metering'})],
+        extend: [light({configureReporting: true, effect: false, powerOnBehavior: false}), electricityMeter({cluster: 'metering'})],
     },
     {
         zigbeeModel: ['43084'],

--- a/src/devices/enbrighten.ts
+++ b/src/devices/enbrighten.ts
@@ -51,7 +51,7 @@ const definitions: Definition[] = [
         model: '43082',
         vendor: 'Enbrighten',
         description: 'Zigbee in-wall smart dimmer',
-        extend: [light({configureReporting: true, effect: false, powerOnBehavior: false}), electricityMeter({cluster: 'metering'})],
+        extend: [light({configureReporting: true, effect: false, powerOnBehaviour: false}), electricityMeter({cluster: 'metering'})],
     },
     {
         zigbeeModel: ['43084'],


### PR DESCRIPTION
According to https://github.com/Koenkk/zigbee2mqtt/discussions/20468#discussioncomment-7997276 device doesn't support `power_on_behavior`.

PS: I don't have the [device in question](https://byjasco.com/enbrighten-zigbee-in-wall-smart-dimmer-with-quickfittm-and-simplewiretm-and-energy-monitoring-white-almond).  I assume this might apply to some (or all) of the other lights/dimmers of the brand but I can't test any of them either. 