### PR TITLE
Handling action 1 and 17 for sinope switch.

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -224,8 +224,8 @@ const fzLocal = {
                 result.minimum_brightness = msg.data['minimumBrightness'];
             }
             if (msg.data.hasOwnProperty('actionReport')) {
-                const lookup = {2: 'up_single', 3: 'up_hold', 4: 'up_double',
-                    18: 'down_single', 19: 'down_hold', 20: 'down_double'};
+                const lookup = {1: 'up_clickdown', 2: 'up_single', 3: 'up_hold', 4: 'up_double',
+                    17: 'down_clickdown', 18: 'down_single', 19: 'down_hold', 20: 'down_double'};
                 result.action = utils.getFromLookup(msg.data['actionReport'], lookup);
             }
             if (msg.data.hasOwnProperty('keypadLockout')) {


### PR DESCRIPTION
The lookup for actionReport was not handling actions 1 and 17 which were generating these errors in the debug log
Error: Expected one of: 2, 3, 4, 18, 19, 20, got: '17'
Error: Expected one of: 2, 3, 4, 18, 19, 20, got: '1'

Added the up_clickdown and down_clickdown actions which are indicating the button is "down" and not yet released. Once released, one of the existing 2, 3, 4, 18, 19, 20 is generated.