### PR TITLE
Add totalActivePower and totalReactivePower to Develco EMIZB-132

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -69,6 +69,7 @@ const develco = {
                     result[utils.postfixWithEndpointName('power_reactive', msg, model, meta)] =
                         msg.data['totalReactivePower'];
                 }
+                return result;
             },
         } satisfies Fz.Converter,
         device_temperature: {
@@ -458,7 +459,7 @@ const definitions: Definition[] = [
             await reporting.currentSummReceived(endpoint);
             await develco.configure.read_sw_hw_version(device, logger);
         },
-        exposes: [e.numeric('power', ea.STATE).withUnit('W').withDescription('Total active power'), 
+        exposes: [e.numeric('power', ea.STATE).withUnit('W').withDescription('Total active power'),
             e.numeric('power_reactive', ea.STATE).withUnit('VAr').withDescription('Total reactive power'),
             e.energy(), e.current(), e.voltage(), e.current_phase_b(), e.voltage_phase_b(), e.current_phase_c(),
             e.voltage_phase_c()],

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -449,9 +449,9 @@ const definitions: Definition[] = [
                 await reporting.rmsCurrent(endpoint);
                 await reporting.activePower(endpoint);
                 await endpoint.configureReporting('haElectricalMeasurement', [{attribute: 'totalActivePower', minimumReportInterval: 5,
-                maximumReportInterval: 3600}], manufacturerOptions);
+                maximumReportInterval: 3600, reportableChange: 1}], manufacturerOptions);
                 await endpoint.configureReporting('haElectricalMeasurement', [{attribute: 'totalReactivePower', minimumReportInterval: 5,
-                maximumReportInterval: 3600}], manufacturerOptions);
+                maximumReportInterval: 3600, reportableChange: 1}], manufacturerOptions);
             } catch (e) {
                 e;
             }

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -58,6 +58,7 @@ const develco = {
                 if (msg.data.rmsVoltage !== 0xFFFF && msg.data.rmsCurrent !== 0xFFFF && msg.data.activePower !== -0x8000) {
                     return fz.electrical_measurement.convert(model, msg, publish, options, meta);
                 }
+                const result: KeyValue = {};
                 if (msg.data.hasOwnProperty('totalActivePower')) {
                     const value = msg.data['totalActivePower'];
                     result[utils.postfixWithEndpointName('total_active_power', msg, model, meta)] =

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -54,6 +54,8 @@ const develco = {
         // https://github.com/Koenkk/zigbee2mqtt/issues/13329
         electrical_measurement: {
             ...fz.electrical_measurement,
+            cluster: 'haElectricalMeasurement',
+            type: ['attributeReport', 'readResponse'],
             convert: (model, msg, publish, options, meta) => {
                 if (msg.data.rmsVoltage !== 0xFFFF && msg.data.rmsCurrent !== 0xFFFF && msg.data.activePower !== -0x8000) {
                     return fz.electrical_measurement.convert(model, msg, publish, options, meta);

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -448,8 +448,10 @@ const definitions: Definition[] = [
                 await reporting.rmsVoltage(endpoint);
                 await reporting.rmsCurrent(endpoint);
                 await reporting.activePower(endpoint);
-                await reporting.totalActivePower(endpoint);
-                await reporting.totalReactivePower(endpoint);
+                await endpoint.configureReporting('haElectricalMeasurement', [{attribute: 'totalActivePower', minimumReportInterval: 5,
+                maximumReportInterval: 3600}], manufacturerOptions);
+                await endpoint.configureReporting('haElectricalMeasurement', [{attribute: 'totalReactivePower', minimumReportInterval: 5,
+                maximumReportInterval: 3600}], manufacturerOptions);
             } catch (e) {
                 e;
             }

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -62,12 +62,10 @@ const develco = {
                 }
                 const result: KeyValue = {};
                 if (msg.data.hasOwnProperty('totalActivePower')) {
-                    const value = msg.data['totalActivePower'];
                     result[utils.postfixWithEndpointName('total_active_power', msg, model, meta)] =
                         msg.data['totalActivePower'];
                 }
                 if (msg.data.hasOwnProperty('totalReactivePower')) {
-                    const value = msg.data['totalReactivePower'];
                     result[utils.postfixWithEndpointName('total_reactive_power', msg, model, meta)] =
                         msg.data['totalReactivePower'];
                 }
@@ -449,9 +447,9 @@ const definitions: Definition[] = [
                 await reporting.rmsCurrent(endpoint);
                 await reporting.activePower(endpoint);
                 await endpoint.configureReporting('haElectricalMeasurement', [{attribute: 'totalActivePower', minimumReportInterval: 5,
-                maximumReportInterval: 3600, reportableChange: 1}], manufacturerOptions);
+                    maximumReportInterval: 3600, reportableChange: 1}], manufacturerOptions);
                 await endpoint.configureReporting('haElectricalMeasurement', [{attribute: 'totalReactivePower', minimumReportInterval: 5,
-                maximumReportInterval: 3600, reportableChange: 1}], manufacturerOptions);
+                    maximumReportInterval: 3600, reportableChange: 1}], manufacturerOptions);
             } catch (e) {
                 e;
             }
@@ -465,7 +463,7 @@ const definitions: Definition[] = [
         },
         exposes: [e.power(), e.energy(), e.current(), e.voltage(), e.current_phase_b(), e.voltage_phase_b(), e.current_phase_c(),
             e.voltage_phase_c(),
-            e.numeric('total_active_power', ea.STATE).withUnit('W').withDescription('Total active power'), 
+            e.numeric('total_active_power', ea.STATE).withUnit('W').withDescription('Total active power'),
             e.numeric('total_reactive_power', ea.STATE).withUnit('VAr').withDescription('Total reactive power')],
         onEvent: async (type, data, device) => {
             if (type === 'message' && data.type === 'attributeReport' && data.cluster === 'seMetering' && data.data['divisor']) {


### PR DESCRIPTION
Please note that the values reported as totalActivePower seems to be identical to instantaneousDemand (power).