### PR TITLE
Add basic support for BMCT-RZ

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1285,6 +1285,8 @@ const definitions: Definition[] = [
         model: 'BMCT-RZ',
         vendor: 'Bosch',
         description: 'Relay, potential free',
+        fromZigbee: [],
+        toZigbee: [],
         exposes: [e.switch()],
     },
     {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1287,7 +1287,8 @@ const definitions: Definition[] = [
         description: 'Relay, potential free',
         fromZigbee: [fz.on_off, fz.power_on_behavior],
         toZigbee: [tz.on_off, tz.power_on_behavior],
-        exposes: [],
+        exposes: [e.switch()],
+,
     },
     {
         zigbeeModel: ['RBSH-MMS-ZB-EU'],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1285,8 +1285,8 @@ const definitions: Definition[] = [
         model: 'BMCT-RZ',
         vendor: 'Bosch',
         description: 'Relay, potential free',
-        fromZigbee: [],
-        toZigbee: [],
+        fromZigbee: [fz.on_off]
+        toZigbee: [fz.on_off]
         exposes: [e.switch()],
     },
     {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1283,7 +1283,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['RBSH-MMR-ZB-EU'],
         model: 'BMCT-RZ',
-        vendor: 'BOSCH',
+        vendor: 'Bosch',
         description: 'Relay, potential free',
         fromZigbee: [fz.on_off, fz.power_on_behavior],
         toZigbee: [tz.on_off, tz.power_on_behavior],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1286,7 +1286,7 @@ const definitions: Definition[] = [
         vendor: 'Bosch',
         description: 'Relay, potential free',
         fromZigbee: [fz.on_off],
-        toZigbee: [fz.on_off],
+        toZigbee: [tz.on_off],
         exposes: [e.switch()],
     },
     {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1285,9 +1285,7 @@ const definitions: Definition[] = [
         model: 'BMCT-RZ',
         vendor: 'Bosch',
         description: 'Relay, potential free',
-        fromZigbee: [fz.on_off, fz.power_on_behavior],
-        toZigbee: [tz.on_off, tz.power_on_behavior],
-        exposes: [e.switch()],
+        extend: [onOff({powerOnBehavior: false})],
     },
     {
         zigbeeModel: ['RBSH-MMS-ZB-EU'],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1281,6 +1281,16 @@ const definitions: Definition[] = [
         exposes: [e.battery_low(), e.contact(), e.vibration(), e.action(['single', 'long'])],
     },
     {
+        zigbeeModel: ['RBSH-MMR-ZB-EU'],
+        model: 'BMCT-RZ',
+        vendor: 'BOSCH',
+        description: 'Relay, potential free',
+        extend: [onOff({powerOnBehavior: false})],
+        fromZigbee: [],
+        toZigbee: [],
+        exposes: [],
+    },
+    {
         zigbeeModel: ['RBSH-MMS-ZB-EU'],
         model: 'BMCT-SLZ',
         vendor: 'Bosch',

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1288,7 +1288,6 @@ const definitions: Definition[] = [
         fromZigbee: [fz.on_off, fz.power_on_behavior],
         toZigbee: [tz.on_off, tz.power_on_behavior],
         exposes: [e.switch()],
-,
     },
     {
         zigbeeModel: ['RBSH-MMS-ZB-EU'],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1,3 +1,4 @@
+import {onOff} from '../lib/modernExtend';
 import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -1285,9 +1286,7 @@ const definitions: Definition[] = [
         model: 'BMCT-RZ',
         vendor: 'Bosch',
         description: 'Relay, potential free',
-        fromZigbee: [fz.on_off],
-        toZigbee: [tz.on_off],
-        exposes: [e.switch()],
+        extend: [onOff({powerOnBehavior: false})],
     },
     {
         zigbeeModel: ['RBSH-MMS-ZB-EU'],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -58,6 +58,10 @@ const stateSwitchType: KeyValue = {
     'rocker_switch_key_change': 0x04,
 };
 
+// BMCT-RZ
+const {onOff} = require('zigbee-herdsman-converters/lib/modernExtend');
+        
+
 // Twinguard
 const smokeSensitivity = {
     'low': 3,
@@ -1281,7 +1285,6 @@ const definitions: Definition[] = [
         exposes: [e.battery_low(), e.contact(), e.vibration(), e.action(['single', 'long'])],
     },
     {
-        const {onOff} = require('zigbee-herdsman-converters/lib/modernExtend');
         zigbeeModel: ['RBSH-MMR-ZB-EU'],
         model: 'BMCT-RZ',
         vendor: 'Bosch',

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -58,10 +58,6 @@ const stateSwitchType: KeyValue = {
     'rocker_switch_key_change': 0x04,
 };
 
-// BMCT-RZ
-const {onOff} = require('zigbee-herdsman-converters/lib/modernExtend');
-        
-
 // Twinguard
 const smokeSensitivity = {
     'low': 3,
@@ -1289,7 +1285,7 @@ const definitions: Definition[] = [
         model: 'BMCT-RZ',
         vendor: 'Bosch',
         description: 'Relay, potential free',
-        extend: [onOff({powerOnBehavior: false})],
+        exposes: [e.switch()],
     },
     {
         zigbeeModel: ['RBSH-MMS-ZB-EU'],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1285,8 +1285,8 @@ const definitions: Definition[] = [
         model: 'BMCT-RZ',
         vendor: 'Bosch',
         description: 'Relay, potential free',
-        fromZigbee: [fz.on_off]
-        toZigbee: [fz.on_off]
+        fromZigbee: [fz.on_off],
+        toZigbee: [fz.on_off],
         exposes: [e.switch()],
     },
     {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1281,6 +1281,7 @@ const definitions: Definition[] = [
         exposes: [e.battery_low(), e.contact(), e.vibration(), e.action(['single', 'long'])],
     },
     {
+        const {onOff} = require('zigbee-herdsman-converters/lib/modernExtend');
         zigbeeModel: ['RBSH-MMR-ZB-EU'],
         model: 'BMCT-RZ',
         vendor: 'Bosch',

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1285,9 +1285,8 @@ const definitions: Definition[] = [
         model: 'BMCT-RZ',
         vendor: 'BOSCH',
         description: 'Relay, potential free',
-        extend: [onOff({powerOnBehavior: false})],
-        fromZigbee: [],
-        toZigbee: [],
+        fromZigbee: [fz.on_off, fz.power_on_behavior],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
         exposes: [],
     },
     {


### PR DESCRIPTION
On/off function works. As this is my first converter, can anyone help?

There are quite some options, many are probably overlapping with the Shutter/Light control II but the internal relays are different and this one has a single relay that is Potential Free.

It supports on/off and pulse mode, default mode seems to be on/off.