### PR TITLE
Draft: Add switch_type to Tuya TS0052

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4797,7 +4797,7 @@ const definitions: Definition[] = [
         model: 'TS0052',
         vendor: 'TuYa',
         description: 'Zigbee dimmer module 1 channel',
-        extend: tuya.extend.light_onoff_brightness(),
+        extend: tuya.extend.light_onoff_brightness({switchType: true}),
     },
     {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_ikvncluo'},

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1386,7 +1386,7 @@ const tuyaExtend = {
     light_onoff_brightness: (options:{
         endpoints?: string[], disablePowerOnBehavior?: boolean, minBrightness?: boolean,
         toZigbee?:Tz.Converter[], exposes?: Expose[], noConfigure?: boolean, disableMoveStep?: boolean,
-        disableTransition?: boolean,
+        disableTransition?: boolean, switchType?: boolean,
     }={}) => {
         options = {
             disablePowerOnBehavior: true, toZigbee: [tuyaTz.do_not_disturb], exposes: [tuyaExposes.doNotDisturb()],
@@ -1401,6 +1401,11 @@ const tuyaExtend = {
         }
         if (options.endpoints) {
             result.exposes = result.exposes.map((e, i) => e.withEndpoint(options.endpoints[i]));
+        }
+        if (options.switchType) {
+            result.fromZigbee.push(tuyaFz.switch_type);
+            result.toZigbee.push(tuyaTz.switch_type);
+            result.exposes.push(tuyaExposes.switchType());
         }
         return result;
     },


### PR DESCRIPTION
The tuya TS0052 supports different switchType. 
Using zigbee2mqtt, I was able to set it using the dev console and the cluster `manuSpecificTuya_3`, but it should be exposed in the specific settings.

This is still a draft because I have to test it properly 