### PR TITLE
Fix exposes property of E2213

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1248,9 +1248,9 @@ const definitions: Definition[] = [
         fromZigbee: [fz.battery, fzLocal.ikea_dots_click_v2_somrig],
         toZigbee: [tz.battery_percentage_remaining],
         exposes: [
-            e.battery().withAccess(ea.STATE_GET), e.action(['dots_1_initial_press',
-                'dots_2_initial_press', 'dots_1_long_press', 'dots_2_long_press',
-                'dots_1_short_release', 'dots_2_short_release', 'dots_1_long_release']),
+            e.battery().withAccess(ea.STATE_GET), e.action(['1_initial_press', '2_initial_press',
+                '1_long_press', '2_long_press', '1_short_release', '2_short_release',
+                '1_long_release', '2_long_release', '1_double_press', '2_double_press']),
         ],
         ota: ota.tradfri,
         configure: async (device, coordinatorEndpoint, logger) => {


### PR DESCRIPTION
The newly added device E2213 (see #6574) has the wrong values for the exposes property:

1. the actions are prefixed with `dots_`, which should not be the case
2. three actions are missing

This small change fixes that.