### PR TITLE
feature: Add category attribute to exposes 

### DIFF
--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -16,7 +16,7 @@ export class Base {
     property?: string;
     description?: string;
     features?: Feature[];
-    category?: 'config' | 'diagnostic';
+    category?: 'system';
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -40,7 +40,6 @@ export class Base {
     withAccess(a: number) {
         assert(this.access !== undefined, 'Cannot add access if not defined yet');
         this.access = a;
-        this.validateCategory();
         return this;
     }
 
@@ -59,21 +58,9 @@ export class Base {
         return this;
     }
 
-    withCategory(category: 'config' | 'diagnostic') {
+    withCategory(category: 'system') {
         this.category = category;
-        this.validateCategory();
         return this;
-    }
-
-    validateCategory() {
-        switch (this.category) {
-        case 'config':
-            assert(this.access & a.SET, 'Config expose must be settable');
-            break;
-        case 'diagnostic':
-            assert(!(this.access & a.SET), 'Diagnostic expose must not be settable');
-            break;
-        }
     }
 
     removeFeature(feature: string) {
@@ -89,7 +76,6 @@ export class Base {
         const f = this.features.find((f) => f.name === feature);
         assert(f.access !== a, `Access mode not changed for '${f.name}'`);
         f.access = a;
-        f.validateCategory();
         return this;
     }
 }

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -16,7 +16,7 @@ export class Base {
     property?: string;
     description?: string;
     features?: Feature[];
-    category?: 'system';
+    category?: 'config' | 'diagnostic';
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -40,6 +40,7 @@ export class Base {
     withAccess(a: number) {
         assert(this.access !== undefined, 'Cannot add access if not defined yet');
         this.access = a;
+        this.validateCategory();
         return this;
     }
 
@@ -58,9 +59,21 @@ export class Base {
         return this;
     }
 
-    withCategory(category: 'system') {
+    withCategory(category: 'config' | 'diagnostic') {
         this.category = category;
+        this.validateCategory();
         return this;
+    }
+
+    validateCategory() {
+        switch (this.category) {
+        case 'config':
+            assert(this.access & a.SET, 'Config expose must be settable');
+            break;
+        case 'diagnostic':
+            assert(!(this.access & a.SET), 'Diagnostic expose must not be settable');
+            break;
+        }
     }
 
     removeFeature(feature: string) {
@@ -76,6 +89,7 @@ export class Base {
         const f = this.features.find((f) => f.name === feature);
         assert(f.access !== a, `Access mode not changed for '${f.name}'`);
         f.access = a;
+        f.validateCategory();
         return this;
     }
 }

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -16,7 +16,7 @@ export class Base {
     property?: string;
     description?: string;
     features?: Feature[];
-    category?: string;
+    category?: 'config' | 'diagnostic';
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -40,6 +40,7 @@ export class Base {
     withAccess(a: number) {
         assert(this.access !== undefined, 'Cannot add access if not defined yet');
         this.access = a;
+        this.validateCategory();
         return this;
     }
 
@@ -58,9 +59,21 @@ export class Base {
         return this;
     }
 
-    withCategory(category: string) {
+    withCategory(category: 'config' | 'diagnostic') {
         this.category = category;
+        this.validateCategory();
         return this;
+    }
+
+    validateCategory() {
+        switch (this.category) {
+        case 'config':
+            assert(this.access & a.SET, 'Config expose must be settable');
+            break;
+        case 'diagnostic':
+            assert(!(this.access & a.SET), 'Diagnostic expose must not be settable');
+            break;
+        }
     }
 
     removeFeature(feature: string) {
@@ -76,6 +89,7 @@ export class Base {
         const f = this.features.find((f) => f.name === feature);
         assert(f.access !== a, `Access mode not changed for '${f.name}'`);
         f.access = a;
+        f.validateCategory();
         return this;
     }
 }

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -16,6 +16,7 @@ export class Base {
     property?: string;
     description?: string;
     features?: Feature[];
+    category?: string;
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -54,6 +55,11 @@ export class Base {
 
     withDescription(description: string) {
         this.description = description;
+        return this;
+    }
+
+    withCategory(category: string) {
+        this.category = category;
         return this;
     }
 


### PR DESCRIPTION
This PR introduces a new `category` attribute for exposes, which allows the developer to mark exposes as non-primary, equivalent to the Home Assistant `entity_category` https://developers.home-assistant.io/docs/core/entity/#registry-properties.

It is the first part of implementing https://github.com/Koenkk/zigbee2mqtt/issues/20532. The ticket also has some more background on why I think this is useful.

For reference, the second part for `homeassistant.ts` is here: https://github.com/slugzero/zigbee2mqtt/commit/eff7dd63a5feaae24065c9baa1aad1947d9016dc
 Before I can open the PR, it needs an update of the dependencies, and an additional test for 100% coverage.