### PR TITLE
Expose `sensor_temp` for Xiaomi SRTS-A01

### DIFF
--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -3369,10 +3369,7 @@ const definitions: Definition[] = [
                 .withSystemMode(['off', 'heat'], ea.ALL)
                 .withPreset(['manual', 'away', 'auto']).setAccess('preset', ea.ALL),
             e.temperature_sensor_select(['internal', 'external']).withAccess(ea.ALL),
-            e.numeric('sensor_temp', ea.SET)
-                .withUnit('°C')
-                .withValueMin(0)
-                .withValueMax(55)
+            e.numeric('sensor_temp', ea.ALL).withUnit('°C').withValueMin(0).withValueMax(55)
                 .withDescription('Input for remote temperature sensor (when sensor is set to external)'),
             e.binary('calibrated', ea.STATE, true, false)
                 .withDescription('Indicates if this valve is calibrated, use the calibrate option to calibrate'),

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -3369,6 +3369,11 @@ const definitions: Definition[] = [
                 .withSystemMode(['off', 'heat'], ea.ALL)
                 .withPreset(['manual', 'away', 'auto']).setAccess('preset', ea.ALL),
             e.temperature_sensor_select(['internal', 'external']).withAccess(ea.ALL),
+            e.numeric('sensor_temp', ea.SET)
+                .withUnit('°C')
+                .withValueMin(0)
+                .withValueMax(55)
+                .withDescription('Input for remote temperature sensor (when sensor is set to external)'),
             e.binary('calibrated', ea.STATE, true, false)
                 .withDescription('Indicates if this valve is calibrated, use the calibrate option to calibrate'),
             e.enum('calibrate', ea.ALL, ['calibrate']).withDescription('Calibrates the valve'),


### PR DESCRIPTION
Expose the `sensor_temp` field for Xiaomi SRTS-A01 (Aqara Smart Radiator Thermostat E1).

See https://github.com/Koenkk/zigbee2mqtt/discussions/14291.

For the minimum and maximum values, I did trial and error.