### PR TITLE
Remove % to power_factor and add SPM01-D2TZ-U01

### DIFF
--- a/src/devices/bituo_technik.ts
+++ b/src/devices/bituo_technik.ts
@@ -9,7 +9,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['SPM01X001'],
         model: 'SPM01-D2TZ-U01',
         vendor: 'BITUO TECHNIK',
-        description: 'Smart Energy Sensor',
+        description: 'Smart energy sensor',
         fromZigbee: [fz.electrical_measurement, fz.metering],
         toZigbee: [],
         exposes: [e.ac_frequency(), e.power(), e.power_reactive(), e.power_apparent(), e.current(),

--- a/src/devices/bituo_technik.ts
+++ b/src/devices/bituo_technik.ts
@@ -1,0 +1,28 @@
+import {Definition} from '../lib/types';
+import * as exposes from '../lib/exposes';
+import * as reporting from '../lib/reporting';
+import fz from '../converters/fromZigbee';
+const e = exposes.presets;
+
+const definitions: Definition[] = [
+    {
+        zigbeeModel: ['SPM01X001'],
+        model: 'SPM01-D2TZ-U01',
+        vendor: 'BITUO TECHNIK',
+        description: 'Smart Energy Sensor',
+        fromZigbee: [fz.electrical_measurement, fz.metering],
+        toZigbee: [],
+        exposes: [e.ac_frequency(), e.power(), e.power_reactive(), e.power_apparent(), e.current(), e.voltage(), e.power_factor(), e.energy(), e.produced_energy()],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
+            await endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
+                acPowerMultiplier: 1, acPowerDivisor: 1,
+            });
+        },
+    }
+    
+];
+
+export default definitions;
+module.exports = definitions;

--- a/src/devices/bituo_technik.ts
+++ b/src/devices/bituo_technik.ts
@@ -12,7 +12,8 @@ const definitions: Definition[] = [
         description: 'Smart Energy Sensor',
         fromZigbee: [fz.electrical_measurement, fz.metering],
         toZigbee: [],
-        exposes: [e.ac_frequency(), e.power(), e.power_reactive(), e.power_apparent(), e.current(), e.voltage(), e.power_factor(), e.energy(), e.produced_energy()],
+        exposes: [e.ac_frequency(), e.power(), e.power_reactive(), e.power_apparent(), e.current(),
+            e.voltage(), e.power_factor(), e.energy(), e.produced_energy()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
@@ -20,8 +21,7 @@ const definitions: Definition[] = [
                 acPowerMultiplier: 1, acPowerDivisor: 1,
             });
         },
-    }
-    
+    },
 ];
 
 export default definitions;

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -21,6 +21,7 @@ import bankamp from './bankamp';
 import bega from './bega';
 import belkin from './belkin';
 import bitron from './bitron';
+import bituo_technik from './bituo_technik';
 import blaupunkt from './blaupunkt';
 import blitzwolf from './blitzwolf';
 import bosch from './bosch';
@@ -312,6 +313,7 @@ export default [
     ...bega,
     ...belkin,
     ...bitron,
+    ...bituo_technik,
     ...blaupunkt,
     ...blitzwolf,
     ...bosch,

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3665,7 +3665,7 @@ const definitions: Definition[] = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        exposes: [tuya.exposes.switch(), e.ac_frequency(), e.energy(), e.power(), e.power_factor().withUnit('%'), 
+        exposes: [tuya.exposes.switch(), e.ac_frequency(), e.energy(), e.power(), e.power_factor().withUnit('%'),
             e.voltage(), e.current(), e.produced_energy(), e.power_reactive(),
             e.numeric('energy_reactive', ea.STATE).withUnit('kVArh').withDescription('Sum of reactive energy'),
             e.numeric('total_energy', ea.STATE).withUnit('kWh').withDescription('Total consumed and produced energy')],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3665,8 +3665,8 @@ const definitions: Definition[] = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        exposes: [tuya.exposes.switch(), e.ac_frequency(), e.energy(), e.power(), e.power_factor(), e.voltage(), e.current(),
-            e.produced_energy(), e.power_reactive(),
+        exposes: [tuya.exposes.switch(), e.ac_frequency(), e.energy(), e.power(), e.power_factor().withUnit('%'), 
+            e.voltage(), e.current(), e.produced_energy(), e.power_reactive(),
             e.numeric('energy_reactive', ea.STATE).withUnit('kVArh').withDescription('Sum of reactive energy'),
             e.numeric('total_energy', ea.STATE).withUnit('kWh').withDescription('Total consumed and produced energy')],
         meta: {
@@ -5965,7 +5965,7 @@ const definitions: Definition[] = [
         exposes: [e.voltage(), e.power(), e.current(),
             e.energy().withDescription('Total forward active energy'),
             e.produced_energy().withDescription('Total reverse active energy'),
-            e.power_factor(), e.ac_frequency(),
+            e.power_factor().withUnit('%'), e.ac_frequency(),
         ],
         meta: {
             tuyaDatapoints: [
@@ -5994,7 +5994,7 @@ const definitions: Definition[] = [
             tuya.exposes.currentWithPhase('a'), tuya.exposes.currentWithPhase('b'), tuya.exposes.currentWithPhase('c'),
             e.energy().withDescription('Total forward active energy'),
             e.produced_energy().withDescription('Total reverse active energy'),
-            e.power_factor(), e.power(),
+            e.power_factor().withUnit('%'), e.power(),
             e.ac_frequency(),
         ],
         meta: {

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -715,7 +715,7 @@ export const presets = {
     pm25: () => new Numeric('pm25', access.STATE).withLabel('PM25').withUnit('µg/m³').withDescription('Measured PM2.5 (particulate matter) concentration'),
     position: () => new Numeric('position', access.STATE).withUnit('%').withDescription('Position'),
     power: () => new Numeric('power', access.STATE).withUnit('W').withDescription('Instantaneous measured power'),
-    power_factor: () => new Numeric('power_factor', access.STATE).withUnit('%').withDescription('Instantaneous measured power factor'),
+    power_factor: () => new Numeric('power_factor', access.STATE).withDescription('Instantaneous measured power factor'),
     power_apparent: () => new Numeric('power_apparent', access.STATE).withUnit('VA').withDescription('Instantaneous measured apparent power'),
     power_on_behavior: (values=['off', 'previous', 'on']) => new Enum('power_on_behavior', access.ALL, values).withLabel('Power-on behavior').withDescription('Controls the behavior when the device is powered on after power loss. If you get an `UNSUPPORTED_ATTRIBUTE` error, the device does not support it.'),
     power_outage_count: (resetsWhenPairing = true) => new Numeric('power_outage_count', access.STATE).withDescription('Number of power outages' + (resetsWhenPairing ? ' (since last pairing)' : '')),


### PR DESCRIPTION
Following discussion [#20593](https://github.com/Koenkk/zigbee2mqtt/discussions/20593) remove the % to power_factor and specify it on tuya device.
Might consider divideBy100 on tuya device in futur to have consistency with standard zigbee.
Add SPM01-D2TZ-U01 device that support power_factor between 0 and 1