### PR TITLE
fix: Add categories to several config/diagnostic exposes

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -985,7 +985,8 @@ const definitions: Definition[] = [
             e.binary('window_open', ea.ALL, 'ON', 'OFF')
                 .withDescription('Window open'),
             e.enum('display_orientation', ea.ALL, Object.keys(displayOrientation))
-                .withDescription('Display orientation'),
+                .withDescription('Display orientation')
+                .withCategory('config'),
             e.numeric('remote_temperature', ea.ALL)
                 .withValueMin(0)
                 .withValueMax(35)
@@ -996,24 +997,29 @@ const definitions: Definition[] = [
             e.numeric('display_ontime', ea.ALL)
                 .withValueMin(5)
                 .withValueMax(30)
-                .withDescription('Specifies the display on-time'),
+                .withDescription('Specifies the display on-time')
+                .withCategory('config'),
             e.numeric('display_brightness', ea.ALL)
                 .withValueMin(0)
                 .withValueMax(10)
-                .withDescription('Specifies the brightness level of the display'),
+                .withDescription('Specifies the brightness level of the display')
+                .withCategory('config'),
             e.enum('displayed_temperature', ea.ALL, Object.keys(displayedTemperature))
-                .withDescription('Temperature displayed on the thermostat'),
+                .withDescription('Temperature displayed on the thermostat')
+                .withCategory('config'),
             e.child_lock().setAccess('state', ea.ALL),
             e.battery(),
             e.enum('setpoint_change_source', ea.STATE, Object.keys(setpointSource))
                 .withDescription('States where the current setpoint originated'),
             e.enum('valve_adapt_status', ea.STATE, Object.keys(adaptationStatus))
                 .withLabel('Adaptation status')
-                .withDescription('Specifies the current status of the valve adaptation'),
+                .withDescription('Specifies the current status of the valve adaptation')
+                .withCategory('diagnostic'),
             e.binary('valve_adapt_process', ea.ALL, true, false)
                 .withLabel('Trigger adaptation process')
                 .withDescription('Trigger the valve adaptation process. Only possible when adaptation status ' +
-                    'is "ready_to_calibrate" or "error".'),
+                    'is "ready_to_calibrate" or "error".')
+                .withCategory('config'),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -1375,21 +1381,29 @@ const definitions: Definition[] = [
             e.battery_low(),
             e.battery_voltage(),
             e.text('config_led_top_left_press', ea.ALL).withLabel('LED config (top left short press)')
-                .withDescription(labelShortPress),
+                .withDescription(labelShortPress)
+                .withCategory('config'),
             e.text('config_led_top_right_press', ea.ALL).withLabel('LED config (top right short press)')
-                .withDescription(labelShortPress),
+                .withDescription(labelShortPress)
+                .withCategory('config'),
             e.text('config_led_bottom_left_press', ea.ALL).withLabel('LED config (bottom left short press)')
-                .withDescription(labelShortPress),
+                .withDescription(labelShortPress)
+                .withCategory('config'),
             e.text('config_led_bottom_right_press', ea.ALL).withLabel('LED config (bottom right short press)')
-                .withDescription(labelShortPress),
+                .withDescription(labelShortPress)
+                .withCategory('config'),
             e.text('config_led_top_left_longpress', ea.ALL).withLabel('LED config (top left long press)')
-                .withDescription(labelLongPress),
+                .withDescription(labelLongPress)
+                .withCategory('config'),
             e.text('config_led_top_right_longpress', ea.ALL).withLabel('LED config (top right long press)')
-                .withDescription(labelLongPress),
+                .withDescription(labelLongPress)
+                .withCategory('config'),
             e.text('config_led_bottom_left_longpress', ea.ALL).withLabel('LED config (bottom left long press)')
-                .withDescription(labelLongPress),
+                .withDescription(labelLongPress)
+                .withCategory('config'),
             e.text('config_led_bottom_right_longpress', ea.ALL).withLabel('LED config (bottom right long press)')
-                .withDescription(labelLongPress),
+                .withDescription(labelLongPress)
+                .withCategory('config'),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -1503,7 +1503,8 @@ const definitions: Definition[] = [
                 .withCategory('config'),
             e.enum('operation_mode', ea.STATE_SET, ['control_left_relay', 'control_right_relay', 'decoupled'])
                 .withDescription('Operation mode for right button')
-                .withEndpoint('right'),
+                .withEndpoint('right')
+                .withCategory('config'),
         ],
         toZigbee: [tz.on_off, {...tz.xiaomi_switch_operation_mode_basic, convertGet: null}, tz.xiaomi_power],
         meta: {multiEndpoint: true},

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -1499,7 +1499,8 @@ const definitions: Definition[] = [
                 'single_left', 'single_right', 'hold_release_left', 'hold_release_left']),
             e.enum('operation_mode', ea.STATE_SET, ['control_left_relay', 'control_right_relay', 'decoupled'])
                 .withDescription('Operation mode for left button')
-                .withEndpoint('left'),
+                .withEndpoint('left')
+                .withCategory('config'),
             e.enum('operation_mode', ea.STATE_SET, ['control_left_relay', 'control_right_relay', 'decoupled'])
                 .withDescription('Operation mode for right button')
                 .withEndpoint('right'),

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -738,7 +738,7 @@ export const presets = {
     power_factor: () => new Numeric('power_factor', access.STATE).withDescription('Instantaneous measured power factor'),
     power_apparent: () => new Numeric('power_apparent', access.STATE).withUnit('VA').withDescription('Instantaneous measured apparent power'),
     power_on_behavior: (values=['off', 'previous', 'on']) => new Enum('power_on_behavior', access.ALL, values).withLabel('Power-on behavior').withDescription('Controls the behavior when the device is powered on after power loss. If you get an `UNSUPPORTED_ATTRIBUTE` error, the device does not support it.'),
-    power_outage_count: (resetsWhenPairing = true) => new Numeric('power_outage_count', access.STATE).withDescription('Number of power outages' + (resetsWhenPairing ? ' (since last pairing)' : '')),
+    power_outage_count: (resetsWhenPairing = true) => new Numeric('power_outage_count', access.STATE).withDescription('Number of power outages' + (resetsWhenPairing ? ' (since last pairing)' : '')).withCategory('diagnostic'),
     power_outage_memory: () => new Binary('power_outage_memory', access.ALL, true, false).withDescription('Enable/disable the power outage memory, this recovers the on/off mode after power failure'),
     power_reactive: () => new Numeric('power_reactive', access.STATE).withUnit('VAR').withDescription('Instantaneous measured reactive power'),
     presence: () => new Binary('presence', access.STATE, true, false).withDescription('Indicates whether the device detected presence'),


### PR DESCRIPTION
I need a handful of exposes with the `category` flag set to implement a test for https://github.com/Koenkk/zigbee2mqtt/pull/20663.

After that PR is also merged, this will fix a few exposes which are currently displayed in the wrong category in Home Assistant after discovery.