### PR TITLE
Change default energy reporting change threshold to 0.01kWh

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -158,8 +158,8 @@ export function electricityMeter(args?: ElectricityMeterArgs): ModernExtend {
         seMetering: {
             // Report change with every 5W change
             power: {attribute: 'instantaneousDemand', divisor: 'divisor', multiplier: 'multiplier', forced: args.power, change: 5},
-            // Report change with every 0.1kWh change
-            energy: {attribute: 'currentSummDelivered', divisor: 'divisor', multiplier: 'multiplier', forced: args.energy, change: 0.1},
+            // Report change with every 0.01kWh change
+            energy: {attribute: 'currentSummDelivered', divisor: 'divisor', multiplier: 'multiplier', forced: args.energy, change: 0.01},
         },
     };
 


### PR DESCRIPTION
Fixes #6787 (imo)

Decided to just make a PR in case you feel this is a sane default too. The current value of 0.1kWh is pretty large especially compared to other more easily fluctuating values being reported with changes as little as 5W or 0.05A. In contrast, it takes two full minutes at 3kW to use 0.1kWh and since most of these devices (I think) are going to be smart plugs that usually only switch "small" loads, it doesn't seem like something that's going to happen often. My dryer uses only half that power generally. Even at a 0.01kWh change that same load is only going to cause a message every 12 seconds so it's not going to flood the network.