### PR TITLE
feat: bosch smoke intruder and smoke alarm triggers

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -943,7 +943,7 @@ const definitions: Definition[] = [
                     dataToSend.command,
                     dataToSend.payload,
                     {
-                        ...boschManufacturer,
+                        ...manufacturerOptions,
                         ...utils.getOptions(meta.mapped, entity),
                     },
                 );
@@ -955,14 +955,14 @@ const definitions: Definition[] = [
                     await entity.read(
                         'ssIasZone',
                         [0xf0],
-                        boschManufacturer,
+                        manufacturerOptions,
                     );
                     break;
                 case 'intruder_state':
                     await entity.read(
                         'ssIasZone',
                         [0xf0],
-                        boschManufacturer,
+                        manufacturerOptions,
                     );
                     break;
                 default: // Unknown key

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -981,7 +981,6 @@ const definitions: Definition[] = [
                 'genBasic',
                 64684]);
             await reporting.batteryPercentageRemaining(endpoint);
-            device.defaultSendRequestWhen = 'immediate';
             device.save();
             await endpoint.unbind('genPollCtrl', coordinatorEndpoint);
         },

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -989,7 +989,7 @@ const definitions: Definition[] = [
             e
                 .binary(
                     'intruder_alarm_state',
-                    ea.SET,
+                    ea.ALL,
                     smokeDetectorAlarmState.intruder_on.toString(),
                     smokeDetectorAlarmState.intruder_off.toString(),
                 )
@@ -997,7 +997,7 @@ const definitions: Definition[] = [
             e
                 .binary(
                     'smoke_alarm_state',
-                    ea.SET,
+                    ea.ALL,
                     smokeDetectorAlarmState.smoke_on.toString(),
                     smokeDetectorAlarmState.smoke_off.toString(),
                 )

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -951,14 +951,14 @@ const definitions: Definition[] = [
             },
             convertGet: async (entity, key, meta) => {
                 switch (key) {
-                case 'alarm_state':
+                case 'smoke_alarm_state':
                     await entity.read(
                         'ssIasZone',
                         [0xf0],
                         manufacturerOptions,
                     );
                     break;
-                case 'intruder_state':
+                case 'intruder_alarm_state':
                     await entity.read(
                         'ssIasZone',
                         [0xf0],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -919,7 +919,7 @@ const definitions: Definition[] = [
         description: 'Smoke alarm detector',
         fromZigbee: [fz.battery, fz.ias_smoke_alarm_1],
         toZigbee: [{
-            key: ['intruder_alarm_state', 'smoke_alarm_state', 'boschSmokeDetectorSiren', 'command'],
+            key: ['intruder_alarm_state', 'smoke_alarm_state'],
             convertSet: async (entity, key, value:smokeSensorData, meta) => {
                 const dataToSend = {
                     cluster: value?.cluster,

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -920,16 +920,31 @@ const definitions: Definition[] = [
         fromZigbee: [fz.battery, fz.ias_smoke_alarm_1],
         toZigbee: [{
             key: ['intruder_alarm_state', 'smoke_alarm_state'],
-            convertSet: async (entity, key, value:smokeSensorData, meta) => {
+            convertSet: async (entity, key, value:string, meta) => {
                 const dataToSend = {
-                    cluster: value?.cluster,
-                    command: value?.command,
-                    payload: value?.payload,
+                    cluster: 'ssIasZone',
+                    command: 128,
+                    payload: {data: ''},
                 };
                 if (key === 'smoke_alarm_state' || key==='intruder_alarm_state') {
-                    dataToSend.cluster = 'ssIasZone';
-                    dataToSend.payload = {data: value};
-                    dataToSend.command = 128;
+                    let convertedValue='';
+                    if (key === 'smoke_alarm_state') {
+                        if (value==='ON') {
+                            convertedValue=smokeDetectorAlarmState.smoke_on.toString();
+                        }
+                        if (value==='OFF') {
+                            convertedValue=smokeDetectorAlarmState.smoke_off.toString();
+                        }
+                    }
+                    if (key === 'intruder_alarm_state') {
+                        if (value==='ON') {
+                            convertedValue=smokeDetectorAlarmState.intruder_on.toString();
+                        }
+                        if (value==='OFF') {
+                            convertedValue=smokeDetectorAlarmState.intruder_off.toString();
+                        }
+                    }
+                    dataToSend.payload.data = convertedValue;
                 }
 
                 //
@@ -989,16 +1004,16 @@ const definitions: Definition[] = [
                 .binary(
                     'intruder_alarm_state',
                     ea.ALL,
-                    smokeDetectorAlarmState.intruder_on.toString(),
-                    smokeDetectorAlarmState.intruder_off.toString(),
+                    'ON',
+                    'OFF',
                 )
                 .withDescription('Toggle the intruder alarm on or off'),
             e
                 .binary(
                     'smoke_alarm_state',
                     ea.ALL,
-                    smokeDetectorAlarmState.smoke_on.toString(),
-                    smokeDetectorAlarmState.smoke_off.toString(),
+                    'ON',
+                    'OFF',
                 )
                 .withDescription('Toggle the smoke alarm on or off')],
     },


### PR DESCRIPTION
I ran into formatting issues. It logs too many changes. Not sure how to align that, how should I do that? @Koenkk
Potentially we could enable some formatter as Prettier to the codebase?
This should allow users to send a mqtt topic to toggle the alarm and intruder state of the smoke detector II.

Add these 2 commands to trigger the intruder and alarm state:
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/18259276/3fdabaab-5367-4fb8-9047-3ce6cfdb69d2)
