### PR TITLE
fix: Replace `defaultSendRequestWhen` with `pendingRequestTimeout`

### DIFF
--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -276,7 +276,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.warning],
         exposes: [e.warning(), e.battery(), e.battery_low(), e.tamper()],
         configure: async (device, coordinatorEndpoint, logger) => {
-            device.defaultSendRequestWhen = 'immediate';
+            device.pendingRequestTimeout = 0;
             device.save();
             await device.getEndpoint(1).unbind('genPollCtrl', coordinatorEndpoint);
         },

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -850,7 +850,7 @@ const definitions: Definition[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic']);
             await reporting.batteryVoltage(endpoint);
             await endpoint.read(0x0502, [0xa000, 0xa001, 0xa002, 0xa003, 0xa004, 0xa005], manufacturerOptions);
-            device.defaultSendRequestWhen = 'immediate';
+            device.pendingRequestTimeout = 0;
             device.save();
             await endpoint.unbind('genPollCtrl', coordinatorEndpoint);
         },

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -3121,7 +3121,7 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         exposes: [e.device_temperature(), e.battery(), e.battery_voltage()],
         extend: [
-            quirkPendingRequestTimeout(),
+            quirkPendingRequestTimeout(3600000), // 1 hour
             quirkAddEndpointCluster({
                 endpointID: 1,
                 inputClusters: [

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -9,7 +9,7 @@ import extend from '../lib/extend';
 import {
     light, numeric, binary, enumLookup, forceDeviceType,
     temperature, humidity, forcePowerSource, quirkAddEndpointCluster,
-    quirkSendWhenActive,
+    quirkPendingRequestTimeout,
 } from '../lib/modernExtend';
 const e = exposes.presets;
 const ea = exposes.access;
@@ -3121,7 +3121,7 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         exposes: [e.device_temperature(), e.battery(), e.battery_voltage()],
         extend: [
-            quirkSendWhenActive(),
+            quirkPendingRequestTimeout(),
             quirkAddEndpointCluster({
                 endpointID: 1,
                 inputClusters: [

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -3121,7 +3121,7 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         exposes: [e.device_temperature(), e.battery(), e.battery_voltage()],
         extend: [
-            quirkPendingRequestTimeout(3600000), // 1 hour
+            quirkPendingRequestTimeout('1_HOUR'),
             quirkAddEndpointCluster({
                 endpointID: 1,
                 inputClusters: [

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -569,8 +569,7 @@ export function quirkAddEndpointCluster(args: QuirkAddEndpointClusterArgs): Mode
     return {configure, isModernExtend: true};
 }
 
-// default timeout = 1h
-export function quirkPendingRequestTimeout(timeoutMs: number = 3600000): ModernExtend {
+export function quirkPendingRequestTimeout(timeoutMs: number): ModernExtend {
     const configure: Configure = async (device, coordinatorEndpoint, logger) => {
         device.pendingRequestTimeout = timeoutMs;
         device.save();

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -21,22 +21,22 @@ function getEndpointsWithInputCluster(device: Zh.Device, cluster: string | numbe
     return endpoints;
 }
 
-const reportingConfigTimeLookup = {
+const timeLookup = {
     '1_HOUR': 3600,
     'MAX': 65000,
     '30_MINUTES': 1800,
     '10_SECONDS': 10,
 };
 
-type ReportingConfigTime = number | keyof typeof reportingConfigTimeLookup;
+type ReportingConfigTime = number | keyof typeof timeLookup;
 type ReportingConfigAttribute = string | number | {ID: number, type: number};
 type ReportingConfig = {min: ReportingConfigTime, max: ReportingConfigTime, change: number | [number, number], attribute: ReportingConfigAttribute}
 export type ReportingConfigWithoutAttribute = Omit<ReportingConfig, 'attribute'>;
 
 function convertReportingConfigTime(time: ReportingConfigTime): number {
     if (isString(time)) {
-        if (!(time in reportingConfigTimeLookup)) throw new Error(`Reporting time '${time}' is unknown`);
-        return reportingConfigTimeLookup[time];
+        if (!(time in timeLookup)) throw new Error(`Reporting time '${time}' is unknown`);
+        return timeLookup[time];
     } else {
         return time;
     }
@@ -569,7 +569,8 @@ export function quirkAddEndpointCluster(args: QuirkAddEndpointClusterArgs): Mode
     return {configure, isModernExtend: true};
 }
 
-export function quirkPendingRequestTimeout(timeoutMs: number): ModernExtend {
+export function quirkPendingRequestTimeout(timeout: keyof typeof timeLookup): ModernExtend {
+    const timeoutMs = timeLookup[timeout] * 1000;
     const configure: Configure = async (device, coordinatorEndpoint, logger) => {
         device.pendingRequestTimeout = timeoutMs;
         device.save();

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -571,7 +571,7 @@ export function quirkAddEndpointCluster(args: QuirkAddEndpointClusterArgs): Mode
 
 export function quirkPendingRequestTimeout(): ModernExtend {
     const configure: Configure = async (device, coordinatorEndpoint, logger) => {
-        device.pendingRequestTimeout = 3600000; // milliseconds => 1 hour
+        device.pendingRequestTimeout = timeoutMs;
         device.save();
     };
 

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -569,9 +569,9 @@ export function quirkAddEndpointCluster(args: QuirkAddEndpointClusterArgs): Mode
     return {configure, isModernExtend: true};
 }
 
-export function quirkSendWhenActive(): ModernExtend {
+export function quirkPendingRequestTimeout(): ModernExtend {
     const configure: Configure = async (device, coordinatorEndpoint, logger) => {
-        device.defaultSendRequestWhen = 'active';
+        device.pendingRequestTimeout = 3600000; // milliseconds => 1 hour
         device.save();
     };
 

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -569,7 +569,8 @@ export function quirkAddEndpointCluster(args: QuirkAddEndpointClusterArgs): Mode
     return {configure, isModernExtend: true};
 }
 
-export function quirkPendingRequestTimeout(): ModernExtend {
+// default timeout = 1h
+export function quirkPendingRequestTimeout(timeoutMs: number = 3600000): ModernExtend {
     const configure: Configure = async (device, coordinatorEndpoint, logger) => {
         device.pendingRequestTimeout = timeoutMs;
         device.save();


### PR DESCRIPTION
`defaultSendRequestWhen` is removed with https://github.com/Koenkk/zigbee-herdsman/pull/860.
This PR replaces it with `pendingRequestTimeout`
