### PR TITLE
Feature: Ability to trigger events from converters on incoming Zigbee messages

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -558,6 +558,11 @@ const fzLocal = {
             const data = msg.data;
             if (data.hasOwnProperty('deviceMode')) {
                 result.device_mode = Object.keys(stateDeviceMode).find((key) => stateDeviceMode[key] === msg.data['deviceMode']);
+                const deviceMode = msg.data['deviceMode'];
+                if (deviceMode !== meta.device.meta.deviceMode) {
+                    meta.device.meta.deviceMode = deviceMode;
+                    meta.deviceExposesChanged();
+                }
             }
             if (data.hasOwnProperty('switchType')) {
                 result.switch_type = Object.keys(stateSwitchType).find((key) => stateSwitchType[key] === msg.data['switchType']);
@@ -578,20 +583,6 @@ const fzLocal = {
             return result;
         },
     } satisfies Fz.Converter,
-    bmct_trigger: {
-        cluster: 'manuSpecificBosch10',
-        attribute: 'deviceMode',
-        event: 'devicesChanged',
-        getEvents: (data, device) => {
-            if (data.hasOwnProperty('deviceMode')) {
-                const deviceMode = data['deviceMode'];
-                if (deviceMode !== device.meta.deviceMode) {
-                    device.meta.deviceMode = deviceMode;
-                    return ['devicesChanged'];
-                }
-            }
-        },
-    } satisfies Fz.Trigger,
     bwa1_alarm_on_motion: {
         cluster: '64684',
         type: ['attributeReport', 'readResponse'],
@@ -1317,7 +1308,6 @@ const definitions: Definition[] = [
         fromZigbee: [fzLocal.bmct, fz.cover_position_tilt, fz.on_off, fz.power_on_behavior],
         toZigbee: [tzLocal.bmct, tz.cover_position_tilt, tz.on_off, tz.power_on_behavior],
         meta: {multiEndpoint: true},
-        triggers: [fzLocal.bmct_trigger],
         endpoint: (device) => {
             return {'left': 2, 'right': 3};
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,13 @@ import assert from 'assert';
 import * as ota from './lib/ota';
 import allDefinitions from './devices';
 import * as utils from './lib/utils';
-import { Definition, Fingerprint, Zh, OnEventData, OnEventType, Configure, Expose, Tz, OtaUpdateAvailableResult, KeyValue, Logger } from './lib/types';
+import { Definition, Fingerprint, Zh, OnEventData, OnEventType, TriggerEventType, Configure, Expose, Tz, OtaUpdateAvailableResult, KeyValue, Logger } from './lib/types';
 import {generateDefinition} from './lib/generateDefinition';
 
 export {
     Definition as Definition,
     OnEventType as OnEventType,
+    TriggerEventType as TriggerEventType,
     Feature as Feature,
     Expose as Expose,
     Numeric as Numeric,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,12 @@ import assert from 'assert';
 import * as ota from './lib/ota';
 import allDefinitions from './devices';
 import * as utils from './lib/utils';
-import { Definition, Fingerprint, Zh, OnEventData, OnEventType, TriggerEventType, Configure, Expose, Tz, OtaUpdateAvailableResult, KeyValue, Logger } from './lib/types';
+import { Definition, Fingerprint, Zh, OnEventData, OnEventType, Configure, Expose, Tz, OtaUpdateAvailableResult, KeyValue, Logger } from './lib/types';
 import {generateDefinition} from './lib/generateDefinition';
 
 export {
     Definition as Definition,
     OnEventType as OnEventType,
-    TriggerEventType as TriggerEventType,
     Feature as Feature,
     Expose as Expose,
     Numeric as Numeric,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,6 @@ export interface KeyValueAny {[s: string]: any}
 export type Publish = (payload: KeyValue) => void;
 export type OnEventType = 'start' | 'stop' | 'message' | 'deviceJoined' | 'deviceInterview' | 'deviceAnnounce' |
     'deviceNetworkAddressChanged' | 'deviceOptionsChanged';
-export type TriggerEventType = 'devicesChanged';
 export type Access = 0b001 | 0b010 | 0b100 | 0b011 | 0b101 | 0b111;
 export type Expose = exposes.Numeric | exposes.Binary | exposes.Enum | exposes.Composite | exposes.List | exposes.Light | exposes.Switch |
     exposes.Lock | exposes.Cover | exposes.Climate | exposes.Text;
@@ -123,7 +122,6 @@ export type Definition = {
     options?: Option[],
     meta?: DefinitionMeta,
     onEvent?: OnEvent,
-    triggers?: Fz.Trigger[],
     ota?: DefinitionOta,
     generated?: boolean,
 } & ({ zigbeeModel: string[] } | { fingerprint: Fingerprint[] })
@@ -143,18 +141,12 @@ export namespace Fz {
         groupID: number, type: string,
         cluster: string | number, linkquality: number
     }
-    export interface Meta {state: KeyValue, logger: Logger, device: Zh.Device}
+    export interface Meta {state: KeyValue, logger: Logger, device: Zh.Device, deviceExposesChanged: () => void}
     export interface Converter {
         cluster: string | number,
         type: string[] | string,
         options?: Option[] | ((definition: Definition) => Option[]);
         convert: (model: Definition, msg: Message, publish: Publish, options: KeyValue, meta: Fz.Meta) => KeyValueAny | void | Promise<void>;
-    }
-    export interface Trigger {
-        cluster: string | number,
-        attribute: string,
-        event: TriggerEventType,
-        getEvents: (data: KeyValue, device: Zh.Device) => TriggerEventType[] | void;
     }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface KeyValueAny {[s: string]: any}
 export type Publish = (payload: KeyValue) => void;
 export type OnEventType = 'start' | 'stop' | 'message' | 'deviceJoined' | 'deviceInterview' | 'deviceAnnounce' |
     'deviceNetworkAddressChanged' | 'deviceOptionsChanged';
+export type TriggerEventType = 'devicesChanged';
 export type Access = 0b001 | 0b010 | 0b100 | 0b011 | 0b101 | 0b111;
 export type Expose = exposes.Numeric | exposes.Binary | exposes.Enum | exposes.Composite | exposes.List | exposes.Light | exposes.Switch |
     exposes.Lock | exposes.Cover | exposes.Climate | exposes.Text;
@@ -122,6 +123,7 @@ export type Definition = {
     options?: Option[],
     meta?: DefinitionMeta,
     onEvent?: OnEvent,
+    triggers?: Fz.Trigger[],
     ota?: DefinitionOta,
     generated?: boolean,
 } & ({ zigbeeModel: string[] } | { fingerprint: Fingerprint[] })
@@ -147,6 +149,12 @@ export namespace Fz {
         type: string[] | string,
         options?: Option[] | ((definition: Definition) => Option[]);
         convert: (model: Definition, msg: Message, publish: Publish, options: KeyValue, meta: Fz.Meta) => KeyValueAny | void | Promise<void>;
+    }
+    export interface Trigger {
+        cluster: string | number,
+        attribute: string,
+        event: TriggerEventType,
+        getEvents: (data: KeyValue, device: Zh.Device) => TriggerEventType[] | void;
     }
 }
 


### PR DESCRIPTION
When working on the [dynamic exposes](https://github.com/Koenkk/zigbee-herdsman-converters/blob/0e38f1cb1ae7af020ff90aa8cd0574363f00183b/src/devices/bosch.ts#L1335) for the BMCT-SLZ, I noticed that there is currently no way to programmatically trigger an event from inside a zigbee-herdsman-converter (or at least none that I could find). So in order to reevaluate the exposes, either zigbee2mqtt has to be restarted, or an event has to be triggered manually from outside the converters (e.g. by changing a device option). I therefore decided to make the `device_mode` an option, because changing this option leads to an immediate reevaluation of the exposes and immediate update of the exposes in the frontend, Home Assistant, etc.

However, I am not happy with that solution: The `device_mode` is an internal state which can be read from the device, and duplicating this as an option requires keeping them in sync somehow. I would rather directly use the device internal state to determine the exposes, but then, with the current implementation, the exposes would only be updated after a zigbee2mqtt restart. It is not a big thing, but it is still inconvenient and not really intuitive for the user.  

I looked at other devices, and I noticed that many of the other function exposes also use a device internal state to determine their exposes, e.g.:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/0e38f1cb1ae7af020ff90aa8cd0574363f00183b/src/devices/lixee.ts#L700
https://github.com/Koenkk/zigbee-herdsman-converters/blob/0e38f1cb1ae7af020ff90aa8cd0574363f00183b/src/devices/bitron.ts#L237
https://github.com/Koenkk/zigbee-herdsman-converters/blob/0e38f1cb1ae7af020ff90aa8cd0574363f00183b/src/devices/ubisys.ts#L796
https://github.com/Koenkk/zigbee-herdsman-converters/blob/0e38f1cb1ae7af020ff90aa8cd0574363f00183b/src/devices/profalux.ts#L51

That means that also these devices will only have a set of default exposes immediately after joining (when the device state is not read yet), and the correct exposes according to the device state are only available after a z2m restart or after some other event triggers a reevaluation of the exposes.

I therefore suggest to introduce a mechanism to allow converters to trigger events on their own, e.g. if a device internal state changes or a device sends a particular message, etc.. This will probably also be useful for other purposes than the dynamic exposes. 

This PR introduces an new `Trigger` for `fromZigbee` converters, which is similar to the `Converter`, but instead of converting the incoming Zigbee message to a MQTT payload, it triggers a set of predefined events based on the incoming Zigbee message.

The implementation does not interfere with or change any of the existing behavior, and it only gives converters access to some predefined events (currently only `devicesChanged`). For devices that don't have any Triggers in their definition, nothing changes.

The PR also includes an "example" implementation of a `Trigger` for the BMCT-SLZ I mentioned.


The corresponding change that would be required in zigbee2mqtt is here: 
https://github.com/slugzero/zigbee2mqtt/commit/4dcd10eb4b5db2a4bab08d4262043594b5e87907
I will prepare another PR for z2m if this PR is accepted.