### PR TITLE
Partially add Schneider Electric AC Fan module support

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -42,6 +42,14 @@ const tzLocal = {
             await endpoint.read(0xFF17, [0x0000], {manufacturerCode: 0x105e});
         },
     } satisfies Tz.Converter,
+    fan_mode: {
+        ...tz.fan_mode,
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertString(value);
+            if (value.toLowerCase() === 'on') value = 'low';
+            return tz.fan_mode.convertSet(entity, key, value, meta);
+        },
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -473,6 +481,20 @@ const definitions: Definition[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
+        },
+    },
+    {
+        zigbeeModel: ['CHFAN/SWITCH/1'],
+        model: '41ECSFWMZ-VW',
+        vendor: 'Schneider Electric',
+        description: 'Wiser 40/300-Series Module AC Fan Controller',
+        fromZigbee: [fz.fan],
+        toZigbee: [tzLocal.fan_mode],
+        exposes: [e.fan().withModes(['off', 'low', 'medium', 'high', 'on'])],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(7);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['hvacFanCtrl']);
+            await reporting.fanMode(endpoint);
         },
     },
     {


### PR DESCRIPTION
# What?

Add partial support for the Schneider Electric AC Fan module, as discussed in https://github.com/Koenkk/zigbee2mqtt/issues/18620

This patch includes the fan module by Schneider electric in a partial form. All of the practical use-cases of the fan are here and working:
- turning on/off (where on defaults to low speed)
- setting speeds to low, medium or high

What is not included is controlling the LED, this requires a little bit more effort and packet sniffing as the standard endpoint of the other Wiser switches do not work for this particular model and/or firmware.

Further detail is described in the issue linked, good idea to just get something in a working form added and when a packet sniffer is flashed and data inspected we can further enhance this with the LED changes.