### PR TITLE
[New device support]: Tuya TS0601, _TZE204_6fk3gewc - PCIe on/off controller

### DIFF
--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -1,6 +1,11 @@
 import {Definition} from '../lib/types';
 import fz from '../converters/fromZigbee';
+import * as tuya from '../lib/tuya';
 import extend from '../lib/extend';
+import * as exposes from '../lib/exposes';
+
+const e = exposes.presets;
+const ea = exposes.access;
 
 const definitions: Definition[] = [
     {
@@ -11,24 +16,17 @@ const definitions: Definition[] = [
         extend: extend.switch(),
         fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
     },
-        {
-        fingerprint: [
-            {
-                modelID: 'TS0601',
-                manufacturerName: '_TZE204_6fk3gewc',
-            },
-        ],
-        zigbeeModel: ['TS0601'],
-    	model: 'PCI E',
+    {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_6fk3gewc']),
+        model: 'PCI E',
         vendor: 'WETEN',
-        description: 'PC-SWITCH',
+        description: 'PC switch',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
             e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l1').withDescription('PC Power'),
             e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l2').withDescription('Shutdown or Reset? Does not seem to actually do anything'),
-/* if possible would be good to swap the values, as currently on means no buzzer noise. */
             e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l3').withDescription('Buzzer on means no buzzer noise'),
 		    e.binary('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK').withEndpoint('l4').withDescription('Child safety lock'),
 		    e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l5').withDescription('To enable or disable the use of RF remote control, does not seem to actually work'),
@@ -48,7 +46,8 @@ const definitions: Definition[] = [
                 [103, 'state_l6', tuya.valueConverter.onOff],
             ],
         },
-    };    
+    },
 ];
+
 export default definitions;
 module.exports = definitions;

--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -27,11 +27,12 @@ const definitions: Definition[] = [
         configure: tuya.configureMagicPacket,
         exposes: [
             e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l1').withDescription('PC Power'),
-            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l2').withDescription('Power on/off'),
-            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l3').withDescription('Buzzer off/on'),
-    		e.binary('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK').withEndpoint('l4').withDescription('Child safety lock on/off'),
-    		e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l5').withDescription('To enable or disable the use of RF remote control'),
-    		e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l6').withDescription('To pair with a RF 433 remote, such as the one that was supplied')
+            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l2').withDescription('Shutdown or Reset? Does not seem to actually do anything'),
+/* if possible would be good to swap the values, as currently on means no buzzer noise. */
+            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l3').withDescription('Buzzer on means no buzzer noise'),
+		    e.binary('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK').withEndpoint('l4').withDescription('Child safety lock'),
+		    e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l5').withDescription('To enable or disable the use of RF remote control, does not seem to actually work'),
+		    e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l6').withDescription('To pair a RF 433 remote, such as the one supplied')
         ],
         endpoint: (device) => {
             return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1};
@@ -40,7 +41,7 @@ const definitions: Definition[] = [
             multiEndpoint: true,
             tuyaDatapoints: [
                 [1, 'state_l1', tuya.valueConverter.onOff],
-                [105, 'state_l105', tuya.valueConverter.onOff],
+                [105, 'state_l2', tuya.valueConverter.onOff],
                 [104, 'state_l3', tuya.valueConverter.onOff],
                 [106, 'child_lock_l4', tuya.valueConverter.lockUnlock],
                 [102, 'state_l5', tuya.valueConverter.onOff],

--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -11,7 +11,43 @@ const definitions: Definition[] = [
         extend: extend.switch(),
         fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
     },
+        {
+        fingerprint: [
+            {
+                modelID: 'TS0601',
+                manufacturerName: '_TZE204_6fk3gewc',
+            },
+        ],
+        zigbeeModel: ['TS0601'],
+    	model: 'PCI E',
+        vendor: 'WETEN',
+        description: 'PC-SWITCH',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l1').withDescription('PC Power'),
+            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l2').withDescription('Power on/off'),
+            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l3').withDescription('Buzzer off/on'),
+    		e.binary('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK').withEndpoint('l4').withDescription('Child safety lock on/off'),
+    		e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l5').withDescription('To enable or disable the use of RF remote control'),
+    		e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l6').withDescription('To pair with a RF 433 remote, such as the one that was supplied')
+        ],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1};
+        },
+        meta: {
+            multiEndpoint: true,
+            tuyaDatapoints: [
+                [1, 'state_l1', tuya.valueConverter.onOff],
+                [105, 'state_l105', tuya.valueConverter.onOff],
+                [104, 'state_l3', tuya.valueConverter.onOff],
+                [106, 'child_lock_l4', tuya.valueConverter.lockUnlock],
+                [102, 'state_l5', tuya.valueConverter.onOff],
+                [103, 'state_l6', tuya.valueConverter.onOff],
+            ],
+        },
+    };    
 ];
-
 export default definitions;
 module.exports = definitions;

--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -24,17 +24,17 @@ const definitions: Definition[] = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         exposes: [
-            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withDescription('PC Power'),		
+            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withDescription('PC Power'),
             e.binary('buzzer_feedback', ea.STATE_SET, 'ON', 'OFF').withDescription('ON means no buzzer noise'),
-	    e.child_lock(),
-	    e.binary('rf_pairing', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables/disables RF 433 remote pairing mode')
+            e.child_lock(),
+            e.binary('rf_pairing', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables/disables RF 433 remote pairing mode'),
         ],
         meta: {
             tuyaDatapoints: [
                 [1, 'state', tuya.valueConverter.onOff],
-            	[104, 'buzzer_feedback', tuya.valueConverter.onOff],
-            	[106, 'child_lock', tuya.valueConverter.lockUnlock],
-            	[103, 'rf_pairing', tuya.valueConverter.onOff],
+                [104, 'buzzer_feedback', tuya.valueConverter.onOff],
+                [106, 'child_lock', tuya.valueConverter.lockUnlock],
+                [103, 'rf_pairing', tuya.valueConverter.onOff],
             ],
         },
     },

--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -16,34 +16,33 @@ const definitions: Definition[] = [
         extend: extend.switch(),
         fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
     },
+const tzDatapoints = {
+    ...tuya.tz.datapoints,
+        key: ['PC_Power', 'shutdown_reset', 'buzzer', 'child_lock', 'RF', 'pair_RF_remote']
+}
     {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE204_6fk3gewc']),
         model: 'PCI E',
         vendor: 'WETEN',
         description: 'PC switch',
         fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
-        configure: tuya.configureMagicPacket,
+        toZigbee: [tzDatapoints],
         exposes: [
-            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l1').withDescription('PC Power'),
-            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l2').withDescription('Shutdown or Reset? Does not seem to actually do anything'),
-            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l3').withDescription('Buzzer on means no buzzer noise'),
-		    e.binary('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK').withEndpoint('l4').withDescription('Child safety lock'),
-		    e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l5').withDescription('To enable or disable the use of RF remote control, does not seem to actually work'),
-		    e.binary('state', ea.STATE_SET, 'ON', 'OFF').withEndpoint('l6').withDescription('To pair a RF 433 remote, such as the one supplied')
+            e.binary('PC_Power', ea.STATE_SET, 'ON', 'OFF').withDescription('PC Power'),		
+	    e.binary('shutdown_reset', ea.STATE_SET, 'ON', 'OFF').withDescription('Shutdown or Reset? Does not seem to actually do anything'),
+            e.binary('buzzer', ea.STATE_SET, 'ON', 'OFF').withDescription('Buzzer on means no buzzer noise'),
+	    e.binary('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK').withDescription('Child safety lock'),
+	    e.binary('RF', ea.STATE_SET, 'ON', 'OFF').withDescription('To enable or disable the use of RF remote control, does not seem to actually work'),
+	    e.binary('pair_RF_remote', ea.STATE_SET, 'ON', 'OFF').withDescription('To pair a RF 433 remote, such as the one supplied')
         ],
-        endpoint: (device) => {
-            return {'l1': 1, 'l2': 1, 'l3': 1, 'l4': 1, 'l5': 1, 'l6': 1};
-        },
         meta: {
-            multiEndpoint: true,
             tuyaDatapoints: [
-                [1, 'state_l1', tuya.valueConverter.onOff],
-                [105, 'state_l2', tuya.valueConverter.onOff],
-                [104, 'state_l3', tuya.valueConverter.onOff],
-                [106, 'child_lock_l4', tuya.valueConverter.lockUnlock],
-                [102, 'state_l5', tuya.valueConverter.onOff],
-                [103, 'state_l6', tuya.valueConverter.onOff],
+                [1, 'PC_Power', tuya.valueConverter.onOff],
+            	[105, 'shutdown_reset', tuya.valueConverter.onOff],
+            	[104, 'buzzer', tuya.valueConverter.onOff],
+            	[106, 'child_lock', tuya.valueConverter.lockUnlock],
+            	[102, 'RF', tuya.valueConverter.onOff],
+            	[103, 'pair_RF_remote', tuya.valueConverter.onOff],
             ],
         },
     },

--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -26,7 +26,7 @@ const definitions: Definition[] = [
         exposes: [
             e.binary('state', ea.STATE_SET, 'ON', 'OFF').withDescription('PC Power'),		
             e.binary('buzzer_feedback', ea.STATE_SET, 'ON', 'OFF').withDescription('ON means no buzzer noise'),
-	    e.child_lock('child_lock', 'LOCK', 'UNLOCK'),
+	    e.child_lock(),
 	    e.binary('rf_pairing', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables/disables RF 433 remote pairing mode')
         ],
         meta: {

--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -16,33 +16,25 @@ const definitions: Definition[] = [
         extend: extend.switch(),
         fromZigbee: [fz.on_off, fz.ignore_basic_report, fz.ignore_time_read],
     },
-const tzDatapoints = {
-    ...tuya.tz.datapoints,
-        key: ['PC_Power', 'shutdown_reset', 'buzzer', 'child_lock', 'RF', 'pair_RF_remote']
-}
     {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE204_6fk3gewc']),
         model: 'PCI E',
         vendor: 'WETEN',
         description: 'PC switch',
         fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tzDatapoints],
+        toZigbee: [tuya.tz.datapoints],
         exposes: [
-            e.binary('PC_Power', ea.STATE_SET, 'ON', 'OFF').withDescription('PC Power'),		
-	    e.binary('shutdown_reset', ea.STATE_SET, 'ON', 'OFF').withDescription('Shutdown or Reset? Does not seem to actually do anything'),
-            e.binary('buzzer', ea.STATE_SET, 'ON', 'OFF').withDescription('Buzzer on means no buzzer noise'),
-	    e.binary('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK').withDescription('Child safety lock'),
-	    e.binary('RF', ea.STATE_SET, 'ON', 'OFF').withDescription('To enable or disable the use of RF remote control, does not seem to actually work'),
-	    e.binary('pair_RF_remote', ea.STATE_SET, 'ON', 'OFF').withDescription('To pair a RF 433 remote, such as the one supplied')
+            e.binary('state', ea.STATE_SET, 'ON', 'OFF').withDescription('PC Power'),		
+            e.binary('buzzer_feedback', ea.STATE_SET, 'ON', 'OFF').withDescription('ON means no buzzer noise'),
+	    e.child_lock('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK'),
+	    e.binary('rf_pairing', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables/disables RF 433 remote pairing mode')
         ],
         meta: {
             tuyaDatapoints: [
-                [1, 'PC_Power', tuya.valueConverter.onOff],
-            	[105, 'shutdown_reset', tuya.valueConverter.onOff],
-            	[104, 'buzzer', tuya.valueConverter.onOff],
+                [1, 'state', tuya.valueConverter.onOff],
+            	[104, 'buzzer_feedback', tuya.valueConverter.onOff],
             	[106, 'child_lock', tuya.valueConverter.lockUnlock],
-            	[102, 'RF', tuya.valueConverter.onOff],
-            	[103, 'pair_RF_remote', tuya.valueConverter.onOff],
+            	[103, 'rf_pairing', tuya.valueConverter.onOff],
             ],
         },
     },

--- a/src/devices/weten.ts
+++ b/src/devices/weten.ts
@@ -26,7 +26,7 @@ const definitions: Definition[] = [
         exposes: [
             e.binary('state', ea.STATE_SET, 'ON', 'OFF').withDescription('PC Power'),		
             e.binary('buzzer_feedback', ea.STATE_SET, 'ON', 'OFF').withDescription('ON means no buzzer noise'),
-	    e.child_lock('child_lock', ea.STATE_SET, 'LOCK', 'UNLOCK'),
+	    e.child_lock('child_lock', 'LOCK', 'UNLOCK'),
 	    e.binary('rf_pairing', ea.STATE_SET, 'ON', 'OFF').withDescription('Enables/disables RF 433 remote pairing mode')
         ],
         meta: {

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1120,7 +1120,7 @@ const tuyaTz = {
             'ph_max', 'ph_min', 'ec_max', 'ec_min', 'orp_max', 'orp_min', 'free_chlorine_max', 'free_chlorine_min', 'target_distance',
             'illuminance_treshold_max', 'illuminance_treshold_min', 'presence_illuminance_switch', 'light_switch', 'light_linkage',
             'indicator_light', 'find_switch', 'detection_method', 'sensor', 'hysteresis', 'max_temperature_protection', 'display_brightness',
-            'screen_orientation', 'regulator_period', 'regulator_set_point', 'upper_stroke_limit', 'middle_stroke_limit', 'lower_stroke_limit',
+            'screen_orientation', 'regulator_period', 'regulator_set_point', 'upper_stroke_limit', 'middle_stroke_limit', 'lower_stroke_limit', 'buzzer_feedback', 'rf_pairing',
         ],
         convertSet: async (entity, key, value, meta) => {
             // A set converter is only called once; therefore we need to loop

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1120,7 +1120,8 @@ const tuyaTz = {
             'ph_max', 'ph_min', 'ec_max', 'ec_min', 'orp_max', 'orp_min', 'free_chlorine_max', 'free_chlorine_min', 'target_distance',
             'illuminance_treshold_max', 'illuminance_treshold_min', 'presence_illuminance_switch', 'light_switch', 'light_linkage',
             'indicator_light', 'find_switch', 'detection_method', 'sensor', 'hysteresis', 'max_temperature_protection', 'display_brightness',
-            'screen_orientation', 'regulator_period', 'regulator_set_point', 'upper_stroke_limit', 'middle_stroke_limit', 'lower_stroke_limit', 'buzzer_feedback', 'rf_pairing',
+            'screen_orientation', 'regulator_period', 'regulator_set_point', 'upper_stroke_limit', 'middle_stroke_limit', 'lower_stroke_limit',
+            'buzzer_feedback', 'rf_pairing',
         ],
         convertSet: async (entity, key, value, meta) => {
             // A set converter is only called once; therefore we need to loop


### PR DESCRIPTION
Hello. This is my first pull request. This sort of thing currently isn't my strength. There's likely formatting issues but I thought this could at least get things going.
This device has been discussed at https://github.com/Koenkk/zigbee2mqtt/issues/19147
This is the device: https://www.aliexpress.com/item/1005003780124727.html
Based on that here's some info.

 TUYA IoT Platform extracted info
`{"1":"Switch","101":"ModeReset","102":"RF remote control","103":"RF study","104":"buzzer","105":"Relay Status","106":"Child Lock","209":"Cycle Timing","210":"Random Timing"}`

Database entry
`{"id":17,"type":"Router","ieeeAddr":"0xa4c1382e33144c13","nwkAddr":22241,"manufId":4417,"manufName":"_TZE204_6fk3gewc","powerSource":"Mains (single phase)","modelId":"TS0601","epList":[1,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":81,"inClusterList":[4,5,61184,0],"outClusterList":[25,10],"clusters":{"genBasic":{"attributes":{"65503":"\u000e\u0000\u0000\u0000e\u000f\u0000\u0000\u0000\u0012# ,\u0017$ ,\u0013h\u0007\u0000\u0000ei\u0007\u0000\u0000\u0012 ,f ,\u0012","65506":56,"65508":0,"stackVersion":0,"dateCode":"","appVersion":74}}},"binds":[{"cluster":61184,"type":"endpoint","deviceIeeeAddress":"0x040d84fffe512f0c","endpointID":1},{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x040d84fffe512f0c","endpointID":1},{"cluster":7,"type":"endpoint","deviceIeeeAddress":"0x040d84fffe512f0c","endpointID":1}],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":74,"stackVersion":0,"hwVersion":1,"dateCode":"","zclVersion":3,"intervewCompleted":true,"meta":{},"lastSeen":1696294086650,"defaultSendRequestWhen":"immediate"}`

Work had begun on adding it in, but appears no one has made a PR for it yet.
I've tweaked it a bit to try to get it working better. It's not to a point that I'm fully happy with it, but I'm not sure how to get it to where I'd like it, so hoping someone could help tweak it before merging.

This is how it looks
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/44917135/47b49d74-b70c-4850-b6c8-dd0bcce5d5db)

I think maybe datapoint 105 is meant to toggle whether doing PC Power will do a shutdown or reset, but it didn't seem to make a difference. Shutdown always seems to be the action taken. For the buzzer state would be good to reverse the values. Enable or disabling the RF remote datapoint 102 doesn't seem to make a difference. The remote works no matter what. All other values work great.
I didn't add 101:ModeReset 209:Cycle Timing or 210:Random Timing as I'm not sure what those do.

This is how it looks in Home Assistant
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/44917135/e2b12cc7-59f9-4781-9ffb-9f5a44a19c51)

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/44917135/77c00a71-1dc0-4cef-9c0d-b5449ce4c71e)
I'm not sure why attributes are repeated. Would be nice if the buttons themselves could load with better names rather than State l1 etc.

Sorry if this is all quite messy. I'm happy to keep working and testing this. Or I'm happy for it to be re-written.

Regarding getting an image for the device, what's the best method of getting it? There's this image, but it has watermarks: https://ae01.alicdn.com/kf/Sbb2a814eb121481abee645ddc323f6d0m.jpg