### PR TITLE
Added support for Hiladuo blinds sold on Amazon

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2802,7 +2802,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_68nvbio9', '_TZE200_pw7mji0l', '_TZE200_cf1sl3tj', '_TZE200_nw1r9hp6']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_68nvbio9', '_TZE200_pw7mji0l', '_TZE200_cf1sl3tj', '_TZE200_nw1r9hp6', '_TZE200_9p5xmj5r']),
         model: 'TS0601_cover_3',
         vendor: 'TuYa',
         description: 'Cover motor',
@@ -2822,6 +2822,7 @@ const definitions: Definition[] = [
             tuya.whitelabel('Zemismart', 'ZM16EL-03/33', 'Cover motor', ['_TZE200_68nvbio9']),
             tuya.whitelabel('Zemismart', 'ZM25EL', 'Cover motor', ['_TZE200_pw7mji0l']),
             tuya.whitelabel('Zemismart', 'ZM85EL-2Z', 'Roman Rod I type U curtains track', ['_TZE200_cf1sl3tj', '_TZE200_nw1r9hp6']),
+            tuya.whitelabel('Hiladuo', '', 'Motorized Roller Shade', ['_TZE200_9p5xmj5r']),
         ],
         meta: {
             // All datapoints go in here

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2822,7 +2822,7 @@ const definitions: Definition[] = [
             tuya.whitelabel('Zemismart', 'ZM16EL-03/33', 'Cover motor', ['_TZE200_68nvbio9']),
             tuya.whitelabel('Zemismart', 'ZM25EL', 'Cover motor', ['_TZE200_pw7mji0l']),
             tuya.whitelabel('Zemismart', 'ZM85EL-2Z', 'Roman Rod I type U curtains track', ['_TZE200_cf1sl3tj', '_TZE200_nw1r9hp6']),
-            tuya.whitelabel('Hiladuo', 'B09M3R35GC', 'Motorized Roller Shade', ['_TZE200_9p5xmj5r']),
+            tuya.whitelabel('Hiladuo', 'B09M3R35GC', 'Motorized roller shade', ['_TZE200_9p5xmj5r']),
         ],
         meta: {
             // All datapoints go in here

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2822,7 +2822,7 @@ const definitions: Definition[] = [
             tuya.whitelabel('Zemismart', 'ZM16EL-03/33', 'Cover motor', ['_TZE200_68nvbio9']),
             tuya.whitelabel('Zemismart', 'ZM25EL', 'Cover motor', ['_TZE200_pw7mji0l']),
             tuya.whitelabel('Zemismart', 'ZM85EL-2Z', 'Roman Rod I type U curtains track', ['_TZE200_cf1sl3tj', '_TZE200_nw1r9hp6']),
-            tuya.whitelabel('Hiladuo', '', 'Motorized Roller Shade', ['_TZE200_9p5xmj5r']),
+            tuya.whitelabel('Hiladuo', 'B09M3R35GC', 'Motorized Roller Shade', ['_TZE200_9p5xmj5r']),
         ],
         meta: {
             // All datapoints go in here


### PR DESCRIPTION
Added support for Hiladuo blinds sold on Amazon ([link](https://a.co/d/edjIpxs)).

These blinds use a white label Tuya motor and seem to work well with the existing cover_3 configuration. 