### PR TITLE
[Danfoss] Fix hardcoded setpoint limit

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -60,7 +60,7 @@ const definitions: Definition[] = [
                 e.climate().withSetpoint('occupied_heating_setpoint', 5, maxSetpoint, 0.5).withLocalTemperature().withPiHeatingDemand()
                     .withSystemMode(['heat']).withRunningState(['idle', 'heat'], ea.STATE),
                 e.numeric('occupied_heating_setpoint_scheduled', ea.ALL)
-                    .withValueMin(5).withValueMax(32).withValueStep(0.5).withUnit('°C')
+                    .withValueMin(5).withValueMax(maxSetpoint).withValueStep(0.5).withUnit('°C')
                     .withDescription('Scheduled change of the setpoint. Alternative method for changing the setpoint. In the opposite ' +
                       'to occupied_heating_setpoint it does not trigger an aggressive response from the actuator. ' +
                       '(more suitable for scheduled changes)'),


### PR DESCRIPTION
I have a eTRV0100, which I can manually turn up to 35 degrees celsius on the device itself and which has also 35 as a limit for occupied_heating_setpoint in Z2M. However, occupied_heating_setpoint_scheduled has a limit of only 32 in Z2M. Because setting the thermostat to a setpoint in homeassistant changes both occupied_heating_setpoint and occupied_heating_setpoint_scheduled to the same value, setting it to anything higher than 32 results in an error.

I highly assume that occupied_heating_setpoint_scheduled also has a limit of 35 for my device and therefore the hardcoded 32 would be wrong.

Please note: The number 35 is hard coded in lines 264, 273 and 276. Perhaps these should also be changed to maxSetpoint.