### PR TITLE
fix: remove deprecated `sendWhen` from converters

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -2211,7 +2211,7 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'siren_led': 3, 'siren': 2, 'led': 1, 'nothing': 0};
             await entity.write('genBasic', {0x400a: {value: utils.getFromLookup(value, lookup), type: 32}},
-                {manufacturerCode: 0x1168, disableDefaultResponse: true, sendWhen: 'active'});
+                {manufacturerCode: 0x1168, disableDefaultResponse: true});
             return {state: {alert_behaviour: value}};
         },
     } satisfies Tz.Converter,
@@ -4496,12 +4496,11 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             switch (key) {
             case 'sensitivity':
-                await entity.write('ssIasZone', {currentZoneSensitivityLevel: utils.getFromLookup(value, {'low': 0, 'medium': 1, 'high': 2})},
-                    {sendWhen: 'active'});
+                await entity.write('ssIasZone', {currentZoneSensitivityLevel: utils.getFromLookup(value, {'low': 0, 'medium': 1, 'high': 2})});
                 break;
             case 'keep_time':
                 await entity.write('ssIasZone',
-                    {61441: {value: utils.getFromLookup(value, {30: 0, 60: 1, 120: 2}), type: 0x20}}, {sendWhen: 'active'});
+                    {61441: {value: utils.getFromLookup(value, {30: 0, 60: 1, 120: 2}), type: 0x20}});
                 break;
             default: // Unknown key
                 throw new Error(`Unhandled key ${key}`);
@@ -4510,7 +4509,7 @@ const converters2 = {
         convertGet: async (entity, key, meta) => {
             // Apparently, reading values may interfere with a commandStatusChangeNotification for changed occupancy.
             // Therefore, read "zoneStatus" as well.
-            await entity.read('ssIasZone', ['currentZoneSensitivityLevel', 61441, 'zoneStatus'], {sendWhen: 'active'});
+            await entity.read('ssIasZone', ['currentZoneSensitivityLevel', 61441, 'zoneStatus']);
         },
     } satisfies Tz.Converter,
     TS0210_sensitivity: {
@@ -4704,7 +4703,7 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             utils.assertEndpoint(entity);
             const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value, Number);
-            entity.write('hvacUserInterfaceCfg', {keypadLockout}, {sendWhen: 'active'});
+            entity.write('hvacUserInterfaceCfg', {keypadLockout});
             entity.saveClusterAttributeKeyValue('hvacUserInterfaceCfg', {keypadLockout});
             return {state: {keypad_lockout: value}};
         },
@@ -4942,7 +4941,7 @@ const converters2 = {
         key: ['calibrate_valve'],
         convertSet: async (entity, key, value, meta) => {
             await entity.command('hvacThermostat', 'wiserSmartCalibrateValve', {},
-                {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
+                {srcEndpoint: 11, disableDefaultResponse: true});
             return {state: {'calibrate_valve': value}};
         },
     } satisfies Tz.Converter,
@@ -4967,7 +4966,7 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             utils.assertNumber(value);
             entity.write('hvacThermostat', {localTemperatureCalibration: Math.round(value * 10)},
-                {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
+                {srcEndpoint: 11, disableDefaultResponse: true});
             return {state: {local_temperature_calibration: value}};
         },
     } satisfies Tz.Converter,
@@ -4976,7 +4975,7 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value, Number);
             await entity.write('hvacUserInterfaceCfg', {keypadLockout},
-                {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
+                {srcEndpoint: 11, disableDefaultResponse: true});
             return {state: {keypad_lockout: value}};
         },
     } satisfies Tz.Converter,

--- a/src/devices/ctm.ts
+++ b/src/devices/ctm.ts
@@ -99,19 +99,6 @@ const fzLocal = {
             return result;
         },
     } satisfies Fz.Converter,
-    ctm_temperature_offset: {
-        cluster: 'msTemperatureMeasurement',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            const result: KeyValue = {};
-            const data = msg.data;
-            if (data.hasOwnProperty(0x0400)) {
-                result.temperature_offset = data[0x0400];
-            }
-
-            return result;
-        },
-    } satisfies Fz.Converter,
     ctm_thermostat: {
         cluster: 'hvacThermostat',
         type: ['attributeReport', 'readResponse'],
@@ -393,17 +380,6 @@ const tzLocal = {
             await entity.read('genOnOff', [0x5001], {manufacturerCode: 0x1337});
         },
     } satisfies Tz.Converter,
-    ctm_temperature_offset: {
-        key: ['temperature_offset'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('msTemperatureMeasurement',
-                {0x0400: {value: value, type: dataType.int8}}, {manufacturerCode: 0x1337, sendWhen: 'active'});
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('msTemperatureMeasurement', [0x0400], {manufacturerCode: 0x1337, sendWhen: 'active'});
-            await entity.read('msTemperatureMeasurement', ['measuredValue'], {sendWhen: 'active'});
-        },
-    } satisfies Tz.Converter,
     ctm_thermostat: {
         key: ['load', 'display_text', 'sensor', 'regulator_mode', 'power_status', 'system_mode', 'night_switching', 'frost_guard',
             'max_floor_temp', 'regulator_setpoint', 'regulation_mode', 'max_floor_guard', 'weekly_timer', 'exteral_sensor_source',
@@ -569,7 +545,7 @@ const tzLocal = {
     ctm_group_config: {
         key: ['group_id'],
         convertGet: async (entity, key, meta) => {
-            await entity.read(0xFEA7, [0x0000], {manufacturerCode: 0x1337, sendWhen: 'active'});
+            await entity.read(0xFEA7, [0x0000], {manufacturerCode: 0x1337});
         },
     } satisfies Tz.Converter,
     ctm_sove_guard: {

--- a/src/devices/plugwise.ts
+++ b/src/devices/plugwise.ts
@@ -55,7 +55,7 @@ const tzLocal = {
         key: ['calibrate_valve'],
         convertSet: async (entity, key, value, meta) => {
             await entity.command('hvacThermostat', 'plugwiseCalibrateValve', {},
-                {srcEndpoint: 11, disableDefaultResponse: true, sendWhen: 'active'});
+                {srcEndpoint: 11, disableDefaultResponse: true});
             return {state: {'calibrate_valve': value}};
         },
     } satisfies Tz.Converter,

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12,7 +12,7 @@ import {ColorMode, colorModeLookup} from '../lib/constants';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import {KeyValue, Definition, Tz, Fz, Expose, KeyValueAny, KeyValueString} from '../lib/types';
-import {onOff} from '../lib/modernExtend';
+import {onOff, quirkCheckinInterval} from '../lib/modernExtend';
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -1117,6 +1117,7 @@ const definitions: Definition[] = [
         description: 'Motion sensor',
         fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, fz.ignore_basic_report, fz.ZM35HQ_attr, legacy.fromZigbee.ZM35HQ_battery],
         toZigbee: [tz.ZM35HQ_attr],
+        extend: [quirkCheckinInterval(15000)],
         exposes: [e.occupancy(), e.battery_low(), e.battery(),
             e.enum('sensitivity', ea.ALL, ['low', 'medium', 'high']).withDescription('PIR sensor sensitivity'),
             e.enum('keep_time', ea.ALL, [30, 60, 120]).withDescription('PIR keep time in seconds'),
@@ -1133,6 +1134,7 @@ const definitions: Definition[] = [
         description: 'Motion sensor',
         fromZigbee: [fz.ias_occupancy_alarm_1, fz.ignore_basic_report, fz.ZM35HQ_attr, fz.battery],
         toZigbee: [tz.ZM35HQ_attr],
+        extend: [quirkCheckinInterval(15000)],
         exposes: [e.occupancy(), e.battery_low(), e.battery(), e.battery_voltage(),
             e.enum('sensitivity', ea.ALL, ['low', 'medium', 'high']).withDescription('PIR sensor sensitivity'),
             e.enum('keep_time', ea.ALL, [30, 60, 120]).withDescription('PIR keep time in seconds'),
@@ -1154,6 +1156,7 @@ const definitions: Definition[] = [
         description: 'Motion sensor',
         fromZigbee: [fz.ias_occupancy_alarm_1, fz.ignore_basic_report, fz.ZM35HQ_attr, fz.battery],
         toZigbee: [tz.ZM35HQ_attr],
+        extend: [quirkCheckinInterval(15000)],
         exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery(), e.battery_voltage(),
             e.enum('sensitivity', ea.ALL, ['low', 'medium', 'high']).withDescription('PIR sensor sensitivity'),
             e.enum('keep_time', ea.ALL, [30, 60, 120]).withDescription('PIR keep time in seconds'),

--- a/src/lib/ota/common.ts
+++ b/src/lib/ota/common.ts
@@ -289,7 +289,7 @@ function sendQueryNextImageResponse(endpoint: Zh.Endpoint, image: Ota.Image, req
 }
 
 function imageNotify(endpoint: Zh.Endpoint) {
-    return endpoint.commandResponse('genOta', 'imageNotify', {payloadType: 0, queryJitter: 100}, {sendWhen: 'immediate'});
+    return endpoint.commandResponse('genOta', 'imageNotify', {payloadType: 0, queryJitter: 100}, {sendPolicy: 'immediate'});
 }
 
 async function requestOTA(endpoint: Zh.Endpoint): Promise<{payload: Ota.ImageInfo}> {


### PR DESCRIPTION
This PR removes the deprecated `sendWhen` from zigbee-herdsman-converters. This is a mere refactor, devices will all behave the same way as they do since at least the beginning of December.

**Note:**
The following converters/devices made use of `sendWhen=active` and I could not find any information whether they have the genPollCtrl cluster or not. If these devices have the genPollCtrl cluster, everything is fine. If not, it might be worth adding a  `quirkCheckinInterval('1_HOUR')` to improve performance. I cannot tell because I don't own any of these devices, and adding this to devices without knowing might do more harm than good. 

A quick search through open issues did not show up anything and potential issues with these devices should be there since at least beginning of December. So I am just leaving this here in case someone searches for these devices in the future. 

* `LS21001_alert_behaviour`: Linkind A001082 (LS21001)        
* ~~`ZM35HQ_attr`: TuYa TS0202 (ZM-35H-Q, IH012-RT01, IH012-RT02)~~
* `wiser_vact_calibrate_valve`, `wiser_sed_thermostat_keypad_lockout`, `wiser_sed_thermostat_local_temperature_calibration`: Schneider Electric EH-ZB-VACT (EER53000)
* `ctm_group_config`: CTM Lyng mTouch Bryter, mTouch_Astro, mSwitch_Mic (Mikrofon)
* `plugwise_calibrate_valve`: Plugwise 106-03


The Schneider Electric CCTFR6400 also made use of `sendWhen`, but according to https://github.com/Koenkk/zigbee2mqtt/discussions/16951#discussion-4938246, it does have the genPollCtrl Cluster, so it should work fine.