### PR TITLE
Add optional `state_action` for contact sensors

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3908,7 +3908,6 @@ const converters1 = {
         },
     } satisfies Fz.Converter,
     xiaomi_contact: {
-        options: [exposes.options.state_action()],
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -1876,6 +1876,7 @@ const definitions: Definition[] = [
         fromZigbee: [xiaomi.fromZigbee.xiaomi_basic, fz.xiaomi_contact],
         toZigbee: [],
         exposes: [e.battery(), e.contact(), e.device_temperature(), e.battery_voltage(), e.power_outage_count(false)],
+        options: [exposes.options.state_action()],
         configure: async (device) => {
             device.powerSource = 'Battery';
             device.save();


### PR DESCRIPTION
This adds the `state_action` option to contact sensors (disabled by default). If enabled, the sensor publishes an additional 'open'/'close' action every time the contact sensor changes its state.

This is something I am using for a while now in a custom converter, which I think could also be useful for others: When using the contact sensor as trigger to increment counter (e.g. I turned my gas and water utility meters smart with MCCGQ1xLMs), both counting state transitions in the MQTT payload and counting MQTT state messages themselves is inaccurate by 1-5%. The former because every lost device message immediately leads to a lost increment, the latter because regular state reportings would also lead to an unwanted increment. 

Triggering on the edges using `action` allows more elaborate counting, e.g. count all rising edges plus all falling edges when the state was already "closed". With a bit of additional debouncing, I am now getting near-accurate counts.