### PR TITLE
feat: add xiaomiOutageCountRestoreBindReporting extend for Aqara TVOC

### DIFF
--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -17,6 +17,7 @@ import * as xiaomi from '../lib/xiaomi';
 const {
     xiaomiAction, xiaomiOperationMode, xiaomiPowerOnBehavior, xiaomiZigbeeOTA,
     xiaomiSwitchType, aqaraAirQuality, aqaraVoc, aqaraDisplayUnit, xiaomiLight,
+    xiaomiOutageCountRestoreBindReporting,
 } = xiaomi.modernExtend;
 import * as utils from '../lib/utils';
 import {Definition, OnEvent, Fz, KeyValue, Tz} from '../lib/types';
@@ -2899,6 +2900,7 @@ const definitions: Definition[] = [
             temperature(),
             humidity(),
             aqaraDisplayUnit(),
+            xiaomiOutageCountRestoreBindReporting(),
             xiaomiZigbeeOTA(),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -213,6 +213,7 @@ describe('ModernExtend', () => {
                 expect.objectContaining({cluster: 'msTemperatureMeasurement'}),
                 expect.objectContaining({cluster: 'msRelativeHumidity'}),
                 expect.objectContaining({cluster: 'aqaraOpple'}),
+                expect.objectContaining({cluster: 'aqaraOpple'}),
             ],
             toZigbee: ['air_quality', 'voc', 'temperature', 'humidity', 'display_unit'],
             exposes: ['air_quality', 'battery', 'device_temperature', 'display_unit', 'humidity', 'linkquality', 'temperature', 'voc', 'voltage'],


### PR DESCRIPTION
This sensor loses binding and reporting information on a power cycle.

Sadly at least this device does not trigger a deviceAnnounce and will just start sending messages again :(

We can detect when this happens if the power_outage_memory increases, so when this happens we restore both bindings and reporting.