### PR TITLE
Update and rename sprut.ts to wirenboard.ts

### DIFF
--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -253,7 +253,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['WBMSW3'],
         model: 'WB-MSW-ZIGBEE v.3',
-        vendor: 'Sprut.device',
+        vendor: 'Wirenboard',
         description: 'Wall-mounted Zigbee sensor',
         fromZigbee: [fzLocal.temperature, fz.illuminance, fz.humidity, fz.occupancy, fzLocal.occupancy_level, fz.co2, fzLocal.voc,
             fzLocal.noise, fzLocal.noise_detected, fz.on_off, fzLocal.occupancy_timeout, fzLocal.noise_timeout, fzLocal.co2_mh_z19b_config,
@@ -320,7 +320,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['WBMSW4'],
         model: 'WB-MSW-ZIGBEE v.4',
-        vendor: 'Sprut.device',
+        vendor: 'Wirenboard',
         description: 'Wall-mounted Zigbee sensor',
         fromZigbee: [fzLocal.temperature, fz.illuminance, fz.humidity, fz.occupancy, fzLocal.occupancy_level, fz.co2, fzLocal.voc,
             fzLocal.noise, fzLocal.noise_detected, fz.on_off, fzLocal.occupancy_timeout, fzLocal.noise_timeout,


### PR DESCRIPTION
This change is supposed to indicate real manufacturer of the devices in the converter file.

**To clarify**

[WB-MSW-ZIGBEE v.4](https://www.zigbee2mqtt.io/devices/WB-MSW-ZIGBEE_v.4.html) and [WB-MSW-ZIGBEE v.3](https://www.zigbee2mqtt.io/devices/WB-MSW-ZIGBEE_v.3.html) sensors are products of [Wirenboard](https://wirenboard.com/en/product/wb-msw4-zigbee/) company, and not a [Sprut](https://spruthub.ru/device/) company.

Wirenboard is a Russian-based hardware company that makes industrial-grade controllers and sensors.

Sprut is a Russian-based company that makes smart-home hubs for local smart home system deployment. Their hubs have zigbee coordinator.

I assume Sprut employees wrote the original converter to make Wirenboard's devices work with their hardware as maybe their back-end is z2m. But I assure you - the two sensors mentioned in the original file are made by Wirenboard company.

_I couldn't find them in the supported devices list on z2m website using Wirenboard and I hope this change will make it less confusing._

