### PR TITLE
fix(profalux): unable to configure old devices (NSAV061)

### DIFF
--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -88,7 +88,7 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genLevelCtrl']);
-            await reporting.currentPositionLiftPercentage(endpoint);
+            await reporting.brightness(endpoint);
         },
     },
     {


### PR DESCRIPTION
The behavior of this devices has been updated by this commit: https://github.com/Koenkk/zigbee-herdsman-converters/commit/893fa578581d1303741b9e3194377af4a0441a65 but `closuresWindowCovering` isn't exposed for this version of the cover.

