### PR TITLE
Update philips.ts for additional model Being Light

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1507,11 +1507,11 @@ const definitions: Definition[] = [
         extend: [philipsLight({colorTemp: {range: [153, 454]}})],
     },
     {
-        zigbeeModel: ['3261048P6'],
+        zigbeeModel: ['3261048P6', '929003053901'],
         model: '3261048P6',
         vendor: 'Philips',
         description: 'Hue Being aluminium',
-        extend: [philipsLight({colorTemp: {range: undefined}})],
+        extend: [philipsLight({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ['3216431P6'],


### PR DESCRIPTION
Add support for '929003053901' of the Being Alum white ambiance light and change Mired range to 153-454 per spec and light capability.