### PR TITLE
 LYWSD03MMC: add temp/humi callibration, show smile, comfort parameters

### DIFF
--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -10,7 +10,18 @@ import * as constants from '../lib/constants';
 const e = exposes.presets;
 const ea = exposes.access;
 import {getFromLookup, getKey, postfixWithEndpointName, isEndpoint} from '../lib/utils';
-import {light, onOff, batteryPercentage, batteryVoltage, temperature, humidity, enumLookup, binary, numeric, quirkAddEndpointCluster} from '../lib/modernExtend';
+import {
+    light,
+    onOff,
+    batteryPercentage,
+    batteryVoltage,
+    temperature,
+    humidity,
+    enumLookup,
+    binary,
+    numeric,
+    quirkAddEndpointCluster
+} from '../lib/modernExtend';
 
 const switchTypesList = {
     'switch': 0x00,
@@ -1288,13 +1299,13 @@ const definitions: Definition[] = [
                     'msRelativeHumidity',
                     'hvacUserInterfaceCfg',
                 ],
-    
+
             }),
-            batteryPercentage(), 
+            batteryPercentage(),
             batteryVoltage(),
-            temperature({reporting: {min: 10, max: 300, change: 10}}), 
+            temperature({reporting: {min: 10, max: 300, change: 10}}),
             humidity({reporting: {min: 10, max: 300, change: 50}}),
-            // Temperature display and show smile. 
+            // Temperature display and show smile.
             // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/28#issue-2033984519
             enumLookup({
                 name: 'temperature_display_mode',
@@ -1311,7 +1322,7 @@ const definitions: Definition[] = [
                 attribute: 'programmingVisibility',
                 description: 'Whether to show a smile on the device screen.',
             }),
-            // Setting offsets for temperature and humidity. 
+            // Setting offsets for temperature and humidity.
             // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/30
             numeric({
                 name: 'temperature_offset',
@@ -1322,7 +1333,7 @@ const definitions: Definition[] = [
                 valueMax: 12.7,
                 valueStep: 0.1,
                 scale: 10,
-                description: 'Temperature offset, in 0.1° steps. The minimum value is -127 (-12.7°). The maximum value is 127 (+12.7°). Requires v0.1.1.6 or newer.',
+                description: 'Temperature offset, in 0.1° steps. Requires v0.1.1.6 or newer.',
             }),
             numeric({
                 name: 'humidity_offset',
@@ -1333,9 +1344,9 @@ const definitions: Definition[] = [
                 valueMax: 12.7,
                 valueStep: 0.1,
                 scale: 10,
-                description: 'The humidity offset is set in 0.1 % steps. The minimum value is -127 (-12.7 %). The maximum value is 127 (+12.7 %). Requires v0.1.1.6 or newer.',
+                description: 'The humidity offset is set in 0.1 % steps. Requires v0.1.1.6 or newer.',
             }),
-            // Comfort parameters. 
+            // Comfort parameters.
             // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/28#issuecomment-1855763432
             numeric({
                 name: 'comfort_temperature_min',
@@ -1344,7 +1355,7 @@ const definitions: Definition[] = [
                 attribute: {ID: 0x0102, type: 40},
                 valueMin: -127,
                 valueMax: 127,
-                description: 'Comfort parameters/Temperature minimum, in 1° steps, range -127..+127. Requires v0.1.1.7 or newer.',
+                description: 'Comfort parameters/Temperature minimum, in 1° steps. Requires v0.1.1.7 or newer.',
             }),
             numeric({
                 name: 'comfort_temperature_max',
@@ -1353,7 +1364,7 @@ const definitions: Definition[] = [
                 attribute: {ID: 0x0103, type: 40},
                 valueMin: -127,
                 valueMax: 127,
-                description: 'Comfort parameters/Temperature maximum, in 1° steps, range -127..+127. Requires v0.1.1.7 or newer.',
+                description: 'Comfort parameters/Temperature maximum, in 1° steps. Requires v0.1.1.7 or newer.',
             }),
             numeric({
                 name: 'comfort_humidity_min',
@@ -1362,7 +1373,7 @@ const definitions: Definition[] = [
                 attribute: {ID: 0x0104, type: 32},
                 valueMin: 0,
                 valueMax: 100,
-                description: 'Comfort parameters/Humidity minimum, in 1% steps, range 0..100. Requires v0.1.1.7 or newer.',
+                description: 'Comfort parameters/Humidity minimum, in 1% steps. Requires v0.1.1.7 or newer.',
             }),
             numeric({
                 name: 'comfort_humidity_max',

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -10,7 +10,7 @@ import * as constants from '../lib/constants';
 const e = exposes.presets;
 const ea = exposes.access;
 import {getFromLookup, getKey, postfixWithEndpointName, isEndpoint} from '../lib/utils';
-import {light, onOff, batteryPercentage, temperature, humidity, enumLookup, binary, numeric, quirkAddEndpointCluster} from '../lib/modernExtend';
+import {light, onOff, batteryPercentage, batteryVoltage, temperature, humidity, enumLookup, binary, numeric, quirkAddEndpointCluster} from '../lib/modernExtend';
 
 const switchTypesList = {
     'switch': 0x00,

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -14,7 +14,6 @@ import {
     light,
     onOff,
     batteryPercentage,
-    batteryVoltage,
     temperature,
     humidity,
     enumLookup,
@@ -1302,7 +1301,6 @@ const definitions: Definition[] = [
 
             }),
             batteryPercentage(),
-            batteryVoltage(),
             temperature({reporting: {min: 10, max: 300, change: 10}}),
             humidity({reporting: {min: 10, max: 300, change: 50}}),
             // Temperature display and show smile.

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -1312,7 +1312,7 @@ const definitions: Definition[] = [
                 lookup: {'celsius': 0, 'fahrenheit': 1},
                 cluster: 'hvacUserInterfaceCfg',
                 attribute: 'tempDisplayMode',
-                description: 'The units of the temperatur displayed on the device screen.',
+                description: 'The units of the temperature displayed on the device screen.',
             }),
             binary({
                 name: 'show_smile',
@@ -1325,7 +1325,7 @@ const definitions: Definition[] = [
             // Setting offsets for temperature and humidity.
             // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/30
             numeric({
-                name: 'temperature_offset',
+                name: 'temperature_calibration',
                 unit: 'C',
                 cluster: 'hvacUserInterfaceCfg',
                 attribute: {ID: 0x0100, type: 40},
@@ -1333,10 +1333,10 @@ const definitions: Definition[] = [
                 valueMax: 12.7,
                 valueStep: 0.1,
                 scale: 10,
-                description: 'Temperature offset, in 0.1° steps. Requires v0.1.1.6 or newer.',
+                description: 'The temperature calibration, in 0.1° steps. Requires v0.1.1.6 or newer.',
             }),
             numeric({
-                name: 'humidity_offset',
+                name: 'humidity_calibration',
                 unit: '%',
                 cluster: 'hvacUserInterfaceCfg',
                 attribute: {ID: 0x0101, type: 40},
@@ -1382,7 +1382,7 @@ const definitions: Definition[] = [
                 attribute: {ID: 0x0105, type: 32},
                 valueMin: 0,
                 valueMax: 100,
-                description: 'Comfort parameters/Humidity maximum, in 1% steps, range 0..100. Requires v0.1.1.7 or newer.',
+                description: 'Comfort parameters/Humidity maximum, in 1% steps. Requires v0.1.1.7 or newer.',
             }),
         ],
         ota: ota.zigbeeOTA,

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -1298,7 +1298,6 @@ const definitions: Definition[] = [
                     'msRelativeHumidity',
                     'hvacUserInterfaceCfg',
                 ],
-
             }),
             batteryPercentage(),
             temperature({reporting: {min: 10, max: 300, change: 10}}),

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -20,7 +20,7 @@ import {
     enumLookup,
     binary,
     numeric,
-    quirkAddEndpointCluster
+    quirkAddEndpointCluster,
 } from '../lib/modernExtend';
 
 const switchTypesList = {

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -10,7 +10,7 @@ import * as constants from '../lib/constants';
 const e = exposes.presets;
 const ea = exposes.access;
 import {getFromLookup, getKey, postfixWithEndpointName, isEndpoint} from '../lib/utils';
-import {light, onOff} from '../lib/modernExtend';
+import {light, onOff, batteryPercentage, temperature, humidity, enumLookup, binary, numeric, quirkAddEndpointCluster} from '../lib/modernExtend';
 
 const switchTypesList = {
     'switch': 0x00,
@@ -1276,21 +1276,103 @@ const definitions: Definition[] = [
         model: 'LYWSD03MMC',
         vendor: 'Custom devices (DiY)',
         description: 'Xiaomi temperature & humidity sensor with custom firmware',
-        fromZigbee: [fz.temperature, fz.humidity, fz.battery, fz.hvac_user_interface],
-        toZigbee: [tz.thermostat_temperature_display_mode],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            const bindClusters = ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg'];
-            await reporting.bind(endpoint, coordinatorEndpoint, bindClusters);
-            await reporting.temperature(endpoint, {min: 10, max: 300, change: 10});
-            await reporting.humidity(endpoint, {min: 10, max: 300, change: 50});
-            await reporting.batteryVoltage(endpoint);
-            await reporting.batteryPercentageRemaining(endpoint);
-        },
-        exposes: [
-            e.temperature(), e.humidity(), e.battery(),
-            e.enum('temperature_display_mode', ea.ALL, ['celsius', 'fahrenheit'])
-                .withDescription('The temperature format displayed on the screen'),
+        extend: [
+            quirkAddEndpointCluster({
+                endpointID: 1,
+                outputClusters: [
+                    'hvacUserInterfaceCfg',
+                ],
+                inputClusters: [
+                    'genPowerCfg',
+                    'msTemperatureMeasurement',
+                    'msRelativeHumidity',
+                    'hvacUserInterfaceCfg',
+                ],
+    
+            }),
+            batteryPercentage(), 
+            batteryVoltage(),
+            temperature({reporting: {min: 10, max: 300, change: 10}}), 
+            humidity({reporting: {min: 10, max: 300, change: 50}}),
+            // Temperature display and show smile. 
+            // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/28#issue-2033984519
+            enumLookup({
+                name: 'temperature_display_mode',
+                lookup: {'celsius': 0, 'fahrenheit': 1},
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: 'tempDisplayMode',
+                description: 'The units of the temperatur displayed on the device screen.',
+            }),
+            binary({
+                name: 'show_smile',
+                valueOn: ['HIDE', 1],
+                valueOff: ['SHOW', 0],
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: 'programmingVisibility',
+                description: 'Whether to show a smile on the device screen.',
+            }),
+            // Setting offsets for temperature and humidity. 
+            // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/30
+            numeric({
+                name: 'temperature_offset',
+                unit: 'C',
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: {ID: 0x0100, type: 40},
+                valueMin: -12.7,
+                valueMax: 12.7,
+                valueStep: 0.1,
+                scale: 10,
+                description: 'Temperature offset, in 0.1° steps. The minimum value is -127 (-12.7°). The maximum value is 127 (+12.7°). Requires v0.1.1.6 or newer.',
+            }),
+            numeric({
+                name: 'humidity_offset',
+                unit: '%',
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: {ID: 0x0101, type: 40},
+                valueMin: -12.7,
+                valueMax: 12.7,
+                valueStep: 0.1,
+                scale: 10,
+                description: 'The humidity offset is set in 0.1 % steps. The minimum value is -127 (-12.7 %). The maximum value is 127 (+12.7 %). Requires v0.1.1.6 or newer.',
+            }),
+            // Comfort parameters. 
+            // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/28#issuecomment-1855763432
+            numeric({
+                name: 'comfort_temperature_min',
+                unit: 'C',
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: {ID: 0x0102, type: 40},
+                valueMin: -127,
+                valueMax: 127,
+                description: 'Comfort parameters/Temperature minimum, in 1° steps, range -127..+127. Requires v0.1.1.7 or newer.',
+            }),
+            numeric({
+                name: 'comfort_temperature_max',
+                unit: 'C',
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: {ID: 0x0103, type: 40},
+                valueMin: -127,
+                valueMax: 127,
+                description: 'Comfort parameters/Temperature maximum, in 1° steps, range -127..+127. Requires v0.1.1.7 or newer.',
+            }),
+            numeric({
+                name: 'comfort_humidity_min',
+                unit: '%',
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: {ID: 0x0104, type: 32},
+                valueMin: 0,
+                valueMax: 100,
+                description: 'Comfort parameters/Humidity minimum, in 1% steps, range 0..100. Requires v0.1.1.7 or newer.',
+            }),
+            numeric({
+                name: 'comfort_humidity_max',
+                unit: '%',
+                cluster: 'hvacUserInterfaceCfg',
+                attribute: {ID: 0x0105, type: 32},
+                valueMin: 0,
+                valueMax: 100,
+                description: 'Comfort parameters/Humidity maximum, in 1% steps, range 0..100. Requires v0.1.1.7 or newer.',
+            }),
         ],
         ota: ota.zigbeeOTA,
     },

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -685,19 +685,6 @@ export function batteryPercentage(args?: Partial<NumericArgs>) {
     });
 }
 
-export function batteryVoltage(args?: Partial<NumericArgs>) {
-    return numeric({
-        name: 'battery_voltage',
-        cluster: 'genPowerCfg',
-        attribute: 'batteryVoltage',
-        reporting: {min: '1_HOUR', max: 'MAX', change: 10},
-        description: 'Voltage of the battery in millivolts',
-        unit: 'mV',
-        access: 'STATE_GET',
-        ...args,
-    });
-}
-
 export function pressure(args?: Partial<NumericArgs>): ModernExtend {
     return numeric({
         name: 'pressure',

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -687,13 +687,12 @@ export function batteryPercentage(args?: Partial<NumericArgs>) {
 
 export function batteryVoltage(args?: Partial<NumericArgs>) {
     return numeric({
-        name: 'battery',
+        name: 'battery_voltage',
         cluster: 'genPowerCfg',
         attribute: 'batteryVoltage',
         reporting: {min: '1_HOUR', max: 'MAX', change: 10},
-        description: 'Remaining battery in %',
-        unit: '%',
-        scale: 2,
+        description: 'Voltage of the battery in millivolts',
+        unit: 'mV',
         access: 'STATE_GET',
         ...args,
     });

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -685,6 +685,20 @@ export function batteryPercentage(args?: Partial<NumericArgs>) {
     });
 }
 
+export function batteryVoltage(args?: Partial<NumericArgs>) {
+    return numeric({
+        name: 'battery',
+        cluster: 'genPowerCfg',
+        attribute: 'batteryVoltage',
+        reporting: {min: '1_HOUR', max: 'MAX', change: 10},
+        description: 'Remaining battery in %',
+        unit: '%',
+        scale: 2,
+        access: 'STATE_GET',
+        ...args,
+    });
+}
+
 export function pressure(args?: Partial<NumericArgs>): ModernExtend {
     return numeric({
         name: 'pressure',


### PR DESCRIPTION
Hello,

I would like to add the following parameters:
* show_smile - Whether to show a smile on the device screen.
* temperature_offset - Temperature offset, in 0.1° steps
* humidity_offset - The humidity offset is set in 0.1 % steps.
* Comfort parameters

I am particularly interested in the offset configuration attributes, as I have 10 devices and I would like to calibrate them so that they return similar values.


I tested this on v.1.35.1-1 as custom converter: 
```js
const {Zcl} = require('zigbee-herdsman');
const {batteryPercentage, temperature, humidity, enumLookup, binary, numeric} = require('zigbee-herdsman-converters/lib/modernExtend');
const {isString} = require('zigbee-herdsman-converters/lib/utils');


function quirkAddEndpointCluster(args) {
    const {inputClusters, outputClusters} = args;

    const configure = async (device, coordinatorEndpoint, logger) => { 
        const endpoint = device.getEndpoint(1);
        inputClusters?.forEach((cluster) => {
            const clusterID = isString(cluster) ?
                Zcl.Utils.getCluster(cluster, device.manufacturerID).ID :
                cluster;

            if (!endpoint.inputClusters.includes(clusterID)) {
                endpoint.inputClusters.push(clusterID);
            }
        });

        outputClusters?.forEach((cluster) => {
            const clusterID = isString(cluster) ?
                Zcl.Utils.getCluster(cluster, device.manufacturerID).ID :
                cluster;

            if (!endpoint.outputClusters.includes(clusterID)) {
                endpoint.outputClusters.push(clusterID);
            }
        });

        device.save();
    }; 

    return {configure, isModernExtend: true}; 
} 

const definition = {
    zigbeeModel: ['LYWSD03MMC'],
    model: 'LYWSD03MMC (CUSTOM)',
    vendor: 'Xiaomi (CUSTOM)',
    description: 'Xiaomi temperature & humidity sensor with custom firmware',
    extend: [
        quirkAddEndpointCluster({
            endpointID: 1,
            outputClusters: [
                'hvacUserInterfaceCfg',
            ],
            inputClusters: [
                'genPowerCfg',
                'msTemperatureMeasurement',
                'msRelativeHumidity',
                'hvacUserInterfaceCfg',
            ],
        }),
        batteryPercentage(), 
        temperature({reporting: {min: 10, max: 300, change: 10}}), 
        humidity({reporting: {min: 10, max: 300, change: 50}}),
        // Temperature display and show smile.
        // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/28#issue-2033984519
        enumLookup({
            name: 'temperature_display_mode',
            lookup: {'celsius': 0, 'fahrenheit': 1},
            cluster: 'hvacUserInterfaceCfg',
            attribute: 'tempDisplayMode',
            description: 'The units of the temperature displayed on the device screen.',
        }),
        binary({
            name: 'show_smile',
            valueOn: ['HIDE', 1],
            valueOff: ['SHOW', 0],
            cluster: 'hvacUserInterfaceCfg',
            attribute: 'programmingVisibility',
            description: 'Whether to show a smile on the device screen.',
        }),
        // Setting offsets for temperature and humidity.
        // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/30
        numeric({
            name: 'temperature_calibration',
            unit: 'C',
            cluster: 'hvacUserInterfaceCfg',
            attribute: {ID: 0x0100, type: 40},
            valueMin: -12.7,
            valueMax: 12.7,
            valueStep: 0.1,
            scale: 10,
            description: 'The temperature calibration, in 0.1° steps. Requires v0.1.1.6 or newer.',
        }),
        numeric({
            name: 'humidity_calibration',
            unit: '%',
            cluster: 'hvacUserInterfaceCfg',
            attribute: {ID: 0x0101, type: 40},
            valueMin: -12.7,
            valueMax: 12.7,
            valueStep: 0.1,
            scale: 10,
            description: 'The humidity offset is set in 0.1 % steps. Requires v0.1.1.6 or newer.',
        }),
        // Comfort parameters.
        // For details, see: https://github.com/pvvx/ZigbeeTLc/issues/28#issuecomment-1855763432
        numeric({
            name: 'comfort_temperature_min',
            unit: 'C',
            cluster: 'hvacUserInterfaceCfg',
            attribute: {ID: 0x0102, type: 40},
            valueMin: -127,
            valueMax: 127,
            description: 'Comfort parameters/Temperature minimum, in 1° steps. Requires v0.1.1.7 or newer.',
        }),
        numeric({
            name: 'comfort_temperature_max',
            unit: 'C',
            cluster: 'hvacUserInterfaceCfg',
            attribute: {ID: 0x0103, type: 40},
            valueMin: -127,
            valueMax: 127,
            description: 'Comfort parameters/Temperature maximum, in 1° steps. Requires v0.1.1.7 or newer.',
        }),
        numeric({
            name: 'comfort_humidity_min',
            unit: '%',
            cluster: 'hvacUserInterfaceCfg',
            attribute: {ID: 0x0104, type: 32},
            valueMin: 0,
            valueMax: 100,
            description: 'Comfort parameters/Humidity minimum, in 1% steps. Requires v0.1.1.7 or newer.',
        }),
        numeric({
            name: 'comfort_humidity_max',
            unit: '%',
            cluster: 'hvacUserInterfaceCfg',
            attribute: {ID: 0x0105, type: 32},
            valueMin: 0,
            valueMax: 100,
            description: 'Comfort parameters/Humidity maximum, in 1% steps. Requires v0.1.1.7 or newer.',
        }),
    ],
    // ota: ota.zigbeeOTA,
};

module.exports = definition;
```

It looks like the following in the UI:
![Screenshot 2024-01-21 at 04 35 35](https://github.com/Koenkk/zigbee-herdsman-converters/assets/120908425/824d7526-5886-4626-af33-c840fe18f11a)

