### PR TITLE
Fix for showing 50% battery instead of 100%

### DIFF
--- a/src/devices/onesti.ts
+++ b/src/devices/onesti.ts
@@ -66,6 +66,7 @@ const definitions: Definition[] = [
             fz.easycodetouch_action],
         toZigbee: [tz.lock, tz.easycode_auto_relock, tz.lock_sound_volume, tz.pincode_lock],
         meta: {pinCodeCount: 1000},
+        meta: {battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(11);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);

--- a/src/devices/onesti.ts
+++ b/src/devices/onesti.ts
@@ -65,8 +65,7 @@ const definitions: Definition[] = [
         fromZigbee: [fzLocal.nimly_pro_lock_actions, fz.lock, fz.lock_operation_event, fz.battery, fz.lock_programming_event,
             fz.easycodetouch_action],
         toZigbee: [tz.lock, tz.easycode_auto_relock, tz.lock_sound_volume, tz.pincode_lock],
-        meta: {pinCodeCount: 1000},
-        meta: {battery: {dontDividePercentage: true}},
+        meta: {pinCodeCount: 1000, battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(11);
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);


### PR DESCRIPTION
Onesti (nimly) does not seem to comply to the ZCL and report a batteryPercentageRemaining of 100 when the battery is full (should be 200).