### PR TITLE
Add support for Linkoze/Adaprox LKWSZ211 scene button

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -664,8 +664,8 @@ const definitions: Definition[] = [
             ],
         },
         whiteLabel: [
-            tuya.whitelabel('Linkoze', 'LKWSZ211', 'Wireless Switch (2-Key)', ['_TZ3210_3ulg9kpo']),
-            tuya.whitelabel('Adaprox', 'LKWSZ211', 'Remote Wireless Switch (2-Key)', ['_TZ3210_3ulg9kpo']),
+            tuya.whitelabel('Linkoze', 'LKWSZ211', 'Wireless switch (2-key)', ['_TZ3210_3ulg9kpo']),
+            tuya.whitelabel('Adaprox', 'LKWSZ211', 'Remote wireless switch (2-key)', ['_TZ3210_3ulg9kpo']),
         ],
     },
     {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -628,6 +628,47 @@ const definitions: Definition[] = [
         ],
     },
     {
+        fingerprint: [
+            {modelID: 'TS0021', manufacturerName: '_TZ3210_3ulg9kpo'},
+            {modelID: 'TS0042', manufacturerName: '_TZ3000_kt7obmnn'},
+        ],
+        model: 'LKWSZ211',
+        vendor: 'TuYa',
+        description: 'Scene remote with 2 keys',
+        fromZigbee: [tuya.fz.datapoints, fz.ignore_basic_report],
+        toZigbee: [tuya.tz.datapoints],
+        onEvent: tuya.onEventSetTime,
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.action([
+                'button_1_single', 'button_1_double', 'button_1_hold',
+                'button_2_single', 'button_2_double', 'button_2_hold',
+            ]),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'action',
+                    tuya.valueConverterBasic.lookup({
+                        'button_1_single': tuya.enum(0),
+                        'button_1_double': tuya.enum(1),
+                        'button_1_hold': tuya.enum(2),
+                    }),
+                ],
+                [2, 'action',
+                    tuya.valueConverterBasic.lookup({
+                        'button_2_single': tuya.enum(0),
+                        'button_2_double': tuya.enum(1),
+                        'button_2_hold': tuya.enum(2),
+                    }),
+                ],
+            ],
+        },
+        whiteLabel: [
+            tuya.whitelabel('Linkoze', 'LKWSZ211', 'Wireless Switch (2-Key)', ['_TZ3210_3ulg9kpo']),
+            tuya.whitelabel('Adaprox', 'LKWSZ211', 'Remote Wireless Switch (2-Key)', ['_TZ3210_3ulg9kpo']),
+        ],
+    },
+    {
         fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_bq5c8xfe'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_bjawzodf'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_qyflbnbj'},


### PR DESCRIPTION
### PR contents
Add support for TuYa-complaint `Linkoze LKWSZ211` Zigbee scene switcher with 2 buttons. This seems to be the OEM name. Official manual is available in english at https://www.meshhub.com/manuals/lkwsz211-en

### Other names
The same device is also white-labeled under `Adaprox` brand as [`Wireless Switch (2-Key)`](https://www.adaprox.io/products/linkoze-wireless-switch-2-key?variant=41178716700877) (especially in Europe, e.g. in Poland sold by a large e-retailer [Kamami](https://kamami.pl/automatyka-domowa/1184385-lkwsz211-bezprzewodowy-przelacznik-zigbee.html)).

My unit was originally sourced from the listing [`Tuya Smart WiFi/Zigbee Switch Push Button Switch 2Gang 6 Scene Wireless Smart Home Remote Controller Automation Scenario Switch`](https://a.aliexpress.com/_mM3HCf6).

### Other versions
The device is also sometimes advertised under `LKWSW201`, but the `...201` model is actually the WiFi version of the same switch (adding here for searchability).

### Battery status
There's no battery status support, or it's broken on both of my units. Even with low battery, as tested with a variable power supply, the device sends datapoint at 10, but with data always being 0s. Once the batteries are too low the device simply doesn't send anything/dies.


### Related PRs
As per [Zigbee2MQTT instruction](https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html) I also added PR with image. See https://github.com/Koenkk/zigbee2mqtt.io/pull/2515