### PR TITLE
Add LEDVANCE Biolux HCL Panel

### DIFF
--- a/src/devices/ledvance.ts
+++ b/src/devices/ledvance.ts
@@ -43,7 +43,7 @@ const definitions: Definition[] = [
         model: '4058075724587',
         vendor: 'LEDVANCE',
         description: 'Biolux HCL Panel 1200 Zigbee tunable white',
-        extend: [(0, ledvance_1.ledvanceLight)({ colorTemp: { range: [153, 370] } })],
+        extend: [ledvanceLight({colorTemp: {range: [153, 370]}})],
     },
     {
         zigbeeModel: ['A60 RGBW Value II'],

--- a/src/devices/ledvance.ts
+++ b/src/devices/ledvance.ts
@@ -39,6 +39,13 @@ const definitions: Definition[] = [
         extend: [ledvanceLight({colorTemp: {range: [153, 370]}, color: true})],
     },
     {
+        zigbeeModel: ['PL HCL300x1200 01'],
+        model: '4058075724587',
+        vendor: 'LEDVANCE',
+        description: 'Biolux HCL Panel 1200 Zigbee tunable white',
+        extend: [(0, ledvance_1.ledvanceLight)({ colorTemp: { range: [153, 370] } })],
+    },
+    {
         zigbeeModel: ['A60 RGBW Value II'],
         model: 'AC25697',
         vendor: 'LEDVANCE',


### PR DESCRIPTION
I could test this in iobroker, but sadly I just can't get zigbee2mqtt running standalone with my Sonoff ZDongle-P 
so I couldn't properly follow https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html

So this will be a draft for now, I guess.

The full product name is: BIOLUX HCL PL 1200 S 37W TW ZB

Product page: https://www.ledvance.de/professional/produkte/leuchten/leuchten-fur-professionelle-anwendung/biolux-human-centric-lighting-hcl/einlege-leuchten--tunable-white-mit-dali-2-oder-zigbee-30-technologie/einlege-leuchten--tunbale-white--110-lmw--werkzeuglose-montage--zigbee-30-c237878?productId=227902

This is the information I get in iobroker:
![Bildschirmfoto vom 2024-01-24 02-15-43](https://github.com/Koenkk/zigbee-herdsman-converters/assets/28605587/b0d5ea26-b515-4ab9-aabe-45f5b6c5eae6)

Note: Just because that information is a bit hard to find, to reset this panel (or rather, the driver box) you turn it off for 5s, then turn it on for 5s, and repeat that 5 times
