### PR TITLE
fix: Ubisys H1 - remote_tempeature is not useful

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -912,7 +912,6 @@ const definitions: Definition[] = [
             ubisysModernExtend.vacationMode(),
             ubisysModernExtend.localTemperatureOffset(),
             ubisysModernExtend.occupiedHeatingSetpointDefault(),
-            ubisysModernExtend.remoteTemperature(),
             ubisysModernExtend.remoteTemperatureDuration(),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -29,17 +29,6 @@ export const ubisysModernExtend = {
         unit: 'ºC',
         ...args,
     }),
-    remoteTemperature: (args?: Partial<NumericArgs>) => numeric({
-        name: 'remote_temperature',
-        cluster: 'hvacThermostat',
-        attribute: 'ubisysRemoteTemperature',
-        description: 'Indicates the remotely measured temperature value, accessible through attribute reports. ' +
-            'For heating regulation, a received remote temperature value, as long as valid, takes precedence over the locally measured one.',
-        scale: 100,
-        unit: 'ºC',
-        access: 'STATE_GET',
-        ...args,
-    }),
     remoteTemperatureDuration: (args?: Partial<NumericArgs>) => numeric({
         name: 'remote_temperature_duration',
         cluster: 'hvacThermostat',


### PR DESCRIPTION
I noticed the attribtute was not reportable making it kind of useless. And local_temp still had the local value making it hard to get up to date values for the temperature the TRV was working off.

In the next minor fw update they will fix this.

```
> I also got remote temperature binding working fine with zigbee2mqtt, I did notice that the custom remote temperature attribute does not support reporting unlike the local temperature variant. It would be nice if the remote temperature one would also support reporting.

With the next firmware we made a change, so that the LocalTemperature attribute consistently reflects the value of a remote temperature measurement when available, the overall outcome is equivalent to having the remote temperature as reportable.
```

Since remote_temperature is mostly useless and they are gonna update local_temperature in the next release, we can simple remove it.