### PR TITLE
IKEA: fix restoration of levelConfig.on_level

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -58,7 +58,7 @@ const bulbOnEvent: OnEvent = async (type, data, device, options, state: KeyValue
             if (onLevel > 255) onLevel = 254;
             if (onLevel < 1) onLevel = 1;
 
-            device.endpoints[0].write('genLevelCtrl', {onLevel: onLevelRaw});
+            device.endpoints[0].write('genLevelCtrl', {onLevel: onLevel});
         }
     }
 };


### PR DESCRIPTION
I noticed that after losing power, the Tradfri driver (ICPSHC24-10EU-IL-1) didn't properly restore the on_level property.
Should fix https://github.com/Koenkk/zigbee2mqtt/issues/19211.
It looks to me like a typo in a refactor mentioned in this comment: https://github.com/Koenkk/zigbee2mqtt/issues/19211#issuecomment-1765932843