### PR TITLE
fix: correct scaling on Ubisys H1 local temperature offset

### DIFF
--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -9,10 +9,10 @@ export const ubisysModernExtend = {
         cluster: 'hvacThermostat',
         attribute: 'ubisysTemperatureOffset',
         description: 'Specifies the temperature offset for the locally measured temperature value.',
-        scale: 100,
+        scale: 10,
         valueStep: 0.5, // H1 interface uses 0.5 step
-        valueMin: -10,
-        valueMax: 10,
+        valueMin: -12.5,
+        valueMax: 12.5,
         unit: 'ºC',
         ...args,
     }),

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -9,10 +9,8 @@ export const ubisysModernExtend = {
         cluster: 'hvacThermostat',
         attribute: 'ubisysTemperatureOffset',
         description: 'Specifies the temperature offset for the locally measured temperature value.',
-        scale: 10,
-        valueStep: 0.5, // H1 interface uses 0.5 step
-        valueMin: -12.5,
-        valueMax: 12.5,
+        valueMin: -10,
+        valueMax: 10,
         unit: 'ºC',
         ...args,
     }),


### PR DESCRIPTION
Should fix https://github.com/Koenkk/zigbee2mqtt/issues/20962, did not hear back from Ubisys on this one. But will verify with the display when I get home if they line up.

Will leave it in draft until I can verify.