### PR TITLE
[Feature] Add energy support for GS (HEIMAN) SKHMP30-I1

### DIFF
--- a/src/devices/gs.ts
+++ b/src/devices/gs.ts
@@ -1,6 +1,7 @@
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
+import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import {light} from '../lib/modernExtend';
 
@@ -27,6 +28,30 @@ const definitions: Definition[] = [
         vendor: 'GS',
         description: 'Smart dimmable, RGB + white (E27 & B22)',
         extend: [light({colorTemp: {range: undefined}, color: true})],
+    },
+    {
+        zigbeeModel: ['SKHMP30-I1'],
+        model: 'SKHMP30-I1',
+        description: 'Smart metering plug',
+        vendor: 'GS',
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
+        toZigbee: [tz.on_off],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
+            await reporting.onOff(endpoint);
+            await reporting.rmsVoltage(endpoint);
+            await reporting.rmsCurrent(endpoint);
+            await reporting.activePower(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint);
+            endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
+                acVoltageMultiplier: 1, acVoltageDivisor: 100,
+                acCurrentMultiplier: 1, acCurrentDivisor: 100,
+                acPowerMultiplier: 1, acPowerDivisor: 10,
+            });
+        },
     },
 ];
 

--- a/src/devices/gs.ts
+++ b/src/devices/gs.ts
@@ -1,9 +1,8 @@
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
-import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
-import {light} from '../lib/modernExtend';
+import {light, onOff, electricityMeter} from '../lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -34,24 +33,7 @@ const definitions: Definition[] = [
         model: 'SKHMP30-I1',
         description: 'Smart metering plug',
         vendor: 'GS',
-        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
-        toZigbee: [tz.on_off],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
-            await reporting.onOff(endpoint);
-            await reporting.rmsVoltage(endpoint);
-            await reporting.rmsCurrent(endpoint);
-            await reporting.activePower(endpoint);
-            await reporting.readMeteringMultiplierDivisor(endpoint);
-            await reporting.currentSummDelivered(endpoint);
-            endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
-                acVoltageMultiplier: 1, acVoltageDivisor: 100,
-                acCurrentMultiplier: 1, acCurrentDivisor: 100,
-                acPowerMultiplier: 1, acPowerDivisor: 10,
-            });
-        },
+        extend: [onOff({powerOnBehavior: false}), electricityMeter()],
     },
 ];
 

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -374,7 +374,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['SKHMP30-I1'],
         model: 'SKHMP30-I1',
         description: 'Smart metering plug',
-        vendor: 'HEIMAN',
+        vendor: 'GS',
         fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
         toZigbee: [tz.on_off],

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -371,30 +371,6 @@ const definitions: Definition[] = [
         exposes: [e.temperature(), e.humidity(), e.battery()],
     },
     {
-        zigbeeModel: ['SKHMP30-I1'],
-        model: 'SKHMP30-I1',
-        description: 'Smart metering plug',
-        vendor: 'GS',
-        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
-        toZigbee: [tz.on_off],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
-            await reporting.onOff(endpoint);
-            await reporting.rmsVoltage(endpoint);
-            await reporting.rmsCurrent(endpoint);
-            await reporting.activePower(endpoint);
-            await reporting.readMeteringMultiplierDivisor(endpoint);
-            await reporting.currentSummDelivered(endpoint);
-            endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
-                acVoltageMultiplier: 1, acVoltageDivisor: 100,
-                acCurrentMultiplier: 1, acCurrentDivisor: 100,
-                acPowerMultiplier: 1, acPowerDivisor: 10,
-            });
-        },
-    },
-    {
         zigbeeModel: ['E_Socket'],
         model: 'HS2ESK-E',
         vendor: 'HEIMAN',

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -375,16 +375,18 @@ const definitions: Definition[] = [
         model: 'SKHMP30-I1',
         description: 'Smart metering plug',
         vendor: 'HEIMAN',
-        fromZigbee: [fz.on_off, fz.electrical_measurement],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage()],
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
         toZigbee: [tz.on_off],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
             await reporting.rmsVoltage(endpoint);
             await reporting.rmsCurrent(endpoint);
             await reporting.activePower(endpoint);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint);
             endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
                 acVoltageMultiplier: 1, acVoltageDivisor: 100,
                 acCurrentMultiplier: 1, acCurrentDivisor: 100,


### PR DESCRIPTION
Found out that `SKHMP30-I1` has standard `seMetering` cluster and can report energy readings. I've verified the numbers and they are at least as accurate as provided power measurements.

Also replaced `vendor` from `HEIMAN` to `GS` as it is a white label device and `GS` vendor already [exists](https://www.zigbee2mqtt.io/supported-devices/#v=GS) in a database.

## TODO

- [x] add energy
- [x] observe and verify energy readings
- [x] refactor as GS device
- [x] convert to modernExtend
