### PR TITLE
[Hotfix] Return detection_interval for Aqara RTCGQ14LM

### DIFF
--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -1748,6 +1748,7 @@ const definitions: Definition[] = [
             e.illuminance().withUnit('lx').withDescription('Measured illuminance in lux'),
             e.motion_sensitivity_select(['low', 'medium', 'high'])
                 .withDescription('Select motion sensitivity to use. Press pairing button right before changing this otherwise it will fail.'),
+            e.detection_interval().withDescription('Time interval between action detection. Press pairing button right before changing this otherwise it will fail.'),
             e.trigger_indicator().withDescription('When this option is enabled then ' +
                 'blue LED will blink once when motion is detected. ' +
                 'Press pairing button right before changing this otherwise it will fail.'),

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -1748,7 +1748,7 @@ const definitions: Definition[] = [
             e.illuminance().withUnit('lx').withDescription('Measured illuminance in lux'),
             e.motion_sensitivity_select(['low', 'medium', 'high'])
                 .withDescription('Select motion sensitivity to use. Press pairing button right before changing this otherwise it will fail.'),
-            e.detection_interval().withDescription('Time interval between action detection. ' + 
+            e.detection_interval().withDescription('Time interval between action detection. ' +
                 'Press pairing button right before changing this otherwise it will fail.'),
             e.trigger_indicator().withDescription('When this option is enabled then ' +
                 'blue LED will blink once when motion is detected. ' +

--- a/src/devices/xiaomi.ts
+++ b/src/devices/xiaomi.ts
@@ -1748,7 +1748,8 @@ const definitions: Definition[] = [
             e.illuminance().withUnit('lx').withDescription('Measured illuminance in lux'),
             e.motion_sensitivity_select(['low', 'medium', 'high'])
                 .withDescription('Select motion sensitivity to use. Press pairing button right before changing this otherwise it will fail.'),
-            e.detection_interval().withDescription('Time interval between action detection. Press pairing button right before changing this otherwise it will fail.'),
+            e.detection_interval().withDescription('Time interval between action detection. ' + 
+                'Press pairing button right before changing this otherwise it will fail.'),
             e.trigger_indicator().withDescription('When this option is enabled then ' +
                 'blue LED will blink once when motion is detected. ' +
                 'Press pairing button right before changing this otherwise it will fail.'),


### PR DESCRIPTION
Somehow completely missed the fact, that I forgot to put `detection_interval` back into exposes during refactoring. This hotfix brings the option back