### PR TITLE
fix: vindstyrke uses a different datatype

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1166,7 +1166,7 @@ const definitions: Definition[] = [
             reporting.temperature(ep, {min: 60, max: 120});
             reporting.humidity(ep, {min: 60, max: 120});
             await ep.configureReporting('pm25Measurement', [{
-                attribute: 'measuredValueIkea',
+                attribute: {ID: 0x0000, type: zigbeeHerdsman.Zcl.DataType.singlePrec},
                 minimumReportInterval: 60, maximumReportInterval: 120, reportableChange: 2,
             }]);
             await ep.configureReporting('msIkeaVocIndexMeasurement', [{


### PR DESCRIPTION
Requires https://github.com/Koenkk/zigbee-herdsman/pull/890

```
Zigbee2MQTT:debug 2024-01-28 10:38:56: Received MQTT message on 'zigbee2mqtt/bridge/request/permit_join' with data '{"device":null,"time":254,"transaction":"8kp3h-4","value":true}'
Zigbee2MQTT:info  2024-01-28 10:38:56: Zigbee: allowing new devices to join.
Zigbee2MQTT:info  2024-01-28 10:38:56: MQTT publish: topic 'zigbee2mqtt/bridge/response/permit_join', payload '{"data":{"time":254,"value":true},"status":"ok","transaction":"8kp3h-4"}'
Zigbee2MQTT:info  2024-01-28 10:39:04: Device '0x90ab96fffefa5d91' joined
Zigbee2MQTT:info  2024-01-28 10:39:04: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x90ab96fffefa5d91","ieee_address":"0x90ab96fffefa5d91"},"type":"device_joined"}'
Zigbee2MQTT:info  2024-01-28 10:39:04: Starting interview of '0x90ab96fffefa5d91'
Zigbee2MQTT:info  2024-01-28 10:39:04: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x90ab96fffefa5d91","ieee_address":"0x90ab96fffefa5d91","status":"started"},"type":"device_interview"}'
Zigbee2MQTT:debug 2024-01-28 10:39:04: Device '0x90ab96fffefa5d91' announced itself
Zigbee2MQTT:info  2024-01-28 10:39:04: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"friendly_name":"0x90ab96fffefa5d91","ieee_address":"0x90ab96fffefa5d91"},"type":"device_announce"}'
Zigbee2MQTT:debug 2024-01-28 10:39:04: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"modelId":"VINDSTYRKA"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:04: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:04: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"manufacturerName":"IKEA of Sweden"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:04: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:04: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"powerSource":1}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:04: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"zclVersion":8}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:05: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"appVersion":1}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:05: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"stackVersion":106}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:05: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"hwVersion":1}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:05: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"dateCode":"20230202"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:05: Skipping message, still interviewing
Zigbee2MQTT:debug 2024-01-28 10:39:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'readResponse', cluster 'genBasic', data '{"swBuildId":"1.0.11"}' from endpoint 1 with groupID 0
Zigbee2MQTT:debug 2024-01-28 10:39:05: Skipping message, still interviewing
Zigbee2MQTT:info  2024-01-28 10:39:05: Successfully interviewed '0x90ab96fffefa5d91', device has successfully been paired
Zigbee2MQTT:info  2024-01-28 10:39:05: Device '0x90ab96fffefa5d91' is supported, identified as: IKEA Vindstyrka air quality and humidity sensor (E2112)
Zigbee2MQTT:info  2024-01-28 10:39:05: MQTT publish: topic 'zigbee2mqtt/bridge/event', payload '{"data":{"definition":{"description":"Vindstyrka air quality and humidity sensor","exposes":[{"access":1,"description":"Measured temperature value","label":"Temperature","name":"temperature","property":"temperature","type":"numeric","unit":"°C"},{"access":1,"description":"Measured relative humidity","label":"Humidity","name":"humidity","property":"humidity","type":"numeric","unit":"%"},{"access":1,"description":"Measured PM2.5 (particulate matter) concentration","label":"PM25","name":"pm25","property":"pm25","type":"numeric","unit":"µg/m³"},{"access":1,"description":"Sensirion VOC index","label":"VOC index","name":"voc_index","property":"voc_index","type":"numeric"},{"access":1,"category":"diagnostic","description":"Link quality (signal strength)","label":"Linkquality","name":"linkquality","property":"linkquality","type":"numeric","unit":"lqi","value_max":255,"value_min":0}],"model":"E2112","options":[{"access":2,"description":"Calibrates the temperature value (absolute offset), takes into effect on next report of device.","label":"Temperature calibration","name":"temperature_calibration","property":"temperature_calibration","type":"numeric"},{"access":2,"description":"Number of digits after decimal point for temperature, takes into effect on next report of device. This option can only decrease the precision, not increase it.","label":"Temperature precision","name":"temperature_precision","property":"temperature_precision","type":"numeric","value_max":3,"value_min":0},{"access":2,"description":"Calibrates the humidity value (absolute offset), takes into effect on next report of device.","label":"Humidity calibration","name":"humidity_calibration","property":"humidity_calibration","type":"numeric"},{"access":2,"description":"Number of digits after decimal point for humidity, takes into effect on next report of device. This option can only decrease the precision, not increase it.","label":"Humidity precision","name":"humidity_precision","property":"humidity_precision","type":"numeric","value_max":3,"value_min":0},{"access":2,"description":"Calibrates the pm25 value (absolute offset), takes into effect on next report of device.","label":"Pm25 calibration","name":"pm25_calibration","property":"pm25_calibration","type":"numeric"}],"supports_ota":true,"vendor":"IKEA"},"friendly_name":"0x90ab96fffefa5d91","ieee_address":"0x90ab96fffefa5d91","status":"successful","supported":true},"type":"device_interview"}'
Zigbee2MQTT:info  2024-01-28 10:39:05: Configuring '0x90ab96fffefa5d91'
Zigbee2MQTT:info  2024-01-28 10:39:06: Successfully configured '0x90ab96fffefa5d91'
Zigbee2MQTT:debug 2024-01-28 10:39:08: Received Zigbee message from '0x90ab96fffefa5d91', type 'attributeReport', cluster 'msIkeaVocIndexMeasurement', data '{"measuredValue":0}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2024-01-28 10:39:08: MQTT publish: topic 'zigbee2mqtt/0x90ab96fffefa5d91', payload '{"linkquality":207,"voc_index":0}'
Zigbee2MQTT:debug 2024-01-28 10:40:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'attributeReport', cluster 'msRelativeHumidity', data '{"measuredValue":4300}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2024-01-28 10:40:05: MQTT publish: topic 'zigbee2mqtt/0x90ab96fffefa5d91', payload '{"humidity":43,"linkquality":189,"voc_index":0}'
Zigbee2MQTT:debug 2024-01-28 10:40:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'attributeReport', cluster 'pm25Measurement', data '{"measuredValue":7}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2024-01-28 10:40:05: MQTT publish: topic 'zigbee2mqtt/0x90ab96fffefa5d91', payload '{"humidity":43,"linkquality":189,"pm25":7,"voc_index":0}'
Zigbee2MQTT:debug 2024-01-28 10:40:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'attributeReport', cluster 'msTemperatureMeasurement', data '{"measuredValue":2100}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2024-01-28 10:40:05: MQTT publish: topic 'zigbee2mqtt/0x90ab96fffefa5d91', payload '{"humidity":43,"linkquality":189,"pm25":7,"temperature":21,"voc_index":0}'
Zigbee2MQTT:debug 2024-01-28 10:40:06: Received Zigbee message from '0x90ab96fffefa5d91', type 'attributeReport', cluster 'msIkeaVocIndexMeasurement', data '{"measuredValue":39}' from endpoint 1 with groupID 0
Zigbee2MQTT:info  2024-01-28 10:40:06: MQTT publish: topic 'zigbee2mqtt/0x90ab96fffefa5d91', payload '{"humidity":43,"linkquality":189,"pm25":7,"temperature":21,"voc_index":39}'
```

Here is a log of the device joining after the change.

```
Zigbee2MQTT:debug 2024-01-28 10:40:05: Received Zigbee message from '0x90ab96fffefa5d91', type 'attributeReport', cluster 'pm25Measurement', data '{"measuredValue":7}' from endpoint 1 with groupID 0
```

Also matches with what is on the actual display.
