### PR TITLE
Detect ZNXNKG02LM button state during rotation

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -5507,8 +5507,10 @@ const converters1 = {
         convert: (model, msg, publish, options, meta) => {
             if (msg.data.hasOwnProperty(570)) {
                 const act: KeyValueNumberString = {1: 'start_rotating', 2: 'rotation', 3: 'stop_rotating'};
+                const state: KeyValueNumberString = {0: 'released', 128: 'pressed'};
                 return {
-                    action: act[msg.data[570]],
+                    action: act[msg.data[570] & ~128],
+                    action_rotation_button_state: state[msg.data[570] & 128],
                     action_rotation_angle: msg.data[558],
                     action_rotation_angle_speed: msg.data[560],
                     action_rotation_percent: msg.data[563],

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3072,6 +3072,7 @@ const definitions: Definition[] = [
         exposes: [e.battery(), e.battery_voltage(),
             e.action(['single', 'double', 'hold', 'release', 'start_rotating', 'rotation', 'stop_rotating']),
             e.enum('operation_mode', ea.ALL, ['event', 'command']).withDescription('Button mode'),
+            e.enum('action_rotation_button_state', ea.STATE, ['released', 'pressed']).withDescription('Button state during rotation'),
             e.numeric('action_rotation_angle', ea.STATE).withUnit('*').withDescription('Rotation angle'),
             e.numeric('action_rotation_angle_speed', ea.STATE).withUnit('*').withDescription('Rotation angle speed'),
             e.numeric('action_rotation_percent', ea.STATE).withUnit('%').withDescription('Rotation percent'),


### PR DESCRIPTION
Aqara knob reports whether button is pressed during rotation. Currently rotating pressed knob results in events without the `action` field. 

* Fix `action` field - `start_rotating`, `rotation`, `stop_rotating` are now also used when rotating pressed knob.
* Add `action_rotation_button_state` field which is set to `pressed` or `released` during rotation.