### PR TITLE
Soft fail on multiple Electricity Meter endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import allDefinitions from './devices';
 import * as utils from './lib/utils';
 import { Definition, Fingerprint, Zh, OnEventData, OnEventType, Configure, Expose, Tz, OtaUpdateAvailableResult, KeyValue, Logger } from './lib/types';
 import {generateDefinition} from './lib/generateDefinition';
+import * as logger from './lib/logger';
 
 export {
     Definition as Definition,
@@ -398,3 +399,5 @@ export async function onEvent(type: OnEventType, data: OnEventData, device: Zh.D
         await device.getEndpoint(1).readResponse('genTime', data.meta.zclTransactionSequenceNumber, {time: secondsLocal});
     }
 }
+
+export const setLogger = logger.setLogger;

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -243,7 +243,7 @@ async function extenderElectricityMeter(endpoints: Zh.Endpoint[]): Promise<Gener
     // TODO: Support multiple endpoints
     console.assert(
         endpoints.length <= 1,
-        'extenderElectricityMeter can accept only one endpoint'
+        'extenderElectricityMeter can accept only one endpoint',
     );
 
     const endpoint = endpoints[0];

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -241,9 +241,10 @@ async function extenderOnOffLight(endpoints: Zh.Endpoint[]): Promise<GeneratedEx
 
 async function extenderElectricityMeter(endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     // TODO: Support multiple endpoints
-    if (endpoints.length > 1) {
-        throw new Error('extenderElectricityMeter can accept only one endpoint');
-    }
+    console.assert(
+        endpoints.length <= 1,
+        'extenderElectricityMeter can accept only one endpoint'
+    );
 
     const endpoint = endpoints[0];
 

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -5,6 +5,7 @@ import * as m from './modernExtend';
 import * as zh from 'zigbee-herdsman/dist';
 import {philipsLight} from './philips';
 import {Endpoint} from 'zigbee-herdsman/dist/controller/model';
+import {logger} from './logger';
 
 interface GeneratedExtend {
     getExtend(): ModernExtend,
@@ -182,7 +183,7 @@ const outputExtenders: Extender[] = [
 async function extenderLock(endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     // TODO: Support multiple endpoints
     if (endpoints.length > 1) {
-        throw new Error('extenderLock can accept only one endpoint');
+        logger.warn('extenderLock can accept only one endpoint');
     }
 
     const endpoint = endpoints[0];
@@ -241,10 +242,9 @@ async function extenderOnOffLight(endpoints: Zh.Endpoint[]): Promise<GeneratedEx
 
 async function extenderElectricityMeter(endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     // TODO: Support multiple endpoints
-    console.assert(
-        endpoints.length <= 1,
-        'extenderElectricityMeter can accept only one endpoint',
-    );
+    if (endpoints.length > 1) {
+        logger.warn('extenderElectricityMeter can accept only one endpoint');
+    }
 
     const endpoint = endpoints[0];
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,12 @@
+import {Logger} from './types';
+
+export let logger: Logger = {
+    info: (msg) => console.log(msg),
+    warn: (msg) => console.warn(msg),
+    error: (msg) => console.error(msg),
+    debug: (msg) => console.debug(msg),
+};
+
+export function setLogger(l: Logger) {
+    logger = l;
+}


### PR DESCRIPTION
Apparently throwing here prevents Z2M from starting. I set it to assert in the logs instead, but I'll let you change as needed @Koenkk since you co-authored the [commit](https://github.com/Koenkk/zigbee-herdsman-converters/commit/a1b6c282e6f98447028bcd912b7a9ac6953e05b2). It will just register the first passed endpoint for now, but I assume this is fine, instead of breaking Z2M, until proper support can be implemented?

Ref: 
https://github.com/Koenkk/zigbee2mqtt/issues/21170