### PR TITLE
fix: set 0 as transition for new devices

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -405,7 +405,7 @@ export function getTransition(entity: Zh.Endpoint | Zh.Group, key: string, meta:
         const time = toNumber(message.transition, 'transition');
         return {time: time * 10, specified: true};
     } else if (options.hasOwnProperty('transition') && options.transition !== '') {
-        const transition = toNumber(options.transition || 0, 'transition');
+        const transition = toNumber(options.transition, 'transition');
         return {time: transition * 10, specified: true};
     } else {
         return {time: 0, specified: false};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -404,8 +404,7 @@ export function getTransition(entity: Zh.Endpoint | Zh.Group, key: string, meta:
     if (message.hasOwnProperty('transition')) {
         const time = toNumber(message.transition, 'transition');
         return {time: time * 10, specified: true};
-    } else if (options.hasOwnProperty('transition')) {
-        if (options.transition == '') {
+    } else if (options.hasOwnProperty('transition') && options.transition !== '') {
             return {time: 0, specified: false};
         }
         const transition = toNumber(options.transition || 0, 'transition');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -405,8 +405,6 @@ export function getTransition(entity: Zh.Endpoint | Zh.Group, key: string, meta:
         const time = toNumber(message.transition, 'transition');
         return {time: time * 10, specified: true};
     } else if (options.hasOwnProperty('transition') && options.transition !== '') {
-            return {time: 0, specified: false};
-        }
         const transition = toNumber(options.transition || 0, 'transition');
         return {time: transition * 10, specified: true};
     } else {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -405,7 +405,10 @@ export function getTransition(entity: Zh.Endpoint | Zh.Group, key: string, meta:
         const time = toNumber(message.transition, 'transition');
         return {time: time * 10, specified: true};
     } else if (options.hasOwnProperty('transition')) {
-        const transition = toNumber(options.transition, 'transition');
+        if (options.transition == '') {
+            return {time: 0, specified: false};
+        }
+        const transition = toNumber(options.transition || 0, 'transition');
         return {time: transition * 10, specified: true};
     } else {
         return {time: 0, specified: false};

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,9 @@
 const utils = require('../src/lib/utils');
+const testUtils = require('./utils');
+const mockDevice = testUtils.mockDevice;
+const mockEndpoint = testUtils.mockEndpoint;
+
+const getTransition = utils.getTransition;
 
 describe('lib/utils.js', () => {
     describe('mapNumberRange', () => {
@@ -19,6 +24,85 @@ describe('lib/utils.js', () => {
         });
         it('should round to specified precision', () => {
             expect(utils.mapNumberRange(3.14, 0, 10, 0, 100, 1)).toEqual(31.4);
+        });
+    });
+
+    describe('getTransition', () => {
+        let entity;
+        let key;
+        let meta
+
+        beforeEach(() => {
+            entity = mockDevice({ manufacturerID: 4476, endpoints:  [{}] });
+
+            key = 'brightness';
+
+            meta = {
+                options: {},
+                message: {}
+            };
+        });
+
+        it('should return {time: 0, specified: false} if manufacturerID is 4476 and key is brightness and message has color or color_temp', () => {
+            meta.message = {
+                color: 'red'
+            };
+
+            const result = getTransition(entity, key, meta);
+
+            expect(result).toEqual({ time: 0, specified: false });
+        });
+
+        it('should return {time: 0, specified: false} if manufacturerID is 4476 and key is brightness and message has color_temp', () => {
+            meta.message = {
+                color_temp: 3000
+            };
+
+            const result = getTransition(entity, key, meta);
+
+            expect(result).toEqual({ time: 0, specified: false });
+        });
+
+        it('should return {time: 0, specified: false} if options.transition is an empty string', () => {
+            meta.options = {
+                transition: ''
+            };
+
+            const result = getTransition(entity, key, meta);
+
+            expect(result).toEqual({ time: 0, specified: false });
+        });
+
+        it('should return {time: 0, specified: false} if options.transition is not specified', () => {
+            const result = getTransition(entity, key, meta);
+
+            expect(result).toEqual({ time: 0, specified: false });
+        });
+
+        it('should return {time: 100, specified: true} if message.transition is specified', () => {
+            meta.message = {
+                transition: 10
+            };
+
+            const result = getTransition(entity, key, meta);
+
+            expect(result).toEqual({ time: 100, specified: true });
+        });
+
+        it('should return {time: 200, specified: true} if options.transition is specified', () => {
+            meta.options = {
+                transition: 20
+            };
+
+            const result = getTransition(entity, key, meta);
+
+            expect(result).toEqual({ time: 200, specified: true });
+        });
+
+        it('should return {time: 0, specified: false} if neither message.transition nor options.transition is specified', () => {
+            const result = getTransition(entity, key, meta);
+
+            expect(result).toEqual({ time: 0, specified: false });
         });
     });
 });


### PR DESCRIPTION
Hello,

I bought a new [IKEA bulb](https://www.zigbee2mqtt.io/devices/LED1836G9.html) and I thought it wasn't working because it had the transition value set to `""`(empty string), which caused the error as below:
```
error 2024-02-02 22:28:16: Publish 'set' 'brightness' to 'Zarówka Adama' failed: 'Error: 'transition' is not a number, got string ()'
debug 2024-02-02 22:28:16: Error: 'transition' is not a number, got string ()
    at toNumber (/app/node_modules/zigbee-herdsman-converters/src/lib/utils.ts:555:15)
    at Object.getTransition (/app/node_modules/zigbee-herdsman-converters/src/lib/utils.ts:408:28)
    at Object.convertSet (/app/node_modules/zigbee-herdsman-converters/src/converters/toZigbee.ts:1024:38)
    at Publish.onMQTTMessage (/app/lib/extension/publish.ts:249:52)
    at EventEmitter.wrappedCallback (/app/lib/eventBus.ts:174:23)
    at EventEmitter.emit (node:events:529:35)
    at EventBus.emitMQTTMessage (/app/lib/eventBus.ts:115:22)
    at MQTT.onMessage (/app/lib/mqtt.ts:141:27)
    at MqttClient.emit (node:events:517:28)
    at handlePublish (/app/node_modules/mqtt/src/lib/handlers/publish.ts:172:11)
```
This fix causes `""` (empty string) to be interpreted as 0, the default value.