### PR TITLE
Add OTA support for the Namron 540139X panel heaters

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -656,6 +656,7 @@ const definitions: Definition[] = [
         model: '540139X',
         vendor: 'Namron',
         description: 'Panel heater 400/600/800/1000 W',
+        ota: ota.zigbeeOTA,
         fromZigbee: [fz.thermostat, fz.metering, fz.electrical_measurement, fzLocal.namron_panelheater, fz.namron_hvac_user_interface],
         toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_local_temperature_calibration, tz.thermostat_system_mode,
             tz.thermostat_running_state, tz.thermostat_local_temperature, tzLocal.namron_panelheater, tz.namron_thermostat_child_lock],


### PR DESCRIPTION
First time contributing to this repo, so please bear with me. 

According to the Namron 540139X panel heaters' manuals, the devices should support standard OTA updates.

Link to manual for the 5401395 (1000 W) variant: https://www.elektroimportoren.no/docs/lib/5401395-Manual-18.pdf