### PR TITLE
Add hint as an additional description for expose items

### DIFF
--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -15,6 +15,7 @@ export class Base {
     endpoint?: string;
     property?: string;
     description?: string;
+    hint?: string;
     features?: Feature[];
     category?: 'config' | 'diagnostic';
 
@@ -56,6 +57,11 @@ export class Base {
 
     withDescription(description: string) {
         this.description = description;
+        return this;
+    }
+
+    withHint(hint: string) {
+        this.hint = hint;
         return this;
     }
 


### PR DESCRIPTION
Some devices may expose quite a lot of items. If these items are supplied with a description, the interface may get cluttered. If the description has certain amount of text describing values of the field, the interface gets too busy.

For example, 3-4 elements occupy the whole screen (even after the text was squeezed already):
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/23584882/f1be7d37-2c29-4f3c-a908-cd4501d04b90)

The idea of the proposed change is to have a `hint` field in addition to the `description` field. The `description` may be used for a short 1-line description of the entity, while the hint may include big amount of text describing entity values or more detailed description of the setting. The `hint` text is not visible by default, but is shown in a hint/bubble when mouse is over the element.

This is the zigbee-herdsman-converter part of the improvement. Once approved, there will be also a corresponding change in the zigbee2mqtt-frontend project.