### PR TITLE
Disable blinking of internal green led in WB-MSW-ZIGBEE v.4

### DIFF
--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -377,11 +377,14 @@ const definitions: Definition[] = [
             // buzzer
             await device.getEndpoint(4).read('genOnOff', ['onOff']);
 
+            // disable internal blinking zigbee state green led on start
+            await device.getEndpoint(5).write('genBinaryOutput', {0x0055: {value: 0x00, type: 0x10}});
+
             device.powerSource = 'Mains (single phase)';
             device.save();
         },
         endpoint: (device) => {
-            return {'default': 1, 'l1': 2, 'l2': 3, 'l3': 4};
+            return {'default': 1, 'l1': 2, 'l2': 3, 'l3': 4, 'l4': 5};
         },
         meta: {multiEndpoint: true, multiEndpointSkip: ['humidity']},
         ota: ota.zigbeeOTA,


### PR DESCRIPTION
Hi there!
* Every such a sensor blinks green inside when works: it is barely noticable during normal coditions, but I use one of them in the bedroom and it it is pretty disturbing at night.
* Contacted device support, but result was 'use black duct tape'.
* So, this little PR disables it on Z2M start.
* Appending new endpoint name (l4) is needed to make it possible to toggle this blinking on and off through dev console: without it Z2M throws an error if I try to access andpoint 5.
* There could be better solution with toggle available in UI (may be something with the use of kmpcil_res005_on_off converter), but my understanding of this repo is not sufficient yet to make it.