### PR TITLE
Koenkk/zigbee2mqtt#21292: `TuYa TS110E_2gang_2` - extend with the new manufacturer name variant `_TZ3210_vfwhhldz`

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5580,7 +5580,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS110E', ['_TZ3210_pagajpog', '_TZ3210_4ubylghk']),
+        fingerprint: tuya.fingerprint('TS110E', ['_TZ3210_pagajpog', '_TZ3210_4ubylghk', '_TZ3210_vfwhhldz']),
         model: 'TS110E_2gang_2',
         vendor: 'TuYa',
         description: '2 channel dimmer',


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#21292