### PR TITLE
Slip relais and status register sub-values into their own JSON structure

### DIFF
--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -191,7 +191,7 @@ const fzLocal = {
                         // @ts-expect-error
                         val = utils.precisionRound(val / 1000, kWh_p); // from Wh to kWh
                         break;
-                    case 'relais':
+                    case 'relais': {
                         // relais is a decimal value representing the bits
                         // of 8 virtual dry contacts.
                         // 0 for an open relay
@@ -204,146 +204,151 @@ const fzLocal = {
                         // relais6 Storage or injection
                         // relais7 Unassigned
                         // relais8 Unassigned
+                        const relais_breakout: KeyValue = {};
                         for (let i = 0; i < 8; i++) {
-                            result[at_snake + (i+1)] = (val & (1<<i)) >>> i;
+                            relais_breakout[at_snake + (i+1)] = (val & (1<<i)) >>> i;
                         }
+                        result[at_snake + '_breakout'] = relais_breakout;
                         break;
+                    }
                     case 'statusRegister': {
                         // val is a String representing hex.
                         // Must convert
                         const valhex = Number('0x' + val);
+                        const statusRegister_breakout: KeyValue = {};
                         // contact sec
-                        result[at_snake + '_contact_sec'] = (valhex & 0x1) == 1 ? 'ouvert' : 'ferme';
+                        statusRegister_breakout['contact_sec'] = (valhex & 0x1) == 1 ? 'ouvert' : 'ferme';
                         // organe de coupure
                         switch ((valhex >>> 1) & 0x7) {
                         case 0:
-                            result[at_snake + '_organe_coupure'] = 'ferme';
+                            statusRegister_breakout['organe_coupure'] = 'ferme';
                             break;
                         case 1:
-                            result[at_snake + '_organe_coupure'] = 'surpuissance';
+                            statusRegister_breakout['organe_coupure'] = 'surpuissance';
                             break;
                         case 2:
-                            result[at_snake + '_organe_coupure'] = 'surtension';
+                            statusRegister_breakout['organe_coupure'] = 'surtension';
                             break;
                         case 3:
-                            result[at_snake + '_organe_coupure'] = 'delestage';
+                            statusRegister_breakout['organe_coupure'] = 'delestage';
                             break;
                         case 4:
-                            result[at_snake + '_organe_coupure'] = 'ordre_CPL_Euridis';
+                            statusRegister_breakout['organe_coupure'] = 'ordre_CPL_Euridis';
                             break;
                         case 5:
-                            result[at_snake + '_organe_coupure'] = 'surchauffe_surcourant';
+                            statusRegister_breakout['organe_coupure'] = 'surchauffe_surcourant';
                             break;
                         case 6:
-                            result[at_snake + '_organe_coupure'] = 'surchauffe_simple';
+                            statusRegister_breakout['organe_coupure'] = 'surchauffe_simple';
                             break;
                         }
                         // etat cache borne distributeur
-                        result[at_snake + '_cache_borne_dist'] = ((valhex >>> 4) & 0x1) == 0 ? 'ferme' : 'ouvert';
+                        statusRegister_breakout['cache_borne_dist'] = ((valhex >>> 4) & 0x1) == 0 ? 'ferme' : 'ouvert';
                         // bit 5 inutilise
                         // surtension sur une des phases
-                        result[at_snake + '_surtension_phase'] = (valhex >>> 6) & 0x1;
+                        statusRegister_breakout['surtension_phase'] = (valhex >>> 6) & 0x1;
                         // depassement puissance de reference
-                        result[at_snake + '_depassement_ref_pow'] = (valhex >>> 7) & 0x1;
+                        statusRegister_breakout['depassement_ref_pow'] = (valhex >>> 7) & 0x1;
                         // consommateur ou producteur
-                        result[at_snake + '_producteur'] = (valhex >>> 8) & 0x1;
+                        statusRegister_breakout['producteur'] = (valhex >>> 8) & 0x1;
                         // sens de l'energie active
-                        result[at_snake + '_sens_energie_active'] = ((valhex >>> 9) & 0x1) == 0 ? 'positive' : 'negative';
+                        statusRegister_breakout['sens_energie_active'] = ((valhex >>> 9) & 0x1) == 0 ? 'positive' : 'negative';
                         // tarif en cours sur le contrat fourniture
-                        result[at_snake + '_tarif_four'] = 'index_' + (((valhex >>> 10) & 0xF) + 1);
+                        statusRegister_breakout['tarif_four'] = 'index_' + (((valhex >>> 10) & 0xF) + 1);
                         // tarif en cours sur le contrat distributeur
-                        result[at_snake + '_tarif_dist'] = 'index_' + (((valhex >>> 14) & 0x3) + 1);
+                        statusRegister_breakout['tarif_dist'] = 'index_' + (((valhex >>> 14) & 0x3) + 1);
                         // mode degrade de l'horloge
-                        result[at_snake + '_horloge'] = ((valhex >>> 16) & 0x1) == 0 ? 'correcte' : 'degradee';
+                        statusRegister_breakout['horloge'] = ((valhex >>> 16) & 0x1) == 0 ? 'correcte' : 'degradee';
                         // TIC historique ou standard
-                        result[at_snake + '_type_tic'] = ((valhex >>> 17) & 0x1) == 0 ? 'historique' : 'standard';
+                        statusRegister_breakout['type_tic'] = ((valhex >>> 17) & 0x1) == 0 ? 'historique' : 'standard';
                         // bit 18 inutilise
                         // etat sortie communicateur Euridis
                         switch ((valhex >>> 19) & 0x3) {
                         case 0:
-                            result[at_snake + '_comm_euridis'] = 'desactivee';
+                            statusRegister_breakout['comm_euridis'] = 'desactivee';
                             break;
                         case 1:
-                            result[at_snake + '_comm_euridis'] = 'activee sans securite';
+                            statusRegister_breakout['comm_euridis'] = 'activee sans securite';
                             break;
                         case 3:
-                            result[at_snake + '_comm_euridis'] = 'activee avec securite';
+                            statusRegister_breakout['comm_euridis'] = 'activee avec securite';
                             break;
                         }
                         // etat CPL
                         switch ((valhex >>> 21) & 0x3) {
                         case 0:
-                            result[at_snake + '_etat_cpl'] = 'nouveau_deverrouille';
+                            statusRegister_breakout['etat_cpl'] = 'nouveau_deverrouille';
                             break;
                         case 1:
-                            result[at_snake + '_etat_cpl'] = 'nouveau_verrouille';
+                            statusRegister_breakout['etat_cpl'] = 'nouveau_verrouille';
                             break;
                         case 2:
-                            result[at_snake + '_etat_cpl'] = 'enregistre';
+                            statusRegister_breakout['etat_cpl'] = 'enregistre';
                             break;
                         }
                         // synchronisation CPL
-                        result[at_snake + '_sync_cpl'] = ((valhex >>> 23) & 0x1) == 0 ? 'non_synchronise' : 'synchronise';
+                        statusRegister_breakout['sync_cpl'] = ((valhex >>> 23) & 0x1) == 0 ? 'non_synchronise' : 'synchronise';
                         // couleur du jour contrat TEMPO historique
                         switch ((valhex >>> 24) & 0x3) {
                         case 0:
-                            result[at_snake + '_tempo_jour'] = 'UNDEF';
+                            statusRegister_breakout['tempo_jour'] = 'UNDEF';
                             break;
                         case 1:
-                            result[at_snake + '_tempo_jour'] = 'BLEU';
+                            statusRegister_breakout['tempo_jour'] = 'BLEU';
                             break;
                         case 2:
-                            result[at_snake + '_tempo_jour'] = 'BLANC';
+                            statusRegister_breakout['tempo_jour'] = 'BLANC';
                             break;
                         case 3:
-                            result[at_snake + '_tempo_jour'] = 'ROUGE';
+                            statusRegister_breakout['tempo_jour'] = 'ROUGE';
                             break;
                         }
                         // couleur demain contrat TEMPO historique
                         switch ((valhex >>> 26) & 0x3) {
                         case 0:
-                            result[at_snake + '_tempo_demain'] = 'UNDEF';
+                            statusRegister_breakout['tempo_demain'] = 'UNDEF';
                             break;
                         case 1:
-                            result[at_snake + '_tempo_demain'] = 'BLEU';
+                            statusRegister_breakout['tempo_demain'] = 'BLEU';
                             break;
                         case 2:
-                            result[at_snake + '_tempo_demain'] = 'BLANC';
+                            statusRegister_breakout['tempo_demain'] = 'BLANC';
                             break;
                         case 3:
-                            result[at_snake + '_tempo_demain'] = 'ROUGE';
+                            statusRegister_breakout['tempo_demain'] = 'ROUGE';
                             break;
                         }
                         // preavis pointe mobile
                         switch ((valhex >>> 28) & 0x3) {
                         case 0:
-                            result[at_snake + '_preavis_pointe_mobile'] = 'AUCUN';
+                            statusRegister_breakout['preavis_pointe_mobile'] = 'AUCUN';
                             break;
                         case 1:
-                            result[at_snake + '_preavis_pointe_mobile'] = 'PM1';
+                            statusRegister_breakout['preavis_pointe_mobile'] = 'PM1';
                             break;
                         case 2:
-                            result[at_snake + '_preavis_pointe_mobile'] = 'PM2';
+                            statusRegister_breakout['preavis_pointe_mobile'] = 'PM2';
                             break;
                         case 3:
-                            result[at_snake + '_preavis_pointe_mobile'] = 'PM3';
+                            statusRegister_breakout['preavis_pointe_mobile'] = 'PM3';
                             break;
                         }
                         // pointe mobile
                         switch ((valhex >>> 30) & 0x3) {
                         case 0:
-                            result[at_snake + '_pointe_mobile'] = 'AUCUN';
+                            statusRegister_breakout['pointe_mobile'] = 'AUCUN';
                             break;
                         case 1:
-                            result[at_snake + '_pointe_mobile'] = 'PM1';
+                            statusRegister_breakout['pointe_mobile'] = 'PM1';
                             break;
                         case 2:
-                            result[at_snake + '_pointe_mobile'] = 'PM2';
+                            statusRegister_breakout['pointe_mobile'] = 'PM2';
                             break;
                         case 3:
-                            result[at_snake + '_pointe_mobile'] = 'PM3';
+                            statusRegister_breakout['pointe_mobile'] = 'PM3';
                             break;
                         }
+                        result[at_snake + '_breakout'] = statusRegister_breakout;
                     }
                     }
                     result[at_snake] = val;


### PR DESCRIPTION
Relais details and status register details are moved to their own JSON, so it does not clutter the first-level values