### PR TITLE
Bosch BTH-RA: reimplemenation of "auto mode"

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1051,7 +1051,7 @@ const definitions: Definition[] = [
                     'This is the temperature measured on the device (by default) or the remote temperature (if set within the last 30 minutes).')
                 .withSetpoint('occupied_heating_setpoint', 5, 30, 0.5)
                 .withLocalTemperatureCalibration(-5, 5, 0.1)
-                .withSystemMode(['off', 'heat'])
+                .withSystemMode(['off', 'heat', 'auto'])
                 .withPiHeatingDemand(ea.ALL)
                 .withRunningState(['idle', 'heat'], ea.STATE),
             e.binary('boost', ea.ALL, 'ON', 'OFF')


### PR DESCRIPTION
With this merged commit https://github.com/Koenkk/zigbee-herdsman-converters/commit/d91e2f3b5f602487357fc9414740365c496866dc the bosch thermostat no longer provides the system modes 'heat', 'off', and 'auto' but only 'heat' and 'off'. This was done because the device internal schedule cannot be adjusted or even deleted with z2m (at the moment).

However, this should be reverted back to all three modes:

- The device does provide this mode, so it would be the normal decision to expose it too
- It even has a hardware button/dial to select the auto mode, it also has a dedicated element in the segmented display to show this mode
- If the device is in auto mode, it is reported as unknown in home assistant, what is kind of misleading
- only auto mode (along with 'heat' and 'off' mode) give the full functionality. It can be useful, even if the built in schudele interferes, e.g.: If the changes of the schedule in auto mode are just catched and reverted by an automation, you are able to have an normal auto mode and the possibility to switch in manual mode directly at the device.
- the removal was a hard breaking change, if all modes have been used in the past 

The change was suggested here https://github.com/Koenkk/zigbee-herdsman-converters/issues/6995 without participation so far.