### PR TITLE
Update neo.ts: Add support to TS0601 / _TZE204_q76rtoa9

### DIFF
--- a/src/devices/neo.ts
+++ b/src/devices/neo.ts
@@ -36,8 +36,8 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_t1blo2bj', '_TZE204_t1blo2bj']),
-        zigbeeModel: ['1blo2bj', 'lrfgpny'],
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_t1blo2bj', '_TZE204_t1blo2bj', '_TZE204_q76rtoa9']),
+        zigbeeModel: ['1blo2bj', 'lrfgpny','q76rtoa9'],
         model: 'NAS-AB02B2',
         vendor: 'Neo',
         description: 'Alarm',

--- a/src/devices/neo.ts
+++ b/src/devices/neo.ts
@@ -37,7 +37,7 @@ const definitions: Definition[] = [
     },
     {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_t1blo2bj', '_TZE204_t1blo2bj', '_TZE204_q76rtoa9']),
-        zigbeeModel: ['1blo2bj', 'lrfgpny','q76rtoa9'],
+        zigbeeModel: ['1blo2bj', 'lrfgpny', 'q76rtoa9'],
         model: 'NAS-AB02B2',
         vendor: 'Neo',
         description: 'Alarm',


### PR DESCRIPTION
Here in Basil EKAZA manufacturer is selling this model of siren with this specs:

TS0601  
_TZE204_q76rtoa9

So, this commit will add support for it.

based on my reply to thread:
https://github.com/Koenkk/zigbee2mqtt/discussions/18649#discussioncomment-8427852