### PR TITLE
Fix YSRSAI WW/CW led controller

### DIFF
--- a/src/devices/ysrsai.ts
+++ b/src/devices/ysrsai.ts
@@ -15,7 +15,10 @@ const definitions: Definition[] = [
         model: 'YSR-MINI-01_wwcw',
         vendor: 'YSRSAI',
         description: 'Zigbee LED controller (WW/CW)',
-        extend: tuya.extend.light_onoff_brightness_colortemp_color(),
+        extend: tuya.extend.light_onoff_brightness_colortemp({colorTempRange: [153, 500], noConfigure: true, exposes: []}),
+        configure: async (device, coordinatorEndpoint, logger) => {
+            device.getEndpoint(1).saveClusterAttributeKeyValue('lightingColorCtrl', {colorCapabilities: 0x10});
+        },
     },
     {
         zigbeeModel: ['ZB-DL01'],


### PR DESCRIPTION
Fix YSRSAI WW/CW LED controller:
- It wrongly reports `colorTempRange` in [light.configure](https://github.com/Koenkk/zigbee-herdsman-converters/blob/36a31e8bab8ce6b9cba29698f1ae1df4a5a734b8/src/lib/extend.ts#L75) as [250; 454]. The real range which I sniffed when managing the device via Smart Life app is [153; 500]. The [250; 454] range gives a very limited adjustment of color temperature - the WW wire voltage is changing between 95% and 100% of input voltage and the CW wire between 65% and 85%. Both start working properly (0%-100%) when the range is set to [153; 500].
- It actually does not support color management, so `light_onoff_brightness_colortemp_color` is replaced with the `light_onoff_brightness_colortemp`.
- It does not support [doNotDisturb](https://github.com/Koenkk/zigbee-herdsman-converters/blob/36a31e8bab8ce6b9cba29698f1ae1df4a5a734b8/src/lib/tuya.ts#L1424), so `exposes` is set to empty.