### PR TITLE
feat: support _TZE204_ztqnh5cg

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5113,7 +5113,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_qasjif9e']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_qasjif9e', '_TZE204_ztqnh5cg']),
         model: 'ZY-M100-S_2',
         vendor: 'TuYa',
         description: 'Mini human breathe sensor',


### PR DESCRIPTION
## Description

Support _TZE204_ztqnh5cg Human Presence Detector. There is no model on the box but only ZT3L chipset model. I reuse a similar device's configuration and pass sanity test.

![CleanShot 2024-02-10 at 22 23 51](https://github.com/Koenkk/zigbee-herdsman-converters/assets/3753893/dc49021a-7922-4e45-a69c-9e5b94043d53)


## Verification
- Target Distance: Yes
- Illumination: Yes
- Presence: Yes (but my device is broken and only reporting 1 nor 0)