### PR TITLE
fix bug with MEG5126-0300/MEG5171-0000

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -630,7 +630,7 @@ const definitions: Definition[] = [
             await reporting.brightness(endpoint);
         },
         endpoint: (device) => {
-            return {'3': 3, 'right': 21, 'left': 22};
+            return {'right': 21, 'left': 22};
         },
     },
     {


### PR DESCRIPTION
Very sorry!

I found a small issue with https://github.com/Koenkk/zigbee-herdsman-converters/pull/7050

MEG5126-0300/MEG5171-0000  reports brightness_l3 and state_l3 instead of brightness and state