### PR TITLE
Add support to Philips LWB019 White Bulb

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -895,7 +895,7 @@ const definitions: Definition[] = [
         extend: [philipsLight()],
     },
     {
-        zigbeeModel: ['LWB006', 'LWB014'],
+        zigbeeModel: ['LWB006', 'LWB014', 'LWB019'],
         model: '9290011370',
         vendor: 'Philips',
         description: 'Hue white A60 bulb E27/B22',


### PR DESCRIPTION
const {onOff} = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['LWB019'],
    model: 'LWB019',
    vendor: 'Signify Netherlands B.V.',
    description: 'Automatically generated definition',
    extend: [onOff({"powerOnBehavior":false})],
    meta: {},
};

module.exports = definition;