### PR TITLE
Add trigger counter for MCCGQ11LM and SJCGQ11LM

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1495,7 +1495,7 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         fromZigbee: [lumi.fromZigbee.lumi_basic, lumi.fromZigbee.lumi_contact],
         toZigbee: [],
-        exposes: [e.battery(), e.contact(), e.device_temperature(), e.battery_voltage(), e.power_outage_count(false)],
+        exposes: [e.battery(), e.contact(), e.device_temperature(), e.battery_voltage(), e.power_outage_count(false), e.trigger_count()],
         configure: async (device) => {
             device.powerSource = 'Battery';
             device.save();
@@ -1509,7 +1509,8 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         fromZigbee: [lumi.fromZigbee.lumi_basic, fz.ias_water_leak_alarm_1],
         toZigbee: [],
-        exposes: [e.battery(), e.water_leak(), e.battery_low(), e.battery_voltage(), e.device_temperature(), e.power_outage_count(false)],
+        exposes: [e.battery(), e.water_leak(), e.battery_low(), e.battery_voltage(), e.device_temperature(), e.power_outage_count(false), 
+            e.trigger_count()],
     },
     {
         zigbeeModel: ['lumi.flood.agl02'],

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1509,7 +1509,7 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_2850_3000'}},
         fromZigbee: [lumi.fromZigbee.lumi_basic, fz.ias_water_leak_alarm_1],
         toZigbee: [],
-        exposes: [e.battery(), e.water_leak(), e.battery_low(), e.battery_voltage(), e.device_temperature(), e.power_outage_count(false), 
+        exposes: [e.battery(), e.water_leak(), e.battery_low(), e.battery_voltage(), e.device_temperature(), e.power_outage_count(false),
             e.trigger_count()],
     },
     {

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -760,6 +760,7 @@ export const presets = {
     temperature: () => new Numeric('temperature', access.STATE).withUnit('°C').withDescription('Measured temperature value'),
     temperature_sensor_select: (sensor_names: string[]) => new Enum('sensor', access.STATE_SET, sensor_names).withDescription('Select temperature sensor to use').withCategory('config'),
     test: () => new Binary('test', access.STATE, true, false).withDescription('Indicates whether the device is being tested'),
+    trigger_count: (sincePowerOutage = true) => new Numeric('trigger_count', exports.access.STATE).withDescription('Indicates how many times the sensor was triggered' + (sincePowerOutage ? ' (since last power outage)' : '')).withCategory('diagnostic'),
     trigger_indicator: () => new Binary('trigger_indicator', access.ALL, true, false).withDescription('Enables trigger indication').withCategory('config'),
     valve_alarm: () => new Binary('valve_alarm', access.STATE, true, false).withCategory('diagnostic'),
     valve_position: () => new Numeric('position', access.ALL).withValueMin(0).withValueMax(100).withDescription('Position of the valve'),

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -217,7 +217,7 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             payload.power_outage_count = value - 1;
             break;
         case '6':
-            if (['MCCGQ11LM', 'SJCGQ11LM'].includes(model.model)) {
+            if (['MCCGQ11LM', 'SJCGQ11LM'].includes(model.model) && Array.isArray(value)) {
                 assertNumber(value[1]);
                 payload.trigger_count = value[1];
             }

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -216,6 +216,12 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             assertNumber(value);
             payload.power_outage_count = value - 1;
             break;
+        case '6':
+            if (['MCCGQ11LM', 'SJCGQ11LM'].includes(model.model)) {
+                assertNumber(value[1]);
+                payload.trigger_count = value[1];
+            }
+            break;
         case '8':
             if (['ZNLDP13LM'].includes(model.model)) {
                 // We don't know what the value means for these devices.


### PR DESCRIPTION
This will add trigger counter for [Aqara door sensor (MCCGQ11LM)](https://www.zigbee2mqtt.io/devices/MCCGQ11LM.html) and [Aqara Water leak sensor (SJCGQ11LM)](https://www.zigbee2mqtt.io/devices/SJCGQ11LM.html). Trigger count indicates how many times the sensor/gercon was triggered. Perhaps other devices can also provide that value, but I don’t have them to test.

The counter is reset after a power outage or repairing. 
The value is send approximately every 40-50 minutes (or by pressing a button on the device).

**Use case:**
Using this, we can make a door sensor, as a pulse counter for an electric/water/gas meter.