### PR TITLE
Add a variation of Xiaomi Aqara spotlight T2

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2275,7 +2275,7 @@ const definitions: Definition[] = [
         extend: [lumiZigbeeOTA(), lumiLight({colorTemp: true})],
     },
     {
-        zigbeeModel: ['lumi.light.acn026'],
+        zigbeeModel: ['lumi.light.acn026', 'lumi.light.acn024'],
         model: 'SSWQD03LM',
         vendor: 'Aqara',
         description: 'Spotlight T2',


### PR DESCRIPTION
As discussed in https://github.com/Koenkk/zigbee2mqtt/discussions/21426, added a new `zigbeeModel` `lumi.light.acn024` to `SSWQD03LM`.