### PR TITLE
fix switch missing for CH2AX/SWITCH/1 and CH10AX/SWITCH/1

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -462,9 +462,9 @@ const definitions: Definition[] = [
         zigbeeModel: ['CH2AX/SWITCH/1'],
         model: '41E2PBSWMZ/356PB2MBTZ',
         vendor: 'Schneider Electric',
-        description: 'Wiser 40/300-Series module switch 2A',
+        description: 'Wiser 40/300-Series module switch 2AX',
         ota: ota.zigbeeOTA,
-        extend: [indicatorMode()],
+        extend: [extend.switch(), indicatorMode()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
@@ -475,8 +475,8 @@ const definitions: Definition[] = [
         zigbeeModel: ['CH10AX/SWITCH/1'],
         model: '41E10PBSWMZ-VW',
         vendor: 'Schneider Electric',
-        description: 'Wiser 40/300-Series module switch 10A with ControlLink',
-        extend: [indicatorMode()],
+        description: 'Wiser 40/300-Series module switch 10AX with ControlLink',
+        extend: [extend.switch(), indicatorMode()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -464,7 +464,7 @@ const definitions: Definition[] = [
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series module switch 2AX',
         ota: ota.zigbeeOTA,
-        extend: [extend.switch(), indicatorMode()],
+        extend: [onOff({powerOnBehavior: true}), indicatorMode()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
@@ -476,7 +476,7 @@ const definitions: Definition[] = [
         model: '41E10PBSWMZ-VW',
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series module switch 10AX with ControlLink',
-        extend: [extend.switch(), indicatorMode()],
+        extend: [onOff({powerOnBehavior: true}), indicatorMode()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);


### PR DESCRIPTION
with https://github.com/Koenkk/zigbee-herdsman-converters/pull/7050#issuecomment-1953232082 there cam a little bug discovered by @alexeiw123 , showing that the switch is missing in the latest version.

Looking back into the PR it's visible that i replace `extend.switch({ .... indication` with `indicatorMode()` but forgot to add `e.switch()` thus removing the functionality.

I tried using modernExtend and hope that `onOff()` is the correct replacement for `e.switch()`