### PR TITLE
Update samotech.ts to remove unsupported exposes

### DIFF
--- a/src/devices/samotech.ts
+++ b/src/devices/samotech.ts
@@ -108,16 +108,8 @@ const definitions: Definition[] = [
         zigbeeModel: ['SM325-ZG'],
         model: 'SM325-ZG',
         vendor: 'Samotech',
-        description: 'Zigbee Smart Pull Cord Dimmer Switch',
-        fromZigbee: extend.light_onoff_brightness().fromZigbee,
-        toZigbee: extend.light_onoff_brightness().toZigbee,
-        configure: async (device, coordinatorEndpoint, logger) => {
-            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
-            await reporting.onOff(endpoint);
-        },
-        exposes: extend.light_onoff_brightness({disablePowerOnBehavior: true, disableEffect: true}).exposes,
+        description: 'Zigbee smart pull cord dimmer switch',
+        extend: [light({configureReporting: true, effect: false, powerOnBehavior: false})],
     },
 ];
 

--- a/src/devices/samotech.ts
+++ b/src/devices/samotech.ts
@@ -108,8 +108,16 @@ const definitions: Definition[] = [
         zigbeeModel: ['SM325-ZG'],
         model: 'SM325-ZG',
         vendor: 'Samotech',
-        description: 'Zigbee smart pull cord dimmer switch',
-        extend: [light({configureReporting: true})],
+        description: 'Zigbee Smart Pull Cord Dimmer Switch',
+        fromZigbee: extend.light_onoff_brightness().fromZigbee,
+        toZigbee: extend.light_onoff_brightness().toZigbee,
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await extend.light_onoff_brightness().configure(device, coordinatorEndpoint, logger);
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
+            await reporting.onOff(endpoint);
+        },
+        exposes: extend.light_onoff_brightness({disablePowerOnBehavior: true, disableEffect: true}).exposes,
     },
 ];
 


### PR DESCRIPTION
Recent merge added support for device SM325 but changes made on merge added additional exposes for "Power On Behaviour" and "Effects". These aren't supported by the device and this maintains functionality but removes those exposes.

Previous merge is here: https://github.com/Koenkk/zigbee-herdsman-converters/pull/7088

Before this change, non functional exposes shown:
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/77809797/24cc9800-9ef3-4bb2-acba-cd694a4f196e)

After this change:
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/77809797/5e9d5631-dec8-4af8-b314-6982b4b56105)
