### PR TITLE
Updates to Linptech ES1ZZ

### DIFF
--- a/src/devices/linptech.ts
+++ b/src/devices/linptech.ts
@@ -78,14 +78,14 @@ const definitions: Definition[] = [
         exposes: [
             e.occupancy().withDescription('Presence state'), e.illuminance().withUnit('lx'),
             e.numeric('target_distance', ea.STATE).withDescription('Distance to target').withUnit('cm'),
-            e.numeric('motion_detection_distance', ea.STATE_SET).withValueMin(75).withValueMax(600)
+            e.numeric('motion_detection_distance', ea.STATE_SET).withValueMin(0).withValueMax(600)
                 .withValueStep(75).withDescription('Motion detection distance').withUnit('cm'),
-            e.numeric('presence_keep_time', ea.STATE).withDescription('Presence keep time').withUnit('s'),
+            e.numeric('presence_keep_time', ea.STATE).withDescription('Presence keep time').withUnit('minutes'),
             e.numeric('motion_detection_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(5)
                 .withValueStep(1).withDescription('Motion detection sensitivity'),
             e.numeric('static_detection_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(5)
                 .withValueStep(1).withDescription('Static detection sensitivity'),
-            e.numeric('fading_time', ea.STATE_SET).withValueMin(10).withValueMax(10000).withValueStep(1)
+            e.numeric('fading_time', ea.STATE_SET).withValueMin(0).withValueMax(10000).withValueStep(1)
                 .withUnit('s').withDescription('Time after which the device will check again for presence'),
         ],
         meta: {

--- a/src/devices/linptech.ts
+++ b/src/devices/linptech.ts
@@ -80,7 +80,7 @@ const definitions: Definition[] = [
             e.numeric('target_distance', ea.STATE).withDescription('Distance to target').withUnit('cm'),
             e.numeric('motion_detection_distance', ea.STATE_SET).withValueMin(0).withValueMax(600)
                 .withValueStep(75).withDescription('Motion detection distance').withUnit('cm'),
-            e.numeric('presence_keep_time', ea.STATE).withDescription('Presence keep time').withUnit('minutes'),
+            e.numeric('presence_keep_time', ea.STATE).withDescription('Presence keep time').withUnit('min'),
             e.numeric('motion_detection_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(5)
                 .withValueStep(1).withDescription('Motion detection sensitivity'),
             e.numeric('static_detection_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(5)


### PR DESCRIPTION
fix(linptech): start values for motion_detection_distance at 0
fix(linptech): start values for fading_time at 0
fix(linptech): use of correct unit for presence_keep_time (minutes)

I have tested the first two and they are honored by the device, though I am not sure if "minutes" is the correct keyword here, it does seem used in other devices.
The last one the following screenshot confirms that it is in fact minutes not seconds:
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/16911399/0a4050eb-ca2b-4150-81d0-2524c96241ad)