### PR TITLE
Enable OTA for Frient HESZB-120

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -549,6 +549,7 @@ const definitions: Definition[] = [
         fromZigbee: [develco.fz.temperature, fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report,
             fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
+        ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(35);


### PR DESCRIPTION
Firmware for this de.vice is already in repo so just adding ota flag See https://github.com/Koenkk/zigbee2mqtt/issues/21512