### PR TITLE
fix system mode for Acova PERCALE 2 and TAFFETAS 2 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint .",
     "test": "ZHC_TEST=true jest test",
     "test-watch": "ZHC_TEST=true jest test --watch",
-    "clean": "rimraf index* devices lib converters tsconfig.tsbuildinfo",
+    "clean": "rimraf --glob index* devices lib converters tsconfig.tsbuildinfo",
     "build": "tsc",
     "build-watch": "tsc --watch",
     "prepack": "npm run clean && npm run build"

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1414,6 +1414,20 @@ const converters2 = {
             await entity.read('hvacThermostat', ['systemMode']);
         },
     } satisfies Tz.Converter,
+    acova_thermostat_system_mode: {
+        key: ['system_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            let systemMode = utils.getKey(constants.acovaThermostatSystemModes, value, undefined, Number);
+            if (systemMode === undefined) {
+                systemMode = utils.getKey(legacy.thermostatSystemModes, value, value, Number);
+            }
+            await entity.write('hvacThermostat', {systemMode});
+            return {readAfterWriteTime: 250, state: {system_mode: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['systemMode']);
+        },
+    } satisfies Tz.Converter,
     thermostat_control_sequence_of_operation: {
         key: ['control_sequence_of_operation'],
         convertSet: async (entity, key, value, meta) => {

--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -7,37 +7,6 @@ const e = exposes.presets;
 
 const definitions: Definition[] = [
     {
-        zigbeeModel: ['PERCALE2 D1.00P1.01Z1.00', 'PERCALE2 D1.00P1.02Z1.00', 'PERCALE2 D1.00P1.03Z1.00', 'TAFFETAS2 D1.00P1.03Z1.00'],
-        model: 'PERCALE2',
-        vendor: 'Acova',
-        description: 'Percale 2 heater',
-        fromZigbee: [fz.thermostat, fz.hvac_user_interface],
-        toZigbee: [
-            tz.thermostat_local_temperature,
-            tz.thermostat_system_mode,
-            tz.thermostat_occupied_heating_setpoint,
-            tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_occupied_cooling_setpoint,
-            tz.thermostat_running_state,
-        ],
-        exposes: [
-            e.climate()
-                .withSetpoint('occupied_heating_setpoint', 7, 28, 0.5)
-                .withSetpoint('unoccupied_heating_setpoint', 7, 28, 0.5)
-                .withLocalTemperature()
-                .withSystemMode(['off', 'heat', 'auto'])
-                .withRunningState(['idle', 'heat']),
-        ],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
-            await reporting.thermostatTemperature(endpoint);
-            await reporting.thermostatRunningState(endpoint);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
-        },
-    },
-    {
         zigbeeModel: ['ALCANTARA2 D1.00P1.01Z1.00\u0000\u0000\u0000\u0000\u0000\u0000',
             'ALCANTARA2 D1.00P1.02Z1.00\u0000\u0000\u0000\u0000\u0000\u0000'],
         model: 'ALCANTARA2',
@@ -70,14 +39,15 @@ const definitions: Definition[] = [
     },
     {
         zigbeeModel: ['TAFFETAS2 D1.00P1.02Z1.00\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
-            'TAFFETAS2 D1.00P1.01Z1.00\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
-        model: 'TAFFETAS2',
+            'TAFFETAS2 D1.00P1.01Z1.00\u0000\u0000\u0000\u0000\u0000\u0000\u0000',
+            'PERCALE2 D1.00P1.01Z1.00', 'PERCALE2 D1.00P1.02Z1.00', 'PERCALE2 D1.00P1.03Z1.00', 'TAFFETAS2 D1.00P1.03Z1.00'],
+        model: 'TAFFETAS2/PERCALE2',
         vendor: 'Acova',
-        description: 'Taffetas 2 heater',
+        description: 'Taffetas 2 / Percale 2 heater',
         fromZigbee: [fz.thermostat, fz.hvac_user_interface, fz.occupancy],
         toZigbee: [
             tz.thermostat_local_temperature,
-            tz.thermostat_system_mode,
+            tz.acova_thermostat_system_mode,
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_running_state,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -44,6 +44,14 @@ export const thermostatSystemModes: KeyValueNumberString = {
     9: 'sleep',
 };
 
+export const acovaThermostatSystemModes: KeyValueNumberString = {
+    0: 'off',
+    1: 'heat',
+    3: 'auto',
+    4: 'away_or_vacation',
+};
+
+
 export const thermostatRunningMode: KeyValueNumberString= {
     0: 'off',
     3: 'cool',


### PR DESCRIPTION
merge percale and taffetas heater as they are sharing some ZigbeeModel anyway.
make the order "heat" works as it seems Acova invert it with "Off"
 fix rimraf --glob for windows npm clean to work


It remains what seems an anomaly to me, the local_temperature is the temperature set on the heater itself (override) and not a measure of the room temperature.