### PR TITLE
fix: use deviceEndpoints extend instead of endpoint defenitions

### DIFF
--- a/src/devices/atsmart.ts
+++ b/src/devices/atsmart.ts
@@ -1,5 +1,5 @@
 import {Definition} from '../lib/types';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -7,7 +7,10 @@ const definitions: Definition[] = [
         model: 'Z6',
         vendor: 'Atsmart',
         description: '3 gang smart wall switch (no neutral wire)',
-        extend: [onOff({endpoints: {left: 1, center: 2, right: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'center': 2, 'right': 3}}),
+            onOff({endpointNames: ['left', 'center', 'right']}),
+        ],
     },
 ];
 

--- a/src/devices/dawon_dns.ts
+++ b/src/devices/dawon_dns.ts
@@ -2,7 +2,7 @@ import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
-import {forcePowerSource, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, forcePowerSource, onOff} from '../lib/modernExtend';
 import {Definition, Fz, Tz} from '../lib/types';
 const e = exposes.presets;
 const ea = exposes.access;
@@ -117,14 +117,20 @@ const definitions: Definition[] = [
         model: 'PM-S240-ZB',
         vendor: 'Dawon DNS',
         description: 'IOT smart switch 2 gang without neutral wire',
-        extend: [onOff({endpoints: {top: 1, bottom: 2}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'bottom': 2}}),
+            onOff({endpointNames: ['top', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['PM-S340-ZB'],
         model: 'PM-S340-ZB',
         vendor: 'Dawon DNS',
         description: 'IOT smart switch 3 gang without neutral wire',
-        extend: [onOff({endpoints: {top: 1, center: 2, bottom: 3}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({endpointNames: ['top', 'center', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['PM-S140R-ZB'],
@@ -138,14 +144,20 @@ const definitions: Definition[] = [
         model: 'PM-S240R-ZB',
         vendor: 'Dawon DNS',
         description: 'IOT smart switch 2 gang without neutral wire',
-        extend: [onOff({endpoints: {top: 1, bottom: 2}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'bottom': 2}}),
+            onOff({endpointNames: ['top', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['PM-S340R-ZB'],
         model: 'PM-S340R-ZB',
         vendor: 'Dawon DNS',
         description: 'IOT smart switch 3 gang without neutral wire',
-        extend: [onOff({endpoints: {top: 1, center: 2, bottom: 3}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({endpointNames: ['top', 'center', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['PM-S150-ZB'],
@@ -159,14 +171,22 @@ const definitions: Definition[] = [
         model: 'PM-S250-ZB',
         vendor: 'Dawon DNS',
         description: 'IOT smart switch 2 gang without neutral wire',
-        extend: [onOff({endpoints: {top: 1, bottom: 2}, powerOnBehavior: false}), forcePowerSource({powerSource: 'Mains (single phase)'})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'bottom': 2}}),
+            onOff({endpointNames: ['top', 'bottom'], powerOnBehavior: false}),
+            forcePowerSource({powerSource: 'Mains (single phase)'}),
+        ],
     },
     {
         zigbeeModel: ['PM-S350-ZB'],
         model: 'PM-S350-ZB',
         vendor: 'Dawon DNS',
         description: 'IOT smart switch 3 gang without neutral wire',
-        extend: [onOff({endpoints: {top: 1, center: 2, bottom: 3}, powerOnBehavior: false}), forcePowerSource({powerSource: 'Mains (single phase)'})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({endpointNames: ['top', 'center', 'bottom'], powerOnBehavior: false}),
+            forcePowerSource({powerSource: 'Mains (single phase)'}),
+        ],
     },
     {
         zigbeeModel: ['PM-C150-ZB'],

--- a/src/devices/diyruz.ts
+++ b/src/devices/diyruz.ts
@@ -6,7 +6,7 @@ import * as constants from '../lib/constants';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
 import {Definition} from '../lib/types';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -17,7 +17,10 @@ const definitions: Definition[] = [
         model: 'DIYRuZ_R4_5',
         vendor: 'DIYRuZ',
         description: '[DiY 4 Relays + 4 switches + 1 buzzer](http://modkam.ru/?p=1054)',
-        extend: [onOff({endpoints: {bottom_left: 1, bottom_right: 2, top_left: 3, top_right: 4, center: 5}})],
+        extend: [
+            deviceEndpoints({endpoints: {'bottom_left': 1, 'bottom_right': 2, 'top_left': 3, 'top_right': 4, 'center': 5}}),
+            onOff({endpointNames: ['bottom_left', 'bottom_right', 'top_left', 'top_right', 'center']}),
+        ],
     },
     {
         zigbeeModel: ['DIYRuZ_KEYPAD20'],

--- a/src/devices/dresden_elektronik.ts
+++ b/src/devices/dresden_elektronik.ts
@@ -1,6 +1,6 @@
 import {Definition} from '../lib/types';
 import * as ota from '../lib/ota';
-import {batteryPercentage, light} from '../lib/modernExtend';
+import {batteryPercentage, deviceEndpoints, light} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -9,7 +9,10 @@ const definitions: Definition[] = [
         vendor: 'Dresden Elektronik',
         description: 'ZigBee Light Link wireless electronic ballast',
         ota: ota.zigbeeOTA,
-        extend: [light({colorTemp: {range: undefined}, color: true, endpoints: {rgb: 10, white: 11}})],
+        extend: [
+            deviceEndpoints({endpoints: {'rgb': 10, 'white': 11}}),
+            light({colorTemp: {range: undefined}, color: true, endpointNames: ['rgb', 'white']}),
+        ],
     },
     {
         zigbeeModel: ['FLS-CT'],
@@ -39,7 +42,10 @@ const definitions: Definition[] = [
         model: 'BN-600078',
         vendor: 'Dresden Elektronik',
         description: 'Zigbee controller for 1-10V/PWM',
-        extend: [light({endpoints: {l1: 11, l2: 12, l3: 13, l4: 14}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 11, 'l2': 12, 'l3': 13, 'l4': 14}}),
+            light({endpointNames: ['l1', 'l2', 'l3', 'l4']}),
+        ],
         meta: {disableDefaultResponse: true},
     },
 ];

--- a/src/devices/ecodim.ts
+++ b/src/devices/ecodim.ts
@@ -4,7 +4,7 @@ import fz from '../converters/fromZigbee';
 const e = exposes.presets;
 import * as ota from '../lib/ota';
 import * as tuya from '../lib/tuya';
-import {light} from '../lib/modernExtend';
+import {deviceEndpoints, light} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -23,7 +23,10 @@ const definitions: Definition[] = [
         model: 'Eco-Dim.05',
         vendor: 'EcoDim',
         description: 'LED dimmer duo 2x 0-100W',
-        extend: [light({effect: false, configureReporting: true, endpoints: {left: 2, right: 1}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 2, 'right': 1}}),
+            light({effect: false, configureReporting: true, endpointNames: ['left', 'right']}),
+        ],
     },
     {
         fingerprint: [

--- a/src/devices/envilar.ts
+++ b/src/devices/envilar.ts
@@ -2,7 +2,7 @@ import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 const e = exposes.presets;
 import fz from '../converters/fromZigbee';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -49,7 +49,10 @@ const definitions: Definition[] = [
         model: '2CH-ZG-BOX-RELAY',
         vendor: 'Envilar',
         description: '2 channel box relay',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
 ];
 

--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -1,6 +1,6 @@
 import {Definition, Fz} from '../lib/types';
 import * as exposes from '../lib/exposes';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 const e = exposes.presets;
 
 const fzLocal = {
@@ -90,7 +90,10 @@ const definitions: Definition[] = [
         model: 'ZB-SW02',
         vendor: 'eWeLink',
         description: 'Smart light switch/2 gang relay',
-        extend: [onOff({endpoints: {left: 1, right: 2}, configureReporting: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'right': 2}}),
+            onOff({endpointNames: ['left', 'right'], configureReporting: false}),
+        ],
         onEvent: async (type, data, device) => {
             device.skipDefaultResponse = true;
         },
@@ -100,7 +103,10 @@ const definitions: Definition[] = [
         model: 'ZB-SW03',
         vendor: 'eWeLink',
         description: 'Smart light switch - 3 gang',
-        extend: [onOff({endpoints: {left: 1, center: 2, right: 3}, configureReporting: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'center': 2, 'right': 3}}),
+            onOff({endpointNames: ['left', 'center', 'right'], configureReporting: false}),
+        ],
         onEvent: async (type, data, device) => {
             device.skipDefaultResponse = true;
         },
@@ -110,7 +116,10 @@ const definitions: Definition[] = [
         model: 'ZB-SW04',
         vendor: 'eWeLink',
         description: 'Smart light switch - 4 gang',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4}, configureReporting: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4'], configureReporting: false}),
+        ],
         onEvent: async (type, data, device) => {
             device.skipDefaultResponse = true;
         },
@@ -120,7 +129,10 @@ const definitions: Definition[] = [
         model: 'ZB-SW05',
         vendor: 'eWeLink',
         description: 'Smart light switch - 5 gang',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5}, configureReporting: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4', 'l5'], configureReporting: false}),
+        ],
         onEvent: async (type, data, device) => {
             device.skipDefaultResponse = true;
         },

--- a/src/devices/ezex.ts
+++ b/src/devices/ezex.ts
@@ -1,5 +1,5 @@
 import {Definition} from '../lib/types';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -7,7 +7,10 @@ const definitions: Definition[] = [
         model: 'ECW-100-A03',
         vendor: 'eZEX',
         description: 'Zigbee switch 3 gang',
-        extend: [onOff({endpoints: {top: 1, center: 2, bottom: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({endpointNames: ['top', 'center', 'bottom']}),
+        ],
     },
 ];
 

--- a/src/devices/feibit.ts
+++ b/src/devices/feibit.ts
@@ -3,7 +3,7 @@ import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -13,7 +13,10 @@ const definitions: Definition[] = [
         model: 'TZSW22FW-L4',
         vendor: 'Feibit',
         description: 'Smart light switch - 2 gang',
-        extend: [onOff({endpoints: {top: 16, bottom: 17}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 16, 'bottom': 17}}),
+            onOff({endpointNames: ['top', 'bottom']}),
+        ],
     },
     {
         zigbeeModel: ['FB56+ZSW1GKJ2.3'],
@@ -125,14 +128,20 @@ const definitions: Definition[] = [
         model: 'SLS301ZB_2',
         vendor: 'Feibit',
         description: 'Smart light switch - 2 gang',
-        extend: [onOff({endpoints: {left: 16, right: 17}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 16, 'right': 17}}),
+            onOff({endpointNames: ['left', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['FB56+ZSW1IKJ2.2', 'FB56+ZSW1IKJ1.1'],
         model: 'SLS301ZB_3',
         vendor: 'Feibit',
         description: 'Smart light switch - 3 gang',
-        extend: [onOff({endpoints: {left: 16, center: 17, right: 18}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 16, 'center': 17, 'right': 18}}),
+            onOff({endpointNames: ['left', 'center', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['FB56+ZSN08KJ2.2'],

--- a/src/devices/gewiss.ts
+++ b/src/devices/gewiss.ts
@@ -3,7 +3,7 @@ import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 const e = exposes.presets;
 
 const definitions: Definition[] = [
@@ -19,7 +19,10 @@ const definitions: Definition[] = [
         model: 'GWA1522',
         description: 'Switch actuator 2 channels with input',
         vendor: 'Gewiss',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         zigbeeModel: ['GWA1531_Shutter'],

--- a/src/devices/hej.ts
+++ b/src/devices/hej.ts
@@ -1,5 +1,5 @@
 import {Definition} from '../lib/types';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -14,37 +14,58 @@ const definitions: Definition[] = [
         model: 'GLSK3ZB-1712',
         vendor: 'Hej',
         description: 'Goqual 2 gang Switch',
-        extend: [onOff({configureReporting: false, endpoints: {top: 1, bottom: 2}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'bottom': 2}}),
+            onOff({configureReporting: false, endpointNames: ['top', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['HejSW03'],
         model: 'GLSK3ZB-1713',
         vendor: 'Hej',
         description: 'Goqual 3 gang Switch',
-        extend: [onOff({configureReporting: false, endpoints: {top: 1, center: 2, bottom: 3}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({configureReporting: false, endpointNames: ['top', 'center', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['HejSW04'],
         model: 'GLSK6ZB-1714',
         vendor: 'Hej',
         description: 'Goqual 4 gang Switch',
-        extend: [onOff({configureReporting: false, endpoints: {top_left: 1, bottom_left: 2, top_right: 3, bottom_right: 4}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top_left': 1, 'bottom_left': 2, 'top_right': 3, 'bottom_right': 4}}),
+            onOff({configureReporting: false, endpointNames: ['top_left', 'bottom_left', 'top_right', 'bottom_right'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['HejSW05'],
         model: 'GLSK6ZB-1715',
         vendor: 'Hej',
         description: 'Goqual 5 gang Switch',
-        extend: [onOff({configureReporting: false, endpoints: {top_left: 1, center_left: 2, bottom_left: 3, top_right: 4, bottom_right: 5},
-            powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top_left': 1, 'center_left': 2, 'bottom_left': 3, 'top_right': 4, 'bottom_right': 5}}),
+            onOff({
+                configureReporting: false,
+                endpointNames: ['top_left', 'center_left', 'bottom_left', 'top_right', 'bottom_right'],
+                powerOnBehavior: false,
+            }),
+        ],
     },
     {
         zigbeeModel: ['HejSW06'],
         model: 'GLSK6ZB-1716',
         vendor: 'Hej',
         description: 'Goqual 6 gang Switch',
-        extend: [onOff({endpoints: {top_left: 1, center_left: 2, bottom_left: 3, top_right: 4, center_right: 5, bottom_right: 6},
-            powerOnBehavior: false, configureReporting: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top_left': 1, 'center_left': 2, 'bottom_left': 3, 'top_right': 4, 'center_right': 5, 'bottom_right': 6}}),
+            onOff({
+                configureReporting: false,
+                endpointNames: ['top_left', 'center_left', 'bottom_left', 'top_right', 'center_right', 'bottom_right'],
+                powerOnBehavior: false,
+            }),
+        ],
     },
 ];
 

--- a/src/devices/honyar.ts
+++ b/src/devices/honyar.ts
@@ -4,7 +4,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import * as tuya from '../lib/tuya';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -14,7 +14,10 @@ const definitions: Definition[] = [
         model: 'U86K31ND6',
         vendor: 'Honyar',
         description: '3 gang switch ',
-        extend: [onOff({endpoints: {left: 1, center: 2, right: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'center': 2, 'right': 3}}),
+            onOff({endpointNames: ['left', 'center', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['HY0043'],

--- a/src/devices/hzc_electric.ts
+++ b/src/devices/hzc_electric.ts
@@ -1,7 +1,7 @@
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
-import {light} from '../lib/modernExtend';
+import {deviceEndpoints, light} from '../lib/modernExtend';
 const e = exposes.presets;
 
 const definitions: Definition[] = [
@@ -10,7 +10,10 @@ const definitions: Definition[] = [
         model: 'D086-ZG',
         vendor: 'HZC Electric',
         description: 'Zigbee dual dimmer',
-        extend: [light({endpoints: {l1: 1, l2: 2}, configureReporting: true})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            light({endpointNames: ['l1', 'l2'], configureReporting: true}),
+        ],
     },
     {
         zigbeeModel: ['TempAndHumSensor-ZB3.0'],

--- a/src/devices/konke.ts
+++ b/src/devices/konke.ts
@@ -4,7 +4,7 @@ import fz from '../converters/fromZigbee';
 import * as legacy from '../lib/legacy';
 import * as utils from '../lib/utils';
 import * as reporting from '../lib/reporting';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -155,14 +155,20 @@ const definitions: Definition[] = [
         model: 'KK-LP-Q02D',
         vendor: 'Konke',
         description: 'Light years switch 2 gangs',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         zigbeeModel: ['3AFE292000068623'],
         model: 'KK-LP-Q03D',
         vendor: 'Konke',
         description: 'Light years switch 3 gangs',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3']}),
+        ],
     },
     {
         zigbeeModel: ['3AFE2610010C0021'],

--- a/src/devices/led_trading.ts
+++ b/src/devices/led_trading.ts
@@ -4,7 +4,7 @@ import * as exposes from '../lib/exposes';
 import * as utils from '../lib/utils';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -49,7 +49,10 @@ const definitions: Definition[] = [
         model: '9134',
         vendor: 'LED-Trading',
         description: 'Powerstrip with 4 sockets and USB',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4', 'l5']}),
+        ],
     },
     {
         zigbeeModel: ['HK-ZCC-ZLL-A'],

--- a/src/devices/lellki.ts
+++ b/src/devices/lellki.ts
@@ -7,7 +7,7 @@ import extend from '../lib/extend';
 const e = exposes.presets;
 const ea = exposes.access;
 import * as tuya from '../lib/tuya';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -21,7 +21,10 @@ const definitions: Definition[] = [
         fromZigbee: [tuya.fz.power_on_behavior_2],
         exposes: [e.power_on_behavior()],
         configure: tuya.configureMagicPacket,
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4', 'l5'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['JZ-ZB-001'],
@@ -39,14 +42,20 @@ const definitions: Definition[] = [
         model: 'JZ-ZB-003',
         vendor: 'LELLKI',
         description: '3 gang switch',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3']}),
+        ],
     },
     {
         zigbeeModel: ['JZ-ZB-002'],
         model: 'JZ-ZB-002',
         vendor: 'LELLKI',
         description: '2 gang touch switch',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_twqctvna'}],

--- a/src/devices/lonsonho.ts
+++ b/src/devices/lonsonho.ts
@@ -6,7 +6,7 @@ import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
 import * as tuya from '../lib/tuya';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -123,7 +123,10 @@ const definitions: Definition[] = [
         model: 'QS-Zigbee-D02-TRIAC-2C-LN',
         vendor: 'Lonsonho',
         description: '2 gang smart dimmer switch module with neutral',
-        extend: [tuya.modernExtend.tuyaLight({minBrightness: true, endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            tuya.modernExtend.tuyaLight({minBrightness: true, endpointNames: ['l1', 'l2']}),
+        ],
         meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
@@ -136,7 +139,10 @@ const definitions: Definition[] = [
         model: 'QS-Zigbee-D02-TRIAC-2C-L',
         vendor: 'Lonsonho',
         description: '2 gang smart dimmer switch module without neutral',
-        extend: [light({endpoints: {l1: 1, l2: 2}, configureReporting: true})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            light({endpointNames: ['l1', 'l2'], configureReporting: true}),
+        ],
     },
     {
         zigbeeModel: ['Plug_01'],

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2057,8 +2057,8 @@ const definitions: Definition[] = [
         extend: [
             lumiSwitchType(),
             lumiPowerOnBehavior({lookup: {'on': 0, 'previous': 1, 'off': 2, 'toggle': 3}}),
-            lumiOperationMode({description: 'Decoupled mode for 1st relay', endpoint: 'l1'}),
-            lumiOperationMode({description: 'Decoupled mode for 2nd relay', endpoint: 'l2'}),
+            lumiOperationMode({description: 'Decoupled mode for 1st relay', endpointName: 'l1'}),
+            lumiOperationMode({description: 'Decoupled mode for 2nd relay', endpointName: 'l2'}),
             lumiAction({endpointNames: ['l1', 'l2']}),
             binary({
                 name: 'interlock',

--- a/src/devices/lupus.ts
+++ b/src/devices/lupus.ts
@@ -6,7 +6,7 @@ import * as reporting from '../lib/reporting';
 const e = exposes.presets;
 const ea = exposes.access;
 import * as ota from '../lib/ota';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -55,7 +55,10 @@ const definitions: Definition[] = [
         model: '12127',
         vendor: 'Lupus',
         description: '2 channel relay',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
 ];
 

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -2,7 +2,7 @@ import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import * as reporting from '../lib/reporting';
 import * as ota from '../lib/ota';
-import {batteryPercentage, humidity, onOff, temperature} from '../lib/modernExtend';
+import {batteryPercentage, deviceEndpoints, humidity, onOff, temperature} from '../lib/modernExtend';
 const e = exposes.presets;
 import tz from '../converters/toZigbee';
 import fz from '../converters/fromZigbee';
@@ -80,7 +80,10 @@ const definitions: Definition[] = [
         model: 'SIN-4-2-20',
         vendor: 'NodOn',
         description: 'Lighting relay switch',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
         ota: ota.zigbeeOTA,
     },
     {
@@ -88,7 +91,10 @@ const definitions: Definition[] = [
         model: 'SIN-4-2-20_PRO',
         vendor: 'NodOn',
         description: 'Lighting relay switch',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
         ota: ota.zigbeeOTA,
     },
     {

--- a/src/devices/nue_3a.ts
+++ b/src/devices/nue_3a.ts
@@ -5,7 +5,7 @@ import * as legacy from '../lib/legacy';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import * as utils from '../lib/utils';
-import {forcePowerSource, light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, forcePowerSource, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -50,7 +50,10 @@ const definitions: Definition[] = [
         model: 'LXN59-2S7LX1.0',
         vendor: 'Nue / 3A',
         description: 'Smart light relay - 2 gang',
-        extend: [onOff({endpoints: {left: 1, right: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'right': 2}}),
+            onOff({endpointNames: ['left', 'right']}),
+        ],
         whiteLabel: [{vendor: 'Zemismart', model: 'ZW-EU-02'}],
     },
     {
@@ -92,28 +95,40 @@ const definitions: Definition[] = [
         model: 'HGZB-43',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 3 gang v2.0',
-        extend: [onOff({endpoints: {top: 1, center: 2, bottom: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({endpointNames: ['top', 'center', 'bottom']}),
+        ],
     },
     {
         zigbeeModel: ['LXN-4S27LX1.0'],
         model: 'HGZB-4S',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 4 gang v2.0',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4']}),
+        ],
     },
     {
         zigbeeModel: ['FB56+ZSW1IKJ1.7', 'FB56+ZSW1IKJ2.5', 'FB56+ZSW1IKJ2.7'],
         model: 'HGZB-043',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 3 gang',
-        extend: [onOff({endpoints: {top: 16, center: 17, bottom: 18}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 16, 'center': 17, 'bottom': 18}}),
+            onOff({endpointNames: ['top', 'center', 'bottom']}),
+        ],
     },
     {
         zigbeeModel: ['FB56+ZSW1JKJ2.7'],
         model: 'HGZB-44',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 4 gang v2.0',
-        extend: [onOff({endpoints: {top_left: 16, top_right: 17, bottom_right: 18, bottom_left: 19}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top_left': 16, 'top_right': 17, 'bottom_right': 18, 'bottom_left': 19}}),
+            onOff({endpointNames: ['top_left', 'top_right', 'bottom_right', 'bottom_left']}),
+        ],
     },
     {
         zigbeeModel: ['FB56+ZSC05HG1.0', 'FNB56-ZBW01LX1.2', 'LXN60-DS27LX1.3'],
@@ -128,7 +143,10 @@ const definitions: Definition[] = [
         model: 'HGZB-042',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 2 gang',
-        extend: [onOff({endpoints: {top: 16, bottom: 17}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 16, 'bottom': 17}}),
+            onOff({endpointNames: ['top', 'bottom']}),
+        ],
     },
     {
         fingerprint: [
@@ -141,7 +159,10 @@ const definitions: Definition[] = [
         model: 'HGZB-42',
         vendor: 'Nue / 3A',
         description: 'Smart light switch - 2 gang v2.0',
-        extend: [onOff({endpoints: {top: 11, bottom: 12}, configureReporting: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 11, 'bottom': 12}}),
+            onOff({endpointNames: ['top', 'bottom'], configureReporting: false}),
+        ],
         configure: async (device, coordinatorEndpoint, logger) => {
             // ConfigureReporting for onOff fails
             // https://github.com/Koenkk/zigbee2mqtt/issues/20867
@@ -168,7 +189,10 @@ const definitions: Definition[] = [
         model: 'MG-AUWS01',
         vendor: 'Nue / 3A',
         description: 'Smart Double GPO',
-        extend: [onOff({endpoints: {left: 11, right: 12}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 11, 'right': 12}}),
+            onOff({endpointNames: ['left', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['FNB56-ZCW25FB1.9'],
@@ -287,7 +311,10 @@ const definitions: Definition[] = [
         model: 'NUE-AUWZO2',
         vendor: 'Nue / 3A',
         description: 'Smart Zigbee double power point',
-        extend: [onOff({endpoints: {left: 1, right: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'right': 2}}),
+            onOff({endpointNames: ['left', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['LXN56-1S27LX1.2', 'LXX60-FN27LX1.0'],
@@ -295,7 +322,8 @@ const definitions: Definition[] = [
         vendor: 'Nue / 3A',
         description: 'Smart fan light switch',
         extend: [
-            onOff({endpoints: {button_light: 1, button_fan_high: 2, button_fan_med: 3, button_fan_low: 4}}),
+            deviceEndpoints({endpoints: {'button_light': 1, 'button_fan_high': 2, 'button_fan_med': 3, 'button_fan_low': 4}}),
+            onOff({endpointNames: ['button_light', 'button_fan_high', 'button_fan_med', 'button_fan_low']}),
             forcePowerSource({powerSource: 'Mains (single phase)'}),
         ],
     },

--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -4,7 +4,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -63,7 +63,10 @@ const definitions: Definition[] = [
         model: 'T18W3Z',
         vendor: 'ORVIBO',
         description: 'Neutral smart switch 3 gang',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3']}),
+        ],
     },
     {
         zigbeeModel: ['fdd76effa0e146b4bdafa0c203a37192', 'c670e231d1374dbc9e3c6a9fffbd0ae6', '75a4bfe8ef9c4350830a25d13e3ab068'],
@@ -86,14 +89,20 @@ const definitions: Definition[] = [
         model: 'RL804QZB',
         vendor: 'ORVIBO',
         description: 'Multi-functional 3 gang relay',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3}, configureReporting: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3'], configureReporting: false}),
+        ],
     },
     {
         zigbeeModel: ['396483ce8b3f4e0d8e9d79079a35a420'],
         model: 'CM10ZW',
         vendor: 'ORVIBO',
         description: 'Multi-functional 3 gang relay',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3']}),
+        ],
     },
     {
         zigbeeModel: ['b467083cfc864f5e826459e5d8ea6079'],
@@ -159,14 +168,20 @@ const definitions: Definition[] = [
         model: 'T30W3Z',
         vendor: 'ORVIBO',
         description: 'Smart light switch - 3 gang',
-        extend: [onOff({endpoints: {top: 1, center: 2, bottom: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({endpointNames: ['top', 'center', 'bottom']}),
+        ],
     },
     {
         zigbeeModel: ['074b3ffba5a045b7afd94c47079dd553'],
         model: 'T21W2Z',
         vendor: 'ORVIBO',
         description: 'Smart light switch - 2 gang',
-        extend: [onOff({endpoints: {top: 1, bottom: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'bottom': 2}}),
+            onOff({endpointNames: ['top', 'bottom']}),
+        ],
     },
     {
         zigbeeModel: ['095db3379e414477ba6c2f7e0c6aa026'],
@@ -198,14 +213,20 @@ const definitions: Definition[] = [
         model: 'R11W2Z',
         vendor: 'ORVIBO',
         description: 'In wall switch - 2 gang',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         zigbeeModel: ['9ea4d5d8778d4f7089ac06a3969e784b', '83b9b27d5ffb4830bf35be5b1023623e', '2810c2403b9c4a5db62cc62d1030d95e'],
         model: 'R20W2Z',
         vendor: 'ORVIBO',
         description: 'In wall switch - 2 gang',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         zigbeeModel: ['131c854783bc45c9b2ac58088d09571c', 'b2e57a0f606546cd879a1a54790827d6', '585fdfb8c2304119a2432e9845cf2623'],
@@ -279,21 +300,30 @@ const definitions: Definition[] = [
         model: 'T40W2Z',
         vendor: 'ORVIBO',
         description: 'MixSwitch 2 gangs',
-        extend: [onOff({endpoints: {left: 1, right: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'right': 2}}),
+            onOff({endpointNames: ['left', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['e8d667cb184b4a2880dd886c23d00976'],
         model: 'T40W3Z',
         vendor: 'ORVIBO',
         description: 'MixSwitch 3 gangs',
-        extend: [onOff({endpoints: {left: 1, center: 2, right: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'center': 2, 'right': 3}}),
+            onOff({endpointNames: ['left', 'center', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['20513b10079f4cc68cffb8b0dc6d3277'],
         model: 'T40W4Z',
         vendor: 'ORVIBO',
         description: 'MixSwitch 4 gangs',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5, l6: 6}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l4': 3, 'l5': 5, 'l6': 6}}),
+            onOff({endpointNames: ['l1', 'l2', 'l4', 'l5', 'l6']}),
+        ],
     },
     {
         zigbeeModel: ['bcb949e87e8c4ea6bc2803052dd8fbf5'],
@@ -322,7 +352,10 @@ const definitions: Definition[] = [
         model: 'T41W2Z',
         vendor: 'ORVIBO',
         description: 'MixSwitch 2 gang (without neutral wire)',
-        extend: [onOff({endpoints: {left: 1, right: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'right': 2}}),
+            onOff({endpointNames: ['left', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['cb7ce9fe2cb147e69c5ea700b39b3d5b'],
@@ -343,7 +376,10 @@ const definitions: Definition[] = [
         model: 'R30W3Z',
         vendor: 'ORVIBO',
         description: 'In-wall switch 3 gang',
-        extend: [onOff({endpoints: {left: 1, center: 2, right: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 1, 'center': 2, 'right': 3}}),
+            onOff({endpointNames: ['left', 'center', 'right']}),
+        ],
     },
     {
         zigbeeModel: ['0e93fa9c36bb417a90ad5d8a184b683a'],

--- a/src/devices/osram.ts
+++ b/src/devices/osram.ts
@@ -5,6 +5,7 @@ import * as ota from '../lib/ota';
 import * as reporting from '../lib/reporting';
 import {ledvanceLight, ledvanceFz, ledvanceOnOff} from '../lib/ledvance';
 import {Definition} from '../lib/types';
+import {deviceEndpoints} from 'src/lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -370,7 +371,10 @@ const definitions: Definition[] = [
         model: '4062172044776_3',
         vendor: 'OSRAM',
         description: 'Zigbee 3.0 DALI CONV LI dimmer for DALI-based luminaires (with two devices)',
-        extend: [ledvanceLight({configureReporting: true, endpoints: {'l1': 10, 'l2': 11}, ota: ota.zigbeeOTA})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 10, 'l2': 11}}),
+            ledvanceLight({configureReporting: true, endpointNames: ['l1', 'l2'], ota: ota.zigbeeOTA}),
+        ],
     },
     {
         fingerprint: [{modelID: 'Zigbee 3.0 DALI CONV LI', endpoints: [{ID: 10}, {ID: 11}, {ID: 25}, {ID: 242}]},
@@ -378,7 +382,10 @@ const definitions: Definition[] = [
         model: '4062172044776_4',
         vendor: 'OSRAM',
         description: 'Zigbee 3.0 DALI CONV LI dimmer for DALI-based luminaires (with two devices and pushbutton)',
-        extend: [ledvanceLight({configureReporting: true, endpoints: {'l1': 10, 'l2': 11, 's1': 25}, ota: ota.zigbeeOTA})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 10, 'l2': 11, 's1': 25}}),
+            ledvanceLight({configureReporting: true, endpointNames: ['l1', 'l2', 's1'], ota: ota.zigbeeOTA}),
+        ],
         fromZigbee: [fz.command_toggle, fz.command_move, fz.command_stop],
         exposes: [e.action(['toggle_s1', 'brightness_move_up_s1', 'brightness_move_down_s1', 'brightness_stop_s1'])],
         onEvent: async (type, data, device) => {

--- a/src/devices/osram.ts
+++ b/src/devices/osram.ts
@@ -5,7 +5,7 @@ import * as ota from '../lib/ota';
 import * as reporting from '../lib/reporting';
 import {ledvanceLight, ledvanceFz, ledvanceOnOff} from '../lib/ledvance';
 import {Definition} from '../lib/types';
-import {deviceEndpoints} from 'src/lib/modernExtend';
+import {deviceEndpoints} from '../lib/modernExtend';
 
 const e = exposes.presets;
 

--- a/src/devices/robb.ts
+++ b/src/devices/robb.ts
@@ -4,7 +4,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 
@@ -43,7 +43,10 @@ const definitions: Definition[] = [
         model: 'ROB_200-050-0',
         vendor: 'ROBB',
         description: '4 port switch with 2 usb ports (no metering)',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4', 'l5']}),
+        ],
         whiteLabel: [{vendor: 'Sunricher', model: 'SR-ZG9023A(EU)'}],
     },
     {

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -8,7 +8,7 @@ import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
 import * as utils from '../lib/utils';
 import * as ota from '../lib/ota';
-import {onOff, light, electricityMeter, identify, enumLookup} from '../lib/modernExtend';
+import {onOff, light, electricityMeter, identify, enumLookup, deviceEndpoints} from '../lib/modernExtend';
 const e = exposes.presets;
 const ea = exposes.access;
 
@@ -28,7 +28,7 @@ function indicatorMode(endpoint?: string) {
         cluster: 'clipsalWiserSwitchConfigurationClusterServer',
         attribute: {ID: 0x0000, type: 0x30},
         description: description,
-        endpoint: endpoint,
+        endpointName: endpoint,
     });
 }
 
@@ -58,7 +58,7 @@ function switchActions(endpoint?: string) {
         cluster: 'clipsalWiserSwitchConfigurationClusterServer',
         attribute: 'SwitchActions',
         description: description,
-        endpoint: endpoint,
+        endpointName: endpoint,
     });
 }
 
@@ -298,7 +298,10 @@ const definitions: Definition[] = [
         model: 'U202DST600ZB',
         vendor: 'Schneider Electric',
         description: 'EZinstall3 2 gang 2x300W dimmer module',
-        extend: [light({endpoints: {l1: 10, l2: 11}, configureReporting: true})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 10, 'l2': 11}}),
+            light({endpointNames: ['l1', 'l2'], configureReporting: true}),
+        ],
     },
     {
         zigbeeModel: ['PUCK/DIMMER/1'],
@@ -567,7 +570,10 @@ const definitions: Definition[] = [
         model: 'U202SRY2KWZB',
         vendor: 'Schneider Electric',
         description: 'Ulti 240V 9.1 A 2 gangs relay switch impress switch module, amber LED',
-        extend: [onOff({endpoints: {l1: 10, l2: 11}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 10, 'l2': 11}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         zigbeeModel: ['1GANG/SHUTTER/1'],
@@ -830,7 +836,10 @@ const definitions: Definition[] = [
         model: 'MEG5126-0300',
         vendor: 'Schneider Electric',
         description: 'Merten MEG5165 PlusLink relais insert with Merten Wiser System M push button (2fold)',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         zigbeeModel: ['EH-ZB-VACT'],
@@ -1073,7 +1082,10 @@ const definitions: Definition[] = [
         model: '3025CSGZ',
         vendor: 'Schneider Electric',
         description: 'Dual connected smart socket',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         zigbeeModel: ['CCT592011_AS'],

--- a/src/devices/shenzhen_homa.ts
+++ b/src/devices/shenzhen_homa.ts
@@ -1,5 +1,5 @@
 import {Definition} from '../lib/types';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -13,7 +13,10 @@ const definitions: Definition[] = [
         model: 'HOMA1001_RGBW',
         vendor: 'Shenzhen Homa',
         description: 'Smart LED driver RGBW',
-        extend: [light({endpoints: {white: 10, rgb: 11}, color: true})],
+        extend: [
+            deviceEndpoints({endpoints: {'white': 10, 'rgb': 11}}),
+            light({endpointNames: ['white', 'rgb'], color: true}),
+        ],
     },
     {
         fingerprint: [
@@ -84,7 +87,10 @@ const definitions: Definition[] = [
         model: 'HLC614-ZLL',
         vendor: 'Shenzhen Homa',
         description: '3 channel relay module',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3']}),
+        ],
     },
     {
         zigbeeModel: ['HOMA1064', '012'],

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -4,7 +4,7 @@ import * as utils from '../lib/utils';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as reporting from '../lib/reporting';
-import {onOff, numeric, enumLookup} from '../lib/modernExtend';
+import {onOff, numeric, enumLookup, deviceEndpoints} from '../lib/modernExtend';
 import * as ota from '../lib/ota';
 import * as globalStore from '../lib/store';
 
@@ -316,36 +316,53 @@ const definitions: Definition[] = [
         model: 'SBM300Z2',
         vendor: 'ShinaSystem',
         description: 'SiHAS IOT smart switch 2 gang',
-        extend: [onOff({endpoints: {top: 1, bottom: 2}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'bottom': 2}}),
+            onOff({endpointNames: ['top', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['SBM300Z3'],
         model: 'SBM300Z3',
         vendor: 'ShinaSystem',
         description: 'SiHAS IOT smart switch 3 gang',
-        extend: [onOff({endpoints: {top: 1, center: 2, bottom: 3}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top': 1, 'center': 2, 'bottom': 3}}),
+            onOff({endpointNames: ['top', 'center', 'bottom'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['SBM300Z4'],
         model: 'SBM300Z4',
         vendor: 'ShinaSystem',
         description: 'SiHAS IOT smart switch 4 gang',
-        extend: [onOff({endpoints: {top_left: 1, bottom_left: 2, top_right: 3, bottom_right: 4}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top_left': 1, 'bottom_left': 2, 'top_right': 3, 'bottom_right': 4}}),
+            onOff({endpointNames: ['top_left', 'bottom_left', 'top_right', 'bottom_right'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['SBM300Z5'],
         model: 'SBM300Z5',
         vendor: 'ShinaSystem',
         description: 'SiHAS IOT smart switch 5 gang',
-        extend: [onOff({endpoints: {top_left: 1, center_left: 2, bottom_left: 3, top_right: 4, bottom_right: 5}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top_left': 1, 'center_left': 2, 'bottom_left': 3, 'top_right': 4, 'bottom_right': 5}}),
+            onOff({endpointNames: ['top_left', 'center_left', 'bottom_left', 'top_right', 'bottom_right'], powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ['SBM300Z6'],
         model: 'SBM300Z6',
         vendor: 'ShinaSystem',
         description: 'SiHAS IOT smart switch 6 gang',
-        extend: [onOff({endpoints: {top_left: 1, center_left: 2, bottom_left: 3, top_right: 4, center_right: 5, bottom_right: 6},
-            powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {'top_left': 1, 'center_left': 2, 'bottom_left': 3, 'top_right': 4, 'center_right': 5, 'bottom_right': 6}}),
+            onOff({
+                endpointNames: ['top_left', 'center_left', 'bottom_left', 'top_right', 'center_right', 'bottom_right'],
+                powerOnBehavior: false,
+            }),
+        ],
     },
     {
         zigbeeModel: ['BSM-300Z'],

--- a/src/devices/spotmau.ts
+++ b/src/devices/spotmau.ts
@@ -1,7 +1,7 @@
 import {Definition} from '../lib/types';
 import * as reporting from '../lib/reporting';
 import extend from '../lib/extend';
-import {onOff} from '../lib/modernExtend';
+import {deviceEndpoints, onOff} from '../lib/modernExtend';
 
 const definitions: Definition[] = [
     {
@@ -22,7 +22,10 @@ const definitions: Definition[] = [
         model: 'SP-PS2-02',
         vendor: 'Spotmau',
         description: 'Smart wall switch - 2 gang',
-        extend: [onOff({endpoints: {left: 16, right: 17}})],
+        extend: [
+            deviceEndpoints({endpoints: {'left': 16, 'right': 17}}),
+            onOff({endpointNames: ['left', 'right']}),
+        ],
     },
 ];
 

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -8,7 +8,7 @@ import * as constants from '../lib/constants';
 import extend from '../lib/extend';
 import * as utils from '../lib/utils';
 import {Definition, Fz, Zh} from '../lib/types';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -59,14 +59,20 @@ const definitions: Definition[] = [
         model: 'SR-ZG9023A-EU',
         vendor: 'Sunricher',
         description: '4 ports switch with 2 usb ports (no metering)',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4, l5: 5}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4, 'l5': 5}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4', 'l5']}),
+        ],
     },
     {
         zigbeeModel: ['ON/OFF(2CH)'],
         model: 'UP-SA-9127D',
         vendor: 'Sunricher',
         description: 'LED-Trading 2 channel AC switch',
-        extend: [onOff({endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            onOff({endpointNames: ['l1', 'l2']}),
+        ],
     },
     {
         fingerprint: [{modelID: 'ON/OFF(2CH)', softwareBuildID: '2.9.2_r54'}],

--- a/src/devices/terncy.ts
+++ b/src/devices/terncy.ts
@@ -5,7 +5,7 @@ import tz from '../converters/toZigbee';
 import * as ota from '../lib/ota';
 import * as reporting from '../lib/reporting';
 import {Definition} from '../lib/types';
-import {light, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, light, onOff} from '../lib/modernExtend';
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -16,7 +16,10 @@ const definitions: Definition[] = [
         model: 'TERNCY-WS01',
         vendor: 'TERNCY',
         description: 'Smart light switch - 4 gang without neutral wire',
-        extend: [onOff({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4}}),
+            onOff({endpointNames: ['l1', 'l2', 'l3', 'l4']}),
+        ],
     },
     {
         zigbeeModel: ['DL001'],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12,7 +12,7 @@ import {ColorMode, colorModeLookup} from '../lib/constants';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import {KeyValue, Definition, Tz, Fz, Expose, KeyValueAny, KeyValueString} from '../lib/types';
-import {onOff, quirkCheckinInterval, batteryPercentage} from '../lib/modernExtend';
+import {onOff, quirkCheckinInterval, batteryPercentage, deviceEndpoints} from '../lib/modernExtend';
 
 const {tuyaLight} = tuya.modernExtend;
 
@@ -2548,7 +2548,10 @@ const definitions: Definition[] = [
         model: 'TS0003',
         vendor: 'TuYa',
         description: '3 gang switch',
-        extend: [onOff({endpoints: {left: 1, center: 2, right: 3}, powerOnBehavior: false})],
+        extend: [
+            deviceEndpoints({endpoints: {left: 1, center: 2, right: 3}}),
+            onOff({endpointNames: ['left', 'center', 'right'], powerOnBehavior: false}),
+        ],
         whiteLabel: [{vendor: 'BSEED', model: 'TS0003', description: 'Zigbee switch'}],
         meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint, logger) => {
@@ -4050,7 +4053,10 @@ const definitions: Definition[] = [
         vendor: 'TuYa',
         description: 'Zigbee dimmer module 2 channel',
         whiteLabel: [{vendor: 'OXT', model: 'SWTZ25'}],
-        extend: [tuyaLight({minBrightness: true, endpoints: {l1: 1, l2: 2}, configureReporting: true})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            tuyaLight({minBrightness: true, endpointNames: ['l1', 'l2'], configureReporting: true}),
+        ],
         configure: async (device, coordinatorEndpoint, logger) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
         },
@@ -5079,7 +5085,10 @@ const definitions: Definition[] = [
         model: 'TS0052_2',
         vendor: 'TuYa',
         description: 'Zigbee dimmer module 2 channel',
-        extend: [tuyaLight({powerOnBehavior: true, configureReporting: true, switchType: true, minBrightness: true, endpoints: {l1: 1, l2: 2}})],
+        extend: [
+            deviceEndpoints({endpoints: {'l1': 1, 'l2': 2}}),
+            tuyaLight({powerOnBehavior: true, configureReporting: true, switchType: true, minBrightness: true, endpointNames: ['l1', 'l2']}),
+        ],
         configure: async (device, coordinatorEndpoint, logger) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
         },

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -165,17 +165,17 @@ function stringifyEps(endpoints: Endpoint[]): string[] {
 
 const inputExtenders: Extender[] = [
     [['msTemperatureMeasurement'], async (eps) => [
-        new Generator({extend: m.temperature, args: {endpoints: stringifyEps(eps)}, source: 'temperature'}),
+        new Generator({extend: m.temperature, args: {endpointNames: stringifyEps(eps)}, source: 'temperature'}),
     ]],
-    [['msPressureMeasurement'], async (eps) => [new Generator({extend: m.pressure, args: {endpoints: stringifyEps(eps)}, source: 'pressure'})]],
-    [['msRelativeHumidity'], async (eps) => [new Generator({extend: m.humidity, args: {endpoints: stringifyEps(eps)}, source: 'humidity'})]],
-    [['msCO2'], async (eps) => [new Generator({extend: m.co2, args: {endpoints: stringifyEps(eps)}, source: 'co2'})]],
+    [['msPressureMeasurement'], async (eps) => [new Generator({extend: m.pressure, args: {endpointNames: stringifyEps(eps)}, source: 'pressure'})]],
+    [['msRelativeHumidity'], async (eps) => [new Generator({extend: m.humidity, args: {endpointNames: stringifyEps(eps)}, source: 'humidity'})]],
+    [['msCO2'], async (eps) => [new Generator({extend: m.co2, args: {endpointNames: stringifyEps(eps)}, source: 'co2'})]],
     [['genPowerCfg'], async () => [new Generator({extend: m.batteryPercentage, source: 'batteryPercentage'})]],
     [['genOnOff', 'lightingColorCtrl'], extenderOnOffLight],
     [['seMetering', 'haElectricalMeasurement'], extenderElectricityMeter],
     [['closuresDoorLock'], extenderLock],
     [['msIlluminanceMeasurement'], async (eps) => [
-        new Generator({extend: m.illuminance, args: {endpoints: stringifyEps(eps)}, source: 'illuminance'}),
+        new Generator({extend: m.illuminance, args: {endpointNames: stringifyEps(eps)}, source: 'illuminance'}),
     ]],
     [['msOccupancySensing'], async (eps) => [
         new Generator({extend: m.occupancy, source: 'occupancy'}),
@@ -209,7 +209,9 @@ async function extenderOnOffLight(endpoints: Zh.Endpoint[]): Promise<GeneratedEx
             prev[curr.ID.toString()] = curr.ID;
             return prev;
         }, {} as Record<string, number>) : undefined;
-        generated.push(new Generator({extend: m.onOff, args: {powerOnBehavior: false, endpoints}, source: 'onOff'}));
+        const endpointNames: string[] = endpoints ? Object.keys(endpoints) : undefined;
+        generated.push(new Generator({extend: m.deviceEndpoints, args: {endpoints: endpoints}, source: 'deviceEndpoints'}));
+        generated.push(new Generator({extend: m.onOff, args: {powerOnBehavior: false, endpointNames: endpointNames}, source: 'onOff'}));
     }
 
     for (const endpoint of lightEndpoints) {

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -210,7 +210,7 @@ async function extenderOnOffLight(endpoints: Zh.Endpoint[]): Promise<GeneratedEx
             return prev;
         }, {} as Record<string, number>) : undefined;
         const endpointNames: string[] = endpoints ? Object.keys(endpoints) : undefined;
-        generated.push(new Generator({extend: m.deviceEndpoints, args: {endpoints: endpoints}, source: 'deviceEndpoints'}));
+        if (endpointNames) generated.push(new Generator({extend: m.deviceEndpoints, args: {endpoints: endpoints}, source: 'deviceEndpoints'}));
         generated.push(new Generator({extend: m.onOff, args: {powerOnBehavior: false, endpointNames: endpointNames}, source: 'onOff'}));
     }
 

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1704,8 +1704,8 @@ const tuyaModernExtend = {
         if (args.powerOnBehavior) {
             result.fromZigbee.push(tuyaFz.power_on_behavior_2);
             result.toZigbee.push(tuyaTz.power_on_behavior_2);
-            if (args.endpoints) {
-                result.exposes.push(...Object.keys(args.endpoints).map((ee) => e.power_on_behavior().withEndpoint(ee)));
+            if (args.endpointNames) {
+                result.exposes.push(...args.endpointNames.map((ee) => e.power_on_behavior().withEndpoint(ee)));
             } else {
                 result.exposes.push(e.power_on_behavior());
             }

--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -107,7 +107,7 @@ const definition = {
     model: 'combo',
     vendor: 'vendor',
     description: 'Automatically generated definition',
-    extend: [temperature({"endpoints":["1"]}), onOff({"powerOnBehavior":false})],
+    extend: [temperature({"endpointNames":["1"]}), onOff({"powerOnBehavior":false})],
     meta: {},
 };
 
@@ -153,7 +153,7 @@ const definition = {
     model: 'combo',
     vendor: '',
     description: 'Automatically generated definition',
-    extend: [deviceEndpoints({"endpoints":{"1":1,"2":2}}), temperature({"endpoints":["1","2"]}), onOff({"powerOnBehavior":false})],
+    extend: [deviceEndpoints({"endpoints":{"1":1,"2":2}}), temperature({"endpointNames":["1","2"]}), onOff({"powerOnBehavior":false})],
     meta: {"multiEndpoint":true},
 };
 


### PR DESCRIPTION
Implemented stashed idea from #7083.

All modern extend now should accept `endpointName` or `endpointNames`. Endpoint defenition is only added using `deviceEndpoints` extend.