### PR TITLE
Support setting motor speed for Aqara roller shade driver E1

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1936,7 +1936,7 @@ const definitions: Definition[] = [
         fromZigbee: [lumi.fromZigbee.lumi_curtain_position, lumi.fromZigbee.lumi_curtain_status,
             fz.ignore_basic_report, lumi.fromZigbee.lumi_specific],
         toZigbee: [lumi.toZigbee.lumi_curtain_position_state, lumi.toZigbee.lumi_curtain_battery,
-            lumi.toZigbee.lumi_curtain_charging_status],
+            lumi.toZigbee.lumi_curtain_charging_status, lumi.toZigbee.lumi_curtain_motor_speed],
         onEvent: async (type, data, device) => {
             if (type === 'message' && data.type === 'attributeReport' && data.cluster === 'genMultistateOutput' &&
                 data.data.hasOwnProperty('presentValue') && data.data['presentValue'] > 1) {
@@ -1946,6 +1946,7 @@ const definitions: Definition[] = [
             }
         },
         exposes: [e.cover_position().setAccess('state', ea.ALL), e.battery().withAccess(ea.STATE_GET), e.device_temperature(),
+            e.enum('motor_speed', ea.ALL, ['low', 'medium', 'high']).withDescription('Speed of the motor'),
             e.binary('charging_status', ea.STATE_GET, true, false)
                 .withDescription('The current charging status.'),
             e.enum('motor_state', ea.STATE, ['declining', 'rising', 'pause', 'blocked'])

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -18,7 +18,7 @@ const {
     lumiAction, lumiOperationMode, lumiPowerOnBehavior, lumiZigbeeOTA,
     lumiSwitchType, lumiAirQuality, lumiVoc, lumiDisplayUnit, lumiLight,
     lumiOutageCountRestoreBindReporting, lumiElectricityMeter, lumiPower,
-    lumiOverloadProtection, lumiLedIndicator, lumiButtonLock,
+    lumiOverloadProtection, lumiLedIndicator, lumiButtonLock, lumiMotorSpeed,
 } = lumi.modernExtend;
 import {Definition, OnEvent} from '../lib/types';
 const {manufacturerCode} = lumi;
@@ -1936,7 +1936,7 @@ const definitions: Definition[] = [
         fromZigbee: [lumi.fromZigbee.lumi_curtain_position, lumi.fromZigbee.lumi_curtain_status,
             fz.ignore_basic_report, lumi.fromZigbee.lumi_specific],
         toZigbee: [lumi.toZigbee.lumi_curtain_position_state, lumi.toZigbee.lumi_curtain_battery,
-            lumi.toZigbee.lumi_curtain_charging_status, lumi.toZigbee.lumi_curtain_motor_speed],
+            lumi.toZigbee.lumi_curtain_charging_status],
         onEvent: async (type, data, device) => {
             if (type === 'message' && data.type === 'attributeReport' && data.cluster === 'genMultistateOutput' &&
                 data.data.hasOwnProperty('presentValue') && data.data['presentValue'] > 1) {
@@ -1946,7 +1946,6 @@ const definitions: Definition[] = [
             }
         },
         exposes: [e.cover_position().setAccess('state', ea.ALL), e.battery().withAccess(ea.STATE_GET), e.device_temperature(),
-            e.enum('motor_speed', ea.ALL, ['low', 'medium', 'high']).withDescription('Speed of the motor'),
             e.binary('charging_status', ea.STATE_GET, true, false)
                 .withDescription('The current charging status.'),
             e.enum('motor_state', ea.STATE, ['declining', 'rising', 'pause', 'blocked'])
@@ -1959,7 +1958,10 @@ const definitions: Definition[] = [
             const endpoint = device.getEndpoint(1);
             await endpoint.read('manuSpecificLumi', [0x040a], {manufacturerCode: manufacturerCode});
         },
-        extend: [lumiZigbeeOTA()],
+        extend: [
+            lumiZigbeeOTA(),
+            lumiMotorSpeed(),
+        ],
     },
     {
         // 'lumi.curtain.acn003' - CN version (ZNCLBL01LM), 'lumi.curtain.agl001' - global version (CM-M01)

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -698,6 +698,11 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
                 running: !!value,
             };
             break;
+        case '1032':
+            if (['ZNJLBL01LM'].includes(model.model)) {
+                payload.motor_speed = value;
+            }
+            break;
         case '1033':
             if (['ZNJLBL01LM'].includes(model.model)) {
                 payload.charging_status = value === 1;
@@ -3756,6 +3761,22 @@ export const toZigbee = {
         key: ['charging_status'],
         convertGet: async (entity, key, meta) => {
             await entity.read('manuSpecificLumi', [0x0409], manufacturerOptions.lumi);
+        },
+    } satisfies Tz.Converter,
+    lumi_curtain_motor_speed: {
+        key: ['motor_speed'],
+        convertSet: async (entity, key, value, meta) => {
+            switch (value) {
+            case 'low':
+                await entity.write('manuSpecificLumi', {0x0408: {value: 0x00, type: 0x20}}, manufacturerOptions.lumi);
+                break;
+            case 'medium':
+                await entity.write('manuSpecificLumi', {0x0408: {value: 0x01, type: 0x20}}, manufacturerOptions.lumi);
+                break;
+            case 'high':
+                await entity.write('manuSpecificLumi', {0x0408: {value: 0x02, type: 0x20}}, manufacturerOptions.lumi);
+                break;
+            }
         },
     } satisfies Tz.Converter,
     lumi_curtain_battery: {

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -3772,25 +3772,6 @@ export const toZigbee = {
             await entity.read('manuSpecificLumi', [0x0409], manufacturerOptions.lumi);
         },
     } satisfies Tz.Converter,
-    lumi_curtain_motor_speed: {
-        key: ['motor_speed'],
-        convertGet: async (entity, key, meta) => {
-            await entity.read('manuSpecificLumi', [0x0408], manufacturerOptions.lumi);
-        },
-        convertSet: async (entity, key, value, meta) => {
-            switch (value) {
-            case 'low':
-                await entity.write('manuSpecificLumi', {0x0408: {value: 0x00, type: 0x20}}, manufacturerOptions.lumi);
-                break;
-            case 'medium':
-                await entity.write('manuSpecificLumi', {0x0408: {value: 0x01, type: 0x20}}, manufacturerOptions.lumi);
-                break;
-            case 'high':
-                await entity.write('manuSpecificLumi', {0x0408: {value: 0x02, type: 0x20}}, manufacturerOptions.lumi);
-                break;
-            }
-        },
-    } satisfies Tz.Converter,
     lumi_curtain_battery: {
         key: ['battery'],
         convertGet: async (entity, key, meta) => {

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -700,7 +700,7 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             break;
         case '1032':
             if (['ZNJLBL01LM'].includes(model.model)) {
-                payload.motor_speed = value;
+                payload.motor_speed = getFromLookup(value, {0: 'low', 1: 'medium', 2: 'high'});
             }
             break;
         case '1033':
@@ -3765,6 +3765,9 @@ export const toZigbee = {
     } satisfies Tz.Converter,
     lumi_curtain_motor_speed: {
         key: ['motor_speed'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('manuSpecificLumi', [0x0408], manufacturerOptions.lumi);
+        },
         convertSet: async (entity, key, value, meta) => {
             switch (value) {
             case 'low':

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -1325,6 +1325,15 @@ export const lumiModernExtend = {
         zigbeeCommandOptions: {manufacturerCode},
         ...args,
     }),
+    lumiMotorSpeed: (args?: Partial<modernExtend.EnumLookupArgs>) => modernExtend.enumLookup({
+        name: 'motor_speed',
+        lookup: {'low': 0, 'medium': 1, 'high': 2},
+        cluster: 'manuSpecificLumi',
+        attribute: {ID: 0x0408, type: 0x20},
+        description: 'Controls the motor speed',
+        zigbeeCommandOptions: {manufacturerCode},
+        ...args,
+    }),
     lumiPowerOnBehavior: (args?: Partial<modernExtend.EnumLookupArgs>) => modernExtend.enumLookup({
         name: 'power_on_behavior',
         lookup: {'on': 0, 'previous': 1, 'off': 2},


### PR DESCRIPTION
Adds support for exposing the motor speed for these drivers, addressing a few feature requests in the z2m repo:
- https://github.com/Koenkk/zigbee2mqtt/issues/18076
- https://github.com/Koenkk/zigbee2mqtt/issues/18431
- https://github.com/Koenkk/zigbee2mqtt/issues/16734

Screenshot of exposes interface:
![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/8350542/57b412c6-db7e-4e47-a6a6-d850f35bf057)

I tested this with my own motors and it works well (and achieves what I wanted it to - to make the motor noise quieter!).

This is my first contribution here and I mostly got this working with trial-and-error, so please let me know if anything needs changing or if something should be done differently. Cheers!