### PR TITLE
Improve `trigger_count` for MCCGQ11LM and SJCGQ11LM

### DIFF
--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -760,7 +760,7 @@ export const presets = {
     temperature: () => new Numeric('temperature', access.STATE).withUnit('°C').withDescription('Measured temperature value'),
     temperature_sensor_select: (sensor_names: string[]) => new Enum('sensor', access.STATE_SET, sensor_names).withDescription('Select temperature sensor to use').withCategory('config'),
     test: () => new Binary('test', access.STATE, true, false).withDescription('Indicates whether the device is being tested'),
-    trigger_count: (sincePowerOutage = true) => new Numeric('trigger_count', exports.access.STATE).withDescription('Indicates how many times the sensor was triggered' + (sincePowerOutage ? ' (since last power outage)' : '')).withCategory('diagnostic'),
+    trigger_count: (sinceScheduledReport = true) => new Numeric('trigger_count', exports.access.STATE).withDescription('Indicates how many times the sensor was triggered' + (sinceScheduledReport ? ' (since last scheduled report)' : '')).withCategory('diagnostic'),
     trigger_indicator: () => new Binary('trigger_indicator', access.ALL, true, false).withDescription('Enables trigger indication').withCategory('config'),
     valve_alarm: () => new Binary('valve_alarm', access.STATE, true, false).withCategory('diagnostic'),
     valve_position: () => new Numeric('position', access.ALL).withValueMin(0).withValueMax(100).withDescription('Position of the valve'),

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -219,7 +219,11 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
         case '6':
             if (['MCCGQ11LM', 'SJCGQ11LM'].includes(model.model) && Array.isArray(value)) {
                 assertNumber(value[1]);
-                payload.trigger_count = value[1];
+                let count = parseInt(value[1]);
+                // Sometimes, especially when the device is connected through another lumi router, the sensor 
+                // send random values after 16 bit (>65536), so we truncate and read this as 16BitUInt.
+                count = parseInt(count.toString(16).slice(-4), 16);
+                payload.trigger_count = count - 1;
             }
             break;
         case '8':

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -219,8 +219,8 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
         case '6':
             if (['MCCGQ11LM', 'SJCGQ11LM'].includes(model.model) && Array.isArray(value)) {
                 assertNumber(value[1]);
-                let count = parseInt(value[1]);
-                // Sometimes, especially when the device is connected through another lumi router, the sensor 
+                let count = value[1];
+                // Sometimes, especially when the device is connected through another lumi router, the sensor
                 // send random values after 16 bit (>65536), so we truncate and read this as 16BitUInt.
                 count = parseInt(count.toString(16).slice(-4), 16);
                 payload.trigger_count = count - 1;


### PR DESCRIPTION
As follow-up of https://github.com/Koenkk/zigbee-herdsman-converters/pull/7086:

- Added filter for incorrect values;
- The counter is reset after each scheduled report (50 min), and not just after a power outage as I initially assumed;
- After scheduled report and reset, the counter will be = 1, so we decrement the value by one.