### PR TITLE
Add color support to Acuity Brands Lighting RB56SC and RB56AC

### DIFF
--- a/src/devices/acuity_brands_lighting.ts
+++ b/src/devices/acuity_brands_lighting.ts
@@ -14,14 +14,14 @@ const definitions: Definition[] = [
         model: 'RB56SC',
         vendor: 'Acuity Brands Lighting (ABL)',
         description: 'Juno Retrobasics 4" and 6" LED smart downlight',
-        extend: [light({colorTemp: {range: [200, 370], startup: false}})],
+        extend: [light({colorTemp: {range: [200, 370], startup: false}, color: true})],
     },
     {
         zigbeeModel: ['ABL-LIGHT-Z-202'],
         model: 'RB56AC',
         vendor: 'Acuity Brands Lighting (ABL)',
         description: 'Juno Retrobasics 4" and 6" LED smart adjustable downlight',
-        extend: [light({colorTemp: {range: [200, 370], startup: false}})],
+        extend: [light({colorTemp: {range: [200, 370], startup: false}, color: true})],
     },
 ];
 


### PR DESCRIPTION
Adding color support to RB56SC and RB56AC.