### PR TITLE
Fix errors thrown by PTM 216Z GP commands without payload

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3173,6 +3173,10 @@ const converters1 = {
             if (hasAlreadyProcessedMessage(msg, model, msg.data.frameCounter, `${msg.device.ieeeAddr}_${commandID}`)) return;
             if (commandID === 224) return;
 
+            if (!msg.data.commandFrame.raw) {
+                return {action: `internal_${commandID}`};
+            }
+
             // Button 1: A0 (top left)
             // Button 2: A1 (bottom left)
             // Button 3: B0 (top right)

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3173,10 +3173,6 @@ const converters1 = {
             if (hasAlreadyProcessedMessage(msg, model, msg.data.frameCounter, `${msg.device.ieeeAddr}_${commandID}`)) return;
             if (commandID === 224) return;
 
-            if (!msg.data.commandFrame.raw) {
-                return {action: `internal_${commandID}`};
-            }
-
             // Button 1: A0 (top left)
             // Button 2: A1 (bottom left)
             // Button 3: B0 (top right)
@@ -3186,9 +3182,10 @@ const converters1 = {
                 '105_6': 'press_3_and_4', '105_7': 'press_1_and_2_and_3', '105_8': 'press_4', '105_9': 'press_1_and_4',
                 '105_10': 'press_2_and_4', '105_11': 'press_1_and_2_and_4', '105_12': 'press_3_and_4', '105_13': 'press_1_and_3_and_4',
                 '105_14': 'press_2_and_3_and_4', '105_15': 'press_all', '105_16': 'press_energy_bar', '106_0': 'release',
+                '104_': 'short_press_2_of_2',
             };
 
-            const ID = `${commandID}_${msg.data.commandFrame.raw.slice(0, 1).join('_')}`;
+            const ID = `${commandID}_${msg.data.commandFrame.raw?.slice(0, 1).join('_') ?? ''}`;
             if (!lookup.hasOwnProperty(ID)) {
                 meta.logger.error(`PTM 216Z: missing command '${ID}'`);
             } else {

--- a/src/devices/enocean.ts
+++ b/src/devices/enocean.ts
@@ -48,7 +48,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         exposes: [e.action(['press_1', 'press_2', 'press_1_and_2', 'press_3', 'press_1_and_3', 'press_3_and_4', 'press_1_and_2_and_3',
             'press_4', 'press_1_and_4', 'press_2_and_4', 'press_1_and_2_and_4', 'press_3_and_4', 'press_1_and_3_and_4',
-            'press_2_and_3_and_4', 'press_all', 'press_energy_bar', 'release'])],
+            'press_2_and_3_and_4', 'press_all', 'press_energy_bar', 'release', 'short_press_2_of_2'])],
     },
 ];
 


### PR DESCRIPTION
```log
debug 2024-02-27 08:51:01: Received Zigbee message from '0x000000000155f47a', type 'commandNotification', cluster 'greenPower', data '{"commandFrame":{},"commandID":104,"frameCounter":971,"options":0,"payloadSize":0,"srcID":22410362}' from endpoint 242 with groupID 2948
info  2024-02-27 08:51:01: MQTT publish: topic 'zigbee2mqtt/0x000000000155f47a', payload '{"action":"internal_104","device":{"friendlyName":"0x000000000155f47a","ieeeAddr":"0x000000000155f47a","manufacturerID":null,"model":"PTM 216Z","networkAddress":62586,"type":"GreenPower"},"elapsed":104886,"linkquality":216}'
info  2024-02-27 08:51:01: MQTT publish: topic 'zigbee2mqtt/0x000000000155f47a', payload '{"action":"","device":{"friendlyName":"0x000000000155f47a","ieeeAddr":"0x000000000155f47a","manufacturerID":null,"model":"PTM 216Z","networkAddress":62586,"type":"GreenPower"},"linkquality":216}'
info  2024-02-27 08:51:01: MQTT publish: topic 'zigbee2mqtt/0x000000000155f47a/action', payload 'internal_104'
```

Credits to @dduransseau & @chris-1243 😉 
https://github.com/Koenkk/zigbee2mqtt/discussions/21462#discussioncomment-8510459