### PR TITLE
Fixes issue of passing function to tuya lookup value converter

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -431,9 +431,9 @@ export const valueConverterBasic = {
     lookup: (map: LookupMap | ((options: KeyValue, device: Zh.Device) => LookupMap),
         fallbackValue?: number | boolean | KeyValue | string | null) => {
         return {
-            to: (v: string, meta: Tz.Meta) => utils.getFromLookup(v, map instanceof Function ? map(meta.options, meta.device) : map),
+            to: (v: string, meta: Tz.Meta) => utils.getFromLookup(v, typeof map === 'function' ? map(meta.options, meta.device) : map),
             from: (v: number, _meta: Fz.Meta, options: KeyValue) => {
-                const m = map instanceof Function ? map(options, _meta.device) : map;
+                const m = typeof map === 'function' ? map(options, _meta.device) : map;
                 const value = Object.entries(m).find((i) => i[1].valueOf() === v);
                 if (!value) {
                     if (fallbackValue !== undefined) return fallbackValue;


### PR DESCRIPTION
I wanted to add additional option to one of my tuya devices and use it inside value converter. Previously I used `tuya.valueConverter.onOff` which is an alias to `valueConverterBasic.lookup({'ON': true, 'OFF': false})`. 

From the source code I learnt that `lookup` can accept a function that accepts device options and returns a mapping (this is exactly what I needed). But after trying to pass a function and return the same map I got this errors in logs:

```
Error: Value 'false' is not allowed, expected one of
```  

Added several `console.log`s in source code to ensure that `lookup` actually receives my function and that for my function `instanceof Function` returns `false`.

After changing the source code from checking function using `instanceof Function` to `typeof ... === 'function'`, it started to  work. For some reason `instanceof Function` returns `false` in my case, don't have explanation here, but it appears that runtime for some reason had 2 `Function` instances which were different in my value converter and inside zigbee-herdsman-converters (maybe they are executed in 2 different processes or sandboxes, converter was passed through docker volume binding).