### PR TITLE
Reference attributes directly from cluster

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -26,7 +26,7 @@ function indicatorMode(endpoint?: string) {
             'always_on': 1,
         },
         cluster: 'manuSpecificSchneiderLightSwitchConfiguration',
-        attribute: {ID: 0x0000, type: 0x30},
+        attribute: 'ledIndication',
         description: description,
         endpointName: endpoint,
     });
@@ -42,7 +42,7 @@ function fanIndicatorMode() {
             'on_with_timeout': 5,
         },
         cluster: 'manuSpecificSchneiderFanSwitchConfiguration',
-        attribute: {ID: 0x0002, type: 0x20},
+        attribute: 'ledIndication',
         description: description,
     });
 }
@@ -58,7 +58,7 @@ function fanIndicatorOrientation() {
             'vertical_bottom': 1,
         },
         cluster: 'manuSpecificSchneiderFanSwitchConfiguration',
-        attribute: {ID: 0x0060, type: 0x20},
+        attribute: 'ledOrientation',
         description: description,
     });
 }

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -25,7 +25,7 @@ function indicatorMode(endpoint?: string) {
             'always_off': 3,
             'always_on': 1,
         },
-        cluster: 'clipsalWiserSwitchConfigurationClusterServer',
+        cluster: 'manuSpecificSchneiderLightSwitchConfiguration',
         attribute: {ID: 0x0000, type: 0x30},
         description: description,
         endpointName: endpoint,


### PR DESCRIPTION
# What?

Change to referencing the attributes directly from the cluster object.

Full disclosure I've looked at the code and from what I understand this is how we should be referencing the data from the cluster, but I would also really need your help here to validate that this is correct. The current implementation doesn't seem to work correctly as hitting the "refresh" button didn't seem to update the value of these LEDs.

Can you please just confirm both this PR and the https://github.com/Koenkk/zigbee-herdsman/pull/942 are compatible and that the integration should work in this way?