### PR TITLE
Reference new named cluster and attribute

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -86,8 +86,8 @@ function switchActions(endpoint?: string) {
             'alternate_dimmer': 8,
             'not_used': 127,
         },
-        cluster: 'clipsalWiserSwitchConfigurationClusterServer',
-        attribute: 'SwitchActions',
+        cluster: 'manuSpecificSchneiderLightSwitchConfiguration',
+        attribute: 'switchActions',
         description: description,
         endpointName: endpoint,
     });


### PR DESCRIPTION
This was missed in a previous PR

Is it also possible that the cluster update didn't make it to the 1.36.0 update? I saw the commit/release notes and can see that `zigbee-herdsmen` looked like the right version, but I really can't make sense of this error. I say this cause I look in the dev console and I can't see the new cluster names that were created over here:
https://github.com/Koenkk/zigbee-herdsman/pull/942
https://github.com/Koenkk/zigbee-herdsman/pull/937

<img width="315" alt="Screenshot 2024-03-02 at 10 08 43 am" src="https://github.com/Koenkk/zigbee-herdsman-converters/assets/20388321/6f150bd8-c464-481e-bb9a-502fb11046f8">
