### PR TITLE
Revert referencing the attribute name

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -26,7 +26,12 @@ function indicatorMode(endpoint?: string) {
             'always_on': 1,
         },
         cluster: 'manuSpecificSchneiderLightSwitchConfiguration',
-        attribute: 'ledIndication',
+        // Trying to reference this attribute by name seemed to fail for an
+        // unknown reason. If anyone can figure this out, feel free to switch
+        // over these attribute keys. Details in issue below:
+        // https://github.com/Koenkk/zigbee-herdsman-converters/issues/7146
+        // attribute: 'ledIndication',
+        attribute: {ID: 0x0000, type: 0x30},
         description: description,
         endpointName: endpoint,
     });


### PR DESCRIPTION
This was changed in https://github.com/Koenkk/zigbee-herdsman-converters/pull/7139 and seemed to break this integration. Unsure as to why this is not working anymore as everything logically looks correct.

For now lets revert this change and hope this resolves the bug and gets this part of the integration working again.

Partially fixes: https://github.com/Koenkk/zigbee-herdsman-converters/issues/7146 