### PR TITLE
Fix the broken LED indicator for Schneider Electric wiser devices

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -502,7 +502,7 @@ const definitions: Definition[] = [
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series module switch 2AX',
         ota: ota.zigbeeOTA,
-        extend: [onOff({powerOnBehavior: true}), indicatorMode('smart')],
+        extend: [onOff({powerOnBehavior: false}), indicatorMode('smart')],
         meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
@@ -518,7 +518,7 @@ const definitions: Definition[] = [
         model: '41E10PBSWMZ-VW',
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series module switch 10AX with ControlLink',
-        extend: [onOff({powerOnBehavior: true}), indicatorMode('smart')],
+        extend: [onOff({powerOnBehavior: false}), indicatorMode('smart')],
         meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -15,7 +15,7 @@ const ea = exposes.access;
 function indicatorMode(endpoint?: string) {
     let description = 'Set Indicator Mode.';
     if (endpoint) {
-        description = 'Set Indicator Mode for ' + endpoint + ' Button.';
+        description = 'Set Indicator Mode for ' + endpoint + ' switch.';
     }
     return enumLookup({
         name: 'indicator_mode',
@@ -484,12 +484,16 @@ const definitions: Definition[] = [
                 .withDescription('Specifies the minimum light output of the ballast'),
             e.numeric('ballast_maximum_level', ea.ALL).withValueMin(1).withValueMax(254)
                 .withDescription('Specifies the maximum light output of the ballast')],
-        extend: [indicatorMode()],
+        extend: [indicatorMode('smart')],
+        meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(3);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'lightingBallastCfg']);
             await reporting.onOff(endpoint);
             await reporting.brightness(endpoint);
+        },
+        endpoint: (device) => {
+            return {'smart': 21};
         },
     },
     {
@@ -498,11 +502,15 @@ const definitions: Definition[] = [
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series module switch 2AX',
         ota: ota.zigbeeOTA,
-        extend: [onOff({powerOnBehavior: true}), indicatorMode()],
+        extend: [onOff({powerOnBehavior: true}), indicatorMode('smart')],
+        meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
+        },
+        endpoint: (device) => {
+            return {'smart': 21};
         },
     },
     {
@@ -510,11 +518,15 @@ const definitions: Definition[] = [
         model: '41E10PBSWMZ-VW',
         vendor: 'Schneider Electric',
         description: 'Wiser 40/300-Series module switch 10AX with ControlLink',
-        extend: [onOff({powerOnBehavior: true}), indicatorMode()],
+        extend: [onOff({powerOnBehavior: true}), indicatorMode('smart')],
+        meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(endpoint);
+        },
+        endpoint: (device) => {
+            return {'smart': 21};
         },
     },
     {


### PR DESCRIPTION
# What?

@Koenkk figured out that issue 👍🏼 
Adds endpoint argument to the indicator mode function so we can target a different endpoint for where this cluster is actually located. By default this will target the same endpoint the device is defaulted on, we need to target a separate endpoint where this LED indicator funcitonality exists.

I'm not sure if this is the best way to achieve this change here, but it 100% works from me testing it.

Also removed this power on feature from these devices as is incompatible and just floods the expose tab with things that don't work anyway.

A minor thing, which I'm sure you will be able to explain, in the UI it renders with an indent for some reason, not obvious to me, but feel free to change it if its obvious to you. No functionality is impacted, just cosmetic:
<img width="875" alt="Screenshot 2024-03-03 at 12 12 58 pm" src="https://github.com/Koenkk/zigbee-herdsman-converters/assets/20388321/05749f48-2ae6-4c11-b0df-dad3cfc5ef41">

# Why?

Fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/7146
Broken in a previous PR: https://github.com/Koenkk/zigbee-herdsman-converters/pull/7094