### PR TITLE
fix(ws-usc01-powersource): set powerSource to Mains for Aqara WS-USC01

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -412,6 +412,8 @@ const definitions: Definition[] = [
             const endpoint1 = device.getEndpoint(1);
             // set "event" mode
             await endpoint1.write('manuSpecificLumi', {'mode': 1}, {manufacturerCode: manufacturerCode, disableResponse: true});
+            device.powerSource = 'Mains (single phase)';
+            device.save();
         },
         extend: [lumiZigbeeOTA()],
     },


### PR DESCRIPTION
Hello, I recently installed an Aqara WS-USC01 single rocker no-neutral switch.  I noticed the user interface is showing "Battery ?" as the power source.  This patch will set it to mains.