### PR TITLE
feat: Add led indicator mode on Schneider Electric S520559

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -32,6 +32,22 @@ function indicatorMode(endpoint?: string) {
     });
 }
 
+function socketIndicatorMode() {
+    const description = 'Set Indicator Mode.';
+    return enumLookup({
+        name: 'indicator_mode',
+        lookup: {
+            'reverse_with_load': 0,
+            'consistent_with_load': 1,
+            'always_off': 2,
+            'always_on': 3,
+        },
+        cluster: 'manuSpecificSchneiderFanSwitchConfiguration',
+        attribute: 'ledIndication',
+        description: description,
+    });
+}
+
 function fanIndicatorMode() {
     const description = 'Set Indicator Mode.';
     return enumLookup({
@@ -1045,6 +1061,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off, tz.power_on_behavior],
         exposes: [e.switch(), e.power(), e.energy(), e.enum('power_on_behavior', ea.ALL, ['off', 'previous', 'on'])
             .withDescription('Controls the behaviour when the device is powered on'), e.current(), e.voltage()],
+        extend: [socketIndicatorMode()],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(6);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -33,7 +33,6 @@ function indicatorMode(endpoint?: string) {
 }
 
 function socketIndicatorMode() {
-    const description = 'Set Indicator Mode.';
     return enumLookup({
         name: 'indicator_mode',
         lookup: {
@@ -44,7 +43,7 @@ function socketIndicatorMode() {
         },
         cluster: 'manuSpecificSchneiderFanSwitchConfiguration',
         attribute: 'ledIndication',
-        description: description,
+        description: 'Set indicator mode',
     });
 }
 


### PR DESCRIPTION
Hi,

I have a Schneider Electric S520559 detected as [EKO09716](https://www.zigbee2mqtt.io/devices/EKO09716.html#schneider%2520electric-eko09716)

I'm able to change le LED Indicator mode from the Dev Console while setting `manuSpecificSchneiderFanSwitchConfiguration` / `ledIndication` to :

 - 0: reverse_with_load
 - 1: consistent_with_load
 - 2: always_off
 - 3: always_on
 
It's quite strange, but yes this socket use `manuSpecificSchneiderFanSwitchConfiguration`
 that is supposed to be for FAN.

FYI, `fanIndicatorMode()` function have also `4` and `5` as possible value and they are not working on this socket. 
So i have duplicate the code, rename the function and change the enum.

I don't understand how make an external converters to validate this PR, but it might works as I understand.

