### PR TITLE
Added support for IKEA Badring

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1299,6 +1299,14 @@ const definitions: Definition[] = [
             await reporting.bind(endpoint2, coordinatorEndpoint, ['genBasic', 'ssIasZone']);
         },
     },
+    {
+        zigbeeModel: ['BADRING Water Leakage Sensor'],
+        model: 'E2202',
+        vendor: 'IKEA',
+        description: 'IKEA Water Leakage Detection Sensor',
+        fromZigbee: [fz.ias_water_leak_alarm_1],
+        exposes: [e.water_leak()],
+    },
 ];
 
 export default definitions;

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -11,7 +11,7 @@ import * as utils from '../lib/utils';
 import * as globalStore from '../lib/store';
 import * as zigbeeHerdsman from 'zigbee-herdsman/dist';
 import {postfixWithEndpointName, precisionRound, isObject, replaceInArray} from '../lib/utils';
-import {onOff, LightArgs, light as lightDontUse} from '../lib/modernExtend';
+import {onOff, LightArgs, light as lightDontUse, iasZoneAlarm} from '../lib/modernExtend';
 import * as semver from 'semver';
 const e = exposes.presets;
 const ea = exposes.access;
@@ -1303,9 +1303,8 @@ const definitions: Definition[] = [
         zigbeeModel: ['BADRING Water Leakage Sensor'],
         model: 'E2202',
         vendor: 'IKEA',
-        description: 'IKEA Water Leakage Detection Sensor',
-        fromZigbee: [fz.ias_water_leak_alarm_1],
-        exposes: [e.water_leak()],
+        description: 'Water leakage detection sensor',
+        extend: [iasZoneAlarm({zoneType: 'water_leak', zoneAttributes: ['alarm_1', 'battery_low']})],
     },
 ];
 


### PR DESCRIPTION
Added support for IKEA Badring

For reference working external converter:

const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const reporting = require('zigbee-herdsman-converters/lib/reporting');
const extend = require('zigbee-herdsman-converters/lib/extend');
const ota = require('zigbee-herdsman-converters/lib/ota');
const tuya = require('zigbee-herdsman-converters/lib/tuya');
const {} = require('zigbee-herdsman-converters/lib/tuya');
const utils = require('zigbee-herdsman-converters/lib/utils');
const globalStore = require('zigbee-herdsman-converters/lib/store');
const e = exposes.presets;
const ea = exposes.access;

const {batteryPercentage, identify} = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['BADRING Water Leakage Sensor'],
    model: 'BADRING Water Leakage Sensor',
    vendor: 'IKEA of Sweden',
    fromZigbee: [fz.ias_water_leak_alarm_1],
    toZigbee: [], 
    description: 'IKEA Water Leakage Detection Sensor and Alarm',
    extend: [batteryPercentage(), identify()],
    exposes: [e.water_leak()],
};

module.exports = definition;
``