### PR TITLE
add support for Innr OSL 132 C

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -632,6 +632,13 @@ const definitions: Definition[] = [
         extend: [light({colorTemp: {range: [153, 555]}, color: {modes: ['xy', 'hs'], applyRedFix: true}, turnsOffAtBrightness1: true})],
     },
     {
+        zigbeeModel: ['OSL 132 C'],
+        model: 'OSL 132 C',
+        vendor: 'Innr',
+        description: 'Outdoor Smart Spot Colour',
+        extend: [light({colorTemp: {range: [100, 1000]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
+    },
+    {
         zigbeeModel: ['BE 220'],
         model: 'BE 220',
         vendor: 'Innr',

--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -635,7 +635,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['OSL 132 C'],
         model: 'OSL 132 C',
         vendor: 'Innr',
-        description: 'Outdoor Smart Spot Colour',
+        description: 'Outdoor smart spot color',
         extend: [light({colorTemp: {range: [100, 1000]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
     },
     {


### PR DESCRIPTION
This PR adds support for the Innr OSL 132 C outdoor spot lights.

Related PR adding the image to zigbee2mqtt.io: https://github.com/Koenkk/zigbee2mqtt.io/pull/2616