### PR TITLE
Update tuya.ts

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2274,7 +2274,7 @@ const definitions: Definition[] = [
     },
     {
         fingerprint: tuya.fingerprint('TS004F', ['_TZ3000_nuombroo', '_TZ3000_xabckq1v', '_TZ3000_czuyt8lz',
-            '_TZ3000_0ht8dnxj']),
+            '_TZ3000_0ht8dnxj', '_TZ3000_b3mgfu0d']),
         model: 'TS004F',
         vendor: 'TuYa',
         description: 'Wireless switch with 4 buttons',


### PR DESCRIPTION
Added Tuya TS004F model _TZ3000_b3mgfu0d

This model is identical to _TZ3000_czuyt8lz and all reporting is the same.

It is worth noting that neither "_TZ3000_czuyt8lz" nor "_TZ3000_b3mgfu0d" support battery level reporting.

However this change is simply to add "_TZ3000_b3mgfu0d" to the supported devices.