### PR TITLE
Extend SMSZB-120 alarm fix to HESZB-120

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -542,9 +542,9 @@ const converters2 = {
             const alarmState = (value === 'alarm' || value === 'OFF' ? 0 : 1);
 
             let info;
-            // For Develco SMSZB-120, introduced change in fw 4.0.5, tested backward with 4.0.4
+            // For Develco SMSZB-120 and HESZB-120, introduced change in fw 4.0.5, tested backward with 4.0.4
             if (Array.isArray(meta.mapped)) throw new Error(`Not supported for groups`);
-            if (['SMSZB-120'].includes(meta.mapped.model)) {
+            if (['SMSZB-120', 'HESZB-120'].includes(meta.mapped.model)) {
                 info = ((alarmState) << 7) + ((alarmState) << 6);
             } else {
                 info = (3 << 6) + ((alarmState) << 2);


### PR DESCRIPTION
In the past a fix was done for disabling the siren on SMSZB-120 devices that got updated to firmware 4.0.5 and higher. Now that OTA updates are supported for HESZB-120 (very similar device) and they are now on 4.0.8, this fix should be applied for this device as well.

Fixes Koenkk/zigbee2mqtt#21721