### PR TITLE
Fix FLSZB-110 temperature reporting

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -812,7 +812,7 @@ const definitions: Definition[] = [
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
             const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint38, { min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10 });
+            await reporting.temperature(endpoint38, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
         },
     },
     {


### PR DESCRIPTION
Currently the Develco/Frient water leak detector's temperature reporting is not working. It only shows null. I looked at the way it is configured for the smoke and heat sensors and used the code from there.

One problem is that changing the reporting interval does not seem to work for this device so whatever values are set in the configuration effectively become hard-coded, unless there is some other way about this? If not, the minimum should perhaps be higher than 1 minute.

Related (stale and closed) issue: https://github.com/Koenkk/zigbee2mqtt/issues/17802