### PR TITLE
fix: Temporary fix for Legrand OTA updates (newer Firmwares)

### DIFF
--- a/src/lib/ota/common.ts
+++ b/src/lib/ota/common.ts
@@ -459,6 +459,12 @@ export async function updateToLatest(device: Zh.Device, logger: Logger, onProgre
                 imageBlockOrPageRequestTimeoutMs = 60 * 60 * 1000;
             }
 
+            // Increase the timeout for Legrand devices, so that they will re-initiate and update themselves
+            // Newer firmwares have ackward behaviours when it comes to the handling of the last bytes of OTA updates
+            if ( request.payload.manufacturerCode === 4129 ) {
+                imageBlockOrPageRequestTimeoutMs = 30 * 60 * 1000;
+            }
+
             const imageBlockRequest = endpoint.waitForCommand('genOta', 'imageBlockRequest', null, imageBlockOrPageRequestTimeoutMs);
             const imagePageRequest = endpoint.waitForCommand('genOta', 'imagePageRequest', null, imageBlockOrPageRequestTimeoutMs);
             waiters.imageBlockOrPageRequest = {


### PR DESCRIPTION
HI @Koenkk,

Attached is yet another PR to address Legrand OTA firmwares, particularly when running newer Firmware versions.
This fixes the issues reported [here](https://github.com/Koenkk/zigbee-OTA/issues/328#issuecomment-1994510285).

This comes with some drawbacks though. Ideally the devices should "fail fast" in order to re-start the process in a timely manner, but there (yet) seems to be no better way to handle those failures.
Let's hope that newer firmware versions improve this.

Cheers