### PR TITLE
Added support for Eglo PIR sensor 99106

### DIFF
--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -52,9 +52,9 @@ const definitions: Definition[] = [
         model: '99106', 
         vendor: 'EGLO', 
         description: 'Eglo Connect-Z Motion (PIR) sensor', 
-        fromZigbee: [fz.command_on, fz.command_move_to_level, fz.command_move_to_color_temp],
+        fromZigbee: [fzLocal.battery, fz.command_on, fz.command_move_to_level, fz.command_move_to_color_temp],
         toZigbee: [], 
-        exposes: [e.action(['on', 'brightness_move_to_level', 'color_temperature_move'])],
+        exposes: [e.battery(), e.action(['on', 'brightness_move_to_level', 'color_temperature_move'])],
     },
 ];
 

--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -52,9 +52,9 @@ const definitions: Definition[] = [
         model: '99106', 
         vendor: 'EGLO', 
         description: 'Eglo Connect-Z Motion (PIR) sensor', 
-        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move_to_color_temp],
+        fromZigbee: [fz.command_on, fz.command_move_to_level, fz.command_move_to_color_temp],
         toZigbee: [], 
-        exposes: [e.action(['on', 'off', 'brightness_move_to_level', 'color_temperature_move'])],
+        exposes: [e.action(['on', 'brightness_move_to_level', 'color_temperature_move'])],
     },
 ];
 

--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -47,6 +47,15 @@ const definitions: Definition[] = [
             'green', 'brightness_step_up', 'brightness_step_down', 'brightness_move_up', 'brightness_move_down', 'brightness_stop',
             'recall_1', 'color_temperature_step_up', 'color_temperature_step_down'])],
     },
+    {
+        zigbeeModel: ['TLSR82xx'],
+        model: '99106', 
+        vendor: 'EGLO', 
+        description: 'Eglo Connect-Z Motion (PIR) sensor', 
+        fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move_to_color_temp],
+        toZigbee: [], 
+        exposes: [e.action(['on', 'off', 'brightness_move_to_level', 'color_temperature_move'])],
+    },
 ];
 
 export default definitions;

--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -52,9 +52,9 @@ const definitions: Definition[] = [
         model: '99106', 
         vendor: 'EGLO', 
         description: 'Eglo Connect-Z Motion (PIR) sensor', 
-        fromZigbee: [fzLocal.battery, fz.command_on, fz.command_move_to_level, fz.command_move_to_color_temp],
+        fromZigbee: [fz.command_on, fz.command_move_to_level, fz.command_move_to_color_temp],
         toZigbee: [], 
-        exposes: [e.battery(), e.action(['on', 'brightness_move_to_level', 'color_temperature_move'])],
+        exposes: [e.action(['on', 'brightness_move_to_level', 'color_temperature_move'])],
     },
 ];
 


### PR DESCRIPTION
Added support, shares zigbeename with AwoX light but identifies as it should. exposes actions, no occupancy or illuminance added