### PR TITLE
hotfix: check for duplicate alarm names in iasZoneAlarm extend

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1041,9 +1041,7 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
                 }
             }
 
-            return {
-                [alarm1Name]: (zoneStatus & 1) > 0,
-                [alarm2Name]: (zoneStatus & 1 << 1) > 0,
+            let payload = {
                 tamper: (zoneStatus & 1 << 2) > 0,
                 battery_low: (zoneStatus & 1 << 3) > 0,
                 supervision_reports: (zoneStatus & 1 << 4) > 0,
@@ -1053,6 +1051,17 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
                 test: (zoneStatus & 1 << 8) > 0,
                 battery_defect: (zoneStatus & 1 << 9) > 0,
             };
+
+            if (bothAlarms) {
+                payload = {[alarm1Name]: (zoneStatus & 1) > 0, ...payload};
+                payload = {[alarm2Name]: (zoneStatus & 1 << 1) > 0, ...payload};
+            } else if (args.zoneAttributes.includes('alarm_1')) {
+                payload = {[alarm1Name]: (zoneStatus & 1) > 0, ...payload};
+            } else if (args.zoneAttributes.includes('alarm_2')) {
+                payload = {[alarm2Name]: (zoneStatus & 1 << 1) > 0, ...payload};
+            }
+
+            return payload;
         },
     }];
 


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/21794 and all other iasZoneAlarm usages with single `alarm_1`.

This is a serious bug. But thankfully it didn't make it to the 1.36.0 release by a couple of ZHC versions.