### PR TITLE
[high-conflict] Update manufacturer codes to use ZCL definition

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Tz, KeyValueAny} from '../lib/types';
 import * as globalStore from '../lib/store';
 import * as constants from '../lib/constants';
@@ -6,7 +7,6 @@ import * as utils from '../lib/utils';
 import * as light from '../lib/light';
 import * as legacy from '../lib/legacy';
 import * as exposes from '../lib/exposes';
-import {Zcl} from 'zigbee-herdsman';
 
 const manufacturerOptions = {
     sunricher: {manufacturerCode: Zcl.ManufacturerCode.SHENZHEN_SUNRICHER_TECHNOLOGY_LTD},
@@ -2177,7 +2177,7 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'siren_led': 3, 'siren': 2, 'led': 1, 'nothing': 0};
             await entity.write('genBasic', {0x400a: {value: utils.getFromLookup(value, lookup), type: 32}},
-                {manufacturerCode: 0x1168, disableDefaultResponse: true});
+                {manufacturerCode: Zcl.ManufacturerCode.LEEDARSON_LIGHTING_CO_LTD, disableDefaultResponse: true});
             return {state: {alert_behaviour: value}};
         },
     } satisfies Tz.Converter,
@@ -2859,7 +2859,7 @@ const converters2 = {
             };
 
             await endpoint.write(
-                'seMetering', {0x0302: {value: utils.getFromLookup(value, lookup).value, type: 49}}, {manufacturerCode: 0x1015},
+                'seMetering', {0x0302: {value: utils.getFromLookup(value, lookup).value, type: 49}}, {manufacturerCode: Zcl.ManufacturerCode.DEVELCO},
             );
 
             // As the device reports the incorrect divisor, we need to set it here
@@ -3954,22 +3954,22 @@ const converters2 = {
         key: ['master_pin_mode'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('closuresDoorLock', {0x4000: {value: value === true ? 1 : 0, type: 0x10}},
-                {manufacturerCode: 4919});
+                {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             return {state: {master_pin_mode: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('closuresDoorLock', [0x4000], {manufacturerCode: 4919});
+            await entity.read('closuresDoorLock', [0x4000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     idlock_rfid_enable: {
         key: ['rfid_enable'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('closuresDoorLock', {0x4001: {value: value === true ? 1 : 0, type: 0x10}},
-                {manufacturerCode: 4919});
+                {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             return {state: {rfid_enable: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('closuresDoorLock', [0x4001], {manufacturerCode: 4919});
+            await entity.read('closuresDoorLock', [0x4001], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     idlock_service_mode: {
@@ -3977,11 +3977,11 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'deactivated': 0, 'random_pin_1x_use': 5, 'random_pin_24_hours': 6};
             await entity.write('closuresDoorLock', {0x4003: {value: utils.getFromLookup(value, lookup), type: 0x20}},
-                {manufacturerCode: 4919});
+                {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             return {state: {service_mode: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('closuresDoorLock', [0x4003], {manufacturerCode: 4919});
+            await entity.read('closuresDoorLock', [0x4003], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     idlock_lock_mode: {
@@ -3989,22 +3989,22 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'auto_off_away_off': 0, 'auto_on_away_off': 1, 'auto_off_away_on': 2, 'auto_on_away_on': 3};
             await entity.write('closuresDoorLock', {0x4004: {value: utils.getFromLookup(value, lookup), type: 0x20}},
-                {manufacturerCode: 4919});
+                {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             return {state: {lock_mode: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('closuresDoorLock', [0x4004], {manufacturerCode: 4919});
+            await entity.read('closuresDoorLock', [0x4004], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     idlock_relock_enabled: {
         key: ['relock_enabled'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('closuresDoorLock', {0x4005: {value: value === true ? 1 : 0, type: 0x10}},
-                {manufacturerCode: 4919});
+                {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             return {state: {relock_enabled: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('closuresDoorLock', [0x4005], {manufacturerCode: 4919});
+            await entity.read('closuresDoorLock', [0x4005], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     schneider_pilot_mode: {
@@ -4014,11 +4014,11 @@ const converters2 = {
             const lookup = {'contactor': 1, 'pilot': 3};
             value = value.toLowerCase();
             const mode = utils.getFromLookup(value, lookup);
-            await entity.write('schneiderSpecificPilotMode', {'pilotMode': mode}, {manufacturerCode: 0x105e});
+            await entity.write('schneiderSpecificPilotMode', {'pilotMode': mode}, {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC});
             return {state: {schneider_pilot_mode: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('schneiderSpecificPilotMode', ['pilotMode'], {manufacturerCode: 0x105e});
+            await entity.read('schneiderSpecificPilotMode', ['pilotMode'], {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC});
         },
     } satisfies Tz.Converter,
     schneider_dimmer_mode: {
@@ -4026,11 +4026,15 @@ const converters2 = {
         convertSet: async (entity, key, value, meta) => {
             const lookup = {'RC': 1, 'RL': 2};
             const mode = utils.getFromLookup(value, lookup);
-            await entity.write('lightingBallastCfg', {0xe000: {value: mode, type: 0x30}}, {manufacturerCode: 0x105e});
+            await entity.write(
+                'lightingBallastCfg',
+                {0xe000: {value: mode, type: 0x30}},
+                {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC},
+            );
             return {state: {dimmer_mode: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('lightingBallastCfg', [0xe000], {manufacturerCode: 0x105e});
+            await entity.read('lightingBallastCfg', [0xe000], {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC});
         },
     } satisfies Tz.Converter,
     wiser_dimmer_mode: {
@@ -4226,11 +4230,11 @@ const converters2 = {
         key: ['led_on_motion'],
         convertSet: async (entity, key, value, meta) => {
             await entity.write('ssIasZone', {0x4000: {value: value === true ? 1 : 0, type: 0x10}},
-                {manufacturerCode: 4919});
+                {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             return {state: {led_on_motion: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('ssIasZone', [0x4000], {manufacturerCode: 4919});
+            await entity.read('ssIasZone', [0x4000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     nodon_pilot_wire_mode: {

--- a/src/devices/atlantic.ts
+++ b/src/devices/atlantic.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition, KeyValue, Tz} from '../lib/types';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
@@ -21,7 +22,7 @@ const tzLocal = {
         key: ['quiet_fan'],
         convertSet: async (entity, key, value, meta) => {
             assert(typeof value === 'boolean');
-            await entity.write('hvacFanCtrl', {0x1000: {value: value ? 1 : 0, type: 0x10}}, {manufacturerCode: 0x125b});
+            await entity.write('hvacFanCtrl', {0x1000: {value: value ? 1 : 0, type: 0x10}}, {manufacturerCode: Zcl.ManufacturerCode.ATLANTIC_GROUP});
             return {state: {quiet_fan: value}};
         },
     } satisfies Tz.Converter,
@@ -31,7 +32,7 @@ const tzLocal = {
             utils.assertString(value, 'ac_louver_position');
             utils.validateValue(value, Object.keys(thermostatPositions));
             const index = thermostatPositions[value.toLowerCase()];
-            await entity.write('hvacThermostat', {0x4273: {value: index, type: 0x30}}, {manufacturerCode: 0x125b});
+            await entity.write('hvacThermostat', {0x4273: {value: index, type: 0x30}}, {manufacturerCode: Zcl.ManufacturerCode.ATLANTIC_GROUP});
             return {state: {ac_louver_position: value}};
         },
     } satisfies Tz.Converter,
@@ -45,9 +46,9 @@ const tzLocal = {
             const boost = value === 'boost' ? 1 : 0;
             const eco = value === 'eco' ? 4 : 0;
 
-            await entity.write('hvacThermostat', {0x4275: {value: activity, type: 0x30}}, {manufacturerCode: 0x125b});
+            await entity.write('hvacThermostat', {0x4275: {value: activity, type: 0x30}}, {manufacturerCode: Zcl.ManufacturerCode.ATLANTIC_GROUP});
             await entity.write('hvacThermostat', {'programingOperMode': eco});
-            await entity.write('hvacThermostat', {0x4270: {value: boost, type: 0x10}}, {manufacturerCode: 0x125b});
+            await entity.write('hvacThermostat', {0x4270: {value: boost, type: 0x10}}, {manufacturerCode: Zcl.ManufacturerCode.ATLANTIC_GROUP});
 
             return {state: {preset: value}};
         },
@@ -58,7 +59,11 @@ const tzLocal = {
             utils.assertString(value, 'swing_mode');
             value = value.toLowerCase();
             utils.validateValue(value, ['on', 'off']);
-            await entity.write('hvacThermostat', {0x4274: {value: value === 'on' ? 1 : 0, type: 0x10}}, {manufacturerCode: 0x125b});
+            await entity.write(
+                'hvacThermostat',
+                {0x4274: {value: value === 'on' ? 1 : 0, type: 0x10}},
+                {manufacturerCode: Zcl.ManufacturerCode.ATLANTIC_GROUP},
+            );
             return {state: {swing_mode: value}};
         },
     } satisfies Tz.Converter,

--- a/src/devices/centralite.ts
+++ b/src/devices/centralite.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition, Fz} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -294,7 +295,11 @@ const definitions: Definition[] = [
                 maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: 10,
             }];
-            await endpoint.configureReporting('manuSpecificCentraliteHumidity', payload, {manufacturerCode: 0x104E});
+            await endpoint.configureReporting(
+                'manuSpecificCentraliteHumidity',
+                payload,
+                {manufacturerCode: Zcl.ManufacturerCode.CENTRALITE_SYSTEMS_INC},
+            );
 
             await reporting.batteryVoltage(endpoint);
         },

--- a/src/devices/ctm.ts
+++ b/src/devices/ctm.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
@@ -367,17 +368,20 @@ const tzLocal = {
     ctm_current_flag: {
         key: ['current_flag'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('genOnOff', [0x5000], {manufacturerCode: 0x1337});
+            await entity.read('genOnOff', [0x5000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     ctm_relay_state: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write('genOnOff',
-                {0x5001: {value: utils.getFromLookup(value, {'OFF': 0, 'ON': 1}), type: dataType.boolean}}, {manufacturerCode: 0x1337});
+            await entity.write(
+                'genOnOff',
+                {0x5001: {value: utils.getFromLookup(value, {'OFF': 0, 'ON': 1}), type: dataType.boolean}},
+                {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS},
+            );
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read('genOnOff', [0x5001], {manufacturerCode: 0x1337});
+            await entity.read('genOnOff', [0x5001], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     ctm_thermostat: {
@@ -545,7 +549,7 @@ const tzLocal = {
     ctm_group_config: {
         key: ['group_id'],
         convertGet: async (entity, key, meta) => {
-            await entity.read(0xFEA7, [0x0000], {manufacturerCode: 0x1337});
+            await entity.read(0xFEA7, [0x0000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
     } satisfies Tz.Converter,
     ctm_sove_guard: {
@@ -557,64 +561,64 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             switch (key) {
             case 'alarm_status':
-                await entity.read(0xFFC9, [0x0001], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0001], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'battery_low':
-                await entity.read(0xFFC9, [0x0002], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0002], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'stove_temperature':
-                await entity.read(0xFFC9, [0x0003], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0003], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'ambient_temperature':
-                await entity.read(0xFFC9, [0x0004], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0004], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'active':
-                await entity.read(0xFFC9, [0x0005], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0005], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'runtime':
-                await entity.read(0xFFC9, [0x0006], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0006], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'runtime_timeout':
-                await entity.read(0xFFC9, [0x0007], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0007], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'reset_reason':
-                await entity.read(0xFFC9, [0x0008], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0008], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'dip_switch':
-                await entity.read(0xFFC9, [0x0009], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0009], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'sw_version':
-                await entity.read(0xFFC9, [0x000A], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x000A], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'hw_version':
-                await entity.read(0xFFC9, [0x000B], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x000B], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'bootloader_version':
-                await entity.read(0xFFC9, [0x000C], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x000C], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'model':
-                await entity.read(0xFFC9, [0x000D], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x000D], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'relay_address':
-                await entity.read(0xFFC9, [0x0010], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0010], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'current_flag':
-                await entity.read(0xFFC9, [0x0100], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0100], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'relay_current':
-                await entity.read(0xFFC9, [0x0101], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0101], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'relay_status':
-                await entity.read(0xFFC9, [0x0102], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0102], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'external_button':
-                await entity.read(0xFFC9, [0x0103], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0103], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'relay_alarm':
-                await entity.read(0xFFC9, [0x0104], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0104], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
             case 'relay_alarm_status':
-                await entity.read(0xFFC9, [0x0105], {manufacturerCode: 0x1337});
+                await entity.read(0xFFC9, [0x0105], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
                 break;
 
             default: // Unknown key
@@ -680,7 +684,7 @@ const definitions: Definition[] = [
             await reporting.batteryVoltage(endpoint);
             await endpoint.read('msTemperatureMeasurement', ['measuredValue']);
             await reporting.temperature(endpoint, {min: constants.repInterval.MINUTES_10, max: constants.repInterval.HOUR, change: 100});
-            await endpoint.read(0xFEA7, [0x0000], {manufacturerCode: 0x1337});
+            await endpoint.read(0xFEA7, [0x0000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
         exposes: [e.battery(), e.temperature(),
             e.action(['recall_1', 'recall_2', 'recall_3', 'on', 'off', 'toggle',
@@ -828,26 +832,26 @@ const definitions: Definition[] = [
             // await endpoint.read('msTemperatureMeasurement', ['measuredValue']);
             await reporting.temperature(endpoint, {min: constants.repInterval.MINUTES_10, max: constants.repInterval.HOUR, change: 100});
             // Alarm status
-            // await endpoint.read(0xFFC9, [0x0001], {manufacturerCode: 0x1337});
+            // await endpoint.read(0xFFC9, [0x0001], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             await endpoint.configureReporting(0xFFC9, [{
                 attribute: {ID: 0x0001, type: dataType.uint8},
                 minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}], {manufacturerCode: 0x1337});
+                reportableChange: 0}], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             // Change battery
-            // await endpoint.read(0xFFC9, [0x0002], {manufacturerCode: 0x1337});
+            // await endpoint.read(0xFFC9, [0x0002], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             await endpoint.configureReporting(0xFFC9, [{
                 attribute: {ID: 0x0002, type: dataType.uint8},
                 minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.MAX,
-                reportableChange: 0}], {manufacturerCode: 0x1337});
+                reportableChange: 0}], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             // Active
-            // await endpoint.read(0xFFC9, [0x0005], {manufacturerCode: 0x1337});
+            // await endpoint.read(0xFFC9, [0x0005], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             await endpoint.configureReporting(0xFFC9, [{
                 attribute: {ID: 0x0005, type: dataType.uint8},
                 minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}], {manufacturerCode: 0x1337});
+                reportableChange: 0}], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
         exposes: [e.battery(), e.battery_low(), e.temperature(),
             e.enum('alarm_status', ea.STATE, ['ok', 'tamper', 'high_temperatur', 'timer', 'battery_alarm', 'error', 'unknown'])
@@ -888,7 +892,7 @@ const definitions: Definition[] = [
                 minimumReportInterval: 0,
                 maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: null}]);
-            await endpoint.read(0xFEA7, [0x0000], {manufacturerCode: 0x1337});
+            await endpoint.read(0xFEA7, [0x0000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
         exposes: [e.switch(), e.action(['on', 'off']),
             e.enum('device_mode', ea.STATE, ['astro_clock', 'timer', 'daily_timer', 'weekly_timer'])
@@ -958,7 +962,7 @@ const definitions: Definition[] = [
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('msTemperatureMeasurement', ['measuredValue']);
             await reporting.temperature(endpoint, {min: constants.repInterval.MINUTES_10, max: constants.repInterval.HOUR, change: 100});
-            await endpoint.read(0xFEA7, [0x0000], {manufacturerCode: 0x1337});
+            await endpoint.read(0xFEA7, [0x0000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
         exposes: [e.temperature(), e.battery(), e.battery_low(), e.smoke(),
             e.action(['on', 'off']),
@@ -1003,12 +1007,12 @@ const definitions: Definition[] = [
             await endpoint.read('msOccupancySensing', ['occupancy']);
             await reporting.occupancy(endpoint);
             // Relay State
-            await endpoint.read('genOnOff', [0x5001], {manufacturerCode: 0x1337});
+            await endpoint.read('genOnOff', [0x5001], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
             await endpoint.configureReporting('genOnOff', [{
                 attribute: {ID: 0x5001, type: dataType.boolean},
                 minimumReportInterval: 1,
                 maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}], {manufacturerCode: 0x1337});
+                reportableChange: 0}], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
         },
         exposes: [e.switch(), e.illuminance(), e.illuminance_lux(), e.occupancy(),
             e.binary('device_enabled', ea.ALL, 'ON', 'OFF')

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -129,7 +130,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 0x1246};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S};
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
 
             // standard ZCL attributes
@@ -298,7 +299,7 @@ const definitions: Definition[] = [
             return features;
         })(16)),
         configure: async (device, coordinatorEndpoint, logger) => {
-            const options = {manufacturerCode: 0x1246};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S};
 
             for (let i = 1; i <= 15; i++) {
                 const endpoint = device.getEndpoint(i);
@@ -415,7 +416,7 @@ const definitions: Definition[] = [
             return features;
         })(16)),
         configure: async (device, coordinatorEndpoint, logger) => {
-            const options = {manufacturerCode: 0x1246};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S};
 
             // Danfoss Icon2 MainController Specific endpoint
             const endpoint232 = device.getEndpoint(232);

--- a/src/devices/datek.ts
+++ b/src/devices/datek.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
@@ -95,7 +96,7 @@ const definitions: Definition[] = [
             fz.ias_enroll, fz.ias_occupancy_alarm_1, fz.ias_occupancy_alarm_1_report, fz.led_on_motion],
         toZigbee: [tz.occupancy_timeout, tz.led_on_motion],
         configure: async (device, coordinatorEndpoint, logger) => {
-            const options = {manufacturerCode: 4919};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS};
             const endpoint = device.getEndpoint(1);
             const binds = ['msIlluminanceMeasurement', 'msTemperatureMeasurement', 'msOccupancySensing', 'ssIasZone'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
@@ -127,7 +128,7 @@ const definitions: Definition[] = [
         meta: {pinCodeCount: 109},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 4919};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS};
             await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
             await reporting.lockState(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition, Fz, Logger, Tz, Zh, KeyValue} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -11,7 +12,7 @@ const e = exposes.presets;
 const ea = exposes.access;
 
 // develco specific cosntants
-const manufacturerOptions = {manufacturerCode: 0x1015};
+const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.DEVELCO};
 
 /* MOSZB-1xx - ledControl - bitmap8 - r/w
  * 0x00 Disable LED when movement is detected.

--- a/src/devices/eurotronic.ts
+++ b/src/devices/eurotronic.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -35,7 +36,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 4151};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.NXP_SEMICONDUCTORS};
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat']);
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);

--- a/src/devices/meazon.ts
+++ b/src/devices/meazon.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -21,7 +22,7 @@ const definitions: Definition[] = [
             const endpoint = device.getEndpoint(10);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
             await reporting.onOff(endpoint, {min: 1, max: 0xfffe});
-            const options = {manufacturerCode: 4406, disableDefaultResponse: false};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.MEAZON_S_A, disableDefaultResponse: false};
             await endpoint.write('seMetering', {0x1005: {value: 0x063e, type: 25}}, options);
             await endpoint.configureReporting('seMetering', [{reportableChange: 1, attribute: {ID: 0x2000, type: 0x29},
                 minimumReportInterval: 1, maximumReportInterval: constants.repInterval.MINUTES_5}], options);
@@ -39,7 +40,7 @@ const definitions: Definition[] = [
             const endpoint = device.getEndpoint(10);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'seMetering']);
             await reporting.onOff(endpoint);
-            const options = {manufacturerCode: 4406, disableDefaultResponse: false};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.MEAZON_S_A, disableDefaultResponse: false};
             await endpoint.write('seMetering', {0x1005: {value: 0x063e, type: 25}}, options);
             await reporting.onOff(endpoint);
             await endpoint.configureReporting('seMetering', [{attribute: {ID: 0x2000, type: 0x29},

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -1,5 +1,5 @@
-import {Definition, Fz, Tz, KeyValue} from '../lib/types';
 import {Zcl} from 'zigbee-herdsman';
+import {Definition, Fz, Tz, KeyValue} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
@@ -516,116 +516,169 @@ const definitions: Definition[] = [
             await reporting.currentSummDelivered(endpoint, {min: 300}); // Report KWH every 5min
             await reporting.readMeteringMultiplierDivisor(endpoint);
 
-            // Custom attributes
-            const options = {manufacturerCode: 0x1224};
-
             // OperateDisplayLcdBrightnesss
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1000, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1000, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // ButtonVibrationLevel
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1001, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1001, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // FloorSensorType
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1002, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1002, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // ControlType
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1003, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1003, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // PowerUpStatus
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1004, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1004, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // FloorSensorCalibration
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1005, type: 0x28},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1005, type: 0x28},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                sunricherManufacturer,
+            );
             // DryTime
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1006, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1006, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                sunricherManufacturer,
+            );
             // ModeAfterDry
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1007, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1007, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // TemperatureDisplay
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1008, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1008, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // WindowOpenCheck
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1009, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1009, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                sunricherManufacturer,
+            );
 
             // Hysterersis
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x100A, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x100A, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                sunricherManufacturer,
+            );
             // DisplayAutoOffEnable
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x100B, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x100B, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
 
             // AlarmAirTempOverValue
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x2001, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x2001, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                sunricherManufacturer,
+            );
             // Away Mode Set
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x2002, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x2002, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
 
             // Trigger initial read
             await endpoint.read('hvacThermostat', ['systemMode', 'runningState', 'occupiedHeatingSetpoint']);
-            await endpoint.read('hvacThermostat', [0x1000, 0x1001, 0x1002, 0x1003], options);
-            await endpoint.read('hvacThermostat', [0x1004, 0x1005, 0x1006, 0x1007], options);
-            await endpoint.read('hvacThermostat', [0x1008, 0x1009, 0x100A, 0x100B], options);
-            await endpoint.read('hvacThermostat', [0x2001, 0x2002], options);
+            await endpoint.read('hvacThermostat', [0x1000, 0x1001, 0x1002, 0x1003], sunricherManufacturer);
+            await endpoint.read('hvacThermostat', [0x1004, 0x1005, 0x1006, 0x1007], sunricherManufacturer);
+            await endpoint.read('hvacThermostat', [0x1008, 0x1009, 0x100A, 0x100B], sunricherManufacturer);
+            await endpoint.read('hvacThermostat', [0x2001, 0x2002], sunricherManufacturer);
         },
         ota: ota.zigbeeOTA,
     },
@@ -711,48 +764,65 @@ const definitions: Definition[] = [
             // LocalTemp is spammy, reports 0.01C diff by default, min change is now 0.5C
             await reporting.thermostatTemperature(endpoint, {min: 0, change: 50});
 
-            // Namron proprietary stuff
-            const options = {manufacturerCode: 0x1224};
-
             // display_brightnesss
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1000, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1000, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // display_auto_off
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1001, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1001, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // power_up_status
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1004, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1004, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // window_open_check
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1009, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1009, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
             // hysterersis
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x100A, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x100A, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                sunricherManufacturer,
+            );
 
             await endpoint.read('hvacThermostat', ['systemMode', 'runningState', 'occupiedHeatingSetpoint']);
             await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);
-            await endpoint.read('hvacThermostat', [0x1000, 0x1001, 0x1004, 0x1009, 0x100A], options);
+            await endpoint.read('hvacThermostat', [0x1000, 0x1001, 0x1004, 0x1009, 0x100A], sunricherManufacturer);
 
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
         },

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import dataType from 'zigbee-herdsman/dist/zcl/definition/dataType';
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
@@ -72,7 +73,7 @@ const definitions: Definition[] = [
                 valueMax: 10000,
                 scale: 1,
                 description: 'Set the impulse duration in milliseconds (set value to 0 to deactivate the impulse mode).',
-                zigbeeCommandOptions: {manufacturerCode: 0x128B},
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
             }),
         ],
         endpoint: (device) => {
@@ -95,7 +96,7 @@ const definitions: Definition[] = [
                 valueMax: 10000,
                 scale: 1,
                 description: 'Set the impulse duration in milliseconds (set value to 0 to deactivate the impulse mode).',
-                zigbeeCommandOptions: {manufacturerCode: 0x128B},
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
             }),
         ],
         endpoint: (device) => {
@@ -181,7 +182,7 @@ const definitions: Definition[] = [
                 valueMax: 10000,
                 scale: 1,
                 description: 'Set the impulse duration in milliseconds (set value to 0 to deactivate the impulse mode).',
-                zigbeeCommandOptions: {manufacturerCode: 0x128B},
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
             }),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -2159,7 +2160,7 @@ const definitions: Definition[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'genOnOff', 'manuSpecificPhilips']);
             await reporting.batteryPercentageRemaining(endpoint);
-            const options = {manufacturerCode: 0x100B, disableDefaultResponse: true};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V, disableDefaultResponse: true};
             await endpoint.write('genBasic', {0x0034: {value: 0, type: 48}}, options);
         },
     },
@@ -2180,7 +2181,7 @@ const definitions: Definition[] = [
             await reporting.bind(endpoint1, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
 
             const endpoint2 = device.getEndpoint(2);
-            const options = {manufacturerCode: 0x100B, disableDefaultResponse: true};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V, disableDefaultResponse: true};
             await endpoint2.write('genBasic', {0x0031: {value: 0x000B, type: 0x19}}, options);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['manuSpecificPhilips', 'genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint2);
@@ -2205,7 +2206,7 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificPhilips', 'genPowerCfg']);
-            const options = {manufacturerCode: 0x100B, disableDefaultResponse: true};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V, disableDefaultResponse: true};
             await endpoint.write('genBasic', {0x0031: {value: 0x000B, type: 0x19}}, options);
             await reporting.batteryPercentageRemaining(endpoint);
         },
@@ -2223,7 +2224,7 @@ const definitions: Definition[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
 
-            const options = {manufacturerCode: 0x100B, disableDefaultResponse: true};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V, disableDefaultResponse: true};
             await endpoint.write('genBasic', {0x0031: {value: 0x000B, type: 0x19}}, options);
             await reporting.bind(endpoint, coordinatorEndpoint, ['manuSpecificPhilips', 'genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
@@ -2255,7 +2256,7 @@ const definitions: Definition[] = [
             await reporting.illuminance(endpoint);
             // read occupancy_timeout and motion_sensitivity
             await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
-            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: 4107});
+            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V});
         },
         ota: ota.zigbeeOTA,
     },
@@ -2284,7 +2285,7 @@ const definitions: Definition[] = [
             await reporting.illuminance(endpoint);
             // read occupancy_timeout and motion_sensitivity
             await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
-            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: 4107});
+            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V});
         },
         ota: ota.zigbeeOTA,
     },
@@ -2359,7 +2360,7 @@ const definitions: Definition[] = [
             await reporting.illuminance(endpoint);
             // read occupancy_timeout and motion_sensitivity
             await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
-            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: 4107});
+            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V});
         },
     },
     {
@@ -2384,7 +2385,7 @@ const definitions: Definition[] = [
             await reporting.illuminance(endpoint);
             // read occupancy_timeout and motion_sensitivity
             await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
-            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: 4107});
+            await endpoint.read('msOccupancySensing', [48], {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V});
         },
         // Temporary disable until OTA is available: https://github.com/Koenkk/zigbee2mqtt/issues/14923
         // ota: ota.zigbeeOTA,
@@ -2908,7 +2909,7 @@ const definitions: Definition[] = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl', 'manuSpecificPhilips', 'genPowerCfg']);
-            const options = {manufacturerCode: 0x100B, disableDefaultResponse: true};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V, disableDefaultResponse: true};
             await endpoint.write('genBasic', {0x0031: {value: 0x000B, type: 0x19}}, options);
             await reporting.batteryPercentageRemaining(endpoint);
         },

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition, Fz, Tz, KeyValue} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -111,7 +112,7 @@ const tzLocal = {
     lift_duration: {
         key: ['lift_duration'],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write(0x0102, {0xe000: {value, type: 0x21}}, {manufacturerCode: 0x105e});
+            await entity.write(0x0102, {0xe000: {value, type: 0x21}}, {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC});
             return {state: {lift_duration: value}};
         },
     } satisfies Tz.Converter,

--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import * as legacy from '../lib/legacy';
@@ -11,7 +12,7 @@ const ea = exposes.access;
 import {precisionRound} from '../lib/utils';
 import {onOff, electricityMeter, light} from '../lib/modernExtend';
 
-const manuSinope = {manufacturerCode: 0x119C};
+const manuSinope = {manufacturerCode: Zcl.ManufacturerCode.SINOPE_TECHNOLOGIES};
 
 const fzLocal = {
     ias_water_leak_alarm: {

--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -81,7 +82,7 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 0x104E};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.CENTRALITE_SYSTEMS_INC};
             await reporting.bind(endpoint, coordinatorEndpoint,
                 ['msTemperatureMeasurement', 'genPowerCfg', 'manuSpecificSamsungAccelerometer']);
             await reporting.temperature(endpoint);
@@ -267,7 +268,7 @@ const definitions: Definition[] = [
         meta: {battery: {voltageToPercentage: '3V_1500_2800'}},
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 0x110A};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SMARTTHINGS_INC};
             await reporting.bind(endpoint, coordinatorEndpoint,
                 ['msTemperatureMeasurement', 'genPowerCfg', 'manuSpecificSamsungAccelerometer']);
             await endpoint.write('manuSpecificSamsungAccelerometer', {0x0000: {value: 0x01, type: 0x20}}, options);
@@ -300,7 +301,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 0x1241};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SAMJIN_CO_LTD};
             await reporting.bind(endpoint, coordinatorEndpoint,
                 ['msTemperatureMeasurement', 'genPowerCfg', 'manuSpecificSamsungAccelerometer']);
             await endpoint.write('manuSpecificSamsungAccelerometer', {0x0000: {value: 0x14, type: 0x20}}, options);
@@ -341,7 +342,11 @@ const definitions: Definition[] = [
                 maximumReportInterval: constants.repInterval.HOUR,
                 reportableChange: 10,
             }];
-            await endpoint.configureReporting('manuSpecificCentraliteHumidity', payload, {manufacturerCode: 0x104E});
+            await endpoint.configureReporting(
+                'manuSpecificCentraliteHumidity',
+                payload,
+                {manufacturerCode: Zcl.ManufacturerCode.CENTRALITE_SYSTEMS_INC},
+            );
 
             await reporting.batteryVoltage(endpoint);
         },

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
@@ -446,7 +447,7 @@ const definitions: Definition[] = [
                 description: 'Tamper-proof status',
                 valueOn: [true, 0x01],
                 valueOff: [false, 0x00],
-                zigbeeCommandOptions: {manufacturerCode: 0x1286},
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.SHENZHEN_COOLKIT_TECHNOLOGY_CO_LTD},
                 access: 'STATE_GET',
             }),
         ],
@@ -480,7 +481,7 @@ const definitions: Definition[] = [
                 lookup: {'dim': 0, 'bright': 1},
                 cluster: 0xFC11,
                 attribute: {ID: 0x2001, type: 0x20},
-                zigbeeCommandOptions: {manufacturerCode: 0x1286},
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.SHENZHEN_COOLKIT_TECHNOLOGY_CO_LTD},
                 description: 'Only updated when occupancy is detected',
                 access: 'STATE',
             }),
@@ -523,7 +524,7 @@ const definitions: Definition[] = [
                 cluster: 0xFC11,
                 attribute: {ID: 0x2001, type: 0x20},
                 description: 'Only updated when occupancy is detected',
-                zigbeeCommandOptions: {manufacturerCode: 0x1286},
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.SHENZHEN_COOLKIT_TECHNOLOGY_CO_LTD},
                 access: 'STATE',
             }),
         ],

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import * as legacy from '../lib/legacy';
@@ -461,109 +462,162 @@ const definitions: Definition[] = [
             await reporting.currentSummDelivered(endpoint);
 
             // Custom attributes
-            const options = {manufacturerCode: 0x1224}; // Sunricher Manufacturer Code
+            const options = {manufacturerCode: Zcl.ManufacturerCode.SHENZHEN_SUNRICHER_TECHNOLOGY_LTD};
 
             // OperateDisplayLcdBrightnesss
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1000, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1000, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // ButtonVibrationLevel
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1001, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1001, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // FloorSensorType
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1002, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1002, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // ControlType
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1003, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1003, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // PowerUpStatus
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1004, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1004, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // FloorSensorCalibration
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1005, type: 0x28},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1005, type: 0x28},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                options,
+            );
             // DryTime
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1006, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1006, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                options,
+            );
             // ModeAfterDry
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1007, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1007, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // TemperatureDisplay
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1008, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1008, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // WindowOpenCheck
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x1009, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
-
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x1009, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                options,
+            );
             // Hysterersis
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x100A, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
-
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x100A, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                options,
+            );
             // DisplayAutoOffEnable
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x100B, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
-
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x100B, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
             // AlarmAirTempOverValue
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x2001, type: 0x20},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 0}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x2001, type: 0x20},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 0,
+                }],
+                options,
+            );
             // Away Mode Set
-            await endpoint.configureReporting('hvacThermostat', [{
-                attribute: {ID: 0x2002, type: 0x30},
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: null}],
-            options);
+            await endpoint.configureReporting(
+                'hvacThermostat',
+                [{
+                    attribute: {ID: 0x2002, type: 0x30},
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: null,
+                }],
+                options,
+            );
 
             // Device does not asks for the time with binding, we need to write time during configure
             syncTime(endpoint);

--- a/src/devices/viessmann.ts
+++ b/src/devices/viessmann.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
 import * as legacy from '../lib/legacy';
@@ -50,7 +51,7 @@ const definitions: Definition[] = [
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
-            const options = {manufacturerCode: 0x1221};
+            const options = {manufacturerCode: Zcl.ManufacturerCode.VIESSMANN_ELEKTRONIK_GMBH};
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic', 'genPowerCfg', 'genIdentify', 'genTime', 'hvacThermostat']);
 
             // standard ZCL attributes

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import allDefinitions from './devices';
 import * as utils from './lib/utils';
 import { Definition, Fingerprint, Zh, OnEventData, OnEventType, Configure, Expose, Tz, OtaUpdateAvailableResult, KeyValue, Logger } from './lib/types';
 import {generateDefinition} from './lib/generateDefinition';
+import {Zcl} from 'zigbee-herdsman';
 import * as logger from './lib/logger';
 
 export {
@@ -353,10 +354,10 @@ export async function onEvent(type: OnEventType, data: OnEventData, device: Zh.D
     // it expects at least one answer. The payload contains the number of seconds
     // since when the device is powered. If the value is too high, it will leave & not pair
     // 23 works, 200 doesn't
-    if (data.meta && data.meta.manufacturerCode === 0x1021 && type === 'message' && data.type === 'read' &&
+    if (data.meta && data.meta.manufacturerCode === Zcl.ManufacturerCode.LEGRAND_GROUP && type === 'message' && data.type === 'read' &&
         data.cluster === 'genBasic' && data.data && data.data.includes(61440)) {
         const endpoint = device.getEndpoint(1);
-        const options = {manufacturerCode: 0x1021, disableDefaultResponse: true};
+        const options = {manufacturerCode: Zcl.ManufacturerCode.LEGRAND_GROUP, disableDefaultResponse: true};
         const payload = {0xf00: {value: 23, type: 35}};
         await endpoint.readResponse('genBasic', data.meta.zclTransactionSequenceNumber, payload, options);
     }

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -1,3 +1,4 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Fz, Tz, OnEvent, KeyValueString, KeyValueAny} from '../lib/types';
 import * as exposes from './exposes';
 import * as utils from '../lib/utils';
@@ -23,7 +24,7 @@ const getApplicableCalibrationModes = (isNLLVSwitch: boolean): KeyValueString =>
         .map((e) => [e[0], e[1].description]));
 };
 
-export const legrandOptions = {manufacturerCode: 0x1021, disableDefaultResponse: true};
+export const legrandOptions = {manufacturerCode: Zcl.ManufacturerCode.LEGRAND_GROUP, disableDefaultResponse: true};
 
 export const _067776 = {
     getCover: () => {


### PR DESCRIPTION
AKA less magic numbers 😉

Remains these, which apparently are not officially assigned to them:

```typescript
    LIVOLO: 0x1AD2,
    LYTKO: 0x7777,
    PERENIO: 0x007B,
```

Like `SPRUT` I suppose they will have to be added as "custom" in herdsman before being changed here. Might I suggest using the `CUSTOM_` prefix, just to be clear and avoid any potential conflict on future ZCL def changes?