### PR TITLE
Fix for showing 200% battery instead of 100% for easy*-locks (Onesti Products AS)

### DIFF
--- a/src/devices/onesti.ts
+++ b/src/devices/onesti.ts
@@ -58,7 +58,37 @@ const fzLocal = {
 
 const definitions: Definition[] = [
     {
-        zigbeeModel: ['easyCodeTouch_v1', 'EasyCodeTouch', 'EasyFingerTouch', 'NimlyPRO', 'NimlyCode', 'NimlyTouch', 'NimlyIn'],
+        zigbeeModel: ['easyCodeTouch_v1', 'EasyCodeTouch', 'EasyFingerTouch'],
+        model: 'easyCodeTouch_v1',
+        vendor: 'Onesti Products AS',
+        description: 'Zigbee module for EasyAccess code touch series',
+        fromZigbee: [fzLocal.nimly_pro_lock_actions, fz.lock, fz.lock_operation_event, fz.battery, fz.lock_programming_event,
+            fz.easycodetouch_action],
+        toZigbee: [tz.lock, tz.easycode_auto_relock, tz.lock_sound_volume, tz.pincode_lock],
+        meta: {pinCodeCount: 1000},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(11);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await reporting.lockState(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
+            await endpoint.read('closuresDoorLock', ['lockState', 'soundVolume']);
+            device.powerSource = 'Battery';
+            device.save();
+        },
+        exposes: [e.lock(), e.battery(), e.sound_volume(),
+            e.enum('last_unlock_source', ea.STATE, ['zigbee', 'keypad', 'fingerprintsensor', 'rfid',
+                'self', 'unknown']).withDescription('Last unlock source'),
+            e.text('last_unlock_user', ea.STATE).withDescription('Last unlock user').withDescription('Last unlock user'),
+            e.enum('last_lock_source', ea.STATE, ['zigbee', 'keypad', 'fingerprintsensor', 'rfid',
+                'self', 'unknown']).withDescription('Last lock source'),
+            e.text('last_lock_user', ea.STATE).withDescription('Last lock user'),
+            e.text('last_used_pin_code', ea.STATE).withDescription('Last used pin code'),
+            e.binary('auto_relock', ea.STATE_SET, true, false).withDescription('Auto relock after 7 seconds.'),
+            e.pincode(),
+        ],
+    },
+    {
+        zigbeeModel: ['NimlyPRO', 'NimlyCode', 'NimlyTouch', 'NimlyIn'],
         model: 'easyCodeTouch_v1',
         vendor: 'Onesti Products AS',
         description: 'Zigbee module for EasyAccess code touch series',

--- a/src/devices/onesti.ts
+++ b/src/devices/onesti.ts
@@ -89,7 +89,7 @@ const definitions: Definition[] = [
     },
     {
         zigbeeModel: ['NimlyPRO', 'NimlyCode', 'NimlyTouch', 'NimlyIn'],
-        model: 'easyCodeTouch_v1',
+        model: 'Nimly',
         vendor: 'Onesti Products AS',
         description: 'Zigbee module for EasyAccess code touch series',
         fromZigbee: [fzLocal.nimly_pro_lock_actions, fz.lock, fz.lock_operation_event, fz.battery, fz.lock_programming_event,


### PR DESCRIPTION
This commit reverts this:
https://github.com/Koenkk/zigbee-herdsman-converters/commit/ec956f7a1aeb8162f5188d995ff763260fef1c35
for easy*-locks

And breaks out Nimly locks to a new zigbeeModel section since only they seem to be reporting battery percentage wrong.

@Koenkk  - I'm really outside my comfort zone with this. Please close this if it is the wrong way of doing it :)