### PR TITLE
Add support for IKEA Jetstrom 3030

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1140,7 +1140,7 @@ const definitions: Definition[] = [
     },
     {
         zigbeeModel: ['JETSTROM 3030 ceiling'],
-        model: 'L2205, L2206 JETSTRÖM',
+        model: 'L2206',
         vendor: 'IKEA',
         description: 'JETSTRÖM LED wall light panel, smart dimmable/wired-in colour and white spectrum, 30x30cm',
         extend: [tradfriLight({colorTemp: true, color: true})],

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1144,7 +1144,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'JETSTRÖM LED wall light panel, smart dimmable/wired-in colour and white spectrum, 30x30cm',
         extend: [tradfriLight({colorTemp: true, color: true})],
-    },    
+    },
     {
         zigbeeModel: ['JETSTROM 40100'],
         model: 'L2208',

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1139,6 +1139,13 @@ const definitions: Definition[] = [
         extend: [tradfriLight()],
     },
     {
+        zigbeeModel: ['JETSTROM 3030 ceiling'],
+        model: 'L2205, L2206 JETSTRÖM',
+        vendor: 'IKEA',
+        description: 'JETSTRÖM LED wall light panel, smart dimmable/wired-in colour and white spectrum, 30x30cm',
+        extend: [tradfriLight({colorTemp: true, color: true})],
+    },    
+    {
         zigbeeModel: ['JETSTROM 40100'],
         model: 'L2208',
         vendor: 'IKEA',


### PR DESCRIPTION
This supports colour unlike the other two Jetstrom lights which have already been added.
Rather bizarrely this is a wall light but the model comes up as ceiling but the other two are ceiling lights but don't..... 