### PR TITLE
feat(add): NAS-PS09B2

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7433,6 +7433,42 @@ const definitions: Definition[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_kyhbrfyl']),
+        model: 'NAS-PS09B2 ',
+        vendor: 'Neo',
+        description: 'Human presence sensor',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.occupancy(),
+            e.enum('human_motion_state', ea.STATE, ['none', 'small', 'large'])
+                .withDescription('Human Motion State'),
+            e.numeric('departure_delay', ea.STATE_SET).withUnit('s').withValueMin(3)
+                .withValueMax(600).withValueStep(1).withDescription('Presence Time'),
+            e.numeric('radar_range', ea.STATE_SET).withUnit('cm').withValueMin(150).withValueMax(600)
+                .withValueStep(75).withDescription('Motion Range Detection'),
+            e.numeric('radar_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(7)
+                .withValueStep(1).withDescription('Motion Detection Sensitivity'),
+            e.numeric('presence_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(7)
+                .withValueStep(1).withDescription('Motionless Detection Sensitivity'),
+            e.numeric('dis_current', ea.STATE).withUnit('cm').withValueMin(0).withValueMax(1000)
+                .withValueStep(1).withLabel('Current distance')
+                .withDescription('Current Distance of Detected Motion'),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'occupancy', tuya.valueConverter.trueFalse1],
+                [11, 'human_motion_state', tuya.valueConverterBasic.lookup({'none': 0, 'small': 1, 'large': 2})],
+                [12, 'departure_delay', tuya.valueConverter.raw],
+                [13, 'radar_range', tuya.valueConverter.raw],
+                [15, 'radar_sensitivity', tuya.valueConverter.raw],
+                [16, 'presence_sensitivity', tuya.valueConverter.raw],
+                [19, 'dis_current', tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_v1jqz5cy']),
         model: 'BLE-YL01',
         vendor: 'TuYa',


### PR DESCRIPTION
Add support for the tuya based Neo NAS-PS09B2 Also sold under the brand Haozee.

https://www.aliexpress.com/i/1005005946786561.html

I ran this config for a while and it seems to be behaving itself so I'm raising this to add it out of the box instead of having to manually configure it with a custom JS file.

Let me know if anything is missing / wrong, but happy to have it corrected if it's quicker / easy.

Issue relating to this (which lead to this PR):
https://github.com/Koenkk/zigbee2mqtt/issues/19292

Other Issues related:
https://github.com/Koenkk/zigbee2mqtt/issues/19828
https://github.com/Koenkk/zigbee2mqtt/issues/19925
https://github.com/Koenkk/zigbee2mqtt/issues/20062
https://github.com/Koenkk/zigbee2mqtt/issues/20188

Note that the `occupancy` and `human motion state` might appear as null, however this appears to be due to the sensor being insanely sensitive and already being in the occupied state from before the device was configured and not regularly sending state updates, only on change. A quick fix is to just unplug the sensor and plug it back in and it'll send the correct states (that or leave the room for a long time and make sure it's pointing somewhere where it won't see micro movements (it seems like it can see through some materials), so it shows the unoccupied state.



 