### PR TITLE
Try to fix unrealistic pressure readings from WSDCGQ12LM.

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1202,7 +1202,7 @@ const definitions: Definition[] = [
         vendor: 'Aqara',
         description: 'Temperature and humidity sensor T1',
         whiteLabel: [{vendor: 'Aqara', model: 'TH-S02D'}],
-        fromZigbee: [lumi.fromZigbee.lumi_specific, fz.temperature, fz.humidity, fz.pressure, fz.battery],
+        fromZigbee: [lumi.fromZigbee.lumi_specific, fz.temperature, fz.humidity, lumi.fromZigbee.lumi_pressure, fz.battery],
         toZigbee: [],
         exposes: [e.temperature(), e.humidity(), e.pressure(), e.device_temperature(), e.battery(), e.battery_voltage(),
             e.power_outage_count(false)],

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2025,16 +2025,10 @@ export const fromZigbee = {
     lumi_pressure: {
         cluster: 'msPressureMeasurement',
         type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            let pressure = 0;
-            if (msg.data.hasOwnProperty('scaledValue')) {
-                const scale = msg.endpoint.getClusterAttributeValue('msPressureMeasurement', 'scale') as number;
-                pressure = msg.data['scaledValue'] / Math.pow(10, scale) / 100.0; // convert to hPa
-            } else {
-                pressure = parseFloat(msg.data['measuredValue']);
-            }
-            if (pressure > 500 && pressure < 2000) {
-                return {pressure};
+        convert: async (model, msg, publish, options, meta) => {
+	    const result = await fz.pressure.convert(model, msg, publish, options, meta);
+            if (result && result.pressure < 500 && result.pressure < 2000) {
+                return result;
             }
         },
     } satisfies Fz.Converter,

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2026,7 +2026,7 @@ export const fromZigbee = {
         cluster: 'msPressureMeasurement',
         type: ['attributeReport', 'readResponse'],
         convert: async (model, msg, publish, options, meta) => {
-	    const result = await fz.pressure.convert(model, msg, publish, options, meta);
+            const result = await fz.pressure.convert(model, msg, publish, options, meta);
             if (result && result.pressure < 500 && result.pressure < 2000) {
                 return result;
             }

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2033,9 +2033,9 @@ export const fromZigbee = {
             } else {
                 pressure = parseFloat(msg.data['measuredValue']);
             }
-	    if (pressure > 500 && pressure < 2000) {
-		return {pressure};
-	    }
+            if (pressure > 500 && pressure < 2000) {
+                return {pressure};
+            }
         },
     } satisfies Fz.Converter,
 

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2022,6 +2022,22 @@ export const fromZigbee = {
             }
         },
     } satisfies Fz.Converter,
+    lumi_pressure: {
+        cluster: 'msPressureMeasurement',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            let pressure = 0;
+            if (msg.data.hasOwnProperty('scaledValue')) {
+                const scale = msg.endpoint.getClusterAttributeValue('msPressureMeasurement', 'scale') as number;
+                pressure = msg.data['scaledValue'] / Math.pow(10, scale) / 100.0; // convert to hPa
+            } else {
+                pressure = parseFloat(msg.data['measuredValue']);
+            }
+	    if (pressure > 500 && pressure < 2000) {
+		return {pressure};
+	    }
+        },
+    } satisfies Fz.Converter,
 
     // lumi class specific
     lumi_feeder: {


### PR DESCRIPTION
Similar to issue koenkk/zigbee2mqtt#798 my instance of the WSDCGQ12LM sporadically returns unrealistic high pressure readings > 30000 hPa. This PR tries to fix this in the same manner as issue koenkk/zigbee2mqtt#798 was fixed in commit 9bdebcd.