### PR TITLE
Add tuya battery power supply for 24GHz millimeter wave +PIR sensors

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5728,7 +5728,7 @@ const definitions: Definition[] = [
         vendor: 'TuYa',
         description: 'PIR 24Ghz human presence sensor',
         fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tzDatapoints],
+        toZigbee: [tuya.tz.datapoints],
         exposes: [
             e.presence(),
             e.enum('motion_state', ea.STATE, ['none', 'large', 'small', 'static']).withDescription('Motion state'),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5734,7 +5734,7 @@ const definitions: Definition[] = [
         exposes: [
             e.presence(),
             e.enum('motion_state', ea.STATE, ['none', 'large', 'small', 'static']).withDescription('Motion state'),
-            e.illuminance_lux(),e.battery(),
+            e.illuminance_lux(), e.battery(),
             e.numeric('fading_time', ea.STATE_SET).withValueMin(0).withValueMax(28800).withValueStep(1).withUnit('s')
                 .withDescription('Presence keep time'),
             e.numeric('static_detection_distance', ea.STATE_SET).withValueMin(0).withValueMax(10).withValueStep(0.01).withUnit('m')
@@ -5755,11 +5755,7 @@ const definitions: Definition[] = [
                 [2, 'static_detection_sensitivity', tuya.valueConverter.raw],
                 [107, 'indicator', tuya.valueConverter.onOff],
                 [121, 'battery', tuya.valueConverter.raw],
-              //  [104, 'small_motion_detection_distance', tuya.valueConverter.divideBy100],
-              //  [105, 'small_motion_detection_sensitivity', tuya.valueConverter.raw],
-              //  [108, 'static_detection_distance', tuya.valueConverter.divideBy100],
-              //  [109, 'static_detection_sensitivity', tuya.valueConverter.raw],
-               
+                
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5362,7 +5362,7 @@ const definitions: Definition[] = [
         fingerprint: tuya.fingerprint('TS0225', ['_TZE200_hl0ss9oa']),
         model: 'ZG-205ZL',
         vendor: 'TuYa',
-        description: '24Ghz human presence sensor',
+        description: '24Ghz/5.8GHz human presence sensor',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         exposes: [
@@ -5667,7 +5667,7 @@ const definitions: Definition[] = [
         fingerprint: tuya.fingerprint('TS0225', ['_TZE200_2aaelwxk']),
         model: 'ZG-205Z/A',
         vendor: 'TuYa',
-        description: '5.8Ghz Human presence sensor',
+        description: '5.8Ghz/24Ghz Human presence sensor',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         exposes: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5518,7 +5518,7 @@ const definitions: Definition[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_qoy0ekbd', '_TZE200_znbl8dj5', '_TZE200_a8sdabtg', '_TZE200_dikkika5','_TZE200_ysm4dsb1']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_qoy0ekbd', '_TZE200_znbl8dj5', '_TZE200_a8sdabtg', '_TZE200_dikkika5']),
         model: 'ZG-227ZL',
         vendor: 'TuYa',
         description: 'Temperature & humidity LCD sensor',
@@ -5530,7 +5530,6 @@ const definitions: Definition[] = [
         whiteLabel: [
             tuya.whitelabel('TuYa', 'ZG-227Z', 'Temperature and humidity sensor', ['_TZE200_a8sdabtg']),
             tuya.whitelabel('KOJIMA', 'KOJIMA-THS-ZG-LCD', 'Temperature and humidity sensor', ['_TZE200_dikkika5']),
-            tuya.whitelabel('KOJIMA', 'KOJIMA-THS-ZG-LITE', 'Temperature and humidity sensor', ['_TZE200_ysm4dsb1']),
         ],
         meta: {
             tuyaDatapoints: [
@@ -5561,6 +5560,9 @@ const definitions: Definition[] = [
                 [1, 'temperature', tuya.valueConverter.divideBy10],
                 [2, 'humidity', tuya.valueConverter.raw],
                 [4, 'battery', tuya.valueConverter.raw],
+                [9, 'temperature_unit', tuya.valueConverter.temperatureUnit],
+                [23, 'temperature_calibration', tuya.valueConverter.divideBy10],
+                [24, 'humidity_calibration', tuya.valueConverter.raw],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5518,7 +5518,7 @@ const definitions: Definition[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_qoy0ekbd', '_TZE200_znbl8dj5', '_TZE200_a8sdabtg', '_TZE200_dikkika5']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_qoy0ekbd', '_TZE200_znbl8dj5', '_TZE200_a8sdabtg', '_TZE200_dikkika5','_TZE200_ysm4dsb1']),
         model: 'ZG-227ZL',
         vendor: 'TuYa',
         description: 'Temperature & humidity LCD sensor',
@@ -5530,6 +5530,7 @@ const definitions: Definition[] = [
         whiteLabel: [
             tuya.whitelabel('TuYa', 'ZG-227Z', 'Temperature and humidity sensor', ['_TZE200_a8sdabtg']),
             tuya.whitelabel('KOJIMA', 'KOJIMA-THS-ZG-LCD', 'Temperature and humidity sensor', ['_TZE200_dikkika5']),
+            tuya.whitelabel('KOJIMA', 'KOJIMA-THS-ZG-LITE', 'Temperature and humidity sensor', ['_TZE200_ysm4dsb1']),
         ],
         meta: {
             tuyaDatapoints: [
@@ -5718,6 +5719,45 @@ const definitions: Definition[] = [
                 // [118, 'auto1', tuya.valueConverter.raw],
                 // [119, 'auto2', tuya.valueConverter.raw],
                 // [120, 'auto3', tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_2aaelwxk']),
+        model: 'ZG-204ZM',
+        vendor: 'TuYa',
+        description: 'PIR 24Ghz human presence sensor',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tzDatapoints],
+        exposes: [
+            e.presence(),
+            e.enum('motion_state', ea.STATE, ['none', 'large', 'small', 'static']).withDescription('Motion state'),
+            e.illuminance_lux(),e.battery(),
+            e.numeric('fading_time', ea.STATE_SET).withValueMin(0).withValueMax(28800).withValueStep(1).withUnit('s')
+                .withDescription('Presence keep time'),
+            e.numeric('static_detection_distance', ea.STATE_SET).withValueMin(0).withValueMax(10).withValueStep(0.01).withUnit('m')
+                .withDescription('Static detection distance'),
+            e.numeric('static_detection_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(10).withValueStep(1).withUnit('x')
+                .withDescription('Static detection sensitivity'),
+            e.binary('indicator', ea.STATE_SET, 'ON', 'OFF').withDescription('LED indicator mode'),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'presence', tuya.valueConverter.trueFalse1],
+                [106, 'illuminance_lux', tuya.valueConverter.raw],
+                [101, 'motion_state', tuya.valueConverterBasic.lookup({
+                    'none': tuya.enum(0), 'large': tuya.enum(1), 'small': tuya.enum(2), 'static': tuya.enum(3),
+                })],
+                [102, 'fading_time', tuya.valueConverter.raw],
+                [4, 'static_detection_distance', tuya.valueConverter.divideBy100],
+                [2, 'static_detection_sensitivity', tuya.valueConverter.raw],
+                [107, 'indicator', tuya.valueConverter.onOff],
+                [121, 'battery', tuya.valueConverter.raw],
+              //  [104, 'small_motion_detection_distance', tuya.valueConverter.divideBy100],
+              //  [105, 'small_motion_detection_sensitivity', tuya.valueConverter.raw],
+              //  [108, 'static_detection_distance', tuya.valueConverter.divideBy100],
+              //  [109, 'static_detection_sensitivity', tuya.valueConverter.raw],
+               
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5554,7 +5554,7 @@ const definitions: Definition[] = [
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
             await device.getEndpoint(1).command('manuSpecificTuya', 'dataQuery', {});
         },
-         exposes: [e.temperature(), e.humidity(), tuya.exposes.temperatureUnit(), tuya.exposes.temperatureCalibration(),
+        exposes: [e.temperature(), e.humidity(), tuya.exposes.temperatureUnit(), tuya.exposes.temperatureCalibration(),
             tuya.exposes.humidityCalibration(), e.battery()],
         meta: {
             tuyaDatapoints: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5754,7 +5754,7 @@ const definitions: Definition[] = [
                 [4, 'static_detection_distance', tuya.valueConverter.divideBy100],
                 [2, 'static_detection_sensitivity', tuya.valueConverter.raw],
                 [107, 'indicator', tuya.valueConverter.onOff],
-                [121, 'battery', tuya.valueConverter.raw],   
+                [121, 'battery', tuya.valueConverter.raw],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5554,7 +5554,8 @@ const definitions: Definition[] = [
             await tuya.configureMagicPacket(device, coordinatorEndpoint, logger);
             await device.getEndpoint(1).command('manuSpecificTuya', 'dataQuery', {});
         },
-        exposes: [e.battery(), e.temperature(), e.humidity()],
+         exposes: [e.temperature(), e.humidity(), tuya.exposes.temperatureUnit(), tuya.exposes.temperatureCalibration(),
+            tuya.exposes.humidityCalibration(), e.battery()],
         meta: {
             tuyaDatapoints: [
                 [1, 'temperature', tuya.valueConverter.divideBy10],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5754,8 +5754,7 @@ const definitions: Definition[] = [
                 [4, 'static_detection_distance', tuya.valueConverter.divideBy100],
                 [2, 'static_detection_sensitivity', tuya.valueConverter.raw],
                 [107, 'indicator', tuya.valueConverter.onOff],
-                [121, 'battery', tuya.valueConverter.raw],
-                
+                [121, 'battery', tuya.valueConverter.raw],   
             ],
         },
     },


### PR DESCRIPTION
1.Add tuya battery power supply for 24GHz millimeter wave +PIR sensors
2.Revise the descriptions of ZG-205ZL and ZG-205Z/A