### PR TITLE
fix: set MCLH-02 color temp range and convert LifeControl to modern extend 

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3227,17 +3227,6 @@ const converters1 = {
             }
         },
     } satisfies Fz.Converter,
-    lifecontrolVoc: {
-        cluster: 'msTemperatureMeasurement',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            const temperature = parseFloat(msg.data['measuredValue']) / 100.0;
-            const humidity = parseFloat(msg.data['minMeasuredValue']) / 100.0;
-            const eco2 = parseFloat(msg.data['maxMeasuredValue']);
-            const voc = parseFloat(msg.data['tolerance']);
-            return {temperature, humidity, eco2, voc};
-        },
-    } satisfies Fz.Converter,
     _8840100H_water_leak_alarm: {
         cluster: 'haApplianceEventsAlerts',
         type: 'commandAlertsNotification',

--- a/src/devices/lifecontrol.ts
+++ b/src/devices/lifecontrol.ts
@@ -7,7 +7,7 @@ import {battery, electricityMeter, iasZoneAlarm, light, onOff} from '../lib/mode
 
 const e = exposes.presets;
 
-function lifecontrolAirMonitor(): ModernExtend {
+function airQuality(): ModernExtend {
     const exposes: Expose[] = [e.temperature(), e.humidity(), e.voc().withUnit('ppb'), e.eco2()];
 
     const fromZigbee: Fz.Converter[] = [{
@@ -105,7 +105,7 @@ const definitions: Definition[] = [
         vendor: 'LifeControl',
         description: 'Air sensor',
         extend: [
-            lifecontrolAirMonitor(),
+            airQuality(),
             battery({dontDividePercentage: true}),
         ],
     },

--- a/src/devices/lifecontrol.ts
+++ b/src/devices/lifecontrol.ts
@@ -30,7 +30,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['Leak_Sensor'],
         model: 'MCLH-07',
         vendor: 'LifeControl',
-        description: 'Water leak switch',
+        description: 'Water leakage sensor',
         extend: [
             iasZoneAlarm({zoneType: 'water_leak', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']}),
             battery({dontDividePercentage: true}),
@@ -40,7 +40,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['Door_Sensor'],
         model: 'MCLH-04',
         vendor: 'LifeControl',
-        description: 'Door sensor',
+        description: 'Open and close sensor',
         extend: [
             iasZoneAlarm({zoneType: 'contact', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']}),
             battery({dontDividePercentage: true}),
@@ -50,7 +50,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['vivi ZLight'],
         model: 'MCLH-02',
         vendor: 'LifeControl',
-        description: 'RGB LED lamp',
+        description: 'Smart light bulb',
         extend: [light({colorTemp: {range: [167, 333]}, color: true})],
     },
     {
@@ -103,7 +103,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['VOC_Sensor'],
         model: 'MCLH-08',
         vendor: 'LifeControl',
-        description: 'Air sensor',
+        description: 'Air quality sensor',
         extend: [
             airQuality(),
             battery({dontDividePercentage: true}),

--- a/src/devices/lifecontrol.ts
+++ b/src/devices/lifecontrol.ts
@@ -34,7 +34,7 @@ const definitions: Definition[] = [
         model: 'MCLH-02',
         vendor: 'LifeControl',
         description: 'RGB LED lamp',
-        extend: [light({colorTemp: {range: undefined}, color: true})],
+        extend: [light({colorTemp: {range: [167, 333]}, color: true})],
     },
     {
         zigbeeModel: ['RICI01'],

--- a/src/devices/lifecontrol.ts
+++ b/src/devices/lifecontrol.ts
@@ -14,20 +14,20 @@ const definitions: Definition[] = [
         model: 'MCLH-07',
         vendor: 'LifeControl',
         description: 'Water leak switch',
-        fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
-        toZigbee: [],
-        meta: {battery: {dontDividePercentage: true}},
-        exposes: [e.water_leak(), e.battery_low(), e.tamper(), e.battery()],
+        extend: [
+            iasZoneAlarm({zoneType: 'water_leak', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']}),
+            battery({dontDividePercentage: true}),
+        ],
     },
     {
         zigbeeModel: ['Door_Sensor'],
         model: 'MCLH-04',
         vendor: 'LifeControl',
         description: 'Door sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
-        toZigbee: [],
-        meta: {battery: {dontDividePercentage: true}},
-        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
+        extend: [
+            iasZoneAlarm({zoneType: 'contact', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']}),
+            battery({dontDividePercentage: true}),
+        ],
     },
     {
         zigbeeModel: ['vivi ZLight'],
@@ -77,20 +77,21 @@ const definitions: Definition[] = [
         model: 'MCLH-05',
         vendor: 'LifeControl',
         description: 'Motion sensor',
-        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery],
-        toZigbee: [],
-        meta: {battery: {dontDividePercentage: true}},
-        exposes: [e.occupancy(), e.battery_low(), e.tamper(), e.battery()],
+        extend: [
+            iasZoneAlarm({zoneType: 'occupancy', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']}),
+            battery({dontDividePercentage: true}),
+        ],
     },
     {
         zigbeeModel: ['VOC_Sensor'],
         model: 'MCLH-08',
         vendor: 'LifeControl',
         description: 'Air sensor',
-        fromZigbee: [fz.lifecontrolVoc, fz.battery],
-        toZigbee: [],
-        meta: {battery: {dontDividePercentage: true}},
-        exposes: [e.temperature(), e.humidity(), e.voc().withUnit('ppb'), e.eco2(), e.battery()],
+        fromZigbee: [fz.lifecontrolVoc],
+        exposes: [e.temperature(), e.humidity(), e.voc().withUnit('ppb'), e.eco2()],
+        extend: [
+            battery({dontDividePercentage: true}),
+        ],
     },
 ];
 

--- a/src/devices/lifecontrol.ts
+++ b/src/devices/lifecontrol.ts
@@ -91,7 +91,7 @@ const definitions: Definition[] = [
         description: 'Smart socket',
         extend: [
             onOff({powerOnBehavior: false}),
-            electricityMeter({reporting: false}),
+            electricityMeter({configureReporting: false}),
             electricityMeterPoll(),
         ],
     },

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1150,9 +1150,10 @@ export interface ElectricityMeterArgs {
     power?: false | MultiplierDivisor,
     voltage?: false | MultiplierDivisor,
     energy?: false | MultiplierDivisor
+    reporting?: boolean
 }
 export function electricityMeter(args?: ElectricityMeterArgs): ModernExtend {
-    args = {cluster: 'both', ...args};
+    args = {cluster: 'both', reporting: true, ...args};
     if (args.cluster === 'metering' && isObject(args.power) && isObject(args.energy) &&
         (args.power?.divisor !== args.energy?.divisor || args.power?.multiplier !== args.energy?.multiplier)) {
         throw new Error(`When cluster is metering, power and energy divisor/multiplier should be equal`);
@@ -1208,39 +1209,43 @@ export function electricityMeter(args?: ElectricityMeterArgs): ModernExtend {
         delete configureLookup.seMetering;
     }
 
-    const configure: Configure = async (device, coordinatorEndpoint, logger) => {
-        for (const [cluster, properties] of Object.entries(configureLookup)) {
-            for (const endpoint of getEndpointsWithCluster(device, cluster, 'input')) {
-                const items: ReportingConfig[] = [];
-                for (const property of Object.values(properties)) {
-                    // In case multiplier or divisor was provided, use that instead of reading from device.
-                    if (property.forced) {
-                        endpoint.saveClusterAttributeKeyValue(cluster, {
-                            [property.divisor]: property.forced.divisor ?? 1,
-                            [property.multiplier]: property.forced.multiplier ?? 1,
-                        });
-                        endpoint.save();
-                    } else {
-                        await endpoint.read(cluster, [property.divisor, property.multiplier]);
-                    }
+    const result: ModernExtend = {exposes, fromZigbee, toZigbee, isModernExtend: true};
 
-                    const divisor = endpoint.getClusterAttributeValue(cluster, property.divisor);
-                    assertNumber(divisor, property.divisor);
-                    const multiplier = endpoint.getClusterAttributeValue(cluster, property.multiplier);
-                    assertNumber(multiplier, property.multiplier);
-                    let change: number | [number, number] = property.change * (divisor / multiplier);
-                    // currentSummDelivered data type is uint48, so reportableChange also is uint48
-                    if (property.attribute === 'currentSummDelivered') change = [0, change];
-                    items.push({attribute: property.attribute, min: '10_SECONDS', max: 'MAX', change});
-                }
-                if (items.length) {
-                    await setupAttributes(endpoint, coordinatorEndpoint, cluster, items, logger);
+    if (args.reporting) {
+        result.configure = async (device, coordinatorEndpoint, logger) => {
+            for (const [cluster, properties] of Object.entries(configureLookup)) {
+                for (const endpoint of getEndpointsWithCluster(device, cluster, 'input')) {
+                    const items: ReportingConfig[] = [];
+                    for (const property of Object.values(properties)) {
+                        // In case multiplier or divisor was provided, use that instead of reading from device.
+                        if (property.forced) {
+                            endpoint.saveClusterAttributeKeyValue(cluster, {
+                                [property.divisor]: property.forced.divisor ?? 1,
+                                [property.multiplier]: property.forced.multiplier ?? 1,
+                            });
+                            endpoint.save();
+                        } else {
+                            await endpoint.read(cluster, [property.divisor, property.multiplier]);
+                        }
+
+                        const divisor = endpoint.getClusterAttributeValue(cluster, property.divisor);
+                        assertNumber(divisor, property.divisor);
+                        const multiplier = endpoint.getClusterAttributeValue(cluster, property.multiplier);
+                        assertNumber(multiplier, property.multiplier);
+                        let change: number | [number, number] = property.change * (divisor / multiplier);
+                        // currentSummDelivered data type is uint48, so reportableChange also is uint48
+                        if (property.attribute === 'currentSummDelivered') change = [0, change];
+                        items.push({attribute: property.attribute, min: '10_SECONDS', max: 'MAX', change});
+                    }
+                    if (items.length) {
+                        await setupAttributes(endpoint, coordinatorEndpoint, cluster, items, logger);
+                    }
                 }
             }
-        }
-    };
+        };
+    }
 
-    return {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
+    return result;
 }
 
 // #endregion

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1150,10 +1150,10 @@ export interface ElectricityMeterArgs {
     power?: false | MultiplierDivisor,
     voltage?: false | MultiplierDivisor,
     energy?: false | MultiplierDivisor
-    reporting?: boolean
+    configureReporting?: boolean
 }
 export function electricityMeter(args?: ElectricityMeterArgs): ModernExtend {
-    args = {cluster: 'both', reporting: true, ...args};
+    args = {cluster: 'both', configureReporting: true, ...args};
     if (args.cluster === 'metering' && isObject(args.power) && isObject(args.energy) &&
         (args.power?.divisor !== args.energy?.divisor || args.power?.multiplier !== args.energy?.multiplier)) {
         throw new Error(`When cluster is metering, power and energy divisor/multiplier should be equal`);
@@ -1211,7 +1211,7 @@ export function electricityMeter(args?: ElectricityMeterArgs): ModernExtend {
 
     const result: ModernExtend = {exposes, fromZigbee, toZigbee, isModernExtend: true};
 
-    if (args.reporting) {
+    if (args.configureReporting) {
         result.configure = async (device, coordinatorEndpoint, logger) => {
             for (const [cluster, properties] of Object.entries(configureLookup)) {
                 for (const endpoint of getEndpointsWithCluster(device, cluster, 'input')) {


### PR DESCRIPTION
- Set color temperature range for `MCLH-02` as per instruction to 167-333 mired (3000-6000K)
- Update device names in accordance to their actual retail names from the manufactures web store
- Convert all devices to Modern Extend
- Added `reporting` parameter to the `electricityMeter` extend to disable reporting if needed