### PR TITLE
Improve Danfoss Icon2 support

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2866,6 +2866,32 @@ const converters1 = {
             return result;
         },
     } satisfies Fz.Converter,
+    danfoss_icon_floor_sensor: {
+        cluster: 'hvacThermostat',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValueAny = {};
+            if (msg.data.hasOwnProperty('danfossRoomFloorSensorMode')) {
+                result[postfixWithEndpointName('room_floor_sensor_mode', msg, model, meta)] =
+                    constants.danfossRoomFloorSensorMode.hasOwnProperty(msg.data['danfossRoomFloorSensorMode']) ?
+                        constants.danfossRoomFloorSensorMode[msg.data['danfossRoomFloorSensorMode']] :
+                        msg.data['danfossRoomFloorSensorMode'];
+            }
+            if (msg.data.hasOwnProperty('danfossFloorMinSetpoint')) {
+                const value = precisionRound(msg.data['danfossFloorMinSetpoint'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('floor_min_setpoint', msg, model, meta)] = value;
+                }
+            }
+            if (msg.data.hasOwnProperty('danfossFloorMaxSetpoint')) {
+                const value = precisionRound(msg.data['danfossFloorMaxSetpoint'], 2) / 100;
+                if (value >= -273.15) {
+                    result[postfixWithEndpointName('floor_max_setpoint', msg, model, meta)] = value;
+                }
+            }
+            return result;
+        },
+    } satisfies Fz.Converter,
     danfoss_icon_battery: {
         cluster: 'genPowerCfg',
         type: ['attributeReport', 'readResponse'],

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1811,6 +1811,12 @@ const converters2 = {
             await entity.read('msTemperatureMeasurement', ['measuredValue']);
         },
     } satisfies Tz.Converter,
+    humidity: {
+        key: ['humidity'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('msRelativeHumidity', ['measuredValue']);
+        },
+    } satisfies Tz.Converter,
     illuminance: {
         key: ['illuminance', 'illuminance_lux'],
         convertGet: async (entity, key, meta) => {

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -2505,6 +2505,36 @@ const converters2 = {
             await entity.read('hvacThermostat', ['danfossRoomStatusCode'], manufacturerOptions.danfoss);
         },
     } satisfies Tz.Converter,
+    danfoss_floor_sensor_mode: {
+        key: ['room_floor_sensor_mode'],
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossRoomFloorSensorMode'], manufacturerOptions.danfoss);
+        },
+    } satisfies Tz.Converter,
+    danfoss_floor_min_setpoint: {
+        key: ['floor_min_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertNumber(value, key);
+            const danfossFloorMinSetpoint = Number((Math.round(Number((value * 2).toFixed(1))) / 2).toFixed(1)) * 100;
+            await entity.write('hvacThermostat', {danfossFloorMinSetpoint}, manufacturerOptions.danfoss);
+            return {state: {floor_min_setpoint: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossFloorMinSetpoint'], manufacturerOptions.danfoss);
+        },
+    } satisfies Tz.Converter,
+    danfoss_floor_max_setpoint: {
+        key: ['floor_max_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertNumber(value, key);
+            const danfossFloorMaxSetpoint = Number((Math.round(Number((value * 2).toFixed(1))) / 2).toFixed(1)) * 100;
+            await entity.write('hvacThermostat', {danfossFloorMaxSetpoint}, manufacturerOptions.danfoss);
+            return {state: {floor_max_setpoint: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('hvacThermostat', ['danfossFloorMaxSetpoint'], manufacturerOptions.danfoss);
+        },
+    } satisfies Tz.Converter,
     danfoss_system_status_code: {
         key: ['system_status_code'],
         convertGet: async (entity, key, meta) => {

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -363,6 +363,8 @@ const definitions: Definition[] = [
             fz.danfoss_thermostat,
             fz.danfoss_icon_battery,
             fz.thermostat,
+            fz.danfoss_icon_floor_sensor,
+            fz.temperature,
             fz.humidity,
             fz.danfoss_icon_hvac_user_interface],
         toZigbee: [
@@ -375,6 +377,10 @@ const definitions: Definition[] = [
             tz.danfoss_output_status,
             tz.danfoss_room_status_code,
             tz.danfoss_system_status_water,
+            tz.danfoss_floor_sensor_mode,
+            tz.danfoss_floor_min_setpoint,
+            tz.danfoss_floor_max_setpoint,
+            tz.temperature,
             tz.danfoss_system_status_code,
             tz.danfoss_multimaster_role,
             tz.thermostat_keypad_lockout,
@@ -402,6 +408,22 @@ const definitions: Definition[] = [
                     features.push(e.enum('room_status_code', ea.STATE_GET, ['no_error', 'missing_rt',
                         'rt_touch_error', 'floor_sensor_short_circuit', 'floor_sensor_disconnected'])
                         .withEndpoint(epName).withDescription('Thermostat status'));
+                    features.push(e.enum('room_floor_sensor_mode', ea.STATE_GET, ['comfort', 'floor_only', 'dual_mode'])
+                        .withEndpoint(epName)
+                        .withDescription('Floor sensor mode'));
+                    features.push(e.numeric('floor_min_setpoint', ea.ALL)
+                        .withValueMin(18).withValueMax(35).withValueStep(0.5).withUnit('°C')
+                        .withEndpoint(epName)
+                        .withDescription('Min floor temperature'));
+                    features.push(e.numeric('floor_max_setpoint', ea.ALL)
+                        .withValueMin(18).withValueMax(35).withValueStep(0.5).withUnit('°C')
+                        .withEndpoint(epName)
+                        .withDescription('Max floor temperature'));
+
+                    features.push(e.numeric('temperature', ea.STATE_GET)
+                        .withUnit('°C')
+                        .withEndpoint(epName)
+                        .withDescription('Floor temperature'));
                 } else {
                     features.push(e.enum('system_status_code', ea.STATE_GET, ['no_error', 'missing_expansion_board',
                         'missing_radio_module', 'missing_command_module', 'missing_master_rail', 'missing_slave_rail_no_1',
@@ -431,6 +453,7 @@ const definitions: Definition[] = [
                 await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.HOUR, max: constants.repInterval.MAX, change: 1});
                 await reporting.thermostatTemperature(endpoint, {min: constants.repInterval.SECONDS_5, max: constants.repInterval.HOUR, change: 50});
                 await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MAX, change: 1});
+                await reporting.temperature(endpoint, {change: 10});
                 await reporting.humidity(endpoint, {min: constants.repInterval.SECONDS_5, max: constants.repInterval.HOUR, change: 1});
 
                 await endpoint.read('hvacThermostat', ['localTemp',
@@ -438,6 +461,14 @@ const definitions: Definition[] = [
                     'minHeatSetpointLimit',
                     'maxHeatSetpointLimit',
                     'systemMode']);
+
+                await endpoint.read('hvacThermostat', [
+                    'danfossRoomFloorSensorMode',
+                    'danfossFloorMinSetpoint',
+                    'danfossFloorMaxSetpoint',
+                ], options);
+                await endpoint.read('msTemperatureMeasurement', ['measuredValue']);
+
                 await endpoint.read('msRelativeHumidity', ['measuredValue']);
                 await endpoint.read('genPowerCfg', ['batteryPercentageRemaining']);
                 await endpoint.read('hvacUserInterfaceCfg', ['keypadLockout']);

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -351,10 +351,11 @@ const definitions: Definition[] = [
     },
     {
         fingerprint: [
-            {modelID: '0x0210', manufacturerName: 'Danfoss'}, // Main Controller
-            {modelID: '0x8040', manufacturerName: 'Danfoss'}, // RT Zigbee - Display
-            {modelID: '0x8041', manufacturerName: 'Danfoss'}, // RT Zigbee - Featured (Infrared)
-            {modelID: '0x8042', manufacturerName: 'Danfoss'}, // RT Zigbee - Sensor
+            {modelID: '0x0210', manufacturerName: 'Danfoss'}, // Icon2 Basic Main Controller
+            {modelID: '0x0211', manufacturerName: 'Danfoss'}, // Icon2 Advanced Main Controller
+            {modelID: '0x8040', manufacturerName: 'Danfoss'}, // Icon2 Room Thermostat
+            {modelID: '0x8041', manufacturerName: 'Danfoss'}, // Icon2 Featured (Infrared) Room Thermostat
+            {modelID: '0x0042', manufacturerName: 'Danfoss'}, // Icon2 Sensor
         ],
         model: 'Icon2',
         vendor: 'Danfoss',

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -381,6 +381,7 @@ const definitions: Definition[] = [
             tz.danfoss_floor_min_setpoint,
             tz.danfoss_floor_max_setpoint,
             tz.temperature,
+            tz.humidity,
             tz.danfoss_system_status_code,
             tz.danfoss_multimaster_role,
             tz.thermostat_keypad_lockout,
@@ -392,7 +393,6 @@ const definitions: Definition[] = [
                 const epName = `${i}`;
                 if (i < 16) {
                     features.push(e.battery().withEndpoint(epName));
-                    features.push(e.humidity().withEndpoint(epName));
                     features.push(e.climate().withSetpoint('occupied_heating_setpoint', 5, 35, 0.5)
                         .withLocalTemperature().withRunningState(['idle', 'heat']).withSystemMode(['heat']).withEndpoint(epName));
                     features.push(e.numeric('min_heat_setpoint_limit', ea.ALL)
@@ -424,6 +424,11 @@ const definitions: Definition[] = [
                         .withUnit('°C')
                         .withEndpoint(epName)
                         .withDescription('Floor temperature'));
+
+                    features.push(e.numeric('humidity', ea.STATE_GET)
+                        .withUnit('%')
+                        .withEndpoint(epName)
+                        .withDescription('Humidity'));
                 } else {
                     features.push(e.enum('system_status_code', ea.STATE_GET, ['no_error', 'missing_expansion_board',
                         'missing_radio_module', 'missing_command_module', 'missing_master_rail', 'missing_slave_rail_no_1',

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -456,11 +456,11 @@ const definitions: Definition[] = [
                 }
                 await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'hvacThermostat', 'msRelativeHumidity', 'hvacUserInterfaceCfg']);
 
-                await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.HOUR, max: constants.repInterval.MAX, change: 1});
-                await reporting.thermostatTemperature(endpoint, {min: constants.repInterval.SECONDS_5, max: constants.repInterval.HOUR, change: 50});
-                await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: constants.repInterval.MAX, change: 1});
+                await reporting.batteryPercentageRemaining(endpoint);
+                await reporting.thermostatTemperature(endpoint);
+                await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
                 await reporting.temperature(endpoint, {change: 10});
-                await reporting.humidity(endpoint, {min: constants.repInterval.SECONDS_5, max: constants.repInterval.HOUR, change: 1});
+                await reporting.humidity(endpoint);
 
                 await endpoint.read('hvacThermostat', ['localTemp',
                     'occupiedHeatingSetpoint',
@@ -487,7 +487,7 @@ const definitions: Definition[] = [
                     await endpoint.configureReporting('hvacThermostat', [{
                         attribute: 'danfossOutputStatus',
                         minimumReportInterval: 0,
-                        maximumReportInterval: constants.repInterval.MINUTES_10,
+                        maximumReportInterval: constants.repInterval.HOUR,
                         reportableChange: 1,
                     }], options);
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -145,6 +145,12 @@ export const danfossRoomStatusCode: KeyValueNumberString = {
     0x0801: 'floor_sensor_disconnected',
 };
 
+export const danfossRoomFloorSensorMode: KeyValueNumberString = {
+    0: 'comfort',
+    1: 'floor_only',
+    2: 'dual_mode',
+};
+
 export const danfossOutputStatus: KeyValueNumberString = {
     0: 'inactive',
     1: 'active',
@@ -310,6 +316,7 @@ exports.danfossAdaptionRunControl = danfossAdaptionRunControl;
 exports.danfossAdaptionRunStatus = danfossAdaptionRunStatus;
 exports.danfossWindowOpen = danfossWindowOpen;
 exports.danfossRoomStatusCode = danfossRoomStatusCode;
+exports.danfossRoomFloorSensorMode = danfossRoomFloorSensorMode;
 exports.danfossOutputStatus = danfossOutputStatus;
 exports.danfossSystemStatusWater = danfossSystemStatusWater;
 exports.danfossSystemStatusCode = danfossSystemStatusCode;


### PR DESCRIPTION
- Add support for the infrared floor sensor
- Add the ability to read humidity attribute manually
- Add model ID for the Advanced Main Controller
- Change reporting values of some attributes to default
- Slight clean-up