### PR TITLE
Add support for Aqara WS-K01D

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3049,6 +3049,23 @@ const definitions: Definition[] = [
         ],
     },
     {
+        zigbeeModel: ['lumi.switch.acn061'],
+        model: 'WS-K01D',
+        vendor: 'Aqara',
+        description: 'Smart 20A Switch H1 (single rocker)',
+        extend: [
+            lumiZigbeeOTA(),
+            lumiPreventReset(),
+            lumiOnOff({operationMode: true, powerOutageMemory: 'binary'}),
+            lumiAction({actionLookup: {'single': 1, 'double': 2}}),
+            lumiElectricityMeter(),
+            lumiPower(),
+            lumiLedDisabledNight(),
+            lumiSetEventMode(),
+            lumiFlipIndicatorLight(),
+        ],
+    },
+    {
         zigbeeModel: ['lumi.remote.cagl02'],
         model: 'CTP-R01',
         vendor: 'Aqara',


### PR DESCRIPTION
Adds support for [Aqara Smart 20A Switch H1](https://www.aqara.com/en/product/smart-20a-wall-switch-sea/) (single rocker)

Verified the following functionality:
- On/Off State
- Device temperature
- Power outage count, Power outage memory
- Operation mode - decoupled/control_relay
- Action
- Energy, Voltage, Current, Power
- Led disabled night, Flip indicator light

