### PR TITLE
feat: add support for Legrand 067761A

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -659,6 +659,23 @@ const definitions: Definition[] = [
             await reporting.onOff(endpoint);
         },
     },
+    {
+        zigbeeModel: [' Remote fan controller\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'],
+        model: '067761A',
+        vendor: 'Legrand',
+        description: 'Exhaust wireless switch',
+        fromZigbee: [fz.identify, fz.command_on, fz.command_off, fz.battery],
+        toZigbee: [],
+        exposes: [
+            e.battery(),
+            e.action(['identify', 'on', 'off']),
+        ],
+        onEvent: readInitialBatteryState,
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'genOnOff']);
+        },
+    },
 ];
 
 export default definitions;


### PR DESCRIPTION
# Add support for Legrand 067761A
* Device is described [here](https://www.legrand.fr/pro/catalogue/commande-sans-fils-pour-vmc-connectee-celiane-with-netatmo-blanc-sans-plaque)
* Documentation PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/2664

# Questions
1. Currently this devices is described as "on/off" and I imagine this is enough but maybe there is something more semantically close to the buttons? e.g. fan high speed and fan low speed
2. The device also supports `genLevelCtrl` but in the context of this particular switch I think it's not supposed to work. Anyways, if I want to add support for it, what should I do? The closest I found is `brightness_move_up` which is very far from what this is supposed to do :sweat_smile: 
3. How do I add support for OTA? It should be the same as the `Wireless remote switch` from Legrand as well as it's on the NLT device list from [here](https://developer.legrand.com/production-firmware-download/)