### PR TITLE
feat: add `COZIGVS` device

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4858,19 +4858,16 @@ const definitions: Definition[] = [
                 .withDescription('Sensitivty of the sensor, press button on the device right before changing this')],
     },
     {
-        model: 'TS0601',
-        vendor: 'TuYa',
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_8ply8mjj']),
-        whiteLabel: [tuya.whitelabel('Conecto', 'COZIGVS', 'Vibration sensor', ['_TZE200_8ply8mjj'])],
+        model: 'COZIGVS',
+        vendor: 'Conecto',
         description: 'Vibration sensor',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
             e.vibration(),
-            e.numeric('sensitivity', ea.STATE_SET)
-                .withValueMin(0)
-                .withValueMax(2)
+            e.numeric('sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(2)
                 .withDescription('Sensitivity of the sensor (single press the button when muted to switch between' +
                     ' low (one beep), medium (two beeps) and max (three beeps))'),
             e.text('buzzer_mute', ea.STATE).withDescription('ON when buzzer is muted (double press the button on device to toggle)'),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4858,6 +4858,32 @@ const definitions: Definition[] = [
                 .withDescription('Sensitivty of the sensor, press button on the device right before changing this')],
     },
     {
+        model: 'TS0601',
+        vendor: 'TuYa',
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_8ply8mjj']),
+        whiteLabel: [tuya.whitelabel('Conecto', 'COZIGVS', 'Vibration sensor', ['_TZE200_8ply8mjj'])],
+        description: 'Vibration sensor',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.vibration(),
+            e.numeric('sensitivity', ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(2)
+                .withDescription('Sensitivity of the sensor (single press the button when muted to switch between' +
+                    ' low (one beep), medium (two beeps) and max (three beeps))'),
+            e.text('buzzer_mute', ea.STATE).withDescription('ON when buzzer is muted (double press the button on device to toggle)'),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'vibration', tuya.valueConverter.trueFalse1],
+                [101, 'sensitivity', tuya.valueConverter.raw],
+                [103, 'buzzer_mute', tuya.valueConverter.onOff],
+            ],
+        },
+    },
+    {
         fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_8bxrzyxz'},
             {modelID: 'TS011F', manufacturerName: '_TZ3000_ky0fq4ho'}],
         model: 'TS011F_din_smart_relay',


### PR DESCRIPTION
This is my first contribution to device converters. Not sure how to get the battery values out.

Tried 
```typescript
{
  // ...
  fromZigbee: [tuya.fz.battery],
  // and/or
  exposes: [e.battery()]
  // ...
}
```
but without luck.

Otherwise works fine.