### PR TITLE
Add BMCT-DZ

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1,4 +1,4 @@
-import {identify, light, onOff, ota, quirkCheckinInterval} from '../lib/modernExtend';
+import {identify, light, onOff, quirkCheckinInterval} from '../lib/modernExtend';
 import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
@@ -1406,6 +1406,7 @@ const definitions: Definition[] = [
         model: 'BMCT-DZ',
         vendor: 'Bosch',
         description: 'Phase-cut dimmer',
+        ota: ota.zigbeeOTA,
         extend: [identify(), ota(), light({configureReporting: true, effect: false})],
     },
     {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1,4 +1,4 @@
-import {identify, light, onOff, quirkCheckinInterval} from '../lib/modernExtend';
+import {identify, light, onOff, ota, quirkCheckinInterval} from '../lib/modernExtend';
 import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1407,7 +1407,7 @@ const definitions: Definition[] = [
         vendor: 'Bosch',
         description: 'Phase-cut dimmer',
         ota: ota.zigbeeOTA,
-        extend: [identify(), ota(), light({configureReporting: true, effect: false})],
+        extend: [identify(), light({configureReporting: true, effect: false})],
     },
     {
         zigbeeModel: ['RBSH-MMR-ZB-EU'],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1402,6 +1402,13 @@ const definitions: Definition[] = [
         exposes: [e.battery_low(), e.contact(), e.vibration(), e.action(['single', 'long'])],
     },
     {
+        zigbeeModel: ['RBSH-MMD-ZB-EU'],
+        model: 'BMCT-DZ',
+        vendor: 'Bosch',
+        description: 'Phase-cut dimmer',
+        extend: [identify(), ota(), light({configureReporting: true, effect: false})],
+    },
+    {
         zigbeeModel: ['RBSH-MMR-ZB-EU'],
         model: 'BMCT-RZ',
         vendor: 'Bosch',

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1,4 +1,4 @@
-import {onOff, quirkCheckinInterval} from '../lib/modernExtend';
+import {identify, light, onOff, quirkCheckinInterval} from '../lib/modernExtend';
 import {Zcl} from 'zigbee-herdsman';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';


### PR DESCRIPTION
Add support for Bosch Smart Home dimmer, [BMCT-DZ](https://www.bosch-smarthome.com/uk/en/products/devices/dimmer/).