### PR TITLE
Fix `args` not used & casing for link quality modern extend.

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -146,11 +146,11 @@ export function forcePowerSource(args: {powerSource: 'Mains (single phase)' | 'B
     return {configure, isModernExtend: true};
 }
 
-export interface LinkqualityArgs {
+export interface LinkQualityArgs {
     reporting?: boolean, attribute?: string | {ID: number, type: number}, reportingConfig?: ReportingConfigWithoutAttribute
 }
-export function linkquality(args?: LinkqualityArgs): ModernExtend {
-    args = {reporting: false, attribute: 'modelId', reportingConfig: {min: '1_HOUR', max: '4_HOURS', change: 0}};
+export function linkQuality(args?: LinkQualityArgs): ModernExtend {
+    args = {reporting: false, attribute: 'modelId', reportingConfig: {min: '1_HOUR', max: '4_HOURS', change: 0}, ...args};
 
     const exposes: Expose[] = [
         e.numeric('linkquality', ea.STATE).withUnit('lqi').withDescription('Link quality (signal strength)')


### PR DESCRIPTION
Casing change to match other functions. _Has no impact on codebase since this function is not yet used._