### PR TITLE
Change AQI scale for Bosch 8750001213 Twinguard 

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -790,6 +790,8 @@ const fzLocal = {
                 }
             }
             if (msg.data.hasOwnProperty('airpurity')) {
+                const iaq = parseInt(msg.data['airpurity'];
+                result.aqi = iaq;
                 result.co2 = utils.precisionRound((msg.data['airpurity'] * 10.0 + 500.0), 2);
                 result.voc = utils.precisionRound((msg.data['airpurity'] * 71.22), 2);
             }
@@ -1333,6 +1335,7 @@ const definitions: Definition[] = [
             e.humidity().withValueMin(0).withValueMax(100).withValueStep(0.1),
             e.voc().withValueMin(0).withValueMax(35610).withValueStep(1),
             e.co2().withValueMin(500).withValueMax(5500).withValueStep(1),
+            e.aqi().withValueMin(0).withValueMax(500).withValueStep(1),
             e.illuminance_lux(), e.battery(),
             e.enum('alarm', ea.ALL, Object.keys(sirenState)).withDescription('Mode of the alarm (sound effect)'),
             e.text('siren_state', ea.STATE).withDescription('Siren state'),

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -793,7 +793,23 @@ const fzLocal = {
                 const iaq = parseInt(msg.data['airpurity'];
                 result.aqi = iaq;
                 result.co2 = utils.precisionRound((msg.data['airpurity'] * 10.0 + 500.0), 2);
-                result.voc = utils.precisionRound((msg.data['airpurity'] * 71.22), 2);
+                let factor = 6;
+                if ((iaq >= 51) && (iaq <= 100)) {
+                    factor = 10;
+                }
+                else if ((iaq >= 101) && (iaq <= 150)) {
+                    factor = 20;
+                }
+                else if ((iaq >= 151) && (iaq <= 200)) {
+                    factor = 50;
+                }
+                else if ((iaq >= 201) && (iaq <= 250)) {
+                    factor = 100;
+                }
+                else if (iaq >= 251) {
+                    factor = 100;
+                }
+                result.voc = (iaq * factor);
             }
             if (msg.data.hasOwnProperty('temperature')) {
                 result.temperature = parseFloat(msg.data['temperature']) / 100.0;

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -796,17 +796,13 @@ const fzLocal = {
                 let factor = 6;
                 if ((iaq >= 51) && (iaq <= 100)) {
                     factor = 10;
-                }
-                else if ((iaq >= 101) && (iaq <= 150)) {
+                } else if ((iaq >= 101) && (iaq <= 150)) {
                     factor = 20;
-                }
-                else if ((iaq >= 151) && (iaq <= 200)) {
+                } else if ((iaq >= 151) && (iaq <= 200)) {
                     factor = 50;
-                }
-                else if ((iaq >= 201) && (iaq <= 250)) {
+                } else if ((iaq >= 201) && (iaq <= 250)) {
                     factor = 100;
-                }
-                else if (iaq >= 251) {
+                } else if (iaq >= 251) {
                     factor = 100;
                 }
                 result.voc = (iaq * factor);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -790,9 +790,9 @@ const fzLocal = {
                 }
             }
             if (msg.data.hasOwnProperty('airpurity')) {
-                const iaq = parseInt(msg.data['airpurity'];
+                const iaq = parseInt(msg.data['airpurity']);
                 result.aqi = iaq;
-                result.co2 = utils.precisionRound((msg.data['airpurity'] * 10.0 + 500.0), 2);
+                result.co2 = ((iaq * 10) + 500);
                 let factor = 6;
                 if ((iaq >= 51) && (iaq <= 100)) {
                     factor = 10;


### PR DESCRIPTION
As it turns out, the IAQ (indoor air quality) index used by the BME680 gas sensor, is not linear. Great... 👀

The first implementation #7286 assumed a linear relationship between IAQ level and TVOC density, and that obviously [wasn't correct](https://github.com/Koenkk/zigbee-herdsman-converters/issues/7274#issuecomment-2030138081). This is an attempt to improve the overall accuracy of the conversion, and align the estimated TVOC density to its corresponding IAQ level.

We'll have to keep in mind, that we're dealing only with estimates here, and **not** with lab-grade sensor readings.