### PR TITLE
add another Yale SL lock model

### DIFF
--- a/src/devices/yale.ts
+++ b/src/devices/yale.ts
@@ -221,6 +221,13 @@ const definitions: Definition[] = [
         extend: [lockExtend()],
     },
     {
+        zigbeeModel: ['YRD256-TSDB'],
+        model: 'YAYRD256HA2619',
+        vendor: 'Yale',
+        description: 'Assure lock SL',
+        extend: [lockExtend()],
+    },
+    {
         zigbeeModel: ['YRD652 TSDB', 'YRD652L TSDB'],
         model: 'YRD652HA20BP',
         vendor: 'Yale',


### PR DESCRIPTION
Add an additional model for Yale's line of locks.

Before the changes, the device was listed as unsupported:
`Zigbee2MQTT:info  2024-04-04 02:52:22: 0x000d6f0018ada8d8 (0x000d6f0018ada8d8): Not supported (EndDevice)`

After this change, the device is now recognized:
`Zigbee2MQTT:info  2024-04-04 02:54:01: 0x000d6f0018ada8d8 (0x000d6f0018ada8d8): YAYRD256HA2619 - Yale Assure lock SL (EndDevice)`



