### PR TITLE
fix: resolve Aqara FP1 (RTCZCGQ11LM) zones problem

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -889,8 +889,7 @@ export const presence = {
     mappers: lumiPresenceMappers,
 
     encodeXCellsDefinition: (xCells?: number[]): number => {
-        // @ts-expect-error
-        if (!xCells || !xCells.size) {
+        if (!xCells?.length) {
             return 0;
         }
         return [...xCells.values()].reduce((accumulator, marker) => accumulator + presence.encodeXCellIdx(marker), 0);


### PR DESCRIPTION
I think I found the problem is in here https://github.com/Koenkk/zigbee-herdsman-converters/blob/dbf535c94244d6fb7966e1110342aad55994dc6b/src/lib/lumi.ts#L888, not sure why xCells is trying to use .size property I think is wrong, I think the correct way is to access .length property, if not please let me know why this peace of code uses .size property.

I will like to suggest this modification: 
![Screenshot 2024-04-07 at 4 31 02 PM](https://github.com/Koenkk/zigbee-herdsman-converters/assets/9154023/374c6b92-f6ee-4c11-8409-09d96071497a)

and here is an example of the code running: 

[code](https://www.typescriptlang.org/play?ssl=13&ssc=22&pln=13&pc=28#code/PTAEHUFMBsGMHsC2lQBd5oBYoCoE8AHSAZVgCcBLA1UABWgEM8BzM+AVwDsATAGiwoBnUENANQAd0gAjQRVSQAUCEmYKsTKGYUAbpGF4OY0BoadYKdJMoL+gzAzIoz3UNEiPOofEVKVqAHSKymAAmkYI7NCuqGqcANag8ABmIjQUXrFOKBJMggBcISGgoAC0oACCbvCwDKgU8JkY7p7ehCTkVDQS2E6gnPCxGcwmZqDSTgzxxWWVoASMFmgYkAAeRJTInN3ymj4d-jSCeNsMq-wuoPaOltigAKoASgAywhK7SbGQZIIz5VWCFzSeCrZagNYbChbHaxUDcCjJZLfSDbExIAgUdxkUBIursJzCFJtXydaiKBCcQQ0AgElFLAC8oAA3sFFCUSnT4NxIAANADCMGgggAIpBkhl5A1OPlQAAKVYC6BCgD8Ms47EQ0m+AG0ALoASjVGq12PpAD5mWz2daEXKAIQKwWCZUBdycZixfWW60+9lOVD4rwABgA3FbfQBfcM+-2B0DagKJx1KwQBHQMaDsfSy-W6gJObjsCyy2UMWCwDVROrwMj8RCOeLfL3msTlyuMdDYgDU81p5kgAU53P5goAktxVrL62RG2R9fwg-qw9aI7xo0PeYroOPVjLZRYlTyd0bNU2TybQC2Wb6SrGyF4AEygABUz7lB+gR4nswAjEvo6urLWskDCYvikB7t8bBkDKTKTIIjQylSlDuhGhrMiIgjEEWFiCAUOIZoIkD8FBNawfBiFXKgKHMBGoB0Ve0bWneXjXjeNpYTh+j4SBQrEUxN6kbWAklBGy7soBYmKMkXCwPUjS9hkqAAHLGt8ggVIIAASazEJAACOWb9rK6qnj8546rq-DYKszwoh6mAWXOSHUcM3p+pAAb3v0ak-AE9YECWOjNhaOgBOgxCue6so-gAbPqAQEAw3CRY4qCyjZdnurE-AAORBrl+oJQAVvAGSyrl+SFWGUbko0VJoog9Y8JezIAERONojQAPoUNwbX5A+vBtQAXo0+gDdqTJtasA0-sNeBzau02zYNC1LbwK0DQAzOt+Q-stM0DQALHtB2bUd+17Q+h2rUNbWLfk223Tte3HS9+SnQ9A0AKwffN335LFH33Y9ADsEa6lJIk+hSCHuK68DMBV3LSOwzC5fwAAG1F4G5VjkB4CigJ1UqgAAJEyCBNS4+aQF1nC9dwEZY-+MPWnDRw1go3AAFrjRpbaIFWnatUyUnsRz9Vc2QPP85w+jgLsemoPhTLavhpkmrqMralr3xQ611PNdwARjQrvySzedOFsW7NW3KZYVsLHZkcyGtOTroAqwAPPrZBmquoDmxBzK7j5Zn8HgTloZeFpsQ7Du2rKdpO+21ZkNqIcBHgBruYnBets7Is1ln4057qrUKxI3ueX7vlmjm4mF+xtUt5LacuxnZcKxXATJdwsrZ6sbPt+xLFF+nnbN2PgFj+yCGy5AfMCxUQsl8J7f-onnNXNzy-y-orUAPLSMVkByYO2yUNmi9ywLSuxCrggJQWRaQCWTv8NqjZ4Pw6aZkgHnRi7dd6mQANKQDwK1JKPxICjm2LKX+-AfyLhDKAFQfJGh6FllRGioBf7jDLIkKw-t7a+idnrDUkDc6tQqGQMgTAAjJDYIgWUACszbxbhPJ2M9W78HFmIYQ6tNa+S9v7PUaE+E3l3tyHQ6hIBYM4OKEYjJq4PCUgADnoYwvAsowajwdpgpAJt5iOAYMgBQPxyFwkgPIiwSiVHaiDJXRkP5pG+jkQoxxFBmDah-K4xqJs6YMyZh4n0XiHGNCcbFQJQZViInCdaFQh9hDcnFJwSUjQbGRMUdE3x2oHyVwAD6MhpPoOkA4NwjhTKKDJWTOCyjvgfAW2pco-lygaJJ7Jck+L8UU0ApTewVP7FfBAw4twijFBKeSjTmkrwtm0h8nSvQ+x9qAY63SSi9PyX47aJSyl9gsGMrkm4nR1JmVKJp+8Fn6DadtFZWzbH2Lycogp+zBmHJGcc6pkyLmZNmdcpetzBBtOOis0AayNlPJ2W8vxx0DnDKIqM355zpkAqufM1JbSfqPJyXY7xuztQIs+UiypJyJlovqYCrFrTcqxQhVCzZ+KXl9O1D9RF5TkU-PMKcmpQp-kNKBffRZuUwZ4psXDeACNoBI1lLClR+pJX1WlQOWVyNcoZGSPATGoAsaEzqCgUmClKbG1psaxmfU6KUxpEpVSZkNLaV0gZIyxYEyJgVb4qyoAHz6hZoYoAA)