### PR TITLE
Fixed/Improved Paulmann Amaris LED panels

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -127,12 +127,12 @@ const definitions: Definition[] = [
         extend: [light({colorTemp: {range: undefined}})],
     },
     {
-        fingerprint: [{modelID: 'RGBW', manufacturerName: 'Paulmann Licht'}],
+        fingerprint: [{modelID: 'RGBW', manufacturerName: 'Paulmann Licht GmbH'}],
         zigbeeModel: ['371000002'],
         model: '371000002',
         vendor: 'Paulmann',
         description: 'Amaris LED panels',
-        extend: [light({colorTemp: {range: undefined}, color: {modes: ['xy', 'hs']}})],
+        extend: [light({colorTemp: {range: [153, 370]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
     },
     {
         zigbeeModel: ['371232040'],


### PR DESCRIPTION
I recently bought the Amaris LED panel 798.10. Unfortunately, the panel did not work straight away. 

The lamp was initialized with the wrong model ([948.47/29165](https://www.zigbee2mqtt.io/devices/948.47_29165.html)) in Zigbee2MQTT. As a result, an incorrect `color_temp` range was displayed in Home Assistant and the lamp occasionally flickered.

After the corresponding adjustments from this PR, the lamp was correctly identified and has been working without any problems ever since. The data from `extend` were generated by the `external definition` function.

Zigbee2MQTT is really new to me, so I'm not sure if I've done everything right here. I just wanted to make my changes available to the public.