### PR TITLE
fix(legacy): use legacyAction in modern extends to avoid problems from converter duplication

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1,5 +1,4 @@
 import {Definition} from '../lib/types';
-import * as legacy from '../lib/legacy';
 import dataType from 'zigbee-herdsman/dist/zcl/definition/dataType';
 import {
     onOff, battery, iasZoneAlarm, identify, forcePowerSource,
@@ -744,13 +743,12 @@ const definitions: Definition[] = [
         model: 'ICTC-G-1',
         vendor: 'IKEA',
         description: 'TRADFRI wireless dimmer',
-        fromZigbee: [ // DEPRECATED
-            legacy.fz.cmd_move, legacy.fz.cmd_move_with_onoff, legacy.fz.cmd_stop, legacy.fz.cmd_stop_with_onoff,
-            legacy.fz.cmd_move_to_level_with_onoff,
-        ],
         extend: [
             identify({isSleepy: true}),
-            commandsLevelCtrl({commands: ['brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_move_to_level']}),
+            commandsLevelCtrl({
+                commands: ['brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_move_to_level'],
+                legacyClick: true,
+            }),
             battery({dontDividePercentage: true}),
             ikeaOta(),
         ],
@@ -792,14 +790,14 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'TRADFRI on/off switch',
         fromZigbee: [ // DEPRECATED
-            legacy.fz.genOnOff_cmdOn, legacy.fz.genOnOff_cmdOff, ikeaLegacy.fromZigbee.E1743_brightness_up,
+            ikeaLegacy.fromZigbee.E1743_brightness_up,
             ikeaLegacy.fromZigbee.E1743_brightness_down, ikeaLegacy.fromZigbee.E1743_brightness_stop,
         ],
         meta: {disableActionGroup: true},
         extend: [
             ikeaConfigureRemote(),
             identify({isSleepy: true}),
-            commandsOnOff({commands: ['on', 'off']}),
+            commandsOnOff({commands: ['on', 'off'], legacyClick: true}),
             commandsLevelCtrl({commands: ['brightness_move_up', 'brightness_move_down', 'brightness_stop']}),
             ikeaBattery(),
             ikeaOta(),
@@ -839,13 +837,14 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'SYMFONISK sound remote, gen 1',
         fromZigbee: [ // DEPRECATED
-            legacy.fz.cmd_move, legacy.fz.cmd_stop, ikeaLegacy.fromZigbee.E1744_play_pause, ikeaLegacy.fromZigbee.E1744_skip,
+            ikeaLegacy.fromZigbee.E1744_play_pause, ikeaLegacy.fromZigbee.E1744_skip,
         ],
         extend: [
             identify({isSleepy: true}),
             commandsOnOff({commands: ['toggle']}),
             commandsLevelCtrl({
                 commands: ['brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_step_up', 'brightness_step_down'],
+                legacyClick: true,
             }),
             ikeaBattery(),
             ikeaOta(),
@@ -856,11 +855,10 @@ const definitions: Definition[] = [
         model: 'E1766',
         vendor: 'IKEA',
         description: 'TRADFRI open/close remote',
-        fromZigbee: [legacy.fz.cover_close, legacy.fz.cover_open, legacy.fz.cover_stop], // DEPRECATED
         extend: [
             ikeaConfigureRemote(),
             identify({isSleepy: true}),
-            commandsWindowCovering(),
+            commandsWindowCovering({legacyClick: true}),
             ikeaBattery(),
             ikeaOta(),
         ],

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -747,7 +747,7 @@ const definitions: Definition[] = [
             identify({isSleepy: true}),
             commandsLevelCtrl({
                 commands: ['brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_move_to_level'],
-                legacyClick: true,
+                legacyAction: true,
             }),
             battery({dontDividePercentage: true}),
             ikeaOta(),
@@ -797,7 +797,7 @@ const definitions: Definition[] = [
         extend: [
             ikeaConfigureRemote(),
             identify({isSleepy: true}),
-            commandsOnOff({commands: ['on', 'off'], legacyClick: true}),
+            commandsOnOff({commands: ['on', 'off'], legacyAction: true}),
             commandsLevelCtrl({commands: ['brightness_move_up', 'brightness_move_down', 'brightness_stop']}),
             ikeaBattery(),
             ikeaOta(),
@@ -844,7 +844,7 @@ const definitions: Definition[] = [
             commandsOnOff({commands: ['toggle']}),
             commandsLevelCtrl({
                 commands: ['brightness_move_up', 'brightness_move_down', 'brightness_stop', 'brightness_step_up', 'brightness_step_down'],
-                legacyClick: true,
+                legacyAction: true,
             }),
             ikeaBattery(),
             ikeaOta(),
@@ -858,7 +858,7 @@ const definitions: Definition[] = [
         extend: [
             ikeaConfigureRemote(),
             identify({isSleepy: true}),
-            commandsWindowCovering({legacyClick: true}),
+            commandsWindowCovering({legacyAction: true}),
             ikeaBattery(),
             ikeaOta(),
         ],

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -638,7 +638,6 @@ export const legacy = {
             type: 'commandToggle',
             options: [options.legacy()],
             convert: (model, msg, publish, options, meta) => {
-                if (hasAlreadyProcessedMessage(msg, model)) return;
                 if (isLegacyEnabled(options)) {
                     return {action: 'play_pause'};
                 }
@@ -649,7 +648,6 @@ export const legacy = {
             type: 'commandStep',
             options: [options.legacy()],
             convert: (model, msg, publish, options, meta) => {
-                if (hasAlreadyProcessedMessage(msg, model)) return;
                 if (isLegacyEnabled(options)) {
                     const direction = msg.data.stepmode === 1 ? 'backward' : 'forward';
                     return {

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -8402,4 +8402,5 @@ export {
     convertTimeTo2ByteHexArray,
     getMetaValue,
     tuyaGetDataValue,
+    ictcg1,
 };

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -394,10 +394,10 @@ export function onOff(args?: OnOffArgs): ModernExtend {
 }
 
 export interface CommandsOnOffArgs {
-    commands?: ('on' | 'off' | 'toggle')[], bind?: boolean, endpointNames?: string[], legacyClick?: boolean,
+    commands?: ('on' | 'off' | 'toggle')[], bind?: boolean, endpointNames?: string[], legacyAction?: boolean,
 }
 export function commandsOnOff(args?: CommandsOnOffArgs): ModernExtend {
-    args = {commands: ['on', 'off', 'toggle'], bind: true, legacyClick: false, ...args};
+    args = {commands: ['on', 'off', 'toggle'], bind: true, legacyAction: false, ...args};
     let actions: string[] = args.commands;
     if (args.endpointNames) {
         actions = args.commands.map((c) => args.endpointNames.map((e) => `${c}_${e}`)).flat();
@@ -426,7 +426,7 @@ export function commandsOnOff(args?: CommandsOnOffArgs): ModernExtend {
         },
     ];
 
-    if (args.legacyClick) {
+    if (args.legacyAction) {
         fromZigbee.push(...[globalLegacy.fromZigbee.genOnOff_cmdOn, globalLegacy.fromZigbee.genOnOff_cmdOff]);
     }
 
@@ -766,12 +766,12 @@ export interface CommandsLevelCtrl {
     commands?: (
         'brightness_move_to_level' | 'brightness_move_up' | 'brightness_move_down' | 'brightness_step_up' | 'brightness_step_down' | 'brightness_stop'
     )[],
-    bind?: boolean, endpointNames?: string[], legacyClick?: boolean,
+    bind?: boolean, endpointNames?: string[], legacyAction?: boolean,
 }
 export function commandsLevelCtrl(args?: CommandsLevelCtrl): ModernExtend {
     args = {commands: [
         'brightness_move_to_level', 'brightness_move_up', 'brightness_move_down', 'brightness_step_up', 'brightness_step_down', 'brightness_stop',
-    ], bind: true, legacyClick: false, ...args};
+    ], bind: true, legacyAction: false, ...args};
     let actions: string[] = args.commands;
     if (args.endpointNames) {
         actions = args.commands.map((c) => args.endpointNames.map((e) => `${c}_${e}`)).flat();
@@ -787,7 +787,7 @@ export function commandsLevelCtrl(args?: CommandsLevelCtrl): ModernExtend {
         fz.command_stop,
     ];
 
-    if (args.legacyClick) {
+    if (args.legacyAction) {
         // Legacy converters with removed hasAlreadyProcessedMessage and redirects
         const legacyFromZigbee: Fz.Converter[] = [
             {
@@ -983,10 +983,10 @@ export function windowCovering(args: WindowCoveringArgs): ModernExtend {
 }
 
 export interface CommandsWindowCoveringArgs {
-    commands?: ('open' | 'close' | 'stop')[], bind?: boolean, endpointNames?: string[], legacyClick: boolean,
+    commands?: ('open' | 'close' | 'stop')[], bind?: boolean, endpointNames?: string[], legacyAction: boolean,
 }
 export function commandsWindowCovering(args?: CommandsWindowCoveringArgs): ModernExtend {
-    args = {commands: ['open', 'close', 'stop'], bind: true, legacyClick: false, ...args};
+    args = {commands: ['open', 'close', 'stop'], bind: true, legacyAction: false, ...args};
     let actions: string[] = args.commands;
     if (args.endpointNames) {
         actions = args.commands.map((c) => args.endpointNames.map((e) => `${c}_${e}`)).flat();
@@ -1014,7 +1014,7 @@ export function commandsWindowCovering(args?: CommandsWindowCoveringArgs): Moder
         },
     ];
 
-    if (args.legacyClick) {
+    if (args.legacyAction) {
         fromZigbee.push(...[globalLegacy.fromZigbee.cover_open, globalLegacy.fromZigbee.cover_close, globalLegacy.fromZigbee.cover_stop]);
     }
 

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1,6 +1,7 @@
 import {Zcl} from 'zigbee-herdsman';
 import tz from '../converters/toZigbee';
 import fz from '../converters/fromZigbee';
+import * as globalLegacy from '../lib/legacy';
 import {
     Fz, Tz, ModernExtend, Range, Zh, DefinitionOta, OnEvent, Access,
     KeyValueString, KeyValue, Configure, Expose, DefinitionMeta, KeyValueAny,
@@ -13,7 +14,7 @@ import {
     getFromLookupByValue, isString, isNumber, isObject, isEndpoint,
     getFromLookup, getEndpointName, assertNumber, postfixWithEndpointName,
     noOccupancySince, precisionRound, batteryVoltageToPercentage, getOptions,
-    hasAlreadyProcessedMessage, addActionGroup,
+    hasAlreadyProcessedMessage, addActionGroup, isLegacyEnabled,
 } from './utils';
 import {logger} from '../lib/logger';
 
@@ -392,8 +393,11 @@ export function onOff(args?: OnOffArgs): ModernExtend {
     return result;
 }
 
-export function commandsOnOff(args?: {commands?: ('on' | 'off' | 'toggle')[], bind?: boolean, endpointNames?: string[]}): ModernExtend {
-    args = {commands: ['on', 'off', 'toggle'], bind: true, ...args};
+export interface CommandsOnOffArgs {
+    commands?: ('on' | 'off' | 'toggle')[], bind?: boolean, endpointNames?: string[], legacyClick?: boolean,
+}
+export function commandsOnOff(args?: CommandsOnOffArgs): ModernExtend {
+    args = {commands: ['on', 'off', 'toggle'], bind: true, legacyClick: false, ...args};
     let actions: string[] = args.commands;
     if (args.endpointNames) {
         actions = args.commands.map((c) => args.endpointNames.map((e) => `${c}_${e}`)).flat();
@@ -421,6 +425,10 @@ export function commandsOnOff(args?: {commands?: ('on' | 'off' | 'toggle')[], bi
             },
         },
     ];
+
+    if (args.legacyClick) {
+        fromZigbee.push(...[globalLegacy.fromZigbee.genOnOff_cmdOn, globalLegacy.fromZigbee.genOnOff_cmdOff]);
+    }
 
     const result: ModernExtend = {exposes, fromZigbee, isModernExtend: true};
 
@@ -758,12 +766,12 @@ export interface CommandsLevelCtrl {
     commands?: (
         'brightness_move_to_level' | 'brightness_move_up' | 'brightness_move_down' | 'brightness_step_up' | 'brightness_step_down' | 'brightness_stop'
     )[],
-    bind?: boolean, endpointNames?: string[]
+    bind?: boolean, endpointNames?: string[], legacyClick?: boolean,
 }
 export function commandsLevelCtrl(args?: CommandsLevelCtrl): ModernExtend {
     args = {commands: [
         'brightness_move_to_level', 'brightness_move_up', 'brightness_move_down', 'brightness_step_up', 'brightness_step_down', 'brightness_stop',
-    ], bind: true, ...args};
+    ], bind: true, legacyClick: false, ...args};
     let actions: string[] = args.commands;
     if (args.endpointNames) {
         actions = args.commands.map((c) => args.endpointNames.map((e) => `${c}_${e}`)).flat();
@@ -778,6 +786,48 @@ export function commandsLevelCtrl(args?: CommandsLevelCtrl): ModernExtend {
         fz.command_step,
         fz.command_stop,
     ];
+
+    if (args.legacyClick) {
+        // Legacy converters with removed hasAlreadyProcessedMessage and redirects
+        const legacyFromZigbee: Fz.Converter[] = [
+            {
+                cluster: 'genLevelCtrl',
+                type: ['commandMove', 'commandMoveWithOnOff'],
+                options: [opt.legacy(), opt.simulated_brightness(' Note: will only work when legacy: false is set.')],
+                convert: (model, msg, publish, options, meta) => {
+                    if (isLegacyEnabled(options)) {
+                        globalLegacy.ictcg1(model, msg, publish, options, 'move');
+                        const direction = msg.data.movemode === 1 ? 'left' : 'right';
+                        return {action: `rotate_${direction}`, rate: msg.data.rate};
+                    }
+                },
+            },
+            {
+                cluster: 'genLevelCtrl',
+                type: ['commandStop', 'commandStopWithOnOff'],
+                options: [opt.legacy()],
+                convert: (model, msg, publish, options, meta) => {
+                    if (isLegacyEnabled(options)) {
+                        const value = globalLegacy.ictcg1(model, msg, publish, options, 'stop');
+                        return {action: `rotate_stop`, brightness: value};
+                    }
+                },
+            },
+            {
+                cluster: 'genLevelCtrl',
+                type: 'commandMoveToLevelWithOnOff',
+                options: [opt.legacy()],
+                convert: (model, msg, publish, options, meta) => {
+                    if (isLegacyEnabled(options)) {
+                        const value = globalLegacy.ictcg1(model, msg, publish, options, 'level');
+                        const direction = msg.data.level === 0 ? 'left' : 'right';
+                        return {action: `rotate_${direction}_quick`, level: msg.data.level, brightness: value};
+                    }
+                },
+            },
+        ];
+        fromZigbee.push(...legacyFromZigbee);
+    }
 
     const result: ModernExtend = {exposes, fromZigbee, isModernExtend: true};
 
@@ -932,8 +982,11 @@ export function windowCovering(args: WindowCoveringArgs): ModernExtend {
     return result;
 }
 
-export function commandsWindowCovering(args?: {commands?: ('open' | 'close' | 'stop')[], bind?: boolean, endpointNames?: string[]}): ModernExtend {
-    args = {commands: ['open', 'close', 'stop'], bind: true, ...args};
+export interface CommandsWindowCoveringArgs {
+    commands?: ('open' | 'close' | 'stop')[], bind?: boolean, endpointNames?: string[], legacyClick: boolean,
+}
+export function commandsWindowCovering(args?: CommandsWindowCoveringArgs): ModernExtend {
+    args = {commands: ['open', 'close', 'stop'], bind: true, legacyClick: false, ...args};
     let actions: string[] = args.commands;
     if (args.endpointNames) {
         actions = args.commands.map((c) => args.endpointNames.map((e) => `${c}_${e}`)).flat();
@@ -960,6 +1013,10 @@ export function commandsWindowCovering(args?: {commands?: ('open' | 'close' | 's
             },
         },
     ];
+
+    if (args.legacyClick) {
+        fromZigbee.push(...[globalLegacy.fromZigbee.cover_open, globalLegacy.fromZigbee.cover_close, globalLegacy.fromZigbee.cover_stop]);
+    }
 
     const result: ModernExtend = {exposes, fromZigbee, isModernExtend: true};
 


### PR DESCRIPTION
This PR should prevent any problems from happening when legacy click was present next to modern extend.

Also partial fix https://github.com/Koenkk/zigbee2mqtt/issues/22084 (yes, the 3rd one).