### PR TITLE
FIX: Bosch BTH-RA

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -506,7 +506,7 @@ const tzLocal = {
                 let onTime = utils.toNumber(value, key);
                 onTime = utils.numberWithinRange(onTime, 5, 30);
                 await entity.write('hvacUserInterfaceCfg', {0x403a: {value: onTime, type: Zcl.DataType.enum8}}, manufacturerOptions);
-                return {state: {display_onTime: onTime}};
+                return {state: {display_ontime: onTime}};
             }
             if (key === 'display_brightness') {
                 let brightness = utils.toNumber(value, key);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -504,9 +504,9 @@ const tzLocal = {
             }
             if (key === 'display_ontime') {
                 let onTime = utils.toNumber(value, key);
-                onTime = utils.numberWithinRange(onTime, 5, 30);
-                await entity.write('hvacUserInterfaceCfg', {0x403a: {value: onTime, type: Zcl.DataType.enum8}}, manufacturerOptions);
-                return {state: {display_ontime: onTime}};
+                ontime = utils.numberWithinRange(ontime, 5, 30);
+                await entity.write('hvacUserInterfaceCfg', {0x403a: {value: ontime, type: Zcl.DataType.enum8}}, manufacturerOptions);
+                return {state: {display_ontime: ontime}};
             }
             if (key === 'display_brightness') {
                 let brightness = utils.toNumber(value, key);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -503,7 +503,7 @@ const tzLocal = {
                 return {state: {display_orientation: value}};
             }
             if (key === 'display_ontime') {
-                let onTime = utils.toNumber(value, key);
+                let ontime = utils.toNumber(value, key);
                 ontime = utils.numberWithinRange(ontime, 5, 30);
                 await entity.write('hvacUserInterfaceCfg', {0x403a: {value: ontime, type: Zcl.DataType.enum8}}, manufacturerOptions);
                 return {state: {display_ontime: ontime}};


### PR DESCRIPTION
display_ontime didn't run correct. Expose would be found two times in payload with different name (display_ontime vs. display_onTime). And only display_onTime was reacting on changes made via frontend. After fix, the right expose "display_ontime" recognize the changes.

```
{
"battery":100,
"boost":"OFF",
"child_lock":"UNLOCK",
"display_brightness":9,

"display_onTime":28,
"display_ontime":24,

"display_orientation":"normal",
"displayed_temperature":"measured",
"last_seen":1712716480664,
"linkquality":168
...
```