### PR TITLE
feat(add): ZDMS16-1 and ZDMS16-2 Avatto dimmer switches

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1699,10 +1699,10 @@ const definitions: Definition[] = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
-                tuya.exposes.lightBrightnessWithMinMax(),
-                tuya.exposes.countdown(),
-                tuya.exposes.switchType(),
-                e.power_on_behavior().withAccess(ea.STATE_SET),
+            tuya.exposes.lightBrightnessWithMinMax(),
+            tuya.exposes.countdown(),
+            tuya.exposes.switchType(),
+            e.power_on_behavior().withAccess(ea.STATE_SET),
         ],
         meta: {
             tuyaDatapoints: [
@@ -1730,13 +1730,13 @@ const definitions: Definition[] = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
-                tuya.exposes.lightBrightnessWithMinMax().withEndpoint('l1'),
-                tuya.exposes.countdown().withEndpoint('l1'),
-                tuya.exposes.switchType().withEndpoint('l1'),
-                tuya.exposes.lightBrightnessWithMinMax().withEndpoint('l2'),
-                tuya.exposes.countdown().withEndpoint('l2'),
-                tuya.exposes.switchType().withEndpoint('l2'),
-                e.power_on_behavior().withAccess(ea.STATE_SET),
+            tuya.exposes.lightBrightnessWithMinMax().withEndpoint('l1'),
+            tuya.exposes.countdown().withEndpoint('l1'),
+            tuya.exposes.switchType().withEndpoint('l1'),
+            tuya.exposes.lightBrightnessWithMinMax().withEndpoint('l2'),
+            tuya.exposes.countdown().withEndpoint('l2'),
+            tuya.exposes.switchType().withEndpoint('l2'),
+            e.power_on_behavior().withAccess(ea.STATE_SET),
         ],
         meta: {
             multiEndpoint: true,

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1686,6 +1686,81 @@ const definitions: Definition[] = [
         ],
     },
     {
+        fingerprint: [
+            {
+                modelID: 'TS0601',
+                manufacturerName: '_TZE204_5cuocqty',
+            },
+        ],
+        model: 'ZDMS16-1',
+        vendor: 'Avatto',
+        description: 'Zigbee 1 channel Dimmer',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+                tuya.exposes.lightBrightnessWithMinMax(),
+                tuya.exposes.countdown(),
+                tuya.exposes.switchType(),
+                e.power_on_behavior().withAccess(ea.STATE_SET),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
+                [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
+                [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
+                [4, 'switch_type', tuya.valueConverter.switchType2],
+                [5, 'max_brightness', tuya.valueConverter.scale0_254to0_1000],
+                [6, 'countdown', tuya.valueConverter.countdown],
+                [14, 'power_on_behavior', tuya.valueConverter.powerOnBehaviorEnum],
+            ],
+        },
+    },
+    {
+        fingerprint: [
+            {
+                modelID: 'TS0601',
+                manufacturerName: '_TZE204_o9gyszw2',
+            },
+        ],
+        model: 'ZDMS16-2',
+        vendor: 'Avatto',
+        description: 'Zigbee 2 channels Dimmer',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+                tuya.exposes.lightBrightnessWithMinMax().withEndpoint('l1'),
+                tuya.exposes.countdown().withEndpoint('l1'),
+                tuya.exposes.switchType().withEndpoint('l1'),
+                tuya.exposes.lightBrightnessWithMinMax().withEndpoint('l2'),
+                tuya.exposes.countdown().withEndpoint('l2'),
+                tuya.exposes.switchType().withEndpoint('l2'),
+                e.power_on_behavior().withAccess(ea.STATE_SET),
+        ],
+        meta: {
+            multiEndpoint: true,
+            tuyaDatapoints: [
+                [1, 'state_l1', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
+                [2, 'brightness_l1', tuya.valueConverter.scale0_254to0_1000],
+                [3, 'min_brightness_l1', tuya.valueConverter.scale0_254to0_1000],
+                [4, 'switch_type_l1', tuya.valueConverter.switchType2],
+                [5, 'max_brightness_l1', tuya.valueConverter.scale0_254to0_1000],
+                [6, 'countdown_l1', tuya.valueConverter.countdown],
+                [7, 'state_l2', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
+                [8, 'brightness_l2', tuya.valueConverter.scale0_254to0_1000],
+                [9, 'min_brightness_l2', tuya.valueConverter.scale0_254to0_1000],
+                [10, 'switch_type_l2', tuya.valueConverter.switchType2],
+                [11, 'max_brightness_l2', tuya.valueConverter.scale0_254to0_1000],
+                [12, 'countdown_l2', tuya.valueConverter.countdown],
+                [14, 'power_on_behavior', tuya.valueConverter.powerOnBehaviorEnum],
+            ],
+        },
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 1};
+        },
+    },
+    {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_p0gzbqct']),
         model: 'TS0601_dimmer_knob',
         vendor: 'TuYa',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1656,7 +1656,7 @@ const definitions: Definition[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_dcnsggvz', '_TZE204_5cuocqty']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_dcnsggvz']),
         model: 'TS0601_dimmer_5',
         vendor: 'TuYa',
         description: '1 gang smart dimmer module',

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -563,6 +563,7 @@ export const valueConverter = {
     powerOnBehavior: valueConverterBasic.lookup({'off': 0, 'on': 1, 'previous': 2}),
     powerOnBehaviorEnum: valueConverterBasic.lookup({'off': new Enum(0), 'on': new Enum(1), 'previous': new Enum(2)}),
     switchType: valueConverterBasic.lookup({'momentary': new Enum(0), 'toggle': new Enum(1), 'state': new Enum(2)}),
+    switchType2: valueConverterBasic.lookup({'toggle': new Enum(0), 'state': new Enum(1), 'momentary': new Enum(2)}),
     backlightModeOffNormalInverted: valueConverterBasic.lookup({'off': new Enum(0), 'normal': new Enum(1), 'inverted': new Enum(2)}),
     backlightModeOffLowMediumHigh: valueConverterBasic.lookup({'off': new Enum(0), 'low': new Enum(1), 'medium': new Enum(2), 'high': new Enum(3)}),
     lightType: valueConverterBasic.lookup({'led': 0, 'incandescent': 1, 'halogen': 2}),


### PR DESCRIPTION
As discussed here: https://github.com/Koenkk/zigbee2mqtt/issues/22175

Aliexpress page: https://it.aliexpress.com/item/1005006523496245.html


These dimmers uses different enum values for switchType comparing to standard tuya dimmers, so a new tuya converter (switchType2) has been introduced in lib/tuya.ts