### PR TITLE
Add support for IKEA JETSTROM 3030 wall version

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -489,6 +489,13 @@ const definitions: Definition[] = [
         extend: [ikeaLight({colorTemp: true}), identify()],
     },
     {
+        zigbeeModel: ['JETSTROM 3030 wall'],
+        model: 'L2205',
+        vendor: 'IKEA',
+        description: 'JETSTROM wall light panel, color/white spectrum, 30x30 cm',
+        extend: [ikeaLight({colorTemp: true, color: true}), identify()],
+    },
+    {
         zigbeeModel: ['JETSTROM 3030 ceiling'],
         model: 'L2206',
         vendor: 'IKEA',

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -499,7 +499,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['JETSTROM 3030 ceiling'],
         model: 'L2206',
         vendor: 'IKEA',
-        description: 'JETSTROM wall light panel, color/white spectrum, 30x30 cm',
+        description: 'JETSTROM ceiling light panel, color/white spectrum, 30x30 cm',
         extend: [ikeaLight({colorTemp: true, color: true}), identify()],
     },
     {


### PR DESCRIPTION
Hello
Previously support for JETSTROM 3030 was added in https://github.com/Koenkk/zigbee-herdsman-converters/pull/7248 but it didn't work for me.

So I found out, that the added/supported version is the ceiling version of the lamp(L2206) and I've got the wall version(L2205).
I guess the only difference is that the wall version is bundled with a cable and an inline switch(on the cable) that you can plug directly into the wall. I havent noticed any other differences.

This pull request adds support for the wall version and fixes description of the ceiling version.