### PR TITLE
Legrand 067776(A): Added support for showing / hiding the tilt control

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -124,14 +124,17 @@ const definitions: Definition[] = [
         fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify,
             fzLegrand.cluster_fc01, fzLegrand.calibration_mode(false)],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tzLegrand.identify, tzLegrand.led_mode, tzLegrand.calibration_mode(false)],
-        exposes: [
-            _067776.getCover(),
-            e.action(['moving', 'identify']),
-            eLegrand.identify(),
-            eLegrand.ledInDark(),
-            eLegrand.ledIfOn(),
-            _067776.getCalibrationModes(false),
-        ],
+        exposes: (device, options) => {
+            return [
+                _067776.getCover(options),
+                e.action(['moving', 'identify']),
+                eLegrand.identify(),
+                eLegrand.ledInDark(),
+                eLegrand.ledIfOn(),
+                _067776.getCalibrationModes(false),
+                e.linkquality(),
+            ];
+        },
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
@@ -182,14 +185,17 @@ const definitions: Definition[] = [
         fromZigbee: [fz.ignore_basic_report, fz.cover_position_tilt, fz.legrand_binary_input_moving, fz.identify,
             fzLegrand.cluster_fc01, fzLegrand.calibration_mode(true)],
         toZigbee: [tz.cover_state, tz.cover_position_tilt, tzLegrand.identify, tzLegrand.led_mode, tzLegrand.calibration_mode(true)],
-        exposes: [
-            _067776.getCover(),
-            e.action(['moving', 'identify']),
-            eLegrand.identify(),
-            eLegrand.ledInDark(),
-            eLegrand.ledIfOn(),
-            _067776.getCalibrationModes(true),
-        ],
+        exposes: (device, options) => {
+            return [
+                _067776.getCover(options),
+                e.action(['moving', 'identify']),
+                eLegrand.identify(),
+                eLegrand.ledInDark(),
+                eLegrand.ledIfOn(),
+                _067776.getCalibrationModes(true),
+                e.linkquality(),
+            ];
+        },
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -42,7 +42,7 @@ const ledColors:{[k: number]: string} = {
 const optsLegrand = {
     identityEffect: () => {
         return e.composite('Identity effect', 'identity_effect', ea.SET)
-            .withDescription('Defines the identification effect to simplify the device identification')
+            .withDescription('Defines the identification effect to simplify the device identification.')
             .withFeature(e.enum('effect', ea.SET, Object.values(ledEffects)).withLabel('Effect'))
             .withFeature(e.enum('color', ea.SET, Object.values(ledColors)).withLabel('Color'));
     },


### PR DESCRIPTION
Added support for hiding the tilt control on Legrand 067776(A) family switches.
Defaults to: "Show tilt control".

<img width="1773" alt="grafik" src="https://github.com/Koenkk/zigbee-herdsman-converters/assets/141126144/0ff8936f-4f63-4268-847e-7a8ec49755ad">

Addresses: https://github.com/Koenkk/zigbee2mqtt/issues/19621
