### PR TITLE
Add smoke sensitivity option for Bosch BSD-2

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -108,7 +108,7 @@ const smokeDetectorAlarmState: KeyValue = {
 };
 
 // Smoke detector II bsd-2
-const smokeDetectorIntruderState: KeyValue = {
+const smokeDetectorBurglarAlarmState: KeyValue = {
     'OFF': 0x0001,
     'ON': 0xb401, // 46081
 };
@@ -175,15 +175,15 @@ Example: 30ff00000102010001`;
 
 const tzLocal = {
     bsd2: {
-        key: ['alarm_smoke', 'alarm_intruder', 'sensitivity'],
+        key: ['alarm_smoke', 'alarm_burglar', 'sensitivity'],
         convertSet: async (entity, key, value: string, meta) => {
             if (key === 'alarm_smoke') {
                 const index = utils.getFromLookup(value, smokeDetectorAlarmState);
                 await entity.command('ssIasZone', 'boschSmokeDetectorSiren', {data: index}, manufacturerOptions);
                 return {state: {alarm_smoke: value}};
             }
-            if (key === 'alarm_intruder') {
-                const index = utils.getFromLookup(value, smokeDetectorIntruderState);
+            if (key === 'alarm_burglar') {
+                const index = utils.getFromLookup(value, smokeDetectorBurglarAlarmState);
                 await entity.command('ssIasZone', 'boschSmokeDetectorSiren', {data: index}, manufacturerOptions);
                 return {state: {alarm_intruder: value}};
             }
@@ -196,7 +196,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             switch (key) {
             case 'alarm_smoke':
-            case 'alarm_intruder':
+            case 'alarm_burglar':
             case 'zone_status':
                 await entity.read('ssIasZone', ['zoneStatus']);
                 break;
@@ -204,7 +204,7 @@ const tzLocal = {
                 await entity.read('ssIasZone', ['currentZoneSensitivityLevel']);
                 break;
             default: // Unknown key
-                throw new Error(`Unhandled key toZigbee.bsd2_alarm_state.convertGet ${key}`);
+                throw new Error(`Unhandled key toZigbee.bsd2.convertGet ${key}`);
             }
         },
     } satisfies Tz.Converter,
@@ -634,7 +634,7 @@ const fzLocal = {
                     battery_low: (zoneStatus & 1<<3) > 0,
                     supervision_reports: (zoneStatus & 1<<4) > 0,
                     restore_reports: (zoneStatus & 1<<5) > 0,
-                    alarm_intruder: (zoneStatus & 1<<7) > 0,
+                    alarm_burglar: (zoneStatus & 1<<7) > 0,
                     test: (zoneStatus & 1<<8) > 0,
                     alarm_silenced: (zoneStatus & 1<<11) > 0,
                 };
@@ -1051,7 +1051,7 @@ const definitions: Definition[] = [
             e.battery(),
             e.battery_low(),
             e.test(),
-            e.binary('alarm_intruder', ea.ALL, 'ON', 'OFF').withDescription('Toggle the intruder alarm on or off'),
+            e.binary('alarm_burglar', ea.ALL, 'ON', 'OFF').withDescription('Toggle the burglar alarm on or off'),
             e.binary('alarm_smoke', ea.ALL, 'ON', 'OFF').withDescription('Toggle the smoke alarm on or off'),
             e.enum('sensitivity', ea.ALL, Object.keys(smokeDetectorSensitivity)).withDescription('Sensitivity of the smoke alarm'),
         ],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -113,6 +113,13 @@ const smokeDetectorIntruderState: KeyValue = {
     'ON': 0xb401, // 46081
 };
 
+// Smoke detector II bsd-2
+const smokeDetectorSensitivity: KeyValue = {
+    'low': 0x0,
+    'medium': 0x1,
+    'high': 0x2,
+};
+
 // Radiator Thermostat II
 const setpointSource = {
     'manual': 0,
@@ -181,7 +188,7 @@ const tzLocal = {
                 return {state: {alarm_intruder: value}};
             }
             if (key === 'sensitivity') {
-                const index = utils.getFromLookup(value, {'low': 0, 'medium': 1, 'high': 2});
+                const index = utils.getFromLookup(value, smokeDetectorSensitivity);
                 await entity.write('ssIasZone', {currentZoneSensitivityLevel: index});
                 return {state: {sensitivity: value}};
             }
@@ -1046,7 +1053,7 @@ const definitions: Definition[] = [
             e.test(),
             e.binary('alarm_intruder', ea.ALL, 'ON', 'OFF').withDescription('Toggle the intruder alarm on or off'),
             e.binary('alarm_smoke', ea.ALL, 'ON', 'OFF').withDescription('Toggle the smoke alarm on or off'),
-            e.enum('sensitivity', ea.ALL, 'low', 'medium', 'high').withDescription('Sensitivity of the smoke alarm'),
+            e.enum('sensitivity', ea.ALL, Object.keys(smokeDetectorSensitivity)).withDescription('Sensitivity of the smoke alarm'),
         ],
     },
     {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -102,13 +102,13 @@ const displayedTemperature = {
 };
 
 // Smoke detector II bsd-2
-const smokeDetectorAlarmState: KeyValue = {
+const smokeAlarmState: KeyValue = {
     'OFF': 0x0000,
     'ON': 0x3c00, // 15360 or 46080 works
 };
 
 // Smoke detector II bsd-2
-const smokeDetectorBurglarAlarmState: KeyValue = {
+const burglarAlarmState: KeyValue = {
     'OFF': 0x0001,
     'ON': 0xb401, // 46081
 };
@@ -178,14 +178,14 @@ const tzLocal = {
         key: ['alarm_smoke', 'alarm_burglar', 'sensitivity'],
         convertSet: async (entity, key, value: string, meta) => {
             if (key === 'alarm_smoke') {
-                const index = utils.getFromLookup(value, smokeDetectorAlarmState);
+                const index = utils.getFromLookup(value, smokeAlarmState);
                 await entity.command('ssIasZone', 'boschSmokeDetectorSiren', {data: index}, manufacturerOptions);
                 return {state: {alarm_smoke: value}};
             }
             if (key === 'alarm_burglar') {
-                const index = utils.getFromLookup(value, smokeDetectorBurglarAlarmState);
+                const index = utils.getFromLookup(value, burglarAlarmState);
                 await entity.command('ssIasZone', 'boschSmokeDetectorSiren', {data: index}, manufacturerOptions);
-                return {state: {alarm_intruder: value}};
+                return {state: {alarm_burglar: value}};
             }
             if (key === 'sensitivity') {
                 const index = utils.getFromLookup(value, smokeDetectorSensitivity);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -113,13 +113,6 @@ const smokeDetectorIntruderState: KeyValue = {
     'ON': 0xb401, // 46081
 };
 
-// Smoke detector II bsd-2
-const smokeDetectorSensitivity: KeyValue = {
-    'low': 0x0,
-    'medium': 0x1,
-    'high': 0x2,
-};
-
 // Radiator Thermostat II
 const setpointSource = {
     'manual': 0,


### PR DESCRIPTION
Includes the following improvements for the Bosch smoke detector:

- Add option to set smoke sensitivity (low, medium, high)
- Minor housekeeping


**Possible breaking changes:** 

- Rename `alarm_intruder` to `alarm_burglar` for consistency