### PR TITLE
fix(GS): use alarm_2 for SGPHM-I1 and attribute cleanup

### DIFF
--- a/src/devices/gs.ts
+++ b/src/devices/gs.ts
@@ -30,14 +30,14 @@ const definitions: Definition[] = [
         model: 'SGMHM-I1',
         vendor: 'GS',
         description: 'Methane gas sensor',
-        extend: [iasZoneAlarm({zoneType: 'gas', zoneAttributes: ['alarm_2', 'tamper', 'battery_low']})],
+        extend: [iasZoneAlarm({zoneType: 'gas', zoneAttributes: ['alarm_2']})],
     },
     {
         zigbeeModel: ['SGPHM-I1'],
         model: 'SGPHM-I1',
         vendor: 'GS',
         description: 'Propane gas sensor',
-        extend: [iasZoneAlarm({zoneType: 'gas', zoneAttributes: ['alarm_2', 'tamper', 'battery_low']})],
+        extend: [iasZoneAlarm({zoneType: 'gas', zoneAttributes: ['alarm_2']})],
     },
     {
         zigbeeModel: ['SKHMP30-I1'],

--- a/src/devices/gs.ts
+++ b/src/devices/gs.ts
@@ -37,7 +37,7 @@ const definitions: Definition[] = [
         model: 'SGPHM-I1',
         vendor: 'GS',
         description: 'Propane gas sensor',
-        extend: [iasZoneAlarm({zoneType: 'gas', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']})],
+        extend: [iasZoneAlarm({zoneType: 'gas', zoneAttributes: ['alarm_2', 'tamper', 'battery_low']})],
     },
     {
         zigbeeModel: ['SKHMP30-I1'],


### PR DESCRIPTION
Multiple reports came in that SGPHM-I1 in fact uses `alarm_2` and was not reporting alarms correctly this whole time.

Also removed `tamper` and `battery_low` attributes form both gas sensors as they don't physically have tampers or batteries.