### PR TITLE
Add option to toggle alarm on all Bosch BSD-2 via broadcast

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -194,7 +194,7 @@ const tzLocal = {
                     Zcl.ManufacturerCode.ROBERT_BOSCH_GMBH,
                     71,
                     'boschSmokeDetectorSiren',
-                    1280,
+                    1280, // ssIasZone
                     {data: index});
                 await meta.device.constructor.adapter.sendZclFrameToAll(255, broadcastFrame, 1, 0xFFFF);
                 return {state: {broadcast_alarm: value}};


### PR DESCRIPTION
Quite an amazing feature of the Bosch smoke detectors. 🤩

By simply issuing a special Zigbee broadcast command, you'll be able to change the alarm/siren state _of all BSD-2 in your network **at once**_.
The main benefit here's that you can e.g. trigger a network-wide fire alarm when only one detector senses smoke, but also silence them all at once, except for the device that initially detected smoke.

**To-Dos**
- [ ] Verify `sendZclFrameToAll` is called correctly
- [ ] Set correct `zclTransactionSequenceNumber`
- [ ] Send broadcast to 0xFFFF; patch `sendZclFrameToAll` in `zigbee-herdsman`?