### PR TITLE
fix(detect): Detect `440400982843` as Philips 915005733701

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1215,7 +1215,7 @@ const definitions: Definition[] = [
         extend: [philipsLight({colorTemp: {range: undefined}, color: true})],
     },
     {
-        zigbeeModel: ['LCT024', '440400982841', '440400982842', 'PCM002'],
+        zigbeeModel: ['LCT024', '440400982841', '440400982842', '440400982843', 'PCM002'],
         model: '915005733701',
         vendor: 'Philips',
         description: 'Hue White and color ambiance Play Lightbar',


### PR DESCRIPTION
Hi!

I just received a [Philips Hue White and color ambiance Play Lightbar](https://www.zigbee2mqtt.io/devices/915005733701.html). It is Zigbee model 440400982843, which does not appears to be supported by the currently released version of Zigbee2MQTT. All the features listed on the "Exposes" tab in the frontend work, so I assume it is safe to just add the model to the list for this existing device.

I have not contributed to this repository before; please let me know if changes to any aspect of this pull request are needed. 