### PR TITLE
Update Elko 4523430 max load value

### DIFF
--- a/src/devices/elko.ts
+++ b/src/devices/elko.ts
@@ -43,9 +43,9 @@ const definitions: Definition[] = [
             tz.elko_regulator_mode, tz.elko_regulator_time, tz.elko_night_switching],
         exposes: [e.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
             e.numeric('load', ea.ALL).withUnit('W')
-                .withDescription('Load in W when heating is on (between 0-2000 W). The thermostat uses the value as input to the ' +
+                .withDescription('Load in W when heating is on (between 0-2300 W). The thermostat uses the value as input to the ' +
                 'mean_power calculation.')
-                .withValueMin(0).withValueMax(2000),
+                .withValueMin(0).withValueMax(2300),
             e.binary('regulator_mode', ea.ALL, 'regulator', 'thermostat')
                 .withDescription('Device in regulator or thermostat mode.'),
             e.numeric('regulator_time', ea.ALL).withUnit('min')


### PR DESCRIPTION
## Changes 
* Update Elko 4523430 max load value 

According to the [device specification](https://www.elko.no/getfile.php/1343780-1712344203/ELKO.no/Produkter%20PIM/EKO05/NO-EKO05680/documents-custom/Datasheet4523430.pdf), the max load is 2300 W. I am currently running with more than 2000W on my device

