### PR TITLE
fix: IKEA VINDSTYRKA uses different DataType for measuredValue

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1,10 +1,10 @@
+import {Zcl} from 'zigbee-herdsman';
 import {Definition} from '../lib/types';
-import dataType from 'zigbee-herdsman/dist/zcl/definition/dataType';
 import {
     onOff, battery, iasZoneAlarm, identify, forcePowerSource,
     temperature, humidity, occupancy, illuminance, windowCovering,
     commandsOnOff, commandsLevelCtrl, commandsWindowCovering, pm25,
-    linkQuality, deviceEndpoints, bindCluster,
+    linkQuality, deviceEndpoints, deviceAddCustomCluster, bindCluster,
 } from '../lib/modernExtend';
 import {
     ikeaConfigureRemote, ikeaLight, ikeaOta,
@@ -940,13 +940,20 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'VINDSTYRKA air quality and humidity sensor',
         extend: [
+            deviceAddCustomCluster(
+                'pm25Measurement',
+                {
+                    ID: 0x042a,
+                    attributes: {
+                        measuredValue: {ID: 0x0000, type: Zcl.DataType.singlePrec},
+                    },
+                    commands: {},
+                    commandsResponse: {},
+                },
+            ),
             temperature(),
             humidity(),
-            pm25({
-                // IKEA used conflicting date type on a standart attribute
-                attribute: {ID: 0x0000, type: dataType.singlePrec},
-                reporting: {min: '1_MINUTE', max: '2_MINUTES', change: 2},
-            }),
+            pm25({reporting: {min: '1_MINUTE', max: '2_MINUTES', change: 2}}),
             ikeaVoc(),
             identify(),
             ikeaOta(),

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -4,7 +4,10 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as constants from '../lib/constants';
 import * as reporting from '../lib/reporting';
-import {binary, enumLookup, forcePowerSource, numeric, onOff, customTimeResponse, battery, ota} from '../lib/modernExtend';
+import {
+    binary, enumLookup, forcePowerSource, numeric, onOff,
+    customTimeResponse, battery, ota, deviceAddCustomCluster,
+} from '../lib/modernExtend';
 import {Definition, Fz, KeyValue, KeyValueAny, ModernExtend, Tz} from '../lib/types';
 import * as utils from '../lib/utils';
 import {logger} from '../lib/logger';
@@ -803,6 +806,28 @@ const definitions: Definition[] = [
             tz.thermostat_running_state,
         ],
         extend: [
+            deviceAddCustomCluster(
+                'customSonoffTrvzb',
+                {
+                    ID: 0xfc11,
+                    attributes: {
+                        childLock: {ID: 0x0000, type: Zcl.DataType.boolean},
+                        tamper: {ID: 0x2000, type: Zcl.DataType.uint8},
+                        illumination: {ID: 0x2001, type: Zcl.DataType.uint8},
+                        openWindow: {ID: 0x6000, type: Zcl.DataType.boolean},
+                        frostProtectionTemperature: {ID: 0x6002, type: Zcl.DataType.int16},
+                        idleSteps: {ID: 0x6003, type: Zcl.DataType.uint16},
+                        closingSteps: {ID: 0x6004, type: Zcl.DataType.uint16},
+                        valveOpeningLimitVoltage: {ID: 0x6005, type: Zcl.DataType.uint16},
+                        valveClosingLimitVoltage: {ID: 0x6006, type: Zcl.DataType.uint16},
+                        valveMotorRunningVoltage: {ID: 0x6007, type: Zcl.DataType.uint16},
+                        valveOpeningDegree: {ID: 0x600B, type: Zcl.DataType.uint8},
+                        valveClosingDegree: {ID: 0x600C, type: Zcl.DataType.uint8},
+                    },
+                    commands: {},
+                    commandsResponse: {},
+                },
+            ),
             binary({
                 name: 'child_lock',
                 cluster: 'customSonoffTrvzb',
@@ -909,30 +934,6 @@ const definitions: Definition[] = [
             await reporting.thermostatSystemMode(endpoint);
             await endpoint.read('hvacThermostat', ['localTemperatureCalibration']);
             await endpoint.read(0xFC11, [0x0000, 0x6000, 0x6002, 0x6003, 0x6004, 0x6005, 0x6006, 0x6007]);
-        },
-        onEvent: async (type, data, device, settings, state) => {
-            const name = 'customSonoffTrvzb';
-            if (!device.customClusters[name]) {
-                device.addCustomCluster(name, {
-                    ID: 0xfc11,
-                    attributes: {
-                        childLock: {ID: 0x0000, type: Zcl.DataType.boolean},
-                        tamper: {ID: 0x2000, type: Zcl.DataType.uint8},
-                        illumination: {ID: 0x2001, type: Zcl.DataType.uint8},
-                        openWindow: {ID: 0x6000, type: Zcl.DataType.boolean},
-                        frostProtectionTemperature: {ID: 0x6002, type: Zcl.DataType.int16},
-                        idleSteps: {ID: 0x6003, type: Zcl.DataType.uint16},
-                        closingSteps: {ID: 0x6004, type: Zcl.DataType.uint16},
-                        valveOpeningLimitVoltage: {ID: 0x6005, type: Zcl.DataType.uint16},
-                        valveClosingLimitVoltage: {ID: 0x6006, type: Zcl.DataType.uint16},
-                        valveMotorRunningVoltage: {ID: 0x6007, type: Zcl.DataType.uint16},
-                        valveOpeningDegree: {ID: 0x600B, type: Zcl.DataType.uint8},
-                        valveClosingDegree: {ID: 0x600C, type: Zcl.DataType.uint8},
-                    },
-                    commands: {},
-                    commandsResponse: {},
-                });
-            }
         },
     },
     {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1,4 +1,5 @@
 import {Zcl} from 'zigbee-herdsman';
+import {ClusterDefinition} from 'zigbee-herdsman/dist/zcl/definition/tstype';
 import tz from '../converters/toZigbee';
 import fz from '../converters/fromZigbee';
 import * as globalLegacy from '../lib/legacy';
@@ -1667,6 +1668,16 @@ export function deviceEndpoints(args: {endpoints: {[n: string]: number}, multiEn
     if (args.multiEndpointSkip) result.meta.multiEndpointSkip = args.multiEndpointSkip;
 
     return result;
+}
+
+export function deviceAddCustomCluster(clusterName: string, clusterDefinition: ClusterDefinition): ModernExtend {
+    const onEvent: OnEvent = async (type, data, device, options, state: KeyValue) => {
+        if (!device.customClusters[clusterName]) {
+            device.addCustomCluster(clusterName, clusterDefinition);
+        }
+    };
+
+    return {onEvent, isModernExtend: true};
 }
 
 export function ignoreClusterReport(args: {cluster: string | number}): ModernExtend {


### PR DESCRIPTION
Now that we have https://github.com/Koenkk/zigbee-herdsman/pull/1019, we can properly fix the IKEA VINDSTYRKA.

- [x] modernExtend to easily inject them by abstracting the onEvent stuff
- [x] VINDSTYRKA should use correct DataType
- [x] make SONOFF device also use new modernExtend


This is the debug log of joining a VINDSTYRKA and reconfiguring the reporting for pm25Measurement.measuredValue via the frontend.

[vindstyrka_join_and_configreport.log](https://github.com/Koenkk/zigbee-herdsman-converters/files/15137706/vindstyrka_join_and_configreport.log)
