### PR TITLE
fix: Fix invalid `contact` for MCCGQ01LM

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -800,10 +800,6 @@ export const numericAttributes2Payload = async (msg: Fz.Message, meta: Fz.Meta, 
             // This is a a complete structure with attributes, like element 0 for state, element 1 for voltage...
             // At this moment we only extract what we are sure, for example, position 0 seems to be always 1 for a
             // occupancy sensor, so we ignore it at this moment
-            if (['MCCGQ01LM'].includes(model.model)) {
-                // @ts-expect-error
-                payload.contact = value[0].elmVal === 0;
-            }
             // @ts-expect-error
             payload.voltage = value[1].elmVal;
             if (model.meta && model.meta.battery && model.meta.battery.voltageToPercentage) {


### PR DESCRIPTION
This PR reverts https://github.com/Koenkk/zigbee-herdsman-converters/pull/4009 (CC: @McGiverGim) as it generated incorrect `contact` values. 

Log in which `contact` incorrectly goes from `true` -> `false`:

```
// Since msg.data['65282'].value[0].elmVal === 0, contact incorrectly becomes `false` here
[2024-04-26 06:30:42] [34mdebug[39m: 	z2m: Received Zigbee message from 'mailbox_new_mail_sensor', type 'attributeReport', cluster 'genBasic', data '{"65282":[{"elmType":16,"elmVal":1},{"elmType":33,"elmVal":2975},{"elmType":33,"elmVal":5032},{"elmType":36,"elmVal":[0,1]},{"elmType":33,"elmVal":552},{"elmType":32,"elmVal":119}]}' from endpoint 1 with groupID 0
[2024-04-26 06:30:42] [34mdebug[39m: 	zhc:lumi: MCCGQ01LM: Processed data into payload {"contact":false,"voltage":2975,"battery":83,"power_outage_count":551}
[2024-04-26 06:30:42] [34mdebug[39m: 	z2m: MQTT publish: topic 'zigbee2mqtt/mailbox_new_mail_sensor', payload '{"battery":83,"contact":false,"linkquality":87,"power_outage_count":551,"voltage":2975}'
// Immediately after the sensor reports the correct `contact` value using the `genOnOff`
[2024-04-26 06:30:42] [34mdebug[39m: 	z2m: Received Zigbee message from 'mailbox_new_mail_sensor', type 'attributeReport', cluster 'genOnOff', data '{"onOff":0}' from endpoint 1 with groupID 0
[2024-04-26 06:30:42] [34mdebug[39m: 	z2m: MQTT publish: topic 'zigbee2mqtt/mailbox_new_mail_sensor', payload '{"battery":83,"contact":true,"linkquality":87,"power_outage_count":551,"voltage":2975}'

```

Based on this we should not use `msg.data['65282'].value[0].elmVal` to determine the `contact` value.