### PR TITLE
Add global option for `cover_position_tilt_disable_report`

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -597,12 +597,17 @@ const converters2 = {
     } satisfies Tz.Converter,
     cover_position_tilt: {
         key: ['position', 'tilt'],
-        options: [exposes.options.invert_cover()],
+        options: [
+            exposes.options.invert_cover(),
+            exposes.options.cover_position_tilt_disable_report(),
+        ],
         convertSet: async (entity, key, value, meta) => {
             utils.assertNumber(value, key);
             const isPosition = (key === 'position');
             const invert = !(utils.getMetaValue(entity, meta.mapped, 'coverInverted', 'allEqual', false) ?
                 !meta.options.invert_cover : meta.options.invert_cover);
+            const disableReport = !(utils.getMetaValue(entity, meta.mapped, 'coverPositionTiltDisableReport', 'allEqual', false) ?
+                !meta.options.cover_position_tilt_disable_report : meta.options.cover_position_tilt_disable_report);
             const position = invert ? 100 - value : value;
 
             // Zigbee officially expects 'open' to be 0 and 'closed' to be 100 whereas
@@ -614,7 +619,7 @@ const converters2 = {
                 isPosition ? {percentageliftvalue: position} : {percentagetiltvalue: position},
                 utils.getOptions(meta.mapped, entity),
             );
-            if (utils.getMetaValue(entity, meta.mapped, 'coverPositionTiltDisableReport', 'allEqual', true)) {
+            if (disableReport) {
                 return;
             } else {
                 return {state: {[isPosition ? 'position' : 'tilt']: value}};

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1518,7 +1518,6 @@ const definitions: Definition[] = [
         ],
         meta: {
             multiEndpoint: true,
-            coverPositionTiltDisableReport: false,
         },
         endpoint: (device) => {
             return {'left': 2, 'right': 3};

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -618,6 +618,7 @@ export const options = {
     illuminance_below_threshold_check: () => new Binary(`illuminance_below_threshold_check`, access.SET, true, false).withDescription(`Set to false to also send messages when illuminance is above threshold in night mode (default true).`),
     state_action: () => new Binary(`state_action`, access.SET, true, false).withDescription(`State actions will also be published as 'action' when true (default false).`),
     identify_timeout: () => new Numeric('identify_timeout', access.SET).withDescription('Sets duration of identification procedure in seconds (i.e., how long device would flash). Value ranges from 1 to 30 seconds (default 3).').withValueMin(1).withValueMax(30),
+    cover_position_tilt_disable_report: () => new Binary(`cover_position_tilt_disable_report`, access.SET, true, false).withDescription(`Do not publish set cover target position as a normal 'position' value (default false).`),
 };
 
 export const presets = {


### PR DESCRIPTION
Includes the following improvements:

- Add global binary option for `cover_position_tilt_disable_report`
- Make `coverPositionTiltDisableReport` user-configurable for Bosch BCMT-SLZ