### PR TITLE
feat: Allow OTA support for Innr SP 240,242 and 244

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -698,6 +698,7 @@ const definitions: Definition[] = [
             onOff(),
             electricityMeter({current: {divisor: 1000}, voltage: {divisor: 1}, power: {divisor: 1}, energy: {divisor: 100}}),
         ],
+        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['SP 242'],
@@ -711,6 +712,7 @@ const definitions: Definition[] = [
             // https://github.com/Koenkk/zigbee-herdsman-converters/issues/6747
             reconfigureReportingsOnDeviceAnnounce(),
         ],
+        ota: ota.zigbeeOTA,
     },
     {
         zigbeeModel: ['SP 244'],
@@ -721,6 +723,7 @@ const definitions: Definition[] = [
             onOff(),
             electricityMeter({current: {divisor: 1000}, voltage: {divisor: 1}, power: {divisor: 1}, energy: {divisor: 100}}),
         ],
+        ota: ota.zigbeeOTA,
     },
 ];
 


### PR DESCRIPTION
This pull requests exposes the OTA capability for the Innr Smart plugs.  So that the firmware provided in [2fddaba](https://github.com/Koenkk/zigbee-OTA/commit/2fddaba1bedbe007e777bd775451cc4343690e7e) could be installed. 

I will test this PR first on one of my plugs before marking it final. 
