### PR TITLE
Add Tuya 2 gang switch

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6426,6 +6426,24 @@ const definitions: Definition[] = [
     },
     {
         fingerprint: [
+            {modelID: 'TS0002', manufacturerName: '_TZ3000_i9w5mehz'},
+        ],
+        model: 'TS0002',
+        vendor: 'TuYa',
+        description: '2-Gang switch with backlight',
+        extend: [tuya.modernExtend.tuyaOnOff({powerOnBehavior2: true, backlightModeOffOn: true, indicatorMode: true, endpoints: ['l1', 'l2']})],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
+        },
+    },
+    {
+        fingerprint: [
             {modelID: 'TS0003', manufacturerName: '_TZ3000_pv4puuxi'},
             {modelID: 'TS0003', manufacturerName: '_TZ3000_avky2mvc'},
         ],


### PR DESCRIPTION
Hello!

Add new switch tuya brand. This switch is already recognized as ["TS0002" switch](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L2839) but this converter doesn't use all available features. And all already added similar switches doesn't have available features too.  For example [this switch](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L2799)
Since I can't check different, already added models, I've decide to add new switch.

If there are any options how to add this new switch to existed with full support of available features, Please provide the idea how to do it and I will update PD. 