### PR TITLE
Fix Eurotronic Zigbee Spirit system mode/host flags

### DIFF
--- a/src/devices/eurotronic.ts
+++ b/src/devices/eurotronic.ts
@@ -2,12 +2,12 @@ import {Zcl} from 'zigbee-herdsman';
 import {Definition} from '../lib/types';
 import * as exposes from '../lib/exposes';
 import fz from '../converters/fromZigbee';
-import * as legacy from '../lib/legacy';
 import tz from '../converters/toZigbee';
 import * as ota from '../lib/ota';
 import * as constants from '../lib/constants';
 import * as reporting from '../lib/reporting';
 const e = exposes.presets;
+const ea = exposes.access;
 
 const definitions: Definition[] = [
     {
@@ -15,13 +15,14 @@ const definitions: Definition[] = [
         model: 'SPZB0001',
         vendor: 'Eurotronic',
         description: 'Spirit Zigbee wireless heater thermostat',
-        fromZigbee: [legacy.fz.eurotronic_thermostat, fz.battery],
+        fromZigbee: [fz.eurotronic_thermostat, fz.battery],
         toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_unoccupied_heating_setpoint,
-            tz.thermostat_local_temperature_calibration, tz.eurotronic_thermostat_system_mode, tz.eurotronic_host_flags,
+            tz.thermostat_local_temperature_calibration, tz.eurotronic_host_flags,
             tz.eurotronic_error_status, tz.thermostat_setpoint_raise_lower, tz.thermostat_control_sequence_of_operation,
             tz.thermostat_remote_sensing, tz.thermostat_local_temperature, tz.thermostat_running_state,
-            tz.eurotronic_current_heating_setpoint, tz.eurotronic_trv_mode, tz.eurotronic_valve_position],
-        exposes: [e.battery(), e.climate().withSetpoint('occupied_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
+            tz.eurotronic_current_heating_setpoint, tz.eurotronic_trv_mode, tz.eurotronic_valve_position, tz.eurotronic_child_lock,
+            tz.eurotronic_mirror_display],
+        exposes: [e.battery(), e.child_lock(), e.climate().withSetpoint('occupied_heating_setpoint', 5, 30, 0.5).withLocalTemperature()
             .withSystemMode(['off', 'auto', 'heat']).withRunningState(['idle', 'heat'])
             .withLocalTemperatureCalibration()
             .withPiHeatingDemand(),
@@ -32,7 +33,10 @@ const definitions: Definition[] = [
             'and the buttons on the device are disabled.'),
         e.numeric('valve_position', exposes.access.ALL).withValueMin(0).withValueMax(255)
             .withDescription('Directly control the radiator valve when `trv_mode` is set to 1. The values range from 0 (valve '+
-            'closed) to 255 (valve fully open)')],
+            'closed) to 255 (valve fully open)'),
+        e.binary('mirror_display', ea.ALL, 'ON', 'OFF')
+            .withDescription('Mirror display of the thermostat. Useful when it is ' +
+            'mounted in a way where the display is presented upside down.')],
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
I wanted to debug why the child_lock option wasn't showing up neither in home assistant nor in the z2m web interface despite seeing traces of it in the logs (child_protection) and also seeing related code. Along the way I noticed that the entire host flags attribute was rather buggy. Setting thermostat mode somewhat worked, but it would frequently report back the wrong state upon attribute reports coming in. Granted, there's a bug in the firmware of those devices which makes parsing of it quite confusing. I've added a comment in the code about that. It seems extremely unlikely that there will be a firmware update changing/fixing that, so I believe my workaround should be safe to use (better than the previous state anyways).

Also it seemed to have a legacy converter which wasn't really used at all any more, which I've cleaned up.

While being at it, I also added the mirror_display option which comes in handy occasionally for those devices.

I am aware that this is not 100% backward compatible (the state object doesn't have window_open and child_protection any more), however, given those were also suffering from the before mentioned bugs and also not properly exposed, I assumed that may be okay... Please let me know if it is not and I can add them back.

The relevant parts (the "exposes") should be backwards compatible and now work properly.