### PR TITLE
Add `colorloop` effect for color lights

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1243,7 +1243,10 @@ const converters2 = {
                 const lookup = {blink: 0, breathe: 1, okay: 2, channel_change: 11, finish_effect: 254, stop_effect: 255};
                 value = value.toLowerCase();
                 if (value === 'colorloop') {
-                    converters2.light_hue_saturation_move.convertSet(entity, 'hue_move', 10, meta);
+                    const transition = meta.message.transition ?? 15;
+                    utils.assertNumber(transition, 'transition');
+                    const speed = Math.min(255, Math.max(1, Math.round(255 / transition)));
+                    converters2.light_hue_saturation_move.convertSet(entity, 'hue_move', speed, meta);
                 } else {
                     const payload = {effectid: utils.getFromLookup(value, lookup), effectvariant: 0};
                     await entity.command('genIdentify', 'triggerEffect', payload, utils.getOptions(meta.mapped, entity));

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1247,12 +1247,11 @@ const converters2 = {
                     utils.assertNumber(transition, 'transition');
                     const speed = Math.min(255, Math.max(1, Math.round(255 / transition)));
                     converters2.light_hue_saturation_move.convertSet(entity, 'hue_move', speed, meta);
+                } else if (value === 'stop_colorloop') {
+                    converters2.light_hue_saturation_move.convertSet(entity, 'hue_move', 'stop', meta);
                 } else {
                     const payload = {effectid: utils.getFromLookup(value, lookup), effectvariant: 0};
                     await entity.command('genIdentify', 'triggerEffect', payload, utils.getOptions(meta.mapped, entity));
-                }
-                if (value === 'stop_effect') {
-                    converters2.light_hue_saturation_move.convertSet(entity, 'hue_move', 'stop', meta);
                 }
             } else if (key === 'alert' || key === 'flash') { // Deprecated
                 let effectid = 0;

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1242,8 +1242,15 @@ const converters2 = {
                 utils.assertString(value, key);
                 const lookup = {blink: 0, breathe: 1, okay: 2, channel_change: 11, finish_effect: 254, stop_effect: 255};
                 value = value.toLowerCase();
-                const payload = {effectid: utils.getFromLookup(value, lookup), effectvariant: 0};
-                await entity.command('genIdentify', 'triggerEffect', payload, utils.getOptions(meta.mapped, entity));
+                if (value === 'colorloop') {
+                    converters2.light_hue_saturation_move.convertSet(entity, 'hue_move', 10, meta);
+                } else {
+                    const payload = {effectid: utils.getFromLookup(value, lookup), effectvariant: 0};
+                    await entity.command('genIdentify', 'triggerEffect', payload, utils.getOptions(meta.mapped, entity));
+                }
+                if (value === 'stop_effect') {
+                    converters2.light_hue_saturation_move.convertSet(entity, 'hue_move', 'stop', meta);
+                }
             } else if (key === 'alert' || key === 'flash') { // Deprecated
                 let effectid = 0;
                 const lookup = {'select': 0x00, 'lselect': 0x01, 'none': 0xFF};

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -754,7 +754,11 @@ export function light(args?: LightArgs): ModernExtend {
     const exposes: Expose[] = lightExpose;
 
     if (args.effect) {
-        exposes.push(e.effect());
+        const effects = e.effect();
+        if (args.color) {
+            effects.values.push('colorloop');
+        }
+        exposes.push(effects);
         toZigbee.push(tz.effect);
     }
 

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -756,7 +756,7 @@ export function light(args?: LightArgs): ModernExtend {
     if (args.effect) {
         const effects = e.effect();
         if (args.color) {
-            effects.values.push('colorloop');
+            effects.values.push('colorloop', 'stop_colorloop');
         }
         exposes.push(effects);
         toZigbee.push(tz.effect);


### PR DESCRIPTION
When I tried to set up some effects for my color lights, I realized that there is no colorloop in the list of supported effects for most of them. Apparently, I am not the first one who is missing this (cf. https://github.com/Koenkk/zigbee2mqtt/issues/1791). So here's my proposal for the implementation. 

The change allows to trigger a continuous color loop with the command `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"effect": colorloop}`. This is in addition to the already-existing command `hue_move` and basically does the same.

As proposed in the feature request, it also accepts a `transition` value from 1...255 to set the time for a full loop, where 1 is shortest and 255 ist longest. I tested it with my lights and it roughly matches the seconds for a full loop, but this does not need to be the case for every light. 
If no value for `transition` is given, a default value of 15 is used.

Example: for the slowest-possible color loop, publish to `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"transition": 255, "effect":"colorloop"}`. To turn off the color loop, publish `{"effect":"stop_effect"}`.