### PR TITLE
Fix _TZ3000_cehuw1lw with appversion 112

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4310,7 +4310,7 @@ const definitions: Definition[] = [
         onEvent: (type, data, device, options) =>
             tuya.onEventMeasurementPoll(type, data, device, options,
                 true, // polling for voltage, current and power
-                [100, 160].includes(device.applicationVersion) || ['1.0.5\u0000'].includes(device.softwareBuildID) //polling for energy
+                [100, 160].includes(device.applicationVersion) || ['1.0.5\u0000'].includes(device.softwareBuildID), // polling for energy
             ),
     },
     {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4280,9 +4280,15 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [160, 100, 69, 68, 65, 64].map((applicationVersion) => {
-            return {modelID: 'TS011F', applicationVersion, priority: -1};
-        }),
+        fingerprint: [
+            {modelID: 'TS011F', applicationVersion: 160, priority: -1},
+            {modelID: 'TS011F', applicationVersion: 100, priority: -1},
+            {modelID: 'TS011F', applicationVersion: 69, priority: -1},
+            {modelID: 'TS011F', applicationVersion: 68, priority: -1},
+            {modelID: 'TS011F', applicationVersion: 65, priority: -1},
+            {modelID: 'TS011F', applicationVersion: 64, priority: -1},
+            {modelID: 'TS011F', softwareBuildID: '1.0.5\u0000', priority: -1},
+        ],
         model: 'TS011F_plug_3',
         description: 'Smart plug (with power monitoring by polling)',
         vendor: 'TuYa',
@@ -4304,7 +4310,7 @@ const definitions: Definition[] = [
         onEvent: (type, data, device, options) =>
             tuya.onEventMeasurementPoll(type, data, device, options,
                 true, // polling for voltage, current and power
-                [100, 160].includes(device.applicationVersion), // polling for energy
+                [100, 160].includes(device.applicationVersion) || ['1.0.5\u0000'].includes(device.softwareBuildID) //polling for energy
             ),
     },
     {


### PR DESCRIPTION
Added application version 112 to the fingerprint check for TS011F with power monitoring by polling due to a misbehaving plug _TZ3000_cehuw1lw running appversion 112, and swBuild 1.0.5 which was reporting amps x 1000 and was not reporting kWh until this change

Not 100% certain this won't break other plugs on appversion 112, so we could potentially use the swBuild 1.0.5 as a fingerprint instead to match, since https://www.zigbee2mqtt.io/devices/TS011F_plug_3.html#tuya-ts011f_plug_3 mentions that plugs with 1.0.5 seem to be impacted specifically 