### PR TITLE
Cover status are inverted for model HK-ZCC-A (LED-Trading 9135)

### DIFF
--- a/src/devices/led_trading.ts
+++ b/src/devices/led_trading.ts
@@ -61,6 +61,7 @@ const definitions: Definition[] = [
         model: '9135',
         vendor: 'LED-Trading',
         description: 'Curtain motor controller',
+        meta: {coverInverted: true},
         fromZigbee: [fz.cover_position_tilt],
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
         exposes: [e.cover_position()],


### PR DESCRIPTION
@manu469 did come up with a fix for the identical sunricher module here: 
[https://github.com/Koenkk/zigbee-herdsman-converters/pull/7334](url)
Its the solution for that problem:
[https://github.com/Koenkk/zigbee2mqtt/issues/18945](url)
i think that would also fix the problem for led-trading 9135 module
can we have this in the next release please?
thank you, regards harald