### PR TITLE
feat: Add command_move and command_stop to Philips/Signify Hue Wall Switch Module (929003017102/RDM001)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2157,7 +2157,7 @@ const definitions: Definition[] = [
         model: '929003017102',
         vendor: 'Philips',
         description: 'Hue wall switch module',
-        fromZigbee: [fz.battery, fz.hue_wall_switch_device_mode, fz.hue_wall_switch, fz.command_toggle],
+        fromZigbee: [fz.battery, fz.hue_wall_switch_device_mode, fz.hue_wall_switch, fz.command_toggle, fz.command_move, fz.command_stop],
         exposes: [
             e.battery(), e.action(['left_press', 'left_press_release', 'right_press', 'right_press_release',
                 'left_hold', 'left_hold_release', 'right_hold', 'right_hold_release', 'toggle']),


### PR DESCRIPTION
It has been [discovered](https://github.com/Koenkk/zigbee2mqtt.io/pull/2464) earlier that the Philips Hue Wall Switch Module has a neat feature where it can also directly control the brightness of a bound group through the `LevelCtrl` cluster. If the Wall Switch is bound to a group, it sends its commands to the group instead of the coordinator. These Zigbee messages are translated and published through MQTT, but I noticed that some messages I can see in the logs, but are not published: `commandMove`, `commandMoveWithOnOff`, `commandStop`, `commandStopWithOnOff`

This PR aims to fix this, and these messages are now published to MQTT.

FYI the Zigbee commands will map to the following actions in Home Assistant:
- `commandMove` → `brightness_move_down`
- `commandMoveWithOnOff` → `brightness_move_up`
- `commandStop` → `brightness_stop`
- `commandStopWithOnOff` → `brightness_stop`