### PR TITLE
Fix Backlight for TS0013

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4847,7 +4847,7 @@ const definitions: Definition[] = [
         model: 'TS0013',
         vendor: 'TuYa',
         description: 'Smart light switch - 3 gang without neutral wire',
-        extend: [tuya.modernExtend.tuyaOnOff({backlightModeLowMediumHigh: true, endpoints: ['left', 'center', 'right']})],
+        extend: [tuya.modernExtend.tuyaOnOff({backlightModeOffNormalInverted: true, endpoints: ['left', 'center', 'right']})],
         endpoint: (device) => {
             return {'left': 1, 'center': 2, 'right': 3};
         },


### PR DESCRIPTION
I noticed for my TS0013 switches the backlight converting didn't work like it did work for the 1 gang and 2 gang switches. 
I noticed the wrong payload is used as the switches don't change the brightness, but do change the inversion.
I modified the code with the right payload.