### PR TITLE
Note QOTO QT-05M timer must be set after starting auto shutdown

### DIFF
--- a/src/devices/qoto.ts
+++ b/src/devices/qoto.ts
@@ -23,9 +23,9 @@ const definitions: Definition[] = [
             e.numeric('valve_state', ea.STATE_SET).withValueMin(0).withValueMax(100).withValueStep(5).withUnit('%')
                 .withDescription('Set valve to %.'),
             e.numeric('valve_state_auto_shutdown', ea.STATE_SET).withValueMin(0).withValueMax(100).withValueStep(5).withUnit('%')
-                .withDescription('Set valve to % with auto shutdown. Must be set before setting auto shutdown in seconds'),
+                .withDescription('Set valve to % with auto shutdown. Must be set before setting the shutdown timer.'),
             e.numeric('shutdown_timer', ea.STATE_SET).withValueMin(0).withValueMax(14400).withUnit('sec')
-                .withDescription('Auto shutdown in seconds. Must be set after setting valve % with auto shutdown.'),
+                .withDescription('Auto shutdown in seconds. Must be set after setting valve state auto shutdown.'),
             e.battery(),
         ],
     },

--- a/src/devices/qoto.ts
+++ b/src/devices/qoto.ts
@@ -22,10 +22,10 @@ const definitions: Definition[] = [
                 .withDescription('Remaning watering time (for auto shutdown). Updates every minute, and every 10s in the last minute.'),
             e.numeric('valve_state', ea.STATE_SET).withValueMin(0).withValueMax(100).withValueStep(5).withUnit('%')
                 .withDescription('Set valve to %.'),
-            e.numeric('shutdown_timer', ea.STATE_SET).withValueMin(0).withValueMax(14400).withUnit('sec')
-                .withDescription('Auto shutdown in seconds.'),
             e.numeric('valve_state_auto_shutdown', ea.STATE_SET).withValueMin(0).withValueMax(100).withValueStep(5).withUnit('%')
-                .withDescription('Set valve to % with auto shutdown.'),
+                .withDescription('Set valve to % with auto shutdown. Must be set before setting auto shutdown in seconds'),
+            e.numeric('shutdown_timer', ea.STATE_SET).withValueMin(0).withValueMax(14400).withUnit('sec')
+                .withDescription('Auto shutdown in seconds. Must be set after setting valve % with auto shutdown.'),
             e.battery(),
         ],
     },


### PR DESCRIPTION
Follows up from https://github.com/Koenkk/zigbee2mqtt/discussions/17904

This updates descriptions, but also changes the order of the fields to be natural given this limitation.