### PR TITLE
change to recognized cluster for 3RSNL02043Z

### DIFF
--- a/src/devices/third_reality.ts
+++ b/src/devices/third_reality.ts
@@ -22,7 +22,8 @@ const fzLocal = {
         },
     } satisfies Fz.Converter,
     thirdreality_private_motion_sensor: {
-        cluster: 'manuSpecificUbisysDeviceSetup',
+        cluster: 'manuSpecificAssaDoorLock',
+        // This cluster ID is 0xFC00. Temporarily modify like this
         type: 'attributeReport',
         convert: (model, msg, publish, options, meta) => {
             const zoneStatus = msg.data[2];


### PR DESCRIPTION
This cluster ID is 0xFC00. Temporarily modify like this.
I see zigbee-herdsman have the FC00 cluster identify.
If necessary, it will be redefined later.