### PR TITLE
feat(yale): add support for YRD410 physical button variant

### DIFF
--- a/src/devices/yale.ts
+++ b/src/devices/yale.ts
@@ -347,7 +347,7 @@ const definitions: Definition[] = [
         extend: [lockExtend()],
     },
     {
-        zigbeeModel: ['YRD410 TS'],
+        zigbeeModel: ['YRD410 TS', 'YRD410 PB'],
         model: 'YRD410-BLE',
         vendor: 'Yale',
         description: 'Assure lock 2',


### PR DESCRIPTION
currently that Physical button variant of the yale assure 2 (yrd410-pb) model shows unsupported, this change add it to the existing definition for the yrd410-ble