### PR TITLE
Add missing `opal` and `glisten` effects to Hue Festavia LCX015

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3334,14 +3334,14 @@ const definitions: Definition[] = [
         zigbeeModel: ['LCX012'],
         model: '929003535301',
         vendor: 'Philips',
-        description: 'Hue Festavia gradient light string 250',
+        description: 'Hue Festavia gradient light string 250 (1st-gen)',
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ['sparkle', 'opal', 'glisten']}})],
     },
     {
-        zigbeeModel: ['LCX017'],
-        model: '929003674601',
+        zigbeeModel: ['LCX015'],
+        model: '9290036744',
         vendor: 'Philips',
-        description: 'Hue Festavia gradient light string 500',
+        description: 'Hue Festavia gradient light string 250',
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ['sparkle', 'opal', 'glisten']}})],
     },
     {
@@ -3349,6 +3349,13 @@ const definitions: Definition[] = [
         model: '9290036745',
         vendor: 'Philips',
         description: 'Hue Festavia gradient light string 100',
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ['sparkle', 'opal', 'glisten']}})],
+    },
+    {
+        zigbeeModel: ['LCX017'],
+        model: '929003674601',
+        vendor: 'Philips',
+        description: 'Hue Festavia gradient light string 500',
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ['sparkle', 'opal', 'glisten']}})],
     },
     {
@@ -3546,13 +3553,6 @@ const definitions: Definition[] = [
         vendor: 'Philips',
         description: 'Hue white ambiance MR16 with Bluetooth',
         extend: [philipsLight({colorTemp: {range: [153, 454]}})],
-    },
-    {
-        zigbeeModel: ['LCX015'],
-        model: '9290036744',
-        vendor: 'Philips',
-        description: 'Hue Festavia gradient light string 250',
-        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ['sparkle']}})],
     },
     {
         zigbeeModel: ['915005914501'],


### PR DESCRIPTION
- Adds the missing `opal` and `glisten` effects to the 2nd-gen Hue Festavia 250 (`LCX015`).
- Re-orders the various Hue Festavia versions to make it harder to miss anything in future adaptions.
- Marks the 1st-gen Hue Festavia 250 as such.