### PR TITLE
Set entity category to configuration for Sonoff TRVZB open/close degree entities

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -970,6 +970,7 @@ const definitions: Definition[] = [
                 name: 'valve_opening_degree',
                 cluster: 'customSonoffTrvzb',
                 attribute: 'valveOpeningDegree',
+                entityCategory: 'config',
                 description: 'Valve open position (percentage) control. ' +
                     'If the opening degree is set to 100%, the valve is fully open when it is opened. ' +
                     'If the opening degree is set to 0%, the valve is fully closed when it is opened, ' +
@@ -984,6 +985,7 @@ const definitions: Definition[] = [
                 name: 'valve_closing_degree',
                 cluster: 'customSonoffTrvzb',
                 attribute: 'valveClosingDegree',
+                entityCategory: 'config',
                 description: 'Valve closed position (percentage) control. ' +
                     'If the closing degree is set to 100%, the valve is fully closed when it is closed. ' +
                     'If the closing degree is set to 0%, the valve is fully opened when it is closed, ' +


### PR DESCRIPTION
Closes #7564

Currently, the entity category is not set for open and close degree meaning the controls display in dashboards and elsewhere in HA. These should be configuration entities managed through admin UI.