### PR TITLE
Remove last `manuSpecificBosch*` usage

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1061,7 +1061,7 @@ const definitions: Definition[] = [
                         boschTestTamper: {
                             ID: 0xF3,
                             parameters: [
-                                {name: 'data', type: DataType.UINT8},
+                                {name: 'data', type: Zcl.DataType.UINT8},
                             ],
                         },
                     },
@@ -1077,7 +1077,7 @@ const definitions: Definition[] = [
                         boschOutdoorSiren: {
                             ID: 240,
                             parameters: [
-                                {name: 'data', type: DataType.UINT8},
+                                {name: 'data', type: Zcl.DataType.UINT8},
                             ],
                         },
                     },

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1052,6 +1052,38 @@ const definitions: Definition[] = [
             e.binary('ac_status', ea.STATE, true, false).withDescription('Is the device plugged in'),
         ],
         extend: [
+            deviceAddCustomCluster(
+                'ssIasZone',
+                {
+                    ID: Zcl.Clusters.ssIasZone.ID,
+                    attributes: {},
+                    commands: {
+                        boschTestTamper: {
+                            ID: 0xF3,
+                            parameters: [
+                                {name: 'data', type: DataType.UINT8},
+                            ],
+                        },
+                    },
+                    commandsResponse: {},
+                },
+            ),
+            deviceAddCustomCluster(
+                'ssIasWd',
+                {
+                    ID: Zcl.Clusters.ssIasWd.ID,
+                    attributes: {},
+                    commands: {
+                        boschOutdoorSiren: {
+                            ID: 240,
+                            parameters: [
+                                {name: 'data', type: DataType.UINT8},
+                            ],
+                        },
+                    },
+                    commandsResponse: {},
+                },
+            ),
             quirkCheckinInterval(0),
         ],
     },

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -715,6 +715,10 @@ const boschExtend = {
             'rocker_switch': 0x03,
             'rocker_switch_key_change': 0x04,
         };
+        const stateOffOn = {
+            'OFF': 0x00,
+            'ON': 0x01,
+        };
         const fromZigbee: Fz.Converter[] = [{
             cluster: 'boschSpecific',
             type: ['attributeReport', 'readResponse'],
@@ -1848,13 +1852,13 @@ const definitions: Definition[] = [
                         confirmButtonPressed: {
                             ID: 0x0010,
                             parameters: [
-                                {name: 'data', type: BuffaloZclDataType.BUFFER},
+                                {name: 'data', type: Zcl.BuffaloZclDataType.BUFFER},
                             ],
                         },
                         pairingCompleted: {
                             ID: 0x0012,
                             parameters: [
-                                {name: 'data', type: BuffaloZclDataType.BUFFER},
+                                {name: 'data', type: Zcl.BuffaloZclDataType.BUFFER},
                             ],
                         },
                     },


### PR DESCRIPTION
While some conversions to `modernExtend` are still quite basic, we at least can now finally remove `manuSpecificBosch*` from ZCL. 😎