### PR TITLE
Expose voltage for WISZB-120

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -588,7 +588,7 @@ const definitions: Definition[] = [
         description: 'Window sensor',
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery, develco.fz.temperature],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature()],
+        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature(), e.voltage()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Context: 'voltage' is in state, but not exposed. I'm using ni-mh rechargeable batteries, so the percentage is not as useful.