### PR TITLE
another keen SV01 model code

### DIFF
--- a/src/devices/keen_home.ts
+++ b/src/devices/keen_home.ts
@@ -26,7 +26,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['SV01-410-MP-1.0', 'SV01-410-MP-1.1', 'SV01-410-MP-1.4', 'SV01-410-MP-1.5', 'SV01-412-MP-1.0', 'SV01-412-MP-1.1',
             'SV01-412-MP-1.3', 'SV01-412-MP-1.4', 'SV01-610-MP-1.0', 'SV01-610-MP-1.1', 'SV01-612-MP-1.0', 'SV01-612-MP-1.1', 'SV01-612-MP-1.2',
-            'SV01-610-MP-1.4', 'SV01-612-MP-1.4'],
+            'SV01-610-MP-1.4', 'SV01-612-MP-1.4', 'SV01-612-EP-1.4'],
         model: 'SV01',
         vendor: 'Keen Home',
         description: 'Smart vent',


### PR DESCRIPTION
Not any different from any other SV01.
 
```
const {battery, identify, onOff, temperature, pressure} = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['SV01-612-EP-1.4'],
    model: 'SV01-612-EP-1.4',
    vendor: 'Keen Home Inc',
    description: 'Automatically generated definition',
    extend: [battery(), identify(), onOff({"powerOnBehavior":false}), temperature(), pressure()],
    meta: {},
};

module.exports = definition;
```