### PR TITLE
fix: ubisys writeStructure for config was not using ZLC.DataType

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -335,7 +335,7 @@ const ubisys = {
                                 selector: {},
                                 dataType: Zcl.DataType.ARRAY,
                                 elementData: {
-                                    elementType: 'data8',
+                                    elementType: Zcl.DataType.DATA8,
                                     elements: value.input_configurations,
                                 },
                             }],
@@ -344,7 +344,7 @@ const ubisys = {
                     } else {
                         await devMgmtEp.write(
                             'manuSpecificUbisysDeviceSetup',
-                            {[attributeInputConfigurations.name]: {elementType: 'data8', elements: value.input_configurations}},
+                            {[attributeInputConfigurations.name]: {elementType: Zcl.DataType.DATA8, elements: value.input_configurations}},
                             manufacturerOptions.ubisysNull,
                         );
                     }
@@ -360,7 +360,7 @@ const ubisys = {
                                 selector: {},
                                 dataType: Zcl.DataType.ARRAY,
                                 elementData: {
-                                    elementType: 'octetStr',
+                                    elementType: Zcl.DataType.OCTET_STR,
                                     elements: value.input_actions,
                                 },
                             }],
@@ -369,7 +369,7 @@ const ubisys = {
                     } else {
                         await devMgmtEp.write(
                             'manuSpecificUbisysDeviceSetup',
-                            {[attributeInputActions.name]: {elementType: 'octetStr', elements: value.input_actions}},
+                            {[attributeInputActions.name]: {elementType: Zcl.DataType.OCTET_STR, elements: value.input_actions}},
                             manufacturerOptions.ubisysNull,
                         );
                     }
@@ -563,7 +563,7 @@ const ubisys = {
                                 selector: {},
                                 dataType: Zcl.DataType.ARRAY,
                                 elementData: {
-                                    elementType: 'octetStr',
+                                    elementType: Zcl.DataType.OCTET_STR,
                                     elements: resultingInputActions,
                                 },
                             }],
@@ -572,7 +572,7 @@ const ubisys = {
                     } else {
                         await devMgmtEp.write(
                             'manuSpecificUbisysDeviceSetup',
-                            {[attributeInputActions.name]: {elementType: 'octetStr', elements: resultingInputActions}},
+                            {[attributeInputActions.name]: {elementType: Zcl.DataType.OCTET_STR, elements: resultingInputActions}},
                             manufacturerOptions.ubisysNull,
                         );
                     }


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/22785

I didn't save the pcaps, but I checked with wireshark that it looked the same as the earlier good capture after this change. The device also accepted and applied the config I pushed.