### PR TITLE
fix(detect): _TZE200_7ytb3h8u as Giex Water Valve

### DIFF
--- a/src/devices/giex.ts
+++ b/src/devices/giex.ts
@@ -68,6 +68,7 @@ const definitions: Definition[] = [
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE200_a7sghmms'},
             {modelID: 'TS0601', manufacturerName: '_TZE204_7ytb3h8u'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_7ytb3h8u'},
         ],
         exposes: [
             ...exportTemplates.giexWaterValve.exposes,


### PR DESCRIPTION
Bought a water valve that had support added a few months ago but despite looking identical, the `manufacturerName` is slightly different. Added the value reported as Zigbee Manufacturer in the z2m UI. 