### PR TITLE
Add _TZE204_myd45weu fingerprint to Tuya TS0601_soil sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1792,7 +1792,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_myd45weu', '_TZE200_ga1maeof', '_TZE200_2se8efxh']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_myd45weu', '_TZE200_ga1maeof', '_TZE200_2se8efxh', '_TZE204_myd45weu']),
         model: 'TS0601_soil',
         vendor: 'Tuya',
         description: 'Soil sensor',


### PR DESCRIPTION
Looks like there is a new fingerprint in Soil Sensors I bought recently which seems to have the same characteristics like `_TZE200_myd45weu` one.