### PR TITLE
WISZB-120: Use "battery_voltage" instead of "voltage"

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -588,7 +588,7 @@ const definitions: Definition[] = [
         description: 'Window sensor',
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery, develco.fz.temperature],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature(), e.voltage()],
+        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature(), e.battery_voltage()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         ota: ota.zigbeeOTA,
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Context: Currently, the wrong unit (V instead of mV) is reported for the battery voltage.