### PR TITLE
[New device support]: Tuya Soil sensor - TS0601 TZE284_g2e6cpnw 

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1812,7 +1812,7 @@ const definitions: Definition[] = [
     },
     {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE284_g2e6cpnw']),
-        model: 'TS0601_soil',
+        model: 'TS0601_soil_2',
         vendor: 'Tuya',
         description: 'Soil sensor',
         fromZigbee: [tuya.fz.datapoints],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1811,6 +1811,24 @@ const definitions: Definition[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_g2e6cpnw']),
+        model: 'TS0601_soil',
+        vendor: 'Tuya',
+        description: 'Soil sensor',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [e.temperature(), e.soil_moisture(), e.battery(), tuya.exposes.batteryState()],
+        meta: {
+            tuyaDatapoints: [
+                [3, 'soil_moisture', tuya.valueConverter.raw],
+                [5, 'temperature', tuya.valueConverter.divideBy10],
+                [102, 'battery_state', tuya.valueConverter.batteryState],
+                [110, 'battery', tuya.valueConverter.divideBy10],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_ip2akl4w', '_TZE200_1agwnems', '_TZE200_la2c2uo9', '_TZE200_579lguh2',
             '_TZE200_vucankjx', '_TZE200_4mh6tyyo', '_TZE204_hlx9tnzb', '_TZE204_n9ctkb6j', '_TZE204_9qhuzgo0', '_TZE200_9cxuhakf',
             '_TZE200_a0syesf5', '_TZE200_3p5ydos3', '_TZE200_swaamsoy', '_TZE200_ojzhk75b', '_TZE200_w4cryh2i', '_TZE200_dfxkcots',


### PR DESCRIPTION
## Link

https://www.aliexpress.com/item/1005007016626219.html

## Database entry

`{"id":19,"type":"EndDevice","ieeeAddr":"0xa4c1382e2ab69997","nwkAddr":40942,"manufId":4417,"manufName":"_TZE284_g2e6cpnw","powerSource":"Battery","modelId":"TS0601","epList":[1],"endpoints":{"1":{"profId":260,"epId":1,"devId":81,"inClusterList":[4,5,61184,0,60672],"outClusterList":[25,10],"clusters":{"genBasic":{"attributes":{"65487":14400,"65503":"��-\u0019��-\u0007\u0000\u0000\u0000\u0000\u0011","65506":56,"65508":1,"65534":0,"appVersion":77,"modelId":"TS0601","manufacturerName":"_TZE284_g2e6cpnw","powerSource":3,"zclVersion":3,"stackVersion":0,"hwVersion":1,"dateCode":""}}},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":77,"stackVersion":0,"hwVersion":1,"dateCode":"","zclVersion":3,"interviewCompleted":true,"meta":{"configured":-903893911},"lastSeen":1717618244776}`

## Comments

Device `0xa4c1382e2ab69997` with Zigbee model `TS0601` and manufacturer name `TZE284_g2e6cpnw`.

I'm not sure if the `102` datapoint is correct. 
I got the following debug info:

```
Received Zigbee message from 'Soil sensor', type 'commandDataReport', cluster 'manuSpecificTuya', data:
 '{
  "dpValues": [
    { "data": { "data": [2], "type": "Buffer" }, "datatype": 4, "dp": 102 }
  ],
  "seq": 3840
}' 
from endpoint 1 with groupID 0
```

The device sends the following messages more frequently:
```
{
    "dpValues": [
      {
        "data": { "data": [0, 0, 0, 0], "type": "Buffer" },
        "datatype": 2,
        "dp": 3
      },
      {
        "data": { "data": [0, 0, 1, 19], "type": "Buffer" },
        "datatype": 2,
        "dp": 5
      },
      {
        "data": { "data": [0, 0, 3, 47], "type": "Buffer" },
        "datatype": 2,
        "dp": 110
      }
    ],
    "seq": 3072
  }
```