### PR TITLE
feat: move manuSpecificIkeaAirPurifier to zhc

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -13,8 +13,9 @@ import {
     ikeaVoc, ikeaConfigureGenPollCtrl, tradfriOccupancy,
     tradfriRequestedBrightness, tradfriCommandsOnOff,
     tradfriCommandsLevelCtrl, styrbarCommandOn,
-    ikeaDotsClick, ikeaArrowClick,
-    ikeaMediaCommands, addCustomClusterManuSpecificIkeaAirPurifier,
+    ikeaDotsClick, ikeaArrowClick, ikeaMediaCommands,
+    addCustomClusterManuSpecificIkeaAirPurifier,
+    addCustomClusterManuSpecificIkeaVocIndexMeasurement,
 } from '../lib/ikea';
 
 const definitions: Definition[] = [
@@ -943,6 +944,7 @@ const definitions: Definition[] = [
         description: 'VINDSTYRKA air quality and humidity sensor',
         ota: ota.zigbeeOTA,
         extend: [
+            addCustomClusterManuSpecificIkeaVocIndexMeasurement(),
             deviceAddCustomCluster(
                 'pm25Measurement',
                 {

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -11,13 +11,10 @@ import {
     ikeaConfigureRemote, ikeaLight, ikeaOta, ikeaConfigureStyrbar,
     ikeaBattery, ikeaAirPurifier, legacy as ikeaLegacy,
     ikeaVoc, ikeaConfigureGenPollCtrl, tradfriOccupancy,
-    tradfriRequestedBrightness,
-    tradfriCommandsOnOff,
-    tradfriCommandsLevelCtrl,
-    styrbarCommandOn,
-    ikeaDotsClick,
-    ikeaArrowClick,
-    ikeaMediaCommands,
+    tradfriRequestedBrightness, tradfriCommandsOnOff,
+    tradfriCommandsLevelCtrl, styrbarCommandOn,
+    ikeaDotsClick, ikeaArrowClick,
+    ikeaMediaCommands, addCustomClusterManuSpecificIkeaAirPurifier,
 } from '../lib/ikea';
 
 const definitions: Definition[] = [
@@ -732,6 +729,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'STARKVIND air purifier',
         extend: [
+            addCustomClusterManuSpecificIkeaAirPurifier(),
             ikeaAirPurifier(),
             identify(),
             ikeaOta(),

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -7,18 +7,19 @@ import {
 import {
     LightArgs, light as lightDontUse, ota, ReportingConfigWithoutAttribute,
     timeLookup, numeric, NumericArgs, setupConfigureForBinding,
-    setupConfigureForReporting,
+    setupConfigureForReporting, deviceAddCustomCluster,
 } from '../lib/modernExtend';
+
 import {tradfri as ikea} from '../lib/ota';
 
 import tz from '../converters/toZigbee';
 import * as constants from '../lib/constants';
 import * as reporting from '../lib/reporting';
 import * as globalStore from '../lib/store';
-import * as zigbeeHerdsman from 'zigbee-herdsman/dist';
+import {Zcl} from 'zigbee-herdsman';
 import * as semver from 'semver';
 
-export const manufacturerOptions = {manufacturerCode: zigbeeHerdsman.Zcl.ManufacturerCode.IKEA_OF_SWEDEN};
+export const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.IKEA_OF_SWEDEN};
 
 const bulbOnEvent: OnEvent = async (type, data, device, options, state: KeyValue) => {
     /**
@@ -664,6 +665,29 @@ export function ikeaMediaCommands(): ModernExtend {
     const configure: Configure[] = [setupConfigureForBinding('genLevelCtrl', 'output')];
 
     return {exposes, fromZigbee, configure, isModernExtend: true};
+}
+
+export function addCustomClusterManuSpecificIkeaAirPurifier(): ModernExtend {
+    return deviceAddCustomCluster(
+        'manuSpecificIkeaAirPurifier',
+        {
+            ID: 0xfc7d,
+            manufacturerCode: Zcl.ManufacturerCode.IKEA_OF_SWEDEN,
+            attributes: {
+                filterRunTime: {ID: 0x0000, type: Zcl.DataType.UINT32},
+                replaceFilter: {ID: 0x0001, type: Zcl.DataType.UINT8},
+                filterLifeTime: {ID: 0x0002, type: Zcl.DataType.UINT32},
+                controlPanelLight: {ID: 0x0003, type: Zcl.DataType.BOOLEAN},
+                particulateMatter25Measurement: {ID: 0x0004, type: Zcl.DataType.UINT16},
+                childLock: {ID: 0x0005, type: Zcl.DataType.BOOLEAN},
+                fanMode: {ID: 0x0006, type: Zcl.DataType.UINT8},
+                fanSpeed: {ID: 0x0007, type: Zcl.DataType.UINT8},
+                deviceRunTime: {ID: 0x0008, type: Zcl.DataType.UINT32},
+            },
+            commands: {},
+            commandsResponse: {},
+        },
+    );
 }
 
 export const legacy = {

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -375,7 +375,7 @@ export function ikeaVoc(args?: Partial<NumericArgs>) {
     return numeric({
         name: 'voc_index',
         label: 'VOC index',
-        cluster: 'msIkeaVocIndexMeasurement',
+        cluster: 'manuSpecificIkeaVocIndexMeasurement',
         attribute: 'measuredValue',
         reporting: {min: '1_MINUTE', max: '2_MINUTES', change: 1},
         description: 'Sensirion VOC index',
@@ -683,6 +683,23 @@ export function addCustomClusterManuSpecificIkeaAirPurifier(): ModernExtend {
                 fanMode: {ID: 0x0006, type: Zcl.DataType.UINT8},
                 fanSpeed: {ID: 0x0007, type: Zcl.DataType.UINT8},
                 deviceRunTime: {ID: 0x0008, type: Zcl.DataType.UINT32},
+            },
+            commands: {},
+            commandsResponse: {},
+        },
+    );
+}
+
+export function addCustomClusterManuSpecificIkeaVocIndexMeasurement(): ModernExtend {
+    return deviceAddCustomCluster(
+        'manuSpecificIkeaVocIndexMeasurement',
+        {
+            ID: 0xfc7e,
+            manufacturerCode: Zcl.ManufacturerCode.IKEA_OF_SWEDEN,
+            attributes: {
+                measuredValue: {ID: 0x0000, type: Zcl.DataType.SINGLE_PREC},
+                measuredMinValue: {ID: 0x0001, type: Zcl.DataType.SINGLE_PREC},
+                measuredMaxValue: {ID: 0x0002, type: Zcl.DataType.SINGLE_PREC},
             },
             commands: {},
             commandsResponse: {},


### PR DESCRIPTION
Merge before https://github.com/Koenkk/zigbee-herdsman/pull/1083

Still working fine after cluster has been moved:

```
[2024-06-08 15:11:41] debug:    z2m: Publishing get 'get' 'pm25' to 'airpurifier/bedroom'
[2024-06-08 15:11:41] debug:    z2m: Received Zigbee message from 'airpurifier/bedroom', type 'readResponse', cluster 'manuSpecificIkeaAirPurifier', data '{"particulateMatter25Measurement":65535}' from endpoint 1 with groupID 0
[2024-06-08 15:11:47] debug:    z2m: Publishing 'set' 'child_lock' to 'airpurifier/bedroom'
[2024-06-08 15:11:50] debug:    z2m: Publishing get 'get' 'child_lock' to 'airpurifier/bedroom'
[2024-06-08 15:11:50] debug:    z2m: Received Zigbee message from 'airpurifier/bedroom', type 'readResponse', cluster 'manuSpecificIkeaAirPurifier', data '{"childLock":1}' from endpoint 1 with groupID 0
```