### PR TITLE
Add manuSpecificIkeaUnknown

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -14,6 +14,7 @@ import {
     tradfriRequestedBrightness, tradfriCommandsOnOff,
     tradfriCommandsLevelCtrl, styrbarCommandOn,
     ikeaDotsClick, ikeaArrowClick, ikeaMediaCommands,
+    addCustomClusterManuSpecificIkeaUnknown,
     addCustomClusterManuSpecificIkeaAirPurifier,
     addCustomClusterManuSpecificIkeaVocIndexMeasurement,
 } from '../lib/ikea';
@@ -398,7 +399,7 @@ const definitions: Definition[] = [
         model: 'LED1537R6/LED1739R5',
         vendor: 'IKEA',
         description: 'TRADFRI bulb GU10, white spectrum, 400 lm',
-        extend: [ikeaLight({colorTemp: true}), identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), identify()],
     },
     {
         zigbeeModel: ['TRADFRI bulb GU10 W 400lm'],
@@ -673,6 +674,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'FYRTUR roller blind, block-out',
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             ikeaConfigureGenPollCtrl(),
             windowCovering({controls: ['lift']}),
             identify(),
@@ -686,6 +688,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'KADRILJ roller blind',
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             ikeaConfigureGenPollCtrl(),
             windowCovering({controls: ['lift']}),
             identify(),
@@ -699,6 +702,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'PRAKTLYSING cellular blind',
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             ikeaConfigureGenPollCtrl(),
             windowCovering({controls: ['lift']}),
             identify(),
@@ -712,6 +716,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'TREDANSEN cellular blind, block-out',
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             ikeaConfigureGenPollCtrl(),
             windowCovering({controls: ['lift']}),
             identify(),
@@ -806,6 +811,7 @@ const definitions: Definition[] = [
         ],
         meta: {disableActionGroup: true},
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             ikeaConfigureRemote(),
             identify({isSleepy: true}),
             commandsOnOff({commands: ['on', 'off'], legacyAction: true}),
@@ -821,6 +827,7 @@ const definitions: Definition[] = [
         description: 'KNYCKLAN open/close water valve remote',
         meta: {disableActionGroup: true},
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             ikeaConfigureRemote(),
             identify({isSleepy: true}),
             commandsOnOff({commands: ['on', 'off']}),
@@ -835,6 +842,7 @@ const definitions: Definition[] = [
         description: 'TRADFRI shortcut button',
         meta: {disableActionGroup: true},
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             identify({isSleepy: true}),
             commandsOnOff({commands: ['on', 'off']}),
             commandsLevelCtrl({commands: ['brightness_move_up', 'brightness_stop']}),
@@ -899,6 +907,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'RODRET wireless dimmer/power switch',
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             bindCluster({cluster: 'genPollCtrl', clusterType: 'input'}),
             identify({isSleepy: true}),
             commandsOnOff({commands: ['on', 'off']}),
@@ -913,6 +922,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'SOMRIG shortcut button',
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             bindCluster({cluster: 'genPollCtrl', clusterType: 'input'}),
             deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
             identify({isSleepy: true}),
@@ -944,6 +954,7 @@ const definitions: Definition[] = [
         description: 'VINDSTYRKA air quality and humidity sensor',
         ota: ota.zigbeeOTA,
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             addCustomClusterManuSpecificIkeaVocIndexMeasurement(),
             deviceAddCustomCluster(
                 'pm25Measurement',
@@ -995,6 +1006,7 @@ const definitions: Definition[] = [
         vendor: 'IKEA',
         description: 'BADRING water leakage sensor',
         extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
             iasZoneAlarm({zoneType: 'water_leak', zoneAttributes: ['alarm_1']}),
             identify({isSleepy: true}),
             battery(),

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -707,6 +707,22 @@ export function addCustomClusterManuSpecificIkeaVocIndexMeasurement(): ModernExt
     );
 }
 
+// Seems to be present on newer IKEA devices like: VINDSTYRKA, RODRET, and BADRING
+//  Also observed on some older devices that had a post DIRIGERA release fw update.
+//  No attributes known.
+export function addCustomClusterManuSpecificIkeaUnknown(): ModernExtend {
+    return deviceAddCustomCluster(
+        'manuSpecificIkeaUnknown',
+        {
+            ID: 0xfc7c,
+            manufacturerCode: Zcl.ManufacturerCode.IKEA_OF_SWEDEN,
+            attributes: {},
+            commands: {},
+            commandsResponse: {},
+        },
+    );
+}
+
 export const legacy = {
     fromZigbee: {
         E1744_play_pause: {


### PR DESCRIPTION
Rebase after https://github.com/Koenkk/zigbee-herdsman-converters/pull/7614

Shows up on newer ikea devices and some devices that had a FW update post DIRIGERA.
Potentially needs to be added to more devices, but I added it on the ones I could verify had it, or devices sharing a fw with devices I verified.
e.g. all ikea blinds seem to share the same base firmware, so I added it to all of them.

I also observed some devices like STARKVIND, GUNNARP panel 40*40, FLOALT panel WS 30x90, and FLOALT panel WS 30x30 not having it.
These devices have not had a new FW release since DIRIGERA to my knowledge. So we can't just add it to all devices.

Since there are no known attributes, it's purely cosmetic but my weird itch is scratched, no more random numeric clusters on my IKEA devices. If we do every somehow get incoming date from one it should be easier to spot now.

<img width="392" alt="Screenshot 2024-06-08 at 16 32 17" src="https://github.com/Koenkk/zigbee-herdsman-converters/assets/379665/1bb025e2-f136-4aec-aed1-3a995f3b2227">

As per discord, It's OK to close and not merge this. But I was in here for the other 2 clusters anyway so not much effort to just do this one too.