### PR TITLE
Disable tuya smartplug polling when device is disabled

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -150,6 +150,8 @@ export async function onEventMeasurementPoll(type: OnEventType, data: OnEventDat
         clearTimeout(globalStore.getValue(device, 'measurement_poll'));
         globalStore.clearValue(device, 'measurement_poll');
     } else if (!globalStore.hasValue(device, 'measurement_poll')) {
+        const disabled=utils.isBoolean(options && options?.disabled) && options.disabled;
+        if (disabled) return;
         const seconds = utils.toNumber(
             options && options.measurement_poll_interval ? options.measurement_poll_interval : 60, 'measurement_poll_interval');
         if (seconds === -1) return;


### PR DESCRIPTION
These smartplugs require polling. but when the device is disabled, we sould not attempt to poll. 
otherwise we are spamming the network and the logs when the device is off

Log excerpt :
```log
[2024-06-08 17:54:34] debug:    zh:controller:endpoint: Error: ZCL command 0xieeeAddr/1 haElectricalMeasurement.read(["rmsVoltage","rmsCurrent","activePower"],>
[2024-06-08 17:55:34] debug:    zh:controller:endpoint: ZCL command 0xieeeAddr/1 haElectricalMeasurement.read(["rmsVoltage","rmsCurrent","activePower"], {"time>
[2024-06-08 17:55:34] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,0,1)
[2024-06-08 17:55:36] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,0)
[2024-06-08 17:55:38] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,1,1)
[2024-06-08 17:55:40] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,1)
[2024-06-08 17:55:40] debug:    zh:zstack: Discovering route to 49561
[2024-06-08 17:55:43] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,2,1)
[2024-06-08 17:55:44] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,2)
[2024-06-08 17:55:44] debug:    zh:zstack: Request network address of '0xieeeAddr'
[2024-06-08 17:55:54] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,3,1)
[2024-06-08 17:55:56] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,3)
[2024-06-08 17:55:58] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,4,1)
[2024-06-08 17:56:00] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,4)
[2024-06-08 17:56:00] debug:    zh:controller:endpoint: Error: ZCL command 0xieeeAddr/1 haElectricalMeasurement.read(["rmsVoltage","rmsCurrent","activePower"],>
[2024-06-08 17:57:00] debug:    zh:controller:endpoint: ZCL command 0xieeeAddr/1 haElectricalMeasurement.read(["rmsVoltage","rmsCurrent","activePower"], {"time>
[2024-06-08 17:57:00] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,0,2)
[2024-06-08 17:57:03] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,0)
[2024-06-08 17:57:05] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,1,2)
[2024-06-08 17:57:07] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,1)
[2024-06-08 17:57:07] debug:    zh:zstack: Discovering route to 49561
[2024-06-08 17:57:10] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,2,1)
[2024-06-08 17:57:12] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,2)
[2024-06-08 17:57:12] debug:    zh:zstack: Request network address of '0xieeeAddr'
[2024-06-08 17:57:22] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,3,1)
[2024-06-08 17:57:24] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,3)
[2024-06-08 17:57:26] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,4,1)
[2024-06-08 17:57:27] debug:    zh:zstack: Data confirm error (0xieeeAddr:49561,205,4)
[2024-06-08 17:57:27] debug:    zh:controller:endpoint: Error: ZCL command 0xieeeAddr/1 haElectricalMeasurement.read(["rmsVoltage","rmsCurrent","activePower"],>
[2024-06-08 17:58:27] debug:    zh:controller:endpoint: ZCL command 0xieeeAddr/1 haElectricalMeasurement.read(["rmsVoltage","rmsCurrent","activePower"], {"time>
[2024-06-08 17:58:27] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xieeeAddr:49561/1 (0,0,1)
```