### PR TITLE
Add "off" fan mode for Inovelli

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -66,7 +66,7 @@ const individualLedEffects: { [key: string]: number } = {
     clear_effect: 255,
 };
 
-const fanModes: { [key: string]: number } = {low: 2, smart: 4, medium: 86, high: 170, on: 255};
+const fanModes: { [key: string]: number } = {off: 0, low: 2, smart: 4, medium: 86, high: 170, on: 255};
 const breezemodes: string[] = ['off', 'low', 'medium', 'high'];
 
 const INOVELLI = 0x122f;
@@ -103,6 +103,9 @@ const intToFanMode = (value: number) => {
     }
     if (value == 4) {
         selectedMode = 'smart';
+    }
+    if (value == 0) {
+        selectedMode = 'off';
     }
     return selectedMode;
 };


### PR DESCRIPTION
Proposed fix for https://github.com/Koenkk/zigbee2mqtt/issues/22987.  Define "off" mode for fans, and allow conversion of 0% brightness to "off" fan mode.

I am generally not set up to be able to test this change personally, but due to the nature of it I am fairly confident this should resolve the issue. (If someone could point me towards how I could easily test this change in a HassOS environment, I would appreciate it)