### PR TITLE
fix(detect): Detect TRADFRI bulb E26 WS globe 1100lm as IKEA LED2201G8

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -214,10 +214,11 @@ const definitions: Definition[] = [
         zigbeeModel: [
             'TRADFRI bulb E27 WS globe 1055lm',
             'TRADFRI bulb E26 WS globe 1055lm',
+            'TRADFRI bulb E26 WS globe 1100lm',
         ],
         model: 'LED2201G8',
         vendor: 'IKEA',
-        description: 'TRADFRI bulb E26/27, white spectrum, globe, opal, 1055 lm',
+        description: 'TRADFRI bulb E26/27, white spectrum, globe, opal, 1055/1100 lm',
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), identify()],
     },
     {


### PR DESCRIPTION
I just bought two IKEA TRADFRI E26 1100lm bulbs and found them to be unsupported. After a little research it seems it's because this California-only version is not documented, hence this PR.

Edit: force-push due to lint issue