### PR TITLE
SPLZB-132: read develco specific sw/hw versions

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -354,6 +354,8 @@ const definitions: Definition[] = [
             await reporting.currentSummDelivered(endpoint, {change: [0, 20]}); // Limit reports to once every 5m, or 0.02kWh
             await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
             await reporting.acFrequency(endpoint);
+            // read develco specific attribute for sw and hw version
+            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {default: 2};
@@ -380,6 +382,8 @@ const definitions: Definition[] = [
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {change: [0, 20]}); // Limit reports to once every 5m, or 0.02kWh
             await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
+            // read develco specific attribute for sw and hw version
+            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {default: 2};

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -352,7 +352,11 @@ const definitions: Definition[] = [
             await reporting.rmsVoltage(endpoint, {min: constants.repInterval.MINUTES_5, change: 400}); // Limit reports to every 5m, or 4V
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {change: [0, 20]}); // Limit reports to once every 5m, or 0.02kWh
-            await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
+            /*
+                seMetering.instantaneousDemand and haElectricalMeasurement.activePower both return the same thing
+                spot checks indicate both return the exact same value, no point in having both report
+            */
+            // await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
             await reporting.acFrequency(endpoint);
             // read develco specific attribute for sw and hw version
             await develco.configure.read_sw_hw_version(device);
@@ -381,7 +385,11 @@ const definitions: Definition[] = [
             await reporting.rmsVoltage(endpoint, {min: constants.repInterval.MINUTES_5, change: 400}); // Limit reports to every 5m, or 4V
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {change: [0, 20]}); // Limit reports to once every 5m, or 0.02kWh
-            await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
+            /*
+                seMetering.instantaneousDemand and haElectricalMeasurement.activePower both return the same thing
+                spot checks indicate both return the exact same value, no point in having both report
+            */
+            // await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
             // read develco specific attribute for sw and hw version
             await develco.configure.read_sw_hw_version(device);
         },


### PR DESCRIPTION
Got one of these for testing, they also need the develco hack.

(I should really get these into a modernExtend sometime soonish, also I noticed hitting check OTA wipes the version as the default genBasic one is not responding, I wonder if there is a way to fix that too but don't see how for now, what does the post update read? I guess we could just not 'update' the value in case of null?

```
[2024-06-18 19:57:52] debug:    zh:controller:endpoint: Error: ZCL command 0x0015bc002f013891/2 genBasic.read(["dateCode","swBuildId"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')
[2024-06-18 19:57:52] info:     z2m: Device 'outlet/bathroom/heater' was updated from 'null' to 'null'
```
)

