### PR TITLE
feat(add): TS000F based TYZGTH4CH-D1RF

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8643,6 +8643,34 @@ const definitions: Definition[] = [
             ],
         },
     },
+    {
+        fingerprint: tuya.fingerprint('TS000F', ['_TZ3218_ya5d6wth']),
+        model: 'TYZGTH4CH-D1RF',
+        vendor: 'Mumubiz',
+        description: '4 channel changeover contact with temperature and humidity sensing',
+        extend: [
+            tuya.modernExtend.tuyaOnOff(
+                {
+                    powerOnBehavior2: true,
+                    onOffCountdown: true,
+                    endpoints: ['l1', 'l2', 'l3', 'l4'],
+                }
+            ),
+            tuya.modernExtend.dpTemperature({dp: 102, scale: 10}),
+            tuya.modernExtend.dpHumidity({dp: 103}),
+        ],
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2, 'l3': 3, 'l4': 4};
+        },
+        exposes: [],
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            for (const ep of [1, 2, 3, 4]) {
+                await reporting.bind(device.getEndpoint(ep), coordinatorEndpoint, ['genOnOff']);
+            }
+        },
+    },
 ];
 
 export default definitions;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8649,13 +8649,7 @@ const definitions: Definition[] = [
         vendor: 'Mumubiz',
         description: '4 channel changeover contact with temperature and humidity sensing',
         extend: [
-            tuya.modernExtend.tuyaOnOff(
-                {
-                    powerOnBehavior2: true,
-                    onOffCountdown: true,
-                    endpoints: ['l1', 'l2', 'l3', 'l4'],
-                }
-            ),
+            tuya.modernExtend.tuyaOnOff({powerOnBehavior2: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3', 'l4']}),
             tuya.modernExtend.dpTemperature({dp: 102, scale: 10}),
             tuya.modernExtend.dpHumidity({dp: 103}),
         ],


### PR DESCRIPTION
This change adds support for the Mumubiz TYZGTH4CH-D1RF
which is based on a Tuya ZT3L module and reports as TS000F.

The device has a connector that supports an external DHT-22 or alike one-wire temperature and humidity senor.
It might also have detection for DS18B20 sensors, but I can't verify it.