### PR TITLE
Adjust model detection for TRADFRI LED2106R3

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -437,6 +437,7 @@ const definitions: Definition[] = [
             'TRADFRIbulbGU10WS345lm',
             'TRADFRI bulb GU10 WS 345lm',
             'TRADFRIbulbGU10WS380lm',
+            'TRADFRI bulb GU10 WS 380lm',
         ],
         model: 'LED2005R5/LED2106R3',
         vendor: 'IKEA',


### PR DESCRIPTION
Newer releases of the TRADFRI GU10 LED2106R3 bulbs have slightly different modelId. Adjust the model detection to include the new modelId string.

This is a followup to Koenkk/zigbee2mqtt#20660.

Relevant DB entry:

```
{"id":5,"type":"Router","ieeeAddr":"0xb43522fffeef3de1","nwkAddr":25956,"manufId":4476,"manufName":"IKEA of Sweden","powerSource":"Mains (single phase)","modelId":"TRADFRI bulb GU10 WS 380lm","epList":[1,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":268,"inClusterList":[0,3,4,5,6,8,768,4096,64636],"outClusterList":[25],"clusters":{"lightingColorCtrl":{"attributes":{"colorCapabilities":16,"colorTempPhysicalMin":250,"colorTempPhysicalMax":454,"colorMode":2,"colorTemperature":370}},"genOnOff":{"attributes":{"onOff":1}},"genLevelCtrl":{"attributes":{"currentLevel":115}}},"binds":[],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[33],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":3,"stackVersion":113,"hwVersion":1,"dateCode":"20230926","swBuildId":"3.0.10","zclVersion":8,"interviewCompleted":true,"meta":{"configured":332242049},"lastSeen":1718921287096}
```