### PR TITLE
fix: add Namron ZigBee FOH Green Bryter K4 (4512727) to whitelabel list

### DIFF
--- a/src/devices/enocean.ts
+++ b/src/devices/enocean.ts
@@ -20,6 +20,7 @@ const definitions: Definition[] = [
             {vendor: 'Sunricher', model: 'SR-ZGP2801K4-FOH-E'},
             {vendor: 'LED-Trading', model: '9125'},
             {vendor: 'Feller', description: 'Smart light control for Philips Hue', model: '4120.2.S.FMI.61'},
+            {vendor: 'Namron', description: ' ZigBee FOH Green Bryter K4', model: '4512727'},
         ],
     },
     {


### PR DESCRIPTION
@Koenkk  per your request in https://github.com/Koenkk/zigbee2mqtt.io/pull/2832