### PR TITLE
Omit battery_low for models that don't have it

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -834,7 +834,7 @@ const definitions: Definition[] = [
             tuya.whitelabel('QA', 'QASD1', 'Door sensor', ['_TZ3000_udyjylt7']),
         ],
         exposes: (device, options) => {
-            const exps: Expose[] = [e.contact(), e.battery_low(), e.battery(), e.battery_voltage()];
+            const exps: Expose[] = [e.contact(), e.battery(), e.battery_voltage()];
             const noTamperModels = [ // manufacturerName for models without a tamper sensor
                 '_TZ3000_2mbfxlzr', // Tuya MC500A
                 '_TZ3000_n2egfsli', // Tuya 19DZT
@@ -845,6 +845,14 @@ const definitions: Definition[] = [
             ];
             if (!device || !noTamperModels.includes(device.manufacturerName)) {
                 exps.push(e.tamper());
+            }
+            const noBatteryLowModels = [
+                '_TZ3000_26fmupbb',
+                '_TZ3000_oxslv1c9',
+                '_TZ3000_osu834un',
+            ];
+            if (!device || !noBatteryLowModels.includes(device.manufacturerName)) {
+                exps.push(e.battery_low());
             }
             exps.push(e.linkquality());
             return exps;


### PR DESCRIPTION
The devices in this PR don't seem to actually ever send a battery alarm. I've only ever seen them report "normal" in z2m. I've been running a sniffer for 24 hours and `zbee_zcl_general.power_config.attr_id > 0x0021` shows no results. If I'm reading https://github.com/Koenkk/zigbee-herdsman/blob/73162478f5e5c3d9058bfada27dfff52b9d2c612/src/zspec/zcl/definition/cluster.ts#L71 right, if reported it should be reported with attribute ID `0x3E`.

Also, I've never had this value flip _before_ a battery dies, so I don't think it is just waiting for a failure state to send.