### PR TITLE
BHI-US: Add missing expose of button actions

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1910,6 +1910,19 @@ const definitions: Definition[] = [
             e.text('config_led_bottom_right_longpress', ea.ALL).withLabel('LED config (bottom right long press)')
                 .withDescription(labelLongPress)
                 .withCategory('config'),
+            e.action([
+                'button_top_left_release',
+                'button_top_right_release',
+                'button_bottom_left_release',
+                'button_bottom_right_release',
+                'button_top_left_longpress',
+                'button_top_right_longpress',
+                'button_bottom_left_longpress',
+                'button_bottom_right_longpress',
+                'button_top_left_longpress_release',
+                'button_top_right_longpress_release',
+                'button_bottom_left_longpress_release',
+                'button_bottom_right_longpress_release']),
         ],
         extend: [
             deviceAddCustomCluster(


### PR DESCRIPTION
According to the discussion in the original PR #6651, add the missing expose of button actions for Bosch BHI-US Universal Switch II (BHI-US)