### PR TITLE
Use 2.1-3V range for Third Reality 3RSS008Z switches

### DIFF
--- a/src/devices/third_reality.ts
+++ b/src/devices/third_reality.ts
@@ -41,6 +41,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         fromZigbee: [fz.on_off, fz.battery],
         toZigbee: [tz.on_off, tz.ignore_transition],
+        meta: {battery: {voltageToPercentage: '3V_2100'}},
         exposes: [e.switch(), e.battery(), e.battery_voltage()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
This matches what ZHA does at https://github.com/zigpy/zha-device-handlers/blob/9df7c3bdd7b37f46cf6e269cec2032aedde698c1/zhaquirks/thirdreality/switch.py#L22.

While the PR at https://github.com/zigpy/zha-device-handlers/pull/208 doesn't say so, I think someone must have tested to get these numbers as ZHA overrides their defaults for it while we are currently just using ours.