### PR TITLE
Add Whitelabel Elivco LSPA9 Smart Plug to `TS011F_plug_1`

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4336,6 +4336,7 @@ const definitions: Definition[] = [
             tuya.whitelabel('Moes', 'MOES_plug', 'Smart plug (with power monitoring)', ['_TZ3000_yujkchbz']),
             tuya.whitelabel('Moes', 'ZK-EU', 'Smart wallsocket (with power monitoring)', ['_TZ3000_ss98ec5d']),
             tuya.whitelabel('Nous', 'A1Z', 'Smart plug (with power monitoring)', ['_TZ3000_ksw8qtmt']),
+            tuya.whitelabel('Elivco', 'LSPA9', 'Smart plug (with power monitoring)', ['_TZ3000_okaz9tjs']),
         ],
         ota: ota.zigbeeOTA,
         extend: [tuya.modernExtend.tuyaOnOff({


### PR DESCRIPTION
This PR adds whitelabel `Elivco` model `LSPA9` (manufacturer name `_TZ3000_okaz9tjs`) to the existing `TS011F_plug_1`.

I noticed [the exception on the code for `_TZ3000_okaz9tjs`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/41b26f2025b0627f984ccf0da65ca4051bd404f0/src/devices/tuya.ts#L4351) and [duplicate entry `TS011F_plug_3`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/41b26f2025b0627f984ccf0da65ca4051bd404f0/src/devices/tuya.ts#L4391).

In my case, because it's shown as `TS011F_plug_1`, I put the white label to `TS011F_plug_1` instead of `TS011F_plug_3`.

## Product Image

![IMG_2716](https://github.com/Koenkk/zigbee-herdsman-converters/assets/277262/f361e271-54d4-4a95-8886-9c314739e302)

## Zigbee2MQTT Dashboard

![Screenshot 2024-06-23 at 21 29 01](https://github.com/Koenkk/zigbee-herdsman-converters/assets/277262/aa22d2a3-60c4-4cb9-a5d9-dd3583914fbf)

## Product URL

[Aliexpress](https://www.aliexpress.com/item/1005006082205547.html)

![Tuya-Smart-Plug-Zigbee-EU-16A-20A-Smart-Socket-With-Power-Monitor-Timing-Voice-Control-Works jpg_500x5000xz jpg_](https://github.com/Koenkk/zigbee-herdsman-converters/assets/277262/64b8fa66-adac-4ae7-8d5b-4713a59e53c6)

## Device Info

<details>
<summary>Device Info JSON</summary>

```json
{
  "id": 3,
  "type": "Router",
  "ieeeAddr": "0x70b3d52b6009d501",
  "nwkAddr": 34126,
  "manufId": 4660,
  "manufName": "_TZ3000_okaz9tjs",
  "powerSource": "Mains (single phase)",
  "modelId": "TS011F",
  "epList": [
    1
  ],
  "endpoints": {
    "1": {
      "profId": 260,
      "epId": 1,
      "devId": 256,
      "inClusterList": [
        0,
        6,
        3,
        4,
        5,
        4096,
        10,
        57345,
        57344,
        1794,
        2820
      ],
      "outClusterList": [
        25
      ],
      "clusters": {
        "genBasic": {
          "attributes": {
            "modelId": "TS011F",
            "manufacturerName": "_TZ3000_okaz9tjs",
            "powerSource": 1,
            "zclVersion": 3,
            "appVersion": 112,
            "stackVersion": 2,
            "hwVersion": 0,
            "swBuildId": "0122052017"
          }
        },
        "haElectricalMeasurement": {
          "attributes": {
            "acCurrentDivisor": 1000,
            "acCurrentMultiplier": 1,
            "rmsVoltage": 235,
            "rmsCurrent": 111,
            "activePower": 16
          }
        },
        "seMetering": {
          "attributes": {
            "divisor": 100,
            "multiplier": 1,
            "currentSummDelivered": [
              0,
              268
            ]
          }
        },
        "genOnOff": {
          "attributes": {
            "32768": 0,
            "moesStartUpOnOff": 2,
            "onOff": 1,
            "offWaitTime": 0,
            "tuyaBacklightMode": 1,
            "onTime": 0
          }
        }
      },
      "binds": [
        {
          "cluster": 6,
          "type": "endpoint",
          "deviceIeeeAddress": "0x90395efffe3ed413",
          "endpointID": 1
        },
        {
          "cluster": 2820,
          "type": "endpoint",
          "deviceIeeeAddress": "0x90395efffe3ed413",
          "endpointID": 1
        },
        {
          "cluster": 1794,
          "type": "endpoint",
          "deviceIeeeAddress": "0x90395efffe3ed413",
          "endpointID": 1
        }
      ],
      "configuredReportings": [
        {
          "cluster": 2820,
          "attrId": 1285,
          "minRepIntval": 5,
          "maxRepIntval": 3600,
          "repChange": 5,
          "manufacturerCode": null
        },
        {
          "cluster": 2820,
          "attrId": 1288,
          "minRepIntval": 5,
          "maxRepIntval": 3600,
          "repChange": 50,
          "manufacturerCode": null
        },
        {
          "cluster": 1794,
          "attrId": 0,
          "minRepIntval": 5,
          "maxRepIntval": 3600,
          "repChange": [
            1,
            1
          ],
          "manufacturerCode": null
        }
      ],
      "meta": {}
    }
  },
  "appVersion": 112,
  "stackVersion": 2,
  "hwVersion": 0,
  "swBuildId": "0122052017",
  "zclVersion": 3,
  "interviewCompleted": true,
  "meta": {
    "configured": 332242049
  },
  "lastSeen": 1719168373728
}
```

</details>



