### PR TITLE
Add endpoint number for P26

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1030,7 +1030,7 @@ const VZM36_ATTRIBUTES : {[s: string]: Attribute} = {
     },
     leadingTrailingEdge_1: {
         ID: 26,
-        dataType: Zcl.DataType.BOOLEAN,
+        dataType: Zcl.DataType.UINT8,
         displayType: 'enum',
         values: {'Leading Edge': 0, 'Trailing Edge': 1},
         min: 0,

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1028,7 +1028,7 @@ const VZM36_ATTRIBUTES : {[s: string]: Attribute} = {
         max: 254,
         description: 'Level of power output during Quick Start Light time (P23).',
     },
-    leadingTrailingEdge: {
+    leadingTrailingEdge_1: {
         ID: 26,
         dataType: Zcl.DataType.BOOLEAN,
         displayType: 'enum',


### PR DESCRIPTION
I believe we need the endpoint to make sure the configuration gets sent to the correct one. At the least it will be consistent with the rest of the vzm36 params.