### PR TITLE
feat: refactor develcoSpecificAirQuality into manuSpecificDevelcoAirQuality

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -34,28 +34,6 @@ const develcoLedControlMap = {
 
 // develco specific converters
 const develco = {
-    configure: {
-        read_sw_hw_version: async (device: Zh.Device) => {
-            for (const ep of device.endpoints) {
-                if (ep.supportsInputCluster('genBasic')) {
-                    try {
-                        const data = await ep.read('genBasic', ['develcoPrimarySwVersion', 'develcoPrimaryHwVersion'], manufacturerOptions);
-
-                        if (data.hasOwnProperty('develcoPrimarySwVersion')) {
-                            device.softwareBuildID = data.develcoPrimarySwVersion.join('.');
-                        }
-
-                        if (data.hasOwnProperty('develcoPrimaryHwVersion')) {
-                            device.hardwareVersion = data.develcoPrimaryHwVersion.join('.');
-                        }
-                    } catch (error) {
-                        /* catch timeouts of sleeping devices */
-                    }
-                    break;
-                }
-            }
-        },
-    },
     fz: {
         // Some Develco devices report strange values sometimes
         // https://github.com/Koenkk/zigbee2mqtt/issues/13329
@@ -313,7 +291,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.power_reactive(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -342,7 +320,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
         options: [exposes.options.precision(`ac_frequency`)],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -361,8 +339,6 @@ const definitions: Definition[] = [
             */
             // await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
             await reporting.acFrequency(endpoint);
-            // read develco specific attribute for sw and hw version
-            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {default: 2};
@@ -377,7 +353,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -394,8 +370,6 @@ const definitions: Definition[] = [
                 spot checks indicate both return the exact same value, no point in having both report
             */
             // await reporting.instantaneousDemand(endpoint, {min: constants.repInterval.MINUTES_5, change: 10});
-            // read develco specific attribute for sw and hw version
-            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {default: 2};
@@ -410,7 +384,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
@@ -435,7 +409,7 @@ const definitions: Definition[] = [
         fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering, develco.fz.device_temperature],
         toZigbee: [tz.on_off],
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -461,7 +435,7 @@ const definitions: Definition[] = [
         fromZigbee: [develco.fz.metering, develco.fz.electrical_measurement, develco.fz.total_power],
         toZigbee: [tz.EMIZB_132_mode],
         ota: ota.zigbeeOTA,
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
@@ -490,7 +464,6 @@ const definitions: Definition[] = [
             endpoint.saveClusterAttributeKeyValue('seMetering', {divisor: 1000, multiplier: 1});
             await reporting.currentSummDelivered(endpoint);
             await reporting.currentSummReceived(endpoint);
-            await develco.configure.read_sw_hw_version(device);
         },
         exposes: [
             e.numeric('power', ea.STATE).withUnit('W').withDescription('Total active power'),
@@ -532,7 +505,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
@@ -545,8 +518,6 @@ const definitions: Definition[] = [
             const endpoint2 = device.getEndpoint(38);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.temperature(endpoint2, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
-
-            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {default: 35};
@@ -574,7 +545,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
@@ -609,7 +580,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
@@ -622,8 +593,6 @@ const definitions: Definition[] = [
             const endpoint2 = device.getEndpoint(38);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.temperature(endpoint2, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
-
-            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {default: 35};
@@ -652,7 +621,7 @@ const definitions: Definition[] = [
         exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature(), e.battery_voltage()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         ota: ota.zigbeeOTA,
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             const endpoint38 = device.getEndpoint(38);
@@ -660,8 +629,6 @@ const definitions: Definition[] = [
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.batteryVoltage(endpoint35);
             await reporting.temperature(endpoint38);
-
-            await develco.configure.read_sw_hw_version(device);
         },
     },
     {
@@ -674,13 +641,11 @@ const definitions: Definition[] = [
         exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         ota: ota.zigbeeOTA,
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryVoltage(endpoint35);
-
-            await develco.configure.read_sw_hw_version(device);
         },
     },
     {
@@ -692,7 +657,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         exposes: [e.battery_low(), e.battery(), e.temperature(), e.vibration(), e.tamper()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
@@ -709,7 +674,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         exposes: [e.contact(), e.battery(), e.battery_low(), e.temperature()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             const endpoint38 = device.getEndpoint(38);
@@ -717,8 +682,6 @@ const definitions: Definition[] = [
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.batteryVoltage(endpoint35);
             await reporting.temperature(endpoint38);
-
-            await develco.configure.read_sw_hw_version(device);
         },
     },
     {
@@ -729,7 +692,6 @@ const definitions: Definition[] = [
         fromZigbee: [fz.ias_occupancy_alarm_1],
         toZigbee: [],
         exposes: [e.occupancy(), e.battery_low(), e.tamper()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
     },
     {
         zigbeeModel: ['MOSZB-140', 'GWA1511_MotionSensor'],
@@ -761,7 +723,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {default: 35};
         },
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), illuminance()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions(), illuminance()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
@@ -772,7 +734,7 @@ const definitions: Definition[] = [
             await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
 
             // zigbee2mqtt#14277 some features are not available on older firmwares
-            await develco.configure.read_sw_hw_version(device);
+            // modernExtend's readGenBasicPrimaryVersions is called before this one, should be fine
             if (device && device.softwareBuildID && Number(device.softwareBuildID.split('.')[0]) >= 3) {
                 await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
             }
@@ -789,7 +751,7 @@ const definitions: Definition[] = [
         fromZigbee: [fz.ias_occupancy_alarm_1],
         toZigbee: [],
         exposes: [e.occupancy(), e.battery_low()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
     },
     {
         whiteLabel: [{vendor: 'Frient', model: 'HMSZB-120', description: 'Temperature & humidity sensor', fingerprint: [{modelID: 'HMSZB-120'}]}],
@@ -802,14 +764,13 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         exposes: [e.battery(), e.battery_low(), e.temperature(), e.humidity()],
         meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(38);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg']);
             await reporting.temperature(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
             await reporting.humidity(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 300});
             await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-            await develco.configure.read_sw_hw_version(device);
         },
     },
     {
@@ -822,7 +783,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {default: 2};
         },
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering']);
@@ -860,7 +821,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {default: 2};
         },
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering']);
@@ -877,7 +838,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         ota: ota.zigbeeOTA,
         exposes: [e.battery_low(), e.tamper(), e.water_leak(), e.temperature(), e.battery_voltage()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
@@ -907,6 +868,7 @@ const definitions: Definition[] = [
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
         ],
         extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
@@ -926,8 +888,6 @@ const definitions: Definition[] = [
             await reporting.temperature(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
             await reporting.humidity(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 300});
             await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-
-            await develco.configure.read_sw_hw_version(device);
         },
     },
     {
@@ -938,7 +898,7 @@ const definitions: Definition[] = [
         fromZigbee: [develco.fz.temperature, fz.battery, fz.ias_enroll, fz.ias_wd, fz.ias_siren],
         toZigbee: [tz.warning, tz.warning_simple, tz.ias_max_duration, tz.squawk],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(43);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic']);
@@ -948,8 +908,6 @@ const definitions: Definition[] = [
 
             const endpoint2 = device.getEndpoint(1);
             await reporting.bind(endpoint2, coordinatorEndpoint, ['genOnOff']);
-
-            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {default: 43};
@@ -992,7 +950,7 @@ const definitions: Definition[] = [
         ],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '4LR6AA1_5v'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(44);
             const clusters = ['genPowerCfg', 'ssIasZone', 'ssIasAce', 'genIdentify'];
@@ -1035,7 +993,7 @@ const definitions: Definition[] = [
             e.switch_().withState('state', true, 'On/off state of switch 1').withEndpoint('l11'),
             e.switch_().withState('state', true, 'On/off state of switch 2').withEndpoint('l12'),
         ],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const ep2 = device.getEndpoint(112);
             await reporting.bind(ep2, coordinatorEndpoint, ['genBinaryInput', 'genBasic']);
@@ -1060,8 +1018,6 @@ const definitions: Definition[] = [
             const ep7 = device.getEndpoint(117);
             await reporting.bind(ep7, coordinatorEndpoint, ['genOnOff']);
             await reporting.onOff(ep7);
-
-            await develco.configure.read_sw_hw_version(device);
         },
         endpoint: (device) => {
             return {l1: 112, l2: 113, l3: 114, l4: 115, l11: 116, l12: 117};
@@ -1076,7 +1032,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         ota: ota.zigbeeOTA,
         exposes: [e.battery(), e.battery_voltage(), e.action(['single'])],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(32);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'genOnOff', 'genIdentify']);

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -5,6 +5,7 @@ import tz from '../converters/toZigbee';
 import * as constants from '../lib/constants';
 import * as exposes from '../lib/exposes';
 import {logger} from '../lib/logger';
+import {develcoModernExtend} from '../lib/develco';
 import {illuminance} from '../lib/modernExtend';
 import * as ota from '../lib/ota';
 import * as reporting from '../lib/reporting';
@@ -152,7 +153,7 @@ const develco = {
             },
         } satisfies Fz.Converter,
         voc: {
-            cluster: 'develcoSpecificAirQuality',
+            cluster: 'manuSpecificDevelcoAirQuality',
             type: ['attributeReport', 'readResponse'],
             convert: (model, msg, publish, options, meta) => {
                 // from Sensirion_Gas_Sensors_SGP3x_TVOC_Concept.pdf
@@ -884,17 +885,18 @@ const definitions: Definition[] = [
                 .enum('air_quality', ea.STATE, ['excellent', 'good', 'moderate', 'poor', 'unhealthy', 'out_of_range', 'unknown'])
                 .withDescription('Measured air quality'),
         ],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(38);
             await reporting.bind(endpoint, coordinatorEndpoint, [
-                'develcoSpecificAirQuality',
+                'manuSpecificDevelcoAirQuality',
                 'msTemperatureMeasurement',
                 'msRelativeHumidity',
                 'genPowerCfg',
             ]);
             await endpoint.configureReporting(
-                'develcoSpecificAirQuality',
+                'manuSpecificDevelcoAirQuality',
                 [{attribute: 'measuredValue', minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 10}],
                 manufacturerOptions,
             );

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -313,6 +313,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.power_reactive(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -341,6 +342,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
         options: [exposes.options.precision(`ac_frequency`)],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -375,6 +377,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -407,6 +410,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
@@ -431,6 +435,7 @@ const definitions: Definition[] = [
         fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering, develco.fz.device_temperature],
         toZigbee: [tz.on_off],
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
@@ -456,6 +461,7 @@ const definitions: Definition[] = [
         fromZigbee: [develco.fz.metering, develco.fz.electrical_measurement, develco.fz.total_power],
         toZigbee: [tz.EMIZB_132_mode],
         ota: ota.zigbeeOTA,
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['haElectricalMeasurement', 'seMetering']);
@@ -526,6 +532,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
@@ -567,6 +574,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
         exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
@@ -601,6 +609,7 @@ const definitions: Definition[] = [
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
@@ -643,6 +652,7 @@ const definitions: Definition[] = [
         exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature(), e.battery_voltage()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         ota: ota.zigbeeOTA,
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             const endpoint38 = device.getEndpoint(38);
@@ -664,6 +674,7 @@ const definitions: Definition[] = [
         exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         ota: ota.zigbeeOTA,
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
@@ -681,6 +692,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
         exposes: [e.battery_low(), e.battery(), e.temperature(), e.vibration(), e.tamper()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
@@ -697,6 +709,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         exposes: [e.contact(), e.battery(), e.battery_low(), e.temperature()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             const endpoint38 = device.getEndpoint(38);
@@ -716,6 +729,7 @@ const definitions: Definition[] = [
         fromZigbee: [fz.ias_occupancy_alarm_1],
         toZigbee: [],
         exposes: [e.occupancy(), e.battery_low(), e.tamper()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
     },
     {
         zigbeeModel: ['MOSZB-140', 'GWA1511_MotionSensor'],
@@ -723,7 +737,6 @@ const definitions: Definition[] = [
         vendor: 'Develco',
         description: 'Motion sensor',
         fromZigbee: [develco.fz.temperature, fz.ias_occupancy_alarm_1, fz.battery, develco.fz.led_control, develco.fz.ias_occupancy_timeout],
-        extend: [illuminance()],
         toZigbee: [develco.tz.led_control, develco.tz.ias_occupancy_timeout],
         exposes: (device, options) => {
             const dynExposes = [];
@@ -748,6 +761,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {default: 35};
         },
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), illuminance()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
@@ -775,6 +789,7 @@ const definitions: Definition[] = [
         fromZigbee: [fz.ias_occupancy_alarm_1],
         toZigbee: [],
         exposes: [e.occupancy(), e.battery_low()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
     },
     {
         whiteLabel: [{vendor: 'Frient', model: 'HMSZB-120', description: 'Temperature & humidity sensor', fingerprint: [{modelID: 'HMSZB-120'}]}],
@@ -787,6 +802,7 @@ const definitions: Definition[] = [
         ota: ota.zigbeeOTA,
         exposes: [e.battery(), e.battery_low(), e.temperature(), e.humidity()],
         meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(38);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg']);
@@ -806,6 +822,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {default: 2};
         },
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering']);
@@ -843,6 +860,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {default: 2};
         },
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
             await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering']);
@@ -859,6 +877,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         ota: ota.zigbeeOTA,
         exposes: [e.battery_low(), e.tamper(), e.water_leak(), e.temperature(), e.battery_voltage()],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
@@ -884,6 +903,10 @@ const definitions: Definition[] = [
             e
                 .enum('air_quality', ea.STATE, ['excellent', 'good', 'moderate', 'poor', 'unhealthy', 'out_of_range', 'unknown'])
                 .withDescription('Measured air quality'),
+        ],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality(),
         ],
         extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
@@ -915,6 +938,7 @@ const definitions: Definition[] = [
         fromZigbee: [develco.fz.temperature, fz.battery, fz.ias_enroll, fz.ias_wd, fz.ias_siren],
         toZigbee: [tz.warning, tz.warning_simple, tz.ias_max_duration, tz.squawk],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(43);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic']);
@@ -968,6 +992,7 @@ const definitions: Definition[] = [
         ],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '4LR6AA1_5v'}},
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(44);
             const clusters = ['genPowerCfg', 'ssIasZone', 'ssIasAce', 'genIdentify'];
@@ -1010,6 +1035,7 @@ const definitions: Definition[] = [
             e.switch_().withState('state', true, 'On/off state of switch 1').withEndpoint('l11'),
             e.switch_().withState('state', true, 'On/off state of switch 2').withEndpoint('l12'),
         ],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const ep2 = device.getEndpoint(112);
             await reporting.bind(ep2, coordinatorEndpoint, ['genBinaryInput', 'genBasic']);
@@ -1037,7 +1063,6 @@ const definitions: Definition[] = [
 
             await develco.configure.read_sw_hw_version(device);
         },
-
         endpoint: (device) => {
             return {l1: 112, l2: 113, l3: 114, l4: 115, l11: 116, l12: 117};
         },
@@ -1051,6 +1076,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         ota: ota.zigbeeOTA,
         exposes: [e.battery(), e.battery_voltage(), e.action(['single'])],
+        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(32);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'genOnOff', 'genIdentify']);

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -8,6 +8,17 @@ import {Fz, Tz, ModernExtend, Configure} from './types';
 const NS = 'zhc:develco';
 
 export const develcoModernExtend = {
+    addCustomClusterManuSpecificDevelcoGenBasic: () =>
+        deviceAddCustomCluster('genBasic', {
+            ID: 0x0000,
+            attributes: {
+                develcoPrimarySwVersion: {ID: 0x8000, type: Zcl.DataType.OCTET_STR, manufacturerCode: Zcl.ManufacturerCode.DEVELCO},
+                develcoPrimaryHwVersion: {ID: 0x8020, type: Zcl.DataType.OCTET_STR, manufacturerCode: Zcl.ManufacturerCode.DEVELCO},
+                develcoLedControl: {ID: 0x8100, type: Zcl.DataType.BITMAP8, manufacturerCode: Zcl.ManufacturerCode.DEVELCO},
+            },
+            commands: {},
+            commandsResponse: {},
+        }),
     addCustomClusterManuSpecificDevelcoAirQuality: () =>
         deviceAddCustomCluster('manuSpecificDevelcoAirQuality', {
             ID: 0xfc03,

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -1,0 +1,24 @@
+import {Zcl} from 'zigbee-herdsman';
+
+import {presets as e, access as ea} from './exposes';
+import {logger} from './logger';
+import {numeric, NumericArgs, deviceAddCustomCluster, setupConfigureForReporting} from './modernExtend';
+import {Fz, Tz, ModernExtend, Configure} from './types';
+
+const NS = 'zhc:develco';
+
+export const develcoModernExtend = {
+    addCustomClusterManuSpecificDevelcoAirQuality: () =>
+        deviceAddCustomCluster('manuSpecificDevelcoAirQuality', {
+            ID: 0xfc03,
+            manufacturerCode: Zcl.ManufacturerCode.DEVELCO,
+            attributes: {
+                measuredValue: {ID: 0x0000, type: Zcl.DataType.UINT16},
+                minMeasuredValue: {ID: 0x0001, type: Zcl.DataType.UINT16},
+                maxMeasuredValue: {ID: 0x0002, type: Zcl.DataType.UINT16},
+                resolution: {ID: 0x0003, type: Zcl.DataType.UINT16},
+            },
+            commands: {},
+            commandsResponse: {},
+        }),
+};

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -2,7 +2,7 @@ import {Zcl} from 'zigbee-herdsman';
 
 import {presets as e, access as ea} from './exposes';
 import {logger} from './logger';
-import {numeric, NumericArgs, deviceAddCustomCluster, setupConfigureForReporting} from './modernExtend';
+import {numeric, NumericArgs, ScaleFunction, deviceAddCustomCluster, setupConfigureForReporting} from './modernExtend';
 import {Fz, Tz, ModernExtend, Configure} from './types';
 
 const NS = 'zhc:develco';
@@ -74,7 +74,12 @@ export const develcoModernExtend = {
             // from Sensirion_Gas_Sensors_SGP3x_TVOC_Concept.pdf
             // "The mean molar mass of this mixture is 110 g/mol and hence,
             // 1 ppb TVOC corresponds to 4.5 μg/m3."
-            scale: 4.5,
+            scale: (value: number, type: 'from' | 'to') => {
+                if (type === 'from') {
+                    return value * 4.5;
+                }
+                return value;
+            },
             unit: 'µg/m³',
             access: 'STATE_GET',
             ...args,


### PR DESCRIPTION
Cleanup some of the develco stuff:
- [x] move clusters from zh to zhc
- [x] move attributes from zh to zhc
- [x] convert the sw/hw reading into modernExtend
- [x] move some of the specific attrbute based converters to modernExtend

Merge before https://github.com/Koenkk/zigbee-herdsman/pull/1097