### PR TITLE
Add support for Livolo Illuminance and Sound Sensor

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2455,6 +2455,23 @@ const converters1 = {
             }
         },
     } satisfies Fz.Converter,
+    livolo_illuminance_state: {
+        cluster: 'genPowerCfg',
+        type: ['raw'],
+        convert: (model, msg, publish, options, meta) => {
+            const dp = msg.data[12];
+            switch (dp) {
+            case 13:
+                return {
+                    illuminance: Number(msg.data[13]),
+                };
+            case 14:
+                return {
+                    noise_detected: msg.data[13] > 2,
+                };
+            }
+        },
+    } satisfies Fz.Converter,
     livolo_pir_state: {
         cluster: 'genPowerCfg',
         type: ['raw'],
@@ -2535,8 +2552,17 @@ const converters1 = {
             [122,209,             245,94,225,34,0,75,18,0,  7,1,7,1,0,11]  occupancy: false
 
             hygrometer
-            [122,209,             191,22,3,24,0,75,18,0, 14,1,8,21,14,11]  temperature: 21 degrees Celcius
+            [122,209,             191,22,3,24,0,75,18,0, 14,1,8,21,14,11]  temperature: 21 degrees Celsius
             [122,209,             191,22,3,24,0,75,18,0, 12,1,9,73,12,11]  humidity: 73%
+
+            illuminance
+            [124,210,21,216,128,  221,0,115,33,0,75,18,0,  19,12,0]          after interview
+            [122,209,             221,0,115,33,0,75,18,0,  12,1,14,4,12,11]  noise: 4 (most noise)
+            [122,209,             221,0,115,33,0,75,18,0,  12,1,14,3,12,11]  noise: 3 (more noise)
+            [122,209,             221,0,115,33,0,75,18,0,  12,1,14,2,12,11]  noise: 2 (no noise)
+            [122,209,             221,0,115,33,0,75,18,0,  12,1,14,2,12,11]  noise: 1 (?)
+            [122,209,             221,0,115,33,0,75,18,0,  12,1,13,20,12,11] lux: 20
+            [122,209,             221,0,115,33,0,75,18,0,  2,0,12,199,1,11]  ??
             */
             const malformedHeader = Buffer.from([0x7c, 0xd2, 0x15, 0xd8, 0x00]);
             const infoHeader = Buffer.from([0x7c, 0xd2, 0x15, 0xd8, 0x80]);
@@ -2589,6 +2615,11 @@ const converters1 = {
                 if (msg.data.includes(Buffer.from([19, 15, 0]), 13)) {
                     logger.debug('Detected Livolo Digital Hygrometer', NS);
                     meta.device.modelID = 'TI0001-hygrometer';
+                    meta.device.save();
+                }
+                if (msg.data.includes(Buffer.from([19, 12, 0]), 13)) {
+                    logger.debug('Detected Livolo Digital Illuminance and Sound Sensor', NS);
+                    meta.device.modelID = 'TI0001-illuminance';
                     meta.device.save();
                 }
             }

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2461,14 +2461,14 @@ const converters1 = {
         convert: (model, msg, publish, options, meta) => {
             const dp = msg.data[12];
             switch (dp) {
-            case 13:
-                return {
-                    illuminance: Number(msg.data[13]),
-                };
-            case 14:
-                return {
-                    noise_detected: msg.data[13] > 2,
-                };
+                case 13:
+                    return {
+                        illuminance: Number(msg.data[13]),
+                    };
+                case 14:
+                    return {
+                        noise_detected: msg.data[13] > 2,
+                    };
             }
         },
     } satisfies Fz.Converter,

--- a/src/devices/livolo.ts
+++ b/src/devices/livolo.ts
@@ -340,9 +340,7 @@ const definitions: Definition[] = [
         model: 'TI0001-illuminance',
         description: 'Zigbee Digital Illuminance and Sound Sensor',
         vendor: 'Livolo',
-        exposes: [
-            e.noise_detected(), e.illuminance().withUnit('%').withValueMin(0).withValueMax(100),
-        ],
+        exposes: [e.noise_detected(), e.illuminance().withUnit('%').withValueMin(0).withValueMax(100)],
         fromZigbee: [fz.livolo_illuminance_state],
         toZigbee: [],
         configure: poll,
@@ -354,7 +352,7 @@ const definitions: Definition[] = [
             if (['start', 'deviceAnnounce'].includes(type)) {
                 await poll(device);
                 if (!globalStore.hasValue(device, 'interval')) {
-                    const interval = setInterval(async () => await poll(device), 300*1000);
+                    const interval = setInterval(async () => await poll(device), 300 * 1000);
                     globalStore.putValue(device, 'interval', interval);
                 }
             }
@@ -363,8 +361,14 @@ const definitions: Definition[] = [
                 if (data.data[0] === 0x7a && data.data[1] === 0xd1) {
                     const endpoint = device.getEndpoint(6);
                     if (dp === 0x02) {
-                        const options = {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
-                            reservedBits: 3, direction: 1, writeUndiv: true};
+                        const options = {
+                            manufacturerCode: 0x1ad2,
+                            disableDefaultResponse: true,
+                            disableResponse: true,
+                            reservedBits: 3,
+                            direction: 1,
+                            writeUndiv: true,
+                        };
                         const payload = {0x2002: {value: [data.data[3], 0, 0, 0, 0, 0, 0], type: data.data[2]}};
                         await endpoint.readResponse('genPowerCfg', 0xe9, payload, options);
                     }

--- a/src/devices/livolo.ts
+++ b/src/devices/livolo.ts
@@ -335,6 +335,43 @@ const definitions: Definition[] = [
             }
         },
     },
+    {
+        zigbeeModel: ['TI0001-illuminance'],
+        model: 'TI0001-illuminance',
+        description: 'Zigbee Digital Illuminance and Sound Sensor',
+        vendor: 'Livolo',
+        exposes: [
+            e.noise_detected(), e.illuminance().withUnit('%').withValueMin(0).withValueMax(100),
+        ],
+        fromZigbee: [fz.livolo_illuminance_state],
+        toZigbee: [],
+        configure: poll,
+        onEvent: async (type, data, device) => {
+            if (type === 'stop') {
+                clearInterval(globalStore.getValue(device, 'interval'));
+                globalStore.clearValue(device, 'interval');
+            }
+            if (['start', 'deviceAnnounce'].includes(type)) {
+                await poll(device);
+                if (!globalStore.hasValue(device, 'interval')) {
+                    const interval = setInterval(async () => await poll(device), 300*1000);
+                    globalStore.putValue(device, 'interval', interval);
+                }
+            }
+            if (data.cluster === 'genPowerCfg' && data.type === 'raw') {
+                const dp = data.data[10];
+                if (data.data[0] === 0x7a && data.data[1] === 0xd1) {
+                    const endpoint = device.getEndpoint(6);
+                    if (dp === 0x02) {
+                        const options = {manufacturerCode: 0x1ad2, disableDefaultResponse: true, disableResponse: true,
+                            reservedBits: 3, direction: 1, writeUndiv: true};
+                        const payload = {0x2002: {value: [data.data[3], 0, 0, 0, 0, 0, 0], type: data.data[2]}};
+                        await endpoint.readResponse('genPowerCfg', 0xe9, payload, options);
+                    }
+                }
+            }
+        },
+    },
 ];
 
 export default definitions;

--- a/src/devices/livolo.ts
+++ b/src/devices/livolo.ts
@@ -338,7 +338,7 @@ const definitions: Definition[] = [
     {
         zigbeeModel: ['TI0001-illuminance'],
         model: 'TI0001-illuminance',
-        description: 'Zigbee Digital Illuminance and Sound Sensor',
+        description: 'Zigbee digital illuminance and sound sensor',
         vendor: 'Livolo',
         exposes: [e.noise_detected(), e.illuminance().withUnit('%').withValueMin(0).withValueMax(100)],
         fromZigbee: [fz.livolo_illuminance_state],


### PR DESCRIPTION
This add support for the [Livolo Illuminance and Sound Sensor (VL-FCJZ-2WP)](https://livolo.in.ua/en/mekhanizm-datchik-zvuka-zigbee-belyy-livolo-vl-fcjz-2wp/).

A couple of remarks/questions:

* The illuminance value reports between 0 and 100%. I hope this current Expose definition works for that.
* The noise value can be 1, 2, 3 and 4. The device manual calls these "silent", "normal", "lively" and "noisy". In practice I've rarely seen 1 ("silent"), but do see 2, 3 and 4. Perhaps I should implement this as an Enum expose. Would that be the best solution?
* I still need to make the device entry PR for zigbee2mqtt.io 