### PR TITLE
feat: migrate more to modernExtend for Develco devices

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -6,7 +6,7 @@ import * as constants from '../lib/constants';
 import {develcoModernExtend} from '../lib/develco';
 import * as exposes from '../lib/exposes';
 import {logger} from '../lib/logger';
-import {humidity, illuminance} from '../lib/modernExtend';
+import {battery, humidity, illuminance} from '../lib/modernExtend';
 import * as ota from '../lib/ota';
 import * as reporting from '../lib/reporting';
 import * as globalStore from '../lib/store';
@@ -441,20 +441,26 @@ const definitions: Definition[] = [
             {vendor: 'Frient', model: '94430', description: 'Smart Intelligent Smoke Alarm'},
             {vendor: 'Cavius', model: '2103', description: 'RF SMOKE ALARM, 5 YEAR 65MM'},
         ],
-        fromZigbee: [fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
+        fromZigbee: [fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
-            develcoModernExtend.temperature(),
+            develcoModernExtend.temperature(), // TODO: ep 38
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']);
-            await reporting.batteryVoltage(endpoint);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
@@ -463,7 +469,6 @@ const definitions: Definition[] = [
             return {default: 35};
         },
         exposes: [
-            e.battery(),
             e.smoke(),
             e.battery_low(),
             e.test(),
@@ -507,20 +512,26 @@ const definitions: Definition[] = [
         vendor: 'Develco',
         description: 'Fire detector with siren',
         whiteLabel: [{vendor: 'Frient', model: '94431', description: 'Smart Intelligent Heat Alarm'}],
-        fromZigbee: [fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
+        fromZigbee: [fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
-            develcoModernExtend.temperature(),
+            develcoModernExtend.temperature(), // TODO: ep 38
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']);
-            await reporting.batteryVoltage(endpoint);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
@@ -529,7 +540,6 @@ const definitions: Definition[] = [
             return {default: 35};
         },
         exposes: [
-            e.battery(),
             e.smoke(),
             e.battery_low(),
             e.test(),
@@ -546,78 +556,101 @@ const definitions: Definition[] = [
         model: 'WISZB-120',
         vendor: 'Develco',
         description: 'Window sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
+        fromZigbee: [fz.ias_contact_alarm_1],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.battery_voltage()],
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
+        exposes: [e.contact(), e.battery_low(), e.tamper()],
         ota: ota.zigbeeOTA,
+        endpoint: (device) => {
+            return {default: 35};
+        },
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
-            develcoModernExtend.temperature(),
+            develcoModernExtend.temperature(), // TODO: ep 38
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint35 = device.getEndpoint(35);
-            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint35);
-        },
     },
     {
         zigbeeModel: ['WISZB-121'],
         model: 'WISZB-121',
         vendor: 'Develco',
         description: 'Window sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
+        fromZigbee: [fz.ias_contact_alarm_1],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper()],
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
+        exposes: [e.contact(), e.battery_low(), e.tamper()],
         ota: ota.zigbeeOTA,
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint35 = device.getEndpoint(35);
-            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint35);
+        endpoint: (device) => {
+            return {default: 35};
         },
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
+        ],
     },
     {
         zigbeeModel: ['WISZB-137'],
         model: 'WISZB-137',
         vendor: 'Develco',
         description: 'Vibration sensor',
-        fromZigbee: [fz.battery, fz.ias_vibration_alarm_1],
+        fromZigbee: [fz.ias_vibration_alarm_1],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: '3V_2100'}},
-        exposes: [e.battery_low(), e.battery(), e.vibration(), e.tamper()],
+        exposes: [e.battery_low(), e.vibration(), e.tamper()],
+        endpoint: (device) => {
+            return {default: 38};
+        },
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),
+            battery({
+                voltageToPercentage: '3V_2100',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint38 = device.getEndpoint(38);
-            await reporting.bind(endpoint38, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint38);
-        },
     },
     {
         zigbeeModel: ['WISZB-138', 'GWA1513_WindowSensor'],
         model: 'WISZB-138',
         vendor: 'Develco',
         description: 'Window sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
+        fromZigbee: [fz.ias_contact_alarm_1],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_low()],
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
+        exposes: [e.contact(), e.battery_low()],
+        endpoint: (device) => {
+            return {default: 35};
+        },
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint35 = device.getEndpoint(35);
-            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint35);
-        },
     },
     {
         zigbeeModel: ['MOSZB-130'],
@@ -633,7 +666,7 @@ const definitions: Definition[] = [
         model: 'MOSZB-140',
         vendor: 'Develco',
         description: 'Motion sensor',
-        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, develco.fz.led_control, develco.fz.ias_occupancy_timeout],
+        fromZigbee: [fz.ias_occupancy_alarm_1, develco.fz.led_control, develco.fz.ias_occupancy_timeout],
         toZigbee: [develco.tz.led_control, develco.tz.ias_occupancy_timeout],
         exposes: (device, options) => {
             const dynExposes = [];
@@ -643,7 +676,6 @@ const definitions: Definition[] = [
             }
             dynExposes.push(e.tamper());
             dynExposes.push(e.battery_low());
-            dynExposes.push(e.battery());
             if (device && device.softwareBuildID && Number(device.softwareBuildID.split('.')[0]) >= 4) {
                 dynExposes.push(
                     e.enum('led_control', ea.ALL, ['off', 'fault_only', 'motion_only', 'both']).withDescription('Control LED indicator usage.'),
@@ -653,23 +685,27 @@ const definitions: Definition[] = [
             return dynExposes;
         },
         ota: ota.zigbeeOTA,
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
         endpoint: (device) => {
             return {default: 35};
         },
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
-            illuminance(),
-            develcoModernExtend.temperature(),
+            develcoModernExtend.temperature(), // TODO: ep 38
+            illuminance(), // TODO: ep 39
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
         configure: async (device, coordinatorEndpoint) => {
-            const endpoint35 = device.getEndpoint(35);
-            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-
             // zigbee2mqtt#14277 some features are not available on older firmwares
             // modernExtend's readGenBasicPrimaryVersions is called before this one, should be fine
+            const endpoint35 = device.getEndpoint(35);
             if (device && device.softwareBuildID && Number(device.softwareBuildID.split('.')[0]) >= 3) {
                 await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
             }
@@ -694,23 +730,25 @@ const definitions: Definition[] = [
         model: 'HMSZB-110',
         vendor: 'Develco',
         description: 'Temperature & humidity sensor',
-        fromZigbee: [fz.battery],
-        toZigbee: [],
         ota: ota.zigbeeOTA,
-        exposes: [e.battery()],
-        meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
+        endpoint: (device) => {
+            return {default: 38};
+        },
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),
             humidity(),
+            battery({
+                voltageToPercentage: '3V_2500_3200',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
             develcoModernExtend.batteryLowAA(),
         ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(38);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['msRelativeHumidity', 'genPowerCfg']);
-            await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-        },
     },
     {
         zigbeeModel: ['ZHEMI101'],
@@ -773,19 +811,26 @@ const definitions: Definition[] = [
         model: 'FLSZB-110',
         vendor: 'Develco',
         description: 'Flood alarm device ',
-        fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
+        fromZigbee: [fz.ias_water_leak_alarm_1],
         toZigbee: [],
         ota: ota.zigbeeOTA,
-        exposes: [e.battery_low(), e.tamper(), e.water_leak(), e.battery_voltage()],
+        exposes: [e.battery_low(), e.tamper(), e.water_leak()],
+        endpoint: (device) => {
+            return {default: 35};
+        },
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
-            develcoModernExtend.temperature(),
+            develcoModernExtend.temperature(), // TODO: ep 38
+            battery({
+                voltageToPercentage: {min: 2800, max: 3000},
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint35 = device.getEndpoint(35);
-            await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-        },
     },
     {
         zigbeeModel: ['AQSZB-110'],
@@ -793,9 +838,9 @@ const definitions: Definition[] = [
         vendor: 'Develco',
         description: 'Air quality sensor',
         ota: ota.zigbeeOTA,
-        fromZigbee: [fz.battery],
-        toZigbee: [],
-        exposes: [e.battery()],
+        endpoint: (device) => {
+            return {default: 38};
+        },
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality(),
@@ -804,32 +849,40 @@ const definitions: Definition[] = [
             develcoModernExtend.airQuality(),
             develcoModernExtend.temperature(),
             humidity(),
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
             develcoModernExtend.batteryLowAA(),
         ],
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(38);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
-        },
     },
     {
         zigbeeModel: ['SIRZB-110', 'SIRZB-111'],
         model: 'SIRZB-110',
         vendor: 'Develco',
         description: 'Customizable siren',
-        fromZigbee: [fz.battery, fz.ias_enroll, fz.ias_wd, fz.ias_siren],
+        fromZigbee: [fz.ias_enroll, fz.ias_wd, fz.ias_siren],
         toZigbee: [tz.warning, tz.warning_simple, tz.ias_max_duration, tz.squawk],
-        meta: {battery: {voltageToPercentage: '3V_2500'}},
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),
+            battery({
+                voltageToPercentage: '3V_2500',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(43);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic']);
-            await reporting.batteryVoltage(endpoint);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd', 'genBasic']);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('ssIasWd', ['maxDuration']);
 
@@ -841,7 +894,6 @@ const definitions: Definition[] = [
         },
         whiteLabel: [{model: 'SIRZB-111', vendor: 'Develco', description: 'Customizable siren', fingerprint: [{modelID: 'SIRZB-111'}]}],
         exposes: [
-            e.battery(),
             e.battery_low(),
             e.test(),
             e.warning(),
@@ -858,7 +910,6 @@ const definitions: Definition[] = [
         whiteLabel: [{vendor: 'Frient', model: 'KEPZB-110'}],
         fromZigbee: [
             fz.command_arm_with_transaction,
-            fz.battery,
             fz.command_emergency,
             fz.ias_no_alarm,
             fz.ignore_iaszone_attreport,
@@ -866,9 +917,7 @@ const definitions: Definition[] = [
         ],
         toZigbee: [tz.arm_mode],
         exposes: [
-            e.battery(),
             e.battery_low(),
-            e.battery_voltage(),
             e.tamper(),
             e.text('action_code', ea.STATE).withDescription('Pin code introduced.'),
             e.numeric('action_transaction', ea.STATE).withDescription('Last action transaction number.'),
@@ -876,13 +925,22 @@ const definitions: Definition[] = [
             e.action(['disarm', 'arm_day_zones', 'arm_night_zones', 'arm_all_zones', 'exit_delay', 'emergency']),
         ],
         ota: ota.zigbeeOTA,
-        meta: {battery: {voltageToPercentage: '4LR6AA1_5v'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            battery({
+                voltageToPercentage: '4LR6AA1_5v',
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(44);
-            const clusters = ['genPowerCfg', 'ssIasZone', 'ssIasAce', 'genIdentify'];
+            const clusters = ['ssIasZone', 'ssIasAce', 'genIdentify'];
             await reporting.bind(endpoint, coordinatorEndpoint, clusters);
-            await reporting.batteryVoltage(endpoint);
         },
         endpoint: (device) => {
             return {default: 44};
@@ -955,15 +1013,25 @@ const definitions: Definition[] = [
         model: 'SBTZB-110',
         vendor: 'Develco',
         description: 'Smart button',
-        fromZigbee: [fz.ewelink_action, fz.battery],
+        fromZigbee: [fz.ewelink_action],
         toZigbee: [],
         ota: ota.zigbeeOTA,
-        exposes: [e.battery(), e.battery_voltage(), e.action(['single'])],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        exposes: [e.action(['single'])],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            battery({
+                voltageToPercentage: {min: 2200, max: 3000},
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(32);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'genOnOff', 'genIdentify']);
-            await reporting.batteryVoltage(endpoint);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genIdentify']);
         },
         endpoint: (device) => {
             return {default: 32};

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -6,7 +6,7 @@ import * as constants from '../lib/constants';
 import {develcoModernExtend} from '../lib/develco';
 import * as exposes from '../lib/exposes';
 import {logger} from '../lib/logger';
-import {illuminance} from '../lib/modernExtend';
+import {humidity, illuminance} from '../lib/modernExtend';
 import * as ota from '../lib/ota';
 import * as reporting from '../lib/reporting';
 import * as globalStore from '../lib/store';
@@ -694,21 +694,21 @@ const definitions: Definition[] = [
         model: 'HMSZB-110',
         vendor: 'Develco',
         description: 'Temperature & humidity sensor',
-        fromZigbee: [fz.battery, fz.humidity],
+        fromZigbee: [fz.battery],
         toZigbee: [],
         ota: ota.zigbeeOTA,
-        exposes: [e.battery(), e.humidity()],
+        exposes: [e.battery()],
         meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
-            develcoModernExtend.batteryLowAA(),
             develcoModernExtend.temperature(),
+            humidity(),
+            develcoModernExtend.batteryLowAA(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(38);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msRelativeHumidity', 'genPowerCfg']);
-            await reporting.humidity(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 300});
             await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
         },
     },
@@ -793,9 +793,9 @@ const definitions: Definition[] = [
         vendor: 'Develco',
         description: 'Air quality sensor',
         ota: ota.zigbeeOTA,
-        fromZigbee: [fz.humidity],
+        fromZigbee: [fz.battery],
         toZigbee: [],
-        exposes: [e.humidity(), e.battery()],
+        exposes: [e.battery()],
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality(),
@@ -803,13 +803,13 @@ const definitions: Definition[] = [
             develcoModernExtend.voc(),
             develcoModernExtend.airQuality(),
             develcoModernExtend.temperature(),
+            humidity(),
             develcoModernExtend.batteryLowAA(),
         ],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(38);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['msRelativeHumidity', 'genPowerCfg']);
-            await reporting.humidity(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 300});
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
         },
     },

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -59,14 +59,6 @@ const develco = {
                 return result;
             },
         } satisfies Fz.Converter,
-        device_temperature: {
-            ...fz.device_temperature,
-            convert: (model, msg, publish, options, meta) => {
-                if (msg.data.currentTemperature !== -0x8000) {
-                    return fz.device_temperature.convert(model, msg, publish, options, meta);
-                }
-            },
-        } satisfies Fz.Converter,
         metering: {
             ...fz.metering,
             convert: (model, msg, publish, options, meta) => {
@@ -231,16 +223,19 @@ const definitions: Definition[] = [
         model: 'SPLZB-131',
         vendor: 'Develco',
         description: 'Power plug',
-        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering, develco.fz.device_temperature],
+        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
-        exposes: [e.switch(), e.power(), e.power_reactive(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        exposes: [e.switch(), e.power(), e.power_reactive(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.deviceTemperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
-            await reporting.deviceTemperature(endpoint);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint, true);
             await reporting.activePower(endpoint, {change: 10}); // Power reports with every 10W change
             await reporting.rmsCurrent(endpoint, {change: 20}); // Current reports with every 20mA change
@@ -259,17 +254,20 @@ const definitions: Definition[] = [
         model: 'SPLZB-132',
         vendor: 'Develco',
         description: 'Power plug',
-        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering, develco.fz.device_temperature],
+        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature(), e.ac_frequency()],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.ac_frequency()],
         options: [exposes.options.precision(`ac_frequency`)],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.deviceTemperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
-            await reporting.deviceTemperature(endpoint);
             // Set to true, to access the acFrequencyDivisor and acFrequencyMultiplier attribute. Not all devices support this.
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint, true);
             await reporting.activePower(endpoint, {change: 10}); // Power reports with every 10W change
@@ -293,16 +291,19 @@ const definitions: Definition[] = [
         model: 'SPLZB-134',
         vendor: 'Develco',
         description: 'Power plug (type G)',
-        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering, develco.fz.device_temperature],
+        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
         toZigbee: [tz.on_off],
         ota: ota.zigbeeOTA,
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.deviceTemperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
-            await reporting.deviceTemperature(endpoint, {change: 2}); // Device temperature reports with 2 degree change
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint, {change: 10}); // Power reports with every 10W change
             await reporting.rmsCurrent(endpoint, {change: 20}); // Current reports with every 20mA change
@@ -350,15 +351,18 @@ const definitions: Definition[] = [
         model: 'SMRZB-143',
         vendor: 'Develco',
         description: 'Smart cable',
-        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering, develco.fz.device_temperature],
+        fromZigbee: [fz.on_off, develco.fz.electrical_measurement, develco.fz.metering],
         toZigbee: [tz.on_off],
-        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy(), e.device_temperature()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        exposes: [e.switch(), e.power(), e.current(), e.voltage(), e.energy()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.deviceTemperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering', 'genDeviceTempCfg']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'haElectricalMeasurement', 'seMetering']);
             await reporting.onOff(endpoint);
-            await reporting.deviceTemperature(endpoint, {change: 2}); // Device temperature reports with 2 degree change
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint, {change: 10}); // Power reports with every 10W change
             await reporting.rmsCurrent(endpoint, {change: 20}); // Current reports with every 20mA change

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -568,12 +568,11 @@ const definitions: Definition[] = [
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(), // TODO: ep 38
             battery({
-                voltageToPercentage: '3V_2500',
                 percentage: true,
                 voltage: true,
                 lowStatus: false,
                 voltageReporting: true,
-                percentageReporting: false,
+                percentageReporting: true,
             }),
         ],
     },

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -67,14 +67,6 @@ const develco = {
                 }
             },
         } satisfies Fz.Converter,
-        temperature: {
-            ...fz.temperature,
-            convert: (model, msg, publish, options, meta) => {
-                if (msg.data.measuredValue !== -0x8000 && msg.data.measuredValue !== 0xffff) {
-                    return fz.temperature.convert(model, msg, publish, options, meta);
-                }
-            },
-        } satisfies Fz.Converter,
         metering: {
             ...fz.metering,
             convert: (model, msg, publish, options, meta) => {
@@ -445,19 +437,15 @@ const definitions: Definition[] = [
             {vendor: 'Frient', model: '94430', description: 'Smart Intelligent Smoke Alarm'},
             {vendor: 'Cavius', model: '2103', description: 'RF SMOKE ALARM, 5 YEAR 65MM'},
         ],
-        fromZigbee: [
-            develco.fz.temperature,
-            fz.battery,
-            fz.ias_smoke_alarm_1_develco,
-            fz.ignore_basic_report,
-            fz.ias_enroll,
-            fz.ias_wd,
-            develco.fz.fault_status,
-        ],
+        fromZigbee: [fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
@@ -466,16 +454,11 @@ const definitions: Definition[] = [
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
-
-            const endpoint2 = device.getEndpoint(38);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint2, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
         },
         endpoint: (device) => {
             return {default: 35};
         },
         exposes: [
-            e.temperature(),
             e.battery(),
             e.smoke(),
             e.battery_low(),
@@ -520,19 +503,15 @@ const definitions: Definition[] = [
         vendor: 'Develco',
         description: 'Fire detector with siren',
         whiteLabel: [{vendor: 'Frient', model: '94431', description: 'Smart Intelligent Heat Alarm'}],
-        fromZigbee: [
-            develco.fz.temperature,
-            fz.battery,
-            fz.ias_smoke_alarm_1_develco,
-            fz.ignore_basic_report,
-            fz.ias_enroll,
-            fz.ias_wd,
-            develco.fz.fault_status,
-        ],
+        fromZigbee: [fz.battery, fz.ias_smoke_alarm_1_develco, fz.ignore_basic_report, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
         toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
         ota: ota.zigbeeOTA,
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
@@ -541,16 +520,11 @@ const definitions: Definition[] = [
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
-
-            const endpoint2 = device.getEndpoint(38);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint2, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
         },
         endpoint: (device) => {
             return {default: 35};
         },
         exposes: [
-            e.temperature(),
             e.battery(),
             e.smoke(),
             e.battery_low(),
@@ -568,19 +542,20 @@ const definitions: Definition[] = [
         model: 'WISZB-120',
         vendor: 'Develco',
         description: 'Window sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery, develco.fz.temperature],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.temperature(), e.battery_voltage()],
+        exposes: [e.contact(), e.battery(), e.battery_low(), e.tamper(), e.battery_voltage()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         ota: ota.zigbeeOTA,
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
-            const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.batteryVoltage(endpoint35);
-            await reporting.temperature(endpoint38);
         },
     },
     {
@@ -605,15 +580,18 @@ const definitions: Definition[] = [
         model: 'WISZB-137',
         vendor: 'Develco',
         description: 'Vibration sensor',
-        fromZigbee: [fz.battery, fz.ias_vibration_alarm_1, fz.temperature],
+        fromZigbee: [fz.battery, fz.ias_vibration_alarm_1],
         toZigbee: [],
         meta: {battery: {voltageToPercentage: '3V_2100'}},
-        exposes: [e.battery_low(), e.battery(), e.temperature(), e.vibration(), e.tamper()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        exposes: [e.battery_low(), e.battery(), e.vibration(), e.tamper()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint38 = device.getEndpoint(38);
-            await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);
-            await reporting.temperature(endpoint38);
+            await reporting.bind(endpoint38, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryVoltage(endpoint38);
         },
     },
@@ -622,18 +600,19 @@ const definitions: Definition[] = [
         model: 'WISZB-138',
         vendor: 'Develco',
         description: 'Window sensor',
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery, develco.fz.temperature],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_low(), e.temperature()],
+        exposes: [e.contact(), e.battery(), e.battery_low()],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
-            const endpoint38 = device.getEndpoint(38);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
             await reporting.batteryVoltage(endpoint35);
-            await reporting.temperature(endpoint38);
         },
     },
     {
@@ -650,7 +629,7 @@ const definitions: Definition[] = [
         model: 'MOSZB-140',
         vendor: 'Develco',
         description: 'Motion sensor',
-        fromZigbee: [develco.fz.temperature, fz.ias_occupancy_alarm_1, fz.battery, develco.fz.led_control, develco.fz.ias_occupancy_timeout],
+        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, develco.fz.led_control, develco.fz.ias_occupancy_timeout],
         toZigbee: [develco.tz.led_control, develco.tz.ias_occupancy_timeout],
         exposes: (device, options) => {
             const dynExposes = [];
@@ -658,7 +637,6 @@ const definitions: Definition[] = [
             if (device && device.softwareBuildID && Number(device.softwareBuildID.split('.')[0]) >= 3) {
                 dynExposes.push(e.numeric('occupancy_timeout', ea.ALL).withUnit('s').withValueMin(5).withValueMax(65535));
             }
-            dynExposes.push(e.temperature());
             dynExposes.push(e.tamper());
             dynExposes.push(e.battery_low());
             dynExposes.push(e.battery());
@@ -675,12 +653,13 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {default: 35};
         },
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions(), illuminance()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            illuminance(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
-            const endpoint38 = device.getEndpoint(38);
-            await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint38, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 100});
-
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryVoltage(endpoint35, {min: constants.repInterval.HOUR, max: 43200, change: 100});
@@ -711,20 +690,20 @@ const definitions: Definition[] = [
         model: 'HMSZB-110',
         vendor: 'Develco',
         description: 'Temperature & humidity sensor',
-        fromZigbee: [fz.battery, develco.fz.temperature, fz.humidity],
+        fromZigbee: [fz.battery, fz.humidity],
         toZigbee: [],
         ota: ota.zigbeeOTA,
-        exposes: [e.battery(), e.temperature(), e.humidity()],
+        exposes: [e.battery(), e.humidity()],
         meta: {battery: {voltageToPercentage: '3V_2500_3200'}},
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.batteryLowAA(),
+            develcoModernExtend.temperature(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(38);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg']);
-            await reporting.temperature(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
+            await reporting.bind(endpoint, coordinatorEndpoint, ['msRelativeHumidity', 'genPowerCfg']);
             await reporting.humidity(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 300});
             await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
         },
@@ -790,17 +769,18 @@ const definitions: Definition[] = [
         model: 'FLSZB-110',
         vendor: 'Develco',
         description: 'Flood alarm device ',
-        fromZigbee: [fz.ias_water_leak_alarm_1, develco.fz.temperature, fz.battery],
+        fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery],
         toZigbee: [],
         ota: ota.zigbeeOTA,
-        exposes: [e.battery_low(), e.tamper(), e.water_leak(), e.temperature(), e.battery_voltage()],
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        exposes: [e.battery_low(), e.tamper(), e.water_leak(), e.battery_voltage()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint35 = device.getEndpoint(35);
             await reporting.bind(endpoint35, coordinatorEndpoint, ['genPowerCfg']);
-            const endpoint38 = device.getEndpoint(38);
-            await reporting.bind(endpoint38, coordinatorEndpoint, ['msTemperatureMeasurement']);
-            await reporting.temperature(endpoint38, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
         },
     },
     {
@@ -809,22 +789,22 @@ const definitions: Definition[] = [
         vendor: 'Develco',
         description: 'Air quality sensor',
         ota: ota.zigbeeOTA,
-        fromZigbee: [develco.fz.temperature, fz.humidity],
+        fromZigbee: [fz.humidity],
         toZigbee: [],
-        exposes: [e.temperature(), e.humidity(), e.battery()],
+        exposes: [e.humidity(), e.battery()],
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.addCustomClusterManuSpecificDevelcoAirQuality(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.voc(),
             develcoModernExtend.airQuality(),
+            develcoModernExtend.temperature(),
             develcoModernExtend.batteryLowAA(),
         ],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(38);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'msRelativeHumidity', 'genPowerCfg']);
-            await reporting.temperature(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 10});
+            await reporting.bind(endpoint, coordinatorEndpoint, ['msRelativeHumidity', 'genPowerCfg']);
             await reporting.humidity(endpoint, {min: constants.repInterval.MINUTE, max: constants.repInterval.MINUTES_10, change: 300});
             await reporting.batteryVoltage(endpoint, {min: constants.repInterval.HOUR, max: 43200, change: 100});
         },
@@ -834,10 +814,14 @@ const definitions: Definition[] = [
         model: 'SIRZB-110',
         vendor: 'Develco',
         description: 'Customizable siren',
-        fromZigbee: [develco.fz.temperature, fz.battery, fz.ias_enroll, fz.ias_wd, fz.ias_siren],
+        fromZigbee: [fz.battery, fz.ias_enroll, fz.ias_wd, fz.ias_siren],
         toZigbee: [tz.warning, tz.warning_simple, tz.ias_max_duration, tz.squawk],
         meta: {battery: {voltageToPercentage: '3V_2500'}},
-        extend: [develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(), develcoModernExtend.readGenBasicPrimaryVersions()],
+        extend: [
+            develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
+            develcoModernExtend.readGenBasicPrimaryVersions(),
+            develcoModernExtend.temperature(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(43);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone', 'ssIasWd', 'genBasic']);

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -2,7 +2,15 @@ import {Zcl} from 'zigbee-herdsman';
 
 import {presets as e, access as ea} from './exposes';
 import {logger} from './logger';
-import {numeric, NumericArgs, ScaleFunction, temperature, deviceAddCustomCluster, setupConfigureForReporting} from './modernExtend';
+import {
+    numeric,
+    NumericArgs,
+    ScaleFunction,
+    temperature,
+    deviceTemperature,
+    deviceAddCustomCluster,
+    setupConfigureForReporting,
+} from './modernExtend';
 import {Fz, Tz, ModernExtend, Configure} from './types';
 
 const NS = 'zhc:develco';
@@ -163,6 +171,12 @@ export const develcoModernExtend = {
     },
     temperature: (args?: Partial<NumericArgs>) =>
         temperature({
+            valueIgnore: [0xffff, -0x8000],
+            ...args,
+        }),
+    deviceTemperature: (args?: Partial<NumericArgs>) =>
+        deviceTemperature({
+            reporting: {min: '5_MINUTES', max: '1_HOUR', change: 2}, // Device temperature reports with 2 degree change
             valueIgnore: [0xffff, -0x8000],
             ...args,
         }),

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -2,7 +2,7 @@ import {Zcl} from 'zigbee-herdsman';
 
 import {presets as e, access as ea} from './exposes';
 import {logger} from './logger';
-import {numeric, NumericArgs, ScaleFunction, deviceAddCustomCluster, setupConfigureForReporting} from './modernExtend';
+import {numeric, NumericArgs, ScaleFunction, temperature, deviceAddCustomCluster, setupConfigureForReporting} from './modernExtend';
 import {Fz, Tz, ModernExtend, Configure} from './types';
 
 const NS = 'zhc:develco';
@@ -161,4 +161,9 @@ export const develcoModernExtend = {
 
         return {exposes: [expose], fromZigbee, isModernExtend: true};
     },
+    temperature: (args?: Partial<NumericArgs>) =>
+        temperature({
+            valueIgnore: [0xffff, -0x8000],
+            ...args,
+        }),
 };

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -197,7 +197,7 @@ export function setupConfigureForReading(cluster: string | number, attributes: (
 }
 
 export function autoDetectInputEndpoint(device: Zh.Device, cluster: string | number): Zh.Endpoint | Zh.Group {
-    return device.endpoints.find((e) => e.supportsInputCluster(cluster));
+    return device.endpoints.find((e) => e.supportsInputCluster(cluster)) ?? device.endpoints[0];
 }
 
 // #region General

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1803,6 +1803,7 @@ export interface NumericArgs {
     valueMin?: number;
     valueMax?: number;
     valueStep?: number;
+    valueIgnore?: number[];
     scale?: number | ScaleFunction;
     label?: string;
     entityCategory?: 'config' | 'diagnostic';
@@ -1820,6 +1821,7 @@ export function numeric(args: NumericArgs): ModernExtend {
         valueMin,
         valueMax,
         valueStep,
+        valueIgnore,
         scale,
         label,
         entityCategory,
@@ -1866,6 +1868,9 @@ export function numeric(args: NumericArgs): ModernExtend {
 
                     let value = msg.data[attributeKey];
                     assertNumber(value);
+
+                    if (valueIgnore && valueIgnore.includes(value)) return;
+
                     if (scale !== undefined) {
                         value = typeof scale === 'number' ? value / scale : scale(value, 'from');
                     }

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -196,6 +196,10 @@ export function setupConfigureForReading(cluster: string | number, attributes: (
     return configure;
 }
 
+export function autoDetectInputEndpoint(device: Zh.Device, cluster: string | number): Zh.Endpoint | Zh.Group {
+    return device.endpoints.find((e) => e.supportsInputCluster(cluster));
+}
+
 // #region General
 
 export function forceDeviceType(args: {type: 'EndDevice' | 'Router'}): ModernExtend {
@@ -355,13 +359,14 @@ export function battery(args?: BatteryArgs): ModernExtend {
             convertGet: async (entity, key, meta) => {
                 // Don't fail GET reqest if reading fails
                 // Split reading is needed for more clear debug logs
+                const ep = autoDetectInputEndpoint(meta.device, 'genPowerCfg');
                 try {
-                    await entity.read('genPowerCfg', ['batteryPercentageRemaining']);
+                    await ep.read('genPowerCfg', ['batteryPercentageRemaining']);
                 } catch (e) {
                     logger.debug(`Reading batteryPercentageRemaining failed: ${e}, device probably doesn't support it`, 'zhc:setupattribute');
                 }
                 try {
-                    await entity.read('genPowerCfg', ['batteryVoltage']);
+                    await ep.read('genPowerCfg', ['batteryVoltage']);
                 } catch (e) {
                     logger.debug(`Reading batteryVoltage failed: ${e}, device probably doesn't support it`, 'zhc:setupattribute');
                 }
@@ -719,7 +724,7 @@ export function occupancy(args?: OccupancyArgs): ModernExtend {
         {
             key: ['occupancy'],
             convertGet: async (entity, key, meta) => {
-                await entity.read('msOccupancySensing', ['occupancy']);
+                await autoDetectInputEndpoint(meta.device, 'msOccupancySensing').read('msOccupancySensing', ['occupancy']);
             },
         },
     ];
@@ -1769,14 +1774,14 @@ export function enumLookup(args: EnumLookupArgs): ModernExtend {
                           const payload = isString(attribute)
                               ? {[attribute]: payloadValue}
                               : {[attribute.ID]: {value: payloadValue, type: attribute.type}};
-                          await entity.write(cluster, payload, zigbeeCommandOptions);
+                          await autoDetectInputEndpoint(meta.device, cluster).write(cluster, payload, zigbeeCommandOptions);
                           return {state: {[key]: value}};
                       }
                     : undefined,
             convertGet:
                 access & ea.GET
                     ? async (entity, key, meta) => {
-                          await entity.read(cluster, [attributeKey], zigbeeCommandOptions);
+                          await autoDetectInputEndpoint(meta.device, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
                       }
                     : undefined,
         },
@@ -1900,14 +1905,14 @@ export function numeric(args: NumericArgs): ModernExtend {
                           const payload = isString(attribute)
                               ? {[attribute]: payloadValue}
                               : {[attribute.ID]: {value: payloadValue, type: attribute.type}};
-                          await entity.write(cluster, payload, zigbeeCommandOptions);
+                          await autoDetectInputEndpoint(meta.device, cluster).write(cluster, payload, zigbeeCommandOptions);
                           return {state: {[key]: value}};
                       }
                     : undefined,
             convertGet:
                 access & ea.GET
                     ? async (entity, key, meta) => {
-                          await entity.read(cluster, [attributeKey], zigbeeCommandOptions);
+                          await autoDetectInputEndpoint(meta.device, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
                       }
                     : undefined,
         },
@@ -1962,14 +1967,14 @@ export function binary(args: BinaryArgs): ModernExtend {
                           const payload = isString(attribute)
                               ? {[attribute]: payloadValue}
                               : {[attribute.ID]: {value: payloadValue, type: attribute.type}};
-                          await entity.write(cluster, payload, zigbeeCommandOptions);
+                          await autoDetectInputEndpoint(meta.device, cluster).write(cluster, payload, zigbeeCommandOptions);
                           return {state: {[key]: value}};
                       }
                     : undefined,
             convertGet:
                 access & ea.GET
                     ? async (entity, key, meta) => {
-                          await entity.read(cluster, [attributeKey], zigbeeCommandOptions);
+                          await autoDetectInputEndpoint(meta.device, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
                       }
                     : undefined,
         },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -639,11 +639,12 @@ describe('index.js', () => {
             'occupancy',
             'tamper',
             'battery_low',
-            'battery',
             'linkquality',
+            'temperature',
             'illuminance_lux',
             'illuminance',
-            'temperature',
+            'battery',
+            'voltage',
         ]);
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -637,13 +637,13 @@ describe('index.js', () => {
         const exposes = MOSZB140.exposes();
         expect(exposes.map((e) => e.name)).toStrictEqual([
             'occupancy',
-            'temperature',
             'tamper',
             'battery_low',
             'battery',
             'linkquality',
             'illuminance_lux',
             'illuminance',
+            'temperature',
         ]);
     });
 


### PR DESCRIPTION
Continuation of the last PR, open issues:
- read goes to the wrong endpoint -> timeouts

Sadly develco uses different endpoints for different clusters. But not always.
e.g. illuminance -> 39, temperature -> 38, humidity -> 38 (but only when there is temperature) ...

Some also sue 35... the genPowerCtl en genPollCtl are on there unless there is only 1 other cluster then they are on the other endpoint. e.g. AQSZB has those on 38 :/ very confusing.

There were also a lot of duplicate convertors that filtered out certain bogus values that occur often for develco, this was improved by adding a `valueIgnore` to the numeric modernExtend. This seems to be something generic enough to implement there.

Possible solutions:
- update numeric, binary, battery, ... base modernExtends to find the correct endpoint if endpointNames are not specified in the toZigbee.convertGet function.