### PR TITLE
fix(detect): Adjust STARKVIND air purifier stand and table variants

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -662,6 +662,7 @@ const definitions: Definition[] = [
         model: 'E2007',
         vendor: 'IKEA',
         description: 'STARKVIND air purifier',
+        whiteLabel: [{vendor: 'IKEA', model: 'E2006', description: 'STARKVIND air purifier table', fingerprint: [{modelID: 'E2006'}]}],
         extend: [addCustomClusterManuSpecificIkeaUnknown(), addCustomClusterManuSpecificIkeaAirPurifier(), ikeaAirPurifier(), identify(), ikeaOta()],
     },
     {


### PR DESCRIPTION
The STARKVIND air purifier has two variants, one for the stand and one for the table.

The table variant has model E2006 and the stand variant has model E2007.