### PR TITLE
(fix) Use ZHA voltage calculation for TS0203 and WSD500A

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -880,6 +880,17 @@ const definitions: Definition[] = [
             exps.push(e.linkquality());
             return exps;
         },
+        meta: {
+            battery: {
+                // These sensors do send a Battery Percentage Remaining (0x0021)
+                // value, but is usually incorrect. For example, a coin battery tested
+                // with a load tester may show 80%, but report 2.5V / 1%. This voltage
+                // calculation matches what ZHA does by default.
+                // https://github.com/Koenkk/zigbee2mqtt/discussions/17337
+                // https://github.com/zigpy/zha-device-handlers/blob/c6ed94a52a469e72b32ece2a92d528060c7fd034/zhaquirks/__init__.py#L195-L228
+                voltageToPercentage: '3V_1500_2800',
+            },
+        },
         configure: async (device, coordinatorEndpoint) => {
             try {
                 const endpoint = device.getEndpoint(1);
@@ -2866,6 +2877,17 @@ const definitions: Definition[] = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
         configure: tuya.configureMagicPacket,
         whiteLabel: [tuya.whitelabel('Tuya', 'TH02Z', 'Temperature and humidity sensor', ['_TZ3000_fllyghyj', '_TZ3000_saiqcn0y'])],
+        meta: {
+            battery: {
+                // These sensors do send a Battery Percentage Remaining (0x0021)
+                // value, but is usually incorrect. For example, a coin battery tested
+                // with a load tester may show 80%, but report 2.5V / 1%. This voltage
+                // calculation matches what ZHA does by default.
+                // https://github.com/Koenkk/zigbee2mqtt/discussions/17337
+                // https://github.com/zigpy/zha-device-handlers/blob/c6ed94a52a469e72b32ece2a92d528060c7fd034/zhaquirks/__init__.py#L195-L228
+                voltageToPercentage: '3V_1500_2800',
+            },
+        },
     },
     {
         fingerprint: [...tuya.fingerprint('TS0201', ['_TZ3000_dowj6gyi', '_TZ3000_8ybe88nf']), {manufacturerName: '_TZ3000_zl1kmjqx'}],


### PR DESCRIPTION
I'm splitting this out from https://github.com/Koenkk/zigbee-herdsman-converters/pull/7681 since this only affects a few devices, while the work in the other PR affects much more and has seen several revisions.