### PR TITLE
Fixing all endpoints being triggered at once when controlling a single endpoint for ZMO-606-S2

### DIFF
--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -358,7 +358,7 @@ const definitions: Definition[] = [
         extend: [tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']}),],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
-            return {'l1': 1, 'l2': 2, 'l3': 3};
+            return {l1: 1, l2: 2, l3: 3};
         },
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -359,14 +359,7 @@ const definitions: Definition[] = [
         endpoint: (device) => {
             return {l1: 1, l2: 2, l3: 3};
         },
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            for (const endpointID of [1, 2, 3]) {
-                const endpoint = device.getEndpoint(endpointID);
-                await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
-                await reporting.onOff(endpoint);
-            }
-        },
+        configure: tuya.configureMagicPacket,
     },
     {
         fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_b1q8kwmh']),

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -356,12 +356,7 @@ const definitions: Definition[] = [
         vendor: 'Zemismart',
         description: 'Smart 2 gangs switch with outlet',
         extend: [
-            tuya.modernExtend.tuyaOnOff({
-                powerOutageMemory: true, 
-                indicatorMode: true, 
-                onOffCountdown: true,
-                endpoints: ['l1', 'l2', 'l3']
-            }),
+            tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']}),
         ],
         meta: {multiEndpoint: true},
         endpoint: (device) => {

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -355,9 +355,7 @@ const definitions: Definition[] = [
         model: 'ZMO-606-S2',
         vendor: 'Zemismart',
         description: 'Smart 2 gangs switch with outlet',
-        extend: [
-            tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']}),
-        ],
+        extend: [tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']}),],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
             return {'l1': 1, 'l2': 2, 'l3': 3};

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -355,7 +355,7 @@ const definitions: Definition[] = [
         model: 'ZMO-606-S2',
         vendor: 'Zemismart',
         description: 'Smart 2 gangs switch with outlet',
-        extend: [tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']}),],
+        extend: [tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']})],
         meta: {multiEndpoint: true},
         endpoint: (device) => {
             return {l1: 1, l2: 2, l3: 3};

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -356,7 +356,6 @@ const definitions: Definition[] = [
         vendor: 'Zemismart',
         description: 'Smart 2 gangs switch with outlet',
         extend: [tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']})],
-        meta: {multiEndpoint: true},
         endpoint: (device) => {
             return {l1: 1, l2: 2, l3: 3};
         },

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -356,10 +356,25 @@ const definitions: Definition[] = [
         vendor: 'Zemismart',
         description: 'Smart 2 gangs switch with outlet',
         extend: [
-            deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
-            identify(),
-            tuya.modernExtend.tuyaOnOff({indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']}),
+            tuya.modernExtend.tuyaOnOff({
+                powerOutageMemory: true, 
+                indicatorMode: true, 
+                onOffCountdown: true,
+                endpoints: ['l1', 'l2', 'l3']
+            }),
         ],
+        meta: {multiEndpoint: true},
+        endpoint: (device) => {
+            return {'l1': 1, 'l2': 2, 'l3': 3};
+        },
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            for (const endpointID of [1, 2, 3]) {
+                const endpoint = device.getEndpoint(endpointID);
+                await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff']);
+                await reporting.onOff(endpoint);
+            }
+        },
     },
     {
         fingerprint: tuya.fingerprint('TS011F', ['_TZ3000_b1q8kwmh']),

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -355,10 +355,10 @@ const definitions: Definition[] = [
         model: 'ZMO-606-S2',
         vendor: 'Zemismart',
         description: 'Smart 2 gangs switch with outlet',
-        extend: [tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']})],
-        endpoint: (device) => {
-            return {l1: 1, l2: 2, l3: 3};
-        },
+        extend: [
+            deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
+            tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, indicatorMode: true, onOffCountdown: true, endpoints: ['l1', 'l2', 'l3']}),
+        ],
         configure: tuya.configureMagicPacket,
     },
     {


### PR DESCRIPTION
I had to add the endpoint return in line 368 and the async configuration for the switch to properly work, without that, when I controlled a single switch, all the other switches were controlled as well