### PR TITLE
fix(detect): Fix fingerprint.modelID for E2006

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -662,7 +662,9 @@ const definitions: Definition[] = [
         model: 'E2007',
         vendor: 'IKEA',
         description: 'STARKVIND air purifier',
-        whiteLabel: [{vendor: 'IKEA', model: 'E2006', description: 'STARKVIND air purifier table', fingerprint: [{modelID: 'E2006'}]}],
+        whiteLabel: [
+            {vendor: 'IKEA', model: 'E2006', description: 'STARKVIND air purifier table', fingerprint: [{modelID: 'STARKVIND Air purifier table'}]},
+        ],
         extend: [addCustomClusterManuSpecificIkeaUnknown(), addCustomClusterManuSpecificIkeaAirPurifier(), ikeaAirPurifier(), identify(), ikeaOta()],
     },
     {


### PR DESCRIPTION
Fix `fingerprint.modelID` that was set incorrectly in #7717.