### PR TITLE
add novadigital water valve fingerprint to moes valve

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -442,7 +442,7 @@ const definitions: Definition[] = [
         whiteLabel: [tuya.whitelabel('Tuya', 'iH-F8260', 'Universal smart IR remote control', ['_TZ3290_gnl5a6a5xvql7c2a'])],
     },
     {
-        fingerprint: tuya.fingerprint('TS0049', ['_TZ3000_cjfmu5he', '_TZ3000_kz1anoi8']),
+        fingerprint: tuya.fingerprint('TS0049', ['_TZ3000_cjfmu5he', '_TZ3000_kz1anoi8','_TZ3000_mq4wujmp']),
         model: 'ZWV-YC',
         vendor: 'Moes',
         description: 'Water valve',

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -442,7 +442,7 @@ const definitions: Definition[] = [
         whiteLabel: [tuya.whitelabel('Tuya', 'iH-F8260', 'Universal smart IR remote control', ['_TZ3290_gnl5a6a5xvql7c2a'])],
     },
     {
-        fingerprint: tuya.fingerprint('TS0049', ['_TZ3000_cjfmu5he', '_TZ3000_kz1anoi8','_TZ3000_mq4wujmp']),
+        fingerprint: tuya.fingerprint('TS0049', ['_TZ3000_cjfmu5he', '_TZ3000_kz1anoi8', '_TZ3000_mq4wujmp']),
         model: 'ZWV-YC',
         vendor: 'Moes',
         description: 'Water valve',


### PR DESCRIPTION
Support for correct detection the water Valve sold by Brazilian company Nova Digital : https://www.novadigitalsmart.com.br/produtos/valvula-inteligente-zigbee-zvl-04

It was detected as generic Tuya and the ON/OFF does not worked, but it worked with this Moes definition (after repairing).

I have new batteries and it showing 100% , have to wait more time to know if battery reporting is correct.

related to [#21788](https://github.com/Koenkk/zigbee2mqtt/issues/21788)




