### PR TITLE
Add extra fingerprint for TS0601 soil sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1942,7 +1942,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_g2e6cpnw']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_g2e6cpnw','_TZE284_sgabhwa6']),
         model: 'TS0601_soil_2',
         vendor: 'Tuya',
         description: 'Soil sensor',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1942,7 +1942,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_g2e6cpnw','_TZE284_sgabhwa6']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_g2e6cpnw', '_TZE284_sgabhwa6']),
         model: 'TS0601_soil_2',
         vendor: 'Tuya',
         description: 'Soil sensor',


### PR DESCRIPTION
My [TS0601 Soil Sensor](https://www.zigbee2mqtt.io/devices/TS0601_soil_2.html) identifies as `_TZE284_sgabhwa6`. After creating an external converter based off the `_TZE284_g2e6cpnw` it reports data:

![image](https://github.com/Koenkk/zigbee-herdsman-converters/assets/639906/1f11451b-9a10-4b1c-9724-684c494e3054)

Not 100% sure if they are the same as the Battery state is `null` 