### PR TITLE
Set multiEndpoint to false for aeotec pico (single) switch

### DIFF
--- a/src/devices/aeotec.ts
+++ b/src/devices/aeotec.ts
@@ -28,7 +28,7 @@ const definitions: Definition[] = [
         vendor: 'AEOTEC',
         description: 'Pico switch with power meter',
         extend: [
-            deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3}}),
+            deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3}, multiEndpointSkip: ['state', 'voltage', 'power', 'current', 'energy']}),
             deviceTemperature(),
             identify(),
             onOff({powerOnBehavior: false}),


### PR DESCRIPTION
The actual returned devices attributes are suffixed with the endpoint name and the attributes without endpoint suffix are always `null`.

The aeotec pico (single) switch only contains one output to switch, so i think `multiEndpoint`  should be set to false. Another way could be to skip the affected attributes with `multiEndpointSkip`.

See the different state snapshots with different `multiEndpoint` configurations below.

state with `multiEndpoint: true` (default)
```
{
    "action": null,
    "current": null,
    "device_temperature": 31,
    "energy": null,
    "linkquality": 196,
    "power": null,
    "state": "OFF",
    "state_1": "ON",
    "voltage": null,
    "power_1": 5.5,
    "voltage_1": 232.4,
    "current_1": 0,
    "energy_1": 0
}
```

state with `multiEndpoint: false`
```
{
    "current": 0.04,
    "device_temperature": 31,
    "energy": 0,
    "linkquality": 182,
    "power": 5.5,
    "state": "ON",
    "voltage": 234.2,
    "action": null
}
```

[aeotec_pico_db_entry.json](https://github.com/user-attachments/files/16117036/aeotec_pico_db_entry.json)
[aeotec device manual](https://aeotec.freshdesk.com/support/solutions/articles/6000261873-aeotec-pico-switch-user-guide)
[zigbee2mqtt device manual](https://www.zigbee2mqtt.io/devices/ZGA002.html)
