### PR TITLE
zigbeetlc: Comfort parameters should scale at 100

### DIFF
--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -17,8 +17,8 @@ const extend = {
         cluster: 'hvacUserInterfaceCfg',
         attribute: {ID: 0x0105, type: Zcl.DataType.UINT16},
         valueMin: 0,
-        valueMax: 9999,
-        scale: 10,
+        valueMax: 100,
+        scale: 100,
         description: 'Comfort parameters/Humidity maximum, in 1% steps, default 60.00%.',
     }),
     comfortHumidityMin: numeric({
@@ -27,8 +27,8 @@ const extend = {
         cluster: 'hvacUserInterfaceCfg',
         attribute: {ID: 0x0104, type: Zcl.DataType.UINT16},
         valueMin: 0,
-        valueMax: 9999,
-        scale: 10,
+        valueMax: 100,
+        scale: 100,
         description: 'Comfort parameters/Humidity minimum, in 1% steps, default 40.00%',
     }),
     comfortTemperatureMin: numeric({
@@ -39,7 +39,7 @@ const extend = {
         valueMin: -50.0,
         valueMax: 120.0,
         valueStep: 0.01,
-        scale: 10,
+        scale: 100,
         description: 'Comfort parameters/Temperature minimum, in 0.01°C steps, default 20.00°C.',
     }),
     comfortTemperatureMax: numeric({
@@ -50,7 +50,7 @@ const extend = {
         valueMin: -50.0,
         valueMax: 120.0,
         valueStep: 0.01,
-        scale: 10,
+        scale: 100,
         description: 'Comfort parameters/Temperature maximum, in 0.01°C steps, default 25.00°C.',
     }),
     display: binary({


### PR DESCRIPTION
Users reported the Comfort parameters for temperature and humidity are wrongly scaled.

The ZigbeeTlc firmware multiplies temperature and comfort settings with a factor 10 internally, while the same is not applied to comfort parameters.

This adjusts the ZigbeeTlc converter to align with that implementation.

Thanks to @Bodengriller for pointing this out and debugging the cause.