### PR TITLE
fix: missing color command in fromZigbee for ZG2858A

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1183,6 +1183,7 @@ export function commandsColorCtrl(args?: CommandsColorCtrl): ModernExtend {
         fz.command_move_color_temperature,
         fz.command_step_color_temperature,
         fz.command_ehanced_move_to_hue_and_saturation,
+        fz.command_move_to_hue_and_saturation,
         fz.command_step_hue,
         fz.command_step_saturation,
         fz.command_color_loop_set,


### PR DESCRIPTION
Since last update and refactoring for [ZG2858A](https://github.com/Koenkk/zigbee-herdsman-converters/pull/7637)
The command is there in the actions but missing in the `fromZigbee`.

The command was [added](https://github.com/Koenkk/zigbee-herdsman-converters/commit/987343ce9bdb4f7f5cc3ddd7c619047d760374b2#diff-41166cc3cbfc23f61f968ff4f055a1919976ebb291708a8b47b2bf3417015e8fR323) in the fromZigbee to fix [zigbee2mqtt/issues/22467](https://github.com/Koenkk/zigbee2mqtt/issues/22467).

