### PR TITLE
add support for MultiTerm ZC0101 device

### DIFF
--- a/src/devices/multiterm.ts
+++ b/src/devices/multiterm.ts
@@ -1,0 +1,91 @@
+import fz from '../converters/fromZigbee';
+import tz from '../converters/toZigbee';
+import * as exposes from '../lib/exposes';
+import {deviceEndpoints} from '../lib/modernExtend';
+import * as reporting from '../lib/reporting';
+import {Definition, Fz, Tz} from '../lib/types';
+import * as utils from '../lib/utils';
+
+const e = exposes.presets;
+const ea = exposes.access;
+
+const endpoints = {
+    silent_mode: 8,
+    heating_cooling: 9,
+    electric_valve: 10,
+};
+
+const states = {
+    silent_mode: ['Inactive', 'Active'],
+    heating_cooling: ['Heating', 'Cooling'],
+    electric_valve: ['Off', 'On'],
+};
+
+const fzLocal = {
+    binary_output: {
+        cluster: 'genBinaryOutput',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            return {state: msg.data.presentValue == 1 ? msg.data.activeText : msg.data.inactiveText};
+        },
+    } satisfies Fz.Converter,
+};
+
+const tzLocal = {
+    fan_mode: {
+        ...tz.fan_mode,
+        convertSet: async (entity, key, value, meta) => {
+            if (String(value).toLowerCase() === 'on') value = 'high';
+            return tz.fan_mode.convertSet(entity, key, value, meta);
+        },
+    } satisfies Tz.Converter,
+    binary_output: {
+        key: Object.keys(endpoints),
+        convertSet: async (entity, key, value, meta) => {
+            const ep = meta.device.getEndpoint(utils.getFromLookup(key, endpoints));
+            const currentStates = utils.getFromLookup(key, states);
+            const newState = currentStates.indexOf(String(value));
+            const payload = {0x0055: {value: newState, type: 0x10}};
+            await ep.write('genBinaryOutput', payload);
+            const state = {state: {}};
+            const normalizedKey = key.replace('/', '_').replace(' ', '_').toLowerCase();
+            state.state = {[normalizedKey]: value};
+            return state;
+        },
+        convertGet: async (entity, key, meta) => {
+            const ep = meta.device.getEndpoint(utils.getFromLookup(key, endpoints));
+            await ep.read('genBinaryOutput', ['presentValue', 'activeText', 'inactiveText', 'description']);
+        },
+    } satisfies Tz.Converter,
+};
+
+const definitions: Definition[] = [
+    {
+        zigbeeModel: ['ZC0101'],
+        model: 'ZC0101',
+        vendor: 'MultiTerm',
+        description: 'ZeeFan Fan Coil Unit controller',
+        extend: [deviceEndpoints({endpoints: {'8': 8, '9': 9, '10': 10}})],
+        meta: {multiEndpoint: true},
+        fromZigbee: [fz.fan, fzLocal.binary_output],
+        toZigbee: [tzLocal.fan_mode, tzLocal.binary_output],
+        exposes: [
+            e.fan().withModes(['off', 'low', 'medium', 'high', 'on']).withLabel('Fan Control'),
+            e.enum('silent_mode', ea.ALL, states.silent_mode).withLabel('Silent mode').withCategory('config'),
+            e.enum('heating_cooling', ea.ALL, states.heating_cooling).withLabel('Heating/Cooling').withCategory('config'),
+            e.enum('electric_valve', ea.ALL, states.electric_valve).withLabel('Electric Valve').withCategory('config'),
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const fanEp = device.getEndpoint(endpoints.silent_mode);
+            const hcEp = device.getEndpoint(endpoints.heating_cooling);
+            const evEp = device.getEndpoint(endpoints.electric_valve);
+            await reporting.bind(fanEp, coordinatorEndpoint, ['genBinaryOutput']);
+            await reporting.bind(fanEp, coordinatorEndpoint, ['hvacFanCtrl']);
+            await reporting.bind(hcEp, coordinatorEndpoint, ['genBinaryOutput']);
+            await reporting.bind(evEp, coordinatorEndpoint, ['genBinaryOutput']);
+        },
+    },
+];
+
+export default definitions;
+module.exports = definitions;

--- a/src/devices/multiterm.ts
+++ b/src/devices/multiterm.ts
@@ -16,9 +16,9 @@ const endpoints = {
 };
 
 const states = {
-    silent_mode: ['Inactive', 'Active'],
-    heating_cooling: ['Heating', 'Cooling'],
-    electric_valve: ['Off', 'On'],
+    silent_mode: ['inactive', 'active'],
+    heating_cooling: ['heating', 'cooling'],
+    electric_valve: ['off', 'on'],
 };
 
 const fzLocal = {
@@ -64,7 +64,7 @@ const definitions: Definition[] = [
         zigbeeModel: ['ZC0101'],
         model: 'ZC0101',
         vendor: 'MultiTerm',
-        description: 'ZeeFan Fan Coil Unit controller',
+        description: 'ZeeFan fan coil unit controller',
         extend: [deviceEndpoints({endpoints: {'8': 8, '9': 9, '10': 10}})],
         meta: {multiEndpoint: true},
         fromZigbee: [fz.fan, fzLocal.binary_output],


### PR DESCRIPTION
The device has one fan mode endpoint and 3 binary output endpoints.

I have followed step by step: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html.

The device works as expected using an external definition in zigbee2mqtt.

I could not test the zigbee herdsman converter with the device as I don't know how :)

P.S. I will add PR to the documentation with image and device information if this PR gets merged.