### PR TITLE
Add support for GL-MC-002P

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -511,7 +511,7 @@ const definitions: Definition[] = [
         model: 'GL-MC-002P',
         vendor: 'Gledopto',
         description: 'Zigbee USB Mini LED Controller RGB+CCT (Pro)',
-        extend: [gledoptoLight({colorTemp: {range: [158,495]}, color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        extend: [gledoptoLight({colorTemp: {range: [158,495]}, color: true})],
     },
     {
         zigbeeModel: ['GL-S-003Z'],

--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -511,7 +511,7 @@ const definitions: Definition[] = [
         model: 'GL-MC-002P',
         vendor: 'Gledopto',
         description: 'Zigbee USB Mini LED Controller RGB+CCT (Pro)',
-        extend: [gledoptoLight({colorTemp: {range: [158,495]}, color: true})],
+        extend: [gledoptoLight({colorTemp: {range: [158, 495]}, color: true})],
     },
     {
         zigbeeModel: ['GL-S-003Z'],

--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -507,6 +507,13 @@ const definitions: Definition[] = [
         extend: [gledoptoLight({colorTemp: {range: undefined}, color: true})],
     },
     {
+        zigbeeModel: ['GL-MC-002P'],
+        model: 'GL-MC-002P',
+        vendor: 'Gledopto',
+        description: 'Zigbee USB Mini LED Controller RGB+CCT (Pro)',
+        extend: [gledoptoLight({colorTemp: {range: [158,495]}, color":{"modes":["xy","hs"],"enhancedHue":true}})],
+    },
+    {
         zigbeeModel: ['GL-S-003Z'],
         model: 'GL-S-003Z',
         vendor: 'Gledopto',


### PR DESCRIPTION
Added support for device: Gledopto Zigbee USB Mini LED Controller RGB+CCT (Pro)