### PR TITLE
feat: Add support for Raex TQL25-2211 

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -216,6 +216,7 @@ import qmotion from './qmotion';
 import qoto from './qoto';
 import quotra from './quotra';
 import rademacher from './rademacher';
+import raex from './raex';
 import rgb_genie from './rgb_genie';
 import robb from './robb';
 import roome from './roome';
@@ -522,6 +523,7 @@ export default [
     ...qoto,
     ...quotra,
     ...rademacher,
+    ...raex,
     ...rgb_genie,
     ...robb,
     ...roome,

--- a/src/devices/raex.ts
+++ b/src/devices/raex.ts
@@ -1,0 +1,15 @@
+import {battery, identify, windowCovering, commandsOnOff} from '../lib/modernExtend';
+import {Definition} from '../lib/types';
+
+const definitions: Definition[] = [
+    {
+        zigbeeModel: ['TQL25-2211'],
+        model: 'TQL25-2211',
+        vendor: 'Raex',
+        description: 'Tubular motor',
+        extend: [battery(), identify(), windowCovering({controls: ['lift']}), commandsOnOff({commands: ['on', 'off', 'toggle']})],
+    },
+];
+
+export default definitions;
+module.exports = definitions;

--- a/src/devices/raex.ts
+++ b/src/devices/raex.ts
@@ -1,4 +1,4 @@
-import {battery, identify, windowCovering, commandsOnOff} from '../lib/modernExtend';
+import {battery, windowCovering} from '../lib/modernExtend';
 import {Definition} from '../lib/types';
 
 const definitions: Definition[] = [
@@ -7,7 +7,7 @@ const definitions: Definition[] = [
         model: 'TQL25-2211',
         vendor: 'Raex',
         description: 'Tubular motor',
-        extend: [battery(), identify(), windowCovering({controls: ['lift']}), commandsOnOff({commands: ['on', 'off', 'toggle']})],
+        extend: [battery(), windowCovering({controls: ['lift']})],
     },
 ];
 


### PR DESCRIPTION
Adding support for Raex TQL25-2211 tubular motor as discussed [here](https://github.com/Koenkk/zigbee2mqtt/issues/23360).
