### PR TITLE
Add support for Immax TS0502C light

### DIFF
--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -97,9 +97,8 @@ const definitions: Definition[] = [
         fingerprint: [{modelID: 'TS0502C', manufacturerName: '_TZ3210_6pwpez2j'}],
         model: 'TS0502C',
         vendor: 'Immax',
-        description: 'Immax NEO FINO Smart pendant light black 80cm CCT 60W, Zigbee 3.0',
+        description: 'Neo FINO Smart pendant light black 80cm CCT 60W, Zigbee 3.0',
         extend: [light({colorTemp: {range: [153, 500]}})],
-        meta: {},
     },
     {
         zigbeeModel: ['Keyfob-ZB3.0'],

--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -94,6 +94,14 @@ const definitions: Definition[] = [
         extend: [tuya.modernExtend.tuyaLight({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
+        fingerprint: [{modelID: 'TS0502C', manufacturerName: '_TZ3210_6pwpez2j'}],
+        model: 'TS0502C',
+        vendor: 'Immax',
+        description: 'Immax NEO FINO Smart pendant light black 80cm CCT 60W, Zigbee 3.0',
+        extend: [light({colorTemp: {range: [153, 500]}})],
+        meta: {},
+    },
+    {
         zigbeeModel: ['Keyfob-ZB3.0'],
         model: '07046L',
         vendor: 'Immax',


### PR DESCRIPTION
Add support for Immax TS0502C light

https://www.immax.eu/immax-neo-fino-smart-pendant-light-black-80cm-cct-60w-zigbee-3-0-p15206/?cid=350

![immax-neo-07158-b80-led-stmievatelny-luster-fino-led-60w-230v-tuya-cierna-do-img-im1053-fd-77-101487490](https://github.com/user-attachments/assets/ac27d242-2d4d-49ec-8c17-c1cc2052e092)


