### PR TITLE
fix: lumiOutageCountRestoreBindReporting sometimes stuck

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -1637,6 +1637,12 @@ export const lumiModernExtend = {
 
                             if (currentOutageCount > previousOutageCount) {
                                 logger.debug('Restoring binding and reporting, device came back after losing power.', NS);
+
+                                // update outageCount in database
+                                meta.device.meta.outageCount = currentOutageCount;
+                                meta.device.save();
+
+                                // restore binding
                                 for (const endpoint of meta.device.endpoints) {
                                     // restore bindings
                                     for (const b of endpoint.binds) {
@@ -1655,10 +1661,6 @@ export const lumiModernExtend = {
                                         ]);
                                     }
                                 }
-
-                                // update outageCount in database
-                                meta.device.meta.outageCount = currentOutageCount;
-                                meta.device.save();
                             }
                         }
                     }

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -1646,19 +1646,27 @@ export const lumiModernExtend = {
                                 for (const endpoint of meta.device.endpoints) {
                                     // restore bindings
                                     for (const b of endpoint.binds) {
-                                        await endpoint.bind(b.cluster.name, b.target);
+                                        try {
+                                            await endpoint.bind(b.cluster.name, b.target);
+                                        } catch (error) {
+                                            // do nothing when callback fails
+                                        }
                                     }
 
                                     // restore reporting
                                     for (const c of endpoint.configuredReportings) {
-                                        await endpoint.configureReporting(c.cluster.name, [
-                                            {
-                                                attribute: c.attribute.name,
-                                                minimumReportInterval: c.minimumReportInterval,
-                                                maximumReportInterval: c.maximumReportInterval,
-                                                reportableChange: c.reportableChange,
-                                            },
-                                        ]);
+                                        try {
+                                            await endpoint.configureReporting(c.cluster.name, [
+                                                {
+                                                    attribute: c.attribute.name,
+                                                    minimumReportInterval: c.minimumReportInterval,
+                                                    maximumReportInterval: c.maximumReportInterval,
+                                                    reportableChange: c.reportableChange,
+                                                },
+                                            ]);
+                                        } catch (error) {
+                                            // do nothing when callback fails
+                                        }
                                     }
                                 }
                             }

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -1636,7 +1636,7 @@ export const lumiModernExtend = {
                             const previousOutageCount = meta.device?.meta?.outageCount ? meta.device.meta.outageCount : 0;
 
                             if (currentOutageCount > previousOutageCount) {
-                                logger.debug('Restoring binding and reporting, device came back after losing power.', NS);
+                                logger.debug(`Restoring binding and reporting, ${msg.device.ieeeAddr} came back after losing power.`, NS);
 
                                 // update outageCount in database
                                 meta.device.meta.outageCount = currentOutageCount;
@@ -1649,7 +1649,7 @@ export const lumiModernExtend = {
                                         try {
                                             await endpoint.bind(b.cluster.name, b.target);
                                         } catch (error) {
-                                            // do nothing when callback fails
+                                            logger.debug(`Failed to re-bind ${b.cluster.name} from ${b.target} for ${msg.device.ieeeAddr}.`, NS);
                                         }
                                     }
 
@@ -1665,7 +1665,10 @@ export const lumiModernExtend = {
                                                 },
                                             ]);
                                         } catch (error) {
-                                            // do nothing when callback fails
+                                            logger.debug(
+                                                `Failed to re-setup reporting of ${c.cluster.name}/${c.attribute.name} for ${msg.device.ieeeAddr}.`,
+                                                NS,
+                                            );
                                         }
                                     }
                                 }


### PR DESCRIPTION
I noticed I was getting bind errors over and over again, due to timeouts. 

There seems to have been some changes in zh, maybe in the past these did not propagate properly to zhc?

When the device recovers from a power outage (aka sometimes battery voltages dips when for example it refreshes the eInk display. We try and restore the bind/reporting settings, generally the device is awake for a bit after this happens before going to sleep.

If we somehow end up hitting a timeout, `meta.outageCount` was never updates because the bind and/or reporting hit an error. So we try again every message we get, but on a normal message the device does not seem to be awake for long to finish all the bind/reporting restores. So we end up where we started.

We can 'avoid' this by updating `meta.outageCount` first and adding a `try {} catch {}` around the bind/reporting restores.

This seems to be doing OK for the 2 power outages I triggered. Will monitor for a few days.