### PR TITLE
fix: fix cluster id that got typoed in #7451

### DIFF
--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -146,7 +146,7 @@ export const ubisysModernExtend = {
         }),
     addCustomClusterManuSpecificUbisysDimmerSetup: () =>
         deviceAddCustomCluster('manuSpecificUbisysDimmerSetup', {
-            ID: 0xfc00,
+            ID: 0xfc01,
             manufacturerCode: Zcl.ManufacturerCode.UBISYS_TECHNOLOGIES_GMBH,
             attributes: {
                 capabilities: {ID: 0x0000, type: Zcl.DataType.BITMAP8},


### PR DESCRIPTION
While moving the clusters out of zh into zhc in #7451 the cluster ID for manuSpecificUbisysDimmerSetup accidentally got changed from 0xfc01 -> 0xfc00. 

This PR corrects this.

Fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/7807