### PR TITLE
Fix: Ignore error when binding to manuSpecificPhilips2

### DIFF
--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -79,12 +79,8 @@ export function philipsLight(args?: modernExtend.LightArgs & {hueEffect?: boolea
                     .withDescription('List of RGB HEX colors'),
             );
             result.configure.push(async (device, coordinatorEndpoint, definition) => {
-                for (const ep of device.endpoints) {
-                    try {
-                        await ep.bind('manuSpecificPhilips2', coordinatorEndpoint);
-                    } catch (error) {
-                        logger.warning(`Could not bind to manuSpecificPhilips2/${ep.ID} to coordinator/${coordinatorEndpoint.ID}`, NS);
-                    }
+                for (const ep of device.endpoints.filter((ep) => ep.supportsInputCluster('manuSpecificPhilips2'))) {
+                    await ep.bind('manuSpecificPhilips2', coordinatorEndpoint);
                 }
             });
         }

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -80,7 +80,11 @@ export function philipsLight(args?: modernExtend.LightArgs & {hueEffect?: boolea
             );
             result.configure.push(async (device, coordinatorEndpoint, definition) => {
                 for (const ep of device.endpoints) {
-                    await ep.bind('manuSpecificPhilips2', coordinatorEndpoint);
+                    try {
+                        await ep.bind('manuSpecificPhilips2', coordinatorEndpoint);
+                    } catch (error) {
+                        logger.warning(`Could not bind to manuSpecificPhilips2/${ep.ID} to coordinator/${coordinatorEndpoint.ID}`, NS);
+                    }
                 }
             });
         }


### PR DESCRIPTION
I have a Philips Signe Floor light (Zigbee device 915005987201) that can show fancy gradients. This one shows errors in the log that look like follows:

```
Aug 01 21:36:18 bossteegje poddos[9695]: [2024-08-01 21:36:18] z2m: Failed to configure 'Staaflamp', attempt 1 (Error: Bind 0x001788010c53faec/242 manuSpecificPhilips2 from '0xe0798dfffeb785a0/1' failed ([ZDO] Failed response by NCP for "7207" cluster "32801" with status=ZDP_INVALID_ENDPOINT.)
Aug 01 21:36:18 bossteegje poddos[9695]:     at EmberOneWaitress.resolveZDO (/app/node_modules/zigbee-herdsman/src/adapter/ember/adapter/oneWaitress.ts:138:35)
Aug 01 21:36:18 bossteegje poddos[9695]:     at EmberAdapter.onZDOResponse (/app/node_modules/zigbee-herdsman/src/adapter/ember/adapter/emberAdapter.ts:663:26)
Aug 01 21:36:18 bossteegje poddos[9695]:     at Ezsp.emit (node:events:517:28)
Aug 01 21:36:18 bossteegje poddos[9695]:     at Ezsp.ezspIncomingMessageHandler (/app/node_modules/zigbee-herdsman/src/adapter/ember/ezsp/ezsp.ts:4517:22)
Aug 01 21:36:18 bossteegje poddos[9695]:     at Ezsp.callbackDispatch (/app/node_modules/zigbee-herdsman/src/adapter/ember/ezsp/ezsp.ts:820:18)
Aug 01 21:36:18 bossteegje poddos[9695]:     at Ezsp.tick (/app/node_modules/zigbee-herdsman/src/adapter/ember/ezsp/ezsp.ts:446:22)
Aug 01 21:36:18 bossteegje poddos[9695]:     at listOnTimeout (node:internal/timers:569:17)
Aug 01 21:36:18 bossteegje poddos[9695]:     at processTimers (node:internal/timers:512:7))
```

This only happens when using the `ember` adapter, and not with the `ezsp` adapter (I have a ZBDongle-E). I guess this is because the `ember` adapter throws an error when a bind fails and `ezsp` silently ignores that, however, I am not sure.
It is known (and documented in the documentation of the bulb) that it does not expose the gradient, so it is not entirely unexpected that this bind fails.

So before merging this, is there somebody with a Philips bulb with gradient support that sees similar behavior?

I also did not dare yet to test this fix. Is there a quick-and-dirty way of swapping my zigbee-herdsman-converters in my running container installation or should I then completely rebuild zigbee2mqtt to test this?