### PR TITLE
Add _TZ3000_h1ipgkwn

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10953,6 +10953,27 @@ const definitions: Definition[] = [
             ],
         },
     },
+    {
+        fingerprint: [{
+                modelID: 'TS0002',
+                manufacturerName: '_TZ3000_h1ipgkwn',
+            },
+        ],
+        model: '2CH Zigbee USB Switch Module',
+        vendor: 'Tuya',
+        description: '2-way USB Smart Adapter',
+        configure: tuya.configureMagicPacket,
+        extend: [
+            tuya.modernExtend.tuyaOnOff({
+                endpoints: ['l1', 'l2']
+            }),
+        ],
+    	endpoint: (device) => {
+    		return {l1: 1, l2: 2};
+    	},
+    	meta: {multiEndpoint: true},
+    	whiteLabel: [tuya.whitelabel('UNSH', '[N/A]', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
+    }
 ];
 
 export default definitions;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10954,7 +10954,8 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{
+        fingerprint: [
+            {
                 modelID: 'TS0002',
                 manufacturerName: '_TZ3000_h1ipgkwn',
             },
@@ -10965,15 +10966,20 @@ const definitions: Definition[] = [
         configure: tuya.configureMagicPacket,
         extend: [
             tuya.modernExtend.tuyaOnOff({
-                endpoints: ['l1', 'l2']
+                endpoints: ['l1', 'l2'],
             }),
         ],
-    	endpoint: (device) => {
-    		return {l1: 1, l2: 2};
-    	},
-    	meta: {multiEndpoint: true},
-    	whiteLabel: [tuya.whitelabel('UNSH', '[N/A]', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
-    }
+        endpoint: (device) => {
+            return {
+                l1: 1,
+                l2: 2,
+            };
+        },
+        meta: {
+            multiEndpoint: true,
+        },
+        whiteLabel: [tuya.whitelabel('UNSH', '[N/A]', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
+    },
 ];
 
 export default definitions;


### PR DESCRIPTION
A Tuya 2-way USB switch, sold under whitelabel by UNSH (no exact model number). See https://www.aliexpress.com/item/1005006406053419.html

Z2m detects it as https://www.zigbee2mqtt.io/devices/TS0002.html#tuya-ts0002, but that's obviously wrong. This device has no metering, too.

Auto-generated external definition, that I derived the PR from:

```js
const {deviceEndpoints, identify, onOff, electricityMeter} = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['TS0002'],
    model: 'TS0002',
    vendor: '_TZ3000_h1ipgkwn',
    description: 'Automatically generated definition',
    extend: [deviceEndpoints({"endpoints":{"1":1,"2":2}}), identify(), onOff({"powerOnBehavior":false,"endpointNames":["1","2"]}), electricityMeter()],
    meta: {"multiEndpoint":true},
};

module.exports = definition;
```

I had to convert it since Tuya examples are in the old style. I added the external definition to z2m and tested it, seems to work fine.