### PR TITLE
Add _TZ3000_mw1pqqqt

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10953,6 +10953,27 @@ const definitions: Definition[] = [
             ],
         },
     },
+    {
+        fingerprint: [{
+                modelID: 'TS0002',
+                manufacturerName: '_TZ3000_h1ipgkwn',
+            },
+        ],
+        model: '2CH Zigbee USB Switch Module',
+        vendor: 'Tuya',
+        description: '2-way USB Smart Adapter',
+        configure: tuya.configureMagicPacket,
+        extend: [
+            tuya.modernExtend.tuyaOnOff({
+                endpoints: ['l1', 'l2']
+            }),
+        ],
+    	endpoint: (device) => {
+    		return {l1: 1, l2: 2};
+    	},
+    	meta: {multiEndpoint: true},
+    	whiteLabel: [tuya.whitelabel('UNSH', '[N/A]', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
+    }
 ];
 
 export default definitions;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10978,7 +10978,35 @@ const definitions: Definition[] = [
         meta: {
             multiEndpoint: true,
         },
-        whiteLabel: [tuya.whitelabel('UNSH', '[N/A]', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
+        whiteLabel: [tuya.whitelabel('UNSH', 'micro_usb_2ch', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
+    },
+    {
+        fingerprint: [
+            {
+                modelID: 'TS0003',
+                manufacturerName: '_TZ3000_mw1pqqqt',
+            },
+        ],
+        model: '3CH Zigbee USB Switch Module',
+        vendor: 'Tuya',
+        description: '3-way USB Smart Adapter',
+        configure: tuya.configureMagicPacket,
+        extend: [
+            tuya.modernExtend.tuyaOnOff({
+                endpoints: ['l1', 'l2', 'l3'],
+            }),
+        ],
+        endpoint: (device) => {
+            return {
+                l1: 1,
+                l2: 2,
+                l3: 3,
+            };
+        },
+        meta: {
+            multiEndpoint: true,
+        },
+        whiteLabel: [tuya.whitelabel('UNSH', 'micro_usb_3ch', '3CH Zigbee USB Switch Module', ['_TZ3000_mw1pqqqt'])],
     },
 ];
 

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10954,7 +10954,8 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [{
+        fingerprint: [
+            {
                 modelID: 'TS0002',
                 manufacturerName: '_TZ3000_h1ipgkwn',
             },
@@ -10965,15 +10966,20 @@ const definitions: Definition[] = [
         configure: tuya.configureMagicPacket,
         extend: [
             tuya.modernExtend.tuyaOnOff({
-                endpoints: ['l1', 'l2']
+                endpoints: ['l1', 'l2'],
             }),
         ],
-    	endpoint: (device) => {
-    		return {l1: 1, l2: 2};
-    	},
-    	meta: {multiEndpoint: true},
-    	whiteLabel: [tuya.whitelabel('UNSH', '[N/A]', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
-    }
+        endpoint: (device) => {
+            return {
+                l1: 1,
+                l2: 2,
+            };
+        },
+        meta: {
+            multiEndpoint: true,
+        },
+        whiteLabel: [tuya.whitelabel('UNSH', '[N/A]', '2CH Zigbee USB Switch Module', ['_TZ3000_h1ipgkwn'])],
+    },
 ];
 
 export default definitions;


### PR DESCRIPTION
A Tuya 3-way USB switch, sold under whitelabel by UNSH (no exact model number). See https://www.aliexpress.com/item/1005006406053419.html

Z2m detects it as https://www.zigbee2mqtt.io/devices/TS0003.html, but that's obviously wrong. This device has no metering, too.

Auto-generated external definition, that I derived the PR from:

```js
const {deviceEndpoints, identify, onOff, electricityMeter} = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['TS0003'],
    model: 'TS0003',
    vendor: '_TZ3000_mw1pqqqt',
    description: 'Automatically generated definition',
    extend: [deviceEndpoints({"endpoints":{"1":1,"2":2,"3":3}}), identify(), onOff({"powerOnBehavior":false,"endpointNames":["1","2","3"]}), electricityMeter()],
    meta: {"multiEndpoint":true},
};

module.exports = definition;
```

I added the external definition to z2m and tested it, seems to work fine.

> [!IMPORTANT]
> PR #7824 should be merged before this one.