### PR TITLE
fix: Use `endpointNames` for `electricityMeter` of ZGA003

### DIFF
--- a/src/devices/aeotec.ts
+++ b/src/devices/aeotec.ts
@@ -47,7 +47,7 @@ const definitions: Definition[] = [
             deviceTemperature(),
             identify(),
             onOff({powerOnBehavior: false, endpointNames: ['1', '2']}),
-            electricityMeter(),
+            electricityMeter({endpointNames: ['1', '2']}),
             commandsOnOff({endpointNames: ['3', '4']}),
             commandsLevelCtrl({endpointNames: ['3', '4']}),
         ],


### PR DESCRIPTION
ZGA003 electricity meter readings do not work, as they are reported for each endpoint separately, but we are trying to read only one endpoint. This fix exposes all readings (supported by `electricityMeter`) and they work now.

See also https://github.com/Koenkk/zigbee2mqtt/discussions/23419#discussioncomment-10236839