### PR TITLE
New 1 gang Tuya

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3563,7 +3563,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint(':', ['_TZ3000_myaaknbq', '_TZ3000_cpozgbrx']),
+        fingerprint: tuya.fingerprint('TS0001', ['_TZ3000_myaaknbq', '_TZ3000_cpozgbrx']),
         model: 'TS0001_switch_module_1',
         vendor: 'Tuya',
         description: '1 gang switch module',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3578,9 +3578,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: [
-            {modelID: 'TS0001', manufacturerName: '_TZ3000_gbshwgag'},
-        ],
+        fingerprint: [{modelID: 'TS0001', manufacturerName: '_TZ3000_gbshwgag'}],
         model: 'TS0001_switch_module_2',
         vendor: 'TuYa',
         description: '1 gang switch with backlight',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3563,7 +3563,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0001', ['_TZ3000_myaaknbq', '_TZ3000_cpozgbrx']),
+        fingerprint: tuya.fingerprint(':', ['_TZ3000_myaaknbq', '_TZ3000_cpozgbrx']),
         model: 'TS0001_switch_module_1',
         vendor: 'Tuya',
         description: '1 gang switch module',
@@ -3572,6 +3572,19 @@ const definitions: Definition[] = [
             tuya.whitelabel('PSMART', 'T441', '1 gang switch module', ['_TZ3000_myaaknbq']),
             tuya.whitelabel('PSMART', 'T461', '1 gang switch module', ['_TZ3000_cpozgbrx']),
         ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+        },
+    },
+    {
+        fingerprint: [
+            {modelID: 'TS0001', manufacturerName: '_TZ3000_gbshwgag'},
+        ],
+        model: 'TS0001_switch_module_2',
+        vendor: 'TuYa',
+        description: '1 gang switch with backlight',
+        extend: [tuya.modernExtend.tuyaOnOff({powerOnBehavior2: true, backlightModeOffOn: true, indicatorMode: true})],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);


### PR DESCRIPTION
Hello!

Add new switch tuya brand. This switch is already recognized as ["TS0001" switch](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L3549) but this converter doesn't use all available features. And all already added similar switches doesn't have available features too. 
Since I can't check different with already added models, I've decide to add new switch.

If there are any options how to add this new switch to existed with full support of available features, Please provide the idea how to do it and I will update PD.