### PR TITLE
chore: Convert ELKO 4523430 to use modern extend syntax

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1926,30 +1926,9 @@ const converters1 = {
             const result: KeyValueAny = {};
             const data = msg.data;
 
-            if (data.hasOwnProperty('elkoLoad')) {
-                // Load
-                result.load = data['elkoLoad'];
-            }
-
             if (data.hasOwnProperty('elkoDisplayText')) {
                 // Display text
                 result.display_text = data['elkoDisplayText'];
-            }
-
-            if (data.hasOwnProperty('elkoSensor')) {
-                // Sensor
-                const sensorModeLookup: KeyValueAny = {'0': 'air', '1': 'floor', '3': 'supervisor_floor'};
-                result.sensor = sensorModeLookup[data['elkoSensor']];
-            }
-
-            if (data.hasOwnProperty('elkoRegulatorTime')) {
-                // Regulator time
-                result.regulator_time = data['elkoRegulatorTime'];
-            }
-
-            if (data.hasOwnProperty('elkoRegulatorMode')) {
-                // Regulator mode
-                result.regulator_mode = data['elkoRegulatorMode'] ? 'regulator' : 'thermostat';
             }
 
             if (data.hasOwnProperty('elkoPowerStatus')) {
@@ -1957,34 +1936,9 @@ const converters1 = {
                 result.system_mode = data['elkoPowerStatus'] ? 'heat' : 'off';
             }
 
-            if (data.hasOwnProperty('elkoMeanPower')) {
-                // Mean power
-                result.mean_power = data['elkoMeanPower'];
-            }
-
             if (data.hasOwnProperty('elkoExternalTemp')) {
                 // External temp (floor)
                 result.floor_temp = utils.precisionRound(data['elkoExternalTemp'], 2) / 100;
-            }
-
-            if (data.hasOwnProperty('elkoNightSwitching')) {
-                // Night switching
-                result.night_switching = data['elkoNightSwitching'] ? 'on' : 'off';
-            }
-
-            if (data.hasOwnProperty('elkoFrostGuard')) {
-                // Frost guard
-                result.frost_guard = data['elkoFrostGuard'] ? 'on' : 'off';
-            }
-
-            if (data.hasOwnProperty('elkoChildLock')) {
-                // Child lock
-                result.child_lock = data['elkoChildLock'] ? 'lock' : 'unlock';
-            }
-
-            if (data.hasOwnProperty('elkoMaxFloorTemp')) {
-                // Max floor temp
-                result.max_floor_temp = data['elkoMaxFloorTemp'];
             }
 
             if (data.hasOwnProperty('elkoRelayState')) {

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1840,16 +1840,6 @@ const converters2 = {
     // #endregion
 
     // #region Non-generic converters
-    elko_load: {
-        key: ['load'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {elkoLoad: value});
-            return {state: {load: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoLoad']);
-        },
-    } satisfies Tz.Converter,
     elko_display_text: {
         key: ['display_text'],
         convertSet: async (entity, key, value, meta) => {
@@ -1875,79 +1865,10 @@ const converters2 = {
             await entity.read('hvacThermostat', ['elkoPowerStatus']);
         },
     } satisfies Tz.Converter,
-    elko_external_temp: {
-        key: ['floor_temp'],
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoExternalTemp']);
-        },
-    } satisfies Tz.Converter,
-    elko_mean_power: {
-        key: ['mean_power'],
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoMeanPower']);
-        },
-    } satisfies Tz.Converter,
-    elko_child_lock: {
-        key: ['child_lock'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {elkoChildLock: value === 'lock'});
-            return {state: {child_lock: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoChildLock']);
-        },
-    } satisfies Tz.Converter,
-    elko_frost_guard: {
-        key: ['frost_guard'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {elkoFrostGuard: value === 'on'});
-            return {state: {frost_guard: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoFrostGuard']);
-        },
-    } satisfies Tz.Converter,
-    elko_night_switching: {
-        key: ['night_switching'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {elkoNightSwitching: value === 'on'});
-            return {state: {night_switching: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoNightSwitching']);
-        },
-    } satisfies Tz.Converter,
     elko_relay_state: {
         key: ['running_state'],
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoRelayState']);
-        },
-    } satisfies Tz.Converter,
-    elko_sensor_mode: {
-        key: ['sensor'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {elkoSensor: utils.getFromLookup(value, {air: '0', floor: '1', supervisor_floor: '3'})});
-            return {state: {sensor: value}};
-        },
-    } satisfies Tz.Converter,
-    elko_regulator_time: {
-        key: ['regulator_time'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {elkoRegulatorTime: value});
-            return {state: {sensor: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoRegulatorTime']);
-        },
-    } satisfies Tz.Converter,
-    elko_regulator_mode: {
-        key: ['regulator_mode'],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write('hvacThermostat', {elkoRegulatorMode: value === 'regulator'});
-            return {state: {regulator_mode: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoRegulatorMode']);
         },
     } satisfies Tz.Converter,
     elko_local_temperature_calibration: {
@@ -1959,19 +1880,6 @@ const converters2 = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('hvacThermostat', ['elkoCalibration']);
-        },
-    } satisfies Tz.Converter,
-    elko_max_floor_temp: {
-        key: ['max_floor_temp'],
-        convertSet: async (entity, key, value, meta) => {
-            utils.assertArray(value);
-            if (value.length <= 14) {
-                await entity.write('hvacThermostat', {elkoMaxFloorTemp: value});
-                return {state: {max_floor_temp: value}};
-            }
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('hvacThermostat', ['elkoMaxFloorTemp']);
         },
     } satisfies Tz.Converter,
     livolo_socket_switch_on_off: {

--- a/src/devices/ctm.ts
+++ b/src/devices/ctm.ts
@@ -102,10 +102,6 @@ const fzLocal = {
                 // Load
                 result.load = data[0x0401];
             }
-            if (data.hasOwnProperty('elkoLoad')) {
-                // Load
-                result.load = data['elkoLoad'];
-            }
             if (data.hasOwnProperty(0x0402)) {
                 // Display text
                 result.display_text = data[0x0402];
@@ -127,26 +123,9 @@ const fzLocal = {
                 };
                 result.sensor = utils.getFromLookup(data[0x0403], sensorModeLookup);
             }
-            if (data.hasOwnProperty('elkoSensor')) {
-                // Sensor
-                const sensorModeLookup = {
-                    0: 'air',
-                    1: 'floor',
-                    2: 'external',
-                    3: 'regulator',
-                    4: 'mv_air',
-                    5: 'mv_external',
-                    6: 'mv_regulator',
-                };
-                result.sensor = utils.getFromLookup(data['elkoSensor'], sensorModeLookup);
-            }
             if (data.hasOwnProperty(0x0405)) {
                 // Regulator mode
                 result.regulator_mode = data[0x0405] ? 'regulator' : 'thermostat';
-            }
-            if (data.hasOwnProperty('elkoRegulatorMode')) {
-                // Regulator mode
-                result.regulator_mode = data['elkoRegulatorMode'] ? 'regulator' : 'thermostat';
             }
             if (data.hasOwnProperty(0x0406)) {
                 // Power status
@@ -160,10 +139,6 @@ const fzLocal = {
                 // Mean power
                 result.mean_power = data[0x0408];
             }
-            if (data.hasOwnProperty('elkoMeanPower')) {
-                // Mean power
-                result.mean_power = data['elkoMeanPower'];
-            }
             if (data.hasOwnProperty(0x0409)) {
                 // Floor temp
                 result.floor_temp = utils.precisionRound(data[0x0409], 2) / 100;
@@ -176,33 +151,17 @@ const fzLocal = {
                 // Night switching
                 result.night_switching = data[0x0411] ? 'ON' : 'OFF';
             }
-            if (data.hasOwnProperty('elkoNightSwitching')) {
-                // Night switching
-                result.night_switching = data['elkoNightSwitching'] ? 'ON' : 'OFF';
-            }
             if (data.hasOwnProperty(0x0412)) {
                 // Frost guard
                 result.frost_guard = data[0x0412] ? 'ON' : 'OFF';
-            }
-            if (data.hasOwnProperty('elkoFrostGuard')) {
-                // Frost guard
-                result.frost_guard = data['elkoFrostGuard'] ? 'ON' : 'OFF';
             }
             if (data.hasOwnProperty(0x0413)) {
                 // Child lock
                 result.child_lock = data[0x0413] ? 'LOCK' : 'UNLOCK';
             }
-            if (data.hasOwnProperty('elkoChildLock')) {
-                // Child lock
-                result.child_lock = data['elkoChildLock'] ? 'LOCK' : 'UNLOCK';
-            }
             if (data.hasOwnProperty(0x0414)) {
                 // Max floor temp
                 result.max_floor_temp = data[0x0414];
-            }
-            if (data.hasOwnProperty('elkoMaxFloorTemp')) {
-                // Max floor temp
-                result.max_floor_temp = data['elkoMaxFloorTemp'];
             }
             if (data.hasOwnProperty(0x0415)) {
                 // Running_state

--- a/src/devices/elko.ts
+++ b/src/devices/elko.ts
@@ -39,7 +39,6 @@ const definitions: Definition[] = [
         fromZigbee: [fz.elko_thermostat, fz.thermostat],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint,
-            tz.thermostat_occupied_heating_setpoint,
             tz.elko_load,
             tz.elko_display_text,
             tz.elko_power_status,

--- a/src/devices/elko.ts
+++ b/src/devices/elko.ts
@@ -2,9 +2,10 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as constants from '../lib/constants';
 import * as exposes from '../lib/exposes';
-import {light} from '../lib/modernExtend';
+import {binary, enumLookup, light, numeric} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {Definition} from '../lib/types';
+
 const ea = exposes.access;
 const e = exposes.presets;
 
@@ -39,43 +40,121 @@ const definitions: Definition[] = [
         fromZigbee: [fz.elko_thermostat, fz.thermostat],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint,
-            tz.elko_load,
             tz.elko_display_text,
             tz.elko_power_status,
-            tz.elko_external_temp,
-            tz.elko_mean_power,
-            tz.elko_child_lock,
-            tz.elko_frost_guard,
             tz.elko_relay_state,
-            tz.elko_sensor_mode,
             tz.elko_local_temperature_calibration,
-            tz.elko_max_floor_temp,
-            tz.elko_regulator_mode,
-            tz.elko_regulator_time,
-            tz.elko_night_switching,
+        ],
+        extend: [
+            numeric({
+                name: 'load',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoLoad',
+                description: 'Load in W when heating is on (between 0-2300 W). The thermostat uses the value as input to the mean_power calculation.',
+                access: 'ALL',
+                unit: 'W',
+                reporting: {min: 0, max: constants.repInterval.HOUR, change: 1},
+                valueMin: 0,
+                valueMax: 2300,
+            }),
+            binary({
+                name: 'regulator_mode',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoRegulatorMode',
+                description: 'Device in regulator or thermostat mode.',
+                access: 'ALL',
+                reporting: {attribute: 'elkoRegulatorMode', min: 0, max: constants.repInterval.HOUR, change: null},
+                valueOn: ['regulator', 0],
+                valueOff: ['thermostat', 1],
+            }),
+            numeric({
+                name: 'regulator_time',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoRegulatorTime',
+                description:
+                    'When device is in regulator mode this controls the time between each ' +
+                    'in/out connection. When device is in thermostat mode this controls the  time between each in/out switch when measured ' +
+                    'temperature is within +-0.5 °C set temperature. Choose a long time for (slow) concrete floors and a short time for ' +
+                    '(quick) wooden floors.',
+                access: 'ALL',
+                reporting: {min: 0, max: constants.repInterval.HOUR, change: 1},
+                unit: 'min',
+                valueMin: 5,
+                valueMax: 20,
+            }),
+            enumLookup({
+                name: 'sensor',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoSensor',
+                description: 'Select temperature sensor to use',
+                reporting: {min: 'MIN', max: 'MAX', change: null},
+                lookup: {air: 0, floor: 1, supervisor_floor: 3},
+            }),
+            numeric({
+                name: 'floor_temp',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoFloorTemp',
+                description: 'Current temperature measured on the external sensor (floor)',
+                access: 'STATE_GET',
+                unit: '°C',
+                reporting: {min: 0, max: constants.repInterval.HOUR, change: 10},
+            }),
+            numeric({
+                name: 'max_floor_temp',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoMaxFloorTemp',
+                description: 'Set max floor temperature (between 20-35 °C) when "supervisor_floor" is set',
+                access: 'ALL',
+                reporting: {min: 0, max: constants.repInterval.HOUR, change: 1},
+                unit: '°C',
+                valueMin: 20,
+                valueMax: 35,
+            }),
+            numeric({
+                name: 'mean_power',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoMeanPower',
+                description: 'Reports average power usage last 10 minutes',
+                access: 'STATE_GET',
+                unit: 'W',
+                reporting: {min: 0, max: constants.repInterval.HOUR, change: 5},
+            }),
+            binary({
+                name: 'child_lock',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoChildLock',
+                description: 'Enables/disables physical input on the device',
+                access: 'ALL',
+                reporting: {attribute: 'elkoChildLock', min: 0, max: constants.repInterval.HOUR, change: null},
+                valueOn: ['lock', 1],
+                valueOff: ['unlock', 0],
+            }),
+            binary({
+                name: 'frost_guard',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoFrostGuard',
+                description:
+                    'When frost guard is ON, it is activated when the thermostat is switched OFF with the ON/OFF button.' +
+                    'At the same time, the display will fade and the text "Frostsikring x °C" appears in the display and remains until the ' +
+                    'thermostat is switched on again.',
+                access: 'ALL',
+                reporting: {attribute: 'elkoFrostGuard', min: 0, max: constants.repInterval.HOUR, change: null},
+                valueOn: ['on', 1],
+                valueOff: ['off', 0],
+            }),
+            binary({
+                name: 'night_switching',
+                cluster: 'hvacThermostat',
+                attribute: 'elkoNightSwitching',
+                description: 'Turn on or off night setting.',
+                access: 'ALL',
+                reporting: {attribute: 'elkoNightSwitching', min: 0, max: constants.repInterval.HOUR, change: null},
+                valueOn: ['on', 1],
+                valueOff: ['off', 0],
+            }),
         ],
         exposes: [
             e.text('display_text', ea.ALL).withDescription('Displayed text on thermostat display (zone). Max 14 characters'),
-            e
-                .numeric('load', ea.ALL)
-                .withUnit('W')
-                .withDescription(
-                    'Load in W when heating is on (between 0-2300 W). The thermostat uses the value as input to the mean_power calculation.',
-                )
-                .withValueMin(0)
-                .withValueMax(2300),
-            e.binary('regulator_mode', ea.ALL, 'regulator', 'thermostat').withDescription('Device in regulator or thermostat mode.'),
-            e
-                .numeric('regulator_time', ea.ALL)
-                .withUnit('min')
-                .withValueMin(5)
-                .withValueMax(20)
-                .withDescription(
-                    'When device is in regulator mode this controls the time between each ' +
-                        'in/out connection. When device is in thermostat mode this controls the  time between each in/out switch when measured ' +
-                        'temperature is within +-0.5 °C set temperature. Choose a long time for (slow) concrete floors and a short time for ' +
-                        '(quick) wooden floors.',
-                ),
             e
                 .climate()
                 .withSetpoint('occupied_heating_setpoint', 5, 50, 1)
@@ -83,24 +162,6 @@ const definitions: Definition[] = [
                 .withLocalTemperatureCalibration()
                 .withSystemMode(['off', 'heat'])
                 .withRunningState(['idle', 'heat']),
-            e.temperature_sensor_select(['air', 'floor', 'supervisor_floor']),
-            e.numeric('floor_temp', ea.STATE_GET).withUnit('°C').withDescription('Current temperature measured from the floor sensor'),
-            e
-                .numeric('max_floor_temp', ea.ALL)
-                .withUnit('°C')
-                .withDescription('Set max floor temperature (between 20-35 °C) when "supervisor_floor" is set')
-                .withValueMin(20)
-                .withValueMax(35),
-            e.numeric('mean_power', ea.STATE_GET).withUnit('W').withDescription('Reports average power usage last 10 minutes'),
-            e.binary('child_lock', ea.ALL, 'lock', 'unlock').withDescription('Enables/disables physical input on the device'),
-            e
-                .binary('frost_guard', ea.ALL, 'on', 'off')
-                .withDescription(
-                    'When frost guard is ON, it is activated when the thermostat is switched OFF with the ON/OFF button.' +
-                        'At the same time, the display will fade and the text "Frostsikring x °C" appears in the display and remains until the ' +
-                        'thermostat is switched on again.',
-                ),
-            e.binary('night_switching', ea.ALL, 'on', 'off').withDescription('Turn on or off night setting.'),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
@@ -111,64 +172,10 @@ const definitions: Definition[] = [
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
 
             // ELKO attributes
-            // Load value
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoLoad',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: 1,
-                },
-            ]);
             // Power status
             await endpoint.configureReporting('hvacThermostat', [
                 {
                     attribute: 'elkoPowerStatus',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: null,
-                },
-            ]);
-            // Power consumption
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoMeanPower',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: 5,
-                },
-            ]);
-            // External temp sensor (floor)
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoExternalTemp',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: 10,
-                },
-            ]);
-            // Child lock active/inactive
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoChildLock',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: null,
-                },
-            ]);
-            // Night switching
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoNightSwitching',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: null,
-                },
-            ]);
-            // Frost guard
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoFrostGuard',
                     minimumReportInterval: 0,
                     maximumReportInterval: constants.repInterval.HOUR,
                     reportableChange: null,
@@ -181,34 +188,6 @@ const definitions: Definition[] = [
                     minimumReportInterval: 0,
                     maximumReportInterval: constants.repInterval.HOUR,
                     reportableChange: null,
-                },
-            ]);
-            // Max floor temp
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoMaxFloorTemp',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: 1,
-                },
-            ]);
-
-            // Regulator mode
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoRegulatorMode',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: null,
-                },
-            ]);
-            // Regulator time
-            await endpoint.configureReporting('hvacThermostat', [
-                {
-                    attribute: 'elkoRegulatorTime',
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: 1,
                 },
             ]);
             // Trigger read


### PR DESCRIPTION
Hi 👋

I'm preparing some modifications to this device, thought I'd clean it up a bit first by implementing the new `extend` syntax.

Please let me know if I overlooked anything (first committer and all that jazz...). I have this device installed in my house, so I have verified that it still functions as intended.

Finally, is my understanding correct that there does not currently exist any modern extend converters for the `text` and `climate` attributes?