### PR TITLE
Add Adeo ZBEK-31

### DIFF
--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -207,6 +207,13 @@ const definitions: Definition[] = [
         extend: [light({colorTemp: {range: [153, 370]}, color: true})],
     },
     {
+        zigbeeModel: ['ZBEK-31'],
+        model: '84870054',
+        vendor: 'ADEO',
+        description: 'ENKI LEXMAN Extraflat 85',
+        extend: [light({colorTemp: {range: [153, 370]}, color: true})],
+    },
+    {
         zigbeeModel: ['ZBEK-34'],
         model: '84870058',
         vendor: 'ADEO',


### PR DESCRIPTION
Add support for [ENKI LEXMAN Extraflat 85](https://www.leroymerlin.fr/produits/decoration-eclairage/luminaire-interieur/spot-encastrable/spot-encastrable-led/spot-a-encastrer-connecte-extraflat-enki-led-couleurs-et-blancs-d8-5-blanc-84870054.html) (Adeo model ZBEK-31)

Pull request for picture https://github.com/Koenkk/zigbee2mqtt.io/pull/2940

