### PR TITLE
Update immax.ts: Added another fingerprint for Neo smart keypad

### DIFF
--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -237,7 +237,7 @@ const definitions: Definition[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_n9clpsht', '_TZE200_nyvavzbj']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_n9clpsht', '_TZE200_nyvavzbj', '_TZE200_moycceze']),
         model: '07505L',
         vendor: 'Immax',
         description: 'Neo smart keypad',


### PR DESCRIPTION
I just received my Immax Neo Keypad (07505L) which identifies itself with another vendor string. Added it to the list of known fingerprints.

Zigbee2Mqtt generates this definition for my keypad:

const definition = {
    zigbeeModel: ['TS0601'],
    model: 'TS0601',
    vendor: '_TZE200_moycceze',
    description: 'Automatically generated definition',
    extend: [],
    meta: {},
};