### PR TITLE
Add manufacturer for Tuya TS0601_fan_5_levels_and_light_switch

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8116,7 +8116,7 @@ const definitions: Definition[] = [
         whiteLabel: [{vendor: 'Lerlink', model: 'T2-Z67/T2-W67'}],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_hmqzfqml', '_TZE200_qanl25yu']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_hmqzfqml', '_TZE200_qanl25yu', '_TZE204_lawxy9e2']),
         model: 'TS0601_fan_and_light_switch',
         vendor: 'Tuya',
         description: 'Fan & light switch',


### PR DESCRIPTION
Added manufacturer for the Zigbee fan controller I bought. Tested and it works fine with the existing configuration.

![image](https://github.com/user-attachments/assets/de1236c1-3c8e-44ad-baf7-2135b32dbda8)
![image](https://github.com/user-attachments/assets/f802a380-4eff-419c-b9c0-6d6ba7de255f)
