### PR TITLE
Fix E2013 from IKEA

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -914,7 +914,8 @@ const definitions: Definition[] = [
         description: 'PARASOLL door/window sensor',
         extend: [
             addCustomClusterManuSpecificIkeaUnknown(),
-            bindCluster({cluster: 'genPollCtrl', clusterType: 'input'}),
+            deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
+            bindCluster({cluster: 'ssIasZone', clusterType: 'input', endpointNames: ['2']}),
             iasZoneAlarm({zoneType: 'contact', zoneAttributes: ['alarm_1']}),
             identify({isSleepy: true}),
             battery(),


### PR DESCRIPTION
Reintroduce both endpoint definition and bind the ssIasZone cluster to allow contact reporting right out of the box. The binding and endpoint definition was (probably unintentionally) removed in #7220 

Related to https://github.com/Koenkk/zigbee2mqtt/issues/22579