### PR TITLE
Update Gledopto Pro LED controllers to standard light ModernExtend

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -241,7 +241,7 @@ const definitions: Definition[] = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee LED Controller WW/CW (pro)',
-        extend: [gledoptoLight({colorTemp: {range: undefined}}), gledoptoConfigureReadModelID()],
+        extend: [light({colorTemp: {range: [158, 500]}}), identify(), gledoptoConfigureReadModelID()],
     },
     {
         zigbeeModel: ['GL-G-003P'],
@@ -341,7 +341,11 @@ const definitions: Definition[] = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee LED Controller RGBW (pro)',
-        extend: [gledoptoLight({colorTemp: {range: undefined}, color: true}), gledoptoConfigureReadModelID()],
+        extend: [
+            light({colorTemp: {range: [158, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}}),
+            identify(),
+            gledoptoConfigureReadModelID(),
+        ],
     },
     {
         fingerprint: [
@@ -414,7 +418,7 @@ const definitions: Definition[] = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee LED Controller RGB (pro)',
-        extend: [gledoptoLight({color: true, powerOnBehavior: true}), gledoptoConfigureReadModelID()],
+        extend: [light({color: {modes: ['xy', 'hs'], enhancedHue: true}}), identify(), gledoptoConfigureReadModelID()],
     },
     {
         zigbeeModel: ['GL-C-008P'],
@@ -426,7 +430,11 @@ const definitions: Definition[] = [
             {vendor: 'Gledopto', model: 'GL-C-001P'},
             {vendor: 'Gledopto', model: 'GL-C-002P'},
         ],
-        extend: [gledoptoLight({colorTemp: {range: [158, 495]}, color: true}), gledoptoConfigureReadModelID()],
+        extend: [
+            light({colorTemp: {range: [158, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}}),
+            identify(),
+            gledoptoConfigureReadModelID(),
+        ],
         meta: {disableDefaultResponse: true},
     },
     {
@@ -453,7 +461,7 @@ const definitions: Definition[] = [
         vendor: 'Gledopto',
         ota: ota.zigbeeOTA,
         description: 'Zigbee LED Controller W (pro)',
-        extend: [gledoptoLight({powerOnBehavior: true}), gledoptoConfigureReadModelID()],
+        extend: [light(), identify(), gledoptoConfigureReadModelID()],
     },
     {
         zigbeeModel: ['GL-C-009S'],


### PR DESCRIPTION
Tested with GL-C-008P Mini, GL-C-006P Mini and GL-C-301P which is a 5in1 device and switches its identity between 003P, 006P, 007P, 008P and 009P.
All of these devices support power on behavior and identify.
Also tested transition which was not working for colors with the old code and works after this change.