### PR TITLE
Add "off" system mode to Vimar 02973.B.

### DIFF
--- a/src/devices/vimar.ts
+++ b/src/devices/vimar.ts
@@ -86,7 +86,7 @@ const definitions: Definition[] = [
                 .withSetpoint('occupied_heating_setpoint', 4, 40, 0.1)
                 .withSetpoint('occupied_cooling_setpoint', 4, 40, 0.1)
                 .withLocalTemperature()
-                .withSystemMode(['off','heat', 'cool']),
+                .withSystemMode(['off', 'heat', 'cool']),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(10);

--- a/src/devices/vimar.ts
+++ b/src/devices/vimar.ts
@@ -86,7 +86,7 @@ const definitions: Definition[] = [
                 .withSetpoint('occupied_heating_setpoint', 4, 40, 0.1)
                 .withSetpoint('occupied_cooling_setpoint', 4, 40, 0.1)
                 .withLocalTemperature()
-                .withSystemMode(['heat', 'cool']),
+                .withSystemMode(['off','heat', 'cool']),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(10);


### PR DESCRIPTION
Add "off" system mode to Vimar 02973.B.

The Vimar 02973.B reports and accepts "off" as system mode:

`2024-08-19 14:08:49z2m:mqtt: MQTT publish: topic 'zigbee2mqtt/Termostato camera', payload '{"linkquality":168,"local_temperature":27.5,"occupied_cooling_setpoint":23,"occupied_heating_setpoint":17,"running_state":"idle","system_mode":"off"}'`

Without "off" as system mode, home assistants logs this error:

`Logger: homeassistant.components.mqtt.climate
Source: components/mqtt/climate.py:703
integration: MQTT ([documentation](https://www.home-assistant.io/integrations/mqtt), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+mqtt%22))
First occurred: 13:05:30 (15 occurrences)
Last logged: 13:15:10

Invalid modes mode: off`