### PR TITLE
Fix TS0222_temperature_humidity model

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6351,7 +6351,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay']),
+        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay', '_TZE204_myd45weu']),
         model: 'TS0222_temperature_humidity',
         vendor: 'Tuya',
         description: 'Temperature & humidity sensor',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6359,7 +6359,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance()],
-        whiteLabel: [tuya.whitelabel('Tuya', 'TS0222_temperature_humidity', 'Soil sensor', ['_TZ3000_kky16aay', '_TZE204_myd45weu'])],
+        whiteLabel: [tuya.whitelabel('Tuya', 'QT-07S', 'Soil sensor', ['_TZE204_myd45weu'])],
     },
     {
         fingerprint: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6359,7 +6359,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance()],
-        whiteLabel: [tuya.whitelabel('Tuya', 'QT-07S', 'Soil sensor', ['_TZ3000_kky16aay', '_TZE204_myd45weu'])],
+        whiteLabel: [tuya.whitelabel('Tuya', 'TS0222_temperature_humidity', 'Soil sensor', ['_TZ3000_kky16aay', '_TZE204_myd45weu'])],
     },
     {
         fingerprint: [


### PR DESCRIPTION
Model should be so that it links to https://www.zigbee2mqtt.io/devices/TS0222_temperature_humidity.html instead of https://www.zigbee2mqtt.io/devices/QT-07S.html