### PR TITLE
Updated sonoff.ts to support a rare version of SNZB-01 button

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -657,9 +657,8 @@ const definitions: Definition[] = [
     },
     {
         zigbeeModel: ['KF01', 'KF-01'],
-        model: 'SNZB-01',
+        model: 'SNZB-01-KF',
         vendor: 'SONOFF',
-        whiteLabel: [{vendor: 'eWeLink', model: 'KF01'}],
         description: 'Wireless button',
         exposes: [e.battery(), e.action(['off', 'single',]), e.battery_voltage()],
         fromZigbee: [fz.command_status_change_notification_action, fz.battery],

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -656,6 +656,22 @@ const definitions: Definition[] = [
         },
     },
     {
+        zigbeeModel: ['KF01', 'KF-01'],
+        model: 'SNZB-01',
+        vendor: 'SONOFF',
+        whiteLabel: [{vendor: 'eWeLink', model: 'KF01'}],
+        description: 'Wireless button',
+        fromZigbee: [fz.command_status_change_notification_action, fz.battery],
+        exposes: [e.battery(), e.action(['off', 'single',]), e.battery_voltage()],
+        toZigbee: [],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'genPowerCfg']);
+            await reporting.batteryVoltage(endpoint, {min: 3600, max: 7200});
+            await reporting.batteryPercentageRemaining(endpoint, {min: 3600, max: 7200});
+        },
+    },
+    {
         fingerprint: [
             // ModelID is from the button (SNZB-01) but this is SNZB-02, wrong modelID in firmware?
             // https://github.com/Koenkk/zigbee2mqtt/issues/4338

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -660,7 +660,7 @@ const definitions: Definition[] = [
         model: 'SNZB-01-KF',
         vendor: 'SONOFF',
         description: 'Wireless button',
-        exposes: [e.battery(), e.action(['off', 'single',]), e.battery_voltage()],
+        exposes: [e.battery(), e.action(['off', 'single']), e.battery_voltage()],
         fromZigbee: [fz.command_status_change_notification_action, fz.battery],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -661,10 +661,10 @@ const definitions: Definition[] = [
         vendor: 'SONOFF',
         whiteLabel: [{vendor: 'eWeLink', model: 'KF01'}],
         description: 'Wireless button',
-        fromZigbee: [fz.command_status_change_notification_action, fz.battery],
         exposes: [e.battery(), e.action(['off', 'single',]), e.battery_voltage()],
+        fromZigbee: [fz.command_status_change_notification_action, fz.battery],
         toZigbee: [],
-        configure: async (device, coordinatorEndpoint, logger) => {
+        configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'genPowerCfg']);
             await reporting.batteryVoltage(endpoint, {min: 3600, max: 7200});


### PR DESCRIPTION
Adding support to a rare version of the SNZB-01 button, model KF01, that I own. It shares the same look as WB01 but only supports single click. It uses the "ssIasZone" endpoint to report button presses so copying the WB01 description didn't work. Now the button works.