### PR TITLE
fix(detect): Detect variant of Eco-dim.05 correctly

### DIFF
--- a/src/devices/ecodim.ts
+++ b/src/devices/ecodim.ts
@@ -29,6 +29,16 @@ const definitions: Definition[] = [
                     {ID: 242, profileID: 41440, inputClusters: [], outputClusters: [33]},
                 ],
             },
+            {
+                type: 'Router',
+                manufacturerName: 'EcoDim BV',
+                modelID: 'Eco-Dim.05 Zigbee',
+                endpoints: [
+                    {ID: 1, profileID: 260, inputClusters: [0, 3, 4, 5, 6, 8, 4096], outputClusters: [25]},
+                    {ID: 2, profileID: 260, inputClusters: [0, 3, 4, 5, 6, 8, 4096], outputClusters: [25]},
+                    {ID: 242, profileID: 41440, inputClusters: [], outputClusters: [33]},
+                ],
+            },
         ],
         model: 'Eco-Dim.05',
         vendor: 'EcoDim',


### PR DESCRIPTION
Eco-dim.05 was not being detected, after doing quick inspection it seems they changes the device modelID for some unknown reason. All values extracted from database.db after pairing

database.db entry:
{"id":2,"type":"Router","ieeeAddr":"0x6c5cb1fffeda9d91","nwkAddr":2955,"manufId":4098,"manufName":"EcoDim BV","powerSource":"Mains (single phase)","modelId":"Eco-Dim.05 Zigbee","epList":[1,2,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":257,"inClusterList":[0,3,4,5,6,8,4096],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"Eco-Dim.05 Zigbee","manufacturerName":"EcoDim BV","appVersion":0,"stackVersion":0,"hwVersion":0,"powerSource":1,"zclVersion":8,"dateCode":"20231223","swBuildId":"1.00"}}},"binds":[],"configuredReportings":[],"meta":{}},"2":{"profId":260,"epId":2,"devId":257,"inClusterList":[0,3,4,5,6,8,4096],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"appVersion":0,"stackVersion":0,"hwVersion":0,"modelId":"Eco-Dim.05 Zigbee","manufacturerName":"EcoDim BV","powerSource":1,"zclVersion":8,"dateCode":"20231223","swBuildId":"1.00"}}},"binds":[],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":0,"stackVersion":0,"hwVersion":0,"dateCode":"20231223","swBuildId":"1.00","zclVersion":8,"interviewCompleted":true,"meta":{"configured":332242049},"lastSeen":1724693350952}