### PR TITLE
add generator for genBinaryOutput and genBinaryInput

### DIFF
--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -237,6 +237,8 @@ const inputExtenders: Extender[] = [
         ['closuresWindowCovering'],
         async (d, eps) => [new Generator({extend: m.windowCovering, args: {controls: ['lift', 'tilt']}, source: 'windowCovering'})],
     ],
+    [['genBinaryInput'], extenderBinaryInput],
+    [['genBinaryOutput'], extenderBinaryOutput],
 ];
 
 const outputExtenders: Extender[] = [
@@ -333,4 +335,46 @@ async function extenderElectricityMeter(device: Zh.Device, endpoints: Zh.Endpoin
         args.cluster = metering ? 'metering' : 'electrical';
     }
     return [new Generator({extend: m.electricityMeter, args, source: `electricityMeter`})];
+}
+
+async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
+    const generated: GeneratedExtend[] = [];
+    for (const endpoint of endpoints) {
+        const source = 'binary_input';
+        const description = `${source}_${endpoint.ID}`;
+        const args: m.BinaryArgs = {
+            name: await getClusterAttributeValue<string>(endpoint, 'genBinaryInput', 'description', description),
+            cluster: 'genBinaryInput',
+            attribute: 'presentValue',
+            reporting: {attribute: 'presentValue', min: 'MIN', max: 'MAX', change: 1},
+            valueOn: ['ON', 1],
+            valueOff: ['OFF', 0],
+            description: description,
+            access: 'STATE_GET',
+            endpointName: `${endpoint.ID}`,
+        };
+        generated.push(new Generator({extend: m.binary, args, source: source}));
+    }
+    return generated;
+}
+
+async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
+    const generated: GeneratedExtend[] = [];
+    for (const endpoint of endpoints) {
+        const source = 'binary_output';
+        const description = `${source}_${endpoint.ID}`;
+        const args: m.BinaryArgs = {
+            name: await getClusterAttributeValue<string>(endpoint, 'genBinaryOutput', 'description', description),
+            cluster: 'genBinaryOutput',
+            attribute: 'presentValue',
+            reporting: {attribute: 'presentValue', min: 'MIN', max: 'MAX', change: 1},
+            valueOn: ['ON', 1],
+            valueOff: ['OFF', 0],
+            description: description,
+            access: 'ALL',
+            endpointName: `${endpoint.ID}`,
+        };
+        generated.push(new Generator({extend: m.binary, args, source: source}));
+    }
+    return generated;
 }

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -340,8 +340,7 @@ async function extenderElectricityMeter(device: Zh.Device, endpoints: Zh.Endpoin
 async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
     for (const endpoint of endpoints) {
-        const source = 'binary_input';
-        const description = `${source}_${endpoint.ID}`;
+        const description = `binary_input_${endpoint.ID}`;
         const args: m.BinaryArgs = {
             name: await getClusterAttributeValue<string>(endpoint, 'genBinaryInput', 'description', description),
             cluster: 'genBinaryInput',
@@ -353,7 +352,7 @@ async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
             access: 'STATE_GET',
             endpointName: `${endpoint.ID}`,
         };
-        generated.push(new Generator({extend: m.binary, args, source: source}));
+        generated.push(new Generator({extend: m.binary, args, source: 'binary'}));
     }
     return generated;
 }
@@ -361,8 +360,7 @@ async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
 async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
     for (const endpoint of endpoints) {
-        const source = 'binary_output';
-        const description = `${source}_${endpoint.ID}`;
+        const description = `binary_output_${endpoint.ID}`;
         const args: m.BinaryArgs = {
             name: await getClusterAttributeValue<string>(endpoint, 'genBinaryOutput', 'description', description),
             cluster: 'genBinaryOutput',
@@ -374,7 +372,7 @@ async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
             access: 'ALL',
             endpointName: `${endpoint.ID}`,
         };
-        generated.push(new Generator({extend: m.binary, args, source: source}));
+        generated.push(new Generator({extend: m.binary, args, source: 'binary'}));
     }
     return generated;
 }


### PR DESCRIPTION
Implement generator for genBinaryOutput and genBinaryInput which was mentioned here https://github.com/Koenkk/zigbee2mqtt/issues/23708

```js
const {deviceEndpoints, binary} = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['v1'],
    model: 'v1',
    vendor: 'esphome',
    description: 'Automatically generated definition',
    extend: [deviceEndpoints({"endpoints":{"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8}}), binary({"name":"zigbee1","cluster":"genBinaryOutput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_output_1","access":"ALL","endpointName":"1"}), binary({"name":"zigbee2","cluster":"genBinaryOutput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_output_2","access":"ALL","endpointName":"2"}), binary({"name":"zigbee3","cluster":"genBinaryOutput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_output_3","access":"ALL","endpointName":"3"}), binary({"name":"zigbee4","cluster":"genBinaryOutput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_output_4","access":"ALL","endpointName":"4"}), binary({"name":"name_test1","cluster":"genBinaryInput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_input_5","access":"STATE_GET","endpointName":"5"}), binary({"name":"name_test2","cluster":"genBinaryInput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_input_6","access":"STATE_GET","endpointName":"6"}), binary({"name":"name_test3","cluster":"genBinaryInput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_input_7","access":"STATE_GET","endpointName":"7"}), binary({"name":"name_test4","cluster":"genBinaryInput","attribute":"presentValue","reporting":{"attribute":"presentValue","min":"MIN","max":"MAX","change":1},"valueOn":["ON",1],"valueOff":["OFF",0],"description":"binary_input_8","access":"STATE_GET","endpointName":"8"})],
    meta: {"multiEndpoint":true},
};

module.exports = definition;
```