### PR TITLE
Add support for new ubisys S1-R (Series 2).

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -735,11 +735,11 @@ const definitions: DefinitionWithExtend[] = [
                 endpoints: [{ID: 1, profileID: 260, deviceID: 266, inputClusters: [0, 3, 4, 5, 6, 1794, 2820], outputClusters: []}],
             },
         ],
-        model: 'S1-R (Series 2)',
+        model: 'S1-R-2',
         vendor: 'ubisys',
         description: 'Power switch S1-R (Series 2)',
         extend: [
-            deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '232': 232}}),
+            deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '232': 232}, multiEndpointSkip: ['state', 'power', 'energy']}),
             identify(),
             onOff({powerOnBehavior: false}),
             electricityMeter({cluster: 'metering', configureReporting: false}),
@@ -753,7 +753,6 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.instantaneousDemand(endpoint);
         },
-        meta: {multiEndpointSkip: ['state', 'power', 'energy']},
         onEvent: async (type, data, device) => {
             /*
              * As per technical doc page 18 section 7.3.4

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -7,6 +7,7 @@ import * as constants from '../lib/constants';
 import * as exposes from '../lib/exposes';
 import * as legacy from '../lib/legacy';
 import {logger} from '../lib/logger';
+import {commandsColorCtrl, commandsLevelCtrl, commandsOnOff, deviceEndpoints, electricityMeter, identify, onOff} from '../lib/modernExtend';
 import * as ota from '../lib/ota';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend, Fz, OnEventType, Tz, OnEventData, Zh, KeyValue, KeyValueAny} from '../lib/types';
@@ -724,6 +725,54 @@ const definitions: DefinitionWithExtend[] = [
             }
         },
         ota: ota.ubisys,
+    },
+    {
+        // S1-R Series 2 uses the same modelId as the regular S1-R, but the energy clusters are located in endpoint 1 (instead of 4, like the regular S1-R).
+        fingerprint: [
+            {
+                manufacturerName: 'ubisys',
+                modelID: 'S1-R (5601)',
+                endpoints: [{ID: 1, profileID: 260, deviceID: 266, inputClusters: [0, 3, 4, 5, 6, 1794, 2820], outputClusters: []}],
+            },
+        ],
+        model: 'S1-R (Series 2)',
+        vendor: 'ubisys',
+        description: 'Power switch S1-R (Series 2)',
+        extend: [
+            deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '232': 232}}),
+            identify(),
+            onOff({powerOnBehavior: false}),
+            electricityMeter({cluster: 'metering', configureReporting: false}),
+            commandsOnOff({endpointNames: ['2', '3']}),
+            commandsLevelCtrl({endpointNames: ['2', '3']}),
+            commandsColorCtrl({endpointNames: ['2', '3']}),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering']);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.instantaneousDemand(endpoint);
+        },
+        meta: {multiEndpointSkip: ['state', 'power', 'energy']},
+        onEvent: async (type, data, device) => {
+            /*
+             * As per technical doc page 18 section 7.3.4
+             * https://www.ubisys.de/wp-content/uploads/ubisys-s1-technical-reference.pdf
+             *
+             * This cluster uses the binding table for managing command targets.
+             * When factory fresh, this cluster is bound to endpoint #1 to
+             * enable local control.
+             *
+             * We use addBinding to 'record' this default binding.
+             */
+            if (type === 'deviceInterview') {
+                const ep1 = device.getEndpoint(1);
+                const ep2 = device.getEndpoint(2);
+                ep2.addBinding('genOnOff', ep1);
+            } else {
+                await ubisysOnEventReadCurrentSummDelivered(type, data, device);
+            }
+        },
     },
     {
         zigbeeModel: ['S2 (5502)', 'S2-R (5602)'],

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -45,7 +45,7 @@ const ubisysPollCurrentSummDelivered = async (type: OnEventType, data: OnEventDa
         await endpoint.read('seMetering', ['currentSummDelivered']);
     };
 
-    utils.onEventPoll(type, data, device, options, 'currentSummDelivered-poll', 60, poll);
+    utils.onEventPoll(type, data, device, options, 'measurement', 60, poll);
 };
 
 const ubisys = {


### PR DESCRIPTION
Adds support for the new ubisys [S1-R (Series 2)](https://smarthome-store.de/power-switch-s1-r.html). Currently a technical reference document for the device is not (yet) available. The main difference seems to be that there is no endpoint `4` in the new device and the energy related clusters are located in endpoint `1` (instead of `4` like the regular S1-R).

The device seems to be working fine:
```
{
    "energy": 0.01,
    "last_seen": "2024-08-29T19:51:12+02:00",
    "linkquality": 116,
    "power": 6.6,
    "state": "ON",
    "action": null
}
```

One thing  i am unsure about is if the fingerprint is working correctly. When i test this `Definition` as external converter with only the `fingerprint` defined (no `zigbeeModel` attribute), the normal S1-R `Definition` is used. As external converter the new `Definition` is only picked up when i trump with the `zigbeeModel` attribute (`S1-R (5601)`). Not sure if this is normal behaviour for external converters or if there something wrong about the fingerprinting?

**db entry (paired with the Definition of this PR)**
```
{
    "id": 9,
    "type": "Router",
    "ieeeAddr": "0x001fee000000a8ea",
    "nwkAddr": 34094,
    "manufId": 4338,
    "manufName": "ubisys",
    "powerSource": "Mains (single phase)",
    "modelId": "S1-R (5601)",
    "epList": [
        1,
        2,
        3,
        232,
        242
    ],
    "endpoints": {
        "1": {
            "profId": 260,
            "epId": 1,
            "devId": 266,
            "inClusterList": [
                0,
                3,
                4,
                5,
                6,
                1794,
                2820
            ],
            "outClusterList": [],
            "clusters": {
                "genBasic": {
                    "attributes": {
                        "modelId": "S1-R (5601)",
                        "manufacturerName": "ubisys",
                        "powerSource": 1,
                        "zclVersion": 8,
                        "appVersion": 1,
                        "stackVersion": 1,
                        "hwVersion": 16,
                        "dateCode": "20240612-DE-FB1",
                        "swBuildId": "2.5.0"
                    }
                },
                "seMetering": {
                    "attributes": {
                        "multiplier": 1,
                        "divisor": 10000
                    }
                },
                "genOnOff": {
                    "attributes": {
                        "onOff": 0
                    }
                }
            },
            "binds": [
                {
                    "cluster": 1794,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                },
                {
                    "cluster": 6,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                }
            ],
            "configuredReportings": [
                {
                    "cluster": 1794,
                    "attrId": 1024,
                    "minRepIntval": 5,
                    "maxRepIntval": 3600,
                    "repChange": 1,
                    "manufacturerCode": null
                },
                {
                    "cluster": 6,
                    "attrId": 0,
                    "minRepIntval": 0,
                    "maxRepIntval": 65000,
                    "repChange": 1,
                    "manufacturerCode": null
                }
            ],
            "meta": {}
        },
        "2": {
            "profId": 260,
            "epId": 2,
            "devId": 260,
            "inClusterList": [
                0,
                3
            ],
            "outClusterList": [
                3,
                5,
                6,
                8,
                768,
                64514
            ],
            "clusters": {},
            "binds": [
                {
                    "cluster": 6,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x001fee000000a8ea",
                    "endpointID": 1
                },
                {
                    "cluster": 6,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                },
                {
                    "cluster": 8,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                },
                {
                    "cluster": 768,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                }
            ],
            "configuredReportings": [],
            "meta": {}
        },
        "3": {
            "profId": 260,
            "epId": 3,
            "devId": 260,
            "inClusterList": [
                0,
                3
            ],
            "outClusterList": [
                3,
                5,
                6,
                8,
                768,
                64514
            ],
            "clusters": {},
            "binds": [
                {
                    "cluster": 6,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                },
                {
                    "cluster": 8,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                },
                {
                    "cluster": 768,
                    "type": "endpoint",
                    "deviceIeeeAddress": "0x00124b002c3a8c02",
                    "endpointID": 1
                }
            ],
            "configuredReportings": [],
            "meta": {}
        },
        "232": {
            "profId": 260,
            "epId": 232,
            "devId": 1287,
            "inClusterList": [
                0,
                61,
                64512,
                64599
            ],
            "outClusterList": [
                3,
                25
            ],
            "clusters": {},
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        },
        "242": {
            "profId": 41440,
            "epId": 242,
            "devId": 97,
            "inClusterList": [],
            "outClusterList": [
                33
            ],
            "clusters": {},
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        }
    },
    "appVersion": 1,
    "stackVersion": 1,
    "hwVersion": 16,
    "dateCode": "20240612-DE-FB1",
    "swBuildId": "2.5.0",
    "zclVersion": 8,
    "interviewCompleted": true,
    "meta": {
        "configured": 332242049
    },
    "lastSeen": 1724949732485
}
```