### PR TITLE
FIX: THE01860A

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6439,7 +6439,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay', '_TZE204_myd45weu', '_TZ3000_t9qqxn70']),
+        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_kky16aay', '_TZE204_myd45weu']),
         model: 'TS0222_temperature_humidity',
         vendor: 'Tuya',
         description: 'Temperature & humidity sensor',
@@ -6449,8 +6449,16 @@ const definitions: Definition[] = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance()],
         whiteLabel: [
             tuya.whitelabel('Tuya', 'QT-07S', 'Soil sensor', ['_TZE204_myd45weu']),
-            tuya.whitelabel('Tuya', 'THE01860A', 'Soil sensor with illuminance', ['_TZ3000_t9qqxn70']),
         ],
+    },
+        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_t9qqxn70']),
+        model: 'THE01860A',
+        vendor: 'Tuya',
+        description: 'Temp & humidity flower sensor with illuminance',
+        fromZigbee: [fromZigbee_1.default.humidity, fromZigbee_1.default.battery, fromZigbee_1.default.temperature, fromZigbee_1.default.illuminance],
+        toZigbee: [],
+        configure: tuya.configureMagicPacket,
+        exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance_lux()],
     },
     {
         fingerprint: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6451,6 +6451,7 @@ const definitions: Definition[] = [
             tuya.whitelabel('Tuya', 'QT-07S', 'Soil sensor', ['_TZE204_myd45weu']),
         ],
     },
+    {
         fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_t9qqxn70']),
         model: 'THE01860A',
         vendor: 'Tuya',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6456,7 +6456,7 @@ const definitions: Definition[] = [
         model: 'THE01860A',
         vendor: 'Tuya',
         description: 'Temp & humidity flower sensor with illuminance',
-        fromZigbee: [fz.default.humidity, fz.default.battery, fz.default.temperature, fz.default.illuminance],
+        fromZigbee: [fz.humidity, fz.battery, fz.temperature, fz.illuminance],
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance_lux()],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6447,9 +6447,7 @@ const definitions: Definition[] = [
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance()],
-        whiteLabel: [
-            tuya.whitelabel('Tuya', 'QT-07S', 'Soil sensor', ['_TZE204_myd45weu']),
-        ],
+        whiteLabel: [tuya.whitelabel('Tuya', 'QT-07S', 'Soil sensor', ['_TZE204_myd45weu'])],
     },
     {
         fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_t9qqxn70']),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6456,7 +6456,7 @@ const definitions: Definition[] = [
         model: 'THE01860A',
         vendor: 'Tuya',
         description: 'Temp & humidity flower sensor with illuminance',
-        fromZigbee: [fromZigbee_1.default.humidity, fromZigbee_1.default.battery, fromZigbee_1.default.temperature, fromZigbee_1.default.illuminance],
+        fromZigbee: [fz.default.humidity, fz.default.battery, fz.default.temperature, fz.default.illuminance],
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.battery(), e.temperature(), e.humidity(), e.illuminance_lux()],


### PR DESCRIPTION
The reason behind the fix:
The fz converter used in the part 'TS0222_temperature_humidity' does not return correct values. This device needs the fz converter: fromZigbee_1.default.humidity