### PR TITLE
Improved battery level accuracy with updated voltage-to-percentage calculation

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -265,18 +265,20 @@ export function getKey<T>(object: {[s: string]: T} | {[s: number]: T}, value: T,
 
 export function batteryVoltageToPercentage(voltage: number, option: BatteryNonLinearVoltage | BatteryLinearVoltage): number {
     if (option === '3V_2100') {
-        let percentage: number = 100; // >= 3000
+        let percentage: number;
 
-        if (voltage < 2100) {
+        if (voltage >= 3200) {
+            percentage = 100;
+        } else if (voltage >= 3000) {
+            percentage = 90 + ((voltage - 3000) * (100 - 90)) / (3200 - 3000);
+        } else if (voltage >= 2900) {
+            percentage = 70 + ((voltage - 2900) * (90 - 70)) / (3000 - 2900);
+        } else if (voltage >= 2800) {
+            percentage = 40 + ((voltage - 2800) * (70 - 40)) / (2900 - 2800);
+        } else if (voltage >= 2700) {
+            percentage = 10 + ((voltage - 2700) * (40 - 10)) / (2800 - 2700);
+        } else {
             percentage = 0;
-        } else if (voltage < 2440) {
-            percentage = 6 - ((2440 - voltage) * 6) / 340;
-        } else if (voltage < 2740) {
-            percentage = 18 - ((2740 - voltage) * 12) / 300;
-        } else if (voltage < 2900) {
-            percentage = 42 - ((2900 - voltage) * 24) / 160;
-        } else if (voltage < 3000) {
-            percentage = 100 - ((3000 - voltage) * 58) / 100;
         }
 
         return Math.round(percentage);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -120,8 +120,12 @@ describe('lib/utils.js', () => {
         });
 
         it('gets non-linear', () => {
-            expect(utils.batteryVoltageToPercentage(2300, '3V_2100')).toStrictEqual(4);
-            expect(utils.batteryVoltageToPercentage(3000, '3V_2100')).toStrictEqual(100);
+            expect(utils.batteryVoltageToPercentage(2600, '3V_2100')).toStrictEqual(0);
+            expect(utils.batteryVoltageToPercentage(2700, '3V_2100')).toStrictEqual(10);
+            expect(utils.batteryVoltageToPercentage(2800, '3V_2100')).toStrictEqual(40);
+            expect(utils.batteryVoltageToPercentage(2900, '3V_2100')).toStrictEqual(70);
+            expect(utils.batteryVoltageToPercentage(3000, '3V_2100')).toStrictEqual(90);
+            expect(utils.batteryVoltageToPercentage(3200, '3V_2100')).toStrictEqual(100);
             expect(utils.batteryVoltageToPercentage(2000, '3V_2100')).toStrictEqual(0);
 
             expect(utils.batteryVoltageToPercentage(2300, '3V_1500_2800')).toStrictEqual(74);


### PR DESCRIPTION
- Updated the voltage-to-percentage conversion to provide a more realistic view of battery levels, especially at lower voltages.
- The previous method sometimes showed full or half-full batteries even when they were actually low.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/8499


## Comparison

| Voltage | Old Conversion Percentage | New Conversion Percentage |
|---------|---------------------------|---------------------------|
| 2600    | 12.4                       | 0.0                       |
| 2650    | 14.4                       | 0.0                       |
| 2700    | 16.4                       | 10.0                      |
| 2750    | 19.5                       | 25.0                      |
| 2800    | 27.0                       | 40.0                      |
| 2850    | 34.5                       | 55.0                      |
| 2900    | 42.0                       | 70.0                      |
| 2950    | 71.0                       | 80.0                      |
| 3000    | 100.0                      | 90.0                      |
| 3050    | 100.0                      | 95.0                      |
| 3100    | 100.0                      | 97.5                      |
| 3150    | 100.0                      | 98.8                      |
| 3200    | 100.0                      | 100.0                     |