### PR TITLE
Fix wrong model in GUI for giex GX02 (_TZE200_7ytb3h8u)

### DIFF
--- a/src/devices/giex.ts
+++ b/src/devices/giex.ts
@@ -85,7 +85,7 @@ const definitions: DefinitionWithExtend[] = [
                 .withUnit('sec')
                 .withDescription('Cycle irrigation interval'),
         ],
-        whiteLabel: [tuya.whitelabel('GiEX', 'GX02', 'Water valve', ['_TZE204_7ytb3h8u', '_TZE284_7ytb3h8u'])],
+        whiteLabel: [tuya.whitelabel('GiEX', 'GX02', 'Water valve', ['_TZE204_7ytb3h8u', '_TZE284_7ytb3h8u', '_TZE200_7ytb3h8u'])],
     },
 ];
 


### PR DESCRIPTION
`giex GX02` was wrongly displayed as model `QT06_2` in the GUI when zigbee manufacturer is `_TZE200_7ytb3h8u`
this issue was reported here - https://github.com/Koenkk/zigbee2mqtt/issues/21844

before
![image](https://github.com/user-attachments/assets/786239fc-ba28-4cab-aa24-90f66cba7049)

after
![image](https://github.com/user-attachments/assets/d41176e5-fe4c-455d-98cc-f7c86c53d356)
