### PR TITLE
Added support for Emos P5630S

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4143,6 +4143,7 @@ const definitions: DefinitionWithExtend[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_7fqkphoq'}, // AFINTEK
             {modelID: 'TS0601', manufacturerName: '_TZE200_rufdtfyv'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_lpwgshtl'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_rk1wojce'}, // Emos P5630S
         ],
         model: 'TS0601_thermostat',
         vendor: 'Tuya',
@@ -4155,6 +4156,7 @@ const definitions: DefinitionWithExtend[] = [
             {vendor: 'Immax', model: '07732B'},
             tuya.whitelabel('Immax', '07732L', 'Radiator valve with thermostat', ['_TZE200_rufdtfyv']),
             {vendor: 'Evolveo', model: 'Heat M30'},
+            tuya.whitelabel('Emos', 'P5630S', 'Radiator valve with thermostat', ['_TZE200_rk1wojce']),
         ],
         meta: {tuyaThermostatPreset: legacy.thermostatPresets, tuyaThermostatSystemMode: legacy.thermostatSystemModes3},
         ota: ota.zigbeeOTA,


### PR DESCRIPTION
Added support for Emos P5630S thermostatic valve similar to other Tuya valves.

Tested states:
```json
{
    "away_mode": "OFF",
    "current_heating_setpoint": 35,
    "force": "open",
    "linkquality": 224,
    "local_temperature": 21,
    "position": 100,
    "preset": "manual",
    "running_state": "heat",
    "system_mode": "heat",
    "temperature": 25
}
```