### PR TITLE
Bugfix for Tuya ZWT198/ZWT100-BH using _TZE204_xnbkhhdr, auto and manual are reversed in preset datapoint.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6433,7 +6433,7 @@ const definitions: DefinitionWithExtend[] = [
                         if (device.manufacturerName === '_TZE200_viy9ihs7') {
                             return {auto: tuya.enum(1), manual: tuya.enum(0), temporary_manual: tuya.enum(2)};
                         } else {
-                            return {manual: tuya.enum(0), auto: tuya.enum(1), temporary_manual: tuya.enum(2)};
+                            return {auto: tuya.enum(0), manual: tuya.enum(1), temporary_manual: tuya.enum(2)};
                         }
                     }),
                 ],


### PR DESCRIPTION
I installed an Avatto wall thermostat (TS0601 _TZE204_xnbkhhdr) and I realized that auto and manual where reversed in preset datapoint in my device, checking the code I noticed that where if branches were the same.