### PR TITLE
Added definition for the Gumax Lighting System

### DIFF
--- a/src/devices/gumax.ts
+++ b/src/devices/gumax.ts
@@ -1,0 +1,18 @@
+import {
+    light,
+} from '../lib/modernExtend';
+import {DefinitionWithExtend} from '../lib/types';
+
+const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ['LST103'],
+        model: 'LST103',
+        vendor: 'Gumax',
+        description: 'Gumax Lighting System',
+        extend: [light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+        meta: {},
+    },
+];
+
+export default definitions;
+module.exports = definitions;

--- a/src/devices/gumax.ts
+++ b/src/devices/gumax.ts
@@ -6,9 +6,8 @@ const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ['LST103'],
         model: 'LST103',
         vendor: 'Gumax',
-        description: 'Gumax Lighting System',
+        description: 'Gumax lighting system',
         extend: [light({colorTemp: {range: [153, 370]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
-        meta: {},
     },
 ];
 

--- a/src/devices/gumax.ts
+++ b/src/devices/gumax.ts
@@ -1,6 +1,4 @@
-import {
-    light,
-} from '../lib/modernExtend';
+import {light} from '../lib/modernExtend';
 import {DefinitionWithExtend} from '../lib/types';
 
 const definitions: DefinitionWithExtend[] = [
@@ -9,7 +7,7 @@ const definitions: DefinitionWithExtend[] = [
         model: 'LST103',
         vendor: 'Gumax',
         description: 'Gumax Lighting System',
-        extend: [light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+        extend: [light({colorTemp: {range: [153, 370]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
         meta: {},
     },
 ];

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -98,6 +98,7 @@ import gledopto from './gledopto';
 import gmmts from './gmmts';
 import gmy from './gmy';
 import gs from './gs';
+import gumax from './gumax';
 import halemeier from './halemeier';
 import hampton_bay from './hampton_bay';
 import heatit from './heatit';
@@ -407,6 +408,7 @@ export default [
     ...gmmts,
     ...gmy,
     ...gs,
+    ...gumax,
     ...halemeier,
     ...hampton_bay,
     ...heatit,


### PR DESCRIPTION
Adding support for the Gumax Lighting System (LST103).

https://www.gumax.com/introduction-gumax-lighting-system/