### PR TITLE
Increase poll interval of Livolo TI0001-hygrometer and TI0001-pir to 300 seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "build": "tsc",
         "build-watch": "tsc --watch",
         "prepack": "npm run clean && npm run build",
-        "prepare": "husky && npm run build"
+        "prepare": "husky"
     },
     "author": "Koen Kanters",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "build": "tsc",
         "build-watch": "tsc --watch",
         "prepack": "npm run clean && npm run build",
-        "prepare": "husky"
+        "prepare": "husky && npm run build"
     },
     "author": "Koen Kanters",
     "license": "MIT",

--- a/src/devices/livolo.ts
+++ b/src/devices/livolo.ts
@@ -271,7 +271,7 @@ const definitions: DefinitionWithExtend[] = [
             if (['start', 'deviceAnnounce'].includes(type)) {
                 await poll(device);
                 if (!globalStore.hasValue(device, 'interval')) {
-                    const interval = setInterval(async () => await poll(device), 10 * 1000);
+                    const interval = setInterval(async () => await poll(device), 300 * 1000);
                     globalStore.putValue(device, 'interval', interval);
                 }
             }
@@ -312,7 +312,7 @@ const definitions: DefinitionWithExtend[] = [
             if (['start', 'deviceAnnounce'].includes(type)) {
                 await poll(device);
                 if (!globalStore.hasValue(device, 'interval')) {
-                    const interval = setInterval(async () => await poll(device), 60 * 1000);
+                    const interval = setInterval(async () => await poll(device), 300 * 1000);
                     globalStore.putValue(device, 'interval', interval);
                 }
             }


### PR DESCRIPTION
I was having issues with the Livolo motion detector (TI0001-pir) having spurious detection events throughout the day. I noticed I was getting payload events every 10 seconds. On the same frequency as this poll interval was set. 

This is unlike the other Livolo devices in the same file, which are all have a 300 seconds interval. Except for the hygrometer.

After setting the TI0001-pir poll interval to 300 seconds, I don't have any false detection events anymore. I've noticed no adverse effects while testing the last 2 months. For consistency I've also put the hygrometer to 300 seconds.


Ps. I need to add `npm run build` to the `prepare` step inside `package.json`. Otherwise, I can't use zigbee-herdsman-converters from a github source in the docker build of zigbee2mqtt. Would it be worth adding that? 