### PR TITLE
Added device IKEA INSPELNING (E2206)

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -604,7 +604,7 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'IKEA',
         description: 'INSPELNING smart plug',
         extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), ikeaOta(), electricityMeter()],
-    },    
+    },
     // #endregion on/off controls
     // #region blinds
     {

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -30,6 +30,7 @@ import {
     commandsWindowCovering,
     deviceAddCustomCluster,
     deviceEndpoints,
+    electricityMeter,
     forcePowerSource,
     humidity,
     iasZoneAlarm,
@@ -597,6 +598,13 @@ const definitions: DefinitionWithExtend[] = [
         description: 'TRETAKT smart plug',
         extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), ikeaOta()],
     },
+    {
+        zigbeeModel: ['INSPELNING Smart plug'],
+        model: 'E2206',
+        vendor: 'IKEA',
+        description: 'INSPELNING smart plug',
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), ikeaOta(), electricityMeter()],
+    },    
     // #endregion on/off controls
     // #region blinds
     {


### PR DESCRIPTION
Adds support for the IKEA INSPELNING (E2206)

This should fix the device support request here: https://github.com/Koenkk/zigbee2mqtt/issues/23961

Looks like everything is working as expected.