### PR TITLE
Add support for SA-028-1 Smart Plug

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -808,7 +808,7 @@ const definitions: DefinitionWithExtend[] = [
         exposes: [e.cover_position(), e.battery()],
     },
     {
-        zigbeeModel: ['Z111PL0H-1JX', 'SA-029-1'],
+        zigbeeModel: ['Z111PL0H-1JX', 'SA-029-1', 'SA-028-1'],
         model: 'SA-028/SA-029',
         vendor: 'SONOFF',
         whiteLabel: [{vendor: 'Woolley', model: 'SA-029-1'}],


### PR DESCRIPTION
Adding support for these Woolley SA-028-1 plugs e.g https://aliexpress.com/i/1005004216522211.html, model is listed https://www.zigbee2mqtt.io/devices/SA-028_SA-029.html but was not included

![Screenshot 2024-09-15 at 14 41 12](https://github.com/user-attachments/assets/ab279866-d221-455f-b7f8-9eefecc4a58d)



