### PR TITLE
fix: TO-Q-SY2-163JZT unable to set over voltage higher than 255

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -496,7 +496,10 @@ const tzLocal = {
                 }
                 case 'over_voltage_threshold': {
                     const state = meta.state['over_voltage_breaker'];
-                    const buf = Buffer.from([3, utils.getFromLookup(state, onOffLookup), 0, utils.toNumber(value, 'over_voltage_breaker')]);
+                    const buf = Buffer.alloc(4);
+                    buf.writeUInt8(3, 0);
+                    buf.writeUInt8(utils.getFromLookup(state, onOffLookup), 1);
+                    buf.writeUInt16BE(utils.toNumber(value, 'over_voltage_threshold'), 2);
                     await entity.command('manuSpecificTuya_3', 'setOptions3', {data: buf});
                     break;
                 }


### PR DESCRIPTION
As described this comment
https://github.com/Koenkk/zigbee2mqtt/issues/21999#issuecomment-2053524181 it wasn't possible to set the over voltage protection over 255. That was due to a overflow.

The fix is tested in hassio-zigbee2mqtt.