### PR TITLE
Add CASAIA CSAC451-WTC-E

### DIFF
--- a/src/devices/casaia.ts
+++ b/src/devices/casaia.ts
@@ -16,6 +16,13 @@ const definitions: DefinitionWithExtend[] = [
         extend: [onOff()],
     },
     {
+        zigbeeModel: ['CSAC451-WTC-E'],
+        model: 'CSAC451-WTC-E',
+        vendor: 'CASAIA',
+        description: 'Dry contact relay switch module in 6-24v AC',
+        extend: [onOff()],
+    },
+    {
         zigbeeModel: ['CTHS317ET'],
         model: 'CTHS-317-ET',
         vendor: 'CASAIA',


### PR DESCRIPTION
Add the CASAIA CSAC451-WTC-E device, device which allows you to control, among other things, gate or garage door motors.

Description : Dry contact relay switch module in 6-24v AC
Test : https://blog.domadoo.fr/90869-casa-ia-csac-451-ac-controle-dacces-zigbee/
Seller : https://shop.smarthome-europe.com/fr/peripheriques/4808-casaia-module-de-controle-d-acces-zigbee-6-24v-dc-contact-sec-et-temporise-a-2-secondes-3770021021120.html

