### PR TITLE
add support for hue tento small (color/white ambiance).

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3807,6 +3807,20 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
+        zigbeeModel: ['929003823001'],
+        model: '929003823001',
+        vendor: 'Philips',
+        description: 'Hue Tento white ambiance 29,1cm',
+        extend: [philipsLight({colorTemp: {range: [153, 438]}})],
+    },
+    {
+        zigbeeModel: ['929003823601'],
+        model: '929003823601',
+        vendor: 'Philips',
+        description: 'Hue Tento color 29,1cm',
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
+    },
+    {
         zigbeeModel: ['929003823701'],
         model: '929003823701',
         vendor: 'Philips',


### PR DESCRIPTION
[tento small color](https://www.philips-hue.com/de-de/p/hue-white---color-ambiance-tento-rundes-wca-led-deckenpanel-29-1-cm-schwarz/8720169330979)
[tento small white ambiance](https://www.philips-hue.com/de-de/p/hue-white-ambiance-tento-rundes-wa-led-deckenpanel-29-1-cm-schwarz/8720169330610#overview)

There are multiple tento variants (size (small, medium, large), form factor (round, square), case color (black, white), light (white, white ambiance, color)). I think most variants could be grouped in the same definition to reduce duplication. I would expect that all tento models with the same light type share the same functionality, so they could be grouped by light type.

Example: The model 929003823601 (round, black, small, color), 929003823701 (round, ???, medium, color) share the same light functions.

But maybe it makes sense to align these later when more models was contributed, to verify this. What do you think?

 