### PR TITLE
fix(lumi): pet feeder LED indicator control

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3849,7 +3849,10 @@ const definitions: DefinitionWithExtend[] = [
                         .withFeature(e.numeric('size', exposes.access.STATE_SET)),
                 )
                 .withDescription('Feeding schedule'),
-            e.binary('led_indicator', ea.STATE_SET, 'ON', 'OFF').withDescription('Led indicator'),
+            e
+                .binary('led_indicator', ea.STATE_SET, 'ON', 'OFF')
+                .withLabel('Disable LED at night')
+                .withDescription('LED indicator will be disabled every day from 21:00 to 09:00'),
             e.child_lock(),
             e.enum('mode', ea.STATE_SET, ['schedule', 'manual']).withDescription('Feeding mode'),
             e.numeric('serving_size', ea.STATE_SET).withValueMin(1).withValueMax(10).withDescription('One serving size').withUnit('portion'),

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3852,11 +3852,24 @@ const definitions: DefinitionWithExtend[] = [
             e
                 .binary('led_indicator', ea.STATE_SET, 'ON', 'OFF')
                 .withLabel('Disable LED at night')
-                .withDescription('LED indicator will be disabled every day from 21:00 to 09:00'),
+                .withDescription('LED indicator will be disabled every day from 21:00 to 09:00')
+                .withCategory('config'),
             e.child_lock(),
             e.enum('mode', ea.STATE_SET, ['schedule', 'manual']).withDescription('Feeding mode'),
-            e.numeric('serving_size', ea.STATE_SET).withValueMin(1).withValueMax(10).withDescription('One serving size').withUnit('portion'),
-            e.numeric('portion_weight', ea.STATE_SET).withValueMin(1).withValueMax(20).withDescription('Portion weight').withUnit('g'),
+            e
+                .numeric('serving_size', ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(10)
+                .withDescription('One serving size')
+                .withUnit('portion')
+                .withCategory('config'),
+            e
+                .numeric('portion_weight', ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(20)
+                .withDescription('Portion weight')
+                .withUnit('g')
+                .withCategory('config'),
         ],
         extend: [lumiZigbeeOTA()],
         configure: async (device, coordinatorEndpoint) => {

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -3760,7 +3760,7 @@ export const toZigbee = {
                     break;
                 }
                 case 'led_indicator':
-                    await sendAttr(0x04170055, getFromLookup(value, {ON: 0, OFF: 1}), 1);
+                    await sendAttr(0x04170055, getFromLookup(value, {ON: 1, OFF: 0}), 1);
                     break;
                 case 'child_lock':
                     await sendAttr(0x04160055, getFromLookup(value, {UNLOCK: 0, LOCK: 1}), 1);


### PR DESCRIPTION
Basically a revert of https://github.com/Koenkk/zigbee-herdsman-converters/commit/3a5c6ae2572bb9e6ad070f6fae99799bf9f6b739

After updating device to firmware version 9761, LED control doesn't work at all. Zigbee2mqtt reports "OFF" state, while indicator is turned on. Controlling the LED state either via zigbee2mqtt or via Home Assistant doesn't result in any change.

I can only assume that previous firmware version (9505) got incorrect status mapping, while latest (9761) fixed this.

refs:
- initial firmware versions https://github.com/Koenkk/zigbee2mqtt/issues/17148#issuecomment-1488366222