### PR TITLE
added current level startup to ikea lights

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -386,7 +386,14 @@ const definitions: DefinitionWithExtend[] = [
         model: 'LED2005R5/LED2106R3',
         vendor: 'IKEA',
         description: 'TRADFRI bulb GU10, white spectrum, 345/380 lm',
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), identify()],
+        extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
+            ikeaLight({
+                colorTemp: true,
+                levelConfig: {disabledFeatures: ['on_off_transition_time', 'on_transition_time', 'off_transition_time', 'on_level']},
+            }),
+            identify(),
+        ],
     },
     // #endregion GU10
     // #region light panels

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -386,14 +386,7 @@ const definitions: DefinitionWithExtend[] = [
         model: 'LED2005R5/LED2106R3',
         vendor: 'IKEA',
         description: 'TRADFRI bulb GU10, white spectrum, 345/380 lm',
-        extend: [
-            addCustomClusterManuSpecificIkeaUnknown(),
-            ikeaLight({
-                colorTemp: true,
-                levelConfig: {disabledFeatures: ['on_off_transition_time', 'on_transition_time', 'off_transition_time', 'on_level']},
-            }),
-            identify(),
-        ],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), identify()],
     },
     // #endregion GU10
     // #region light panels

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -90,7 +90,10 @@ const bulbOnEvent: OnEvent = async (type, data, device, options, state: KeyValue
 
 export function ikeaLight(args?: Omit<LightArgs, 'colorTemp'> & {colorTemp?: true | {range: Range; viaColor: true}}) {
     const colorTemp: {range: Range} = args?.colorTemp ? (args.colorTemp === true ? {range: [250, 454]} : args.colorTemp) : undefined;
-    const result = lightDontUse({...args, colorTemp});
+    const levelConfig: {disabledFeatures?: string[]} = args?.levelConfig
+        ? args.levelConfig
+        : {disabledFeatures: ['on_off_transition_time', 'on_transition_time', 'off_transition_time', 'on_level']};
+    const result = lightDontUse({...args, colorTemp, levelConfig});
     result.ota = ikea;
     result.onEvent = bulbOnEvent;
     if (isObject(args?.colorTemp) && args.colorTemp.viaColor) {


### PR DESCRIPTION
I've added the current level startup to the Ikea lights LED2005R5/LED2106R3 as requested in [zigbee2mqtt#22786](https://github.com/Koenkk/zigbee2mqtt/issues/22786)

It might be worth considering including the attribute in the ikeaLight class, as the poweronbehavior is also set there by default and requires the current level startup or on level anyways. I therefore see no reason to make this attribute directly available to users. 
However, I have refrained from doing this for the time being, as I only have this one device type to test and, to be honest, I am not deep enough in the code to be able to make a qualified judgment. 
I tested with this external converter. Works without any problems. 



```
const { light } = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['TRADFRI bulb GU10 WS 345lm'],
    model: 'TRADFRI bulb GU10 WS 345lm',
    vendor: 'IKEA of Sweden',
    description: 'Automatically generated definition',
    extend: [
        light(
            { 
                colorTemp: { "range": [250, 454] }, 
                levelConfig: { 
                    disabledFeatures: [
                        "on_off_transition_time",
                        "on_transition_time", 
                        "off_transition_time",
                        "on_level"
                    ]
                }
            } 
        ) 
    ], 
    meta: {}
};

module.exports = definition;
```

