### PR TITLE
add device Tuya's _TZE200_ppuj1vem

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12114,6 +12114,23 @@ const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
+    {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_ppuj1vem']),
+        model: 'ZPIR-10',
+        vendor: 'Tuya',
+        description: 'Treatlife Human presence sensor',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [e.occupancy(), e.battery(), e.illuminance()],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'occupancy', tuya.valueConverter.trueFalse0],
+                [4, 'battery', tuya.valueConverter.raw],
+                [101, 'illuminance', tuya.valueConverter.raw],
+            ],
+        },
+    }
 ];
 
 export default definitions;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12130,7 +12130,7 @@ const definitions: DefinitionWithExtend[] = [
                 [101, 'illuminance', tuya.valueConverter.raw],
             ],
         },
-    }
+    },
 ];
 
 export default definitions;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12121,7 +12121,6 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Treatlife Human presence sensor',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
-        configure: tuya.configureMagicPacket,
         exposes: [e.occupancy(), e.battery(), e.illuminance()],
         meta: {
             tuyaDatapoints: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12118,7 +12118,7 @@ const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_ppuj1vem']),
         model: 'ZPIR-10',
         vendor: 'Tuya',
-        description: 'Treatlife Human presence sensor',
+        description: 'Treatlife human presence sensor',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         exposes: [e.occupancy(), e.battery(), e.illuminance()],


### PR DESCRIPTION
This pull request includes an addition to the `src/devices/tuya.ts` file to support a new Tuya device model. The change introduces a new device definition for the `ZPIR-10` model, which is a Treatlife Human presence sensor.

New device support:

* Added a new device definition for the `ZPIR-10` model, including its fingerprint, vendor, description, and configuration details. The device exposes occupancy, battery, and illuminance data points. (`src/devices/tuya.ts`)

https://github.com/Koenkk/zigbee2mqtt/issues/24124