### PR TITLE
Add Philips Hue Twilight (white & black)

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -4894,6 +4894,11 @@ const converters1 = {
         type: 'commandOn',
         convert: (model, msg, publish, options, meta) => {},
     } satisfies Fz.Converter,
+    ignore_command_off: {
+        cluster: 'genOnOff',
+        type: 'commandOff',
+        convert: (model, msg, publish, options, meta) => {},
+    } satisfies Fz.Converter,
     ignore_command_off_with_effect: {
         cluster: 'genOnOff',
         type: 'commandOffWithEffect',

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -4894,7 +4894,7 @@ const converters1 = {
         type: 'commandOn',
         convert: (model, msg, publish, options, meta) => {},
     } satisfies Fz.Converter,
-    ignore_command_off: {
+    ignore_command_off_with_effect: {
         cluster: 'genOnOff',
         type: 'commandOffWithEffect',
         convert: (model, msg, publish, options, meta) => {},

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -4339,6 +4339,25 @@ const converters1 = {
             }
         },
     } satisfies Fz.Converter,
+    hue_twilight: {
+        cluster: 'manuSpecificPhilips',
+        type: 'commandHueNotification',
+        convert: (model, msg, publish, options, meta) => {
+            const buttonLookup: KeyValueAny = {1: 'dot', 2: 'hue'};
+            const button = buttonLookup[msg.data['button']];
+            const typeLookup: KeyValueAny = {0: 'press', 1: 'hold', 2: 'press_release', 3: 'hold_release'};
+            const type = typeLookup[msg.data['type']];
+            const payload: KeyValueAny = {action: `${button}_${type}`};
+
+            // duration
+            if (type === 'press') globalStore.putValue(msg.endpoint, 'press_start', Date.now());
+            else if (type === 'hold' || type === 'release') {
+                payload.action_duration = (Date.now() - globalStore.getValue(msg.endpoint, 'press_start')) / 1000;
+            }
+
+            return payload;
+        },
+    } satisfies Fz.Converter,
     tuya_relay_din_led_indicator: {
         cluster: 'genOnOff',
         type: ['attributeReport', 'readResponse'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2221,7 +2221,7 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Hue dimmer switch',
         fromZigbee: [
             fz.ignore_command_on,
-            fz.ignore_command_off,
+            fz.ignore_command_off_with_effect,
             fz.ignore_command_step,
             fz.ignore_command_stop,
             legacy.fz.hue_dimmer_switch,
@@ -2273,7 +2273,7 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Hue dimmer switch',
         fromZigbee: [
             fz.ignore_command_on,
-            fz.ignore_command_off,
+            fz.ignore_command_off_with_effect,
             fz.ignore_command_step,
             fz.ignore_command_stop,
             fz.hue_dimmer_switch,

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -6,7 +6,7 @@ import * as exposes from '../lib/exposes';
 import * as legacy from '../lib/legacy';
 import {deviceEndpoints, identify, quirkCheckinInterval} from '../lib/modernExtend';
 import * as ota from '../lib/ota';
-import {philipsFz, philipsLight, philipsOnOff, philipsTz} from '../lib/philips';
+import {philipsFz, philipsLight, philipsOnOff, philipsTwilightOnOff, philipsTz} from '../lib/philips';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend} from '../lib/types';
 
@@ -3833,6 +3833,34 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Philips',
         description: 'Hue White and Color Ambiance Datura Ceiling light small',
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
+    },
+    {
+        zigbeeModel: ['LGT001'],
+        model: '929003711201',
+        vendor: 'Philips',
+        description: 'Hue Twilight sleep and wake-up light white',
+        extend: [
+            deviceEndpoints({endpoints: {switch: 1, back: 11, front: 12}}),
+
+            philipsLight({colorTemp: {range: [153, 500]}, color: true, endpointNames: ['front']}),
+            philipsLight({colorTemp: {range: [153, 500]}, color: true, gradient: true, endpointNames: ['back']}),
+
+            philipsTwilightOnOff(),
+        ],
+    },
+    {
+        zigbeeModel: ['LGT002'],
+        model: '929003711301',
+        vendor: 'Philips',
+        description: 'Hue Twilight sleep and wake-up light black',
+        extend: [
+            deviceEndpoints({endpoints: {switch: 1, back: 11, front: 12}}),
+
+            philipsLight({colorTemp: {range: [153, 500]}, color: true, endpointNames: ['front']}),
+            philipsLight({colorTemp: {range: [153, 500]}, color: true, gradient: true, endpointNames: ['back']}),
+
+            philipsTwilightOnOff(),
+        ],
     },
 ];
 

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -103,17 +103,7 @@ export function philipsOnOff(args?: modernExtend.OnOffArgs) {
 }
 
 export function philipsTwilightOnOff() {
-    const fromZigbee = [
-        fz.ignore_command_on,
-        fz.ignore_command_off,
-        // Contrary to the name, fz.ignore_command_off only ignores commandOffWithEffect.
-        {
-            cluster: 'genOnOff',
-            type: 'commandOff',
-            convert: (model, msg, publish, options, meta) => {},
-        } satisfies Fz.Converter,
-        fz.hue_twilight,
-    ];
+    const fromZigbee = [fz.ignore_command_on, fz.ignore_command_off, fz.hue_twilight];
     const exposes = [
         e.action([
             'dot_press',

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -1,6 +1,8 @@
 import {Zcl} from 'zigbee-herdsman';
 
+import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
+import * as reporting from '../lib/reporting';
 import {ColorRGB, ColorXY} from './color';
 import * as libColor from './color';
 import * as exposes from './exposes';
@@ -8,7 +10,7 @@ import {logger} from './logger';
 import * as modernExtend from './modernExtend';
 import * as ota from './ota';
 import * as globalStore from './store';
-import {Fz, KeyValue, KeyValueAny, Tz} from './types';
+import {Configure, Fz, KeyValue, KeyValueAny, ModernExtend, Tz} from './types';
 import * as utils from './utils';
 import {exposeEndpoints, isObject} from './utils';
 
@@ -97,6 +99,41 @@ export function philipsOnOff(args?: modernExtend.OnOffArgs) {
     args = {powerOnBehavior: false, ota: ota.zigbeeOTA, ...args};
     const result = modernExtend.onOff(args);
     result.toZigbee.push(philipsTz.hue_power_on_behavior, philipsTz.hue_power_on_error);
+    return result;
+}
+
+export function philipsTwilightOnOff() {
+    const fromZigbee = [
+        fz.ignore_command_on,
+        fz.ignore_command_off,
+        // Contrary to the name, fz.ignore_command_off only ignores commandOffWithEffect.
+        {
+            cluster: 'genOnOff',
+            type: 'commandOff',
+            convert: (model, msg, publish, options, meta) => {},
+        } satisfies Fz.Converter,
+        fz.hue_twilight,
+    ];
+    const exposes = [
+        e.action([
+            'dot_press',
+            'dot_hold',
+            'dot_press_release',
+            'dot_hold_release',
+            'hue_press',
+            'hue_hold',
+            'hue_press_release',
+            'hue_hold_release',
+        ]),
+    ];
+    const toZigbee: Tz.Converter[] = [];
+    const configure: Configure[] = [
+        async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'manuSpecificPhilips']);
+        },
+    ];
+    const result: ModernExtend = {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
     return result;
 }
 


### PR DESCRIPTION
Adds support for 
* [Hue Twilight sleep and wake-up light white](https://www.philips-hue.com/en-gb/p/sleep-and-wake-up-light-twilight-sleep-and-wake-up-light-white/8720169262997) (`929003711201` aka `LGT001`)
* [Hue Twilight sleep and wake-up light black](https://www.philips-hue.com/en-gb/p/sleep-and-wake-up-light-twilight-sleep-and-wake-up-light-black/8720169263055) (`929003711301` aka `LGT002`)

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/23652