### PR TITLE
Fix 12 of the 13 Typescript inferred type cannot be named without a reference errors

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -4526,7 +4526,7 @@ const converters3 = {
     } satisfies Tz.Converter,
 };
 
-const converters = {...converters1, ...converters2, ...converters3};
+const converters: KeyValueAny = {...converters1, ...converters2, ...converters3};
 
 export default converters;
 module.exports = converters;

--- a/src/lib/ledvance.ts
+++ b/src/lib/ledvance.ts
@@ -26,7 +26,7 @@ export const ledvanceFz = {
     } satisfies Fz.Converter,
 };
 
-export const ledvanceTz = {
+export const ledvanceTz: KeyValue = {
     ledvance_commands: {
         /* deprecated osram_*/
         key: ['set_transition', 'remember_state', 'osram_set_transition', 'osram_remember_state'],

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -8,7 +8,7 @@ import * as exposes from './exposes';
 import * as light from './light';
 import {logger} from './logger';
 import * as globalStore from './store';
-import {Definition, Fz, KeyValueNumberString, Publish, Tz, Zh} from './types';
+import {Definition, Fz, KeyValue, KeyValueNumberString, Publish, Tz, Zh} from './types';
 import * as utils from './utils';
 
 const fromZigbeeStore: KeyValueAny = {};
@@ -8428,7 +8428,7 @@ const thermostatSystemModes: {[s: number]: string} = {
 };
 
 const fromZigbee = {...fromZigbee1, ...fromZigbee2};
-const toZigbee = {...toZigbee1, ...toZigbee2};
+const toZigbee: KeyValue = {...toZigbee1, ...toZigbee2};
 
 export {
     fromZigbee as fz,

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -115,7 +115,7 @@ export const readInitialBatteryState: OnEvent = async (type, data, device, optio
     }
 };
 
-export const tzLegrand = {
+export const tzLegrand: KeyValueAny = {
     auto_mode: {
         key: ['auto_mode'],
         convertSet: async (entity, key, value, meta) => {

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -3665,7 +3665,7 @@ export const fromZigbee = {
     } satisfies Fz.Converter,
 };
 
-export const toZigbee = {
+export const toZigbee: KeyValueAny = {
     // lumi generic
     lumi_power: {
         key: ['power'],

--- a/src/lib/ota/zigbeeOTA.ts
+++ b/src/lib/ota/zigbeeOTA.ts
@@ -99,7 +99,7 @@ async function isNewImageAvailable(current: Ota.ImageInfo, device: Zh.Device, ge
     return await common.isNewImageAvailable(current, device, getImageMeta);
 }
 
-export async function getFirmwareFile(image: KeyValueAny) {
+export async function getFirmwareFile(image: KeyValueAny): Promise<{data: Buffer}> {
     const urlOrName = image.url;
 
     // First try to download firmware file with the URL provided

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -127,7 +127,7 @@ export function philipsTwilightOnOff() {
     return result;
 }
 
-export const philipsTz = {
+export const philipsTz: KeyValueAny = {
     gradient_scene: {
         key: ['gradient_scene'],
         convertSet: async (entity, key, value, meta) => {

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1231,7 +1231,7 @@ export const valueConverter = {
     },
 };
 
-const tuyaTz = {
+const tuyaTz: KeyValue = {
     power_on_behavior_1: {
         key: ['power_on_behavior', 'power_outage_memory'],
         convertSet: async (entity, key, value, meta) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -248,7 +248,7 @@ export function exposeEndpoints<T extends Expose>(expose: T, endpointNames?: str
     return endpointNames ? (endpointNames.map((ep) => expose.clone().withEndpoint(ep)) as T[]) : [expose];
 }
 
-export function enforceEndpoint(entity: Zh.Endpoint, key: string, meta: Tz.Meta) {
+export function enforceEndpoint(entity: Zh.Endpoint, key: string, meta: Tz.Meta): Zh.Endpoint {
     // @ts-expect-error ignore
     const multiEndpointEnforce: {[s: string]: number} = getMetaValue(entity, meta.mapped, 'multiEndpointEnforce', 'allEqual', []);
     if (multiEndpointEnforce && isObject(multiEndpointEnforce) && multiEndpointEnforce[key] !== undefined) {
@@ -458,7 +458,7 @@ export function getSceneState(entity: Zh.Group | Zh.Endpoint, sceneID: number, g
     return null;
 }
 
-export function getEntityOrFirstGroupMember(entity: Zh.Group | Zh.Endpoint) {
+export function getEntityOrFirstGroupMember(entity: Zh.Group | Zh.Endpoint): Zh.Endpoint | null {
     if (isGroup(entity)) {
         return entity.members.length > 0 ? entity.members[0] : null;
     } else {

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -1,7 +1,7 @@
 import * as exposes from './exposes';
 import {logger} from './logger';
 import * as globalStore from './store';
-import {Fz, Tz, Zh} from './types';
+import {Fz, KeyValue, Tz, Zh} from './types';
 
 const NS = 'zhc:zosung';
 const ea = exposes.access;
@@ -208,7 +208,7 @@ export const fzZosung = {
     } satisfies Fz.Converter,
 };
 
-export const tzZosung = {
+export const tzZosung: KeyValue = {
     zosung_ir_code_to_send: {
         key: ['ir_code_to_send'],
         convertSet: async (entity, key, value, meta) => {


### PR DESCRIPTION
When compiling zigbee-herdsman-converters within zigbee2mqtt/node-modules I get 13 inferred type errors.

The steps to reproduce this compile error are simply:
```
cd zigbee2mqtt/node_modules
rm -rf zigbee-herdsman-converters
git clone https://github.com/Koenkk/zigbee-herdsman-converters.git
cd zigbee-herdsman-converters
npm ci
npm run build
```
The compile errors are:
```
Found 13 errors in 10 files.

Errors  Files
     2  src/converters/toZigbee.ts:4529
     1  src/lib/ledvance.ts:29
     1  src/lib/legacy.ts:8431
     1  src/lib/legrand.ts:118
     2  src/lib/lumi.ts:1432
     1  src/lib/ota/zigbeeOTA.ts:102
     1  src/lib/philips.ts:130
     1  src/lib/tuya.ts:1234
     2  src/lib/utils.ts:251
     1  src/lib/zosung.ts:211
```
I'm not 100% sure I have the correct fixes but at least the compiler doesn't complain with these additional type declarations.
One compile error remains that I wasn't able to fix:
```
src/lib/lumi.ts:1432:14 - error TS2742: The inferred type of 'lumiModernExtend' cannot be named without a reference to 'zigbee-herdsman-converters/node_modules/zigbee-herdsman/dist/controller/model'. This is likely not portable. A type annotation is necessary.

1432 export const lumiModernExtend = {
                  ~~~~~~~~~~~~~~~~
```

Interestingly these compile errors don't occur when downloading and building zigbee-herdsman-converters elsewhere, i.e. in a folder outside of zigbee2mqtt/node_modules.