### PR TITLE
Change ZWT198/ZWT100-BH minimum deadzone value and step

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6522,8 +6522,8 @@ const definitions: DefinitionWithExtend[] = [
                 .numeric('deadzone_temperature', ea.STATE_SET)
                 .withUnit('°C')
                 .withValueMax(10)
-                .withValueMin(0.5)
-                .withValueStep(0.5)
+                .withValueMin(0.1)
+                .withValueStep(0.1)
                 .withPreset('default', 1, 'Default value')
                 .withDescription('The delta between local_temperature (5<t<35)and current_heating_setpoint to trigger Heat'),
             e.enum('backlight_mode', ea.STATE_SET, ['off', 'low', 'medium', 'high']).withDescription('Intensity of the backlight'),


### PR DESCRIPTION
Default minimum deadzone for ZWT198/ZWT100-BH can be set to as low as 0.1, and step also can be adjust by 0.1 °C. 
I test it with external converter and everything works fine (for ZWT198). 

I also made changes in docs