### PR TITLE
Add Müller Licht Tint Aris

### DIFF
--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -17,12 +17,12 @@ function mullerLichtLight(args: LightArgs) {
 
 const definitions: DefinitionWithExtend[] = [
     {
-    zigbeeModel: ['tint-ExtendedColor'],
-    model: '404043/404044/404045/404046/404047/404091/404092/404093',
-    vendor: 'Müller Licht',
-    description: 'frameless tint LED-Panel Aris white+color (1800-6500K+RGB) 6500 K',
-    extend: [mullerLichtLight({"colorTemp":{"range":[153,555]},"color":{"modes":["xy","hs"]}})],
-    };
+        zigbeeModel: ['tint-ExtendedColor'],
+        model: '404043/404044/404045/404046/404047/404091/404092/404093',
+        vendor: 'Müller Licht',
+        description: 'frameless tint LED-Panel Aris white+color (1800-6500K+RGB) 6500 K',
+        extend: [mullerLichtLight({"colorTemp":{"range":[153,555]},"color":{"modes":["xy","hs"]}})],
+    },
     {
         zigbeeModel: ['tint-Spotlights'],
         model: '404051',

--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -17,6 +17,13 @@ function mullerLichtLight(args: LightArgs) {
 
 const definitions: DefinitionWithExtend[] = [
     {
+    zigbeeModel: ['tint-ExtendedColor'],
+    model: '404043/404044/404045/404046/404047/404091/404092/404093',
+    vendor: 'Müller Licht',
+    description: 'frameless tint LED-Panel Aris white+color (1800-6500K+RGB) 6500 K',
+    extend: [mullerLichtLight({"colorTemp":{"range":[153,555]},"color":{"modes":["xy","hs"]}})],
+    };
+    {
         zigbeeModel: ['tint-Spotlights'],
         model: '404051',
         vendor: 'Müller Licht',


### PR DESCRIPTION
Hey @Koenkk ,

Can you please check. I am pretty sure it won't work like this because the zigbeeModel already exists. But I don't know what else to do, because that is what I get from "generate_external_definition".

Thanks