### PR TITLE
Lidl HG06338 add feature On/Off USB

### DIFF
--- a/src/devices/lidl.ts
+++ b/src/devices/lidl.ts
@@ -353,16 +353,16 @@ const definitions: DefinitionWithExtend[] = [
         model: 'HG06338',
         vendor: 'Lidl',
         description: 'Silvercrest 3 gang switch, with 4 USB (EU, FR, CZ, BS)',
-        extend: [tuya.modernExtend.tuyaOnOff({endpoints: ['l1', 'l2', 'l3']})],
+        extend: [tuya.modernExtend.tuyaOnOff({endpoints: ['l1', 'l2', 'l3', 'l4']})],
         meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            for (const ID of [1, 2, 3]) {
+            for (const ID of [1, 2, 3, 242]) {
                 await reporting.bind(device.getEndpoint(ID), coordinatorEndpoint, ['genOnOff']);
             }
         },
         endpoint: (device) => {
-            return {l1: 1, l2: 2, l3: 3};
+            return {l1: 1, l2: 2, l3: 3, l4: 242};
         },
     },
     {


### PR DESCRIPTION
Add the feature switch on/off of the 4 USBs that seems to have been omitted

From [ZHA](https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/tuya/ts011f_plug.py#L358-L367), the quirk indicates the dndpoint number corresponding to the "socket" containing the 4 USBs

On ZHA it worked fine, and when I switched to Z2M I lost the On/Off function of its 4 USBs. I haven't yet been able to test it on Z2M, but I think it should be fine, don't you?
