### PR TITLE
Add definition for Philips Hue LCZ002 Ellipse E27 smart bulb

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -139,7 +139,7 @@ const definitions: DefinitionWithExtend[] = [
         model: 'LCZ002',
         vendor: 'Signify Netherlands B.V.',
         description: 'Hue Ellipse E27 smart bulb',
-        extend: [philipsLight({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
         meta: {},
     },
     {

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -128,19 +128,11 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight({colorTemp: {range: [153, 454]}})],
     },
     {
-        zigbeeModel: ['LCZ001'],
+        zigbeeModel: ['LCZ001', 'LCZ002'],
         model: '8719514419278',
         vendor: 'Philips',
         description: 'Hue Ellipse E27 smart bulb',
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true})],
-    },
-    {
-        zigbeeModel: ['LCZ002'],
-        model: 'LCZ002',
-        vendor: 'Signify Netherlands B.V.',
-        description: 'Hue Ellipse E27 smart bulb',
-        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
-        meta: {},
     },
     {
         zigbeeModel: ['929003056701'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -135,6 +135,14 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
+        zigbeeModel: ['LCZ002'],
+        model: 'LCZ002',
+        vendor: 'Signify Netherlands B.V.',
+        description: 'Hue Ellipse E27 smart bulb',
+        extend: [philipsLight({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        meta: {},
+    },
+    {
         zigbeeModel: ['929003056701'],
         model: '929003056701',
         vendor: 'Philips',


### PR DESCRIPTION
This bulb appears to be a hardware revision of the already supported 8719514419278

Docs PR with device product image is here: https://github.com/Koenkk/zigbee2mqtt.io/pull/3085