### PR TITLE
Add definition for Philips Hue 1745930V7 outdoor Impress wall lamp

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1875,7 +1875,6 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Philips',
         description: 'Hue outdoor Impress wall lamp',
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
-        meta: {},
     },
     {
         zigbeeModel: ['1745930P7'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1870,6 +1870,14 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight({colorTemp: {range: undefined}, color: true})],
     },
     {
+        zigbeeModel: ['1745930V7'],
+        model: '1745930V7',
+        vendor: 'Philips',
+        description: 'Hue outdoor Impress wall lamp',
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
+        meta: {},
+    },
+    {
         zigbeeModel: ['1745930P7'],
         model: '1745930P7',
         vendor: 'Philips',


### PR DESCRIPTION
This lamp appears to be a hardware revision of the already supported Hue Impress wall lamps

Docs PR with device product image is here: https://github.com/Koenkk/zigbee2mqtt.io/pull/3086