### PR TITLE
Update Ikea TRADFRI LED1949C5 with E17/440 lm variant

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -315,10 +315,10 @@ const definitions: DefinitionWithExtend[] = [
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight(), identify()],
     },
     {
-        zigbeeModel: ['TRADFRIbulbE14WScandleopal470lm', 'TRADFRIbulbE12WScandleopal450lm'],
+        zigbeeModel: ['TRADFRIbulbE14WScandleopal470lm', 'TRADFRIbulbE12WScandleopal450lm', 'TRADFRIbulbE17WScandleopal440lm'],
         model: 'LED1949C5',
         vendor: 'IKEA',
-        description: 'TRADFRI bulb E12/E14, white spectrum, candle, opal, 450/470 lm',
+        description: 'TRADFRI bulb E12/E14/E17, white spectrum, candle, opal, 450/470/440 lm',
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), identify()],
     },
     {


### PR DESCRIPTION
These E17/440 lm variants of the already supported TRADFRI LED1949C5 bulbs are sold in Japan.  