### PR TITLE
feat: add support for IKEA Home Smart OTA firmware updates

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -4,6 +4,7 @@ import {
     addCustomClusterManuSpecificIkeaAirPurifier,
     addCustomClusterManuSpecificIkeaUnknown,
     addCustomClusterManuSpecificIkeaVocIndexMeasurement,
+    homesmartOta,
     ikeaAirPurifier,
     ikeaArrowClick,
     ikeaBattery,
@@ -602,7 +603,7 @@ const definitions: DefinitionWithExtend[] = [
         model: 'E2206',
         vendor: 'IKEA',
         description: 'INSPELNING smart plug',
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), ikeaOta(), electricityMeter()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), homesmartOta(), electricityMeter()],
         configure: async (device) => {
             const endpoint = device.getEndpoint(1);
             // Enable reporting of powerDivisor, needs to change dynamically with the amount of power

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -17,7 +17,7 @@ import {
     setupConfigureForReporting,
     timeLookup,
 } from '../lib/modernExtend';
-import {tradfri as ikea} from '../lib/ota';
+import {tradfri as ikea, homesmart as ikeaHS} from '../lib/ota';
 import * as reporting from '../lib/reporting';
 import * as globalStore from '../lib/store';
 import {Configure, Expose, Fz, KeyValue, KeyValueAny, ModernExtend, OnEvent, Range, Tz} from '../lib/types';
@@ -122,6 +122,10 @@ export function ikeaLight(args?: Omit<LightArgs, 'colorTemp'> & {colorTemp?: tru
 
 export function ikeaOta(): ModernExtend {
     return ota(ikea);
+}
+
+export function homesmartOta(): ModernExtend {
+    return ota(ikeaHS);
 }
 
 export function ikeaBattery(): ModernExtend {

--- a/src/lib/ota/OTA_URLs.md
+++ b/src/lib/ota/OTA_URLs.md
@@ -54,6 +54,18 @@ Release changelogs
 
 https://ww8.ikea.com/ikeahomesmart/releasenotes/releasenotes.html
 
+### IKEA Home Smart
+
+IKEA Home Smart device OTA firmware images are made publicly available by IKEA (first-party) at the following URL:
+
+Download-URL:
+
+https://fw.ota.homesmart.ikea.com/check/update/prod
+
+Release changelogs
+
+https://static.homesmart.ikea.com/releaseNotes/
+
 ### LEDVANCE/Sylvania and OSRAM Lightify
 
 LEDVANCE/Sylvania and OSRAM Lightify Zigbee OTA firmware images are made publicly available by LEDVANCE (first-party) at the following URL:

--- a/src/lib/ota/common.ts
+++ b/src/lib/ota/common.ts
@@ -770,10 +770,10 @@ export async function getNewImage(
 
     const download = downloadImage ? await downloadImage(meta) : await getAxios().get(meta.url, {responseType: 'arraybuffer'});
 
-    const checksum = meta.sha512 || meta.sha256;
+    const checksum = meta.sha512 || meta.sha256 || meta.sha3_256;
 
     if (checksum) {
-        const hash = crypto.createHash(meta.sha512 ? 'sha512' : 'sha256');
+        const hash = crypto.createHash(meta.sha512 ? 'sha512' : meta.sha256 ? 'sha256' : meta.sha3_256 ? 'sha3-256' : 'sha256');
         hash.update(download.data);
 
         assert(hash.digest('hex') === checksum, `File checksum validation failed`);

--- a/src/lib/ota/homesmart.ts
+++ b/src/lib/ota/homesmart.ts
@@ -1,0 +1,110 @@
+import {logger} from '../logger';
+import {KeyValue, KeyValueAny, Ota, Zh} from '../types';
+import * as common from './common';
+
+const url = 'https://fw.ota.homesmart.ikea.com/check/update/prod';
+
+/**
+ * IKEA HomeSmart intermediate certificate used for verifying OTA (Over-the-Air) updates.
+ *
+ * This CA (Certificate Authority) certificate is necessary to establish a secure
+ * connection when fetching firmware update metadata and binaries from IKEA's
+ * HomeSmart OTA servers.
+ *
+ * - The certificate is included here as part of the custom CA bundle to allow the
+ *   client to validate the IKEA OTA servers' SSL certificates.
+ * - It is appended to the default system CAs to avoid overriding the default trusted
+ *   root CAs.
+ *
+ * @type {string[]}
+ */
+const caBundle = [
+    `-----BEGIN CERTIFICATE-----
+MIICQTCCAcagAwIBAgIUAr5VleESJnRg+J9oehqJc+MGphIwCgYIKoZIzj0EAwMw
+SzELMAkGA1UEBhMCU0UxGjAYBgNVBAoMEUlLRUEgb2YgU3dlZGVuIEFCMSAwHgYD
+VQQDDBdJS0VBIEhvbWUgc21hcnQgUm9vdCBDQTAeFw0yMTA1MjYxOTE1NDVaFw00
+NjA1MjAxOTE1NDRaMFAxCzAJBgNVBAYTAlNFMRowGAYDVQQKDBFJS0VBIG9mIFN3
+ZWRlbiBBQjElMCMGA1UEAwwcSUtFQSBIb21lIHNtYXJ0IE9UQSBUcnVzdCBDQTB2
+MBAGByqGSM49AgEGBSuBBAAiA2IABC6Db3/cBpl//CmRX7Ur90ikDbpLtaCcvcJT
+p72LY585dsMUA7cjZQlAQdNfI7zSr0Y8O9w0dIoqz8HL8G7E/pYChhvQPUgx1avn
+6IEtdWLwI0XPPsFtLO8jRJFIsjkeAaNmMGQwEgYDVR0TAQH/BAgwBgEB/wIBADAf
+BgNVHSMEGDAWgBRx2USd9fQzJkDjMB1joIs7J73B/DAdBgNVHQ4EFgQUrRAWZaau
+bKmqMPHU92uXboPJn8cwDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMDA2kAMGYC
+MQDcIekS7OcwMcLXMtP6rWfZUsJF7iI59t3rEame11vIdY/sFHHWWm07OLJ7gRwg
+NpwCMQDhMc3sX2cBD3zZ2zDwCjFBCudhgWLc2eqNy/b5mY+/Ppdp6EX11PZK0Hb9
+dZ2TSWM=
+-----END CERTIFICATE-----`,
+    `-----BEGIN CERTIFICATE-----
+MIICGDCCAZ+gAwIBAgIUdfH0KDnENv/dEcxH8iVqGGGDqrowCgYIKoZIzj0EAwMw
+SzELMAkGA1UEBhMCU0UxGjAYBgNVBAoMEUlLRUEgb2YgU3dlZGVuIEFCMSAwHgYD
+VQQDDBdJS0VBIEhvbWUgc21hcnQgUm9vdCBDQTAgFw0yMTA1MjYxOTAxMDlaGA8y
+MDcxMDUxNDE5MDEwOFowSzELMAkGA1UEBhMCU0UxGjAYBgNVBAoMEUlLRUEgb2Yg
+U3dlZGVuIEFCMSAwHgYDVQQDDBdJS0VBIEhvbWUgc21hcnQgUm9vdCBDQTB2MBAG
+ByqGSM49AgEGBSuBBAAiA2IABIDRUvKGFMUu2zIhTdgfrfNcPULwMlc0TGSrDLBA
+oTr0SMMV4044CRZQbl81N4qiuHGhFzCnXapZogkiVuFu7ZqSslsFuELFjc6ZxBjk
+Kmud+pQM6QQdsKTE/cS06dA+P6NCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4E
+FgQUcdlEnfX0MyZA4zAdY6CLOye9wfwwDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49
+BAMDA2cAMGQCMG6mFIeB2GCFch3r0Gre4xRH+f5pn/bwLr9yGKywpeWvnUPsQ1KW
+ckMLyxbeNPXdQQIwQc2YZDq/Mz0mOkoheTUWiZxK2a5bk0Uz1XuGshXmQvEg5TGy
+2kVHW/Mz9/xwpy4u
+-----END CERTIFICATE-----`,
+];
+
+const NS = 'zhc:ota:homesmart';
+
+/**
+ * Helper functions
+ */
+
+export async function getImageMeta(current: Ota.ImageInfo, device: Zh.Device): Promise<Ota.ImageMeta> {
+    logger.debug(`Call getImageMeta for ${device.modelID}`, NS);
+    const {data: images} = await common.getAxios(caBundle).get(url);
+
+    if (!images?.length) {
+        throw new Error(`HomeSmartOTA: Error getting firmware page at ${url}`);
+    }
+
+    const image = images.find((img: KeyValue) => img.fw_image_type === current.imageType);
+
+    if (!image) {
+        return null;
+    }
+
+    //Get firmware metadata
+    const imageMeta = common.parseImage((await common.getAxios(caBundle).get(image.fw_binary_url, {responseType: 'arraybuffer'})).data);
+
+    return {
+        fileVersion: imageMeta.header.fileVersion,
+        fileSize: imageMeta.header.totalImageSize,
+        url: image.fw_binary_url,
+        sha3_256: image.fw_sha3_256,
+    };
+}
+
+export async function getFirmwareFile(image: KeyValueAny) {
+    const urlOrName = image.url;
+
+    if (common.isValidUrl(urlOrName)) {
+        logger.debug(`Downloading firmware image from '${urlOrName}' using the IKEA Home Smart custom CA certificates`, NS);
+        const response = await common.getAxios(caBundle).get(urlOrName, {responseType: 'arraybuffer'});
+        return response;
+    }
+
+    throw new Error(`HomeSmart OTA: Invalid firmware URL: ${urlOrName}`);
+}
+
+/**
+ * Interface implementation
+ */
+
+export async function isUpdateAvailable(device: Zh.Device, requestPayload: Ota.ImageInfo = null) {
+    return await common.isUpdateAvailable(device, requestPayload, common.isNewImageAvailable, getImageMeta);
+}
+
+export async function updateToLatest(device: Zh.Device, onProgress: Ota.OnProgress) {
+    return await common.updateToLatest(device, onProgress, common.getNewImage, getImageMeta, getFirmwareFile);
+}
+
+exports.getImageMeta = getImageMeta;
+exports.isUpdateAvailable = isUpdateAvailable;
+exports.updateToLatest = updateToLatest;

--- a/src/lib/ota/index.ts
+++ b/src/lib/ota/index.ts
@@ -1,6 +1,7 @@
 import {Ota} from '../types';
 import * as common from './common';
 import * as gmmts from './gmmts';
+import * as homesmart from './homesmart';
 import * as inovelli from './inovelli';
 import * as jethome from './jethome';
 import * as ledvance from './ledvance';
@@ -13,6 +14,6 @@ import * as zigbeeOTA from './zigbeeOTA';
 
 const {setDataDir} = common;
 
-export {inovelli, ledvance, salus, lixee, securifi, tradfri, ubisys, zigbeeOTA, jethome, gmmts, setDataDir};
+export {inovelli, ledvance, salus, lixee, securifi, tradfri, homesmart, ubisys, zigbeeOTA, jethome, gmmts, setDataDir};
 
 export type ImageInfo = Ota.ImageInfo;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -417,6 +417,7 @@ export namespace Ota {
         sha256?: string;
         force?: boolean;
         sha512?: string;
+        sha3_256?: string;
         hardwareVersionMin?: number;
         hardwareVersionMax?: number;
     }


### PR DESCRIPTION
- Introduced `homesmartOta()` for managing IKEA Home Smart firmware updates from a new endpoint.
- Updated INSPELNING smart plug configuration to use `homesmartOta()` for OTA.
- Added checksum support for SHA-3 256 in OTA logic.
- Created a new module for handling IKEA Home Smart OTA logic (`homesmart.ts`), including certificate handling and secure download.
- Updated documentation with IKEA Home Smart OTA URL and release notes location.