### PR TITLE
Add Tuya NovaDigital WS-US-ZB - _TZ3000_785olaiq

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8750,6 +8750,7 @@ const definitions: DefinitionWithExtend[] = [
         fingerprint: [
             {modelID: 'TS0003', manufacturerName: '_TZ3000_pv4puuxi'},
             {modelID: 'TS0003', manufacturerName: '_TZ3000_avky2mvc'},
+            {modelID: 'TS0003', manufacturerName: '_TZ3000_785olaiq'},
         ],
         model: 'TS0003_switch_3_gang',
         vendor: 'Tuya',
@@ -8768,6 +8769,7 @@ const definitions: DefinitionWithExtend[] = [
         whiteLabel: [
             tuya.whitelabel('Homeetec', '37022474_1', '3 Gang switch with backlight', ['_TZ3000_pv4puuxi']),
             tuya.whitelabel('RoomsAI', '37022474_2', '3 Gang switch with backlight', ['_TZ3000_avky2mvc']),
+            tuya.whitelabel('NovaDigital', 'WS-US-ZB', '3 Gang switch with backlight', ['_TZ3000_785olaiq']),
         ],
     },
     {


### PR DESCRIPTION
Adding new device from NovaDigital.

It is being recognized as https://www.zigbee2mqtt.io/devices/TS0003.html#tuya-ts0003 and not exposing the backlight and powerOnBehavior2.

I tested it using the extension below with success:

const reporting = require('zigbee-herdsman-converters/lib/reporting'); const {} = require('zigbee-herdsman-converters/lib/modernExtend'); const tuya = require('zigbee-herdsman-converters/lib/tuya');

const definition = {
        fingerprint: [
            {modelID: 'TS0003', manufacturerName: '_TZ3000_785olaiq'},
        ],
        model: 'TS0003_new',
        vendor: 'Tuya',
        description: '3-Gang switch with backlight',
        extend: [tuya.modernExtend.tuyaOnOff({powerOnBehavior2: true, backlightModeOffOn: true, endpoints: ['left', 'center', 'right']})],
        endpoint: (device) => {
            return {left: 1, center: 2, right: 3};
        },
        meta: {multiEndpoint: true},
        configure: async (device, coordinatorEndpoint) => {
            await tuya.configureMagicPacket(device, coordinatorEndpoint);
            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ['genOnOff']);
            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ['genOnOff']);
        },
        whiteLabel: [
            tuya.whitelabel('NovaDigital', 'WS-US-ZB', '3 Gang switch with backlight', ['_TZ3000_785olaiq']),
        ],
    };
module.exports = definition;