### PR TITLE
Support new device: Philio PAT04A water leak detector

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -209,6 +209,7 @@ import paul_neuhaus from './paul_neuhaus';
 import paulmann from './paulmann';
 import peq from './peq';
 import perenio from './perenio';
+import philio from './philio';
 import philips from './philips';
 import plaid from './plaid';
 import plugwise from './plugwise';
@@ -517,6 +518,7 @@ export default [
     ...paulmann,
     ...peq,
     ...perenio,
+    ...philio,
     ...philips,
     ...plaid,
     ...plugwise,

--- a/src/devices/philio.ts
+++ b/src/devices/philio.ts
@@ -1,9 +1,5 @@
-import fz from '../converters/fromZigbee';
-import * as exposes from '../lib/exposes';
-import * as reporting from '../lib/reporting';
+import {battery, iasZoneAlarm} from '../lib/modernExtend';
 import {DefinitionWithExtend} from '../lib/types';
-
-const e = exposes.presets;
 
 const definitions: DefinitionWithExtend[] = [
     {
@@ -11,15 +7,8 @@ const definitions: DefinitionWithExtend[] = [
         model: 'PAT04-A',
         vendor: 'Philio',
         description: 'Water leak detector',
-        fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery, fz.ignore_basic_report],
+        extend: [iasZoneAlarm({zoneType: 'water_leak', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']}), battery()],
         whiteLabel: [{vendor: 'Evology', model: 'PAT04-A'}],
-        toZigbee: [],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint);
-        },
-        exposes: [e.water_leak(), e.battery_low(), e.tamper(), e.linkquality()],
     },
 ];
 

--- a/src/devices/philio.ts
+++ b/src/devices/philio.ts
@@ -1,0 +1,27 @@
+import fz from '../converters/fromZigbee';
+import * as exposes from '../lib/exposes';
+import * as reporting from '../lib/reporting';
+import {DefinitionWithExtend} from '../lib/types';
+
+const e = exposes.presets;
+
+const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ['PAT04A-v1.1.5'],
+        model: 'PAT04-A',
+        vendor: 'Philio',
+        description: 'Water leak detector',
+        fromZigbee: [fz.ias_water_leak_alarm_1, fz.battery, fz.ignore_basic_report],
+        whiteLabel: [{vendor: 'Evology', model: 'PAT04-A'}],
+        toZigbee: [],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+        exposes: [e.water_leak(), e.battery_low(), e.tamper(), e.linkquality()],
+    },
+];
+
+export default definitions;
+module.exports = definitions;


### PR DESCRIPTION
I have an unsupported water leak detector from Evology (brand of french hardware store Leroy Merlin) but I know that's a white labeled model from brand Philio, model PAT04A.
So I tried to declare this device in a file dedicated to the original brand.
But I don't know if I can use white labeling feature like that.
I currently don't know the "zigbeeModel" of Philio one.
The definition is deeply inspired from Tuya TS0207_water_leak_detector.