### PR TITLE
Tuya BAC-003 & BAC-002-ALZB: Add current_cooling_setpoint

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3463,7 +3463,17 @@ const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [4, 'preset', tuya.valueConverterBasic.lookup({manual: true, auto: false})],
+                [16, 'current_cooling_setpoint', tuya.valueConverter.raw],
                 [16, 'current_heating_setpoint', tuya.valueConverter.raw],
+                [
+                    16,
+                    null,
+                    {
+                        from: (v, meta) => {
+                            return {current_cooling_setpoint: v, current_heating_setpoint: v};
+                        },
+                    },
+                ],
                 [24, 'local_temperature', tuya.valueConverter.divideBy10],
                 [26, 'deadzone_temperature', tuya.valueConverter.raw],
                 [27, 'local_temperature_calibration', tuya.valueConverter.localTemperatureCalibration],


### PR DESCRIPTION
When the airconditioning control (FCU) is set to mode `cool`, MatterBridge integration using Google Home sends `current_cooling_setpoint`, as opposed to `current_heating_setpoint`.

This change adapts the converter to handle `current_cooling_setpoint` and `current_heating_setpoint` equally, both map to tuya setpoint datapoint `16` on the device.