### PR TITLE
fix: Prevent IKEA PARASOLL and BADRING being stuck on a previously reported state after it rapidly changes back and forth.

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -931,7 +931,7 @@ const definitions: DefinitionWithExtend[] = [
                 zoneType: 'contact',
                 zoneAttributes: ['alarm_1'],
                 // This is required to prevent the device's reported state being stuck after it quickly changed back and forth:
-                configureZoneStatusReportingEndpoint: 2,
+                zoneStatusReporting: true,
             }),
             identify({isSleepy: true}),
             battery(),
@@ -950,7 +950,7 @@ const definitions: DefinitionWithExtend[] = [
                 zoneType: 'water_leak',
                 zoneAttributes: ['alarm_1'],
                 // This is required to prevent the device's reported state being stuck after it quickly changed back and forth:
-                configureZoneStatusReportingEndpoint: 1,
+                zoneStatusReporting: true,
             }),
             identify({isSleepy: true}),
             battery(),

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -927,18 +927,16 @@ const definitions: DefinitionWithExtend[] = [
             addCustomClusterManuSpecificIkeaUnknown(),
             deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
             bindCluster({cluster: 'ssIasZone', clusterType: 'input', endpointNames: ['2']}),
-            iasZoneAlarm({zoneType: 'contact', zoneAttributes: ['alarm_1']}),
+            iasZoneAlarm({
+                zoneType: 'contact',
+                zoneAttributes: ['alarm_1'],
+                // This is required to prevent the device's reported state being stuck after it quickly changed back and forth:
+                configureZoneStatusReportingEndpoint: 2,
+            }),
             identify({isSleepy: true}),
             battery(),
             ikeaOta(),
         ],
-        configure: async (device) => {
-            const endpoint = device.getEndpoint(2);
-            // This is required to prevent the device's reported state being stuck after it quickly changed back and forth
-            await endpoint.configureReporting('ssIasZone', [
-                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: repInterval.MAX, reportableChange: 0},
-            ]);
-        },
     },
     {
         zigbeeModel: ['BADRING Water Leakage Sensor'],
@@ -948,18 +946,16 @@ const definitions: DefinitionWithExtend[] = [
         extend: [
             addCustomClusterManuSpecificIkeaUnknown(),
             bindCluster({cluster: 'ssIasZone', clusterType: 'input'}),
-            iasZoneAlarm({zoneType: 'water_leak', zoneAttributes: ['alarm_1']}),
+            iasZoneAlarm({
+                zoneType: 'water_leak',
+                zoneAttributes: ['alarm_1'],
+                // This is required to prevent the device's reported state being stuck after it quickly changed back and forth:
+                configureZoneStatusReportingEndpoint: 1,
+            }),
             identify({isSleepy: true}),
             battery(),
             ikeaOta(),
         ],
-        configure: async (device) => {
-            const endpoint = device.getEndpoint(1);
-            // This is required to prevent the device's reported state being stuck after it quickly changed back and forth
-            await endpoint.configureReporting('ssIasZone', [
-                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: repInterval.MAX, reportableChange: 0},
-            ]);
-        },
     },
     // #endregion sensors
 ];

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -931,6 +931,13 @@ const definitions: DefinitionWithExtend[] = [
             battery(),
             ikeaOta(),
         ],
+        configure: async (device) => {
+            const endpoint = device.getEndpoint(2);
+            // This is required to prevent the device's reported state being stuck after it quickly changed back and forth
+            await endpoint.configureReporting('ssIasZone', [
+                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: 65000, reportableChange: 0},
+            ]);
+        },
     },
     {
         zigbeeModel: ['BADRING Water Leakage Sensor'],
@@ -945,6 +952,13 @@ const definitions: DefinitionWithExtend[] = [
             battery(),
             ikeaOta(),
         ],
+        configure: async (device) => {
+            const endpoint = device.getEndpoint(1);
+            // This is required to prevent the device's reported state being stuck after it quickly changed back and forth
+            await endpoint.configureReporting('ssIasZone', [
+                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: 65000, reportableChange: 0},
+            ]);
+        },
     },
     // #endregion sensors
 ];

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1,5 +1,6 @@
 import {Zcl} from 'zigbee-herdsman';
 
+import {repInterval} from '../lib/constants';
 import {
     addCustomClusterManuSpecificIkeaAirPurifier,
     addCustomClusterManuSpecificIkeaUnknown,
@@ -608,7 +609,7 @@ const definitions: DefinitionWithExtend[] = [
             // Enable reporting of powerDivisor, needs to change dynamically with the amount of power
             // For details, see: https://github.com/Koenkk/zigbee2mqtt/issues/23961#issuecomment-2366733453
             await endpoint.configureReporting('haElectricalMeasurement', [
-                {attribute: 'acPowerDivisor', minimumReportInterval: 10, maximumReportInterval: 65000, reportableChange: 1},
+                {attribute: 'acPowerDivisor', minimumReportInterval: 10, maximumReportInterval: repInterval.MAX, reportableChange: 1},
             ]);
         },
     },
@@ -935,7 +936,7 @@ const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(2);
             // This is required to prevent the device's reported state being stuck after it quickly changed back and forth
             await endpoint.configureReporting('ssIasZone', [
-                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: 65000, reportableChange: 0},
+                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: repInterval.MAX, reportableChange: 0},
             ]);
         },
     },
@@ -956,7 +957,7 @@ const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             // This is required to prevent the device's reported state being stuck after it quickly changed back and forth
             await endpoint.configureReporting('ssIasZone', [
-                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: 65000, reportableChange: 0},
+                {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: repInterval.MAX, reportableChange: 0},
             ]);
         },
     },

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -7,7 +7,6 @@ import * as globalLegacy from '../lib/legacy';
 import {logger} from '../lib/logger';
 import {zigbeeOTA} from '../lib/ota';
 import * as globalStore from '../lib/store';
-import {repInterval} from './constants';
 import {Cover, presets as e, access as ea, Numeric, options as opt} from './exposes';
 import {configure as lightConfigure} from './light';
 import {
@@ -1408,7 +1407,7 @@ export interface IasArgs {
     zoneType: iasZoneType;
     zoneAttributes: iasZoneAttribute[];
     alarmTimeout?: boolean;
-    configureZoneStatusReportingEndpoint?: number;
+    zoneStatusReporting?: boolean;
     description?: string;
 }
 export function iasZoneAlarm(args: IasArgs): ModernExtend {
@@ -1564,14 +1563,10 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
     ];
 
     let configure: Configure[];
-
-    if (args.configureZoneStatusReportingEndpoint !== undefined) {
+    if (args.zoneStatusReporting) {
         configure = [
-            async (device) => {
-                const endpoint = device.getEndpoint(args.configureZoneStatusReportingEndpoint);
-                await endpoint.configureReporting('ssIasZone', [
-                    {attribute: 'zoneStatus', minimumReportInterval: 0, maximumReportInterval: repInterval.MAX, reportableChange: 0},
-                ]);
+            async (device, coordinatorEndpoint) => {
+                await setupAttributes(device, coordinatorEndpoint, 'ssIasZone', [{attribute: 'zoneStatus', min: 'MIN', max: 'MAX', change: 0}]);
             },
         ];
     }


### PR DESCRIPTION
Credit goes to @legsim for [discovering](https://github.com/Koenkk/zigbee2mqtt/issues/22579#issuecomment-2425173192) that configuring reporting for the `ssIasZone` cluster's `zoneStatus` attribute with `minimumReportInterval: 0` fixes a common problem with the PARASOLL and BADRING sensors where their state can become stuck on a previously reported state after it rapidly changes back and forth.