### PR TITLE
Smoke and heat alarm fixes for table full error (SMSZB-120 and HESZB-120)

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -397,7 +397,13 @@ const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
-            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd']); //, 'genBasic', 'genBinaryInput']);
+            // Device supports only 4 binds (otherwise you get TABLE_FULL error)
+            // https://github.com/Koenkk/zigbee2mqtt/issues/23684
+            if (endpoint.binds.some((b) => b.cluster.name === 'genPollCtrl')) {
+                await device.getEndpoint(1).unbind('genPollCtrl', coordinatorEndpoint);
+            }
+
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd']);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
@@ -468,7 +474,14 @@ const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
-            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd']); //, 'genBasic', 'genBinaryInput']);
+            // Device supports only 4 binds (otherwise you get TABLE_FULL error)
+            // https://github.com/Koenkk/zigbee2mqtt/issues/23684
+            if (endpoint.binds.some((b) => b.cluster.name === 'genPollCtrl')) {
+                await device.getEndpoint(1).unbind('genPollCtrl', coordinatorEndpoint);
+            }
+
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd']);
+
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -397,7 +397,7 @@ const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
-            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd']); //, 'genBasic', 'genBinaryInput']);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);
@@ -468,16 +468,7 @@ const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(35);
 
-            // Device returns `ZDP_TABLE_FULL` on bind even though it succeeds
-            // https://github.com/Koenkk/zigbee2mqtt/issues/22492
-            for (const cluster of ['ssIasZone', 'ssIasWd', 'genBasic', 'genBinaryInput']) {
-                try {
-                    await endpoint.bind(cluster, coordinatorEndpoint);
-                } catch {
-                    logger.debug(`Failed to bind '${cluster}'`, NS);
-                }
-            }
-
+            await reporting.bind(endpoint, coordinatorEndpoint, ['ssIasZone', 'ssIasWd']); //, 'genBasic', 'genBinaryInput']);
             await endpoint.read('ssIasZone', ['iasCieAddr', 'zoneState', 'zoneId']);
             await endpoint.read('genBinaryInput', ['reliability', 'statusFlags']);
             await endpoint.read('ssIasWd', ['maxDuration']);


### PR DESCRIPTION
Bind only 4 clusters (genpollcntrl, ssIasZone, ssIasWd and powercfg)  to avoid 'Table full' error