### PR TITLE
Define endpoint in definition.toZigbee containing key 'state'

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -486,7 +486,7 @@ export function onOff(args?: OnOffArgs): ModernExtend {
         : exposeEndpoints(e.switch(), args.endpointNames);
 
     const fromZigbee: Fz.Converter[] = [args.skipDuplicateTransaction ? fz.on_off_skip_duplicate_transaction : fz.on_off];
-    const toZigbee: Tz.Converter[] = [tz.on_off];
+    const toZigbee: Tz.Converter[] = [{...tz.on_off, endpoint: args?.endpointNames}];
 
     if (args.powerOnBehavior) {
         exposes.push(...exposeEndpoints(e.power_on_behavior(['off', 'on', 'toggle', 'previous']), args.endpointNames));
@@ -961,7 +961,7 @@ export function light(args?: LightArgs): ModernExtend {
 
     const fromZigbee: Fz.Converter[] = [fz.on_off, fz.brightness, fz.ignore_basic_report, fz.level_config];
     const toZigbee: Tz.Converter[] = [
-        tz.light_onoff_brightness,
+        {...tz.light_onoff_brightness, endpoint: args?.endpointNames},
         tz.ignore_transition,
         tz.level_config,
         tz.ignore_rate,
@@ -1243,12 +1243,13 @@ export function commandsColorCtrl(args?: CommandsColorCtrl): ModernExtend {
 
 export interface LockArgs {
     pinCodeCount: number;
+    endpointNames?: string[];
 }
 export function lock(args?: LockArgs): ModernExtend {
     args = {...args};
 
     const fromZigbee = [fz.lock, fz.lock_operation_event, fz.lock_programming_event, fz.lock_pin_code_response, fz.lock_user_status_response];
-    const toZigbee = [tz.lock, tz.pincode_lock, tz.lock_userstatus, tz.lock_auto_relock_time, tz.lock_sound_volume];
+    const toZigbee = [{...tz.lock, endpoint: args?.endpointNames} , tz.pincode_lock, tz.lock_userstatus, tz.lock_auto_relock_time, tz.lock_sound_volume];
     const exposes = [
         e.lock(),
         e.pincode(),
@@ -1282,7 +1283,7 @@ export function windowCovering(args: WindowCoveringArgs): ModernExtend {
     const exposes: Expose[] = [coverExpose];
 
     const fromZigbee: Fz.Converter[] = [fz.cover_position_tilt];
-    const toZigbee: Tz.Converter[] = [tz.cover_state, tz.cover_position_tilt];
+    const toZigbee: Tz.Converter[] = [{...tz.cover_state, endpoint: args?.endpointNames}, tz.cover_position_tilt];
 
     const result: ModernExtend = {exposes, fromZigbee, toZigbee, isModernExtend: true};
 

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1249,7 +1249,13 @@ export function lock(args?: LockArgs): ModernExtend {
     args = {...args};
 
     const fromZigbee = [fz.lock, fz.lock_operation_event, fz.lock_programming_event, fz.lock_pin_code_response, fz.lock_user_status_response];
-    const toZigbee = [{...tz.lock, endpoint: args?.endpointNames} , tz.pincode_lock, tz.lock_userstatus, tz.lock_auto_relock_time, tz.lock_sound_volume];
+    const toZigbee = [
+        {...tz.lock, endpoint: args?.endpointNames},
+        tz.pincode_lock,
+        tz.lock_userstatus,
+        tz.lock_auto_relock_time,
+        tz.lock_sound_volume,
+    ];
     const exposes = [
         e.lock(),
         e.pincode(),

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -486,7 +486,7 @@ export function onOff(args?: OnOffArgs): ModernExtend {
         : exposeEndpoints(e.switch(), args.endpointNames);
 
     const fromZigbee: Fz.Converter[] = [args.skipDuplicateTransaction ? fz.on_off_skip_duplicate_transaction : fz.on_off];
-    const toZigbee: Tz.Converter[] = [{...tz.on_off, endpoint: args?.endpointNames}];
+    const toZigbee: Tz.Converter[] = [{...tz.on_off, endpoints: args?.endpointNames}];
 
     if (args.powerOnBehavior) {
         exposes.push(...exposeEndpoints(e.power_on_behavior(['off', 'on', 'toggle', 'previous']), args.endpointNames));
@@ -961,7 +961,7 @@ export function light(args?: LightArgs): ModernExtend {
 
     const fromZigbee: Fz.Converter[] = [fz.on_off, fz.brightness, fz.ignore_basic_report, fz.level_config];
     const toZigbee: Tz.Converter[] = [
-        {...tz.light_onoff_brightness, endpoint: args?.endpointNames},
+        {...tz.light_onoff_brightness, endpoints: args?.endpointNames},
         tz.ignore_transition,
         tz.level_config,
         tz.ignore_rate,
@@ -1250,7 +1250,7 @@ export function lock(args?: LockArgs): ModernExtend {
 
     const fromZigbee = [fz.lock, fz.lock_operation_event, fz.lock_programming_event, fz.lock_pin_code_response, fz.lock_user_status_response];
     const toZigbee = [
-        {...tz.lock, endpoint: args?.endpointNames},
+        {...tz.lock, endpoints: args?.endpointNames},
         tz.pincode_lock,
         tz.lock_userstatus,
         tz.lock_auto_relock_time,
@@ -1289,7 +1289,7 @@ export function windowCovering(args: WindowCoveringArgs): ModernExtend {
     const exposes: Expose[] = [coverExpose];
 
     const fromZigbee: Fz.Converter[] = [fz.cover_position_tilt];
-    const toZigbee: Tz.Converter[] = [{...tz.cover_state, endpoint: args?.endpointNames}, tz.cover_position_tilt];
+    const toZigbee: Tz.Converter[] = [{...tz.cover_state, endpoints: args?.endpointNames}, tz.cover_position_tilt];
 
     const result: ModernExtend = {exposes, fromZigbee, toZigbee, isModernExtend: true};
 

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1762,7 +1762,7 @@ export function getHandlersForDP(
         : [
               {
                   key: [name],
-                  endpoint: endpoint,
+                  endpoints: [endpoint],
                   convertSet: async (entity, key, value, meta) => {
                       // A set converter is only called once; therefore we need to loop
                       const state: KeyValue = {};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -331,7 +331,7 @@ export namespace Tz {
     export interface Converter {
         key?: string[];
         options?: Option[] | ((definition: Definition) => Option[]);
-        endpoint?: string | string[];
+        endpoints?: string[];
         convertSet?: (entity: Zh.Endpoint | Zh.Group, key: string, value: unknown, meta: Tz.Meta) => Promise<ConvertSetResult>;
         convertGet?: (entity: Zh.Endpoint | Zh.Group, key: string, meta: Tz.Meta) => Promise<void>;
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -331,7 +331,7 @@ export namespace Tz {
     export interface Converter {
         key?: string[];
         options?: Option[] | ((definition: Definition) => Option[]);
-        endpoint?: string;
+        endpoint?: string | string[];
         convertSet?: (entity: Zh.Endpoint | Zh.Group, key: string, value: unknown, meta: Tz.Meta) => Promise<ConvertSetResult>;
         convertGet?: (entity: Zh.Endpoint | Zh.Group, key: string, meta: Tz.Meta) => Promise<void>;
     }


### PR DESCRIPTION
Purpose of this change is described in [issue #24352](https://github.com/Koenkk/zigbee2mqtt/issues/24352) (repo: zigbee2mqtt)

This fix allows the selection of the proper converter among others using the same key `state` with multi endpoints device when sending a command _state_ at [zigbee2mqtt\lib\extension\publish.ts](https://github.com/Koenkk/zigbee2mqtt/blob/e06848db8c5ad247c27e959eb85465a30134769f/lib/extension/publish.ts#L262) at  line 262 `const converter = converters.find((c) => (!c.key || c.key.includes(key)) && (!c.endpoint || c.endpoint == endpointName));`

