### PR TITLE
Add Support for Chacon roller shutter module ZB-ERSM-01

### DIFF
--- a/src/devices/chacon.ts
+++ b/src/devices/chacon.ts
@@ -1,0 +1,18 @@
+import {commandsWindowCovering, windowCovering} from '../lib/modernExtend';
+import {DefinitionWithExtend} from '../lib/types';
+
+const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ['ZB-ERSM-01'],
+        model: 'ZB-ERSM-01',
+        vendor: 'Chacon',
+        description: 'Roller shutter module',
+        extend: [
+            windowCovering({controls: ['lift'], coverMode: true}),
+            commandsWindowCovering({commands: ['open', 'close', 'stop'], legacyAction: false}),
+        ],
+    },
+];
+
+export default definitions;
+module.exports = definitions;

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -38,6 +38,7 @@ import candeo from './candeo';
 import casaia from './casaia';
 import cel from './cel';
 import centralite from './centralite';
+import chacon from './chacon';
 import cleode from './cleode';
 import cleverio from './cleverio';
 import climax from './climax';
@@ -348,6 +349,7 @@ export default [
     ...casaia,
     ...cel,
     ...centralite,
+    ...chacon,
     ...cleode,
     ...cleverio,
     ...climax,


### PR DESCRIPTION
Add Support for Chacon roller shutter module ZB-ERSM-01, using modern Extend
New manufacturer