### PR TITLE
Update AC01353010G minimum voltage

### DIFF
--- a/src/devices/osram.ts
+++ b/src/devices/osram.ts
@@ -268,7 +268,7 @@ const definitions: DefinitionWithExtend[] = [
         description: 'SMART+ Motion Sensor',
         fromZigbee: [fz.temperature, fz.ias_occupancy_only_alarm_2, fz.ignore_basic_report, fz.battery],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: {min: 1900, max: 3000}}},
+        meta: {battery: {voltageToPercentage: {min: 2100, max: 3000}}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement', 'genPowerCfg']);


### PR DESCRIPTION
Multiple of these devices consistently report 2200mV before ceasing to report.

Update the minimum voltage so that zigbee2mqtt reports a lower minimum battery % value, rather than ~27%, before the devices runs out of power and stops reporting.