### PR TITLE
Correct local temperature calibration min and max value on SONOFF TRVZB

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -916,7 +916,7 @@ const definitions: DefinitionWithExtend[] = [
                 .climate()
                 .withSetpoint('occupied_heating_setpoint', 4, 35, 0.5)
                 .withLocalTemperature()
-                .withLocalTemperatureCalibration(-7.0, 7.0, 0.2)
+                .withLocalTemperatureCalibration(-12.8, 12.7, 0.2)
                 .withSystemMode(['off', 'auto', 'heat'], ea.ALL, 'Mode of the thermostat')
                 .withRunningState(['idle', 'heat'], ea.STATE_GET),
             e.battery(),


### PR DESCRIPTION
Experimentally found out the supported calibration range for SNOFF TRVZB. When sending a message to MQTT with subject zigbee2mqtt/0x0cae5ffffebc15dc/set/local_temperature_calibration and transmitting deliberately large values, I received an error explicitly specifying the acceptable range: The value of "value" is out of range. It must be >= -128 and <= 127. Received 160. Send this max 12.7 and minv -12.8 values work correct, error not raise.