### PR TITLE
Develco MOSZB-153: Fix illuminance reporting & unlock LED, timeout control

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -702,7 +702,14 @@ const definitions: DefinitionWithExtend[] = [
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),
             illuminance({reporting: {min: 60, max: 3600, change: 500}}),
-            battery(),
+            battery({
+                voltageToPercentage: {min: 2500, max: 3000},
+                percentage: true,
+                voltage: true,
+                lowStatus: false,
+                voltageReporting: true,
+                percentageReporting: false,
+            }),
             iasZoneAlarm({zoneType: 'occupancy', zoneAttributes: ['alarm_1']}),
         ],
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -684,7 +684,7 @@ const definitions: DefinitionWithExtend[] = [
         toZigbee: [develco.tz.led_control, develco.tz.ias_occupancy_timeout],
         exposes: (device, options) => {
             const dynExposes = [];
-            if (device && device.softwareBuildID && Number(device.softwareBuildID.split('.')[0]) >= 2) {
+            if (Number(device?.softwareBuildID?.split('.')[0]) >= 2) {
                 dynExposes.push(e.numeric('occupancy_timeout', ea.ALL).withUnit('s').withValueMin(5).withValueMax(65535));
                 dynExposes.push(
                     e.enum('led_control', ea.ALL, ['off', 'fault_only', 'motion_only', 'both']).withDescription('Control LED indicator usage.'),

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -684,10 +684,8 @@ const definitions: DefinitionWithExtend[] = [
         toZigbee: [develco.tz.led_control, develco.tz.ias_occupancy_timeout],
         exposes: (device, options) => {
             const dynExposes = [];
-            if (Number(device?.softwareBuildID?.split('.')[0]) >= 3) {
+            if (device && device.softwareBuildID && Number(device.softwareBuildID.split('.')[0]) >= 2) {
                 dynExposes.push(e.numeric('occupancy_timeout', ea.ALL).withUnit('s').withValueMin(5).withValueMax(65535));
-            }
-            if (Number(device?.softwareBuildID?.split('.')[0]) >= 4) {
                 dynExposes.push(
                     e.enum('led_control', ea.ALL, ['off', 'fault_only', 'motion_only', 'both']).withDescription('Control LED indicator usage.'),
                 );
@@ -703,16 +701,14 @@ const definitions: DefinitionWithExtend[] = [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),
-            illuminance(),
+            illuminance({reporting: {min: 60, max: 3600, change: 500}}),
             battery(),
-            iasZoneAlarm({zoneType: 'occupancy', zoneAttributes: ['alarm_1', 'battery_low', 'tamper']}),
+            iasZoneAlarm({zoneType: 'occupancy', zoneAttributes: ['alarm_1']}),
         ],
         configure: async (device, coordinatorEndpoint) => {
-            const endpoint35 = device.getEndpoint(35);
-            if (Number(device?.softwareBuildID?.split('.')[0]) >= 3) {
+            if (device && device.softwareBuildID && Number(device.softwareBuildID.split('.')[0]) >= 2) {
+                const endpoint35 = device.getEndpoint(35);
                 await endpoint35.read('ssIasZone', ['develcoAlarmOffDelay'], manufacturerOptions);
-            }
-            if (Number(device?.softwareBuildID?.split('.')[0]) >= 4) {
                 await endpoint35.read('genBasic', ['develcoLedControl'], manufacturerOptions);
             }
         },


### PR DESCRIPTION
This pull request makes several improvements to the Develco MOSZB-153 device definition added yesterday.

**1. Reduced excessive illuminance reporting**

- Adjusted the illuminance reporting configuration by setting _min: 60_, _max: 3600_, and _change: 500_. This reduces the frequency of illuminance reports, minimizing unnecessary network traffic and improving performance.

**2. Enabled led control and occupancy timeout settings**

- Corrected the software build ID checks from >=3 and >=4 to >=2. This change unlocks the LED indicator control (led_control) and occupancy timeout (occupancy_timeout) features for devices with firmware version 2 or higher, which were previously inaccessible.

**3. Updated IAS zone attributes**

- Streamlined the IAS zone attributes by including only 'alarm_1' in zoneAttributes. Removed 'battery_low' and 'tamper' attributes.

These changes improve the functionalities and user experience of the Develco MOSZB-153 within Zigbee2MQTT by providing better control over device features and reducing unnecessary network load.