### PR TITLE
Improvements to Tuya ZY-M100-24G ('_TZE204_ijxvkhd0')

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10399,36 +10399,45 @@ const definitions: DefinitionWithExtend[] = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
-            e.enum('state', ea.STATE, ['none', 'presence', 'move']).withDescription('Presence state sensor'),
-            e.presence().withDescription('Occupancy'),
-            e.numeric('distance', ea.STATE).withDescription('Target distance'),
-            e.illuminance_lux().withDescription('Illuminance sensor'),
-            e.numeric('move_sensitivity', ea.STATE_SET).withValueMin(1).withValueMax(10).withValueStep(1).withDescription('Motion sensitivity'),
-            e.numeric('presence_sensitivity', ea.STATE_SET).withValueMin(1).withValueMax(10).withValueStep(1).withDescription('Presence sensitivity'),
-            e
-                .numeric('radar_range', ea.STATE_SET)
+            e.enum('state', ea.STATE, ['none', 'presence', 'move']).withDescription('Presence state'),
+            e.occupancy(),
+            e.numeric('distance', ea.STATE).withUnit('m').withDescription('Target distance'),
+            e.illuminance_lux(),
+            e.numeric('motion_sensitivity', ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(10)
+                .withValueStep(1)
+                .withCategory('config')
+                .withDescription('Motion sensitivity'),
+            e.numeric('occupancy_sensitivity', ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(10)
+                .withValueStep(1)
+                .withCategory('config')
+                .withDescription('Occupancy sensitivity'),
+            e.numeric('max_range', ea.STATE_SET)
                 .withValueMin(1.5)
                 .withValueMax(5.5)
                 .withValueStep(1)
                 .withUnit('m')
+                .withCategory('config')
                 .withDescription('Maximum range'),
-            e
-                .numeric('presence_timeout', ea.STATE_SET)
+            e.numeric('occupancy_timeout', ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(1500)
                 .withValueStep(1)
                 .withUnit('s')
-                .withDescription('Fade time'),
+                .withDescription('Occupancy timeout'),
         ],
         meta: {
             multiEndpoint: true,
             tuyaDatapoints: [
-                [112, 'presence', tuya.valueConverter.trueFalse1],
-                [106, 'move_sensitivity', tuya.valueConverter.divideBy10FromOnly],
-                [111, 'presence_sensitivity', tuya.valueConverter.divideBy10FromOnly],
-                [107, 'radar_range', tuya.valueConverter.divideBy100],
+                [112, 'occupancy', tuya.valueConverter.trueFalse1],
+                [106, 'motion_sensitivity', tuya.valueConverter.raw],
+                [111, 'occupancy_sensitivity', tuya.valueConverter.raw],
+                [107, 'max_range', tuya.valueConverter.divideBy100],
                 [109, 'distance', tuya.valueConverter.divideBy100],
-                [110, 'presence_timeout', tuya.valueConverter.raw],
+                [110, 'occupancy_timeout', tuya.valueConverter.raw],
                 [104, 'illuminance_lux', tuya.valueConverter.raw],
                 [102, 'illuminance_treshold_max', tuya.valueConverter.raw],
                 [103, 'illuminance_treshold_min', tuya.valueConverter.raw],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10403,26 +10403,30 @@ const definitions: DefinitionWithExtend[] = [
             e.occupancy(),
             e.numeric('distance', ea.STATE).withUnit('m').withDescription('Target distance'),
             e.illuminance_lux(),
-            e.numeric('motion_sensitivity', ea.STATE_SET)
+            e
+                .numeric('motion_sensitivity', ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(10)
                 .withValueStep(1)
                 .withCategory('config')
                 .withDescription('Motion sensitivity'),
-            e.numeric('occupancy_sensitivity', ea.STATE_SET)
+            e
+                .numeric('occupancy_sensitivity', ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(10)
                 .withValueStep(1)
                 .withCategory('config')
                 .withDescription('Occupancy sensitivity'),
-            e.numeric('max_range', ea.STATE_SET)
+            e
+                .numeric('max_range', ea.STATE_SET)
                 .withValueMin(1.5)
                 .withValueMax(5.5)
                 .withValueStep(1)
                 .withUnit('m')
                 .withCategory('config')
                 .withDescription('Maximum range'),
-            e.numeric('occupancy_timeout', ea.STATE_SET)
+            e
+                .numeric('occupancy_timeout', ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(1500)
                 .withValueStep(1)


### PR DESCRIPTION
The Tuya mm-wave radar model ZY-M100-24G is supported in ZHC, but the support is a bit lacking. I have added the `m` unit to the distance sensor, replaced `presence` with `occupancy` to better align with the terminology used in Home Assistance (I have found no obvious distinction when searching for this for other entities, but HA treats "presence" as "being at home" while "occupancy" is treated as "person detected", and that is good enough for me as a norm).

I am also marking the configuration settings as being of the `config` category.

This is coupled with [this PR](https://github.com/Koenkk/zigbee2mqtt/pull/24555) for Z2M which adds corresponding HA metadata.