### PR TITLE
lib/tuya: tuyaTz.datapoints wrongly updates { state: } object

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1459,7 +1459,7 @@ const tuyaTz = {
 
                 if (dpEntry[3] && dpEntry[3].optimistic === false) continue;
 
-                state[key] = value;
+                state[attr] = value;
             }
             return {state};
         },


### PR DESCRIPTION
After looking more into the behavior reported in https://github.com/Koenkk/zigbee2mqtt/issues/24425, it happens only for Tuya devices and its not an error in Zigbee2MQTT itself.

Problem:

When publishing a `set` message with multiple properties specified, the tuzaTz.datapoints default converter fails to update the state correctly.

tuyaTz.datapoints loops through the properties in the current message (because [ConverterSet is called only once](https://github.com/robvanoostenrijk/zigbee-herdsman-converters/blob/b528c02fb84a6b4efd6a1ad6d32af63dadd3735d/src/lib/tuya.ts#L1426).

However when it builds the state object to return it uses the `key` parameter of the main call, not the loop variable `attr`.
This causes the values to be overwritten in the state object under the same `key`.

For example:
```json
{ "preset": "manual", "system_mode": "cool", "current_heating_setpoint": 27 }
``` 

Leads to state:
```json
{ "preset": 27 }
```

And
```json
{ "current_heating_setpoint": 27, "preset": "manual", "system_mode": "cool"  }
``` 
to
```json
{ "current_heating_setpoint": "cool" }
```

This PR resolves the issue by correctly using the `attr` loop variable to build the return state.

Note: The device values were set correctly, however the state in Zigbee2MQTT did not reflect the device state due to the wrong return value.