### PR TITLE
Add support for Hue Cher Pendant 929003054201

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -296,6 +296,14 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight({colorTemp: {range: [153, 454]}})],
     },
     {
+        zigbeeModel: ['929003054201'],
+        model: '929003054201',
+        vendor: 'Philips',
+        description: 'Hue White Ambiance Cher Pendant',
+        extend: [philipsLight({"colorTemp":{"range":[153,454]}})],
+        meta: {},
+    },
+    {
         zigbeeModel: ['5063131P7'],
         model: '5063131P7',
         vendor: 'Philips',

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -300,8 +300,7 @@ const definitions: DefinitionWithExtend[] = [
         model: '929003054201',
         vendor: 'Philips',
         description: 'Hue White Ambiance Cher Pendant',
-        extend: [philipsLight({"colorTemp":{"range":[153,454]}})],
-        meta: {},
+        extend: [philipsLight({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ['5063131P7'],


### PR DESCRIPTION
Add support for the Hue Cher Pendant Whit Ambiance Lamp with model number 929003054201.
There seem to be multiple different model numbers around with the same capabilities.

PR for the device image is at https://github.com/Koenkk/zigbee2mqtt.io/pull/3181