### PR TITLE
fix: changed device vendor name from Namron AS to Namron

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -1369,7 +1369,7 @@ const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ['4512782', '4512781'],
         model: '4512782',
-        vendor: 'Namron AS',
+        vendor: 'Namron',
         description: 'Rotary dimmer with screen',
         extend: [
             light({effect: false, configureReporting: true, powerOnBehavior: false}),


### PR DESCRIPTION
Updated the vendor name of the newly added thermostat (#8119) to align with existing devices from the same manufacturer, which are all listed under the vendor name `Namron` rather than `Namron AS`.
