### PR TITLE
Restore divideBy10FromOnly for Tuya ZY-M100-24G

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10612,8 +10612,8 @@ const definitions: DefinitionWithExtend[] = [
             multiEndpoint: true,
             tuyaDatapoints: [
                 [112, 'occupancy', tuya.valueConverter.trueFalse1],
-                [106, 'motion_sensitivity', tuya.valueConverter.raw],
-                [111, 'occupancy_sensitivity', tuya.valueConverter.raw],
+                [106, 'motion_sensitivity', tuya.valueConverter.divideBy10FromOnly],
+                [111, 'occupancy_sensitivity', tuya.valueConverter.divideBy10FromOnly],
                 [107, 'max_range', tuya.valueConverter.divideBy100],
                 [109, 'distance', tuya.valueConverter.divideBy100],
                 [110, 'occupancy_timeout', tuya.valueConverter.raw],


### PR DESCRIPTION
This is a partial revert of https://github.com/Koenkk/zigbee-herdsman-converters/pull/8229. Apparently, the sensitivity controls for occupancy and move is doing some weird things; reading and publishing values in different magnitute.

This makes the value jump up and down when changing it (going between 0.6 and 6, or 6 and 60) but it seems to stabilize after a while. This is not ideal, but better than the fix in https://github.com/Koenkk/zigbee-herdsman-converters/pull/8229 which results in an endless stream of log messages.

I still hope it is possible to find an even better solution, but in the meantime, this fixes the regression.