### PR TITLE
Udate tuya.ys - Fix improper indicator_mode for _TZ3000_6l1pjfqe (TOMZN TOB9Z-63M)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7184,7 +7184,7 @@ const definitions: DefinitionWithExtend[] = [
             e.voltage(),
             e.energy(),
             e.enum('power_outage_memory', ea.ALL, ['on', 'off', 'restore']).withDescription('Recover state after power outage'),
-            e.enum('indicator_mode', ea.STATE_SET, ['off', 'on_off', 'off_on']).withDescription('Relay LED indicator mode'),
+            e.enum('indicator_mode', ea.STATE_SET, ['off', 'on/off', 'off/on']).withDescription('Relay LED indicator mode'),
         ],
         options: [exposes.options.measurement_poll_interval()],
         onEvent: (type, data, device, options) => tuya.onEventMeasurementPoll(type, data, device, options, true, false),


### PR DESCRIPTION


Fix the indicator mode state, to fix the following issue:

    Invalid option for select.breaz_02_indicator_mode: 'off/on' (valid options: ['off', 'on_off', 'off_on'])

Device impacted is _TZ3000_6l1pjfqe (TOMZN TOB9Z-63M)
Payload from the device is the following:

    024-11-05 11:12:50z2m:mqtt: MQTT publish: topic 'zigbee2mqtt/BreaZ_02', payload '{"child_lock":"UNLOCK","current":0,"energy":17.72,"indicator_mode":"off/on","linkquality":40,"power":0,"power_outage_memory":"on","state":"ON","update":{"installed_version":69,"latest_version":69,"state":"idle"},"update_available":null,"voltage":232}'

