### PR TITLE
Fix inconsistent battery percentage reading for VA4220ZB

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -1674,7 +1674,6 @@ const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             const binds = ['genBasic', 'genGroups', 'genOnOff', 'ssIasZone', 'genLevelCtrl', 'genPowerCfg', 'seMetering', 'manuSpecificSinope'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.batteryPercentageRemaining(endpoint);
             await reporting.onOff(endpoint);
             await reporting.brightness(endpoint); // valve position
             try {


### PR DESCRIPTION
Removed reporting.batteryPercentageRemaining for VA4220ZB to avoid inconsistent battery percentage reading. Relying instead only on the existing meta configuration for battery reporting.

The batteryPercentageRemaining attribute for this device always reports 0, it cause the exposed battery percentage value to oscillate between 0 and the correct value calculated by the meta voltageToPercentange battery reading. batteryPercentageRemaining and voltageToPercentage are in conflict.