### PR TITLE
feat: Add running state to Saswell TRV climate

### DIFF
--- a/src/devices/saswell.ts
+++ b/src/devices/saswell.ts
@@ -75,6 +75,7 @@ const definitions: DefinitionWithExtend[] = [
                 .withSetpoint('current_heating_setpoint', 5, 30, 0.5, ea.STATE_SET)
                 .withLocalTemperature(ea.STATE)
                 .withSystemMode(['off', 'heat', 'auto'], ea.STATE_SET)
+                .withRunningState(['idle', 'heat'], ea.STATE)
                 // Range is -6 - 6 and step 1: https://github.com/Koenkk/zigbee2mqtt/issues/11777
                 .withLocalTemperatureCalibration(-6, 6, 1, ea.STATE_SET),
         ],

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -3769,7 +3769,7 @@ const fromZigbee1 = {
             switch (dp) {
                 case dataPoints.saswellHeating:
                     // heating status 1 - heating
-                    return {heating: value ? 'ON' : 'OFF'};
+                    return {heating: value ? 'ON' : 'OFF', running_state: value ? 'heat' : 'idle'};
                 case dataPoints.saswellWindowDetection:
                     return {window_detection: value ? 'ON' : 'OFF'};
                 case dataPoints.saswellFrostDetection:


### PR DESCRIPTION

I happen to own this TRV (white-labeled as RTX). It was lacking the running state interface of climate (in HA) although it provides `heating` binary sensor. I kept the heating state attribute for backward compatibility.
