### PR TITLE
Add support for Philips A60 bulb (Model 9290002269A)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -72,6 +72,13 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight()],
     },
     {
+        zigbeeModel: ['LWF004'],
+        model: '9290002269A',
+        vendor: 'Philips',
+        description: 'Philips Hue A60 bulb with on/off control',
+        extend: [philipsLight()],
+    },
+    {
         zigbeeModel: ['LTA013'],
         model: '929003596001',
         vendor: 'Philips',

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -72,7 +72,7 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight()],
     },
     {
-        zigbeeModel: ['LWF004'],
+        zigbeeModel: ['LWF005'],
         model: '9290002269A',
         vendor: 'Philips',
         description: 'Philips Hue A60 bulb with on/off control',


### PR DESCRIPTION
The zigbeeModel  was taken from another device from the repo, did not work and just increased by 1. I don't have the box of the bulb. I found this buld at uni in a box and I want to use it for my thesis. I only have the model which seems to be an old one.
