### PR TITLE
Add support for Moes Smart Light Sensor

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -2,7 +2,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
 import * as legacy from '../lib/legacy';
-import {actionEnumLookup, battery, deviceEndpoints, onOff} from '../lib/modernExtend';
+import {actionEnumLookup, battery, deviceEndpoints, illuminance, onOff} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import * as tuya from '../lib/tuya';
 import {DefinitionWithExtend} from '../lib/types';
@@ -611,6 +611,13 @@ const definitions: DefinitionWithExtend[] = [
             }),
             tuya.modernExtend.tuyaLedIndicator(),
         ],
+    },
+    {
+        zigbeeModel: ['TS0222'],
+        model: 'ZSS-QT-LS-C',
+        vendor: '_TZ3000_9kbbfeho',
+        description: 'Moes Smart Light Sensor',
+        extend: [battery(), illuminance()],
     },
 ];
 

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -2,7 +2,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
 import * as legacy from '../lib/legacy';
-import {actionEnumLookup, battery, deviceEndpoints, illuminance, onOff} from '../lib/modernExtend';
+import {actionEnumLookup, battery, deviceEndpoints, onOff} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import * as tuya from '../lib/tuya';
 import {DefinitionWithExtend} from '../lib/types';
@@ -611,13 +611,6 @@ const definitions: DefinitionWithExtend[] = [
             }),
             tuya.modernExtend.tuyaLedIndicator(),
         ],
-    },
-    {
-        zigbeeModel: ['TS0222'],
-        model: 'ZSS-QT-LS-C',
-        vendor: '_TZ3000_9kbbfeho',
-        description: 'Moes Smart Light Sensor',
-        extend: [battery(), illuminance()],
     },
 ];
 

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7034,7 +7034,7 @@ const definitions: DefinitionWithExtend[] = [
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.battery(), e.illuminance(), e.illuminance_lux()],
-        whiteLabel: [tuya.whitelabel('Moes', 'ZSS-QT-LS-C', 'Light Sensor', ['_TZ3000_9kbbfeho'])],
+        whiteLabel: [tuya.whitelabel('Moes', 'ZSS-QT-LS-C', 'Light sensor', ['_TZ3000_9kbbfeho'])],
     },
     {
         fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_t9qqxn70']),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7026,7 +7026,7 @@ const definitions: DefinitionWithExtend[] = [
         whiteLabel: [tuya.whitelabel('Tuya', 'QT-07S', 'Soil sensor', ['_TZE204_myd45weu'])],
     },
     {
-        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_8uxxzz4b', '_TZ3000_hy6ncvmw']),
+        fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_8uxxzz4b', '_TZ3000_hy6ncvmw', '_TZ3000_9kbbfeho']),
         model: 'TS0222_light',
         vendor: 'Tuya',
         description: 'Light sensor',
@@ -7034,6 +7034,7 @@ const definitions: DefinitionWithExtend[] = [
         toZigbee: [],
         configure: tuya.configureMagicPacket,
         exposes: [e.battery(), e.illuminance(), e.illuminance_lux()],
+        whiteLabel: [tuya.whitelabel('Moes', 'ZSS-QT-LS-C', 'Light Sensor', ['_TZ3000_9kbbfeho'])],
     },
     {
         fingerprint: tuya.fingerprint('TS0222', ['_TZ3000_t9qqxn70']),


### PR DESCRIPTION
Bought a Moes Smart Light Sensor, unsupported.

https://www.ebay.co.uk/itm/405314591779

![image](https://github.com/user-attachments/assets/3b64d457-98fb-4031-92bd-be41380a7f7d)
![s-l960_clear](https://github.com/user-attachments/assets/e16aff2d-7885-4cfd-86f2-d04462d374ac)



## Device Info
- Manufacturer: Moes
- Model: ZSS-QT-LS-C (as on back of device) 

## Tuya
The device is marketed as Tuya, however there is no `manuSpecificTuya` cluster, therefore I ignored the Tuya-specific guidance in the [Support for new Tuya Devices](https://www.zigbee2mqtt.io/advanced/support-new-devices/02_support_new_tuya_devices.html) documentation. Please let me know if this was a bad call.

## Unsupported Clusters
The device works fine returning illuminance data (raw & lux), as well as battery.
However, there are also clusters present for Temperature (`msTemperatureMeasurement`), and Relative Humidity (`msRelativeHumidity`). I've left these out because them simply return 0, and I don't believe they're implemented; the device specification itself makes no claims it senses either temperature or humidity.