### PR TITLE
Add another variation of Tuya HY368 radiator termostat

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4243,6 +4243,7 @@ const definitions: DefinitionWithExtend[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_lpwgshtl'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_rk1wojce'}, // Emos P5630S
             {modelID: 'TS0601', manufacturerName: '_TZE200_rndg81sf'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_qjp4ynvi'},
         ],
         model: 'TS0601_thermostat',
         vendor: 'Tuya',


### PR DESCRIPTION
Seems like just another variation of the same product. I have manually edited `node_modules/zigbee-herdsman-converters/devices/tuya.js` on my local installation of Zigbee2Mqtt to include this line and it seems to work fine.