### PR TITLE
Fixed LoraTap SC400ZB-EU calibration time reading

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2213,7 +2213,7 @@ const converters1 = {
                 if (meta.device.manufacturerName === '_TZ3000_cet6ch1r') {
                     const endpoint = msg.endpoint.ID;
                     const calibrationLookup: KeyValueAny = {1: 'up', 2: 'down'};
-                    result[postfixWithEndpointName(`calibration_time_'${calibrationLookup[endpoint]}'`, msg, model, meta)] = value;
+                    result[postfixWithEndpointName(`calibration_time_${calibrationLookup[endpoint]}`, msg, model, meta)] = value;
                 } else {
                     result[postfixWithEndpointName('calibration_time', msg, model, meta)] = value;
                 }


### PR DESCRIPTION
Calibration times for my _TZ3000_cet6ch1r devices were not being read, so went looking at the logs and found the cause:

`"calibration_time_'down'":17,"calibration_time_'up'":17,"calibration_time_down":null,"calibration_time_up":null`

Removing these single quotes fixes the issue.