### PR TITLE
Detect `TRADFRIbulbG125E26WSopal440lm` as IKEA LED1936G5

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -110,10 +110,10 @@ const definitions: DefinitionWithExtend[] = [
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight(), identify()],
     },
     {
-        zigbeeModel: ['TRADFRIbulbG125E27WSopal470lm', 'TRADFRIbulbG125E26WSopal450lm', 'TRADFRIbulbG125E26WSopal470lm'],
+        zigbeeModel: ['TRADFRIbulbG125E27WSopal470lm', 'TRADFRIbulbG125E26WSopal450lm', 'TRADFRIbulbG125E26WSopal470lm', 'TRADFRIbulbG125E26WSopal440lm'],
         model: 'LED1936G5',
         vendor: 'IKEA',
-        description: 'TRADFRI bulb E26/E27, white spectrum, globe, opal, 450/470 lm',
+        description: 'TRADFRI bulb E26/E27, white spectrum, globe, opal, 440/450/470 lm',
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), identify()],
     },
     {


### PR DESCRIPTION
I don't have a picture handy, but the model number LED1936G5 is printed on the base.
The bulb is bought in Japan, which is probably why it's different.