### PR TITLE
Fix overall power for TS0601_3_phase_clamp_meter

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8770,7 +8770,7 @@ const definitions: DefinitionWithExtend[] = [
                 [111, 'energy_b', tuya.valueConverter.divideBy1000],
                 [121, 'energy_c', tuya.valueConverter.divideBy1000],
                 [131, 'current', tuya.valueConverter.divideBy1000],
-                [9, 'power', tuya.valueConverter.raw],
+                [9, 'power', tuya.valueConverter.power],
                 [102, 'power_factor_a', tuya.valueConverter.raw],
                 [112, 'power_factor_b', tuya.valueConverter.raw],
                 [122, 'power_factor_c', tuya.valueConverter.raw],


### PR DESCRIPTION
This fixes total power reporting for negative power on the `TS0601_3_phase_clamp_meter` (without relay) by making it also use the `power` converter added in f7dfbc4dcd9c8744973a3536d43893faae643fa3.