### PR TITLE
Add support for tasmota-flashed Sonoff ZBBridge (EFR32MG21 router)

### DIFF
--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -10,6 +10,7 @@ import {
     commandsOnOff,
     deviceEndpoints,
     enumLookup,
+    forcePowerSource,
     humidity,
     light,
     numeric,
@@ -702,6 +703,13 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.soil_moisture(firstEndpoint, overrides);
         },
         exposes: [e.soil_moisture(), e.battery(), e.illuminance(), e.temperature()],
+    },
+    {
+        zigbeeModel: ['UT-01'],
+        model: 'EFR32MG21.Router',
+        vendor: 'Custom devices (DiY)',
+        description: 'EFR32MG21 Zigbee bridge router',
+        extend: [forcePowerSource({powerSource: 'Mains (single phase)'})],
     },
     {
         zigbeeModel: ['UT-02'],


### PR DESCRIPTION
As discussed [here](https://github.com/Koenkk/zigbee-herdsman-converters/issues/8306).

Not sure if the UT-01 `model` I added is problematic as I reused the UT-02 `model` [here](https://github.com/Koenkk/zigbee-herdsman-converters/compare/master...alichaudry:add-zigbee-device-ut-01?expand=1#diff-a99472ce90979a9a68446eba23f31154105e803dc1324e74582d3724ef190028R715-R716).

Also open to any other changes that may need to go in.