### PR TITLE
Added Nedis ZBWS40WT as whitelabel for Tuya TS0044

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3259,6 +3259,7 @@ const definitions: DefinitionWithExtend[] = [
             {vendor: 'Haozee', model: 'ESW-OZAA-EU'},
             {vendor: 'LoraTap', model: 'SS6400ZB'},
             {vendor: 'Moes', model: 'ZT-SY-EU-G-4S-WH-MS'},
+            {vendor: 'Nedis', model: 'ZBWS40WT'},
             tuya.whitelabel('Moes', 'ZT-SR-EU4', 'Star Ring 4 Gang Scene Switch', ['_TZ3000_a4xycprs']),
             tuya.whitelabel('Tuya', 'TS0044_1', 'Zigbee 4 button remote - 12 scene', ['_TZ3000_dziaict4', '_TZ3000_mh9px7cq', '_TZ3000_j61x9rxn']),
             tuya.whitelabel('Tuya', 'TM-YKQ004', 'Zigbee 4 button remote - 12 scene', ['_TZ3000_u3nv1jwk']),


### PR DESCRIPTION
Bought the product, looks and works exactly the same as the Tuya TS0044

Link for the product: https://nedis.com/en-us/product/smart-home/energy/switches/550774462/smartlife-wall-switch-zigbee-30-wall-mount-android-ios-plastic-white