### PR TITLE
BTH-RA Matter enabled device is reporting different model when switched to Zigbee mode

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1349,7 +1349,10 @@ const definitions: DefinitionWithExtend[] = [
         exposes: [e.temperature(), e.battery(), e.occupancy(), e.battery_low(), e.tamper()],
     },
     {
-        zigbeeModel: ['RBSH-TRV0-ZB-EU'],
+        zigbeeModel: [
+            'RBSH-TRV0-ZB-EU',
+            'RBSH-TRV1-ZB-EU'
+        ],
         model: 'BTH-RA',
         vendor: 'Bosch',
         description: 'Radiator thermostat II',


### PR DESCRIPTION
There are 2 variants of Radiator thermostat II - with and without Matter