### PR TITLE
fix: Detect ZY-M100-24G wall mounted variant

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10691,7 +10691,7 @@ const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_ya4ft0w4']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_ya4ft0w4', '_TZE200_ya4ft0w4']),
         model: 'ZY-M100-24GV3',
         vendor: 'Tuya',
         description: '24G MmWave radar human presence motion sensor（added distance switch）',


### PR DESCRIPTION
I bought a different variant of the same sensor that was not detected properly. This PR fixes it. I tested the changes in zigbee2mqtt and the sensor works properly in my setup.