### PR TITLE
Add _TZE204_qyflbnbj support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1028,6 +1028,7 @@ const definitions: DefinitionWithExtend[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_vs0skpuc'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_44af8vyi'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_zl1kmjqx'},
+            {modelID: 'TS0601', manufacturerName: '_TZE204_qyflbnbj'},
         ],
         model: 'TS0601_temperature_humidity_sensor_1',
         vendor: 'Tuya',
@@ -1036,7 +1037,7 @@ const definitions: DefinitionWithExtend[] = [
         toZigbee: [],
         exposes: (device, options) => {
             const exps: Expose[] = [e.temperature(), e.humidity(), e.battery()];
-            if (!device || device.manufacturerName === '_TZE200_qyflbnbj') {
+            if (!device || device.manufacturerName === '_TZE200_qyflbnbj' || device.manufacturerName === '_TZE204_qyflbnbj') {
                 exps.push(e.battery_low());
                 exps.push(e.enum('battery_level', ea.STATE, ['low', 'middle', 'high']).withDescription('Battery level state'));
             }


### PR DESCRIPTION
This PR adds support for `_TZE204_qyflbnbj`.
This device seems to be equivalent to those that are already defined as `TS0601_temperature_humidity_sensor_1`, and this can also be seen [in Hubitat](https://raw.githubusercontent.com/kkossev/Hubitat/development/Drivers/Tuya%20Temperature%20Humidity%20Illuminance%20LCD%20Display%20with%20a%20Clock/Tuya_Temperature_Humidity_Illuminance_LCD_Display_with_a_Clock.groovy).