### PR TITLE
Bosch BSP-FZ2 (Plug Compact): Fix failing interview due to wrong device configuration

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1763,7 +1763,7 @@ const definitions: DefinitionWithExtend[] = [
         model: 'BSP-FZ2',
         vendor: 'Bosch',
         description: 'Plug compact EU',
-        extend: [onOff(), electricityMeter(), ota()],
+        extend: [onOff(), electricityMeter({voltage: false, current: false}), ota()],
         whiteLabel: [
             {vendor: 'Bosch', model: 'BSP-EZ2', description: 'Plug compact FR', fingerprint: [{modelID: 'RBSH-SP-ZB-FR'}]},
             {vendor: 'Bosch', model: 'BSP-GZ2', description: 'Plug compact UK', fingerprint: [{modelID: 'RBSH-SP-ZB-GB'}]},


### PR DESCRIPTION
Due to refactoring in #7996 , Z2M tries to access/configure both voltage and current readings. These are unsupported attributes on the Bosch BSP-FZ2, which results in a failing/incomplete interview.

```
[2024-11-22 23:05:10] debug:    zh:controller:endpoint: Error: ZCL command 0x6c5cb1fffe102cc7/1 haElectricalMeasurement.read(["acCurrentDivisor","acCurrentMultiplier"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')
    at Endpoint.checkStatus (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:350:28)                                                                                                                                                                                                                                                                                                                                            
    at Endpoint.zclCommand (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:956:26)                                                                
    at processTicksAndRejections (node:internal/process/task_queues:95:5)                                                                                                                                                                                                                                                                                                                                                                          
    at Endpoint.read (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:446:29)                                                                                                                                                                                                                                                                                                                                                   
    at result.configure (/app/node_modules/zigbee-herdsman-converters/src/lib/modernExtend.ts:1925:37)                                                                                                                                                                                                                                                                                                                                             
    at Object.configure (/app/node_modules/zigbee-herdsman-converters/src/index.ts:205:21)                                
    at Configure.configure (/app/lib/extension/configure.ts:130:13)                                                                                                                                                                                                                                                                                                                                                                                
    at Immediate.<anonymous> (/app/lib/extension/configure.ts:75:17)                                                                                                                                                                                                                                                                                               
[2024-11-22 23:05:10] error:    z2m: Failed to configure 'kitchen-refrigerator-plug', attempt 1 (Error: ZCL command 0x6c5cb1fffe102cc7/1 haElectricalMeasurement.read(["acCurrentDivisor","acCurrentMultiplier"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')                                       
    at Endpoint.checkStatus (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:350:28)                                                                                                                                                                                                                                                                                                                                            
    at Endpoint.zclCommand (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:956:26)                                                                                     
    at processTicksAndRejections (node:internal/process/task_queues:95:5)                                                                                                                                                                                                                                                           
    at Endpoint.read (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:446:29)                                                                                                                                                                                                                                                                                                                                   
    at result.configure (/app/node_modules/zigbee-herdsman-converters/src/lib/modernExtend.ts:1925:37) 
    at Object.configure (/app/node_modules/zigbee-herdsman-converters/src/index.ts:205:21)                                
    at Configure.configure (/app/lib/extension/configure.ts:130:13)                                                                                                                                                                                                                                                                                                                                       
    at Immediate.<anonymous> (/app/lib/extension/configure.ts:75:17))

[...]

[2024-11-22 23:14:36] debug:    zh:controller:endpoint: Error: ZCL command 0x6c5cb1fffe102cc7/1 haElectricalMeasurement.read(["acVoltageDivisor","acVoltageMultiplier"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')                                                                                
    at Endpoint.checkStatus (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:350:28)                                                                                                                                                                                                                                                                                                                                            
    at Endpoint.zclCommand (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:956:26)                                                                                                                                                                                                                                                                                                                                             
    at processTicksAndRejections (node:internal/process/task_queues:95:5)                                                                                                                                                                                                                                                                                                                                                                          
    at Endpoint.read (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:446:29)                                                                                                                                                                                                                                                                                                                                                   
    at result.configure (/app/node_modules/zigbee-herdsman-converters/src/lib/modernExtend.ts:1925:37)                                                                                                                                                                                                                                                                                                                                             
    at Object.configure (/app/node_modules/zigbee-herdsman-converters/src/index.ts:205:21)                                                                                                                                                                                                                                                                                                                                                         
    at Configure.configure (/app/lib/extension/configure.ts:130:13)                                                                                                                                                                                                                                                                                                                                                                                
    at Configure.onMQTTMessage (/app/lib/extension/configure.ts:57:21)                                                                                                                                                                                                                                                                                                                                                                             
    at EventEmitter.wrappedCallback (/app/lib/eventBus.ts:206:17)                                                                                                                                                                                                                                                                                                                                                                                  
[2024-11-22 23:14:36] error:    z2m: Failed to configure 'kitchen-refrigerator-plug', attempt 1 (Error: ZCL command 0x6c5cb1fffe102cc7/1 haElectricalMeasurement.read(["acVoltageDivisor","acVoltageMultiplier"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')                                       
    at Endpoint.checkStatus (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:350:28)                                                                                                                                                                                                                                                                                                                                            
    at Endpoint.zclCommand (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:956:26)                                                                                                                                                                                                                                                                                                                                             
    at processTicksAndRejections (node:internal/process/task_queues:95:5)                                                                                                                                                                                                                                                                                                                                                                          
    at Endpoint.read (/app/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:446:29)                                                                                                                                                                                                                                                                                                                                                   
    at result.configure (/app/node_modules/zigbee-herdsman-converters/src/lib/modernExtend.ts:1925:37)                                                                                                                                                                                                                                                                                                                                             
    at Object.configure (/app/node_modules/zigbee-herdsman-converters/src/index.ts:205:21)                                                                                                                                                                                                                                                                                                                                                         
    at Configure.configure (/app/lib/extension/configure.ts:130:13)                                                                                                                                                                                                                                                                                                                                                                                
    at Configure.onMQTTMessage (/app/lib/extension/configure.ts:57:21)                                                                                                                                                                                                                                                                                                                                                                             
    at EventEmitter.wrappedCallback (/app/lib/eventBus.ts:206:17))
```

This PR fixes the issue by disabling voltage and current readings for the BSP-FZ2.