### PR TITLE
feat(add):  support Tuya `_TZ3210_bfwvfyx1` as TS0505B

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1681,6 +1681,19 @@ const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint('TS0505B', ['_TZ3210_bfwvfyx1']),
+        model: 'TS0505B_4',
+        vendor: 'Tuya',
+        description: 'Zigbee RGB+CCT light',
+        whiteLabel: [tuya.whitelabel('Tuya', 'TS0505B_4_4', 'Zigbee 3.0 15W led light bulb E27 RGBCW', ['_TZ3210_bfwvfyx1'])],
+        toZigbee: [tz.on_off, tzLocal.led_control, tuya.tz.do_not_disturb],
+        fromZigbee: [fz.on_off, fz.tuya_led_controller, fz.brightness, fz.ignore_basic_report],
+        exposes: [e.light_brightness_colortemp_colorhs([50, 1000]).removeFeature('color_temp_startup'), tuya.exposes.doNotDisturb()],
+        configure: async (device, coordinatorEndpoint) => {
+            device.getEndpoint(1).saveClusterAttributeKeyValue('lightingColorCtrl', {colorCapabilities: 29});
+        },
+    },
+    {
         zigbeeModel: ['TS0503B'],
         model: 'TS0503B',
         vendor: 'Tuya',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1685,7 +1685,7 @@ const definitions: DefinitionWithExtend[] = [
         model: 'TS0505B_4',
         vendor: 'Tuya',
         description: 'Zigbee RGB+CCT light',
-        whiteLabel: [tuya.whitelabel('Tuya', 'TS0505B_4_4', 'Zigbee 3.0 15W led light bulb E27 RGBCW', ['_TZ3210_bfwvfyx1'])],
+        whiteLabel: [tuya.whitelabel('Tuya', 'TS0505B_4_1', 'Zigbee 3.0 15W led light bulb E27 RGBCW', ['_TZ3210_bfwvfyx1'])],
         toZigbee: [tz.on_off, tzLocal.led_control, tuya.tz.do_not_disturb],
         fromZigbee: [fz.on_off, fz.tuya_led_controller, fz.brightness, fz.ignore_basic_report],
         exposes: [e.light_brightness_colortemp_colorhs([50, 1000]).removeFeature('color_temp_startup'), tuya.exposes.doNotDisturb()],


### PR DESCRIPTION
## Description
This Pull Request adds support for Tuya 15W led light bulb E27 RGBCW from [AliExpress](https://www.aliexpress.us/item/1005005721435025.html).
There is currently no support for `_TZ3210_bfwvfyx1` fingerprint which causes this devices to be defaulted to `TS0505B_1` whose implementation is barely compatible and unable to properly control color.

![Untitled](https://github.com/user-attachments/assets/423d5f19-8c26-4b21-9528-6355b95f6c4b)

### Additional Info
In order to just get the color working `_TZ3210_bfwvfyx1` could just be added to `TS0505B_2` supported fingerprints but this new device accepts a color temperature range from `50` to `1000` instead so I took the initiative to give it its own definition.