### PR TITLE
Busch-Jaeger 6735/6736/6737: Drop deprecated switch state

### DIFF
--- a/src/devices/busch_jaeger.ts
+++ b/src/devices/busch_jaeger.ts
@@ -45,10 +45,6 @@ const definitions: DefinitionWithExtend[] = [
             //  2. The top rocker will not be usable (not emit any events) as it's hardwired to the relay/dimmer
             if (!device || device.getEndpoint(0x12) != null) {
                 expose.push(e.light_brightness().withEndpoint('relay'));
-                // Exposing the device as a switch without endpoint is actually wrong, but this is the historic
-                // definition and we are keeping it for compatibility reasons.
-                // DEPRECATED and should be removed in the future
-                expose.push(e.switch());
             }
             // Not all devices support all actions (depends on number of rocker rows and if relay/dimmer is installed),
             // but defining all possible actions here won't do any harm.


### PR DESCRIPTION
Since this device has breaking changes in Z2M 2.0 (payload changes) we can use this as a chance to drop the deprecated state as well.

These are multi-endpoint devices and therefore the state needs to be prefixed by the endpoint name (`state_relay`). The `state` attribute never worked properly (e.g. it did not update when device was turned on directly).

For Home Assistant users there has been a note in the [docs](https://www.zigbee2mqtt.io/devices/6735_6736_6737.html#home-assistant-device-discovered-both-as-light-and-switch) for quite a while that the `switch` entity needs to be ignored.