### PR TITLE
Add GL-C-310P Gledopto Relay Switch

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -991,7 +991,7 @@ const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ['GL-C-310P'],
         model: 'GL-C-310P',
         vendor: 'Gledopto',
-        description: 'Zigbee Relay Switch',
+        description: 'Zigbee relay switch',
         extend: [onOff()],
     },
 ];

--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -987,6 +987,13 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Zigbee triac AC dimmer',
         extend: [gledoptoLight({configureReporting: true})],
     },
+    {
+        zigbeeModel: ['GL-C-310P'],
+        model: 'GL-SD-301P',
+        vendor: 'Gledopto',
+        description: 'Zigbee Relay Switch',
+        extend: [onOff()],
+    },
 ];
 
 export default definitions;

--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -989,7 +989,7 @@ const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ['GL-C-310P'],
-        model: 'GL-SD-301P',
+        model: 'GL-C-310P',
         vendor: 'Gledopto',
         description: 'Zigbee Relay Switch',
         extend: [onOff()],


### PR DESCRIPTION
Adds the new GL-C-310P Zigbee Relay Switch from Gledopto that returns the `GL-C-310P` ModelId.
Purchased from https://www.aliexpress.com/item/1005007719250927.html.
Used the modern extend `[onOff()])` as this exposed Power-on behavior for me.  `[gledoptoOnOff()]` did not.

In saying that, not 100% sure that having the Power on values of `Off`, `On`, `Toggle` and `Previous` is quite right as the "Power-off memory function" of this device has only two states.
`On` Lights up by default when powered on
`Previous` Remember the state of the on/off before power failure.
Please adjust if required.

**Note:**
Tested with Push (Momentary) Switch and Rocker Switch attached. Both worked as expected.
Short press manual `Reset` button to change modes.
Indicator light `Flashing` - Push Switch attached
Indicator light `Steady On` - Rocker Switch attached.

**FYI**
The GL-C-310P.js yaml that worked in my local configuration.yaml was:
```
const {onOff} = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    zigbeeModel: ['GL-C-310P'],
    model: 'GL-C-310P',
    vendor: 'GLEDOPTO',
    description: 'Zigbee Relay Switch',
    extend: [onOff()],
//    extend: [gledoptoOnOff()],
//    extend: [onOff({"configureReporting":false})],
    meta: {},
};

module.exports = definition;
```
The commented out lines were altenative `extend` options I tried, that both worked, but didn't expose the Power-on behavior.