### PR TITLE
Exposing action_brightness_delta to allow better blueprints

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7598,6 +7598,7 @@ const definitions: DefinitionWithExtend[] = [
                 'rotate_left',
                 'rotate_right',
             ]),
+            e.numeric("action_brightness_delta", ea.STATE).withValueMin(-255).withValueMax(255),
             e.numeric('action_step_size', ea.STATE).withValueMin(0).withValueMax(255),
             e.numeric('action_transition_time', ea.STATE).withUnit('s'),
             e.numeric('action_rate', ea.STATE).withValueMin(0).withValueMax(255),


### PR DESCRIPTION
This enables home assistant users to have a better dimming experience using automations like, therefore zha is not needed anymore for smooth dimming experience.

[https://github.com/[TheUnlimited64/tuya_smart_knob_blueprint](https://github.com/TheUnlimited64/tuya_smart_knob_blueprint)](url)

Only issue currently (atleast with mine) is that there seems to be a cooldown after ~2s. If I dimm long enough it stops receiving. But I'm not sure how to mitigate it.