### PR TITLE
Add support for E2223 variant of IKEA INSPELNING smart plug

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -618,8 +618,25 @@ const definitions: DefinitionWithExtend[] = [
         extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), ikeaOta()],
     },
     {
+        fingerprint: [{modelID: 'E2206', manufacturerName: 'IKEA'}],
         zigbeeModel: ['INSPELNING Smart plug'],
         model: 'E2206',
+        vendor: 'IKEA',
+        description: 'INSPELNING smart plug',
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), ota(), electricityMeter()],
+        configure: async (device) => {
+            const endpoint = device.getEndpoint(1);
+            // Enable reporting of powerDivisor, needs to change dynamically with the amount of power
+            // For details, see: https://github.com/Koenkk/zigbee2mqtt/issues/23961#issuecomment-2366733453
+            await endpoint.configureReporting('haElectricalMeasurement', [
+                {attribute: 'acPowerDivisor', minimumReportInterval: 10, maximumReportInterval: repInterval.MAX, reportableChange: 1},
+            ]);
+        },
+    },
+    {
+        fingerprint: [{modelID: 'INSPELNING Smart plug', manufacturerName: 'IKEA of Sweden'}],
+        zigbeeModel: ['INSPELNING Smart plug'],
+        model: 'E2223',
         vendor: 'IKEA',
         description: 'INSPELNING smart plug',
         extend: [addCustomClusterManuSpecificIkeaUnknown(), onOff(), identify(), ota(), electricityMeter()],


### PR DESCRIPTION
My E2223 variant of the IKEA INSPELNING smart plug has the same zigbeeModel as the pre-existing E2206 of 'INSPELNING Smart plug'.  In addition model was also set to 'INSPELNING Smart plug' rather than the actual model as it is for the E2206.   fingerprint has been used to separate the two models on the differences in model and vendor texts.

An image for E2223 has been added to https://github.com/Koenkk/zigbee2mqtt.io

Extract from generated_external_definition below just to illustrate:

const definition = {
    zigbeeModel: ['INSPELNING Smart plug'],
    model: 'INSPELNING Smart plug',
    vendor: 'IKEA of Sweden',
    description: 'Automatically generated definition',
    extend: [light(), electricityMeter()],
    meta: {},
};