### PR TITLE
added a default to set the temperature

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -937,7 +937,7 @@ export const valueConverter = {
             if (Object.keys(dayByte).indexOf(weekDay) === -1) {
                 throw new Error('Invalid "week_day" property value: ' + weekDay);
             }
-            let weekScheduleType;
+            let weekScheduleType = 'separate';
             if (meta.state && meta.state.working_day) weekScheduleType = meta.state.working_day;
             const payload = [];
 


### PR DESCRIPTION
I ran in to the same Issue as in https://github.com/Koenkk/zigbee-herdsman-converters/issues/6418
Unfortunately, I hadn't been able how to figure out a way to pass the information about the schedule type. Therefore, I felt back to a system with a default value of separate, which is the least restrictive.
It is not ideal but at least gets the things going.
Hopefully that helps the affected people, even if my frontend in form of iobroker.zigbee is still using version 19.
