### PR TITLE
Set the path to pnpm store inside the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
 
-    "postCreateCommand": "pnpm i --frozen-lockfile",
+    "postCreateCommand": "pnpm config set store-dir /home/node/.local/share/pnpm/store && pnpm i --frozen-lockfile",
 
     "customizations": {
         "vscode": {


### PR DESCRIPTION
When running pnpm in the dev container, it doesn't have the path to the store directory set (it's not inherited from the environmental variables because it's located in a different volume. This can lead pnpm to create a store directory inside the repository itself which is not ideal. Setting it as follows in the `/home/node` folder avoids permissions errors during running the dev container. See https://github.com/pnpm/pnpm/issues/5803#issuecomment-1974820613 for more details.
