### PR TITLE
Adding new ID for Tuya SOS button

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2976,6 +2976,7 @@ const definitions: DefinitionWithExtend[] = [
             '_TZ3000_0dumfk2z',
             '_TZ3000_ssp0maqm',
             '_TZ3000_p3fph1go',
+            '_TZ3000_9r5jaajv',
         ]),
         model: 'TS0215A_sos',
         vendor: 'Tuya',


### PR DESCRIPTION
Just purchased the MOES SOS button 

It is just rebranded Tuya SOS button - battery, one button 

Zigbee Model
TS0215A
Zigbee Manufacturer
_TZ3000_9r5jaajv