### PR TITLE
Added support for CONECTO COZIGTHS1 by adding fingerprint to NOUS E6

### DIFF
--- a/src/devices/nous.ts
+++ b/src/devices/nous.ts
@@ -81,7 +81,7 @@ const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_wtikaxzs', '_TZE200_nnrfa68v']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_wtikaxzs', '_TZE200_nnrfa68v', '_TZE200_zppcgbdj']),
         model: 'E6',
         vendor: 'Nous',
         description: 'Temperature & humidity LCD sensor',


### PR DESCRIPTION
Did some testing and found that the CONECTO COZIGTHS1 is basically a relabel of the NOUS e6.

For reference CONECTO COZIGTHS1:
https://www.power.no/smarte-hjem/smart-varmestyring-og-klima/inneklima-og-temperatursensorer/conecto-zigbee-temperaturfuktighetssensor-med-skjerm/p-2267907/
vs
https://nous.technology/product/e6.html

Tested and working through manual add to zigbee2mqtt.