### PR TITLE
feat(add): support Tuya _TZE204_9mjy74mp as TRV601

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5082,7 +5082,7 @@ const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE204_rtrmfadk'},
-            {modelID: 'TS0601', manufacturerName: '_TZE204_9mjy74mp'} // MOES
+            {modelID: 'TS0601', manufacturerName: '_TZE204_9mjy74mp'}, // MOES
         ],
         model: 'TRV601',
         vendor: 'Tuya',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5080,7 +5080,10 @@ const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE204_rtrmfadk'}],
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE204_rtrmfadk'},
+            {modelID: 'TS0601', manufacturerName: '_TZE204_9mjy74mp'} // MOES
+        ],
         model: 'TRV601',
         vendor: 'Tuya',
         description: 'Thermostatic radiator valve.',


### PR DESCRIPTION
This Pull Request adds support for Tuya MOES TRV from [AliExpress](https://es.aliexpress.com/item/1005006068601747.html).
There is currently no support for _TZE204_9mjy74mp fingerprint.

I tested the external definition provided in https://github.com/Koenkk/zigbee2mqtt/issues/24178 for a few months working well.

![image](https://github.com/user-attachments/assets/5ba9f9c5-af9b-45f3-84ac-865392730001)
