### PR TITLE
Add innr filament bulbs RF-271-T/RF-273-T

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -815,6 +815,13 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Smart E26 LED bulb',
         extend: [light({turnsOffAtBrightness1: true})],
     },
+    {
+        zigbeeModel: ['RF 271 T'],
+        model: 'RF 271 T',
+        vendor: 'Innr',
+        description: 'Smart E27 filament LED globe light bulb',
+        extend: [light({colorTemp: {range: [153, 556]}, turnsOffAtBrightness1: true})],
+    },
 ];
 
 export default definitions;

--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -822,6 +822,13 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Smart E27 filament LED globe light bulb',
         extend: [light({colorTemp: {range: [153, 556]}, turnsOffAtBrightness1: true})],
     },
+    {
+        zigbeeModel: ['RF 273 T'],
+        model: 'RF 273 T',
+        vendor: 'Innr',
+        description: 'Smart E27 filament LED light bulb',
+        extend: [light({colorTemp: {range: [153, 556]}, turnsOffAtBrightness1: true})],
+    },
 ];
 
 export default definitions;


### PR DESCRIPTION
Add the new Innr filament bulbs RF 271 T and RF 273 T.
I've tested both, and they worked perfectly out of the box with the generated external definition — awesome work! 🚀
The only manual adjustment I had to make was adding the `turnsOffAtBrightness1` property.

There is a third model, RF 274 T, which I assume has a different bulb shape but should function the same as the other two. Unfortunately, I don’t own this type, so I can’t test this assumption. Should I add the model RF 274 T anyway?

Different filament bulb types: https://www.innr.com/wp-content/uploads/2024/06/innr-SAR-002-2002-UK-DoC-RF-262-271-T-273-T-274-T-v1.0.pdf

Documentation PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/3286 