### PR TITLE
Fix bug in tuyaModernExtend

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1808,7 +1808,7 @@ export function getHandlersForDP(
         : [
               {
                   key: [name],
-                  endpoints: [endpoint],
+                  endpoints: endpoint ? [endpoint] : undefined,
                   convertSet: async (entity, key, value, meta) => {
                       // A set converter is only called once; therefore we need to loop
                       const state: KeyValue = {};


### PR DESCRIPTION
Bug introduced in #8190 and prevents `tuyaModernExtend` functioning when no endpoint is specified. Low impact as almost no converters use this yet.

When endpoint is undefined, array is still truthy. Correction to ensure value is falsy when zigbee2mqtt is matching the converter.

I now have a converter working for a garage door opener if `tuyaModernExtend` is ready to be used more widely?