### PR TITLE
add Livarno Home HG08130B

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3017,7 +3017,7 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Light controller',
         extend: [tuya.modernExtend.tuyaLight({colorTemp: {range: [153, 500]}})],
         whiteLabel: [
-            tuya.whitelabel('Lidl', 'HG06492B', 'Livarno Lux E14 candle CCT', ['_TZ3000_oborybow']),
+            tuya.whitelabel('Lidl', 'HG06492B/HG08130B', 'Livarno Home E14 candle CCT', ['_TZ3000_oborybow']),
             tuya.whitelabel('Lidl', 'HG06492A/HG08130A', 'Livarno Lux GU10 spot CCT', ['_TZ3000_el5kt5im']),
             tuya.whitelabel('Lidl', 'HG06492C/HG08130C/HG09154C', 'Livarno Lux E27 bulb CCT', ['_TZ3000_49qchf10']),
             tuya.whitelabel('Lidl', '14147206L', 'Livarno Lux ceiling light', ['_TZ3000_rylaozuc', '_TZ3000_5fkufhn1']),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -439,8 +439,8 @@ describe('index.js', () => {
         };
 
         const HG06492B_match = await index.findByDevice(HG06492B);
-        expect(HG06492B_match.model).toBe('HG06492B');
-        expect(HG06492B_match.description).toBe('Livarno Lux E14 candle CCT');
+        expect(HG06492B_match.model).toBe('HG06492B/HG08130B');
+        expect(HG06492B_match.description).toBe('Livarno Home E14 candle CCT');
         expect(HG06492B_match.vendor).toBe('Lidl');
 
         const TS0502A_match = await index.findByDevice(TS0502A);


### PR DESCRIPTION
- Add the HG08130B E14 candle lamp, which are currently sold by Lidl, to the self reported Vendor strings
- Fixes Livarno Home, being called Livarno Lux. Which is, I think, either an older branding or the branding for non-smart home lamps, as it's neither printed on the lamps, the packaging or shown on the Website in relation to those lamps.