### PR TITLE
fix description of Livarno Home HG06104A

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3081,7 +3081,7 @@ const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel('Lidl', '14148906L', 'Livarno Lux mood light RGB+CCT', ['_TZ3000_9cpuaca6']),
             tuya.whitelabel('Lidl', '14149505L/14149506L_1', 'Livarno Lux light bar RGB+CCT (black/white)', ['_TZ3000_gek6snaj']),
             tuya.whitelabel('Mycket', 'MS-SP-LE27WRGB', 'E27 RGBW bulb', ['_TZ3000_evag0pvn']),
-            tuya.whitelabel('Lidl', 'HG06104A', 'Livarno Lux smart LED light strip 2.5m', ['_TZ3000_riwp3k79', '_TZ3000_riwp3k79']),
+            tuya.whitelabel('Lidl', 'HG06104A', 'Livarno Home RGB+CCT LED light strip 2m', ['_TZ3000_riwp3k79', '_TZ3000_riwp3k79']),
         ],
         configure: async (device, coordinatorEndpoint) => {
             device.getEndpoint(1).saveClusterAttributeKeyValue('lightingColorCtrl', {colorCapabilities: 29});


### PR DESCRIPTION
- It's 2 meters, not 2.5 meters
- The branding is "Livarno Home", not "Livarno Lux"
- Added that it's an "RGBCCT" LED strip

Packaging:

![IMG_20241206_170157](https://github.com/user-attachments/assets/52028775-0882-449c-a04d-3b539ce56b8b)

This supersedes https://github.com/Koenkk/zigbee2mqtt.io/pull/3301