### PR TITLE
Regroup SMLIGHT routers, add Nerivec silabs routers

### DIFF
--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -13,6 +13,7 @@ import {
     forcePowerSource,
     humidity,
     light,
+    linkQuality,
     numeric,
     onOff,
     quirkAddEndpointCluster,
@@ -240,6 +241,38 @@ function ptvoAddStandardExposes(endpoint: Zh.Endpoint, expose: Expose[], options
 
 const definitions: DefinitionWithExtend[] = [
     {
+        /** @see https://github.com/Nerivec/silabs-firmware-builder/releases */
+        fingerprint: [
+            {modelID: 'ZGA008', manufacturerName: 'Aeotec', applicationVersion: 200},
+            {modelID: 'ZB-GW04', manufacturerName: 'easyiot', applicationVersion: 200},
+            {modelID: 'ZB-GW04-1v1', manufacturerName: 'easyiot', applicationVersion: 200},
+            {modelID: 'ZB-GW04-1v2', manufacturerName: 'easyiot', applicationVersion: 200},
+            {modelID: 'SkyConnect', manufacturerName: 'NabuCasa', applicationVersion: 200},
+            {modelID: 'SLZB-06M', manufacturerName: 'SMLIGHT', applicationVersion: 200},
+            {modelID: 'SLZB-07', manufacturerName: 'SMLIGHT', applicationVersion: 200},
+            {modelID: 'SLZB-07MG24', manufacturerName: 'SMLIGHT', applicationVersion: 200},
+            {modelID: 'DONGLE-E', manufacturerName: 'SONOFF', applicationVersion: 200},
+            {modelID: 'MGM240P', manufacturerName: 'SparkFun', applicationVersion: 200},
+            {modelID: 'MGM24', manufacturerName: 'TubesZB', applicationVersion: 200},
+            {modelID: 'MGM24PB', manufacturerName: 'TubesZB', applicationVersion: 200},
+        ],
+        model: 'Silabs series 2 router',
+        vendor: 'Silabs',
+        description: 'Silabs series 2 adapter with router firmware',
+        toZigbee: [tz.factory_reset],
+        exposes: [
+            e
+                .enum('reset', ea.SET, ['reset'])
+                .withDescription(
+                    'Resets and launches the bootloader for flashing. If USB, ensure the device is already connected to the machine where you intend to flash it before triggering this.',
+                ),
+        ],
+        extend: [linkQuality({reporting: true})],
+        // prevent timeout with tz.factory_reset (reboots adapter into bootloader, hence disconnected)
+        // since this is the only tz, it's not a problem to disable this globally
+        meta: {disableDefaultResponse: true},
+    },
+    {
         zigbeeModel: ['ti.router'],
         model: 'ti.router',
         vendor: 'Custom devices (DiY)',
@@ -260,25 +293,6 @@ const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(8);
-            const payload = [{attribute: 'zclVersion', minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
-            await endpoint.configureReporting('genBasic', payload);
-        },
-    },
-    {
-        zigbeeModel: ['SLZB-06p7', 'SLZB-07', 'SLZB-0xp7'],
-        model: 'SLZB-06p7',
-        vendor: 'SMLIGHT',
-        description: 'Router',
-        fromZigbee: [fz.linkquality_from_basic],
-        toZigbee: [],
-        exposes: [],
-        whiteLabel: [
-            {vendor: 'SMLIGHT', model: 'SLZB-07', description: 'Router', fingerprint: [{modelID: 'SLZB-07'}]},
-            {vendor: 'SMLIGHT', model: 'SLZB-0xp7', description: 'Router', fingerprint: [{modelID: 'SLZB-0xp7'}]},
-        ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.endpoints[0];
             const payload = [{attribute: 'zclVersion', minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];
             await reporting.bind(endpoint, coordinatorEndpoint, ['genBasic']);
             await endpoint.configureReporting('genBasic', payload);

--- a/src/devices/smlight.ts
+++ b/src/devices/smlight.ts
@@ -1,18 +1,20 @@
-import fz from '../converters/fromZigbee';
-import {forcePowerSource} from '../lib/modernExtend';
+import {forcePowerSource, linkQuality} from '../lib/modernExtend';
 import {DefinitionWithExtend} from '../lib/types';
 
 const definitions: DefinitionWithExtend[] = [
     {
-        zigbeeModel: ['SLZB-06M', 'SLZB-06'],
+        zigbeeModel: ['SLZB-06M', 'SLZB-06', 'SLZB-06p7', 'SLZB-07', 'SLZB-0xp7', 'SLZB-07Mg24'],
         model: 'SLZB-06M',
         vendor: 'SMLIGHT',
         description: 'Router',
-        fromZigbee: [fz.linkquality_from_basic],
-        toZigbee: [],
-        exposes: [],
-        extend: [forcePowerSource({powerSource: 'Mains (single phase)'})],
-        whiteLabel: [{vendor: 'SMLIGHT', model: 'SLZB-06', description: 'Router', fingerprint: [{modelID: 'SLZB-06'}]}],
+        whiteLabel: [
+            {vendor: 'SMLIGHT', model: 'SLZB-06', description: 'Router', fingerprint: [{modelID: 'SLZB-06'}]},
+            {vendor: 'SMLIGHT', model: 'SLZB-06p7', description: 'Router', fingerprint: [{modelID: 'SLZB-06p7'}]},
+            {vendor: 'SMLIGHT', model: 'SLZB-07', description: 'Router', fingerprint: [{modelID: 'SLZB-07'}]},
+            {vendor: 'SMLIGHT', model: 'SLZB-0xp7', description: 'Router', fingerprint: [{modelID: 'SLZB-0xp7'}]},
+            {vendor: 'SMLIGHT', model: 'SLZB-07Mg24', description: 'Router', fingerprint: [{modelID: 'SLZB-07Mg24'}]},
+        ],
+        extend: [linkQuality({reporting: true}), forcePowerSource({powerSource: 'Mains (single phase)'})],
     },
 ];
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,6 +132,36 @@ describe('index.js', () => {
         expect((await index.findByDevice(TS011F_plug_1)).model).toBe('TS011F_plug_1');
     });
 
+    it('finds router builds with priority from manufacturer', async () => {
+        const customSLZB06M = {
+            type: 'Router',
+            manufacturerName: 'SMLIGHT',
+            modelID: 'SLZB-06M',
+            applicationVersion: 200,
+        };
+        const fromManufSLZB06M = {
+            type: 'Router',
+            manufacturerName: 'SMLIGHT',
+            modelID: 'SLZB-06M',
+        };
+        const customSLZB07 = {
+            type: 'Router',
+            manufacturerName: 'SMLIGHT',
+            modelID: 'SLZB-07',
+            applicationVersion: 200,
+        };
+        const fromManufSLZB07 = {
+            type: 'Router',
+            manufacturerName: 'SMLIGHT',
+            modelID: 'SLZB-07',
+        };
+
+        expect((await index.findByDevice(customSLZB06M)).model).toBe('Silabs series 2 router');
+        expect((await index.findByDevice(fromManufSLZB06M)).model).toBe('SLZB-06M');
+        expect((await index.findByDevice(customSLZB07)).model).toBe('Silabs series 2 router');
+        expect((await index.findByDevice(fromManufSLZB07)).model).toBe('SLZB-07');
+    });
+
     it('Find by device should prefer fingerprint match over zigbeeModel', async () => {
         const mullerEndpoints = [
             {ID: 1, profileID: 49246, deviceID: 544, inputClusters: [0, 3, 4, 5, 6, 8, 768, 2821, 4096], outputClusters: [25]},


### PR DESCRIPTION
Meant to be compatible with versions AFTER [v2024.6.2-update3](https://github.com/Nerivec/silabs-firmware-builder/releases/tag/v2024.6.2-update3) (tagged with special app version to avoid conflict with manufacturer builds).