### PR TITLE
Add support for Danfoss Icon Basic Main Controller

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -342,6 +342,7 @@ const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: [
+            {modelID: '0x0200', manufacturerName: 'Danfoss'}, // Icon Basic Main Controller
             {modelID: '0x8020', manufacturerName: 'Danfoss'}, // RT24V Display
             {modelID: '0x8021', manufacturerName: 'Danfoss'}, // RT24V Display  Floor sensor
             {modelID: '0x8030', manufacturerName: 'Danfoss'}, // RTbattery Display


### PR DESCRIPTION
Danfoss Icon Basic Main Controller (088U1142) has modelID 0x0200