### PR TITLE
Add support for Sibling _TZE200_qsoecqlk TRV

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -320,12 +320,12 @@ const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: [
             {modelID: 'TS0601', manufacturerName: '_TZE200_b6wax7g0'},
-            {modelID: 'TS0601', manufacturerName: '_TZE200_qsoecqlk'}, 
+            {modelID: 'TS0601', manufacturerName: '_TZE200_qsoecqlk'},
         ],
         model: 'BRT-100-TRV',
         vendor: 'Moes',
         description: 'Thermostatic radiator valve',
-        whiteLabel: [tuya.whitelabel('Sibling', 'Powerswitch-ZK(W)', 'Thermostatic radiator valve', ['_TZE200_qsoecqlk']) ],
+        whiteLabel: [tuya.whitelabel('Sibling', 'Powerswitch-ZK(W)', 'Thermostatic radiator valve', ['_TZE200_qsoecqlk'])],
         // ota: true,
         // OTA available but bricks device https://github.com/Koenkk/zigbee2mqtt/issues/18840
         onEvent: tuya.onEventSetLocalTime,

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -318,10 +318,14 @@ const definitions: DefinitionWithExtend[] = [
         exposes: [e.battery(), e.illuminance(), e.humidity(), e.temperature()],
     },
     {
-        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_b6wax7g0'}],
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_b6wax7g0'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_qsoecqlk'}, 
+        ],
         model: 'BRT-100-TRV',
         vendor: 'Moes',
         description: 'Thermostatic radiator valve',
+        whiteLabel: [tuya.whitelabel('Sibling', 'Powerswitch-ZK(W)', 'Thermostatic radiator valve', ['_TZE200_qsoecqlk']) ],
         // ota: true,
         // OTA available but bricks device https://github.com/Koenkk/zigbee2mqtt/issues/18840
         onEvent: tuya.onEventSetLocalTime,


### PR DESCRIPTION
Add support for Sibling Powerswitch-ZK(W) TRV  - https://sibling.ru/all/climate/umnaya-termogolovka-sibling-belaya-370/
Looks and acts similar to moes trv, tested locally.