### PR TITLE
Minor SNZB-03P documentation fixe

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1012,7 +1012,7 @@ const definitions: DefinitionWithExtend[] = [
                 name: 'motion_timeout',
                 cluster: 0x0406,
                 attribute: {ID: 0x0020, type: 0x21},
-                description: 'Unoccupied to occupied delay',
+                description: 'Occupied to unoccupied delay',
                 valueMin: 5,
                 valueMax: 60,
             }),


### PR DESCRIPTION
That's actually not a delay for occupancy. When you enter the room it immediately says you enter the room. However there's a no-movement timeout before it says "unoccupied".

Tied to https://github.com/Koenkk/zigbee2mqtt.io/pull/3317.