### PR TITLE
Fix: Danfoss eTRV - timestatus should be set to 1 when setting time

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -336,7 +336,7 @@ const definitions: DefinitionWithExtend[] = [
             // So, we need to write time during configure (same as for HEIMAN devices)
             const time = Math.round((new Date().getTime() - constants.OneJanuary2000) / 1000);
             // Time-master + synchronised
-            const values = {timeStatus: 3, time: time, timeZone: new Date().getTimezoneOffset() * -1 * 60};
+            const values = {timeStatus: 1, time: time, timeZone: new Date().getTimezoneOffset() * -1 * 60};
             await endpoint.write('genTime', values);
         },
     },


### PR DESCRIPTION
It is the responsibility of the ZigBee coordinator, after writing to the "Time" attribute, to update "Time Status" "synchronized" bit to "1"

This is from the "Common ZigBee Cluster Specification" for the Danfoss eTRV.
https://assets.danfoss.com/documents/284715/AM375549618098en-000103.pdf