### PR TITLE
fix(detect): Detect _TZE204_3ejwxpmu as TS0601_co2_sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1312,7 +1312,7 @@ const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_ogkdpgy2', '_TZE200_3ejwxpmu']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_ogkdpgy2', '_TZE200_3ejwxpmu', '_TZE204_3ejwxpmu']),
         model: 'TS0601_temperature_humidity_co2_sensor',
         vendor: 'Tuya',
         description: 'NDIR co2 sensor',


### PR DESCRIPTION
Extends fingerprint of TuYa TS0601_co2_sensor (NDIR co2 sensor). 
Testing with external definition was successful:

`const definition = {
    zigbeeModel: ['TS0601'],
    model: 'TS0601',
    vendor: '_TZE204_3ejwxpmu',
    description: 'Automatically generated definition',
    extend: [],
    meta: {},
    fromZigbee: [legacy.fromZigbee.tuya_air_quality], // We will add this later
    toZigbee: [], // Should be empty, unless device can be controlled (e.g. lights, switches).
    exposes: [e.temperature(), e.humidity(), e.co2()],
};`

![image](https://github.com/user-attachments/assets/cc3db9d3-5d44-4b00-8c3a-ccd5bc622699)
