### PR TITLE
Fix inverted `state` on Tuya motorized blinds

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -585,8 +585,7 @@ export const valueConverter = {
         },
         from: (v: number, meta: Fz.Meta, options: KeyValue, publish: Publish) => {
             const position = options.invert_cover ? 100 - v : v;
-            const closed = options.invert_cover ? position === 100 : position === 0;
-            publish({state: closed ? 'CLOSE' : 'OPEN'});
+            publish({state: position === 0 ? 'CLOSE' : 'OPEN'});
             return position;
         },
     },
@@ -596,8 +595,7 @@ export const valueConverter = {
         },
         from: (v: number, meta: Fz.Meta, options: KeyValue, publish: Publish) => {
             const position = options.invert_cover ? v : 100 - v;
-            const closed = options.invert_cover ? position === 100 : position === 0;
-            publish({state: closed ? 'CLOSE' : 'OPEN'});
+            publish({state: position === 0 ? 'CLOSE' : 'OPEN'});
             return position;
         },
     },


### PR DESCRIPTION
When "Invert cover" is enabled, the state published when the covers reach the ends are reversed. This is because the inverted position is used to determine the `state` and is then inverted once more.

To resolve this, the `state` is determined using the final position only. The `state` will be published as CLOSE when the position is 0, otherwise OPEN is published.

Verified with the A-OK AM25 that is recognized as B09M3R35GC _TZE200_9p5xmj5r Unable to verify with a motor that is non-inverted.