### PR TITLE
Add 929003822801 Philips Hue Tento white 29,1cm

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3936,6 +3936,13 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ['xy', 'hs'], enhancedHue: true}})],
     },
     {
+        zigbeeModel: ['929003822801'],
+        model: '929003822801',
+        vendor: 'Philips',
+        description: 'Hue Tento white 29,1cm',
+        extend: [philipsLight()],
+    },
+    {
         zigbeeModel: ['929003736201_01', '929003736201_02'],
         model: '929003736201',
         vendor: 'Philips',


### PR DESCRIPTION
added 929003822801
https://www.philips-hue.com/de-de/p/hue-white-tento-rundes-w-led-deckenpanel-29-1-cm-schwarz/8720169330498#overview