### PR TITLE
Remove power on behaviour for Z111PL0H-1JX/Woolley SA-028

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -959,7 +959,7 @@ const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ['Z111PL0H-1JX'],
-        model: 'SA-028/SA-029',
+        model: 'Z111PL0H-1JX',
         vendor: 'SONOFF',
         whiteLabel: [{vendor: 'Woolley', model: 'SA-028-1'}],
         description: 'Smart Plug',

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -950,12 +950,20 @@ const definitions: DefinitionWithExtend[] = [
         exposes: [e.cover_position(), e.battery()],
     },
     {
-        zigbeeModel: ['Z111PL0H-1JX', 'SA-029-1', 'SA-028-1'],
+        zigbeeModel: ['SA-029-1', 'SA-028-1'],
         model: 'SA-028/SA-029',
         vendor: 'SONOFF',
         whiteLabel: [{vendor: 'Woolley', model: 'SA-029-1'}],
         description: 'Smart Plug',
         extend: [onOff(), forcePowerSource({powerSource: 'Mains (single phase)'})],
+    },
+    {
+        zigbeeModel: ['Z111PL0H-1JX'],
+        model: 'SA-028/SA-029',
+        vendor: 'SONOFF',
+        whiteLabel: [{vendor: 'Woolley', model: 'SA-028-1'}],
+        description: 'Smart Plug',
+        extend: [onOff({powerOnBehavior: false}), forcePowerSource({powerSource: 'Mains (single phase)'})],
     },
     {
         zigbeeModel: ['SNZB-01P'],


### PR DESCRIPTION
Got a couple more of these Woolley plugs, though seems like this batch I got with the model Z111PL0H-1JX identifier do not have power on behavior. (also mentioned by https://github.com/Koenkk/zigbee2mqtt/issues/10282#issuecomment-1427547908)

db entry:
> {"id":122,"type":"Router","ieeeAddr":"0x00124b0025798705","nwkAddr":50011,"manufId":4742,"manufName":"SONOFF","powerSource":"Mains (single phase)","modelId":"Z111PL0H-1JX","epList":[1,13,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":256,"inClusterList":[0,3,4,5,6,64599,64672],"outClusterList":[25],"clusters":{"genOnOff":{"attributes":{"onOff":1}},"genBasic":{"attributes":{"modelId":"Z111PL0H-1JX","manufacturerName":"SONOFF","powerSource":1,"zclVersion":3,"hwVersion":1,"dateCode":"20211223","swBuildId":"1.0.1"}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b002f8b1364","endpointID":1},{"cluster":0,"type":"endpoint","deviceIeeeAddress":"0x00124b002f8b1364","endpointID":1},{"cluster":25,"type":"endpoint","deviceIeeeAddress":"0x00124b002f8b1364","endpointID":1}],"configuredReportings":[{"cluster":6,"attrId":0,"minRepIntval":0,"maxRepIntval":65000,"repChange":1}],"meta":{}},"13":{"profId":49246,"epId":13,"devId":57694,"inClusterList":[4096],"outClusterList":[4096],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"hwVersion":1,"dateCode":"20211223","swBuildId":"1.0.1","zclVersion":3,"interviewCompleted":true,"meta":{"configured":332242049},"lastSeen":1734876337875}

When trying to set power on behavior:

> [2024-12-22 19:23:44] info: 	z2m:mqtt: MQTT publish: topic 'zigbee2mqtt/Outlet Living Room 2', payload '{"last_seen":"2024-12-22T19:23:44+07:00","linkquality":123,"power_on_behavior":null,"state":"ON"}'
> [2024-12-22 19:23:44] error: 	z2m: Publish 'get' 'power_on_behavior' to 'Outlet Living Room 2' failed: 'Error: ZCL command 0x00124b0025798705/1 genOnOff.read(["startUpOnOff"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')'
> [2024-12-22 19:23:47] info: 	z2m:mqtt: MQTT publish: topic 'zigbee2mqtt/Outlet Living Room 2', payload '{"last_seen":"2024-12-22T19:23:47+07:00","linkquality":123,"power_on_behavior":null,"state":"ON"}'
> [2024-12-22 19:23:47] error: 	z2m: Publish 'set' 'power_on_behavior' to 'Outlet Living Room 2' failed: 'Error: Got `UNSUPPORTED_ATTRIBUTE` error, device does not support power on behaviour'