### PR TITLE
Fix mode enum values for TRV603

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5381,7 +5381,7 @@ const definitions: DefinitionWithExtend[] = [
                     'mode',
                     tuya.valueConverterBasic.lookup({
                         auto: tuya.enum(0),
-                        manual: tuya.enum(1),
+                        manual: tuya.enum(2),
                     }),
                 ],
                 [4, 'current_heating_setpoint', tuya.valueConverter.divideBy10],


### PR DESCRIPTION
During using of TRV603 I noticed that enum for setting mode is using values (0,2) instead of (0,1) which cause errors during usage.