### PR TITLE
Add support for Salus FC600

### DIFF
--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -1,4 +1,5 @@
 import fz from '../converters/fromZigbee';
+import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
 import {electricityMeter, onOff} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
@@ -93,6 +94,55 @@ const definitions: DefinitionWithExtend[] = [
         fromZigbee: [],
         toZigbee: [],
         exposes: [],
+        ota: {manufacturerName: 'SalusControls'},
+    },
+    {
+        zigbeeModel: ['FC600'],
+        model: 'FC600',
+        vendor: 'Salus Controls',
+        description: 'Fan coil thermostat',
+        extend: [],
+        fromZigbee: [fz.thermostat, fz.fan],
+        toZigbee: [
+            tz.thermostat_local_temperature,
+            tz.thermostat_local_temperature_calibration,
+            tz.thermostat_occupancy,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_setpoint_raise_lower,
+            tz.thermostat_control_sequence_of_operation,
+            tz.thermostat_system_mode,
+            tz.thermostat_running_mode,
+            tz.thermostat_weekly_schedule,
+            tz.thermostat_clear_weekly_schedule,
+            tz.thermostat_relay_status_log,
+            tz.thermostat_running_state,
+            tz.thermostat_keypad_lockout,
+            tz.fan_mode,
+        ],
+        exposes: [
+            e
+                .climate()
+                .withSetpoint('occupied_heating_setpoint', 5, 40, 0.5)
+                .withLocalTemperature()
+                .withSystemMode(['off', 'heat', 'cool', 'auto'])
+                .withRunningMode(['off', 'cool', 'heat'])
+                .withRunningState(['idle', 'heat', 'cool'])
+                .withLocalTemperatureCalibration(-3, 3, 0.5)
+                .withFanMode(['off', 'low', 'medium', 'high', 'auto']),
+            e.keypad_lockout(),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(9);
+            const binds = ['genBasic', 'genIdentify', 'genTime', 'hvacThermostat', 'hvacFanCtrl', 'hvacUserInterfaceCfg'];
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.fanMode(endpoint);
+            await reporting.thermostatRunningMode(endpoint);
+            await reporting.thermostatRunningState(endpoint);
+        },
         ota: {manufacturerName: 'SalusControls'},
     },
 ];

--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -143,7 +143,7 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.thermostatRunningMode(endpoint);
             await reporting.thermostatRunningState(endpoint);
         },
-        ota: {manufacturerName: 'SalusControls'},
+        ota: true,
     },
 ];
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -84,6 +84,10 @@ export const thermostatRunningStates: KeyValueAny = {
     14: 'cool',
     15: 'cool',
     22: 'cool',
+    33: 'heat',
+    34: 'cool',
+    65: 'heat',
+    66: 'cool',
 };
 
 export const thermostatAcLouverPositions: KeyValueNumberString = {


### PR DESCRIPTION
Feedback welcome!

TODO:

- `running_state` will report values not in `thermostatRunningStates` constants if the fan is running on med or high speed. Should I add those states to `thermostatRunningStates` in `src/lib/constants.ts` or is there a better way?
- OTA fails with `device.definition.ota.isUpdateAvailable is not a function`. I haven't been able to figure this out so far. If I can't make it work I'll remove it from the definition.
- I don't know how the "presets" like eco/off etc are configured. I think it's nice to have but I don't see this as a blocker