### PR TITLE
Add endpoint capability to lock type

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -294,17 +294,17 @@ const converters1 = {
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValueAny = {};
             if (msg.data.lockState !== undefined) {
-                result.state = msg.data.lockState == 1 ? 'LOCK' : 'UNLOCK';
+                result[postfixWithEndpointName('state', msg, model, meta)] = msg.data.lockState == 1 ? 'LOCK' : 'UNLOCK';
                 const lookup = ['not_fully_locked', 'locked', 'unlocked'];
-                result.lock_state = lookup[msg.data['lockState']];
+                result[postfixWithEndpointName('lock_state', msg, model, meta)] = lookup[msg.data['lockState']];
             }
 
             if (msg.data.autoRelockTime !== undefined) {
-                result.auto_relock_time = msg.data.autoRelockTime;
+                result[postfixWithEndpointName('auto_relock_time', msg, model, meta)] = msg.data.autoRelockTime;
             }
 
             if (msg.data.soundVolume !== undefined) {
-                result.sound_volume = constants.lockSoundVolume[msg.data.soundVolume];
+                result[postfixWithEndpointName('sound_volume', msg, model, meta)] = constants.lockSoundVolume[msg.data.soundVolume];
             }
 
             if (msg.data.doorState !== undefined) {
@@ -316,7 +316,7 @@ const converters1 = {
                     4: 'error_unspecified',
                     0xff: 'undefined',
                 };
-                result.door_state = lookup[msg.data['doorState']];
+                result[postfixWithEndpointName('door_state', msg, model, meta)] = lookup[msg.data['doorState']];
             }
             return result;
         },

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -332,8 +332,20 @@ const converters2 = {
     lock: {
         key: ['state'],
         convertSet: async (entity, key, value, meta) => {
-            utils.assertString(value, key);
-            await entity.command('closuresDoorLock', `${value.toLowerCase()}Door`, {pincodevalue: ''}, utils.getOptions(meta.mapped, entity));
+            // If no pin code is provided, value is a only string. Ex: "UNLOCK"
+            let state = utils.isString(value) ? value.toUpperCase() : null;
+            let pincode = '';
+            // If pin code is provided, value is an object including command and code. Ex: {command: "UNLOCK", code: "1234"}
+            if (utils.isObject(value)) {
+                if (value.code) {
+                    pincode = utils.isString(value.code) ? value.code : '';
+                }
+                if (value.command) {
+                    state = utils.isString(value.command) ? value.command.toUpperCase() : null;
+                }
+            }
+            utils.validateValue(state, ['LOCK', 'UNLOCK', 'TOGGLE']);
+            await entity.command('closuresDoorLock', `${state.toLowerCase()}Door`, {pincodevalue: pincode}, utils.getOptions(meta.mapped, entity));
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('closuresDoorLock', ['lockState']);

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -335,13 +335,13 @@ const converters2 = {
             // If no pin code is provided, value is a only string. Ex: "UNLOCK"
             let state = utils.isString(value) ? value.toUpperCase() : null;
             let pincode = '';
-            // If pin code is provided, value is an object including command and code. Ex: {command: "UNLOCK", code: "1234"}
+            // If pin code is provided, value is an object including new state and code. Ex: {state: "UNLOCK", code: "1234"}
             if (utils.isObject(value)) {
                 if (value.code) {
                     pincode = utils.isString(value.code) ? value.code : '';
                 }
-                if (value.command) {
-                    state = utils.isString(value.command) ? value.command.toUpperCase() : null;
+                if (value.state) {
+                    state = utils.isString(value.state) ? value.state.toUpperCase() : null;
                 }
             }
             utils.validateValue(state, ['LOCK', 'UNLOCK', 'TOGGLE']);

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -14,12 +14,10 @@ import {
     humidity,
     light,
     linkQuality,
-    lock,
     numeric,
     onOff,
     quirkAddEndpointCluster,
     temperature,
-    windowCovering,
 } from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend, Expose, Fz, KeyValue, KeyValueAny, Tz, Zh} from '../lib/types';
@@ -1193,18 +1191,6 @@ const definitions: DefinitionWithExtend[] = [
                 description: 'Input state',
                 endpointNames: ['in1', 'in2', 'in3', 'in4'],
             }),
-        ],
-    },
-    {
-        zigbeeModel: ['GADOLOCK'],
-        model: 'GADOLOCK',
-        vendor: 'Custom devices (DiY)',
-        description: 'Garage door with lock',
-        extend: [
-            deviceEndpoints({endpoints: {relay: 1, door: 2, latch: 3}}),
-            onOff({powerOnBehavior: false, endpointNames: ['relay']}),
-            windowCovering({controls: ['lift'], coverInverted: true, stateSource: 'lift', coverMode: false, endpointNames: ['door']}),
-            lock({pinCodeCount: 10, endpointNames: ['latch']}),
         ],
     },
 ];

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -14,10 +14,12 @@ import {
     humidity,
     light,
     linkQuality,
+    lock,
     numeric,
     onOff,
     quirkAddEndpointCluster,
     temperature,
+    windowCovering,
 } from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend, Expose, Fz, KeyValue, KeyValueAny, Tz, Zh} from '../lib/types';
@@ -1191,6 +1193,18 @@ const definitions: DefinitionWithExtend[] = [
                 description: 'Input state',
                 endpointNames: ['in1', 'in2', 'in3', 'in4'],
             }),
+        ],
+    },
+    {
+        zigbeeModel: ['GADOLOCK'],
+        model: 'GADOLOCK',
+        vendor: 'Custom devices (DiY)',
+        description: 'Garage door with lock',
+        extend: [
+            deviceEndpoints({endpoints: {relay: 1, door: 2, latch: 3}}),
+            onOff({powerOnBehavior: false, endpointNames: ['relay']}),
+            windowCovering({controls: ['lift'], coverInverted: true, stateSource: 'lift', coverMode: false, endpointNames: ['door']}),
+            lock({pinCodeCount: 10, endpointNames: ['latch']}),
         ],
     },
 ];

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1267,8 +1267,11 @@ export function lock(args?: LockArgs): ModernExtend {
         setupConfigureForReporting('closuresDoorLock', 'lockState', {min: 'MIN', max: '1_HOUR', change: 0}, ea.STATE_GET),
     ];
     const meta: DefinitionMeta = {pinCodeCount: args.pinCodeCount};
-
-    return {fromZigbee, toZigbee, exposes, configure, meta, isModernExtend: true};
+    const result: ModernExtend = {fromZigbee, toZigbee, exposes, configure, meta, isModernExtend: true};
+    if (args.endpointNames) {
+        result.exposes = flatten(exposes.map((expose) => args.endpointNames.map((endpoint) => expose.clone().withEndpoint(endpoint))));
+    }
+    return result;
 }
 
 export interface WindowCoveringArgs {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -441,7 +441,9 @@ describe('index.js', () => {
                     property = expose.property.slice(0, (expose.endpoint.length + 1) * -1);
                 }
 
-                const toZigbee = device.toZigbee.find((item) => item.key.includes(property));
+                const toZigbee = device.toZigbee.find(
+                    (item) => item.key.includes(property) && (!item.endpoints || (expose.endpoint && item.endpoints.includes(expose.endpoint))),
+                );
 
                 if ((expose.access & _access.SET) != (toZigbee && toZigbee.convertSet ? _access.SET : 0)) {
                     throw new Error(`${device.model} - ${property}, supports set: ${!!(toZigbee && toZigbee.convertSet)}`);


### PR DESCRIPTION
Purpose of this change:
- add endpoint capability to lock in `fromZigbee` converter and `modernExtend` lock function
- add pincode capability for LOCK, UNLOCK, TOGGLE _state_ commands in `toZigbee lock` set converter
- add dummy garage door and lock  'GADOLOCK' device in `custom_devices_diy` definitions for test purpose. This device is made of  several endpoints using state key in `toZigbee` converter : onOff, windowCovering, lock
- fix proper toZigbee selection with device made of several endpoints using state key in `toZigbee` converter in _exposes access_ test

In short, this change supplements issue Koenkk/zigbee2mqtt#24352 for lock.

Note : A complementary PR will be submitted shortly in repo [Koenkk/zigbee2mqtt](https://github.com/Koenkk/zigbee2mqtt) to add endpoint support to lock type in lib/extension/homeassistant.ts :arrow_right: See PR https://github.com/Koenkk/zigbee2mqtt/pull/25359

:slightly_smiling_face: Thanks in advance for the review of this PR. Should you have any remark, please ask. 
