### PR TITLE
Add support for RBSH-SWD2-ZB

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1772,7 +1772,7 @@ const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ['RBSH-SWD-ZB'],
+        zigbeeModel: ['RBSH-SWD-ZB', 'RBSH-SWD2-ZB'],
         model: 'BSEN-C2',
         vendor: 'Bosch',
         description: 'Door/window contact II',


### PR DESCRIPTION
RBSH-SWD2-ZB is the same as RBSH-SWD-ZB but reports different model. RBSH-SWD2-ZB is the with matter and zigbee. Same as #8351