### PR TITLE
fix: read pilot wire mode for Nodon and Equation modules

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -5311,26 +5311,6 @@ const converters2 = {
             }
         },
     } satisfies Fz.Converter,
-    nodon_pilot_wire_mode: {
-        cluster: 'manuSpecificNodOnPilotWire',
-        type: ['attributeReport', 'readResponse'],
-        convert: (model, msg, publish, options, meta) => {
-            const payload: KeyValueAny = {};
-            const mode = msg.data['mode'];
-
-            if (mode === 0x00) payload.pilot_wire_mode = 'off';
-            else if (mode === 0x01) payload.pilot_wire_mode = 'comfort';
-            else if (mode === 0x02) payload.pilot_wire_mode = 'eco';
-            else if (mode === 0x03) payload.pilot_wire_mode = 'frost_protection';
-            else if (mode === 0x04) payload.pilot_wire_mode = 'comfort_-1';
-            else if (mode === 0x05) payload.pilot_wire_mode = 'comfort_-2';
-            else {
-                logger.warning(`wrong mode : ${mode}`, NS);
-                payload.pilot_wire_mode = 'unknown';
-            }
-            return payload;
-        },
-    } satisfies Fz.Converter,
     TS110E: {
         cluster: 'genLevelCtrl',
         type: ['attributeReport', 'readResponse'],

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -22,7 +22,6 @@ const manufacturerOptions = {
     tint: {manufacturerCode: Zcl.ManufacturerCode.MUELLER_LICHT_INTERNATIONAL_INC},
     legrand: {manufacturerCode: Zcl.ManufacturerCode.LEGRAND_GROUP, disableDefaultResponse: true},
     viessmann: {manufacturerCode: Zcl.ManufacturerCode.VIESSMANN_ELEKTRONIK_GMBH},
-    nodon: {manufacturerCode: Zcl.ManufacturerCode.NODON},
 };
 
 const converters1 = {
@@ -4321,25 +4320,6 @@ const converters2 = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read('ssIasZone', [0x4000], {manufacturerCode: Zcl.ManufacturerCode.DATEK_WIRELESS_AS});
-        },
-    } satisfies Tz.Converter,
-    nodon_pilot_wire_mode: {
-        key: ['pilot_wire_mode'],
-        convertSet: async (entity, key, value, meta) => {
-            const mode = utils.getFromLookup(value, {
-                off: 0x00,
-                comfort: 0x01,
-                eco: 0x02,
-                frost_protection: 0x03,
-                'comfort_-1': 0x04,
-                'comfort_-2': 0x05,
-            });
-            const payload = {mode: mode};
-            await entity.command('manuSpecificNodOnPilotWire', 'setMode', payload);
-            return {state: {pilot_wire_mode: value}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read('manuSpecificNodOnPilotWire', [0x0000], manufacturerOptions.nodon);
         },
     } satisfies Tz.Converter,
     // #endregion

--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -2,6 +2,7 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
 import {battery, electricityMeter, humidity, iasZoneAlarm, illuminance, light, onOff, quirkCheckinInterval, temperature} from '../lib/modernExtend';
+import {nodonPilotWire} from '../lib/nodon';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend, Fz, Tz} from '../lib/types';
 
@@ -400,19 +401,18 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'ADEO',
         description: 'Equation pilot wire heating module',
         ota: true,
-        fromZigbee: [fz.on_off, fz.metering, fz.nodon_pilot_wire_mode],
-        toZigbee: [tz.on_off, tz.nodon_pilot_wire_mode],
-        exposes: [e.switch(), e.power(), e.energy(), e.pilot_wire_mode()],
+        fromZigbee: [fz.on_off, fz.metering],
+        toZigbee: [tz.on_off],
+        exposes: [e.switch(), e.power(), e.energy()],
         configure: async (device, coordinatorEndpoint) => {
             const ep = device.getEndpoint(1);
-            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering', 'manuSpecificNodOnPilotWire']);
+            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering']);
             await reporting.onOff(ep, {min: 1, max: 3600, change: 0});
             await reporting.readMeteringMultiplierDivisor(ep);
             await reporting.instantaneousDemand(ep);
             await reporting.currentSummDelivered(ep);
-            const p = reporting.payload('mode', 0, 120, 0, {min: 1, max: 3600, change: 0});
-            await ep.configureReporting('manuSpecificNodOnPilotWire', p);
         },
+        extend: [...nodonPilotWire(true)],
     },
     {
         zigbeeModel: ['ZB-Remote-D0001'],

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -16,6 +16,7 @@ import {
     temperature,
     windowCovering,
 } from '../lib/modernExtend';
+import {nodonPilotWire} from '../lib/nodon';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend} from '../lib/types';
 
@@ -278,18 +279,18 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'NodOn',
         description: 'Pilot wire heating module',
         ota: true,
-        fromZigbee: [fz.on_off, fz.metering, fz.nodon_pilot_wire_mode],
-        toZigbee: [tz.on_off, tz.nodon_pilot_wire_mode],
-        exposes: [e.power(), e.energy(), e.pilot_wire_mode()],
+        fromZigbee: [fz.on_off, fz.metering],
+        toZigbee: [tz.on_off],
+        exposes: [e.power(), e.energy()],
         configure: async (device, coordinatorEndpoint) => {
             const ep = device.getEndpoint(1);
-            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering', 'manuSpecificNodOnPilotWire']);
+            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering']);
             await reporting.onOff(ep, {min: 1, max: 3600, change: 0});
             await reporting.readMeteringMultiplierDivisor(ep);
             await reporting.instantaneousDemand(ep);
             await reporting.currentSummDelivered(ep);
-            await ep.read('manuSpecificNodOnPilotWire', ['mode']);
         },
+        extend: [...nodonPilotWire(true)],
     },
     {
         zigbeeModel: ['SIN-4-FP-21'],
@@ -297,18 +298,18 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'NodOn',
         description: 'Pilot wire heating module',
         ota: true,
-        fromZigbee: [fz.on_off, fz.metering, fz.nodon_pilot_wire_mode],
-        toZigbee: [tz.on_off, tz.nodon_pilot_wire_mode],
-        exposes: [e.power(), e.energy(), e.pilot_wire_mode()],
+        fromZigbee: [fz.on_off, fz.metering],
+        toZigbee: [tz.on_off],
+        exposes: [e.power(), e.energy()],
         configure: async (device, coordinatorEndpoint) => {
             const ep = device.getEndpoint(1);
-            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering', 'manuSpecificNodOnPilotWire']);
+            await reporting.bind(ep, coordinatorEndpoint, ['genBasic', 'genIdentify', 'genOnOff', 'seMetering']);
             await reporting.onOff(ep, {min: 1, max: 3600, change: 0});
             await reporting.readMeteringMultiplierDivisor(ep);
             await reporting.instantaneousDemand(ep);
             await reporting.currentSummDelivered(ep);
-            await ep.read('manuSpecificNodOnPilotWire', ['mode']);
         },
+        extend: [...nodonPilotWire(true)],
     },
     {
         zigbeeModel: ['STPH-4-1-00'],

--- a/src/lib/nodon.ts
+++ b/src/lib/nodon.ts
@@ -1,0 +1,93 @@
+import {Zcl} from 'zigbee-herdsman';
+
+import * as exposes from './exposes';
+import {logger} from './logger';
+import {deviceAddCustomCluster} from './modernExtend';
+import * as reporting from './reporting';
+import {KeyValueAny, ModernExtend} from './types';
+import * as utils from './utils';
+
+const e = exposes.presets;
+const NS = 'zhc:nodon';
+
+const PILOT_WIRE_CLUSTER = 'customClusterNodOnPilotWire';
+const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.NODON};
+
+const pilotWireCluster = deviceAddCustomCluster(PILOT_WIRE_CLUSTER, {
+    ID: 0xfc00,
+    manufacturerCode: Zcl.ManufacturerCode.NODON,
+    attributes: {
+        mode: {ID: 0x0000, type: Zcl.DataType.UINT8},
+    },
+    commands: {
+        setMode: {
+            ID: 0x0000,
+            parameters: [{name: 'mode', type: Zcl.DataType.UINT8}],
+        },
+    },
+    commandsResponse: {},
+});
+
+const pilotWireConfig = (configureReporting: boolean): ModernExtend => {
+    return {
+        exposes: [e.pilot_wire_mode()],
+        fromZigbee: [
+            {
+                cluster: PILOT_WIRE_CLUSTER,
+                type: ['attributeReport', 'readResponse'],
+                convert: (model, msg, publish, options, meta) => {
+                    const payload: KeyValueAny = {};
+                    const mode = msg.data['mode'];
+
+                    if (mode === 0x00) payload.pilot_wire_mode = 'off';
+                    else if (mode === 0x01) payload.pilot_wire_mode = 'comfort';
+                    else if (mode === 0x02) payload.pilot_wire_mode = 'eco';
+                    else if (mode === 0x03) payload.pilot_wire_mode = 'frost_protection';
+                    else if (mode === 0x04) payload.pilot_wire_mode = 'comfort_-1';
+                    else if (mode === 0x05) payload.pilot_wire_mode = 'comfort_-2';
+                    else {
+                        logger.warning(`wrong mode : ${mode}`, NS);
+                        payload.pilot_wire_mode = 'unknown';
+                    }
+                    return payload;
+                },
+            },
+        ],
+        toZigbee: [
+            {
+                key: ['pilot_wire_mode'],
+                convertSet: async (entity, key, value, meta) => {
+                    const mode = utils.getFromLookup(value, {
+                        off: 0x00,
+                        comfort: 0x01,
+                        eco: 0x02,
+                        frost_protection: 0x03,
+                        'comfort_-1': 0x04,
+                        'comfort_-2': 0x05,
+                    });
+                    const payload = {mode: mode};
+                    await entity.command(PILOT_WIRE_CLUSTER, 'setMode', payload);
+                    return {state: {pilot_wire_mode: value}};
+                },
+                convertGet: async (entity, key, meta) => {
+                    await entity.read(PILOT_WIRE_CLUSTER, [0x0000], manufacturerOptions);
+                },
+            },
+        ],
+        configure: [
+            async (device, coordinatorEndpoint) => {
+                const ep = device.getEndpoint(1);
+                await reporting.bind(ep, coordinatorEndpoint, [PILOT_WIRE_CLUSTER]);
+                if (configureReporting) {
+                    const p = reporting.payload('mode', 0, 120, 0, {min: 1, max: 3600, change: 0});
+                    await ep.configureReporting(PILOT_WIRE_CLUSTER, p);
+                } else {
+                    await ep.read(PILOT_WIRE_CLUSTER, ['mode']);
+                }
+            },
+        ],
+        isModernExtend: true,
+    };
+};
+
+export const nodonPilotWire = (configureReporting: boolean): ModernExtend[] => [pilotWireCluster, pilotWireConfig(configureReporting)];


### PR DESCRIPTION
Moved the cluster and zigbee parsers to dedicated file to avoid confusion with manuSpecificAssaDoorLock in findClusterNameById.

Affect: SIN-4-FP-20, SIN-4-FP-21, SIN-4-FP-21_EQU

Fixes Koenkk/zigbee2mqtt#25333