### PR TITLE
Detect _TZE284_locansqn as Nous TH01Z

### DIFF
--- a/src/devices/nous.ts
+++ b/src/devices/nous.ts
@@ -27,6 +27,7 @@ const definitions: DefinitionWithExtend[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_snloy4rw'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_eanjj2pa'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_ydrdfkim'},
+            {modelID: 'TS0601', manufacturerName: '_TZE284_locansqn'},
         ],
         model: 'SZ-T04',
         vendor: 'Nous',


### PR DESCRIPTION
_TZE284_locansqn is the same as all other variants of TH01Z but report a different manufacturer. It features same LCD screen, same sensors and a clock.