### PR TITLE
[New manufacturer : Yokis] Add support for several Yokis devices

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -309,6 +309,7 @@ import xyzroe from './xyzroe';
 import yale from './yale';
 import yandex from './yandex';
 import ynoa from './ynoa';
+import yokis from './yokis';
 import yookee from './yookee';
 import ysrsai from './ysrsai';
 import zemismart from './zemismart';
@@ -627,6 +628,7 @@ export default [
     ...yale,
     ...yandex,
     ...ynoa,
+    ...yokis,
     ...yookee,
     ...ysrsai,
     ...zemismart,

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -370,11 +370,11 @@ const YokisClustersDefinition: {
             // This attribute defines the value of the high dim limit, used during a dimming loop, on a long press for example. This value is set in %. Default: 0x64, Min-Max: 0x00 - 0x64
             highDimLimit: {ID: 0x0009, type: Zcl.DataType.UINT8},
             // This attribute defines the time before the nightlight begin. This value is set in seconds. Default: 0x00000000, Min-Max: 0x00000000 – 0xFFFFFFFE
-            nightLightStartingDelay: {ID: 0x0009, type: Zcl.DataType.UINT32},
+            nightLightStartingDelay: {ID: 0x000c, type: Zcl.DataType.UINT32},
             // This attribute defines the dimming value at the start of the nightlight. This value is set in %. Default: 0x28, Min-Max: 0x00 - 0x64
-            nightLightStartingBrightness: {ID: 0x000c, type: Zcl.DataType.UINT8},
+            nightLightStartingBrightness: {ID: 0x000d, type: Zcl.DataType.UINT8},
             // This attribute defines the dimming value at the last step of the nightlight. This attribute must be lower than 0x000D :Nightlight starting brightness. This value is set in %. Default: 0x05, Min-Max: 0x00 - 0x64
-            nightLightEndingBrightness: {ID: 0x000d, type: Zcl.DataType.UINT8},
+            nightLightEndingBrightness: {ID: 0x000e, type: Zcl.DataType.UINT8},
             // This attribute defines the ramp duration of the nightlight. The ramp is running after the end of the starting delay and until the ending bright is reached. This value is set in seconds. Default: 0x00000E10, Min-Max: 0x00000000 – 0x05265C00
             nightLightRampTime: {ID: 0x000f, type: Zcl.DataType.UINT32},
             // This attribute defines the total duration of the nightlight. It must not be lower than 0x000F : Nightlight ramp time. This value is set in seconds. Default: 0x00000E10, Min-Max: 0x00000000 – 0x05265C00
@@ -396,7 +396,87 @@ const YokisClustersDefinition: {
             // This attribute defines the value of each step during the ramp down of the nightlight mode. This value is set in %. Default: 0x01, Min-Max: 0x01 - 0x64
             stepNightLigth: {ID: 0x0018, type: Zcl.DataType.UINT8},
         },
-        commands: {},
+        commands: {
+            // Start dimming up, from current position to the upper dim limit. When the limit is reached, stay at this position.
+            dimUp: {
+                ID: 0x00,
+                parameters: [],
+            },
+            // Start dimming down, from current position to the lower dim limit. When the limit is reached, stay at this position.
+            dimDown: {
+                ID: 0x01,
+                parameters: [],
+            },
+            // Start the dimming loop process for the selected duration.
+            dim: {
+                ID: 0x02,
+                parameters: [
+                    // Set the duration of the ramp for the continuous variation, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.
+                    {name: 'ul_RampContinuousDuration', type: Zcl.DataType.UINT32},
+                    // Set the step size, otherwise use 0xFF to use the one configured in the product.. Value is in %.
+                    {name: 'uc_StepContinuous', type: Zcl.DataType.UINT8},
+                ],
+            },
+            // Stop the actual dimming process.
+            dimStop: {
+                ID: 0x04,
+                parameters: [],
+            },
+            // Start dimming to the min value set in the device.
+            dimToMin: {
+                ID: 0x05,
+                parameters: [
+                    // Set the transition time to the selected value, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.
+                    {name: 'ul_TransitionTime', type: Zcl.DataType.UINT32},
+                ],
+            },
+            // Start dimming to the max value set in the device.
+            dimToMax: {
+                ID: 0x06,
+                parameters: [
+                    // Set the transition time to the selected value, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.
+                    {name: 'ul_TransitionTime', type: Zcl.DataType.UINT32},
+                ],
+            },
+            // Start the nightlight mode with the given parameters.
+            startNightLightMode: {
+                ID: 0x07,
+                parameters: [
+                    // Set the starting delay value, used before the start of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.
+                    {name: 'ul_ChildModeStartingDelay', type: Zcl.DataType.UINT32},
+                    // Set the brightness at the beginning of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %.
+                    {name: 'uc_ChildModeBrightnessStart', type: Zcl.DataType.UINT8},
+                    // Set the brightness at the end of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %.
+                    {name: 'uc_ChildModeBrightnessEnd', type: Zcl.DataType.UINT8},
+                    // Set the ramp duration, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.
+                    {name: 'ul_ChildModeRampDuration', type: Zcl.DataType.UINT32},
+                    // Set the total duration of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.
+                    {name: 'ul_ChildModeOnDuration', type: Zcl.DataType.UINT32},
+                    // Set the step size between each dim, otherwise use 0xFF to use the one configured in the product. Value is in %.
+                    {name: 'uc_ChildStep', type: Zcl.DataType.UINT8},
+                ],
+            },
+            // Start the nightlight mode from the current dimming value.
+            startNightLightModeCurrent: {
+                ID: 0x08,
+                parameters: [],
+            },
+            // Start dimming to the favorite position 1.
+            moveToFavorite1: {
+                ID: 0x09,
+                parameters: [],
+            },
+            // Start dimming to the favorite position 2.
+            moveToFavorite2: {
+                ID: 0x0a,
+                parameters: [],
+            },
+            // Start dimming to the favorite position 3.
+            moveToFavorite3: {
+                ID: 0x0b,
+                parameters: [],
+            },
+        },
         commandsResponse: {},
     },
     manuSpecificYokisWindowCovering: {
@@ -664,6 +744,102 @@ const yokisExtendChecks = {
                 uc_SequenceAmount: input.tuc_BlinkAmount.length,
                 // [{"undefined":1},{"undefined":1}] > [1,1]
                 tuc_BlinkAmount: input.tuc_BlinkAmount.map((elem) => (typeof elem === 'object' ? Object.values(elem).shift() : elem)),
+            },
+        };
+    },
+    parseDim: (input: KeyValueAny) => {
+        let _ul_RampContinuousDuration, _uc_StepContinuous;
+
+        if (!input || typeof input !== 'object') {
+            return yokisExtendChecks.failure({reason: 'NOT_OBJECT'});
+        }
+
+        if (!('ul_RampContinuousDuration' in input) || !utils.isNumber(input.ul_RampContinuousDuration)) {
+            _ul_RampContinuousDuration = 0xffffffff; // use default value
+        } else _ul_RampContinuousDuration = input.ul_RampContinuousDuration;
+
+        if (!('uc_StepContinuous' in input) || !utils.isNumber(input.uc_StepContinuous)) {
+            _uc_StepContinuous = 0xff; // use default value
+        } else _uc_StepContinuous = input.uc_StepContinuous;
+
+        return {
+            isSuccess: true,
+            payload: {
+                ul_RampContinuousDuration: _ul_RampContinuousDuration,
+                uc_StepContinuous: _uc_StepContinuous,
+            },
+        };
+    },
+    parseDimMinMax: (input: KeyValueAny) => {
+        let _ul_TransitionTime, _action;
+
+        if (!input || typeof input !== 'object') {
+            return yokisExtendChecks.failure({reason: 'NOT_OBJECT'});
+        }
+
+        if (!('ul_TransitionTime' in input) || !utils.isNumber(input.ul_TransitionTime)) {
+            _ul_TransitionTime = 0xffffffff; // use default value
+        } else _ul_TransitionTime = input.ul_TransitionTime;
+
+        if (!('action' in input)) {
+            return yokisExtendChecks.failure({reason: 'MISSING_ACTION'});
+        } else {
+            _action = input.action;
+        }
+
+        return {
+            isSuccess: true,
+            action: _action,
+            payload: {
+                ul_TransitionTime: _ul_TransitionTime,
+            },
+        };
+    },
+    parseStartNightLightMode: (input: KeyValueAny) => {
+        let _ul_ChildModeStartingDelay,
+            _uc_ChildModeBrightnessStart,
+            _uc_ChildModeBrightnessEnd,
+            _ul_ChildModeRampDuration,
+            _ul_ChildModeOnDuration,
+            _uc_ChildStep;
+
+        if (!input || typeof input !== 'object') {
+            return yokisExtendChecks.failure({reason: 'NOT_OBJECT'});
+        }
+
+        if (!('ul_ChildModeStartingDelay' in input) || !utils.isNumber(input.ul_ChildModeStartingDelay)) {
+            _ul_ChildModeStartingDelay = 0xffffffff; // use default value
+        } else _ul_ChildModeStartingDelay = input.ul_ChildModeStartingDelay;
+
+        if (!('uc_ChildModeBrightnessStart' in input) || !utils.isNumber(input.uc_ChildModeBrightnessStart)) {
+            _uc_ChildModeBrightnessStart = 0xff; // use default value
+        } else _uc_ChildModeBrightnessStart = input.uc_ChildModeBrightnessStart;
+
+        if (!('uc_ChildModeBrightnessEnd' in input) || !utils.isNumber(input.uc_ChildModeBrightnessEnd)) {
+            _uc_ChildModeBrightnessEnd = 0xff; // use default value
+        } else _uc_ChildModeBrightnessEnd = input.uc_ChildModeBrightnessEnd;
+
+        if (!('ul_ChildModeRampDuration' in input) || !utils.isNumber(input.ul_ChildModeRampDuration)) {
+            _ul_ChildModeRampDuration = 0xffffffff; // use default value
+        } else _ul_ChildModeRampDuration = input.ul_ChildModeRampDuration;
+
+        if (!('ul_ChildModeOnDuration' in input) || !utils.isNumber(input.ul_ChildModeOnDuration)) {
+            _ul_ChildModeOnDuration = 0xffffffff; // use default value
+        } else _ul_ChildModeOnDuration = input.ul_ChildModeOnDuration;
+
+        if (!('uc_ChildStep' in input) || !utils.isNumber(input.uc_ChildStep)) {
+            _uc_ChildStep = 0xff; // use default value
+        } else _uc_ChildStep = input.uc_ChildStep;
+
+        return {
+            isSuccess: true,
+            payload: {
+                ul_ChildModeStartingDelay: _ul_ChildModeStartingDelay,
+                uc_ChildModeBrightnessStart: _uc_ChildModeBrightnessStart,
+                uc_ChildModeBrightnessEnd: _uc_ChildModeBrightnessEnd,
+                ul_ChildModeRampDuration: _ul_ChildModeRampDuration,
+                ul_ChildModeOnDuration: _ul_ChildModeOnDuration,
+                uc_ChildStep: _uc_ChildStep,
             },
         };
     },
@@ -1121,6 +1297,254 @@ const yokisCommandsExtend = {
             isModernExtend: true,
         };
     },
+    dimmerDim: (): ModernExtend => {
+        const exposes = e
+            .composite('dimmerDim', 'dimProp', ea.SET)
+            .withDescription('Start the dimming loop process for the selected duration.')
+            .withFeature(
+                e
+                    .numeric('ul_RampContinuousDuration', ea.SET)
+                    .withUnit('ms')
+                    .withDescription(
+                        'Set the duration of the ramp for the continuous variation, otherwise use 0xFFFFFFFF to use the one configured in the product.',
+                    ),
+            )
+            .withFeature(
+                e
+                    .numeric('uc_StepContinuous', ea.SET)
+                    .withUnit('s')
+                    .withDescription('Set the step size, otherwise use 0xFF to use the one configured in the product.. Value is in %.'),
+            )
+            .withCategory('config');
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ['dimProp'],
+                convertSet: async (entity, key, value, meta) => {
+                    // const options = utils.getOptions(meta.mapped, entity);
+                    // logger.debug('Invoked converter with options:' + JSON.stringify(options));
+
+                    const commandWrapper = yokisExtendChecks.parseDim(value);
+
+                    if (!commandWrapper.isSuccess) {
+                        logger.warning(
+                            // @ts-expect-error  CommandWrapper contains always contains the error attribute only when isSuccess is false
+                            `encountered an error (${commandWrapper.error.reason}) ` +
+                                `while parsing configuration commands (input: ${JSON.stringify(value)})`,
+                            NS,
+                        );
+
+                        return;
+                    }
+
+                    yokisExtendChecks.log(key, value, commandWrapper.payload);
+
+                    // NB: we are using the Cluster name defined in ZH over Cluster hexcode (due to conflict on cluster ID)
+                    await entity.command('manuSpecificYokisDimmer', 'dim', commandWrapper.payload);
+                },
+            },
+        ];
+
+        return {
+            exposes: [exposes],
+            toZigbee,
+            isModernExtend: true,
+        };
+    },
+    dimmerDimMinMax: (): ModernExtend => {
+        const exposes = e
+            .composite('dimmerDimMinMax', 'dimMinMaxProp', ea.SET)
+            .withDescription('Start dimming to the min or max value set in the device')
+            .withFeature(
+                e
+                    .numeric('ul_TransitionTime', ea.SET)
+                    .withUnit('ms')
+                    .withDescription(
+                        'Set the transition time to the selected value, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.',
+                    ),
+            )
+            .withFeature(e.enum('action', ea.SET, ['dimToMin', 'dimToMax']))
+            .withCategory('config');
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ['dimMinMaxProp'],
+                convertSet: async (entity, key, value, meta) => {
+                    // const options = utils.getOptions(meta.mapped, entity);
+                    // logger.debug('Invoked converter with options:' + JSON.stringify(options));
+
+                    const commandWrapper = yokisExtendChecks.parseDimMinMax(value);
+
+                    if (!commandWrapper.isSuccess) {
+                        logger.warning(
+                            // @ts-expect-error  CommandWrapper contains always contains the error attribute only when isSuccess is false
+                            `encountered an error (${commandWrapper.error.reason}) ` +
+                                `while parsing configuration commands (input: ${JSON.stringify(value)})`,
+                            NS,
+                        );
+
+                        return;
+                    }
+
+                    yokisExtendChecks.log(key, value, commandWrapper.payload);
+
+                    // NB: we are using the Cluster name defined in ZH over Cluster hexcode (due to conflict on cluster ID)
+                    await entity.command('manuSpecificYokisDimmer', commandWrapper.action, commandWrapper.payload);
+                },
+            },
+        ];
+
+        return {
+            exposes: [exposes],
+            toZigbee,
+            isModernExtend: true,
+        };
+    },
+    dimmerUpDown: (): ModernExtend => {
+        const exposes = e.enum('DimmerUpDown', ea.SET, ['dimUp', 'dimDown']).withDescription('Dim up or Down').withCategory('config');
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ['DimmerUpDown'],
+                convertSet: async (entity, key, value: string, meta) => {
+                    yokisExtendChecks.log(key, value);
+                    await entity.command('manuSpecificYokisDimmer', value, {});
+                },
+            },
+        ];
+
+        return {
+            exposes: [exposes],
+            toZigbee,
+            isModernExtend: true,
+        };
+    },
+    dimmerMoveToFavorite: (): ModernExtend => {
+        const exposes = e
+            .enum('DimmerMoveToFavorite1', ea.SET, ['moveToFavorite1', 'moveToFavorite2', 'moveToFavorite3'])
+            .withDescription('Start dimming to the favorite position 1, 2 or 3')
+            .withCategory('config');
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ['DimmerMoveToFavorite1'],
+                convertSet: async (entity, key, value: string, meta) => {
+                    yokisExtendChecks.log(key, value);
+                    await entity.command('manuSpecificYokisDimmer', value, {});
+                },
+            },
+        ];
+
+        return {
+            exposes: [exposes],
+            toZigbee,
+            isModernExtend: true,
+        };
+    },
+    dimmerStartNightLightModeCurrent: (): ModernExtend => {
+        const exposes = e
+            .enum('DimmerStarnightModeCurrent', ea.SET, ['startNightLightModeCurrent'])
+            .withDescription('Trigger Starnight mode from the current diming value')
+            .withCategory('config');
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ['DimmerStarnightModeCurrent'],
+                convertSet: async (entity, key, value: string, meta) => {
+                    yokisExtendChecks.log(key, value);
+                    await entity.command('manuSpecificYokisDimmer', value, {});
+                },
+            },
+        ];
+
+        return {
+            exposes: [exposes],
+            toZigbee,
+            isModernExtend: true,
+        };
+    },
+    dimmerStartNightLightMode: (): ModernExtend => {
+        const exposes = e
+            .composite('dimmerStartNightLightMode', 'dimmerStartNightLightModeProp', ea.SET)
+            .withDescription('Start the nightlight mode with the given parameters')
+            .withFeature(
+                e
+                    .numeric('ul_ChildModeStartingDelay', ea.SET)
+                    .withUnit('ms')
+                    .withDescription(
+                        'Set the starting delay value, used before the start of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.',
+                    ),
+            )
+            .withFeature(
+                e
+                    .numeric('uc_ChildModeBrightnessStart', ea.SET)
+                    .withUnit('%')
+                    .withDescription(
+                        'Set the brightness at the beginning of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %.',
+                    ),
+            )
+            .withFeature(
+                e
+                    .numeric('uc_ChildModeBrightnessEnd', ea.SET)
+                    .withUnit('%')
+                    .withDescription(
+                        'Set the brightness at the end of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %.',
+                    ),
+            )
+            .withFeature(
+                e
+                    .numeric('ul_ChildModeRampDuration', ea.SET)
+                    .withUnit('ms')
+                    .withDescription('Set the ramp duration, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.'),
+            )
+            .withFeature(
+                e
+                    .numeric('ul_ChildModeOnDuration', ea.SET)
+                    .withUnit('ms')
+                    .withDescription(
+                        'Set the total duration of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.',
+                    ),
+            )
+            .withFeature(
+                e
+                    .numeric('uc_ChildStep', ea.SET)
+                    .withUnit('%')
+                    .withDescription(
+                        'Set the step size between each dim, otherwise use 0xFF to use the one configured in the product. Value is in %.',
+                    ),
+            )
+            .withCategory('config');
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ['dimmerStartNightLightModeProp'],
+                convertSet: async (entity, key, value, meta) => {
+                    const commandWrapper = yokisExtendChecks.parseStartNightLightMode(value);
+
+                    if (!commandWrapper.isSuccess) {
+                        logger.warning(
+                            // @ts-expect-error  CommandWrapper contains always contains the error attribute only when isSuccess is false
+                            `encountered an error (${commandWrapper.error.reason}) ` +
+                                `while parsing configuration commands (input: ${JSON.stringify(value)})`,
+                            NS,
+                        );
+
+                        return;
+                    }
+
+                    yokisExtendChecks.log(key, value, commandWrapper.payload);
+
+                    await entity.command('manuSpecificYokisDimmer', 'startNightLightMode', commandWrapper.payload);
+                },
+            },
+        ];
+
+        return {
+            exposes: [exposes],
+            toZigbee,
+            isModernExtend: true,
+        };
+    },
 };
 
 const yokisLightControlExtend: ModernExtend[] = [
@@ -1562,7 +1986,282 @@ const YokisSubSystemExtend: ModernExtend[] = [
 ];
 
 const YokisDimmerExtend: ModernExtend[] = [
-    // TODO: Placeholder - pending documentation
+    // currentPosition
+    numeric({
+        name: 'CurrentPosition',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'currentPosition',
+        description: 'This attribute defines the current position, in %',
+        access: 'STATE_GET',
+        entityCategory: 'diagnostic',
+    }),
+
+    // memoryPosition
+    numeric({
+        name: 'MemoryPosition',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'memoryPosition',
+        description: 'This attribute defines the memory position, in %',
+        access: 'STATE_GET',
+        entityCategory: 'diagnostic',
+    }),
+
+    // RampUp
+    binary({
+        name: 'eRampUp',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'eRampUp',
+        description: 'This attribute defines if a ramp up should be used or not.',
+        valueOn: ['ON', 0x01],
+        valueOff: ['OFF', 0x00],
+        entityCategory: 'config',
+    }),
+    numeric({
+        name: 'RampUp',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'rampUp',
+        description: 'This attribute defines the time taken during the ramp up in ms.',
+        valueMin: 0x00000000,
+        valueMax: 0x05265c00,
+        valueStep: 1000,
+        entityCategory: 'config',
+    }),
+
+    // RampDown
+    binary({
+        name: 'eRampDown',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'eRampDown',
+        description: 'This attribute defines if a ramp down should be used or not.',
+        valueOn: ['ON', 0x01],
+        valueOff: ['OFF', 0x00],
+        entityCategory: 'config',
+    }),
+    numeric({
+        name: 'RampDown',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'rampDown',
+        description: 'This attribute defines the time taken during the ramp down in ms.',
+        valueMin: 0x00000000,
+        valueMax: 0x05265c00,
+        valueStep: 1000,
+        entityCategory: 'config',
+    }),
+
+    // rampContinuousTime
+    numeric({
+        name: 'RampContinuousTime',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'rampContinuousTime',
+        description: 'This attribute defines the time taken during the ramp loop in ms.',
+        valueMin: 0x00000000,
+        valueMax: 0x05265c00,
+        valueStep: 1000,
+        entityCategory: 'config',
+    }),
+
+    // stepUp
+    numeric({
+        name: 'StepUp',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'stepUp',
+        description: 'This attribute defines the value of each step during a dimming up. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // lowDimLimit
+    numeric({
+        name: 'LowDimLimit',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'lowDimLimit',
+        description:
+            'This attribute defines the value of the low dim limit, used during a dimming loop, on a long press for example. This value is set in %',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // highDimLimit
+    numeric({
+        name: 'HighDimLimit',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'highDimLimit',
+        description:
+            'This attribute defines the value of the high dim limit, used during a dimming loop, on a long press for example. This value is set in %',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // nightLightStartingDelay
+    numeric({
+        name: 'NightLightStartingDelay',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'nightLightStartingDelay',
+        description: 'This attribute defines the time before the nightlight begin. This value is set in seconds.',
+        valueMin: 0x00000000,
+        valueMax: 0xfffffffe,
+        valueStep: 10,
+        entityCategory: 'config',
+    }),
+
+    // nightLightStartingBrightness
+    numeric({
+        name: 'NightLightStartingBrightness',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'nightLightStartingBrightness',
+        description: 'This attribute defines the dimming value at the start of the nightlight. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // nightLightEndingBrightness
+    numeric({
+        name: 'NightLightEndingBrightness',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'nightLightEndingBrightness',
+        description:
+            'This attribute defines the dimming value at the last step of the nightlight. This attribute must be lower than 0x000D : Nightlight starting brightness. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // nightLightRampTime
+    numeric({
+        name: 'NightLightRampTime',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'nightLightRampTime',
+        description:
+            'This attribute defines the ramp duration of the nightlight. The ramp is running after the end of the starting delay and until the ending bright is reached. This value is set in seconds.',
+        valueMin: 0x00000000,
+        valueMax: 0x05265c00,
+        valueStep: 10,
+        entityCategory: 'config',
+    }),
+
+    // nightLightOnTime
+    numeric({
+        name: 'NightLightOnTime',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'nightLightOnTime',
+        description:
+            'This attribute defines the total duration of the nightlight. It must not be lower than 0x000F : Nightlight ramp time. This value is set in seconds.',
+        valueMin: 0x00000000,
+        valueMax: 0x00409980,
+        valueStep: 10,
+        entityCategory: 'config',
+    }),
+
+    // favoritePosition1
+    numeric({
+        name: 'FavoritePosition1',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'favoritePosition1',
+        description: 'This attribute defines the value of the favorite position 1. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // favoritePosition2
+    numeric({
+        name: 'FavoritePosition2',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'favoritePosition2',
+        description: 'This attribute defines the value of the favorite position 2. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // favoritePosition3
+    numeric({
+        name: 'FavoritePosition3',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'favoritePosition3',
+        description: 'This attribute defines the value of the favorite position 3. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // stepControllerMode
+    binary({
+        name: 'StepControllerMode',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'stepControllerMode',
+        description:
+            'This attribute enables or disables the 2-step controller mode. This mode enable product to run without any ramp before and after ON or OFF. It acts like a relay.',
+        valueOn: ['ON', 0x01],
+        valueOff: ['OFF', 0x00],
+        entityCategory: 'config',
+    }),
+
+    // memoryPositionMode
+    binary({
+        name: 'MemoryPositionMode',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'memoryPositionMode',
+        description: 'This attribute enables or disables the memory position mode at first push button release. ',
+        valueOn: ['ON', 0x01],
+        valueOff: ['OFF', 0x00],
+        entityCategory: 'config',
+    }),
+
+    // stepDown
+    numeric({
+        name: 'StepDown',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'stepDown',
+        description: 'This attribute defines the value of each step during a dimming down. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // stepContinuous
+    numeric({
+        name: 'StepContinuous',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'stepContinuous',
+        description: 'This attribute defines the value of each step during a dimming loop. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    // stepNightLigth
+    numeric({
+        name: 'StepNightLigth',
+        cluster: 'manuSpecificYokisDimmer',
+        attribute: 'stepNightLigth',
+        description: 'This attribute defines the value of each step during the ramp down of the nightlight mode. This value is set in %.',
+        valueMin: 0x00,
+        valueMax: 0x64,
+        valueStep: 1,
+        entityCategory: 'config',
+    }),
+
+    yokisCommandsExtend.dimmerDim(),
+    yokisCommandsExtend.dimmerUpDown(),
+    yokisCommandsExtend.dimmerDimMinMax(),
+    yokisCommandsExtend.dimmerMoveToFavorite(),
+    yokisCommandsExtend.dimmerStartNightLightModeCurrent(),
+    yokisCommandsExtend.dimmerStartNightLightMode(),
 ];
 
 const YokisWindowCoveringExtend: ModernExtend[] = [
@@ -1570,7 +2269,125 @@ const YokisWindowCoveringExtend: ModernExtend[] = [
 ];
 
 const YokisChannelExtend: ModernExtend[] = [
-    // TODO : Placeholder - pending documentation
+    // On/Off cluster mode
+    enumLookup({
+        name: 'On/Off cluster mode',
+        lookup: onOffClusterModeEnum,
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'onOffClusterMode',
+        description: `Define the command to send to the servers using cluster On/Off. Values are: 
+-	0x00 – TOGGLE (1)
+-	0x01 – ON
+-	0x02 – OFF
+-	0x03 – OFF 
+`,
+        entityCategory: 'config',
+    }),
+
+    // Level control cluster mode
+    enumLookup({
+        name: 'Level control cluster mode',
+        lookup: levelControlClusterModeEnum,
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'levelControlClusterMode',
+        description: `Define the command to send to the servers using cluster Level control. Values are: 
+-	0x00 – Nothing 
+-	0x01 – Move up
+-	0x02 – Move down
+-	0x03 – Stop
+`,
+        entityCategory: 'config',
+    }),
+
+    // Window covering cluster mode
+    enumLookup({
+        name: 'Window covering cluster mode',
+        lookup: windowCoveringClusterModeEnum,
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'windowCoveringClusterMode',
+        description: `Define the command to send to the servers using cluster Window Covering. Values are: 
+-	0x00 – TOGGLE (1)
+-	0x01 – UP/OPEN
+-	0x02 – DOWN/CLOSE
+-	0x03 – STOP
+`,
+        entityCategory: 'config',
+    }),
+
+    // Cluster to be used
+    // Supports reporting
+    numeric({
+        name: 'ClusterToBeUsed',
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'clusterToBeUsed',
+        description: `Defines the cluster that will be used by the channel to create an order. 
+
+If the value is set to 0xFFF0 the device will use a cluster priority list in order to choose the correct cluster and create the order associate depending on the target binded to the channel. The device will check which cluster the target declares and use the highest priority
+
+The priority list is:
+-	Yokis Input cluster (0xFC02)
+-	Window covering (0x0102)
+-	On Off (0x0006)
+-	Level Control (0x0008)
+-	Yokis Pilot Wire (0xFC0A)
+-	Yokis Light Control (0xFC06)
+
+This mode allows the user to “mix” multiple device type on the same channel.
+
+When a cluster is specified, the channel will only “control” the device binded with this specific cluster.
+`,
+        entityCategory: 'config',
+    }),
+
+    // Sending mode
+    enumLookup({
+        name: 'Sending mode ',
+        lookup: sendingModeEnum,
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'sendingMode',
+        description: `Define the channel sending mode:
+-	0x00 : DIRECT
+-	0x01 : BROADCAST
+-	0x02: GROUP (Will use the Group Id)
+`,
+        entityCategory: 'config',
+    }),
+
+    // Yokis light control mode
+    enumLookup({
+        name: 'Yokis light control mode',
+        lookup: yokisLightControlModeEnum,
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'yokisLightControlMode',
+        description: `Define the light control mode used between remote and the binded device. Values are: 
+-	0x00 – Mode pulse
+-	0x01 – Mode deaf
+`,
+        entityCategory: 'config',
+    }),
+
+    // Yokis pilot wire cluster mode
+    enumLookup({
+        name: 'Yokis pilot wire cluster mode',
+        lookup: yokisPilotWireClusterModeEnum,
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'yokisPilotWireClusterMode',
+        description: `Define the command to send to the servers using cluster Yokis Pilot Wire. Values are: 
+-	0x00 – TOGGLE (1) 
+-	0x01 – CONFORT
+-	0x02 – ECO
+`,
+        entityCategory: 'config',
+    }),
+
+    // Group id
+    numeric({
+        name: 'GroupId',
+        cluster: 'manuSpecificYokisChannel',
+        attribute: 'groupId',
+        description: `Indicate the group id who will receive the command from the dedicated endpoint. Only used when the sending mode is set to “GROUP” (0x02)`,
+        entityCategory: 'config',
+    }),
 ];
 
 const YokisPilotWireExtend: ModernExtend[] = [
@@ -1689,7 +2506,7 @@ const definitions: DefinitionWithExtend[] = [
             // ...YokisInputExtend,
             // ...YokisEntryExtend,
             // ...YokisSubSystemExtend,
-            // ...YokisDimmerExtend,
+            ...YokisDimmerExtend,
             // ...YokisStatsExtend,
         ],
     },

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -10,7 +10,7 @@ import {logger} from '../lib/logger';
 import * as exposes from '../lib/exposes';
 import * as utils from '../lib/utils';
 import {Zcl} from 'zigbee-herdsman';
-import {TsType as ZclType} from 'zigbee-herdsman/dist/zcl/definition';
+import {ClusterDefinition} from 'zigbee-herdsman/dist/zspec/zcl/definition/tstype';
 
 // #region Constants
 
@@ -75,7 +75,7 @@ const contactModeEnum: { [s: string]: number } = {
 // #region Custom cluster definition
 
 const YokisClustersDefinition: {
-    [s: string]: ZclType.ClusterDefinition
+    [s: string]: ClusterDefinition
 } = {
     manuSpecificYokisDevice: {
         ID: 0xFC01,
@@ -85,6 +85,7 @@ const YokisClustersDefinition: {
             configurationChanged: {ID: 0x0005, type: Zcl.DataType.ENUM16},
         },
         commands: {
+            // Reset setting depending on RESET ACTION value
             resetToFactorySettings: {
                 ID: 0x00,
                 response: 0,
@@ -93,11 +94,13 @@ const YokisClustersDefinition: {
                     {name: 'uc_ResetAction', type: Zcl.DataType.INT8},
                 ],
             },
+            // Relaunch BLE advertising for 15 minutes
             relaunchBleAdvert: {
                 ID: 0x11,
                 response: 0,
                 parameters: [],
             },
+            // Open ZigBee network
             openNetwork: {
                 ID: 0x12,
                 response: 0,
@@ -599,10 +602,10 @@ const yokisCommandsExtend = {
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [{
-            key: ['RelaunchBle'],
+            key: ['RelaunchBleAdvert'],
             convertSet: async (entity, key, value, meta) => {
                 yokisExtendChecks.log(key, value);
-                await entity.command('manuSpecificYokisDevice', 'RelaunchBleAdvert', {});
+                await entity.command('manuSpecificYokisDevice', 'relaunchBleAdvert', {});
             },
         }];
 
@@ -1545,10 +1548,10 @@ const definitions: Definition[] = [
             deviceAddCustomClusters([
                 'manuSpecificYokisDevice', 'manuSpecificYokisInput', 'manuSpecificYokisLightControl',
                 'manuSpecificYokisDimmer', 'manuSpecificYokisWindowCovering', 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel', 'manuSpecificYokisPilotWire', 'manuSpecificYokisStats',
+                'manuSpecificYokisPilotWire',
             ]),
             identify(),
-            forcePowerSource({powerSource: 'Battery'}),
+            forcePowerSource({powerSource: 'Battery'}), // until Battery cluster is implemented
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
@@ -1563,11 +1566,11 @@ const definitions: Definition[] = [
             deviceAddCustomClusters([
                 'manuSpecificYokisDevice', 'manuSpecificYokisInput', 'manuSpecificYokisLightControl',
                 'manuSpecificYokisDimmer', 'manuSpecificYokisWindowCovering', 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel', 'manuSpecificYokisPilotWire', 'manuSpecificYokisStats',
+                'manuSpecificYokisPilotWire',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
             identify(),
-            forcePowerSource({powerSource: 'Battery'}),
+            forcePowerSource({powerSource: 'Battery'}), // until Battery cluster is implemented
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
@@ -1582,11 +1585,11 @@ const definitions: Definition[] = [
             deviceAddCustomClusters([
                 'manuSpecificYokisDevice', 'manuSpecificYokisInput', 'manuSpecificYokisLightControl',
                 'manuSpecificYokisDimmer', 'manuSpecificYokisWindowCovering', 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel', 'manuSpecificYokisPilotWire', 'manuSpecificYokisStats',
+                'manuSpecificYokisPilotWire',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '4': 4}}),
             identify(),
-            forcePowerSource({powerSource: 'Battery'}),
+            forcePowerSource({powerSource: 'Battery'}), // until Battery cluster is implemented
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
@@ -1601,14 +1604,15 @@ const definitions: Definition[] = [
             deviceAddCustomClusters([
                 'manuSpecificYokisDevice', 'manuSpecificYokisInput', 'manuSpecificYokisLightControl',
                 'manuSpecificYokisDimmer', 'manuSpecificYokisWindowCovering', 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel', 'manuSpecificYokisPilotWire', 'manuSpecificYokisStats',
+                'manuSpecificYokisPilotWire',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8}}),
             identify(),
-            forcePowerSource({powerSource: 'Battery'}),
+            forcePowerSource({powerSource: 'Battery'}), // until Battery cluster is implemented
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
+            ...YokisDeviceExtend,
         ],
     },
     { // TLM1-UP
@@ -1620,10 +1624,10 @@ const definitions: Definition[] = [
             deviceAddCustomClusters([
                 'manuSpecificYokisDevice', 'manuSpecificYokisInput', 'manuSpecificYokisLightControl',
                 'manuSpecificYokisDimmer', 'manuSpecificYokisWindowCovering', 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel', 'manuSpecificYokisPilotWire', 'manuSpecificYokisStats',
+                'manuSpecificYokisPilotWire',
             ]),
             identify(),
-            forcePowerSource({powerSource: 'Battery'}),
+            forcePowerSource({powerSource: 'Battery'}), // until Battery cluster is implemented
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
@@ -1638,11 +1642,11 @@ const definitions: Definition[] = [
             deviceAddCustomClusters([
                 'manuSpecificYokisDevice', 'manuSpecificYokisInput', 'manuSpecificYokisLightControl',
                 'manuSpecificYokisDimmer', 'manuSpecificYokisWindowCovering', 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel', 'manuSpecificYokisPilotWire', 'manuSpecificYokisStats',
+                'manuSpecificYokisPilotWire',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
             identify(),
-            forcePowerSource({powerSource: 'Battery'}),
+            forcePowerSource({powerSource: 'Battery'}), // until Battery cluster is implemented
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
@@ -1657,11 +1661,11 @@ const definitions: Definition[] = [
             deviceAddCustomClusters([
                 'manuSpecificYokisDevice', 'manuSpecificYokisInput', 'manuSpecificYokisLightControl',
                 'manuSpecificYokisDimmer', 'manuSpecificYokisWindowCovering', 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel', 'manuSpecificYokisPilotWire', 'manuSpecificYokisStats',
+                'manuSpecificYokisPilotWire',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '4': 4}}),
             identify(),
-            forcePowerSource({powerSource: 'Battery'}),
+            forcePowerSource({powerSource: 'Battery'}), // until Battery cluster is implemented
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -1159,7 +1159,7 @@ const yokisCommandsExtend = {
     pulse: (): ModernExtend => {
         const exposes = e
             .composite('pulseCommand', 'pulseProp', ea.SET)
-            .withDescription('This command allows the relay to be controlled with an impulse. The pulse time is defined by PulseLength.')
+            .withDescription('This command allows the relay to be controlled with an impulse. The pulse time is defined by PulseLength')
             .withFeature(e.numeric('pulseLength', ea.SET).withValueMax(65535).withUnit('ms').withDescription('Pulse length'))
             .withCategory('config');
 
@@ -1196,13 +1196,13 @@ const yokisCommandsExtend = {
     deafBlink: (): ModernExtend => {
         const exposes = e
             .composite('deafBlinkCommand', 'deafBlinkProp', ea.SET)
-            .withDescription('Start a deaf sequene on a device only if the attribute “eDeaf” is set to Enable.')
+            .withDescription('Start a deaf sequene on a device only if the attribute “eDeaf” is set to Enable')
             .withFeature(
                 e
                     .numeric('uc_BlinkAmount', ea.SET)
                     .withDescription(
                         'If defined will force the number of blink to be done during one sequence (only for this order).' +
-                            'if not the device will use its own value.',
+                            'if not the device will use its own value',
                     ),
             )
             .withFeature(
@@ -1229,7 +1229,7 @@ const yokisCommandsExtend = {
                     )
                     .withLengthMin(0)
                     .withLengthMax(6)
-                    .withDescription('Array with the number of blink to be done for each sequence. Will override “uc_BlinkAmount“.'),
+                    .withDescription('Array with the number of blink to be done for each sequence. Will override “uc_BlinkAmount“'),
             )
             .withCategory('config');
 
@@ -1373,14 +1373,14 @@ const yokisCommandsExtend = {
                     .numeric('ul_RampContinuousDuration', ea.SET)
                     .withUnit('ms')
                     .withDescription(
-                        'Set the duration of the ramp for the continuous variation, otherwise use 0xFFFFFFFF to use the one configured in the product.',
+                        'Set the duration of the ramp for the continuous variation, otherwise use 0xFFFFFFFF to use the one configured in the product',
                     ),
             )
             .withFeature(
                 e
                     .numeric('uc_StepContinuous', ea.SET)
                     .withUnit('s')
-                    .withDescription('Set the step size, otherwise use 0xFF to use the one configured in the product.. Value is in %.'),
+                    .withDescription('Set the step size, otherwise use 0xFF to use the one configured in the product. Value is in %'),
             )
             .withCategory('config');
 
@@ -1427,7 +1427,7 @@ const yokisCommandsExtend = {
                     .numeric('ul_TransitionTime', ea.SET)
                     .withUnit('ms')
                     .withDescription(
-                        'Set the transition time to the selected value, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.',
+                        'Set the transition time to the selected value, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms',
                     ),
             )
             .withFeature(e.enum('action', ea.SET, ['dimToMin', 'dimToMax']))
@@ -1539,7 +1539,7 @@ const yokisCommandsExtend = {
                     .numeric('ul_ChildModeStartingDelay', ea.SET)
                     .withUnit('ms')
                     .withDescription(
-                        'Set the starting delay value, used before the start of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.',
+                        'Set the starting delay value, used before the start of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms',
                     ),
             )
             .withFeature(
@@ -1547,7 +1547,7 @@ const yokisCommandsExtend = {
                     .numeric('uc_ChildModeBrightnessStart', ea.SET)
                     .withUnit('%')
                     .withDescription(
-                        'Set the brightness at the beginning of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %.',
+                        'Set the brightness at the beginning of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %',
                     ),
             )
             .withFeature(
@@ -1555,21 +1555,21 @@ const yokisCommandsExtend = {
                     .numeric('uc_ChildModeBrightnessEnd', ea.SET)
                     .withUnit('%')
                     .withDescription(
-                        'Set the brightness at the end of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %.',
+                        'Set the brightness at the end of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %',
                     ),
             )
             .withFeature(
                 e
                     .numeric('ul_ChildModeRampDuration', ea.SET)
                     .withUnit('ms')
-                    .withDescription('Set the ramp duration, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.'),
+                    .withDescription('Set the ramp duration, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms'),
             )
             .withFeature(
                 e
                     .numeric('ul_ChildModeOnDuration', ea.SET)
                     .withUnit('ms')
                     .withDescription(
-                        'Set the total duration of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms.',
+                        'Set the total duration of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms',
                     ),
             )
             .withFeature(
@@ -1577,7 +1577,7 @@ const yokisCommandsExtend = {
                     .numeric('uc_ChildStep', ea.SET)
                     .withUnit('%')
                     .withDescription(
-                        'Set the step size between each dim, otherwise use 0xFF to use the one configured in the product. Value is in %.',
+                        'Set the step size between each dim, otherwise use 0xFF to use the one configured in the product. Value is in %',
                     ),
             )
             .withCategory('config');
@@ -1616,21 +1616,30 @@ const yokisCommandsExtend = {
 
 // Custom cluster exposition
 const YokisDeviceExtend: ModernExtend[] = [
-    numeric({
-        name: 'ConfigurationChanged',
-        cluster: 'manuSpecificYokisDevice',
-        attribute: 'configurationChanged',
-        description: 'Indicate if the device configuration has changed. 0 to 0xFFFE -> No Change, 0xFFFF -> Change have been detected',
-        access: 'STATE_SET',
-        valueMin: 0,
-        valueMax: 3600,
-        reporting: {min: 0, max: repInterval.HOUR, change: 1},
-        entityCategory: 'config',
-    }),
+    // ConfigurationChanged => This attribute is used by Yokis-based controller and probably not very useful at the moment, as we don't know which configuration was changed.
+    // Leaving it here for future evaluation
+    //
+    // numeric({
+    //     name: 'ConfigurationChanged',
+    //     cluster: 'manuSpecificYokisDevice',
+    //     attribute: 'configurationChanged',
+    //     description: `Indicate if the device configuration has changed:
+    //     - 0 to 0xFFFE -> No Change
+    //     - 0xFFFF -> Change have been detected`,
+    //     access: 'STATE_SET',
+    //     valueMin: 0,
+    //     valueMax: 3600,
+    //     reporting: {min: 0, max: repInterval.HOUR, change: 1},
+    //     entityCategory: 'config',
+    // }),
 
     yokisCommandsExtend.resetToFactorySettings(),
     yokisCommandsExtend.relaunchBleAdvert(),
-    yokisCommandsExtend.openNetwork(),
+
+    // openNetwork command : very specific case where the Yokis devices can create their own Zigbee network without the need of a coordinator
+    // Leaving it here for future evaluation
+    //
+    // yokisCommandsExtend.openNetwork(),
 ];
 
 const YokisInputExtend: ModernExtend[] = [
@@ -1667,8 +1676,8 @@ const YokisInputExtend: ModernExtend[] = [
         cluster: 'manuSpecificYokisInput',
         attribute: 'lastLocalCommandState',
         description: 'Indicate the last known state of the local BP',
-        valueOn: ['ON', 0x01],
-        valueOff: ['OFF', 0x00],
+        valueOn: ['PRESSED', 0x01],
+        valueOff: ['RELEASED', 0x00],
         access: 'STATE_GET',
         entityCategory: 'diagnostic',
     }),
@@ -1679,12 +1688,18 @@ const YokisInputExtend: ModernExtend[] = [
         cluster: 'manuSpecificYokisInput',
         attribute: 'lastBPConnectState',
         description: 'Indicate the last known state of the Bp connect',
-        valueOn: ['ON', 0x01],
-        valueOff: ['OFF', 0x00],
+        valueOn: ['PRESSED', 0x01],
+        valueOff: ['RELEASED', 0x00],
         access: 'STATE_GET',
         entityCategory: 'diagnostic',
     }),
 
+    yokisCommandsExtend.sendPress(),
+    yokisCommandsExtend.sendRelease(),
+    yokisCommandsExtend.selectInputMode(),
+];
+
+const YokisInputExtendWithBacklight: ModernExtend[] = [
     // BacklightIntensity
     numeric({
         name: 'BacklightIntensity',
@@ -1696,9 +1711,7 @@ const YokisInputExtend: ModernExtend[] = [
         entityCategory: 'config',
     }),
 
-    yokisCommandsExtend.sendPress(),
-    yokisCommandsExtend.sendRelease(),
-    yokisCommandsExtend.selectInputMode(),
+    ...YokisInputExtend,
 ];
 
 const YokisEntryExtend: ModernExtend[] = [
@@ -1779,7 +1792,7 @@ const YokisSubSystemExtend: ModernExtend[] = [
         lookup: powerFailureModeEnum,
         cluster: 'manuSpecificYokisSubSystem',
         attribute: 'powerFailureMode',
-        description: 'Define the device behavior after power failure ',
+        description: 'Define the device behavior after power failure',
         entityCategory: 'config',
         // zigbeeCommandOptions: manufacturerOptions,
     }),
@@ -1787,6 +1800,8 @@ const YokisSubSystemExtend: ModernExtend[] = [
 
 const yokisLightControlExtend: ModernExtend[] = [
     // OnOff => this is redundant from the GenOnOff state
+    // Leaving it here for future evaluation
+    //
     // binary({
     //     name: 'OnOff',
     //     cluster: 'manuSpecificYokisLightControl',
@@ -1812,20 +1827,23 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // onTimer
-    binary({
-        name: 'eOnTimer',
-        cluster: 'manuSpecificYokisLightControl',
-        attribute: 'eOnTimer',
-        description: 'Enable (0x01) / Disable (0x00) use of onTimer.',
-        valueOn: ['ON', 0x01],
-        valueOff: ['OFF', 0x00],
-        entityCategory: 'config',
-    }),
+    // eOnTimer => This attribute has been superseded by just using onTimer (a "0" onTimer will deactivate it)
+    // Leaving it here for future evaluation
+    //
+    // binary({
+    //     name: 'eOnTimer',
+    //     cluster: 'manuSpecificYokisLightControl',
+    //     attribute: 'eOnTimer',
+    //     description: 'Enable (0x01) / Disable (0x00) use of onTimer',
+    //     valueOn: ['ON', 0x01],
+    //     valueOff: ['OFF', 0x00],
+    //     entityCategory: 'config',
+    // }),
     numeric({
         name: 'onTimer',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'onTimer',
-        description: 'Define the ON embedded timer duration in seconds.',
+        description: 'Define the ON embedded timer duration in seconds. A `0` value will deactivate the timer',
         valueMin: 0,
         valueMax: 3600,
         valueStep: 1,
@@ -1838,7 +1856,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'ePreOnDelay',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'ePreOnDelay',
-        description: 'Enable (0x01) / Disable (0x00) PreOn delay.',
+        description: 'Enable (`0x01`) / Disable (`0x00`) PreOn delay',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -1847,7 +1865,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'PreOnDelay',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'preOnDelay',
-        description: 'Define the PreOn embedded delay in seconds.',
+        description: 'Define the PreOn embedded delay in seconds',
         valueMin: 0,
         valueMax: 3600,
         valueStep: 1,
@@ -1860,7 +1878,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'ePreOffDelay',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'ePreOffDelay',
-        description: 'Enable (0x01) / Disable (0x00) PreOff delay.',
+        description: 'Enable (`0x01`) / Disable (`0x00`) PreOff delay',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -1869,7 +1887,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'PreOffDelay',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'preOffDelay',
-        description: 'Define the PreOff embedded delay in seconds.',
+        description: 'Define the PreOff embedded delay in seconds',
         valueMin: 0,
         valueMax: 3600,
         valueStep: 1,
@@ -1882,7 +1900,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'PulseDuration',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'pulseDuration',
-        description: 'Set the value of ON pulse length.',
+        description: 'Set the value of ON pulse length',
         valueMin: 0x0014,
         valueMax: 0xfffe,
         valueStep: 1,
@@ -1933,7 +1951,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'eStopAnnounce',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'eStopAnnounce',
-        description: 'Enable (0x01) / Disable (0x00) the announcement before turning OFF',
+        description: 'Enable (`0x01`) / Disable (`0x00`) the announcement before turning OFF',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -1955,7 +1973,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'eDeaf',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'eDeaf',
-        description: 'Enable (0x01) / Disable (0x00) Deaf Actions',
+        description: 'Enable (`0x01`) / Disable (`0x00`) Deaf Actions',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -1964,7 +1982,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'DeafBlinkAmount',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'deafBlinkAmount',
-        description: 'Define number of blink to do when receiving the DEAF action. One blink is considered as one ON step followed by one OFF step.',
+        description: 'Define number of blink to do when receiving the DEAF action. One blink is considered as one ON step followed by one OFF step',
         valueMin: 0x00,
         valueMax: 0x14,
         valueStep: 1,
@@ -1986,7 +2004,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'eBlink',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'eBlink',
-        description: 'Enable (0x01) / Disable (0x00) Blink  Actions',
+        description: 'Enable (`0x01`) / Disable (`0x00`) Blink  Actions',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -1995,7 +2013,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         name: 'BlinkAmount',
         cluster: 'manuSpecificYokisLightControl',
         attribute: 'blinkAmount',
-        description: 'Number of blinks done when receiving the corresponding order. One blink is considered as one ON step followed by one OFF step.',
+        description: 'Number of blinks done when receiving the corresponding order. One blink is considered as one ON step followed by one OFF step',
         valueMin: 0x00,
         valueMax: 0x14,
         valueStep: 1,
@@ -2080,7 +2098,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'eRampUp',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'eRampUp',
-        description: 'This attribute defines if a ramp up should be used or not.',
+        description: 'This attribute defines if a ramp up should be used or not',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -2089,7 +2107,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'RampUp',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'rampUp',
-        description: 'This attribute defines the time taken during the ramp up in ms.',
+        description: 'This attribute defines the time taken during the ramp up in ms',
         valueMin: 0x00000000,
         valueMax: 0x05265c00,
         valueStep: 1000,
@@ -2101,7 +2119,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'eRampDown',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'eRampDown',
-        description: 'This attribute defines if a ramp down should be used or not.',
+        description: 'This attribute defines if a ramp down should be used or not',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -2110,7 +2128,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'RampDown',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'rampDown',
-        description: 'This attribute defines the time taken during the ramp down in ms.',
+        description: 'This attribute defines the time taken during the ramp down in ms',
         valueMin: 0x00000000,
         valueMax: 0x05265c00,
         valueStep: 1000,
@@ -2122,7 +2140,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'RampContinuousTime',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'rampContinuousTime',
-        description: 'This attribute defines the time taken during the ramp loop in ms.',
+        description: 'This attribute defines the time taken during the ramp loop in ms',
         valueMin: 0x00000000,
         valueMax: 0x05265c00,
         valueStep: 1000,
@@ -2134,7 +2152,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'StepUp',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'stepUp',
-        description: 'This attribute defines the value of each step during a dimming up. This value is set in %.',
+        description: 'This attribute defines the value of each step during a dimming up. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2172,7 +2190,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'NightLightStartingDelay',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'nightLightStartingDelay',
-        description: 'This attribute defines the time before the nightlight begin. This value is set in seconds.',
+        description: 'This attribute defines the time before the nightlight begin. This value is set in seconds',
         valueMin: 0x00000000,
         valueMax: 0xfffffffe,
         valueStep: 10,
@@ -2184,7 +2202,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'NightLightStartingBrightness',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'nightLightStartingBrightness',
-        description: 'This attribute defines the dimming value at the start of the nightlight. This value is set in %.',
+        description: 'This attribute defines the dimming value at the start of the nightlight. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2197,7 +2215,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'nightLightEndingBrightness',
         description:
-            'This attribute defines the dimming value at the last step of the nightlight. This attribute must be lower than 0x000D : Nightlight starting brightness. This value is set in %.',
+            'This attribute defines the dimming value at the last step of the nightlight. This attribute must be lower than 0x000D : Nightlight starting brightness. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2210,7 +2228,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'nightLightRampTime',
         description:
-            'This attribute defines the ramp duration of the nightlight. The ramp is running after the end of the starting delay and until the ending bright is reached. This value is set in seconds.',
+            'This attribute defines the ramp duration of the nightlight. The ramp is running after the end of the starting delay and until the ending bright is reached. This value is set in seconds',
         valueMin: 0x00000000,
         valueMax: 0x05265c00,
         valueStep: 10,
@@ -2223,7 +2241,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'nightLightOnTime',
         description:
-            'This attribute defines the total duration of the nightlight. It must not be lower than 0x000F : Nightlight ramp time. This value is set in seconds.',
+            'This attribute defines the total duration of the nightlight. It must not be lower than 0x000F : Nightlight ramp time. This value is set in seconds',
         valueMin: 0x00000000,
         valueMax: 0x00409980,
         valueStep: 10,
@@ -2235,7 +2253,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'FavoritePosition1',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'favoritePosition1',
-        description: 'This attribute defines the value of the favorite position 1. This value is set in %.',
+        description: 'This attribute defines the value of the favorite position 1. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2247,7 +2265,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'FavoritePosition2',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'favoritePosition2',
-        description: 'This attribute defines the value of the favorite position 2. This value is set in %.',
+        description: 'This attribute defines the value of the favorite position 2. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2259,7 +2277,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'FavoritePosition3',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'favoritePosition3',
-        description: 'This attribute defines the value of the favorite position 3. This value is set in %.',
+        description: 'This attribute defines the value of the favorite position 3. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2272,7 +2290,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'stepControllerMode',
         description:
-            'This attribute enables or disables the 2-step controller mode. This mode enable product to run without any ramp before and after ON or OFF. It acts like a relay.',
+            'This attribute enables or disables the 2-step controller mode. This mode enable product to run without any ramp before and after ON or OFF. It acts like a relay',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -2283,7 +2301,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'MemoryPositionMode',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'memoryPositionMode',
-        description: 'This attribute enables or disables the memory position mode at first push button release. ',
+        description: 'This attribute enables or disables the memory position mode at first push button release',
         valueOn: ['ON', 0x01],
         valueOff: ['OFF', 0x00],
         entityCategory: 'config',
@@ -2294,7 +2312,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'StepDown',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'stepDown',
-        description: 'This attribute defines the value of each step during a dimming down. This value is set in %.',
+        description: 'This attribute defines the value of each step during a dimming down. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2306,7 +2324,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'StepContinuous',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'stepContinuous',
-        description: 'This attribute defines the value of each step during a dimming loop. This value is set in %.',
+        description: 'This attribute defines the value of each step during a dimming loop. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2318,7 +2336,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         name: 'StepNightLigth',
         cluster: 'manuSpecificYokisDimmer',
         attribute: 'stepNightLigth',
-        description: 'This attribute defines the value of each step during the ramp down of the nightlight mode. This value is set in %.',
+        description: 'This attribute defines the value of each step during the ramp down of the nightlight mode. This value is set in %',
         valueMin: 0x00,
         valueMax: 0x64,
         valueStep: 1,
@@ -2486,14 +2504,15 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisLightControl',
                 'manuSpecificYokisStats',
             ]),
-            onOff({powerOnBehavior: false}),
+            onOff({powerOnBehavior: false}), // StartupOnOff is not supported
             identify(),
             ...yokisLightControlExtend,
             ...YokisDeviceExtend,
-            ...YokisInputExtend,
+            // ...YokisInputExtend,
             ...YokisEntryExtend,
             ...YokisSubSystemExtend,
-            ...YokisStatsExtend,
+            // ...YokisLoadManagerExtend, // Pending implementation
+            // ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2512,14 +2531,15 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisLightControl',
                 'manuSpecificYokisStats',
             ]),
-            onOff({powerOnBehavior: false}),
+            onOff({powerOnBehavior: false}), // StartupOnOff is not supported
             identify(),
             ...yokisLightControlExtend,
-            // ...YokisDeviceExtend,
+            ...YokisDeviceExtend,
             // ...YokisInputExtend,
-            // ...YokisEntryExtend,
-            // ...YokisSubSystemExtend,
-            // ...YokisStatsExtend,
+            ...YokisEntryExtend,
+            ...YokisSubSystemExtend,
+            // ...YokisLoadManagerExtend, // Pending implementation
+            // ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2538,14 +2558,15 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisLightControl',
                 'manuSpecificYokisStats',
             ]),
-            onOff({powerOnBehavior: false}),
+            onOff({powerOnBehavior: false}), // StartupOnOff is not supported
             identify(),
             ...yokisLightControlExtend,
-            // ...YokisDeviceExtend,
+            ...YokisDeviceExtend,
             // ...YokisInputExtend,
-            // ...YokisEntryExtend,
-            // ...YokisSubSystemExtend,
-            // ...YokisStatsExtend,
+            ...YokisEntryExtend,
+            ...YokisSubSystemExtend,
+            // ...YokisLoadManagerExtend, // Pending implementation
+            // ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2565,15 +2586,16 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisDimmer',
                 'manuSpecificYokisStats',
             ]),
-            light({configureReporting: true, powerOnBehavior: false}), // TODO: review dimmer cluster instead
+            light({configureReporting: true, powerOnBehavior: false}), // StartupOnOff is not supported, TODO: review dimmer cluster instead
             identify(),
             ...yokisLightControlExtend,
-            // ...YokisDeviceExtend,
+            ...YokisDeviceExtend,
             // ...YokisInputExtend,
-            // ...YokisEntryExtend,
-            // ...YokisSubSystemExtend,
+            ...YokisEntryExtend,
+            ...YokisSubSystemExtend,
             ...YokisDimmerExtend,
-            // ...YokisStatsExtend,
+            // ...YokisLoadManagerExtend, // Pending implementation
+            // ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2595,12 +2617,13 @@ const definitions: DefinitionWithExtend[] = [
             identify(),
             windowCovering({controls: ['lift']}),
             commandsWindowCovering(),
-            // ...YokisDeviceExtend,
+            ...YokisDeviceExtend,
             // ...YokisInputExtend,
             // ...YokisEntryExtend,
             // ...YokisSubSystemExtend,
             ...YokisWindowCoveringExtend,
-            // ...YokisStatsExtend
+            // ...YokisLoadManagerExtend, // Pending implementation
+            // ...YokisStatsExtend // Pending implementation
         ],
     },
     {
@@ -2617,16 +2640,13 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisDimmer',
                 'manuSpecificYokisWindowCovering',
                 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel',
                 'manuSpecificYokisPilotWire',
-                'manuSpecificYokisStats',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
             identify(),
-            commandsOnOff({endpointNames: ['1', '2']}),
-            // commandsLevelCtrl(),
-            // commandsWindowCovering(),
-            // ...yokisLightControlExtend,
+            commandsOnOff(),
+            commandsLevelCtrl(),
+            commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
         ],
@@ -2645,16 +2665,13 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisDimmer',
                 'manuSpecificYokisWindowCovering',
                 'manuSpecificYokisChannel',
-                'manuSpecificYokisChannel',
                 'manuSpecificYokisPilotWire',
-                'manuSpecificYokisStats',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '4': 4}}),
             identify(),
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
-            // ...yokisLightControlExtend,
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
         ],
@@ -2676,10 +2693,12 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisPilotWire',
                 'manuSpecificYokisTemperatureMeasurement',
             ]),
-            //identify(),
+            identify(),
             commandsOnOff(),
-            //commandsLevelCtrl(),
-            //commandsWindowCovering(),
+            commandsLevelCtrl(),
+            commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
         ],
     },
     {
@@ -2703,6 +2722,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
         ],
     },
     {
@@ -2726,6 +2747,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
         ],
     },
     {
@@ -2749,12 +2772,13 @@ const definitions: DefinitionWithExtend[] = [
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
-            ...YokisDeviceExtend,
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
         ],
     },
     {
         // TLM1-UP
-        zigbeeModel: ['TLM1-UP'],
+        zigbeeModel: ['TLM1-UP', 'TLM503-UP'],
         model: 'TLM1-UP',
         vendor: 'YOKIS',
         description: 'Wall-mounted 1-button transmitter',
@@ -2767,16 +2791,19 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisWindowCovering',
                 'manuSpecificYokisChannel',
                 'manuSpecificYokisPilotWire',
+                'manuSpecificYokisTemperatureMeasurement',
             ]),
             identify(),
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
         ],
     },
     {
         // TLM2-UP
-        zigbeeModel: ['TLM2-UP'],
+        zigbeeModel: ['TLM2-UP', 'TLM2_503-UP'],
         model: 'TLM2-UP',
         vendor: 'YOKIS',
         description: 'Wall-mounted 2-button transmitter',
@@ -2789,17 +2816,20 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisWindowCovering',
                 'manuSpecificYokisChannel',
                 'manuSpecificYokisPilotWire',
+                'manuSpecificYokisTemperatureMeasurement',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
             identify(),
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
         ],
     },
     {
         // TLM4-UP
-        zigbeeModel: ['TLM4-UP'],
+        zigbeeModel: ['TLM4-UP', 'TLM4_503-UP'],
         model: 'TLM4-UP',
         vendor: 'YOKIS',
         description: 'Wall-mounted 4-button transmitter',
@@ -2812,12 +2842,41 @@ const definitions: DefinitionWithExtend[] = [
                 'manuSpecificYokisWindowCovering',
                 'manuSpecificYokisChannel',
                 'manuSpecificYokisPilotWire',
+                'manuSpecificYokisTemperatureMeasurement',
             ]),
             deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '4': 4}}),
             identify(),
             commandsOnOff(),
             commandsLevelCtrl(),
             commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
+        ],
+    },
+    {
+        // GALET4-UP
+        zigbeeModel: ['GALET4-UP'],
+        model: 'GALET4-UP',
+        vendor: 'YOKIS',
+        description: '4-button remote control',
+        extend: [
+            deviceAddCustomClusters([
+                'manuSpecificYokisDevice',
+                'manuSpecificYokisInput',
+                'manuSpecificYokisLightControl',
+                'manuSpecificYokisDimmer',
+                'manuSpecificYokisWindowCovering',
+                'manuSpecificYokisChannel',
+                'manuSpecificYokisPilotWire',
+                'manuSpecificYokisTemperatureMeasurement',
+            ]),
+            deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '4': 4}}),
+            identify(),
+            commandsOnOff(),
+            commandsLevelCtrl(),
+            commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
         ],
     },
 ];

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -1,10 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* TODO : remove eslint-disable when dev is done */
-
 import {Zcl} from 'zigbee-herdsman';
 import {ClusterDefinition} from 'zigbee-herdsman/dist/zspec/zcl/definition/tstype';
 
-import {repInterval} from '../lib/constants';
 import * as exposes from '../lib/exposes';
 import {logger} from '../lib/logger';
 import {
@@ -15,14 +11,14 @@ import {
     deviceAddCustomCluster,
     deviceEndpoints,
     enumLookup,
-    forcePowerSource,
+    // forcePowerSource,
     identify,
     light,
     numeric,
     onOff,
     windowCovering,
 } from '../lib/modernExtend';
-import {DefinitionWithExtend, KeyValue, KeyValueAny, ModernExtend, OnEvent, Tz} from '../lib/types';
+import {DefinitionWithExtend, KeyValueAny, ModernExtend, Tz} from '../lib/types';
 import * as utils from '../lib/utils';
 
 // #region Constants
@@ -30,7 +26,7 @@ import * as utils from '../lib/utils';
 const e = exposes.presets;
 const ea = exposes.access;
 
-const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.YOKIS};
+// const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.YOKIS};
 const NS = 'zhc:yokis';
 
 // stateAfterBlinkEnum (manuSpecificYokisLightControl)
@@ -547,13 +543,13 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('uc_OpeningTime' in input) || !utils.isNumber(input.uc_OpeningTime)) {
+        if (!('opening_time' in input) || !utils.isNumber(input.opening_time)) {
             throw new Error(`INVALID_OPENNETWORK_OPENINGTIME`);
         }
 
         return {
             payload: {
-                uc_OpeningTime: input.uc_OpeningTime,
+                uc_OpeningTime: input.opening_time,
             },
         };
     },
@@ -562,13 +558,13 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('uc_InputMode' in input) || !Object.keys(inputModeEnum).includes(input.uc_InputMode)) {
+        if (!('select_input_mode' in input) || !Object.keys(inputModeEnum).includes(input.select_input_mode)) {
             throw new Error(`INVALID_INPUTMODE`);
         }
 
         return {
             payload: {
-                uc_InputMode: utils.getFromLookup(input.uc_InputMode, inputModeEnum),
+                uc_InputMode: utils.getFromLookup(input.select_input_mode, inputModeEnum),
             },
         };
     },
@@ -577,43 +573,43 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('uc_BrightnessStart' in input) || !utils.isNumber(input.uc_BrightnessStart)) {
+        if (!('brightness_start' in input) || !utils.isNumber(input.brightness_start)) {
             throw new Error(`INVALID_MOVE_BRIGHTNESSSTART`);
         }
 
-        if (!('uc_BrightnessEnd' in input) || !utils.isNumber(input.uc_BrightnessEnd)) {
+        if (!('brightness_end' in input) || !utils.isNumber(input.brightness_end)) {
             throw new Error(`INVALID_MOVE_BRIGHTNESSEND`);
         }
 
-        if (!('ul_PreTimerValue' in input) || !utils.isNumber(input.ul_PreTimerValue)) {
+        if (!('pre_timer_value' in input) || !utils.isNumber(input.pre_timer_value)) {
             throw new Error(`INVALID_MOVE_PRETIMERVALUE`);
         }
 
-        if (!('b_PreTimerEnable' in input) || !utils.isBoolean(input.b_PreTimerEnable)) {
+        if (!('enable_pre_timer' in input) || !utils.isBoolean(input.enable_pre_timer)) {
             throw new Error(`INVALID_MOVE_PRETIMERENABLE`);
         }
 
-        if (!('ul_TimerValue' in input) || !utils.isNumber(input.ul_TimerValue)) {
+        if (!('timer_value' in input) || !utils.isNumber(input.timer_value)) {
             throw new Error(`INVALID_MOVE_TIMERVALUE`);
         }
 
-        if (!('b_TimerEnable' in input) || !utils.isBoolean(input.b_TimerEnable)) {
+        if (!('enable_timer' in input) || !utils.isBoolean(input.enable_timer)) {
             throw new Error(`INVALID_MOVE_TIMERENABLE`);
         }
 
-        if (!('ul_TransitionTime' in input) || !utils.isNumber(input.ul_TransitionTime)) {
+        if (!('transition_time' in input) || !utils.isNumber(input.transition_time)) {
             throw new Error(`INVALID_MOVE_TRANSITIONTIME`);
         }
 
         return {
             payload: {
-                uc_BrightnessStart: input.uc_BrightnessStart,
-                uc_BrightnessEnd: input.uc_BrightnessEnd,
-                ul_PreTimerValue: input.ul_PreTimerValue,
-                b_PreTimerEnable: input.b_PreTimerEnable ? 1 : 0,
-                ul_TimerValue: input.ul_TimerValue,
-                b_TimerEnable: input.b_TimerEnable ? 1 : 0,
-                ul_TransitionTime: input.ul_TransitionTime,
+                uc_BrightnessStart: input.brightness_start,
+                uc_BrightnessEnd: input.brightness_end,
+                ul_PreTimerValue: input.pre_timer_value,
+                b_PreTimerEnable: input.enable_pre_timer ? 1 : 0,
+                ul_TimerValue: input.timer_value,
+                b_TimerEnable: input.enable_timer ? 1 : 0,
+                ul_TransitionTime: input.transition_time,
             },
         };
     },
@@ -622,33 +618,33 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('uc_BlinkAmount' in input) || !utils.isNumber(input.uc_BlinkAmount)) {
+        if (!('blink_amount' in input) || !utils.isNumber(input.blink_amount)) {
             throw new Error(`INVALID_BLINK_BLINKAMOUNT`);
         }
 
-        if (!('ul_BlinkOnPeriod' in input) || !utils.isNumber(input.ul_BlinkOnPeriod)) {
+        if (!('blink_on_period' in input) || !utils.isNumber(input.blink_on_period)) {
             throw new Error(`INVALID_BLINK_BLINKONPERIOD`);
         }
 
-        if (!('ul_BlinkOffPeriod' in input) || !utils.isNumber(input.ul_BlinkOffPeriod)) {
+        if (!('blink_off_period' in input) || !utils.isNumber(input.blink_off_period)) {
             throw new Error(`INVALID_BLINK_BLINKOFFPERIOD`);
         }
 
-        if (!('uc_StateAfterSequence' in input)) {
+        if (!('state_after_sequence' in input) || !Object.keys(stateAfterBlinkEnum).includes(input.state_after_sequence)) {
             throw new Error(`MISSING_BLINK_STATEAFTERSEQUENCE`);
         }
 
-        if (!('b_DoPeriodicCycle' in input) || !utils.isBoolean(input.b_DoPeriodicCycle)) {
+        if (!('do_periodic_cycle' in input) || !utils.isBoolean(input.do_periodic_cycle)) {
             throw new Error(`INVALID_BLINK_DOPERIODICYCLE`);
         }
 
         return {
             payload: {
-                uc_BlinkAmount: input.uc_BlinkAmount,
-                ul_BlinkOnPeriod: input.ul_BlinkOnPeriod,
-                ul_BlinkOffPeriod: input.ul_BlinkOffPeriod,
-                uc_StateAfterSequence: utils.getFromLookup(input.uc_StateAfterSequence, stateAfterBlinkEnum),
-                b_DoPeriodicCycle: input.b_DoPeriodicCycle ? 1 : 0,
+                uc_BlinkAmount: input.blink_amount,
+                ul_BlinkOnPeriod: input.blink_on_period,
+                ul_BlinkOffPeriod: input.blink_off_period,
+                uc_StateAfterSequence: utils.getFromLookup(input.state_after_sequence, stateAfterBlinkEnum),
+                b_DoPeriodicCycle: input.do_periodic_cycle ? 1 : 0,
             },
         };
     },
@@ -657,13 +653,13 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('pulseLength' in input) || !utils.isNumber(input.pulseLength)) {
+        if (!('pulse_length' in input) || !utils.isNumber(input.pulse_length)) {
             throw new Error(`INVALID_PULSE_PULSELENGTH`);
         }
 
         return {
             payload: {
-                PulseLength: input.pulseLength,
+                PulseLength: input.pulse_length,
             },
         };
     },
@@ -672,19 +668,19 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('uc_BlinkAmount' in input) || !utils.isNumber(input.uc_BlinkAmount)) {
+        if (!('blink_amount' in input) || !utils.isNumber(input.blink_amount)) {
             throw new Error(`INVALID_BLINK_AMOUNT`);
         }
 
-        if (!('uc_BlinkAmount' in input) || !utils.isNumber(input.ul_BlinkOnTime)) {
+        if (!('blink_on_time' in input) || !utils.isNumber(input.blink_on_time)) {
             throw new Error(`INVALID_BLINK_ONTIME`);
         }
 
-        if (!('uc_BlinkAmount' in input) || !utils.isNumber(input.uc_SequenceAmount)) {
+        if (!('sequence_amount' in input) || !utils.isNumber(input.sequence_amount)) {
             throw new Error(`INVALID_SEQUENCE_AMOUNT`);
         }
 
-        if (input.tuc_BlinkAmount && Array.isArray(input.tuc_BlinkAmount)) {
+        if (input.sequence_of_blinks && Array.isArray(input.sequence_of_blinks)) {
             // if (input.uc_SequenceAmount < input.tuc_BlinkAmount.length) {
             //     // more sequences configured than expected, pop extragenous
             //     for(let i = 0; i < input.tuc_BlinkAmount.length - input.uc_SequenceAmount; i++) {
@@ -700,7 +696,7 @@ const yokisExtendChecks = {
             // }
 
             // Updating number of elements
-            input.uc_SequenceAmount = input.tuc_BlinkAmount.length;
+            input.sequence_amount = input.sequence_of_blinks.length;
         } else {
             throw new Error(`INVALID_TUC_BLINKAMOUNT`);
         }
@@ -711,11 +707,10 @@ const yokisExtendChecks = {
 
         return {
             payload: {
-                uc_BlinkAmount: input.uc_BlinkAmount,
-                ul_BlinkOnTime: input.ul_BlinkOnTime,
-                uc_SequenceAmount: input.tuc_BlinkAmount.length,
-                // [{"undefined":1},{"undefined":1}] > [1,1]
-                tuc_BlinkAmount: input.tuc_BlinkAmount.map((elem) => (typeof elem === 'object' ? Object.values(elem).shift() : elem)),
+                uc_BlinkAmount: input.blink_amount,
+                ul_BlinkOnTime: input.blink_on_time,
+                uc_SequenceAmount: input.sequence_of_blinks.length,
+                tuc_BlinkAmount: input.sequence_of_blinks.map((elem) => (typeof elem === 'object' ? Object.values(elem).shift() : elem)), // [{"undefined":1},{"undefined":1}] > [1,1]
             },
         };
     },
@@ -726,13 +721,13 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('ul_RampContinuousDuration' in input) || !utils.isNumber(input.ul_RampContinuousDuration)) {
+        if (!('ramp_continuous_duration' in input) || !utils.isNumber(input.ramp_continuous_duration)) {
             _ul_RampContinuousDuration = 0xffffffff; // use default value
-        } else _ul_RampContinuousDuration = input.ul_RampContinuousDuration;
+        } else _ul_RampContinuousDuration = input.ramp_continuous_duration;
 
-        if (!('uc_StepContinuous' in input) || !utils.isNumber(input.uc_StepContinuous)) {
+        if (!('step_continuous' in input) || !utils.isNumber(input.step_continuous)) {
             _uc_StepContinuous = 0xff; // use default value
-        } else _uc_StepContinuous = input.uc_StepContinuous;
+        } else _uc_StepContinuous = input.step_continuous;
 
         return {
             payload: {
@@ -748,9 +743,9 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('ul_TransitionTime' in input) || !utils.isNumber(input.ul_TransitionTime)) {
+        if (!('transition_time' in input) || !utils.isNumber(input.transition_time)) {
             _ul_TransitionTime = 0xffffffff; // use default value
-        } else _ul_TransitionTime = input.ul_TransitionTime;
+        } else _ul_TransitionTime = input.transition_time;
 
         if (!('action' in input)) {
             throw new Error(`MISSING_ACTION`);
@@ -777,29 +772,29 @@ const yokisExtendChecks = {
             throw new Error(`NOT_OBJECT`);
         }
 
-        if (!('ul_ChildModeStartingDelay' in input) || !utils.isNumber(input.ul_ChildModeStartingDelay)) {
+        if (!('childmode_starting_delay' in input) || !utils.isNumber(input.childmode_starting_delay)) {
             _ul_ChildModeStartingDelay = 0xffffffff; // use default value
-        } else _ul_ChildModeStartingDelay = input.ul_ChildModeStartingDelay;
+        } else _ul_ChildModeStartingDelay = input.childmode_starting_delay;
 
-        if (!('uc_ChildModeBrightnessStart' in input) || !utils.isNumber(input.uc_ChildModeBrightnessStart)) {
+        if (!('childmode_brightness_start' in input) || !utils.isNumber(input.childmode_brightness_start)) {
             _uc_ChildModeBrightnessStart = 0xff; // use default value
-        } else _uc_ChildModeBrightnessStart = input.uc_ChildModeBrightnessStart;
+        } else _uc_ChildModeBrightnessStart = input.childmode_brightness_start;
 
-        if (!('uc_ChildModeBrightnessEnd' in input) || !utils.isNumber(input.uc_ChildModeBrightnessEnd)) {
+        if (!('childmode_brightness_end' in input) || !utils.isNumber(input.childmode_brightness_end)) {
             _uc_ChildModeBrightnessEnd = 0xff; // use default value
-        } else _uc_ChildModeBrightnessEnd = input.uc_ChildModeBrightnessEnd;
+        } else _uc_ChildModeBrightnessEnd = input.childmode_brightness_end;
 
-        if (!('ul_ChildModeRampDuration' in input) || !utils.isNumber(input.ul_ChildModeRampDuration)) {
+        if (!('childmode_ramp_duration' in input) || !utils.isNumber(input.childmode_ramp_duration)) {
             _ul_ChildModeRampDuration = 0xffffffff; // use default value
-        } else _ul_ChildModeRampDuration = input.ul_ChildModeRampDuration;
+        } else _ul_ChildModeRampDuration = input.childmode_ramp_duration;
 
-        if (!('ul_ChildModeOnDuration' in input) || !utils.isNumber(input.ul_ChildModeOnDuration)) {
+        if (!('childmode_on_duration' in input) || !utils.isNumber(input.childmode_on_duration)) {
             _ul_ChildModeOnDuration = 0xffffffff; // use default value
-        } else _ul_ChildModeOnDuration = input.ul_ChildModeOnDuration;
+        } else _ul_ChildModeOnDuration = input.childmode_on_duration;
 
-        if (!('uc_ChildStep' in input) || !utils.isNumber(input.uc_ChildStep)) {
+        if (!('childmode_step' in input) || !utils.isNumber(input.childmode_step)) {
             _uc_ChildStep = 0xff; // use default value
-        } else _uc_ChildStep = input.uc_ChildStep;
+        } else _uc_ChildStep = input.childmode_step;
 
         return {
             payload: {
@@ -823,13 +818,13 @@ const yokisExtendChecks = {
 const yokisCommandsExtend = {
     resetToFactorySettings: (): ModernExtend => {
         const exposes = e
-            .enum('uc_ResetAction', ea.SET, Object.keys(resetActionEnum))
-            .withDescription('Ititiate long duration on')
+            .enum('reset_to_factory_settings', ea.SET, Object.keys(resetActionEnum))
+            .withDescription('Reset setting depending on RESET ACTION value')
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['uc_ResetAction'],
+                key: ['reset_to_factory_settings'],
                 convertSet: async (entity, key, value: string, meta) => {
                     const commandWrapper = yokisExtendChecks.parseResetInput(value);
 
@@ -848,13 +843,13 @@ const yokisCommandsExtend = {
     },
     relaunchBleAdvert: (): ModernExtend => {
         const exposes = e
-            .enum('RelaunchBleAdvert', ea.SET, ['RelaunchBle'])
+            .enum('relaunch_ble_advert', ea.SET, ['relaunch_ble_advert'])
             .withDescription('Relaunch BLE advertising for 15 minutes')
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['RelaunchBleAdvert'],
+                key: ['relaunch_ble_advert'],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
                     await entity.command('manuSpecificYokisDevice', 'relaunchBleAdvert', {});
@@ -870,11 +865,11 @@ const yokisCommandsExtend = {
     },
     openNetwork: (): ModernExtend => {
         const exposes = e
-            .composite('OpenNetworkCommand', 'OpenNetworkProp', ea.SET)
+            .composite('open_network_command', 'open_network_prop', ea.SET)
             .withDescription('Open ZigBee network')
             .withFeature(
                 e
-                    .numeric('uc_OpeningTime', ea.SET)
+                    .numeric('opening_time', ea.SET) //uc_OpeningTime
                     .withValueMin(0)
                     .withValueMax(255)
                     .withUnit('s')
@@ -884,7 +879,7 @@ const yokisCommandsExtend = {
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['OpenNetworkProp'],
+                key: ['open_network_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     const commandWrapper = yokisExtendChecks.parseOpenNetworkInput(value);
 
@@ -903,41 +898,53 @@ const yokisCommandsExtend = {
     },
     moveToPosition: (): ModernExtend => {
         const exposes = e
-            .composite('move_to_position_command', 'moveToPositionProp', ea.SET)
+            .composite('move_to_position_command', 'move_to_position_prop', ea.SET)
             .withDescription(
                 'Move to position specified in uc_BrightnessEnd parameter.' +
                     'If TOR mode is set (no dimming) or MTR : if uc_BrightnessEnd under 50% will set to OFF else will be set to ON',
             )
-            .withFeature(e.numeric('uc_BrightnessStart', ea.SET).withDescription(''))
-            .withFeature(e.numeric('uc_BrightnessEnd', ea.SET).withDescription(''))
             .withFeature(
                 e
-                    .numeric('ul_PreTimerValue', ea.SET)
+                    .numeric('brightness_start', ea.SET) // uc_BrightnessStart
+                    .withDescription('Define the brightness at the beginning of the transition, in %'),
+            )
+            .withFeature(
+                e
+                    .numeric('brightness_end', ea.SET) // uc_BrightnessEnd
+                    .withDescription('Define the brightness at the end of the transition, in %'),
+            )
+            .withFeature(
+                e
+                    .numeric('pre_timer_value', ea.SET) // ul_PreTimerValue
                     .withUnit('s')
-                    .withDescription('If defined will force the pretimer value (only for this order) if not the device will use its own value.'),
+                    .withDescription('Define the pre timer value, otherwise use 0xFFFFFFFF to use the one configured in the product'),
             )
             .withFeature(
                 e
-                    .binary('b_PreTimerEnable', ea.SET, true, false)
-                    .withDescription('If defined will force the pretimer use (only for this order) if not the device will use its own value.'),
+                    .binary('enable_pre_timer', ea.SET, true, false) // b_PreTimerEnable
+                    .withDescription('Define whether the device should use the pre timer or not, if 0xFF then use the one configured in product'),
             )
             .withFeature(
                 e
-                    .numeric('ul_TimerValue', ea.SET)
+                    .numeric('timer_value', ea.SET) // ul_TimerValue
                     .withUnit('s')
-                    .withDescription('If defined will force the OnTimer value (only for this order) if not the device will use its own value.'),
+                    .withDescription('Define the timer ON value, otherwise use 0xFFFFFFFF to use the one configured in the product'),
             )
             .withFeature(
                 e
-                    .binary('b_TimerEnable', ea.SET, true, false)
-                    .withDescription('If defined will force the OnTimer use (only for this order) if not the device will use its own value.'),
+                    .binary('enable_timer', ea.SET, true, false) // b_TimerEnable
+                    .withDescription('Define whether the device should use the timer ON or not, if 0xFF then use the one configured in product'),
             )
-            .withFeature(e.numeric('ul_TransitionTime', ea.SET).withDescription(''))
+            .withFeature(
+                e
+                    .numeric('transition_time', ea.SET) // ul_TransitionTime
+                    .withDescription('Define the transition time from the brightness start to the brightness end, in ms'),
+            )
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['moveToPositionProp'],
+                key: ['move_to_position_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     // const options = utils.getOptions(meta.mapped, entity);
                     // logger.debug('Invoked converter with options:' + JSON.stringify(options));
@@ -946,7 +953,6 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    // NB: we are using the Cluster name defined in ZH over Cluster hexcode (due to conflict on cluster ID)
                     await entity.command('manuSpecificYokisLightControl', 'moveToPosition', commandWrapper.payload);
                 },
             },
@@ -960,38 +966,42 @@ const yokisCommandsExtend = {
     },
     blink: (): ModernExtend => {
         const exposes = e
-            .composite('blink_command', 'blinkProp', ea.SET)
+            .composite('blink_command', 'blink_prop', ea.SET)
             .withDescription('With this command, the module is asked to perform a blinking sequence.')
             .withFeature(
                 e
-                    .numeric('uc_BlinkAmount', ea.SET)
+                    .numeric('blink_amount', ea.SET) // uc_BlinkAmount
                     .withDescription(
-                        'If defined will force the number of blink to be done (only for this order).' + 'if not the device will use its own value.',
+                        'If defined will force the number of blink to be done (only for this order) if not the device will use its own value.',
                     ),
             )
             .withFeature(
                 e
-                    .numeric('ul_BlinkOnPeriod', ea.SET)
+                    .numeric('blink_on_period', ea.SET) // ul_BlinkOnPeriod
                     .withDescription('If defined will force the blink’s “on time” (only for this order) if not the device will use its own value.'),
             )
             .withFeature(
                 e
-                    .numeric('ul_BlinkOffPeriod', ea.SET)
+                    .numeric('blink_off_period', ea.SET) // ul_BlinkOffPeriod
                     .withDescription('If defined will force the blink’s “off time” (only for this order) if not the device will use its own value.'),
             )
             .withFeature(
                 e
-                    .enum('uc_StateAfterSequence', ea.SET, Object.keys(stateAfterBlinkEnum))
+                    .enum('state_after_sequence', ea.SET, Object.keys(stateAfterBlinkEnum)) // uc_StateAfterSequence
                     .withDescription(
-                        'If defined will force the state after the sequence (only for this order).' + 'if not the device will use its own value-',
+                        'If defined will force the state after the sequence (only for this order). if not the device will use its own value-',
                     ),
             )
-            .withFeature(e.binary('b_DoPeriodicCycle', ea.SET, true, false).withDescription('If set to true the blinking will be “infinite”'))
+            .withFeature(
+                e
+                    .binary('do_periodic_cycle', ea.SET, true, false) // b_DoPeriodicCycle
+                    .withDescription('If set to true the blinking will be “infinite”'),
+            )
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['blinkProp'],
+                key: ['blink_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     const commandWrapper = yokisExtendChecks.parseBlinkInput(value);
 
@@ -1010,14 +1020,20 @@ const yokisCommandsExtend = {
     },
     pulse: (): ModernExtend => {
         const exposes = e
-            .composite('pulse_command', 'pulseProp', ea.SET)
+            .composite('pulse_command', 'pulse_prop', ea.SET)
             .withDescription('This command allows the relay to be controlled with an impulse. The pulse time is defined by PulseLength')
-            .withFeature(e.numeric('pulseLength', ea.SET).withValueMax(65535).withUnit('ms').withDescription('Pulse length'))
+            .withFeature(
+                e
+                    .numeric('pulse_length', ea.SET) // pulseLength
+                    .withValueMax(65535)
+                    .withUnit('ms')
+                    .withDescription('Pulse length'),
+            )
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['pulseProp'],
+                key: ['pulse_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     const commandWrapper = yokisExtendChecks.parsePulseInput(value);
 
@@ -1036,24 +1052,23 @@ const yokisCommandsExtend = {
     },
     deafBlink: (): ModernExtend => {
         const exposes = e
-            .composite('deaf_blink_command', 'deafBlinkProp', ea.SET)
+            .composite('deaf_blink_command', 'deaf_blink_prop', ea.SET)
             .withDescription('Start a deaf sequene on a device only if the attribute “eDeaf” is set to Enable')
             .withFeature(
                 e
-                    .numeric('uc_BlinkAmount', ea.SET)
+                    .numeric('blink_amount', ea.SET) // uc_BlinkAmount
                     .withDescription(
-                        'If defined will force the number of blink to be done during one sequence (only for this order).' +
-                            'if not the device will use its own value',
+                        'If defined will force the number of blink to be done during one sequence (only for this order) if not the device will use its own value',
                     ),
             )
             .withFeature(
                 e
-                    .numeric('ul_BlinkOnTime', ea.SET)
+                    .numeric('blink_on_time', ea.SET) // ul_BlinkOnTime
                     .withDescription('If defined will force the blink’s “on time” (only for this order) if not the device will use its own value'),
             )
             .withFeature(
                 e
-                    .numeric('uc_SequenceAmount', ea.STATE)
+                    .numeric('sequence_amount', ea.STATE) // uc_SequenceAmount
                     .withValueMin(0)
                     .withValueMax(6)
                     .withDescription('If defined will set the number of sequence to be done. Each sequence is spaced by 1 second. (Max 6)'),
@@ -1061,11 +1076,11 @@ const yokisCommandsExtend = {
             .withFeature(
                 e
                     .list(
-                        'tuc_BlinkAmount',
+                        'sequence_of_blinks', // tuc_BlinkAmount
                         ea.SET,
                         e
                             .composite('uc_BlinkAmountItems', 'uc_BlinkAmountItems', ea.SET)
-                            .withLabel('')
+                            .withLabel('Number of blink items for the sequence')
                             .withFeature(e.numeric('uc_BlinkAmountItem', ea.SET).withLabel('Blinks')),
                     )
                     .withLengthMin(0)
@@ -1076,15 +1091,13 @@ const yokisCommandsExtend = {
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['deafBlinkProp'],
+                key: ['deaf_blink_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     const commandWrapper = yokisExtendChecks.parseDeafBlinkPropInput(value);
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
                     await entity.command('manuSpecificYokisLightControl', 'deafBlink', commandWrapper.payload);
-
-                    // return {state: {deafBlinkProp: commandWrapper.value}};
                 },
             },
         ];
@@ -1096,11 +1109,14 @@ const yokisCommandsExtend = {
         };
     },
     longOnCommand: (): ModernExtend => {
-        const exposes = e.enum('longOnCommand', ea.SET, ['longOnAction']).withDescription('Ititiate long duration on').withCategory('config');
+        const exposes = e
+            .enum('long_on_command', ea.SET, ['longOnAction'])
+            .withDescription('Switch output ON for LONG ON DURATION time')
+            .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['longOnCommand'],
+                key: ['long_on_command'],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
                     await entity.command('manuSpecificYokisLightControl', 'longOn', {});
@@ -1116,13 +1132,13 @@ const yokisCommandsExtend = {
     },
     sendPress: (): ModernExtend => {
         const exposes = e
-            .enum('SendPress', ea.SET, ['SendPress'])
+            .enum('send_press', ea.SET, ['SendPress'])
             .withDescription('Send to the server cluster a button press')
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['SendPress'],
+                key: ['send_press'],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
                     await entity.command('manuSpecificYokisDevice', 'sendPress', {});
@@ -1138,13 +1154,13 @@ const yokisCommandsExtend = {
     },
     sendRelease: (): ModernExtend => {
         const exposes = e
-            .enum('SendRelease', ea.SET, ['SendRelease'])
+            .enum('send_release', ea.SET, ['SendRelease'])
             .withDescription('Send to the server cluster a button release')
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['SendRelease'],
+                key: ['send_release'],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
                     await entity.command('manuSpecificYokisDevice', 'sendRelease', {});
@@ -1160,13 +1176,13 @@ const yokisCommandsExtend = {
     },
     selectInputMode: (): ModernExtend => {
         const exposes = e
-            .enum('uc_InputMode', ea.SET, Object.keys(inputModeEnum))
+            .enum('select_input_mode', ea.SET, Object.keys(inputModeEnum))
             .withDescription('Change the Input mode to use switch input, wired relay or simple push button')
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['uc_InputMode'],
+                key: ['select_input_mode'],
                 convertSet: async (entity, key, value, meta) => {
                     const commandWrapper = yokisExtendChecks.parseInputModeInput(value);
 
@@ -1185,11 +1201,11 @@ const yokisCommandsExtend = {
     },
     dimmerDim: (): ModernExtend => {
         const exposes = e
-            .composite('dimmer_dim_command', 'dimProp', ea.SET)
+            .composite('dimmer_loop_command', 'dimmer_prop', ea.SET)
             .withDescription('Start the dimming loop process for the selected duration.')
             .withFeature(
                 e
-                    .numeric('ul_RampContinuousDuration', ea.SET)
+                    .numeric('ramp_continuous_duration', ea.SET) // ul_RampContinuousDuration
                     .withUnit('ms')
                     .withDescription(
                         'Set the duration of the ramp for the continuous variation, otherwise use 0xFFFFFFFF to use the one configured in the product',
@@ -1197,7 +1213,7 @@ const yokisCommandsExtend = {
             )
             .withFeature(
                 e
-                    .numeric('uc_StepContinuous', ea.SET)
+                    .numeric('step_continuous', ea.SET) // uc_StepContinuous
                     .withUnit('s')
                     .withDescription('Set the step size, otherwise use 0xFF to use the one configured in the product. Value is in %'),
             )
@@ -1205,7 +1221,7 @@ const yokisCommandsExtend = {
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['dimProp'],
+                key: ['dimmer_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     // const options = utils.getOptions(meta.mapped, entity);
                     // logger.debug('Invoked converter with options:' + JSON.stringify(options));
@@ -1214,7 +1230,6 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    // NB: we are using the Cluster name defined in ZH over Cluster hexcode (due to conflict on cluster ID)
                     await entity.command('manuSpecificYokisDimmer', 'dim', commandWrapper.payload);
                 },
             },
@@ -1228,11 +1243,11 @@ const yokisCommandsExtend = {
     },
     dimmerDimMinMax: (): ModernExtend => {
         const exposes = e
-            .composite('dimmer_dim_min_max_command', 'dimMinMaxProp', ea.SET)
+            .composite('dimmer_min_max_command', 'dimmer_min_max_prop', ea.SET)
             .withDescription('Start dimming to the min or max value set in the device')
             .withFeature(
                 e
-                    .numeric('ul_TransitionTime', ea.SET)
+                    .numeric('transition_time', ea.SET) // ul_TransitionTime
                     .withUnit('ms')
                     .withDescription(
                         'Set the transition time to the selected value, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms',
@@ -1243,7 +1258,7 @@ const yokisCommandsExtend = {
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['dimMinMaxProp'],
+                key: ['dimmer_min_max_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     // const options = utils.getOptions(meta.mapped, entity);
                     // logger.debug('Invoked converter with options:' + JSON.stringify(options));
@@ -1252,7 +1267,6 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    // NB: we are using the Cluster name defined in ZH over Cluster hexcode (due to conflict on cluster ID)
                     await entity.command('manuSpecificYokisDimmer', commandWrapper.action, commandWrapper.payload);
                 },
             },
@@ -1265,11 +1279,11 @@ const yokisCommandsExtend = {
         };
     },
     dimmerUpDown: (): ModernExtend => {
-        const exposes = e.enum('DimmerUpDown', ea.SET, ['dimUp', 'dimDown']).withDescription('Dim up or Down').withCategory('config');
+        const exposes = e.enum('dimmer_Up_down_command', ea.SET, ['dimUp', 'dimDown']).withDescription('Dim up or Down').withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['DimmerUpDown'],
+                key: ['dimmer_Up_down_command'],
                 convertSet: async (entity, key, value: string, meta) => {
                     yokisExtendChecks.log(key, value);
                     await entity.command('manuSpecificYokisDimmer', value, {});
@@ -1285,13 +1299,13 @@ const yokisCommandsExtend = {
     },
     dimmerMoveToFavorite: (): ModernExtend => {
         const exposes = e
-            .enum('DimmerMoveToFavorite1', ea.SET, ['moveToFavorite1', 'moveToFavorite2', 'moveToFavorite3'])
+            .enum('dimmer_move_to_favorite', ea.SET, ['moveToFavorite1', 'moveToFavorite2', 'moveToFavorite3'])
             .withDescription('Start dimming to the favorite position 1, 2 or 3')
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['DimmerMoveToFavorite1'],
+                key: ['dimmer_move_to_favorite'],
                 convertSet: async (entity, key, value: string, meta) => {
                     yokisExtendChecks.log(key, value);
                     await entity.command('manuSpecificYokisDimmer', value, {});
@@ -1307,13 +1321,13 @@ const yokisCommandsExtend = {
     },
     dimmerStartNightLightModeCurrent: (): ModernExtend => {
         const exposes = e
-            .enum('DimmerStarnightModeCurrent', ea.SET, ['startNightLightModeCurrent'])
+            .enum('dimmer_start_nightlight_command', ea.SET, ['startNightLightModeCurrent'])
             .withDescription('Trigger Starnight mode from the current diming value')
             .withCategory('config');
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['DimmerStarnightModeCurrent'],
+                key: ['dimmer_start_nightlight_command'],
                 convertSet: async (entity, key, value: string, meta) => {
                     yokisExtendChecks.log(key, value);
                     await entity.command('manuSpecificYokisDimmer', value, {});
@@ -1329,11 +1343,11 @@ const yokisCommandsExtend = {
     },
     dimmerStartNightLightMode: (): ModernExtend => {
         const exposes = e
-            .composite('dimmer_start_nightlight_mode_command', 'dimmerStartNightLightModeProp', ea.SET)
+            .composite('dimmer_start_nightlight_custom_command', 'dimmer_start_nightlight_custom_prop', ea.SET)
             .withDescription('Start the nightlight mode with the given parameters')
             .withFeature(
                 e
-                    .numeric('ul_ChildModeStartingDelay', ea.SET)
+                    .numeric('childmode_starting_delay', ea.SET) // ul_ChildModeStartingDelay
                     .withUnit('ms')
                     .withDescription(
                         'Set the starting delay value, used before the start of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms',
@@ -1341,7 +1355,7 @@ const yokisCommandsExtend = {
             )
             .withFeature(
                 e
-                    .numeric('uc_ChildModeBrightnessStart', ea.SET)
+                    .numeric('childmode_brightness_start', ea.SET) // uc_ChildModeBrightnessStart
                     .withUnit('%')
                     .withDescription(
                         'Set the brightness at the beginning of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %',
@@ -1349,7 +1363,7 @@ const yokisCommandsExtend = {
             )
             .withFeature(
                 e
-                    .numeric('uc_ChildModeBrightnessEnd', ea.SET)
+                    .numeric('childmode_brightness_end', ea.SET) // uc_ChildModeBrightnessEnd
                     .withUnit('%')
                     .withDescription(
                         'Set the brightness at the end of the ramp, otherwise use 0xFF to use the one configured in the product. Value is in %',
@@ -1357,13 +1371,13 @@ const yokisCommandsExtend = {
             )
             .withFeature(
                 e
-                    .numeric('ul_ChildModeRampDuration', ea.SET)
+                    .numeric('childmode_ramp_duration', ea.SET) // ul_ChildModeRampDuration
                     .withUnit('ms')
                     .withDescription('Set the ramp duration, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms'),
             )
             .withFeature(
                 e
-                    .numeric('ul_ChildModeOnDuration', ea.SET)
+                    .numeric('childmode_on_duration', ea.SET) // ul_ChildModeOnDuration
                     .withUnit('ms')
                     .withDescription(
                         'Set the total duration of the nightlight, otherwise use 0xFFFFFFFF to use the one configured in the product. Value is in ms',
@@ -1371,7 +1385,7 @@ const yokisCommandsExtend = {
             )
             .withFeature(
                 e
-                    .numeric('uc_ChildStep', ea.SET)
+                    .numeric('childmode_step', ea.SET) // uc_ChildStep
                     .withUnit('%')
                     .withDescription(
                         'Set the step size between each dim, otherwise use 0xFF to use the one configured in the product. Value is in %',
@@ -1381,7 +1395,7 @@ const yokisCommandsExtend = {
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ['dimmerStartNightLightModeProp'],
+                key: ['dimmer_start_nightlight_custom_prop'],
                 convertSet: async (entity, key, value, meta) => {
                     const commandWrapper = yokisExtendChecks.parseStartNightLightMode(value);
 
@@ -1485,6 +1499,7 @@ const YokisInputExtend: ModernExtend[] = [
     yokisCommandsExtend.selectInputMode(),
 ];
 
+/* Pending checks for a specific device
 const YokisInputExtendWithBacklight: ModernExtend[] = [
     // BacklightIntensity
     numeric({
@@ -1499,6 +1514,7 @@ const YokisInputExtendWithBacklight: ModernExtend[] = [
 
     ...YokisInputExtend,
 ];
+*/
 
 const YokisEntryExtend: ModernExtend[] = [
     // eShortPress
@@ -2141,6 +2157,7 @@ const YokisWindowCoveringExtend: ModernExtend[] = [
     // TODO : Placeholder - pending documentation
 ];
 
+/* Pending checks for a specific device
 const YokisChannelExtend: ModernExtend[] = [
     // On/Off cluster mode
     enumLookup({
@@ -2262,6 +2279,11 @@ When a cluster is specified, the channel will only “control” the device bind
         entityCategory: 'config',
     }),
 ];
+*/
+
+const YokisLoadManagerExtend: ModernExtend[] = [
+    // TODO : Placeholder - pending documentation
+];
 
 const YokisPilotWireExtend: ModernExtend[] = [
     // TODO : Placeholder - pending documentation
@@ -2290,13 +2312,13 @@ const definitions: DefinitionWithExtend[] = [
             deviceAddCustomCluster('manuSpecificYokisStats', YokisClustersDefinition['manuSpecificYokisStats']), // Pending implementation
             onOff({powerOnBehavior: false}), // StartupOnOff is not supported
             identify(),
+            ...YokisSubSystemExtend,
             ...yokisLightControlExtend,
             ...YokisDeviceExtend,
-            // ...YokisInputExtend,
+            ...YokisInputExtend,
             ...YokisEntryExtend,
-            ...YokisSubSystemExtend,
-            // ...YokisLoadManagerExtend, // Pending implementation
-            // ...YokisStatsExtend, // Pending implementation
+            ...YokisLoadManagerExtend, // Pending implementation
+            ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2315,13 +2337,13 @@ const definitions: DefinitionWithExtend[] = [
             deviceAddCustomCluster('manuSpecificYokisStats', YokisClustersDefinition['manuSpecificYokisStats']), // Pending implementation
             onOff({powerOnBehavior: false}), // StartupOnOff is not supported
             identify(),
+            ...YokisSubSystemExtend,
             ...yokisLightControlExtend,
             ...YokisDeviceExtend,
-            // ...YokisInputExtend,
+            ...YokisInputExtend,
             ...YokisEntryExtend,
-            ...YokisSubSystemExtend,
-            // ...YokisLoadManagerExtend, // Pending implementation
-            // ...YokisStatsExtend, // Pending implementation
+            ...YokisLoadManagerExtend, // Pending implementation
+            ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2340,13 +2362,13 @@ const definitions: DefinitionWithExtend[] = [
             deviceAddCustomCluster('manuSpecificYokisStats', YokisClustersDefinition['manuSpecificYokisStats']), // Pending implementation
             onOff({powerOnBehavior: false}), // StartupOnOff is not supported
             identify(),
+            ...YokisSubSystemExtend,
             ...yokisLightControlExtend,
             ...YokisDeviceExtend,
-            // ...YokisInputExtend,
+            ...YokisInputExtend,
             ...YokisEntryExtend,
-            ...YokisSubSystemExtend,
-            // ...YokisLoadManagerExtend, // Pending implementation
-            // ...YokisStatsExtend, // Pending implementation
+            ...YokisLoadManagerExtend, // Pending implementation
+            ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2367,13 +2389,13 @@ const definitions: DefinitionWithExtend[] = [
             light({configureReporting: true, powerOnBehavior: false}), // StartupOnOff is not supported, TODO: review dimmer cluster instead
             identify(),
             ...yokisLightControlExtend,
-            ...YokisDeviceExtend,
-            // ...YokisInputExtend,
-            ...YokisEntryExtend,
             ...YokisSubSystemExtend,
             ...YokisDimmerExtend,
-            // ...YokisLoadManagerExtend, // Pending implementation
-            // ...YokisStatsExtend, // Pending implementation
+            ...YokisDeviceExtend,
+            ...YokisInputExtend,
+            ...YokisEntryExtend,
+            ...YokisLoadManagerExtend, // Pending implementation
+            ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2393,13 +2415,13 @@ const definitions: DefinitionWithExtend[] = [
             identify(),
             windowCovering({controls: ['lift']}),
             commandsWindowCovering(),
-            ...YokisDeviceExtend,
-            // ...YokisInputExtend,
-            // ...YokisEntryExtend,
-            // ...YokisSubSystemExtend,
+            ...YokisSubSystemExtend,
             ...YokisWindowCoveringExtend,
-            // ...YokisLoadManagerExtend, // Pending implementation
-            // ...YokisStatsExtend // Pending implementation
+            ...YokisDeviceExtend,
+            ...YokisInputExtend,
+            ...YokisEntryExtend,
+            ...YokisLoadManagerExtend, // Pending implementation
+            ...YokisStatsExtend, // Pending implementation
         ],
     },
     {
@@ -2424,6 +2446,7 @@ const definitions: DefinitionWithExtend[] = [
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
             // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2447,6 +2470,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2470,6 +2495,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2493,6 +2520,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2516,6 +2545,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2539,6 +2570,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2562,6 +2595,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2586,6 +2621,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2610,6 +2647,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
     {
@@ -2634,6 +2673,8 @@ const definitions: DefinitionWithExtend[] = [
             commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
         ],
     },
 ];


### PR DESCRIPTION
Disclaimer : i do not represent Yokis company, but i was in contact with them to help add support for their devices into Zigbee2Mqtt. This is still a work in progress but the current status is very functional already.

This PR is the first iteration to provide support for Yokis products:
- Declare Yokis custom clusters
- Provide default checks for some attributes
- Use of ModernExtend exclusively

Some clusters are declared but not implemented, as some documentation is still pending and additional tests are required.

List of devices:
- MTR500E-UP
- MTR1300E-UP
- MTR2000E-UP
- MTV300E-UP
- MVR500E-UP
- E2BP-UP / E2BPA-UP
- E4BP-UP / E4BPA-UP / E4BPX-UP
- TLC1-UP
- TLC2-UP
- TLC4-UP
- TLC8-UP
- TLM1-UP / TLM503-UP
- TLM2-UP / TLM2_503-UP
- TLM4-UP / TLM4_503-UP
- GALET4-UP

Another PR will be submitted to the documentation site shortly.