### PR TITLE
Add support for Hue Globe E27 smart bulb

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -147,6 +147,13 @@ const definitions: DefinitionWithExtend[] = [
         extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
+        zigbeeModel: ['LCO001'],
+        model: '8719514419155',
+        vendor: 'Philips',
+        description: 'Hue Globe E27 smart bulb',
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: true})],
+    },
+    {
         zigbeeModel: ['929003056701'],
         model: '929003056701',
         vendor: 'Philips',


### PR DESCRIPTION
It looks fancy, but code-wise not a very bulb, just a regular Philips Hue one with color support.

Comes with https://github.com/Koenkk/zigbee2mqtt.io/pull/3380