### PR TITLE
fix: Fix configure failure for Datek HSE2905E

### DIFF
--- a/src/devices/datek.ts
+++ b/src/devices/datek.ts
@@ -5,7 +5,7 @@ import tz from '../converters/toZigbee';
 import * as constants from '../lib/constants';
 import {repInterval} from '../lib/constants';
 import * as exposes from '../lib/exposes';
-import {electricityMeter, onOff, temperature} from '../lib/modernExtend';
+import {electricityMeter, temperature} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend} from '../lib/types';
 
@@ -41,7 +41,19 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Datek',
         description: 'Datek Eva AMS HAN power-meter sensor',
         fromZigbee: [fz.hw_version],
-        extend: [onOff(), electricityMeter({threePhase: true, fzMetering: fz.metering_datek, producedEnergy: true}), temperature()],
+        extend: [
+            electricityMeter({
+                cluster: 'metering',
+                fzMetering: fz.metering_datek,
+                producedEnergy: true,
+            }),
+            electricityMeter({
+                cluster: 'electrical',
+                threePhase: true,
+                power: false,
+            }),
+            temperature(),
+        ],
         ota: true,
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
The Datek HSE2905E meter reader stopped working properly after a refactor in e8883c0. The device doesn't actually expose an onOff cluster. It also doesn't support power readings on the HA cluster, so separately extend the `electricityMeter` object for SE Metering and HA Electricity Measurement.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/25401
