### PR TITLE
add preset for Salus FC600

### DIFF
--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -1,7 +1,9 @@
+import {Zcl} from 'zigbee-herdsman';
+
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
-import {electricityMeter, onOff} from '../lib/modernExtend';
+import {electricityMeter, onOff, deviceAddCustomCluster, enumLookup} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend} from '../lib/types';
 
@@ -101,7 +103,45 @@ const definitions: DefinitionWithExtend[] = [
         model: 'FC600',
         vendor: 'Salus Controls',
         description: 'Fan coil thermostat',
-        extend: [],
+        extend: [
+            deviceAddCustomCluster('manuSpecificSalus', {
+                ID: 0xfc04,
+                manufacturerCode: Zcl.ManufacturerCode.COMPUTIME,
+                attributes: {
+                    frostSetpoint: {ID: 0x0000, type: Zcl.DataType.INT16},
+                    minFrostSetpoint: {ID: 0x0001, type: Zcl.DataType.INT16},
+                    maxFrostSetpoint: {ID: 0x0002, type: Zcl.DataType.INT16},
+                    timeDisplayFormat: {ID: 0x0003, type: Zcl.DataType.BOOLEAN},
+                    attr4: {ID: 0x0004, type: Zcl.DataType.UINT16},
+                    attr5: {ID: 0x0005, type: Zcl.DataType.UINT8},
+                    attr6: {ID: 0x0006, type: Zcl.DataType.UINT16},
+                    attr7: {ID: 0x0007, type: Zcl.DataType.UINT8},
+                    autoCoolingSetpoint: {ID: 0x0008, type: Zcl.DataType.INT16},
+                    autoHeatingSetpoint: {ID: 0x0009, type: Zcl.DataType.INT16},
+                    holdType: {ID: 0x000a, type: Zcl.DataType.UINT8},
+                    shortCycleProtection: {ID: 0x000b, type: Zcl.DataType.UINT16},
+                    coolingFanDelay: {ID: 0x000c, type: Zcl.DataType.UINT16},
+                    ruleCoolingSetpoint: {ID: 0x000d, type: Zcl.DataType.INT16},
+                    ruleHeatingSetpoint: {ID: 0x000e, type: Zcl.DataType.INT16},
+                    attr15: {ID: 0x000f, type: Zcl.DataType.BOOLEAN},
+                },
+                commands: {
+                    resetDevice: {
+                        ID: 0x01,
+                        parameters: [],
+                    },
+                },
+                commandsResponse: {},
+            }),
+            enumLookup({
+                name: 'preset',
+                lookup: {schedule: 0, temporary_override: 1, permanent_override: 2, standby: 7, eco: 10},
+                cluster: 'manuSpecificSalus',
+                attribute: 'holdType',
+                description: 'Operation mode',
+                reporting:  {min: 0, max: 3600, change: 0},
+            }),
+        ],
         fromZigbee: [fz.thermostat, fz.fan],
         toZigbee: [
             tz.thermostat_local_temperature,
@@ -134,7 +174,7 @@ const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(9);
-            const binds = ['genBasic', 'genIdentify', 'genTime', 'hvacThermostat', 'hvacFanCtrl', 'hvacUserInterfaceCfg'];
+            const binds = ['genBasic', 'genTime', 'hvacThermostat', 'hvacFanCtrl', 'hvacUserInterfaceCfg'];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);

--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -3,7 +3,7 @@ import {Zcl} from 'zigbee-herdsman';
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
-import {electricityMeter, onOff, deviceAddCustomCluster, enumLookup} from '../lib/modernExtend';
+import {deviceAddCustomCluster, electricityMeter, enumLookup, onOff} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend} from '../lib/types';
 
@@ -139,7 +139,7 @@ const definitions: DefinitionWithExtend[] = [
                 cluster: 'manuSpecificSalus',
                 attribute: 'holdType',
                 description: 'Operation mode',
-                reporting:  {min: 0, max: 3600, change: 0},
+                reporting: {min: 0, max: 3600, change: 0},
             }),
         ],
         fromZigbee: [fz.thermostat, fz.fan],


### PR DESCRIPTION
Feedback welcome!

While trying to figure out how to control presets on Salus FC 600 (https://github.com/Koenkk/zigbee-herdsman-converters/pull/8528) I was able to map out parts of a manufacturer specific cluster it uses.

I was able to probe attributes `0x0004`-`0x0007` and `0x000f` (and their data types) but I could not figure out their purpose. I have labeled them `attr4`, `attr5` and so on using their decimal IDs, perhaps someone will figure out the purpose later on. Please let me know if this is not a good approach.

The attributes `0x0000`-`0x0002` don't exist in this device (FC600) but I believe they still belong to this cluster.  Since the cluster is now defined within the device I'm not sure if I should keep them them for documentation purpose, or leave them out.

The command performs a soft reset (reboot) of the thermostat, and the thermostat never sends back the response. I don't know if and how it's possible to flag this, so that the command doesn't time out with an exception when in fact it was successful.

