### PR TITLE
Add Nedis ZBPO130FWT as whitelabel under Tuya TS011F_plug_1

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5522,6 +5522,7 @@ const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel('Elivco', 'LSPA9', 'Smart plug (with power monitoring)', ['_TZ3000_okaz9tjs']),
             tuya.whitelabel('PSMART', 'T440', 'Smart wallsocket (with power monitoring)', ['_TZ3000_y4ona9me']),
             tuya.whitelabel('Nous', 'A6Z', 'Outdoor smart socket', ['_TZ3000_266azbg3']),
+            tuya.whitelabel('Nedis', 'ZBPO130FWT', 'Outdoor smart plug (with power monitoring)', ['_TZ3000_3ias4w4o']),
         ],
         ota: true,
         extend: [


### PR DESCRIPTION
Nedis ZBPO130FWT (_TZ3000_3ias4w4o) outdoor smart plug is detected as a Tuya TS011F_plug_1.