### PR TITLE
Add TZE284_rccxox8p manufacturer ID to PA-44Z converter

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5689,7 +5689,7 @@ const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_m9skfctm', '_TZE200_rccxox8p']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_m9skfctm', '_TZE200_rccxox8p', '_TZE284_rccxox8p']),
         model: 'PA-44Z',
         vendor: 'Tuya',
         description: 'Photoelectric smoke detector',


### PR DESCRIPTION
As mentioned the issue from Zigbee2mqtt repo, the manufacturer id could be added to the PA-44Z converter:

https://github.com/Koenkk/zigbee2mqtt/issues/24916

This is the device:

https://es.aliexpress.com/item/1005005969814125.html?spm=a2g0o.order_list.order_list_main.46.6c26194dG6jP9c&gatewayAdapt=glo2esp

And currently is not detected correctly:

<img width="880" alt="image" src="https://github.com/user-attachments/assets/15a41dd9-91de-4607-9e59-463968321a40" />
