### PR TITLE
Add White Label Girier `JR-ZPM03` Smart Plug (`_TZ3000_okaz9tjs`) to `TS011F_plug_3`

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5593,6 +5593,7 @@ const definitions: DefinitionWithExtend[] = [
             {vendor: 'AVATTO', model: 'MIUCOT10Z'},
             {vendor: 'Neo', model: 'NAS-WR01B'},
             {vendor: 'Neo', model: 'PLUG-001SPB2'},
+            {vendor: 'Girier', model: 'JR-ZPM03', fingerprint: [{manufacturerName: '_TZ3000_okaz9tjs', manufacturerID: 4660}]},
             tuya.whitelabel('Tuya', 'BSD29_1', 'Smart plug (with power monitoring by polling)', ['_TZ3000_okaz9tjs']),
         ],
         ota: true,


### PR DESCRIPTION
This PR adds whitelabel `Girier` model `JR-ZPM03` (manufacturer name `_TZ3000_okaz9tjs`) to the existing `TS011F_plug_3`.

In my case, it's incorrectly shown as Tuya `BSD29_1`, I put the white label to `TS011F_plug_3` and added the `manufacturerID` to the fingerprint to differentiate with the existing.

It addresses the issue reported here https://github.com/Koenkk/zigbee2mqtt/issues/24721 

## Zigbee2MQTT Dashboard

<img width="1237" alt="Screenshot 2025-01-04 at 14 27 04" src="https://github.com/user-attachments/assets/9dc89f86-70a7-4ca6-b3b6-f63d006a539e" />

## Product Image

![IMG_5416](https://github.com/user-attachments/assets/1340a5bf-87a6-4ae9-82da-ba361b3d04a2)
![IMG_5417](https://github.com/user-attachments/assets/33329520-9c9c-44ad-aa42-11359ad01718)

## Product Link

[AliExpress](https://www.aliexpress.com/item/1005006243423977.html)

![S16d4fe526eca4d31b50253f356aed674I](https://github.com/user-attachments/assets/f72fcde7-9342-456b-a68e-5f8ef3993000)

## Device Info JSON

```json
{
  "id": 15,
  "type": "Router",
  "ieeeAddr": "0x70b3d52b60124c70",
  "nwkAddr": 3636,
  "manufId": 4660,
  "manufName": "_TZ3000_okaz9tjs",
  "powerSource": "Mains (single phase)",
  "modelId": "TS011F",
  "epList": [
    1
  ],
  "endpoints": {
    "1": {
      "profId": 260,
      "epId": 1,
      "devId": 81,
      "inClusterList": [
        0,
        6,
        3,
        4,
        5,
        57345,
        2820,
        1794
      ],
      "outClusterList": [
        25
      ],
      "clusters": {
        "genBasic": {
          "attributes": {
            "modelId": "TS011F",
            "manufacturerName": "_TZ3000_okaz9tjs",
            "powerSource": 1,
            "zclVersion": 2,
            "appVersion": 100,
            "stackVersion": 1,
            "hwVersion": 2,
            "dateCode": "20210625",
            "swBuildId": "500+TZSKT31BS102"
          }
        },
        "haElectricalMeasurement": {
          "attributes": {
            "acCurrentDivisor": 1000,
            "acCurrentMultiplier": 1,
            "rmsVoltage": 231,
            "rmsCurrent": 587,
            "activePower": 82
          }
        },
        "seMetering": {
          "attributes": {
            "divisor": 100,
            "multiplier": 1,
            "currentSummDelivered": 229
          }
        },
        "genOnOff": {
          "attributes": {
            "onOff": 1
          }
        },
        "manuSpecificTuya_3": {
          "attributes": {
            "powerOnBehavior": 2
          }
        }
      },
      "binds": [],
      "configuredReportings": [],
      "meta": {}
    }
  },
  "appVersion": 4660,
  "stackVersion": 1,
  "hwVersion": 2,
  "dateCode": "20210625",
  "swBuildId": "500+TZSKT31BS102",
  "zclVersion": 2,
  "interviewCompleted": true,
  "meta": {
    "configured": 332242049
  },
  "lastSeen": 1735989812717
}
```