### PR TITLE
feat(add): TS0726_3_gang

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6707,6 +6707,30 @@ const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint('TS0726', ['_TZ3002_rbnycsav']),
+        model: 'TS0726_3_gang',
+        vendor: 'Tuya',
+        description: '3 gang switch with neutral wire',
+        fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fz.ignore_basic_report, fzLocal.TS0726_action],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode],
+        exposes: [
+            ...[1, 2, 3].map((ep) => e.switch().withEndpoint(`l${ep}`)),
+            ...[1, 2, 3].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
+            ...[1, 2, 3].map((ep) => e.enum('switch_mode', ea.STATE_SET, ['switch', 'scene']).withEndpoint(`l${ep}`)),
+            e.action(['scene_1', 'scene_2', 'scene_3']),
+        ],
+        endpoint: (device) => {
+            return {l1: 1, l2: 2, l3: 3};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            for (const ep of [1, 2, 3]) {
+                await reporting.bind(device.getEndpoint(ep), coordinatorEndpoint, ['genOnOff']);
+            }
+        },
+    },
+    {
         zigbeeModel: ['TS0726'],
         model: 'TS0726_4_gang',
         vendor: 'Tuya',


### PR DESCRIPTION
![Screenshot 2025-01-05 at 12 53 18 PM](https://github.com/user-attachments/assets/8e5b33b7-fd9f-4c50-a4ba-635cb6cbbe8e)

Adding 3-gang version of TS0726 to remove below error logs:

```
z2m: Failed to configure 'Dining switch', attempt 1 (TypeError: Cannot read properties of undefined (reading 'bind')
    at Object.bind (/app/node_modules/.pnpm/zigbee-herdsman-converters@21.12.0/node_modules/src/lib/reporting.ts:42:24)
    at Object.configure (/app/node_modules/.pnpm/zigbee-herdsman-converters@21.12.0/node_modules/src/devices/tuya.ts:6727:33)
    at Configure.configure (/app/lib/extension/configure.ts:124:13)
```


database.db
```
{"id":8,"type":"Router","ieeeAddr":"0xa4c1385e0cef84bf","nwkAddr":57817,"manufId":4417,"manufName":"_TZ3002_rbnycsav","powerSource":"Mains (single phase)","modelId":"TS0726","epList":[1,2,3,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":4,"inClusterList":[3,4,5,6,57344,57345,0],"outClusterList":[25,10],"clusters":{"genBasic":{"attributes":{"65503":"���.\u0016","65506":54,"65508":0,"65534":0,"modelId":"TS0726","manufacturerName":"_TZ3002_rbnycsav","powerSource":1,"zclVersion":3,"appVersion":82,"stackVersion":0,"hwVersion":1,"dateCode":""}},"genOnOff":{"attributes":{"onOff":0,"onTime":0,"offWaitTime":0,"tuyaBacklightMode":1,"moesStartUpOnOff":0,"tuyaBacklightSwitch":1}},"manuSpecificTuya_3":{"attributes":{"powerOnBehavior":0,"switchMode":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x847127fffedfe258","endpointID":1}],"configuredReportings":[],"meta":{}},"2":{"profId":260,"epId":2,"devId":4,"inClusterList":[4,5,6,57345],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":1,"onTime":0,"offWaitTime":0}},"manuSpecificTuya_3":{"attributes":{"powerOnBehavior":0,"switchMode":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x847127fffedfe258","endpointID":1}],"configuredReportings":[],"meta":{}},"3":{"profId":260,"epId":3,"devId":4,"inClusterList":[4,5,6,57345],"outClusterList":[],"clusters":{"genOnOff":{"attributes":{"onOff":1,"onTime":0,"offWaitTime":0}},"manuSpecificTuya_3":{"attributes":{"powerOnBehavior":0,"switchMode":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x847127fffedfe258","endpointID":1}],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":82,"stackVersion":0,"hwVersion":1,"dateCode":"","zclVersion":3,"interviewCompleted":true,"meta":{},"lastSeen":1736050384659}

```