### PR TITLE
New Fix for ZWT198 preset modes

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7091,10 +7091,10 @@ const definitions: DefinitionWithExtend[] = [
                     'preset',
                     tuya.valueConverterBasic.lookup((_, device) => {
                         // https://github.com/Koenkk/zigbee2mqtt/issues/21353#issuecomment-1938328429
-                        if (device.manufacturerName === '_TZE200_viy9ihs7') {
-                            return {auto: tuya.enum(0), manual: tuya.enum(1), temporary_manual: tuya.enum(2)};
-                        } else {
+                        if (device.manufacturerName === '_TZE204_lzriup1j') {
                             return {auto: tuya.enum(1), manual: tuya.enum(0), temporary_manual: tuya.enum(2)};
+                        } else {
+                            return {auto: tuya.enum(0), manual: tuya.enum(1), temporary_manual: tuya.enum(2)};
                         }
                     }),
                 ],


### PR DESCRIPTION
Device info:

Description: Avatto wall thermostat
Zigbee Manufacturer: _TZE204_xnbkhhdr
Model: [ZWT198](https://www.zigbee2mqtt.io/devices/ZWT198_ZWT100-BH.html#tuya-zwt198%252Fzwt100-bh)

Unfortunately, the 2.0.0 update has once again swapped **manual** and **auto** preset modes. I have the _TZE204_xnbkhhdr version, where the following is definitely correct:

{auto: tuya.enum(0), manual: tuya.enum(1), temporary_manual: tuya.enum(2)}

I don't have the other varieties, so I can't check them, but based on a little research:

- based on #8446 and @domome 's comment the correct code for _TZE204_lzriup1j:

   {auto: tuya.enum(1), manual: tuya.enum(0), temporary_manual: tuya.enum(2)} 

- based on #8298 the correct code for _TZE200_viy9ihs7:

   {auto: tuya.enum(0), manual: tuya.enum(1), temporary_manual: tuya.enum(2)}