### PR TITLE
CCT5010-0001 was sold under the name 550B1012 in Denmark

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -682,7 +682,7 @@ const definitions: DefinitionWithExtend[] = [
                 .enum('dimmer_mode', ea.ALL, ['auto', 'rc', 'rl', 'rl_led'])
                 .withDescription('Sets dimming mode to autodetect or fixed RC/RL/RL_LED mode (max load is reduced in RL_LED)'),
         ],
-        whiteLabel: [{vendor: 'Elko', model: 'EKO07090'}],
+        whiteLabel: [{vendor: 'Elko', model: 'EKO07090'}, {vendor: 'Schneider Electric', model: '550B1012'}],
     },
     {
         zigbeeModel: ['PUCK/SWITCH/1'],

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -682,7 +682,10 @@ const definitions: DefinitionWithExtend[] = [
                 .enum('dimmer_mode', ea.ALL, ['auto', 'rc', 'rl', 'rl_led'])
                 .withDescription('Sets dimming mode to autodetect or fixed RC/RL/RL_LED mode (max load is reduced in RL_LED)'),
         ],
-        whiteLabel: [{vendor: 'Elko', model: 'EKO07090'}, {vendor: 'Schneider Electric', model: '550B1012'}],
+        whiteLabel: [
+            {vendor: 'Elko', model: 'EKO07090'},
+            {vendor: 'Schneider Electric', model: '550B1012'},
+        ],
     },
     {
         zigbeeModel: ['PUCK/SWITCH/1'],


### PR DESCRIPTION
Adding as white label model for lack of a better place. It was sold as a fully first-party product, albeit with additional "Lauritz Knudsen by Schneider Electric" branding.

Originally made as a PR to zigbee2mqtt.io: [zigbee2mqtt.io#3351](https://github.com/Koenkk/zigbee2mqtt.io/pull/3351):

> Not sure exactly how we usually document multiple model numbers for the same hardware when it's not quite a white label situation. It was sold with both Schneider Electric and "LK" (Lauritz Knudsen) branding on the device (see https://www.lk.dk/produkter/550B1012/wiser-tradlos-lysdaemper-for-indbygning-puck)
> 
> They exists as two different products in Schneider Electric's catalog
> 
>     * https://www.se.com/dk/da/product/CCT5010-0001/connected-dimmer-wiser-micro-module/
> 
>     * https://www.se.com/dk/da/product/550B1012/wiser-tr%C3%A5dl%C3%B8s-lysd%C3%A6mper-for-indbygning-puck/
> 
> 
> - but their ["dimmer guide"](https://www1.lk.dk/apps/dimmertool/dimmerGuide.ph7) makes it clear that they are in fact the same product with two different SKUs (or CRs whatever that means):
> 
> ![image](https://private-user-images.githubusercontent.com/308129/398305897-7ec2995c-c07c-4cdd-9334-1d73875249d9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzYxNjg5NzMsIm5iZiI6MTczNjE2ODY3MywicGF0aCI6Ii8zMDgxMjkvMzk4MzA1ODk3LTdlYzI5OTVjLWMwN2MtNGNkZC05MzM0LTFkNzM4NzUyNDlkOS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwMTA2JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDEwNlQxMzA0MzNaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01ZjM5ZThhYjliMDkxZjA0NzlhOWZmZjEwMzNkNjI4ZjliMDA3N2MyZjhjOTkxOTc2Njg5NDA4NTBjMTNkZTg0JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.C7AXju7FdTEsEe8W943cF5qSo7gdFyASJqBgQqdxqC4)

