### PR TITLE
fix: Fix Centralite 4257050-ZHAC to ignore 'transition'

### DIFF
--- a/src/devices/centralite.ts
+++ b/src/devices/centralite.ts
@@ -102,7 +102,7 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Centralite',
         description: '3-Series smart dimming outlet',
         fromZigbee: [fz.restorable_brightness, fz.on_off, fz.electrical_measurement],
-        toZigbee: [tz.light_onoff_restorable_brightness],
+        toZigbee: [tz.light_onoff_restorable_brightness, tz.ignore_transition],
         exposes: [e.light_brightness(), e.power(), e.voltage(), e.current()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Came across the error below getting logged when an HA automation was dimming the light down with a transition.

`error: z2m: No converter available for 'transition' (4)`

Added a `tz.ignore_transition` to reduce log spam.
Tested as an external converter using HA add-on running on the latest HAOS.