### PR TITLE
fix Salus FC600 OTA

### DIFF
--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -183,7 +183,7 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.thermostatRunningMode(endpoint);
             await reporting.thermostatRunningState(endpoint);
         },
-        ota: true,
+        ota: {manufacturerName: 'SalusControls'},
     },
 ];
 


### PR DESCRIPTION
Device reports `zhc:tz: Read result of 'genBasic': {"manufacturerName":"SALUS"}` but in OTA index it's `SalusControls`.