### PR TITLE
feat: add A-OK AM25 _TZE200_7shyddj3

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4095,6 +4095,7 @@ const definitions: DefinitionWithExtend[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_2odrmqwq'},
             {modelID: 'TS0601', manufacturerName: '_TZE204_lh3arisb'},
             {modelID: 'TS0601', manufacturerName: '_TZE284_udank5zs'},
+            {modelID: 'TS0601', manufacturerName: '_TZE200_7shyddj3'},
         ],
         model: 'TS0601_cover_1',
         vendor: 'Tuya',


### PR DESCRIPTION
I recently got some roller blinds installed that use the AM25 tube motors from A-OK. They showed up as unsupported but adding the new ID (`_TZE200_7shyddj3`) in an external converter has worked fine for the past few weeks.