### PR TITLE
feat(add): Gewiss GWA1201 two-way switch

### DIFF
--- a/src/devices/gewiss.ts
+++ b/src/devices/gewiss.ts
@@ -1,13 +1,21 @@
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
-import {deviceEndpoints, onOff} from '../lib/modernExtend';
+import {deviceEndpoints, electricityMeter, identify, onOff} from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend} from '../lib/types';
 
 const e = exposes.presets;
 
 const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ['GWA1201_TWO_WAY_SWITCH'],
+        model: 'GWA1201_TWO_WAY_SWITCH',
+        vendor: 'Gewiss',
+        description: 'GWA1201',
+        extend: [onOff(), electricityMeter(), identify()],
+        ota: true,
+    },
     {
         zigbeeModel: ['GWA1521_Actuator_1_CH_PF'],
         model: 'GWA1521',


### PR DESCRIPTION
GWA1201 is a two-way light switch with a push button, two AC inputs and 2 AC outputs controlled by two normal open relays in antiphase (when one output is open, the other is closed or viceversa). It also reports approximate current and energy consumption (but not voltage, apparently) of the load.

https://www.gewiss.com/ww/en/products/product.1000000.1008169.GWA1201

It contains the following endpoints and clusters:

Endpoint 1
- Output clusters
  - genIdentify
  - genBinaryInput
  - genOta
  - msOccupancySensing
- Input clusters
  - genBasic
  - genIdentify
  - genGroups
  - genScenes
  - genOnOff
  - genAlarms
  - seMetering
  - haElectricalMeasurement
  - 64882
  - 64884
  - 64889
  - 64893 Endpoint 20
- Output clusters
  - genIdentify
  - genGroups
  - genScenes
  - genOnOff
  - genLevelCtrl
  - genOta
  - closuresWindowCovering
  - 64880
  - 64881
  - 64882
- Input clusters
  - genBasic
  - genIdentify
  - genBinaryInput
  - msOccupancySensing
  - 64885
  - 64893 Endpoint 30
- Output clusters
  - genIdentify
  - genGroups
  - genScenes
  - genOnOff
  - genLevelCtrl
  - genOta
  - closuresWindowCovering
  - 64880
  - 64881
  - 64882
- Input clusters
  - genBasic
  - genIdentify
  - genBinaryInput
  - msOccupancySensing
  - 64885
  - 64893 Endpoint 100
- Output clusters
  - genIdentify
  - genTime
  - msTemperatureMeasurement
  - 64890
  - Input clusters
  - genBasic
  - genIdentify
  - genGroups
  - msIlluminanceMeasurement
  - 64890
  - 64891
  - 64892 Endpoint 110
- Output clusters
  - genIdentify
  - genGroups
  - genScenes
  - genOnOff
  - genLevelCtrl
  - genOta
  - closuresWindowCovering
  - 64880
  - 64881
  - 64882
- Input clusters
  - genBasic
  - genIdentify
  - genBinaryInput
  - msOccupancySensing
  - 64885
  - 64893 Endpoint 242
- Output clusters
  - greenPower
- Input clusters
  - greenPower

I don't know what more than 3/4 of these clusters do, but the basic functionality is covered with genOnOff, genIdentify and haElectricalMeasurement.

There are also some of these, which I don't know how to suppress:

```
Failed to configure 'Yard light switch', attempt 1 (Error: ZCL command 0x287681fffe05c160/1 haElectricalMeasurement.read(["acVoltageDivisor","acVoltageMultiplier"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')
    at Endpoint.checkStatus (/app/node_modules/.pnpm/zigbee-herdsman@3.2.1/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:349:28)
    at Endpoint.zclCommand (/app/node_modules/.pnpm/zigbee-herdsman@3.2.1/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:954:26)
    at Endpoint.read (/app/node_modules/.pnpm/zigbee-herdsman@3.2.1/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:445:29)
    at result.configure (/app/node_modules/.pnpm/zigbee-herdsman-converters@21.12.0/node_modules/src/lib/modernExtend.ts:1924:37)
    at Object.configure (/app/node_modules/.pnpm/zigbee-herdsman-converters@21.12.0/node_modules/src/index.ts:257:21)
    at Configure.configure (/app/lib/extension/configure.ts:124:13)
    at Configure.onReconfigure (/app/lib/extension/configure.ts:29:9)
    at EventEmitter.wrappedCallback (/app/lib/eventBus.ts:204:17))
```

acVoltageDivisor and acVoltageMultiplier indeed seem to be unsupported attributes, just like rmsVoltage itself.