### PR TITLE
feat: add SIMON i7 2g dimmer light switch

### DIFF
--- a/src/devices/simon.ts
+++ b/src/devices/simon.ts
@@ -1,0 +1,34 @@
+import {deviceEndpoints, light} from '../lib/modernExtend';
+import {DefinitionWithExtend} from '../lib/types';
+
+const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ['SM0502'],
+        model: 'i7 SM0502',
+        vendor: 'SIMON',
+        description: 'i7 2-gang smart dimming switch',
+        extend: [
+            deviceEndpoints({
+                endpoints: {
+                    l1: 1,
+                    l2: 2,
+                },
+            }),
+            light({
+                endpointNames: ['l1'],
+                configureReporting: true,
+            }),
+            light({
+                endpointNames: ['l2'],
+                configureReporting: true,
+            }),
+        ],
+        meta: {
+            multiEndpoint: true,
+            multiEndpointSkip: ['state', 'brightness'],
+        },
+    },
+];
+
+export default definitions;
+module.exports = definitions;


### PR DESCRIPTION
Added support for dimmers. 

- Works: State+Control for On/Off/Brightness for the 2 separate switches