### PR TITLE
Ubisys S1-R (Series 2)

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -6,6 +6,7 @@ import * as exposes from '../lib/exposes';
 import * as legacy from '../lib/legacy';
 import * as light from '../lib/light';
 import {logger} from '../lib/logger';
+import {determineEndpoint} from '../lib/modernExtend';
 import * as globalStore from '../lib/store';
 import {KeyValue, KeyValueAny, Tz} from '../lib/types';
 import * as utils from '../lib/utils';
@@ -1791,46 +1792,53 @@ const converters2 = {
     electrical_measurement_power: {
         key: ['power'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['activePower']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['activePower']);
         },
     } satisfies Tz.Converter,
     electrical_measurement_power_phase_b: {
         key: ['power_phase_b'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['activePowerPhB']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['activePowerPhB']);
         },
     } satisfies Tz.Converter,
     electrical_measurement_power_phase_c: {
         key: ['power_phase_c'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['activePowerPhC']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['activePowerPhC']);
         },
     } satisfies Tz.Converter,
     metering_power: {
         key: ['power'],
         convertGet: async (entity, key, meta) => {
             utils.assertEndpoint(entity);
-            await utils.enforceEndpoint(entity, key, meta).read('seMetering', ['instantaneousDemand']);
+            const ep = determineEndpoint(entity, meta, 'seMetering');
+            await ep.read('seMetering', ['instantaneousDemand']);
         },
     } satisfies Tz.Converter,
     currentsummdelivered: {
         key: ['energy'],
         convertGet: async (entity, key, meta) => {
             utils.assertEndpoint(entity);
-            await utils.enforceEndpoint(entity, key, meta).read('seMetering', ['currentSummDelivered']);
+            const ep = determineEndpoint(entity, meta, 'seMetering');
+            await ep.read('seMetering', ['currentSummDelivered']);
         },
     } satisfies Tz.Converter,
     currentsummreceived: {
         key: ['produced_energy'],
         convertGet: async (entity, key, meta) => {
             utils.assertEndpoint(entity);
-            await utils.enforceEndpoint(entity, key, meta).read('seMetering', ['currentSummReceived']);
+            const ep = determineEndpoint(entity, meta, 'seMetering');
+            await ep.read('seMetering', ['currentSummReceived']);
         },
     } satisfies Tz.Converter,
     frequency: {
         key: ['ac_frequency'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['acFrequency']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['acFrequency']);
         },
     } satisfies Tz.Converter,
     electrical_measurement_power_reactive: {
@@ -1842,43 +1850,50 @@ const converters2 = {
     powerfactor: {
         key: ['power_factor'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['powerFactor']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['powerFactor']);
         },
     } satisfies Tz.Converter,
     acvoltage: {
         key: ['voltage'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['rmsVoltage']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['rmsVoltage']);
         },
     } satisfies Tz.Converter,
     acvoltage_phase_b: {
         key: ['voltage_phase_b'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['rmsVoltagePhB']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['rmsVoltagePhB']);
         },
     } satisfies Tz.Converter,
     acvoltage_phase_c: {
         key: ['voltage_phase_c'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['rmsVoltagePhC']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['rmsVoltagePhC']);
         },
     } satisfies Tz.Converter,
     accurrent: {
         key: ['current'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['rmsCurrent']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['rmsCurrent']);
         },
     } satisfies Tz.Converter,
     accurrent_phase_b: {
         key: ['current_phase_b'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['rmsCurrentPhB']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['rmsCurrentPhB']);
         },
     } satisfies Tz.Converter,
     accurrent_phase_c: {
         key: ['current_phase_c'],
         convertGet: async (entity, key, meta) => {
-            await entity.read('haElectricalMeasurement', ['rmsCurrentPhC']);
+            const ep = determineEndpoint(entity, meta, 'haElectricalMeasurement');
+            await ep.read('haElectricalMeasurement', ['rmsCurrentPhC']);
         },
     } satisfies Tz.Converter,
     temperature: {

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -752,7 +752,7 @@ const definitions: DefinitionWithExtend[] = [
         endpoint: (device) => {
             return {l1: 1, l2: 2, s1: 3, s2: 4};
         },
-        meta: {multiEndpoint: true},
+        meta: {multiEndpoint: true, multiEndpointSkip: ['power', 'energy']},
         options: [exposes.options.measurement_poll_interval()],
         extend: [ubisysModernExtend.addCustomClusterManuSpecificUbisysDeviceSetup()],
         configure: async (device, coordinatorEndpoint) => {
@@ -940,7 +940,7 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.instantaneousDemand(endpoint);
         },
-        meta: {multiEndpoint: true},
+        meta: {multiEndpoint: true, multiEndpointSkip: ['state', 'brightness', 'power', 'energy']},
         options: [exposes.options.measurement_poll_interval()],
         endpoint: (device) => {
             return {default: 1, s1: 2, s2: 3};

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -616,32 +616,22 @@ const definitions: DefinitionWithExtend[] = [
         model: 'S1',
         vendor: 'Ubisys',
         description: 'Power switch S1',
-        exposes: [
-            e.switch(),
-            e.action(['toggle', 'on', 'off', 'recall_*', 'brightness_move_up', 'brightness_move_down', 'brightness_stop']),
-            e.power_on_behavior(),
-            e.power().withAccess(ea.STATE_GET),
-            e.energy().withAccess(ea.STATE_GET),
-        ],
-        fromZigbee: [
-            fz.on_off,
-            fz.metering,
-            fz.command_toggle,
-            fz.command_on,
-            fz.command_off,
-            fz.command_recall,
-            fz.command_move,
-            fz.command_stop,
-            fz.power_on_behavior,
-            ubisys.fz.configure_device_setup,
-        ],
-        toZigbee: [tz.on_off, tz.metering_power, tz.currentsummdelivered, ubisys.tz.configure_device_setup, tz.power_on_behavior],
-        endpoint: (device) => {
-            return {l1: 1, s1: 2, meter: 3};
-        },
-        meta: {multiEndpointEnforce: {power: 3, energy: 3}},
+        fromZigbee: [ubisys.fz.configure_device_setup],
+        toZigbee: [ubisys.tz.configure_device_setup],
+        //endpoint: (device) => {
+        //    return {l1: 1, s1: 2, meter: 3};
+        //},
+        //meta: {multiEndpointEnforce: {power: 3, energy: 3}},
         options: [exposes.options.measurement_poll_interval()],
-        extend: [ubisysModernExtend.addCustomClusterManuSpecificUbisysDeviceSetup()],
+        extend: [
+            // NOTE: identify is supported but no visual indicator so omitted here
+            m.onOff({powerOnBehavior: true}),
+            m.electricityMeter({cluster: 'metering', configureReporting: false}),
+            m.commandsOnOff({endpointNames: ['2']}),
+            m.commandsLevelCtrl({endpointNames: ['2']}),
+            m.commandsColorCtrl({endpointNames: ['2']}),
+            ubisysModernExtend.addCustomClusterManuSpecificUbisysDeviceSetup(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(3);
             await reporting.bind(endpoint, coordinatorEndpoint, ['seMetering']);

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -618,10 +618,10 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Power switch S1',
         fromZigbee: [ubisys.fz.configure_device_setup],
         toZigbee: [ubisys.tz.configure_device_setup],
-        //endpoint: (device) => {
-        //    return {l1: 1, s1: 2, meter: 3};
-        //},
-        //meta: {multiEndpointEnforce: {power: 3, energy: 3}},
+        endpoint: (device) => {
+            return {l1: 1, s1: 2};
+        },
+        meta: {multiEndpoint: true},
         options: [exposes.options.measurement_poll_interval()],
         extend: [
             // NOTE: identify is supported but no visual indicator so omitted here
@@ -666,17 +666,9 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Power switch S1-R',
         fromZigbee: [ubisys.fz.configure_device_setup],
         toZigbee: [ubisys.tz.configure_device_setup],
-        //meta: {multiEndpointEnforce: {power: 4, energy: 4}},
-        //endpoint: (device) => {
-        //    const endpoints = {l1: 1, s1: 2, s2: 3, meter: 4};
-        //
-        //  // Series 2 (hwVer >= 16 has metering on endpoint 1)
-        //    if (device.hardwareVersion >= 16) {
-        //        endpoints.meter = 1;
-        //    }
-        //
-        //    return endpoints;
-        //},
+        endpoint: (device) => {
+            return {l1: 1, s1: 2, s2: 3};
+        },
         options: [exposes.options.measurement_poll_interval()],
         extend: [
             m.identify(),
@@ -759,9 +751,9 @@ const definitions: DefinitionWithExtend[] = [
         ],
         toZigbee: [tz.on_off, tz.metering_power, ubisys.tz.configure_device_setup, tz.power_on_behavior, tz.currentsummdelivered],
         endpoint: (device) => {
-            return {l1: 1, l2: 2, s1: 3, s2: 4, meter: 5};
+            return {l1: 1, l2: 2, s1: 3, s2: 4};
         },
-        meta: {multiEndpoint: true, multiEndpointSkip: ['power', 'energy'], multiEndpointEnforce: {power: 5, energy: 5}},
+        meta: {multiEndpoint: true},
         options: [exposes.options.measurement_poll_interval()],
         extend: [ubisysModernExtend.addCustomClusterManuSpecificUbisysDeviceSetup()],
         configure: async (device, coordinatorEndpoint) => {
@@ -949,10 +941,10 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.instantaneousDemand(endpoint);
         },
-        meta: {multiEndpoint: true, multiEndpointSkip: ['state', 'brightness', 'power', 'energy'], multiEndpointEnforce: {power: 4, energy: 4}},
+        meta: {multiEndpoint: true},
         options: [exposes.options.measurement_poll_interval()],
         endpoint: (device) => {
-            return {default: 1, s1: 2, s2: 3, meter: 4};
+            return {default: 1, s1: 2, s2: 3};
         },
         onEvent: async (type, data, device, settings) => {
             /*
@@ -1022,10 +1014,7 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint1, coordinatorEndpoint, ['closuresWindowCovering']);
             await reporting.currentPositionLiftPercentage(endpoint1);
         },
-        endpoint: (device) => {
-            return {default: 1, meter: 3};
-        },
-        meta: {multiEndpointEnforce: {power: 3, energy: 3}},
+        meta: {multiEndpoint: true},
         options: [exposes.options.measurement_poll_interval()],
         onEvent: async (type, data, device, settings) => {
             /*
@@ -1059,11 +1048,6 @@ const definitions: DefinitionWithExtend[] = [
             fz.command_cover_open,
             fz.command_cover_close,
             fz.command_cover_stop,
-            // NOTE:    Previous configuration if something does not work correctly. Easy way to roll back
-            //legacy.fz.ubisys_c4_scenes,
-            //legacy.fz.ubisys_c4_onoff,
-            //legacy.fz.ubisys_c4_level,
-            //legacy.fz.ubisys_c4_cover,
             ubisys.fz.configure_device_setup,
         ],
         toZigbee: [ubisys.tz.configure_device_setup],

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -621,7 +621,6 @@ const definitions: DefinitionWithExtend[] = [
         endpoint: (device) => {
             return {l1: 1, s1: 2};
         },
-        meta: {multiEndpoint: true},
         options: [exposes.options.measurement_poll_interval()],
         extend: [
             // NOTE: identify is supported but no visual indicator so omitted here
@@ -1014,7 +1013,6 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint1, coordinatorEndpoint, ['closuresWindowCovering']);
             await reporting.currentPositionLiftPercentage(endpoint1);
         },
-        meta: {multiEndpoint: true},
         options: [exposes.options.measurement_poll_interval()],
         onEvent: async (type, data, device, settings) => {
             /*

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -674,39 +674,29 @@ const definitions: DefinitionWithExtend[] = [
         model: 'S1-R',
         vendor: 'Ubisys',
         description: 'Power switch S1-R',
-        exposes: [
-            e.switch(),
-            e.action(['toggle', 'on', 'off', 'recall_*', 'brightness_move_up', 'brightness_move_down', 'brightness_stop']),
-            e.power_on_behavior(),
-            e.power().withAccess(ea.STATE_GET),
-            e.energy().withAccess(ea.STATE_GET),
-        ],
-        fromZigbee: [
-            fz.on_off,
-            fz.metering,
-            fz.command_toggle,
-            fz.command_on,
-            fz.command_off,
-            fz.command_recall,
-            fz.command_move,
-            fz.command_stop,
-            fz.power_on_behavior,
-            ubisys.fz.configure_device_setup,
-        ],
-        toZigbee: [tz.on_off, tz.metering_power, tz.currentsummdelivered, ubisys.tz.configure_device_setup, tz.power_on_behavior],
-        meta: {multiEndpointEnforce: {power: 4, energy: 4}},
-        endpoint: (device) => {
-            const endpoints = {l1: 1, s1: 2, meter: 4};
-
-            // Series 2 (hwVer >= 16 has metering on endpoint 1)
-            if (device.hardwareVersion >= 16) {
-                endpoints.meter = 1;
-            }
-
-            return endpoints;
-        },
-        extend: [ubisysModernExtend.addCustomClusterManuSpecificUbisysDeviceSetup()],
+        fromZigbee: [ubisys.fz.configure_device_setup],
+        toZigbee: [ubisys.tz.configure_device_setup],
+        //meta: {multiEndpointEnforce: {power: 4, energy: 4}},
+        //endpoint: (device) => {
+        //    const endpoints = {l1: 1, s1: 2, s2: 3, meter: 4};
+        //
+        //  // Series 2 (hwVer >= 16 has metering on endpoint 1)
+        //    if (device.hardwareVersion >= 16) {
+        //        endpoints.meter = 1;
+        //    }
+        //
+        //    return endpoints;
+        //},
         options: [exposes.options.measurement_poll_interval()],
+        extend: [
+            m.identify(),
+            m.onOff({powerOnBehavior: true}),
+            m.electricityMeter({cluster: 'metering', configureReporting: false}),
+            m.commandsOnOff({endpointNames: ['2', '3']}),
+            m.commandsLevelCtrl({endpointNames: ['2', '3']}),
+            m.commandsColorCtrl({endpointNames: ['2', '3']}),
+            ubisysModernExtend.addCustomClusterManuSpecificUbisysDeviceSetup(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             // Series 2 has metering on endpoint 1, older devices on endpoint 4
             // hardwareVersion is 16


### PR DESCRIPTION
Ubisys support contacted me since customers seem to have problems with this device on the latest z2m.

Based on information from them the only big change is that the metering is now done on endpoint 1 not 4. We can differentiate between the `S1-R` and `S1-R Series 2` by checking genBasic.hwVersion.

I don't have a S1-R and S1-R Series 2 myself and there is also no easy way to install both to make this easier, however ubisys support has a test setup using z2m on HA and they can test this before it gets merged.

So far this PR does the following:
- drop the attempt to support the series 2 using fingerprinting, this does not to be working at all (based on comments from ubisys support, and these devices are (nearly) identical and share the same zigbeeModel as such)
- switch all use of `ubisysOnEventReadCurrentSummDelivered` over to `ubisysPollCurrentSummDelivered`
- pull in some of the modernExtend changes from fingerprint variant
- update endpoints and configure functions to key of device.hardwareVersion
- add missing endpoint 3 for S1-R as per technical manual

But I got stuck on the following:
- telling the electricityMeter modernExtend to use a different endpoint based on device.hardwareVersion
- ~~S1-R seems to support powerOnBehavior based on the existing code, but it was disabled on the series 2 one.~~
<img width="952" alt="image" src="https://github.com/user-attachments/assets/9df46a7d-7f3a-4545-b4ca-6e462be63e65" />

Technical manual says this is supported.


@Koenkk can you help me with the electricityMeter metering one? Also I though there was a guide somewhere on how to test changes like this on z2m when using HA, but I can't find it anymore. What would be the easiest way for Ubisys support to pull in these changes to test?

Meanwhile I will reach out to support and point them to this draft PR, they should be able to answer my other open issue.