### PR TITLE
Add support for Moes BHT series Thermostat device (TS0601/_TZE204_xalsoe3m)

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -108,6 +108,7 @@ const definitions: DefinitionWithExtend[] = [
             {modelID: 'TS0601', manufacturerName: '_TZE204_aoclfnxz'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_u9bfwha0'},
             {modelID: 'TS0601', manufacturerName: '_TZE204_u9bfwha0'},
+            {modelID: 'TS0601', manufacturerName: '_TZE204_xalsoe3m'},
         ],
         model: 'BHT-002-GCLZB',
         vendor: 'Moes',


### PR DESCRIPTION
This device has the same functionality as `_TZE204_aoclfnxz`.