### PR TITLE
Add Niko switch action reporting functionality

### DIFF
--- a/src/devices/niko.ts
+++ b/src/devices/niko.ts
@@ -227,8 +227,6 @@ const local = {
         switch_led_sync_mode: {
             key: ['led_sync_mode'],
             convertSet: async (entity, key, value, meta) => {
-                // This could be set endpoint specific, where the first 4 bits are used for the left button and the last 4 bits for the right button
-                //const ep = meta.endpoint_name === undefined ? 1 : {l1: 1, l2: 2}[meta.endpoint_name];
                 const ledSyncMap: {[key: string]: number} = {Off: 0, On: 1, Inverted: 2};
                 // @ts-expect-error ignore
                 if (ledSyncMap[value] === undefined) {


### PR DESCRIPTION
Some Niko switches are not reporting state updates as 'action' values.
Based on research in https://github.com/Koenkk/zigbee2mqtt/issues/13737 and https://github.com/zigpy/zha-device-handlers/pull/3701.

Changes:
* Add `switchActionReporting` attribute to enable or disable the reporting of `action` values
* Move custom Niko Clusters `manuSpecificNiko1` and `manuSpecificNiko2` from zigbee-herdsman to modernExtend `manuSpecificNikoConfig` and `manuSpecificNikoState`
* Change `ledState` property from `ON/OFF` to `ON/OFF/Blue/Red/Purple`
* Add `ledSyncMode` option
* Change `action` implementation to support pushing multiple buttons together
* action `null` values are not published anymore