### PR TITLE
Workaround IKEA bulbs freezing during a brightness & color transition

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -33,7 +33,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1545G12",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 980 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: [
@@ -102,7 +102,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1936G5",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 440/450/470 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: [
@@ -114,14 +114,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2003G10",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/27, white spectrum, globe, opal, 1055/1100/1160 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRIbulbE26WSglobeclear800lm", "TRADFRIbulbE27WSglobeclear806lm", "TRADFRIbulbE26WSglobeclear806lm"],
         model: "LED2004G8",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, clear, 800/806 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: [
@@ -169,14 +169,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1732G11",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 1000 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E27 WW 806lm", "TRADFRI bulb E26 WW 806lm"],
         model: "LED1836G9",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, warm white, globe, opal, 806 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({turnsOffAtBrightness1: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({turnsOffAtBrightness1: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E27 WS clear 806lm", "TRADFRI bulb E26 WS clear 806lm"],
@@ -209,7 +209,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2035G10",
         vendor: "IKEA",
         description: "TRADFRI bulb B22, white spectrum, globe, opal, 1055 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     // #endregion E26/E27/B22
     {
@@ -225,7 +225,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "TRADFRI bulb E12/E14/E26/E27, color/white spectum, globe, opal, 600 lm",
         extend: [
             addCustomClusterManuSpecificIkeaUnknown(),
-            ikeaLight({colorTemp: {range: [153, 500], viaColor: true}, color: true}), // light is pure RGB (XY), advertise 2000K-6500K
+            ikeaLight({colorTemp: {range: [153, 500], viaColor: true}, color: true, withUnfreezeSupport: true}), // light is pure RGB (XY), advertise 2000K-6500K
             m.identify(),
         ],
     },
@@ -249,7 +249,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1835C6",
         vendor: "IKEA",
         description: "TRADFRI bulb E12/E14/E17, white spectrum, candle, opal, 450/470/440 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E14 WS globe 470lm", "TRADFRI bulb E12 WS globe 450lm"],
@@ -263,7 +263,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1733G7",
         vendor: "IKEA",
         description: "TRADFRI bulb E14, white spectrum, globe, opal, 600 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E14 W op/ch 400lm", "TRADFRI bulb E12 W op/ch 400lm", "TRADFRI bulb E17 W op/ch 400lm"],
@@ -317,7 +317,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1949C5",
         vendor: "IKEA",
         description: "TRADFRI bulb E12/E14/E17, white spectrum, candle, opal, 450/470/440 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E14 CWS globe 806lm", "TRADFRI bulb E12 CWS globe 800lm", "TRADFRI bulb E17 CWS globe 810lm"],
@@ -346,7 +346,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1537R6/LED1739R5",
         vendor: "IKEA",
         description: "TRADFRI bulb GU10, white spectrum, 400 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb GU10 W 400lm"],

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -33,7 +33,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1545G12",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 980 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: [
@@ -102,7 +102,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1936G5",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 440/450/470 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: [
@@ -114,14 +114,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2003G10",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/27, white spectrum, globe, opal, 1055/1100/1160 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRIbulbE26WSglobeclear800lm", "TRADFRIbulbE27WSglobeclear806lm", "TRADFRIbulbE26WSglobeclear806lm"],
         model: "LED2004G8",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, clear, 800/806 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: [
@@ -169,14 +169,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1732G11",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 1000 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E27 WW 806lm", "TRADFRI bulb E26 WW 806lm"],
         model: "LED1836G9",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, warm white, globe, opal, 806 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({turnsOffAtBrightness1: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({turnsOffAtBrightness1: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E27 WS clear 806lm", "TRADFRI bulb E26 WS clear 806lm"],
@@ -209,7 +209,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2035G10",
         vendor: "IKEA",
         description: "TRADFRI bulb B22, white spectrum, globe, opal, 1055 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     // #endregion E26/E27/B22
     {
@@ -225,7 +225,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "TRADFRI bulb E12/E14/E26/E27, color/white spectum, globe, opal, 600 lm",
         extend: [
             addCustomClusterManuSpecificIkeaUnknown(),
-            ikeaLight({colorTemp: {range: [153, 500], viaColor: true}, color: true, withUnfreezeSupport: true}), // light is pure RGB (XY), advertise 2000K-6500K
+            ikeaLight({colorTemp: {range: [153, 500], viaColor: true}, color: true}), // light is pure RGB (XY), advertise 2000K-6500K
             m.identify(),
         ],
     },
@@ -249,7 +249,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1835C6",
         vendor: "IKEA",
         description: "TRADFRI bulb E12/E14/E17, white spectrum, candle, opal, 450/470/440 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E14 WS globe 470lm", "TRADFRI bulb E12 WS globe 450lm"],
@@ -263,7 +263,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1733G7",
         vendor: "IKEA",
         description: "TRADFRI bulb E14, white spectrum, globe, opal, 600 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E14 W op/ch 400lm", "TRADFRI bulb E12 W op/ch 400lm", "TRADFRI bulb E17 W op/ch 400lm"],
@@ -317,7 +317,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1949C5",
         vendor: "IKEA",
         description: "TRADFRI bulb E12/E14/E17, white spectrum, candle, opal, 450/470/440 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E14 CWS globe 806lm", "TRADFRI bulb E12 CWS globe 800lm", "TRADFRI bulb E17 CWS globe 810lm"],
@@ -346,7 +346,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1537R6/LED1739R5",
         vendor: "IKEA",
         description: "TRADFRI bulb GU10, white spectrum, 400 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, withUnfreezeSupport: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb GU10 W 400lm"],

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -921,6 +921,10 @@ export const options = {
         new Binary("local_temperature_based_on_sensor", access.SET, true, false)
             .withLabel("Local temperature sensor reporting")
             .withDescription("Base local temperature on sensor choice (default false)."),
+    unfreeze_support: () =>
+        new Binary("unfreeze_support", access.SET, true, false).withDescription(
+            "Whether to unfreeze IKEA lights (that are known to be frozen) before issuing a command, false: no unfreeze support, true: unfreeze support (default true).",
+        ),
 };
 
 export const presets = {

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -871,7 +871,11 @@ const willFreeze = (clusterKey: string | number, payload: KeyValue): payload is 
     payload.rate !== 1 &&
     payload.movemode !== 0;
 
-// keys for whom we need to unfreeze the light before issuing a corresponding command to said light
+// Certain IKEA lights will freeze when given a brightness or temperature change with a transition
+// We track if a light is frozen and if so, before issuing further commands, we send a command known to unfreeze the light
+// https://github.com/Koenkk/zigbee2mqtt/issues/18574
+//
+// These are keys for whom we need to unfreeze the light before issuing a corresponding command to said light
 const keysNeedingUnfreeze = new Set(["state", "brightness", "brightness_percent", "color_temp", "color_temp_percent"]);
 
 const ikea_bulb_unfreeze = (next: Tz.Converter["convertSet"]) => {

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -78,7 +78,7 @@ const bulbOnEvent: OnEvent = async (type, data, device, options, state: KeyValue
     }
 };
 
-export function ikeaLight(args?: Omit<m.LightArgs, "colorTemp"> & {colorTemp?: true | {range: Range; viaColor: true}}) {
+export function ikeaLight(args?: Omit<m.LightArgs, "colorTemp"> & {colorTemp?: true | {range: Range; viaColor: true}; withUnfreezeSupport?: true}) {
     const colorTemp: {range: Range} = args?.colorTemp ? (args.colorTemp === true ? {range: [250, 454]} : args.colorTemp) : undefined;
     const levelConfig: {disabledFeatures?: LevelConfigFeatures} = args?.levelConfig
         ? args.levelConfig
@@ -93,7 +93,7 @@ export function ikeaLight(args?: Omit<m.LightArgs, "colorTemp"> & {colorTemp?: t
         result.exposes.push(presets.light_color_options());
     }
 
-    if (result.toZigbee) {
+    if (args?.withUnfreezeSupport && result.toZigbee) {
         result.toZigbee = result.toZigbee.map((orig) => {
             if (orig.key?.some((k) => keysNeedingUnfreeze.has(k))) {
                 return {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -461,7 +461,7 @@ export function getTransition(entity: Zh.Endpoint | Zh.Group, key: string, meta:
         manufacturerIDs = [entity.getDevice().manufacturerID];
     }
 
-    if (manufacturerIDs.includes(4476)) {
+    if (manufacturerIDs.includes(Zcl.ManufacturerCode.IKEA_OF_SWEDEN)) {
         /**
          * When setting both brightness and color temperature with a transition, the brightness is skipped
          * for IKEA TRADFRI bulbs.


### PR DESCRIPTION
This PR resolves Koenkk/zigbee2mqtt#18574 by unfreezing IKEA bulbs (that we know to be frozen) before sending commands to them.

Any toZigbee handlers that use commands which will need the bulb to not be frozen are wrapped by `ikea_bulb_unfreeze()`.

`ikea_bulb_unfreeze()` will:
- detect if the key is likely to need an unfreeze (e.g. `state: off`) and if so:
- install a proxy the entity's `command()` method where:
        - a frozen bulb is unfrozen before submitting a command to it
        - remember that a bulb is frozne, if a freezing command is sent to the bulb (e.g. colour transition)

The unfreeze method used is `genLevelCtrl.stop`, which works for all bulbs (as far as we know) and crucially completes the previous transition, which is probably more beneficial than leaving the bulb in a halfway state.

[Brightness transitions] with a colour are still skipped (Koenkk/zigbee2mqtt#1810) - this PR does not alter that.

Tested with:
```sh
pub() {
  mosquitto_pub -t "$light"/set -m "$1"
}

light=zigbee2mqtt/...

echo "turning on, dim & cool"
pub '{"state": "on", "brightness": 2, "color_temp": 150, "transition": 0}'

sleep 2
echo "converting to bright & warm"
pub '{"brightness": 255, "color_temp": 500, "transition": 5}'

sleep 3
echo "turning off"
pub '{"state": "off"}'
```


[Brightness transitions]: https://github.com/Koenkk/zigbee-herdsman-converters/blob/b1ea96f097c53e78b363433e0b96e992afe7914d/src/lib/utils.ts#L464-L474=
