### PR TITLE
Support _TZE200_jkfbph7l (AVATTO ME167)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4757,6 +4757,7 @@ const definitions: DefinitionWithExtend[] = [
             '_TZE200_bvu2wnxz' /* model: 'ME167', vendor: 'AVATTO' */,
             '_TZE200_6rdj8dzm' /* model: 'ME167', vendor: 'AVATTO' */,
             '_TZE200_9xfjixap' /* model: 'ME167', vendor: 'AVATTO' */,
+            '_TZE200_jkfbph7l' /* model: 'ME167', vendor: 'AVATTO' */,
             '_TZE200_p3dbf6qs' /* model: 'ME168', vendor: 'AVATTO' */,
             '_TZE200_rxntag7i' /* model: 'ME168', vendor: 'AVATTO' */,
             '_TZE200_ybsqljjg' /* model: 'ME168', vendor: 'AVATTO' */,
@@ -4779,6 +4780,7 @@ const definitions: DefinitionWithExtend[] = [
                 '_TZE200_bvu2wnxz',
                 '_TZE200_6rdj8dzm',
                 '_TZE200_9xfjixap',
+                '_TZE200_jkfbph7l'
             ]),
             tuya.whitelabel('AVATTO', 'ME168', 'Thermostatic radiator valve', ['_TZE200_rxntag7i', '_TZE200_ybsqljjg']),
             tuya.whitelabel('AVATTO', 'TRV06_1', 'Thermostatic radiator valve', ['_TZE200_hvaxb2tc', '_TZE284_o3x45p96']),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4780,7 +4780,7 @@ const definitions: DefinitionWithExtend[] = [
                 '_TZE200_bvu2wnxz',
                 '_TZE200_6rdj8dzm',
                 '_TZE200_9xfjixap',
-                '_TZE200_jkfbph7l'
+                '_TZE200_jkfbph7l',
             ]),
             tuya.whitelabel('AVATTO', 'ME168', 'Thermostatic radiator valve', ['_TZE200_rxntag7i', '_TZE200_ybsqljjg']),
             tuya.whitelabel('AVATTO', 'TRV06_1', 'Thermostatic radiator valve', ['_TZE200_hvaxb2tc', '_TZE284_o3x45p96']),


### PR DESCRIPTION
I bought six of these AVATTO ME167 thermostatic radiator valve, two of them came with a different vendor id (visually the same device). Here is the support for the devices with the `_TZE200_jkfbph7l` id.

Successful locally tested via an external converter. 