### PR TITLE
Fix CO2 value interpretation

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -503,7 +503,7 @@ const converters1 = {
         cluster: 'msCO2',
         type: ['attributeReport', 'readResponse'],
         convert: (model, msg, publish, options, meta) => {
-            return {co2: Math.floor(msg.data.measuredValue * 1000000)};
+            return {co2: Math.floor(1 / msg.data.measuredValue)};
         },
     } satisfies Fz.Converter,
     occupancy: {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -941,15 +941,18 @@ export function occupancy(args?: OccupancyArgs): ModernExtend {
 }
 
 export function co2(args?: Partial<NumericArgs>) {
+    const fraction_of_1: ScaleFunction = (value: number, type: 'from' | 'to') => {
+        return 1 / value;
+    };
     return numeric({
         name: 'co2',
         cluster: 'msCO2',
         label: 'CO2',
         attribute: 'measuredValue',
-        reporting: {min: '10_SECONDS', max: '1_HOUR', change: 0.00005}, // 50 ppm change
+        reporting: {min: '10_SECONDS', max: '1_HOUR', change: fraction_of_1(50 /*ppm*/, 'to')},
         description: 'Measured value',
         unit: 'ppm',
-        scale: 0.000001,
+        scale: fraction_of_1,
         access: 'STATE_GET',
         ...args,
     });

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -941,7 +941,7 @@ export function occupancy(args?: OccupancyArgs): ModernExtend {
 }
 
 export function co2(args?: Partial<NumericArgs>) {
-    const fraction_of_1: ScaleFunction = (value: number, type: 'from' | 'to') => {
+    const fractionOf1: ScaleFunction = (value: number, type: 'from' | 'to') => {
         return 1 / value;
     };
     return numeric({
@@ -949,10 +949,10 @@ export function co2(args?: Partial<NumericArgs>) {
         cluster: 'msCO2',
         label: 'CO2',
         attribute: 'measuredValue',
-        reporting: {min: '10_SECONDS', max: '1_HOUR', change: fraction_of_1(50 /*ppm*/, 'to')},
+        reporting: {min: '10_SECONDS', max: '1_HOUR', change: fractionOf1(50 /*ppm*/, 'to')},
         description: 'Measured value',
         unit: 'ppm',
-        scale: fraction_of_1,
+        scale: fractionOf1,
         access: 'STATE_GET',
         ...args,
     });


### PR DESCRIPTION
The zigbee standard specifies that the values of section 4.13 Concentration Measurement are to be represented between 0 and 1 (section 4.13.2.1 Attributes). Further it is explained in section 4.13.2.1.1 MeasuredValue Attribute that "MeasuredValue represents the concentration as a fraction of 1 (one)."

Because the current implementation multiplies the given MeasuredValue by 1000000 (million) the published value is not only wrong, but changes in the inverse direction. The larger the actual measured value becomes (the larger the denominator is), the smaller MeasuredValue becomes.

| Device (PPM) | MeasuredValue | z2m (PPM) |
|--------------|---------------|-----------|
| 800          | 0.00125       | 1250      |
| 1250         | 0.00080       | 800       |


- [x] I have tried this change as external converter with my own co2 zigbee device.
- [ ] Dependent changes
   - `modernExtend.ts` seems to make similar assumptions too, but I do not know how / when `scale` and `change` are used - before or after the conversion took place.
   - some other place?
- [ ] Figure out if some existing devices actually implement MeasuredValue in the current way. And provide device specific workarounds.
   - I would need help with that, as I own no other co2 sensor.