### PR TITLE
Custom system/preset mode mapping for TRV602Z

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5216,7 +5216,7 @@ const definitions: DefinitionWithExtend[] = [
                         on: tuya.enum(5),
                     }),
                 ],
-                [2, 'system_mode', tuya.valueConverter.thermostatSystemModeAndPreset('system_mode')],
+                [2, 'system_mode', tuya.valueConverter.thermostatTRV602ZSystemModeAndPreset('system_mode')],
                 [3, 'running_state', tuya.valueConverterBasic.lookup({heat: 1, idle: 0})],
                 [4, 'current_heating_setpoint', tuya.valueConverter.divideBy10],
                 [5, 'local_temperature', tuya.valueConverter.divideBy10],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5204,18 +5204,8 @@ const definitions: DefinitionWithExtend[] = [
         ],
         meta: {
             tuyaDatapoints: [
-                [
-                    2,
-                    'preset',
-                    tuya.valueConverterBasic.lookup({
-                        off: tuya.enum(0),
-                        antifrost: tuya.enum(1),
-                        eco: tuya.enum(2),
-                        comfort: tuya.enum(3),
-                        auto: tuya.enum(4),
-                        on: tuya.enum(5),
-                    }),
-                ],
+                [2, null, tuya.valueConverter.thermostatTRV602ZSystemModeAndPreset(null)],
+                [2, 'preset', tuya.valueConverter.thermostatTRV602ZSystemModeAndPreset('preset')],
                 [2, 'system_mode', tuya.valueConverter.thermostatTRV602ZSystemModeAndPreset('system_mode')],
                 [3, 'running_state', tuya.valueConverterBasic.lookup({heat: 1, idle: 0})],
                 [4, 'current_heating_setpoint', tuya.valueConverter.divideBy10],

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1192,6 +1192,9 @@ export const valueConverter = {
                 };
                 const systemModeLookup = {
                     0: 'off',
+                    1: 'auto',
+                    2: 'auto',
+                    3: 'auto',
                     4: 'auto',
                     5: 'heat',
                 };

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1178,6 +1178,44 @@ export const valueConverter = {
             },
         };
     },
+    thermostatTRV602ZSystemModeAndPreset: (toKey: string) => {
+        return {
+            from: (v: string) => {
+                utils.assertNumber(v, 'system_mode');
+                const presetLookup = {
+                    0: 'off',
+                    1: 'antifrost',
+                    2: 'eco',
+                    3: 'comfort',
+                    4: 'auto',
+                    5: 'on',
+                };
+                const systemModeLookup = {
+                    0: 'off',
+                    4: 'auto',
+                    5: 'heat',
+                };
+                return {preset: presetLookup[v], system_mode: systemModeLookup[v]};
+            },
+            to: (v: string) => {
+                const presetLookup = {
+                    off: new Enum(0),
+                    antifrost: new Enum(1),
+                    eco: new Enum(2),
+                    comfort: new Enum(3),
+                    auto: new Enum(4),
+                    on: new Enum(5),
+                };
+                const systemModeLookup = {
+                    off: new Enum(0),
+                    auto: new Enum(4),
+                    heat: new Enum(5),
+                };
+                const lookup = toKey === 'preset' ? presetLookup : systemModeLookup;
+                return utils.getFromLookup(v, lookup);
+            },
+        };
+    },
     ZWT198_schedule: {
         from: (value: number[], meta: Fz.Meta, options: KeyValue) => {
             const programmingMode = [];


### PR DESCRIPTION
The default value converter `thermostatSystemModeAndPreset` is not suitable for this valve. Currently system mode "heat" changes preset mode to "comfort" while system mode "off" changes preset mode to "eco".

Please do not merge this PR yet. For some reason with these changes the valve will not respond to changing system or preset modes at all. I have zero past experience with this so I hope @Koenkk or @SteveOswald (as you made changes to this valve's support recently) can see where I made a mistake. At the moment I'm out of ideas. Nothing in the Z2M logs even with the debug level.