### PR TITLE
feat: add SIMON i7 2g dimmer light switch

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -250,6 +250,7 @@ import shinasystem from './shinasystem';
 import shyugj from './shyugj';
 import siglis from './siglis';
 import sikom from './sikom';
+import simon from './simon';
 import sinope from './sinope';
 import siterwell from './siterwell';
 import skydance from './skydance';
@@ -569,6 +570,7 @@ export default [
     ...shyugj,
     ...siglis,
     ...sikom,
+    ...simon,
     ...sinope,
     ...siterwell,
     ...skydance,

--- a/src/devices/simon.ts
+++ b/src/devices/simon.ts
@@ -4,26 +4,10 @@ import {DefinitionWithExtend} from '../lib/types';
 const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ['SM0502'],
-        model: 'i7 SM0502',
+        model: 'SM0502',
         vendor: 'SIMON',
         description: 'i7 2-gang smart dimming switch',
-        extend: [
-            deviceEndpoints({
-                endpoints: {
-                    left: 1,
-                    right: 2,
-                },
-            }),
-            light({
-                endpointNames: ['left'],
-            }),
-            light({
-                endpointNames: ['right'],
-            }),
-        ],
-        meta: {
-            multiEndpoint: true,
-        },
+        extend: [deviceEndpoints({endpoints: {left: 1, right: 2}}), light({endpointNames: ['left', 'right']})],
     },
 ];
 

--- a/src/devices/simon.ts
+++ b/src/devices/simon.ts
@@ -1,0 +1,31 @@
+import {deviceEndpoints, light} from '../lib/modernExtend';
+import {DefinitionWithExtend} from '../lib/types';
+
+const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ['SM0502'],
+        model: 'i7 SM0502',
+        vendor: 'SIMON',
+        description: 'i7 2-gang smart dimming switch',
+        extend: [
+            deviceEndpoints({
+                endpoints: {
+                    left: 1,
+                    right: 2,
+                },
+            }),
+            light({
+                endpointNames: ['left'],
+            }),
+            light({
+                endpointNames: ['right'],
+            }),
+        ],
+        meta: {
+            multiEndpoint: true,
+        },
+    },
+];
+
+export default definitions;
+module.exports = definitions;


### PR DESCRIPTION
Add support for SIMON's 2g dimmer switches. This allows control and state(On/Off/Brightness) reporting for both 'Left' and 'Right' gang switches.