### PR TITLE
fix TZE200/TZE204_ya4ft0w4 forgetting settings

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10905,8 +10905,8 @@ const definitions: DefinitionWithExtend[] = [
             e.numeric('distance', ea.STATE).withDescription('Target distance'),
             e.binary('find_switch', ea.STATE_SET, 'ON', 'OFF').withDescription('distance switch'),
             e.illuminance().withDescription('Illuminance sensor'),
-            e.numeric('move_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(10).withValueStep(1).withDescription('Motion Sensitivity'),
-            e.numeric('presence_sensitivity', ea.STATE_SET).withValueMin(0).withValueMax(10).withValueStep(1).withDescription('Presence Sensitivity'),
+            e.numeric('move_sensitivity', ea.STATE_SET).withValueMin(1).withValueMax(10).withValueStep(1).withDescription('Motion Sensitivity'),
+            e.numeric('presence_sensitivity', ea.STATE_SET).withValueMin(1).withValueMax(10).withValueStep(1).withDescription('Presence Sensitivity'),
             e
                 .numeric('detection_distance_min', ea.STATE_SET)
                 .withValueMin(0)


### PR DESCRIPTION
Should fix that the device loses settings:
https://github.com/Koenkk/zigbee2mqtt/issues/24049

minimum presence and detection sensivity must be at least 1 else settings are getting lost e.g. at service restart,
Tested with my  _TZE204_ya4ft0w4.

see values from:
https://github.com/wzwenzhi/Wenzhi-ZigBee2mqtt/blob/main/M100-ya4ft0-V3-20240907.js

Yushi Nishida