### PR TITLE
SmartThings IM6001-MPP01: change constants.repInterval to 1 minute from 5 hours

### DIFF
--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -308,13 +308,13 @@ const definitions: DefinitionWithExtend[] = [
             await endpoint.write('genPollCtrl', {longPollInterval: 3600});
             await reporting.temperature(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
-            const payloadA = reporting.payload('acceleration', 10, constants.repInterval.HOUR, 5);
+            const payloadA = reporting.payload('acceleration', 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadA, options);
-            const payloadX = reporting.payload('x_axis', 10, constants.repInterval.HOUR, 5);
+            const payloadX = reporting.payload('x_axis', 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadX, options);
-            const payloadY = reporting.payload('y_axis', 10, constants.repInterval.HOUR, 5);
+            const payloadY = reporting.payload('y_axis', 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadY, options);
-            const payloadZ = reporting.payload('z_axis', 10, constants.repInterval.HOUR, 5);
+            const payloadZ = reporting.payload('z_axis', 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting('manuSpecificSamsungAccelerometer', payloadZ, options);
         },
         exposes: [e.temperature(), e.contact(), e.battery_low(), e.tamper(), e.battery(), e.moving(), e.x_axis(), e.y_axis(), e.z_axis()],


### PR DESCRIPTION
Accelerometer sensors for SmartThings IM6001-MPP01 were all reporting NULL. I adjusted constants.repInterval to 1 minute from 5 hours which is how the other SmartThings devices with accelerometers are coded. Tested as external converter on my own setup and can confirm movement is reported properly.