### PR TITLE
Fix missing mqtt action messages for Legrand Wireless Shutter switch (0067646)

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -111,7 +111,7 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Legrand',
         description: 'Wireless shutter switch',
         ota: true,
-        meta: {battery: {voltageToPercentage: {min: 2500, max: 3000}}},
+        meta: {battery: {voltageToPercentage: {min: 2500, max: 3000}}, publishDuplicateTransaction: true},
         fromZigbee: [
             fz.identify,
             fz.ignore_basic_report,


### PR DESCRIPTION
Update Legrand Wireless Shutter switch (0067646)
Same fix as Legrand Wireless switches 067773/067774 as per [issue 14256](https://github.com/Koenkk/zigbee2mqtt/issues/14256 )
Tested as external converter and confirmed working