### PR TITLE
Invert direction for Smartwings shades

### DIFF
--- a/src/devices/smartwings.ts
+++ b/src/devices/smartwings.ts
@@ -5,13 +5,15 @@ import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend, Tz, Zh} from '../lib/types';
 import {assertString, getFromLookup, getOptions} from '../lib/utils';
 
-const backwards_cover_state = {
-    key: ['state'],
-    convertSet: async (entity: Zh.Endpoint, key: string, value: number | string, meta: Tz.Meta) => {
-        const lookup = {open: 'downClose', close: 'upOpen', stop: 'stop', on: 'downClose', off: 'upOpen'};
-        assertString(value, key);
-        value = value.toLowerCase();
-        await entity.command('closuresWindowCovering', getFromLookup(value, lookup), {}, getOptions(meta.mapped, entity));
+const tzLocal = {
+    backwards_cover_state: {
+        key: ['state'],
+        convertSet: async (entity: Zh.Endpoint, key: string, value: number | string, meta: Tz.Meta) => {
+            const lookup = {open: 'downClose', close: 'upOpen', stop: 'stop', on: 'downClose', off: 'upOpen'};
+            assertString(value, key);
+            value = value.toLowerCase();
+            await entity.command('closuresWindowCovering', getFromLookup(value, lookup), {}, getOptions(meta.mapped, entity));
+        },
     },
 };
 
@@ -24,7 +26,7 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Smartwings',
         description: 'Roller shade',
         fromZigbee: [fz.cover_position_tilt, fz.battery],
-        toZigbee: [backwards_cover_state, tz.cover_position_tilt],
+        toZigbee: [tzLocal.backwards_cover_state, tz.cover_position_tilt],
         meta: {battery: {dontDividePercentage: true}, coverInverted: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/smartwings.ts
+++ b/src/devices/smartwings.ts
@@ -2,7 +2,18 @@ import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
 import * as reporting from '../lib/reporting';
-import {DefinitionWithExtend} from '../lib/types';
+import {DefinitionWithExtend, Tz, Zh} from '../lib/types';
+import {assertString, getFromLookup, getOptions} from '../lib/utils';
+
+const backwards_cover_state = {
+    key: ['state'],
+    convertSet: async (entity: Zh.Endpoint, key: string, value: number | string, meta: Tz.Meta) => {
+        const lookup = {open: 'downClose', close: 'upOpen', stop: 'stop', on: 'downClose', off: 'upOpen'};
+        assertString(value, key);
+        value = value.toLowerCase();
+        await entity.command('closuresWindowCovering', getFromLookup(value, lookup), {}, getOptions(meta.mapped, entity));
+    },
+};
 
 const e = exposes.presets;
 
@@ -13,7 +24,7 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Smartwings',
         description: 'Roller shade',
         fromZigbee: [fz.cover_position_tilt, fz.battery],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt],
+        toZigbee: [backwards_cover_state, tz.cover_position_tilt],
         meta: {battery: {dontDividePercentage: true}, coverInverted: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Inspired by ZHA's approach, and feedback form SmartWings support, I confirmed that this converter works and am now proposing that we merge it to the main codebase.

For shades to work well, you still need to invert their Zigbee state (press Up & Down together for 5s, then Press the P button under the battery cover once).

Fixes https://github.com/koenkk/zigbee2mqtt/issues/22847
The above issue is where I got the external converter code from, I slightly adjusted it to be more consistent with the code in this repository, but logic should be identical.

ZHA's pull request for those shades has a lot of investigation and context on them: https://github.com/zigpy/zha-device-handlers/pull/2220