### PR TITLE
SNZB-02D - add support for comfort levels and temperature units.

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -853,7 +853,80 @@ const definitions: DefinitionWithExtend[] = [
         model: 'SNZB-02D',
         vendor: 'SONOFF',
         description: 'Temperature and humidity sensor with screen',
-        extend: [m.battery(), m.temperature(), m.humidity(), m.bindCluster({cluster: 'genPollCtrl', clusterType: 'input'})],
+        extend: [
+            m.deviceAddCustomCluster('customSonoffSnzb02d', {
+                ID: 0xfc11,
+                attributes: {
+                    comfortTemperatureMax: {ID: 0x0003, type: Zcl.DataType.INT16},
+                    comfortTemperatureMin: {ID: 0x0004, type: Zcl.DataType.INT16},
+                    comfortHumidityMin: {ID: 0x0005, type: Zcl.DataType.UINT16},
+                    comfortHumidityMax: {ID: 0x0006, type: Zcl.DataType.UINT16},
+                    temperatureUnits: {ID: 0x0007, type: Zcl.DataType.UINT16},
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+            m.battery(),
+            m.temperature(),
+            m.humidity(),
+            m.bindCluster({cluster: 'genPollCtrl', clusterType: 'input'}),
+            m.numeric({
+                name: 'comfort_temperature_min',
+                cluster: 'customSonoffSnzb02d',
+                attribute: 'comfortTemperatureMin',
+                description:
+                    'Minimum temperature that is considered comfortable. The device will display ❄️ when the temperature is lower than this value. Note: wake up the device by pressing the button on the back before changing this value.',
+                valueMin: -10,
+                valueMax: 60,
+                scale: 100,
+                valueStep: 0.1,
+                unit: '°C',
+            }),
+            m.numeric({
+                name: 'comfort_temperature_max',
+                cluster: 'customSonoffSnzb02d',
+                attribute: 'comfortTemperatureMax',
+                description:
+                    'Maximum temperature that is considered comfortable. The device will display 🔥 when the temperature is higher than this value. Note: wake up the device by pressing the button on the back before changing this value.',
+                valueMin: -10,
+                valueMax: 60,
+                scale: 100,
+                valueStep: 0.1,
+                unit: '°C',
+            }),
+            m.numeric({
+                name: 'comfort_humidity_min',
+                cluster: 'customSonoffSnzb02d',
+                attribute: 'comfortHumidityMin',
+                description:
+                    'Minimum relative humidity that is considered comfortable. The device will display ☀️ when the humidity is lower than this value. Note: wake up the device by pressing the button on the back before changing this value.',
+                valueMin: 5,
+                valueMax: 95,
+                scale: 100,
+                valueStep: 0.1,
+                unit: '%',
+            }),
+            m.numeric({
+                name: 'comfort_humidity_max',
+                cluster: 'customSonoffSnzb02d',
+                attribute: 'comfortHumidityMax',
+                description:
+                    'Maximum relative humidity that is considered comfortable. The device will display 💧 when the humidity is higher than this value. Note: wake up the device by pressing the button on the back before changing this value.',
+                valueMin: 5,
+                valueMax: 95,
+                scale: 100,
+                valueStep: 0.1,
+                unit: '%',
+            }),
+            m.enumLookup({
+                name: 'temperature_units',
+                lookup: {Celsius: 0, Fahrenheit: 1},
+                cluster: 'customSonoffSnzb02d',
+                attribute: 'temperatureUnits',
+                description:
+                    'The unit of the temperature displayed on the device screen. Note: wake up the device by pressing the button on the back before changing this value.',
+            }),
+        ],
     },
     {
         fingerprint: [


### PR DESCRIPTION
Adds support for setting the temperature and humidity comfort levels, in addition to setting the display temperature units (Celsius/Fahrenheit) on the Sonoff SNZB-02D. Depending on these values, icons are displayed on the device as shown below:

![IMG_4358](https://github.com/user-attachments/assets/4ca3e763-b9f2-460e-bcc7-fa8e5422835d)
![IMG_4359](https://github.com/user-attachments/assets/a4d4ed9b-523d-4256-8c9b-88ed745f58c1)

The properties are exposed in the Z2M UI as shown below:

<img width="1328" alt="image" src="https://github.com/user-attachments/assets/387e817b-f3e4-41cc-8f03-3d096a0ab30c" />

Note that the button on the back of the device needs to be pressed before changing the values in the Z2M UI. Not entirely sure why (presumably to wake it up to receive commands), the device sends a ZCL "On/Off: Toggle" command when the button is pressed. This is the same behaviour when using the Sonoff Bridge and the eWeLink app (the app waits for the button press before writing attributes to the device).



