### PR TITLE
Add Lidl HG09155C and HG09155B to the list of Lidl devices

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1592,7 +1592,7 @@ const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel('Lidl', 'HG07834B/HG09155B/HG08131B', 'Livarno Home E14 candle RGB+CCT', ['_TZ3000_th6zqqy6']),
             tuya.whitelabel('Lidl', 'HG07834B', 'Livarno Home E14 candle RGB+CCT', ['_TZ3000_wr6g6olr']),
             tuya.whitelabel('Lidl', 'HG08131C', 'Livarno Home outdoor E27 bulb in set with flare', ['_TZ3000_q50zhdsc']),
-            tuya.whitelabel('Lidl', 'HG07834C/HG08131C', 'Livarno Home E27 bulb RGB+CCT', ['_TZ3000_qd7hej8u']),
+            tuya.whitelabel('Lidl', 'HG07834C/HG09155C/HG08131C', 'Livarno Home E27 bulb RGB+CCT', ['_TZ3000_qd7hej8u']),
             tuya.whitelabel('MiBoxer', 'FUT037Z+', 'RGB led controller', ['_TZB210_417ikxay', '_TZB210_wxazcmsh']),
             tuya.whitelabel('Lidl', 'HG08383B', 'Livarno outdoor LED light chain', ['_TZ3000_bwlvyjwk']),
             tuya.whitelabel('Lidl', 'HG08383A', 'Livarno outdoor LED light chain', ['_TZ3000_taspddvq']),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1589,7 +1589,7 @@ const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel('Lidl', '14158704L', 'Livarno Home LED floor lamp, RGBW', ['_TZ3210_z1vlyufu']),
             tuya.whitelabel('Lidl', '14158804L', 'Livarno Home LED desk lamp RGBW', ['_TZ3210_hxtfthp5']),
             tuya.whitelabel('Lidl', 'HG07834A/HG09155A/HG08131A', 'Livarno Home GU10 spot RGB+CCT', ['_TZ3000_quqaeew6']),
-            tuya.whitelabel('Lidl', 'HG07834B/HG08131B', 'Livarno Home E14 candle RGB+CCT', ['_TZ3000_th6zqqy6']),
+            tuya.whitelabel('Lidl', 'HG07834B/HG09155B/HG08131B', 'Livarno Home E14 candle RGB+CCT', ['_TZ3000_th6zqqy6']),
             tuya.whitelabel('Lidl', 'HG07834B', 'Livarno Home E14 candle RGB+CCT', ['_TZ3000_wr6g6olr']),
             tuya.whitelabel('Lidl', 'HG08131C', 'Livarno Home outdoor E27 bulb in set with flare', ['_TZ3000_q50zhdsc']),
             tuya.whitelabel('Lidl', 'HG07834C/HG08131C', 'Livarno Home E27 bulb RGB+CCT', ['_TZ3000_qd7hej8u']),


### PR DESCRIPTION
@Adastreia [reported](https://github.com/Koenkk/zigbee2mqtt/issues/21286#issuecomment-2617086442), that his HG09155C and HG09155B are not correctly identified. This PR will add both devices to the list of devices for the alias.

