### PR TITLE
Device/tuya bac 002

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3457,6 +3457,14 @@ const definitions: DefinitionWithExtend[] = [
                     .withSetpoint('current_heating_setpoint', 5, 35, 1, ea.STATE_SET)
                     .withPreset(['auto', 'manual'])
                     .withLocalTemperatureCalibration(-3, 3, 1, ea.STATE_SET),
+                e.child_lock(),
+                e
+                    .composite('schedule', 'schedule', ea.STATE_SET)
+                    .withFeature(e.text('weekdays', ea.SET).withDescription('Schedule (1-5), 4 periods in format "hh:mm/tt".'))
+                    .withFeature(e.text('saturday', ea.SET).withDescription('Schedule (6), 4 periods in format "hh:mm/tt".'))
+                    .withFeature(e.text('sunday', ea.SET).withDescription('Schedule (7), 4 periods in format "hh:mm/tt".'))
+                    .withDescription('Auto-mode schedule, 4 periods each per category. Example: "06:00/20 11:30/21 13:30/22 17:30/23.5".'),
+                e.max_temperature().withValueMin(35).withValueMax(45).withPreset('default', 35, 'Default value'),
                 e
                     .numeric('deadzone_temperature', ea.STATE_SET)
                     .withUnit('°C')
@@ -3465,13 +3473,6 @@ const definitions: DefinitionWithExtend[] = [
                     .withValueStep(1)
                     .withPreset('default', 1, 'Default value')
                     .withDescription('The delta between local_temperature and current_heating_setpoint to trigger activity'),
-                e.child_lock(),
-                e
-                    .composite('schedule', 'schedule', ea.STATE_SET)
-                    .withFeature(e.text('weekdays', ea.SET).withDescription('Schedule (1-5), 4 periods in format "hh:mm/tt".'))
-                    .withFeature(e.text('saturday', ea.SET).withDescription('Schedule (6), 4 periods in format "hh:mm/tt".'))
-                    .withFeature(e.text('sunday', ea.SET).withDescription('Schedule (7), 4 periods in format "hh:mm/tt".'))
-                    .withDescription('Auto-mode schedule, 4 periods each per category. Example: "06:00/20 11:30/21 13:30/22 17:30/23.5".'),
             ];
         },
         meta: {
@@ -3518,6 +3519,7 @@ const definitions: DefinitionWithExtend[] = [
                 ],
                 [4, 'preset', tuya.valueConverterBasic.lookup({manual: true, auto: false})],
                 [16, 'current_heating_setpoint', tuya.valueConverter.raw],
+                [19, 'max_temperature', tuya.valueConverter.raw],
                 [24, 'local_temperature', tuya.valueConverter.divideBy10],
                 [26, 'deadzone_temperature', tuya.valueConverter.raw],
                 [27, 'local_temperature_calibration', tuya.valueConverter.localTemperatureCalibration],


### PR DESCRIPTION
Refactored BAC-002-AZLB / BAC-003:

* Added device specific setting to indicate if 2-pipe (cooling / fan) or 4-pipe (cooling, heating & fan) mode is configured on the device, adjusting available `system_mode` options accordingly
* Updated onEvent to `onEventSetLocalTime` correcting the device day / time as reported in https://github.com/Koenkk/zigbee2mqtt/issues/25718
* Added meta `publishDuplicateTransaction: true`, as device originated messages are always `seqId` 1. (This fixes broken device updates (not reflecting) in zigbee2mqtt somewhere recently, possibly version 2.x upgrade?)
* Removed `state` attribute entirely, as Home Assistant and others use `system_mode` for climate controls
* Refactored schedule format and parsing logic somewhere more maintainable
* Added `max_temperature` datapoint from device service menu
* Removed `current_cooling_setpoint` as it confused downstream systems, though intended to fix Matter integration
* Tidied up DP#2 to use a single meta configuration entry