### PR TITLE
Add another fingerprint for Tuya TOQCB2-80 device

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,7 @@
-[![NPM](https://nodei.co/npm/zigbee-herdsman-converters.png)](https://nodei.co/npm/zigbee-herdsman-converters/)
+# NOTICE
 
-# zigbee-herdsman-converters
+This is a custom forked version of zigbee-herdsman-converters by Koen Kanters.
 
-Collection of device converters to be used with zigbee-herdsman.
+For general use, please refer to Koen Kanters's awesome projects:
 
-## Breaking changes
-
-20.0.0
-
-- A toZigbee converter is now allowed to not define any `key`, in this case the converter should be used for any key.
-
-    19.0.0
-
-- Legacy extend was removed
-
-    18.0.0
-
-- After converting a message with a fromZigbee converter, `postProcessConvertedFromZigbeeMessage` should be called now (for applying calibration/precision)
-
-    17.0.0
-
-- Various methods in `index.ts` are now async and return a `Promise`
-
-    15.0.0
-
-- OTA `isUpdateAvailable` now returns an object instead of a boolean (e.g. `{available: true, currentFileVersion: 120, otaFileVersion: 125}`)
-- OTA `updateToLatest` now returns a number (`fileVersion` of the new OTA) instead of a void
-
-## Contributing
-
-See [Zigbee2MQTT how to support new devices](https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html).
-
-## Submitting a pull request
-
-If you'd like to submit a pull request, you should run the following commands to ensure your changes will pass the tests:
-
-```sh
-npm install -g pnpm
-pnpm install --frozen-lockfile
-pnpm run eslint --fix
-pnpm run pretty:write
-pnpm run build
-pnpm test
-```
-
-If any of those commands finish with an error your PR won't pass the tests and will likely be rejected.
+[zigbee2mqtt](https://github.com/Koenkk/zigbee2mqtt) and [zigbee-herdsman](https://github.com/Koenkk/zigbee-herdsman)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "zigbee-herdsman-converters",
+    "name": "@namelessd76/zigbee-herdsman-converters",
     "version": "21.27.0",
-    "description": "Collection of device converters to be used with zigbee-herdsman",
+    "description": "Custom fork from zigbee-herdsman-converters",
     "main": "index.js",
     "types": "index.d.ts",
     "files": [
@@ -16,7 +16,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Koenkk/zigbee-herdsman-converters.git"
+        "url": "git+https://github.com/namelessd76/zigbee-herdsman-converters.git"
     },
     "keywords": [
         "aqara",
@@ -39,7 +39,7 @@
         "prepack": "pnpm run clean && pnpm run build",
         "prepare": "husky"
     },
-    "author": "Koen Kanters",
+    "author": "Nameless D",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/Koenkk/zigbee-herdsman-converters/issues"

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12374,7 +12374,7 @@ const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_q22avxbv', '_TZE204_mrffaamu', '_TZE204_tzreobvu']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE204_q22avxbv', '_TZE204_mrffaamu', '_TZE204_tzreobvu', '_TZE284_mrffaamu']),
         model: 'TOQCB2-80',
         vendor: 'Tuya',
         description: 'Smart circuit breaker',


### PR DESCRIPTION
I've got a Tongou Tuya Smart Circuit Breaker (https://www.aliexpress.com/item/1005006420715418.html) which has a sticker TOQCB2-80 on it, but it's reported as _TZE284_mrffaamu instead of already supported _TZE204_mrffaamu.