### PR TITLE
Yokis : updating device definition

### DIFF
--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -2411,8 +2411,8 @@ const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        // E2BPA-UP
-        zigbeeModel: ['E2BPA-UP', 'E2BP-UP'],
+        // E2BP-UP
+        zigbeeModel: ['E2BP-UP'],
         model: 'E2BP-UP',
         vendor: 'YOKIS',
         description: 'Flush-mounted independent 2-channel transmitter',
@@ -2436,8 +2436,33 @@ const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        // E4BPA-UP
-        zigbeeModel: ['E4BPA-UP', 'E4BP-UP', 'E4BPX-UP'],
+        // E2BPA-UP
+        zigbeeModel: ['E2BPA-UP'],
+        model: 'E2BPA-UP',
+        vendor: 'YOKIS',
+        description: 'Flush-mounted independent 2-channel transmitter (main powered)',
+        extend: [
+            deviceAddCustomCluster('manuSpecificYokisDevice', YokisClustersDefinition['manuSpecificYokisDevice']),
+            deviceAddCustomCluster('manuSpecificYokisInput', YokisClustersDefinition['manuSpecificYokisInput']),
+            deviceAddCustomCluster('manuSpecificYokisLightControl', YokisClustersDefinition['manuSpecificYokisLightControl']),
+            deviceAddCustomCluster('manuSpecificYokisDimmer', YokisClustersDefinition['manuSpecificYokisDimmer']),
+            deviceAddCustomCluster('manuSpecificYokisWindowCovering', YokisClustersDefinition['manuSpecificYokisWindowCovering']), // Pending implementation
+            deviceAddCustomCluster('manuSpecificYokisChannel', YokisClustersDefinition['manuSpecificYokisChannel']),
+            deviceAddCustomCluster('manuSpecificYokisPilotWire', YokisClustersDefinition['manuSpecificYokisPilotWire']), // Pending implementation
+            deviceEndpoints({endpoints: {'1': 1, '2': 2}}),
+            identify(),
+            commandsOnOff(),
+            commandsLevelCtrl(),
+            commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
+        ],
+    },
+    {
+        // E4BP-UP
+        zigbeeModel: ['E4BP-UP'],
         model: 'E4BP-UP',
         vendor: 'YOKIS',
         description: 'Flush-mounted independent 4-channel transmitter',
@@ -2454,6 +2479,31 @@ const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff(),
             m.commandsLevelCtrl(),
             m.commandsWindowCovering(),
+            // ...YokisDeviceExtend,
+            // ...YokisInputExtend,
+            // ...YokisChannelExtend,
+            ...YokisPilotWireExtend,
+        ],
+    },
+    {
+        // E4BPX-UP
+        zigbeeModel: ['E4BPX-UP'],
+        model: 'E4BPX-UP',
+        vendor: 'YOKIS',
+        description: 'Flush-mounted independent 4-channel transmitter (with antenna)',
+        extend: [
+            deviceAddCustomCluster('manuSpecificYokisDevice', YokisClustersDefinition['manuSpecificYokisDevice']),
+            deviceAddCustomCluster('manuSpecificYokisInput', YokisClustersDefinition['manuSpecificYokisInput']),
+            deviceAddCustomCluster('manuSpecificYokisLightControl', YokisClustersDefinition['manuSpecificYokisLightControl']),
+            deviceAddCustomCluster('manuSpecificYokisDimmer', YokisClustersDefinition['manuSpecificYokisDimmer']),
+            deviceAddCustomCluster('manuSpecificYokisWindowCovering', YokisClustersDefinition['manuSpecificYokisWindowCovering']), // Pending implementation
+            deviceAddCustomCluster('manuSpecificYokisChannel', YokisClustersDefinition['manuSpecificYokisChannel']),
+            deviceAddCustomCluster('manuSpecificYokisPilotWire', YokisClustersDefinition['manuSpecificYokisPilotWire']), // Pending implementation
+            deviceEndpoints({endpoints: {'1': 1, '2': 2, '3': 3, '4': 4}}),
+            identify(),
+            commandsOnOff(),
+            commandsLevelCtrl(),
+            commandsWindowCovering(),
             // ...YokisDeviceExtend,
             // ...YokisInputExtend,
             // ...YokisChannelExtend,

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -2342,7 +2342,7 @@ const definitions: DefinitionWithExtend[] = [
     },
     {
         // MTR1300E-UP
-        zigbeeModel: ['MTR1300E-UP'],
+        zigbeeModel: ['MTR1300E-UP', 'MTR1300EB-UP'],
         model: 'MTR1300E-UP',
         vendor: 'YOKIS',
         description: 'Remote power switch with timer 1300W',

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -1428,8 +1428,6 @@ const yokisTz = {
 function YokisOnOff(args?: m.OnOffArgs): ModernExtend {
     const result: ModernExtend = {...m.onOff(args), toZigbee: [yokisTz.on_off]};
 
-    logger.debug(`YokisOnOff: ${JSON.stringify(result)}`, NS);
-
     return result;
 }
 


### PR DESCRIPTION
This PR covers the following issues:
- https://github.com/LaurentChardin/zigbee-herdsman-converters/issues/14
- https://github.com/LaurentChardin/zigbee-herdsman-converters/issues/9

it also switch from the default `onOff` modernExtend to a custom one, because Yokis devices do not implement the timer function of the Zigbee specs (they came later in another revision). Deferencing the key in the `toZigbee` ensures wrong documentation is not generated on the website.