### PR TITLE
Prevent Tuya packets from being reprocessed by checking entire packet instead of `seq` only

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1867,7 +1867,7 @@ const tuyaFz = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'commandActiveStatusReport', 'commandActiveStatusReportAlt'],
         convert: (model, msg, publish, options, meta) => {
-            if (utils.hasAlreadyProcessedMessage(msg, model, msg.data.seq)) return;
+            if (utils.hasAlreadyProcessedMessage(msg, model, msg.data)) return;
             const result: KeyValue = {};
             if (!model.meta || !model.meta.tuyaDatapoints) throw new Error('No datapoints map defined');
             const datapoints = model.meta.tuyaDatapoints;

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1867,7 +1867,7 @@ const tuyaFz = {
         cluster: 'manuSpecificTuya',
         type: ['commandDataResponse', 'commandDataReport', 'commandActiveStatusReport', 'commandActiveStatusReportAlt'],
         convert: (model, msg, publish, options, meta) => {
-            if (utils.hasAlreadyProcessedMessage(msg, model, msg.data)) return;
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
             const result: KeyValue = {};
             if (!model.meta || !model.meta.tuyaDatapoints) throw new Error('No datapoints map defined');
             const datapoints = model.meta.tuyaDatapoints;


### PR DESCRIPTION
Prevent duplicate Tuya packets from being reprocessed by comparing the entire packet instead of just referring to the `seq`.

There seem to be devices that repeatedly send their reports with the same sequence ID.

https://github.com/Koenkk/zigbee2mqtt/issues/25605 should still be fixed, as far as I have seen, the packages were identical.

See https://github.com/Koenkk/zigbee2mqtt/issues/26124 and probably https://github.com/Koenkk/zigbee2mqtt/issues/26145, https://github.com/Koenkk/zigbee2mqtt/issues/26148 also