### PR TITLE
Add support for light_brightness_move and light_brightness step to Inovelli switches

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1980,6 +1980,8 @@ const definitions: DefinitionWithExtend[] = [
             tz.power_on_behavior,
             tz.ignore_transition,
             tz.identify,
+            tz.light_brightness_move,
+            tz.light_brightness_step,
             tzLocal.inovelli_led_effect,
             tzLocal.inovelli_individual_led_effect,
             tzLocal.inovelli_parameters(VZM30_ATTRIBUTES, INOVELLI_CLUSTER_NAME),
@@ -2030,6 +2032,8 @@ const definitions: DefinitionWithExtend[] = [
             tz.power_on_behavior,
             tz.ignore_transition,
             tz.identify,
+            tz.light_brightness_move,
+            tz.light_brightness_step,
             tzLocal.inovelli_led_effect,
             tzLocal.inovelli_individual_led_effect,
             tzLocal.inovelli_parameters(VZM31_ATTRIBUTES, INOVELLI_CLUSTER_NAME),
@@ -2101,6 +2105,8 @@ const definitions: DefinitionWithExtend[] = [
         toZigbee: [
             tz.identify,
             tzLocal.vzm36_fan_on_off, // Need to use VZM36 specific converter
+            tz.light_brightness_move,
+            tz.light_brightness_step,
             tzLocal.fan_mode(2),
             tzLocal.light_onoff_brightness_inovelli,
             tzLocal.inovelli_parameters(VZM36_ATTRIBUTES, INOVELLI_CLUSTER_NAME),


### PR DESCRIPTION
It turns out Inovelli switches support moving and stepping (except they have a bug in the firmware that prevents moving down from working). This exposes that functionality for the VZM30, VZM31, VZM36 that all support it. VZM35 is a fan switch and does not support it.

This was tested by both myself and @InovelliUSA 