### PR TITLE
Initial support for ViCare 7963223 Climate Sensor. Based on the '7637…

### DIFF
--- a/src/devices/viessmann.ts
+++ b/src/devices/viessmann.ts
@@ -29,6 +29,15 @@ const definitions: DefinitionWithExtend[] = [
         exposes: [e.battery(), e.temperature(), e.humidity()],
     },
     {
+        zigbeeModel: ['7963223'],
+        model: '7963223',
+        vendor: 'Viessmann',
+        description: 'ViCare climate sensor',
+        fromZigbee: [fz.temperature, fz.humidity, fz.battery],
+        toZigbee: [],
+        exposes: [e.battery(), e.temperature(), e.humidity()],
+    },
+    {
         zigbeeModel: ['7637434'],
         model: 'ZK03840',
         vendor: 'Viessmann',


### PR DESCRIPTION
…435'/'ZK03839' with just the zigbeeModel and model changed. Note that his device supports two power options: micro USB or battery. Battery is exposed but will not have a meaningful value when powered by micro USB.