### PR TITLE
fix: Enable OTA for newer Hue Motion Sensors

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2625,8 +2625,7 @@ const definitions: DefinitionWithExtend[] = [
             await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
             await endpoint.read('msOccupancySensing', [48], {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V});
         },
-        // Temporary disable until OTA is available: https://github.com/Koenkk/zigbee2mqtt/issues/14923
-        // ota: true,
+        ota: true,
     },
     {
         zigbeeModel: ['LOM001'],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2596,6 +2596,7 @@ const definitions: DefinitionWithExtend[] = [
             await endpoint.read('msOccupancySensing', ['pirOToUDelay']);
             await endpoint.read('msOccupancySensing', [48], {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V});
         },
+        ota: true,
     },
     {
         zigbeeModel: ['SML004'],


### PR DESCRIPTION
- Enables OTA for Hue Motion Sensor `SML003` (an image is now available).
- Enables OTA for Hue Outdoor Motion Sensor `SML004` (I'm assuming an image is available as the firmware changelog states that there are updates for all accessories).