### PR TITLE
Add support for Develco (Frient) WISZB-131: Entry Sensor 2 Pro

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -555,13 +555,7 @@ const definitions: DefinitionWithExtend[] = [
         model: 'WISZB-131',
         vendor: 'Develco',
         description: 'Contact sensor', // For door or window
-        fromZigbee: [fz.ias_contact_alarm_1],
-        toZigbee: [],
-        exposes: [e.contact(), e.battery_low()],
         ota: true,
-        endpoint: (device) => {
-            return {default: 35};
-        },
         configure: async (device, coordinatorEndpoint, definition) => {
             /*
              * BUGFIX: When adding a new WISZB-131 contact sensor to z2m, if the magnet is never brought close to it,
@@ -586,6 +580,8 @@ const definitions: DefinitionWithExtend[] = [
             device.save();
         },
         extend: [
+            m.iasZoneAlarm({zoneType: 'contact', zoneAttributes: ['alarm_1', 'battery_low']}),
+            m.deviceEndpoints({endpoints: {default: 35}}),
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -578,7 +578,7 @@ const definitions: DefinitionWithExtend[] = [
                 if (data && typeof data.description !== 'undefined') {
                     return; // If the description is successfully read, no further action is required.
                 }
-            } catch (error) {
+            } catch {
                 // In case of a read failure, we proceed to force the cluster value.
             }
             // Forcefully inject the genBinaryInput cluster with the default attribute

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -560,18 +560,18 @@ const definitions: DefinitionWithExtend[] = [
         exposes: [e.contact(), e.battery_low()],
         ota: true,
         endpoint: (device) => {
-            return { default: 35 };
+            return {default: 35};
         },
         configure: async (device, coordinatorEndpoint, definition) => {
             /*
-            * BUGFIX: When adding a new WISZB-131 contact sensor to z2m, if the magnet is never brought close to it,
-            * genBinaryInput remains 'undiscovered'. This causes zstack to hang waiting for the sensor to discover
-            * that endpoint when z2m is restarted after the sensor's batteries are removed.
-            * 
-            * By forcing this discovery and patching the device database for already configured devices,
-            * the issue appears to be resolved. This configure function ensures the genBinaryInput cluster
-            * is properly registered even if the magnetic sensor was never triggered during initial setup.
-            */
+             * BUGFIX: When adding a new WISZB-131 contact sensor to z2m, if the magnet is never brought close to it,
+             * genBinaryInput remains 'undiscovered'. This causes zstack to hang waiting for the sensor to discover
+             * that endpoint when z2m is restarted after the sensor's batteries are removed.
+             *
+             * By forcing this discovery and patching the device database for already configured devices,
+             * the issue appears to be resolved. This configure function ensures the genBinaryInput cluster
+             * is properly registered even if the magnetic sensor was never triggered during initial setup.
+             */
             const ep = device.getEndpoint(35);
             try {
                 const data = await ep.read('genBinaryInput', ['description'], manufacturerOptions);
@@ -582,7 +582,7 @@ const definitions: DefinitionWithExtend[] = [
                 // In case of a read failure, we proceed to force the cluster value.
             }
             // Forcefully inject the genBinaryInput cluster with the default attribute
-            ep.clusters.genBinaryInput = { attributes: { description: 'Magnet Open' } };
+            ep.clusters.genBinaryInput = {attributes: {description: 'Magnet Open'}};
             device.save();
         },
         extend: [
@@ -590,7 +590,7 @@ const definitions: DefinitionWithExtend[] = [
             develcoModernExtend.readGenBasicPrimaryVersions(),
             develcoModernExtend.temperature(),
             m.battery({
-                voltageToPercentage: { min: 2500, max: 3000 },
+                voltageToPercentage: {min: 2500, max: 3000},
                 percentage: true,
                 voltage: true,
                 lowStatus: false,


### PR DESCRIPTION
Added compatibility for the WISZB-131 contact sensor.

If the magnet is never activated during commissioning, the internal genBinaryInput endpoint remains undiscovered, which may cause zstack to hang on hub restart when the battery is removed:

```
[2025-02-08 11:45:46] debug:    zh:zstack: Data confirm error (0x0015bc0044012556:15105,240,4)
[2025-02-08 11:45:46] debug:    zh:controller:endpoint: Request Queue (0x0015bc0044012556/35): queue request (transaction failed) (Error: Data request failed with error: 'MAC transaction expired' (240))
[2025-02-08 11:45:46] debug:    zh:controller:requestqueue: Request Queue (0x0015bc0044012556/35): Sending when active. Expires: 1739015098838
```

This PR forces the injection of the missing genBinaryInput cluster (with the attribute "Magnet Open") to prevent that issue.