### PR TITLE
Make sure toggle events are fired when ZBM5 devices are in detached relay mode

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1487,6 +1487,7 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Zigbee Smart one-channel wall switch (type 120).',
         exposes: [],
         ota: true,
+        fromZigbee: [fz.on_off, fz.command_toggle],
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1}}),
             m.commandsOnOff({commands: ['toggle'], endpointNames: ['l1']}),
@@ -1525,6 +1526,7 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Zigbee Smart two-channel wall switch (type 120).',
         exposes: [],
         ota: true,
+        fromZigbee: [fz.on_off, fz.command_toggle],
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             m.commandsOnOff({commands: ['toggle'], endpointNames: ['l1', 'l2']}),
@@ -1567,6 +1569,7 @@ const definitions: DefinitionWithExtend[] = [
         description: 'Zigbee Smart three-channel wall switch (type 120).',
         exposes: [],
         ota: true,
+        fromZigbee: [fz.on_off, fz.command_toggle],
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
             m.commandsOnOff({commands: ['toggle'], endpointNames: ['l1', 'l2', 'l3']}),


### PR DESCRIPTION
As mentioned on the issue https://github.com/Koenkk/zigbee2mqtt/issues/26264, when the Sonoff ZBM5 switches are in [detached relay mode](https://www.zigbee2mqtt.io/devices/ZBM5-3C-120.html#detach-relay-mode-composite). the toggle event isn't fired because there is no converter.

```
[2025-02-08 18:49:14] debug:    z2m: No converter available for 'ZBM5-3C-120' with cluster 'genOnOff' and type 'commandToggle' and data '{}'
```

This PR simply add the converters so they are properly captured and pushed allowing for those devices to properly work with smart bulbs as their load.

> Note: This is my first time digging on Z2M so I apologize if this is not the right place to fix it and if that is the case, please let me know where to go.

Although this PR fixed the original issue and trigger the events making it possible for HA automations to turn on/off lights and groups or lights, this does not fixes the Zigbee Group binding. I have no idea how to make it work so the toggle event can be properly bound to a group to turn the whole group on/off at Zigbee level not relying on HA. If anyone has any idea please let me know.

The setup I used to test is:

1. ZBM5-3C-120 with 1 of the buttons/endpoints with the `detach_relay_outlet3` set to `ENABLE`.
2. 8x Philips Hue bulbs in a Zigbee Group
3. HA with an automation with the following:
```
alias: New automation
description: ""
triggers:
  - domain: mqtt
    device_id: f9bdd6087a1a2ddd712b190781594de4
    type: action
    subtype: toggle_l3
    trigger: device
conditions: []
actions:
  - action: light.toggle
    metadata: {}
    data:
      transition: 1
    target:
      entity_id: light.dining_room_lights
mode: single
```

This worked perfectly fine but again, requires HA and it is not at the Zigbee level.

I'd appreciate any guidance/review on the PR. We can merge this and proceed on another thread/PR how to move on with the Zigbeed level group.

Thanks!