### PR TITLE
Exposing action_group for EGLO 99099

### DIFF
--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -4,6 +4,7 @@ import * as m from '../lib/modernExtend';
 import {DefinitionWithExtend} from '../lib/types';
 
 const e = exposes.presets;
+const ea = exposes.access;
 
 const definitions: DefinitionWithExtend[] = [
     {
@@ -73,6 +74,7 @@ const definitions: DefinitionWithExtend[] = [
                 'color_temperature_step_up',
                 'color_temperature_step_down',
             ]),
+            e.numeric('action_group', ea.STATE),
         ],
     },
     {


### PR DESCRIPTION
Exposing action group enables the usage of group selector buttons, enhancing the capabilities of the remote.