### PR TITLE
Add update frequency /ac frequency precision to SDM01v1.5

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10008,7 +10008,6 @@ const definitions: DefinitionWithExtend[] = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
-        options: [exposes.options.precision('ac_frequency')],
         exposes: [
             tuya.exposes.voltageWithPhase('a'),
             tuya.exposes.voltageWithPhase('b'),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10008,6 +10008,7 @@ const definitions: DefinitionWithExtend[] = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
+        options: [exposes.options.precision('ac_frequency')],
         exposes: [
             tuya.exposes.voltageWithPhase('a'),
             tuya.exposes.voltageWithPhase('b'),
@@ -10032,6 +10033,13 @@ const definitions: DefinitionWithExtend[] = [
             tuya.exposes.powerFactorWithPhase('a'),
             tuya.exposes.powerFactorWithPhase('b'),
             tuya.exposes.powerFactorWithPhase('c'),
+            e
+                .numeric('update_frequency', ea.STATE_SET)
+                .withUnit('s')
+                .withDescription('Update frequency')
+                .withValueMin(5)
+                .withValueMax(3600)
+                .withPreset('default', 10, 'Default value'),
         ],
         meta: {
             tuyaDatapoints: [
@@ -10040,6 +10048,7 @@ const definitions: DefinitionWithExtend[] = [
                 [29, 'power', tuya.valueConverter.raw],
                 [32, 'ac_frequency', tuya.valueConverter.divideBy100],
                 [50, 'power_factor', tuya.valueConverter.raw],
+                [102, 'update_frequency', tuya.valueConverterBasic.divideBy(1)],
                 [103, 'voltage_a', tuya.valueConverter.divideBy10],
                 [104, 'current_a', tuya.valueConverter.divideBy1000],
                 [105, 'power_a', tuya.valueConverter.raw],


### PR DESCRIPTION
adds update frequency to define how often the device should push data updates
adds ac frequency precision option to make the AC frequency reporting more useful (you can see the spikes when the energy market adds or remove load to the grid...) maybe the default precision of 0 is not right and should be changed to 2 globally ?
 
tested on an very spamy  [SDM01](https://www.zigbee2mqtt.io/devices/SDM01.html) that got a firmware update on a tuya gateway, and now reacts as a [SDM01v1.5](https://www.zigbee2mqtt.io/devices/SDM01V1.5.html) (same data points), although it is not recognized as such