### PR TITLE
feat(lumiLight): custom color temp range

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -199,7 +199,7 @@ const definitions: DefinitionWithExtend[] = [
         vendor: 'Aqara',
         description: 'Opple MX480',
         meta: {turnsOffAtBrightness1: true},
-        extend: [lumiLight({colorTemp: true, powerOutageMemory: 'switch'}), lumiZigbeeOTA()],
+        extend: [lumiLight({colorTemp: true, powerOutageMemory: 'switch', colorTempRange: [175, 370]}), lumiZigbeeOTA()],
     },
     {
         zigbeeModel: ['lumi.light.cwjwcn01'],

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -1427,13 +1427,14 @@ export const lumiModernExtend = {
     lumiLight: (
         args?: Omit<modernExtend.LightArgs, 'colorTemp'> & {
             colorTemp?: true;
+            colorTempRange?: Range;
             powerOutageMemory?: 'switch' | 'light' | 'enum';
             deviceTemperature?: boolean;
             powerOutageCount?: boolean;
         },
     ) => {
         args = {powerOutageCount: true, deviceTemperature: true, ...args};
-        const colorTemp: {range: Range; startup: boolean} = args.colorTemp ? {startup: false, range: [153, 370]} : undefined;
+        const colorTemp: {range: Range; startup: boolean} = args.colorTemp ? {startup: false, range: args.colorTempRange || [153, 370]} : undefined;
         const result = modernExtend.light({effect: false, powerOnBehavior: false, ...args, colorTemp});
         result.fromZigbee.push(
             fromZigbee.lumi_bulb_interval,


### PR DESCRIPTION
Add support for a custom color temperature range in the lumiLight extension.
This change allows users to override the default range ([153,370]) with a custom one.
For example, for Opple MX480 the correct color temperature range is 175-370.
