### PR TITLE
Add support for ZBCMR-01 NovaDigital roller blind motor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4127,10 +4127,10 @@ const definitions: DefinitionWithExtend[] = [
         fingerprint: [...tuya.fingerprint('TS0601', ['_TZE200_eegnwoyw']), ...tuya.fingerprint('TS0105', ['_TZE600_ogyg1y6b'])],
         model: 'TS0601_cover_2',
         vendor: 'Tuya',
-        description: 'Curtain motor fixed speed',
+        description: 'Curtain motor or roller blind motor with fixed speed',
         whiteLabel: [
-            {vendor: 'Zemismart', model: 'BCM100DB'},
-            {vendor: 'NovaDigital', model: 'ZBCMR-01'},
+            tuya.whitelabel('Zemismart', 'BCM100DB', 'Curtain Motor', ['_TZE200_eegnwoyw']),
+            tuya.whitelabel('NovaDigital', 'ZBCMR-01', 'Roller Blind Motor', ['_TZE600_ogyg1y6b']),
         ],
         fromZigbee: [legacy.fromZigbee.tuya_cover, fz.ignore_basic_report],
         toZigbee: [legacy.toZigbee.tuya_cover_control],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4124,11 +4124,14 @@ const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_eegnwoyw']),
+        fingerprint: [...tuya.fingerprint('TS0601', ['_TZE200_eegnwoyw']), ...tuya.fingerprint('TS0105', ['_TZE600_ogyg1y6b'])],
         model: 'TS0601_cover_2',
         vendor: 'Tuya',
         description: 'Curtain motor fixed speed',
-        whiteLabel: [{vendor: 'Zemismart', model: 'BCM100DB'}],
+        whiteLabel: [
+            {vendor: 'Zemismart', model: 'BCM100DB'},
+            {vendor: 'NovaDigital', model: 'ZBCMR-01'},
+        ],
         fromZigbee: [legacy.fromZigbee.tuya_cover, fz.ignore_basic_report],
         toZigbee: [legacy.toZigbee.tuya_cover_control],
         exposes: [e.cover_position().setAccess('position', ea.STATE_SET)],


### PR DESCRIPTION
Added support for ZBCMR-01 roller blind motor sold under the NovaDigital brand in Brazil
I actually just used the same TS0601_cover_2 device, just added the fingerprint for it

Here is the generated external definition for reference:
<img width="604" alt="Screenshot 2025-02-15 at 19 30 16" src="https://github.com/user-attachments/assets/c597c2c3-9bc7-4962-9ffb-0d7755683726" />
