### PR TITLE
Update default ac frequency precision

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -142,7 +142,7 @@ export function hasAlreadyProcessedMessage(msg: Fz.Message, model: Definition, I
 }
 
 export const calibrateAndPrecisionRoundOptionsDefaultPrecision: KeyValue = {
-    ac_frequency: 0,
+    ac_frequency: 2,
     temperature: 2,
     humidity: 2,
     pressure: 1,


### PR DESCRIPTION
AC frequency is tightly managed by grid operators, fluctuations are really small Curent precision of 0 means the values are not really useful (typical changes are in 0.02 Hz range)