### PR TITLE
Add support to Nova Digital TS0601_TZE204_unsxl4ir

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10592,7 +10592,7 @@ const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_k6jhsr0q']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_k6jhsr0q', '_TZE204_unsxl4ir']),
         model: 'ZS-TYG3-SM-41Z',
         vendor: 'Tuya',
         description: '4 gang smart switch with backlight and neutral wire',

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10632,6 +10632,7 @@ const definitions: DefinitionWithExtend[] = [
                 [16, 'backlight_mode', tuya.valueConverter.onOff],
             ],
         },
+        whiteLabel: [tuya.whitelabel('Nova Digital', 'FZB-4', 'Interruptor de 4 canais com backlight e neutro', ['TZE204_unsxl4ir'])],
     },
     {
         fingerprint: tuya.fingerprint('TS0601', ['_TZE200_nvodulvi']),


### PR DESCRIPTION
It's my first contribution, I apologize if I did something wrong. 

This device is equal to **[Tuya 4 Gangs with backlight and neutral](https://www.novadigitalsmart.com.br/produtos/interruptor-inteligente-tecla-fisica-4x4-fzb-4-6---w-b)**, it's actually a whitelabel. 

Thx!