### PR TITLE
HS2WD-E: remove unsupported features from exposes

### DIFF
--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -302,7 +302,13 @@ const definitions: DefinitionWithExtend[] = [
         },
         exposes: [
             e.battery(),
-            e.numeric('max_duration', ea.ALL).withUnit('s').withValueMin(0).withValueMax(600).withDescription('Max duration of Siren'),
+            e
+                .numeric('max_duration', ea.ALL)
+                .withUnit('s')
+                .withValueMin(0)
+                .withValueMax(600)
+                .withDescription('Max duration of Siren')
+                .withCategory('config'),
             e
                 .warning()
                 .removeFeature('level')

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -291,15 +291,25 @@ const definitions: DefinitionWithExtend[] = [
         model: 'HS2WD-E',
         vendor: 'HEIMAN',
         description: 'Smart siren',
-        fromZigbee: [fz.battery, fz.ignore_basic_report],
-        toZigbee: [tz.warning],
+        fromZigbee: [fz.battery, fz.ignore_basic_report, fz.ias_wd],
+        toZigbee: [tz.warning, tz.ias_max_duration],
         meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
             await reporting.batteryPercentageRemaining(endpoint);
+            await endpoint.read('ssIasWd', ['maxDuration']);
         },
-        exposes: [e.battery(), e.warning()],
+        exposes: [
+            e.battery(),
+            e.numeric('max_duration', ea.ALL).withUnit('s').withValueMin(0).withValueMax(600).withDescription('Max duration of Siren'),
+            e
+                .warning()
+                .removeFeature('level')
+                .removeFeature('strobe_level')
+                .removeFeature('mode')
+                .withFeature(e.enum('mode', ea.SET, ['stop', 'emergency']).withDescription('Mode of the warning (sound effect)')),
+        ],
     },
     {
         zigbeeModel: ['HT-EM', 'TH-EM', 'TH-T_V14'],


### PR DESCRIPTION
* This [HS2WD-E](https://www.zigbee2mqtt.io/devices/HS2WD-E.html) siren has one tone only, no volume/level, no strobe level. might as well stop exposing those as it causes endless frustrations...
* Exposes a missing max_duration, that is discovered as config.
  * In practice this means that no matter the duration, it will not trigger for longer than the set value to avoid runaway alarms (device defaults to 240 s). 
  * tested, at last a feature that is properly implemented on the siren.
