### PR TITLE
ubisys: we have OTA images for the H10

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -1334,6 +1334,7 @@ export const definitions: DefinitionWithExtend[] = [
                 await reporting.onOff(endpoint);
             }
         },
+        ota: true,
     },
     {
         zigbeeModel: ['R0 (5501)'],


### PR DESCRIPTION
@cmaschke I'm 95% sure this will fix the OTA not available you're seeing for the H10.

I was tired last night and accidentally checked the H1 to see if it was enabled.