### PR TITLE
[FIX]: Increase TS0601_thermostat_4 maximum heating value and permissible calibration limits

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4944,15 +4944,15 @@ export const definitions: DefinitionWithExtend[] = [
             e.battery_low(),
             e
                 .climate()
-                .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET)
+                .withSetpoint('current_heating_setpoint', 5, 45, 0.5, ea.STATE_SET)
                 .withLocalTemperature(ea.STATE)
                 .withPreset(['schedule', 'holiday', 'manual', 'comfort', 'eco'])
                 .withSystemMode(['off', 'heat'], ea.STATE)
-                .withLocalTemperatureCalibration(-3, 3, 1, ea.STATE_SET),
+                .withLocalTemperatureCalibration(-12, 12, 0.5, ea.STATE_SET),
             ...tuya.exposes.scheduleAllDays(ea.STATE_SET, 'HH:MM/C HH:MM/C HH:MM/C HH:MM/C HH:MM/C HH:MM/C'),
-            e.holiday_temperature().withValueMin(5).withValueMax(30),
-            e.comfort_temperature().withValueMin(5).withValueMax(30),
-            e.eco_temperature().withValueMin(5).withValueMax(30),
+            e.holiday_temperature().withValueMin(5).withValueMax(45),
+            e.comfort_temperature().withValueMin(5).withValueMax(45),
+            e.eco_temperature().withValueMin(5).withValueMax(45),
             e
                 .binary('scale_protection', ea.STATE_SET, 'ON', 'OFF')
                 .withDescription(


### PR DESCRIPTION
Based on https://github.com/Koenkk/zigbee2mqtt/issues/19462

Hello, I recently [purchased](https://a.aliexpress.com/_Ew3QOXq) 3 thermal heads of this model and noticed that the set values ​​in the templates do not correspond to the actual ones.

My devices are detected as expected as TS0601_thermostat_4.
generated_external_definition:
```
const definition = {
    zigbeeModel: ['TS0601'],
    model: 'TS0601',
    vendor: '_TZE204_pcdmj88b',
    description: 'Automatically generated definition',
    extend: [],
    meta: {},
};

module.exports = definition;
```

each set value is tested on hardware. so please review my pool request.