### PR TITLE
PA-44Z: expose the test property to ring the alarm

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5787,7 +5787,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.smoke(),
             e.battery(),
             tuya.exposes.silence(),
-            e.test(),
+            tuya.exposes.test(),
             e.numeric('smoke_concentration', ea.STATE).withUnit('ppm').withDescription('Parts per million of smoke detected'),
             e.binary('device_fault', ea.STATE, true, false).withDescription('Indicates a fault with the device'),
         ],


### PR DESCRIPTION
This change aims to enable the alarm to be triggered via home assistant.

I'm a new user so I'm not sure whether this would work. Intuitively, the alarm should be able to be triggered by home assistant. The test button rings the alarm so I'd assume that setting the property to True would ring the alarm. It's worth a try.