### PR TITLE
Heimgard SLM2 - Locking history for internal vs external lock status

### DIFF
--- a/src/devices/heimgard_technologies.ts
+++ b/src/devices/heimgard_technologies.ts
@@ -1,11 +1,13 @@
 import fz from '../converters/fromZigbee';
 import tz from '../converters/toZigbee';
 import * as exposes from '../lib/exposes';
+import * as h from '../lib/heimgard';
 import * as m from '../lib/modernExtend';
 import * as reporting from '../lib/reporting';
 import {DefinitionWithExtend} from '../lib/types';
 
 const e = exposes.presets;
+const ea = exposes.access;
 
 const definitions: DefinitionWithExtend[] = [
     {
@@ -46,8 +48,16 @@ const definitions: DefinitionWithExtend[] = [
         model: 'HT-SLM-2',
         vendor: 'Heimgard Technologies',
         description: 'Doorlock with fingerprint',
-        fromZigbee: [fz.lock, fz.battery, fz.lock_pin_code_response, fz.lock_user_status_response],
-        toZigbee: [tz.lock, tz.lock_sound_volume, tz.identify, tz.pincode_lock, tz.lock_userstatus],
+        fromZigbee: [
+            fz.lock,
+            fz.battery,
+            fz.lock_pin_code_response,
+            fz.lock_user_status_response,
+            h.fromZigbee.heimgard_slm_2_battery_volt,
+            h.fromZigbee.heimgard_slm_2_lock,
+            h.fromZigbee.heimgard_slm_2_lockState,
+        ],
+        toZigbee: [tz.lock, h.toZigbee.antiBogus, tz.identify, tz.pincode_lock, tz.lock_userstatus],
         meta: {pinCodeCount: 39},
         ota: true,
         configure: async (device, coordinatorEndpoint) => {
@@ -56,8 +66,25 @@ const definitions: DefinitionWithExtend[] = [
             await reporting.lockState(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
             await endpoint.read('closuresDoorLock', ['lockState', 'soundVolume']);
+            device.powerSource = 'Battery';
+            device.save();
         },
-        exposes: [e.lock(), e.pincode(), e.battery(), e.sound_volume()],
+        extend: [h.slm_2.soundVolume()],
+        exposes: [
+            e.lock(),
+            e
+                .enum('last_unlock_source', ea.STATE, ['pin', 'remote', 'function_key', 'rfid_tag', 'fingerprint', 'self'])
+                .withDescription('Physical override key will not be reported'),
+            e.text('last_unlock_by_user', ea.STATE).withDescription('Last user that opened the lock'),
+            e.enum('inner_lock_state', ea.STATE, ['LOCK', 'UNLOCK', 'UNKNOWN']),
+            e
+                .binary('safety_locking', ea.ALL, 'Enabled', 'Disabled')
+                .withLabel('Enforced locking')
+                .withDescription("Enforcing locking of the device if the state is bogus and can't safely be determined."),
+            e.pincode(),
+            e.battery(),
+            e.voltage(),
+        ],
     },
     {
         zigbeeModel: ['HC-IWDIM-1'],

--- a/src/lib/heimgard.ts
+++ b/src/lib/heimgard.ts
@@ -1,0 +1,207 @@
+import {Zcl} from 'zigbee-herdsman';
+
+import fz from '../converters/fromZigbee';
+import tz from '../converters/toZigbee';
+import * as utils from '../lib/utils';
+import * as modernExtend from './modernExtend';
+import {Fz, KeyValue, Tz} from './types';
+
+// Lock state changes requested by the following. Tested against device HT-SLM-2.
+// remote = executed from zigbee2mqtt
+const lockChangeSource = {0: 'pin', 1: 'remote', 2: 'function_key', 3: 'rfid_tag', 4: 'fingerprint', 255: 'self'};
+
+export interface LockStateHistory {
+    time: number;
+    interiorLockState: string;
+    exteriorLockState: string;
+}
+
+export enum lockSide {
+    interior,
+    exterior,
+    unknown,
+}
+
+function identifyLockStateFromHistory(meta: Fz.Meta): lockSide {
+    const history: LockStateHistory[] = (meta.state?.history as LockStateHistory[]) ?? [];
+
+    const filteredHistory: LockStateHistory[] = [];
+    let lastEntry: LockStateHistory | null = null;
+
+    history.forEach((entry) => {
+        if (!lastEntry || entry.interiorLockState !== lastEntry.interiorLockState || entry.exteriorLockState !== lastEntry.exteriorLockState) {
+            filteredHistory.push(entry);
+        }
+        lastEntry = entry;
+    });
+
+    let lastInteriorChange = null;
+    let lastExteriorChange = null;
+
+    for (let i = 1; i < filteredHistory.length; i++) {
+        const prevEntry = filteredHistory[i - 1];
+        const currentEntry = filteredHistory[i];
+
+        if (prevEntry.interiorLockState === 'locked' && currentEntry.interiorLockState === 'unlocked') {
+            lastInteriorChange = currentEntry;
+        }
+
+        if (prevEntry.exteriorLockState === 'locked' && currentEntry.exteriorLockState === 'unlocked') {
+            lastExteriorChange = currentEntry;
+        }
+    }
+
+    if (lastInteriorChange && lastExteriorChange) {
+        if (lastInteriorChange.time > lastExteriorChange.time) {
+            return lockSide.interior;
+        } else {
+            return lockSide.exterior;
+        }
+    } else if (lastInteriorChange) {
+        return lockSide.interior;
+    } else if (lastExteriorChange) {
+        return lockSide.exterior;
+    } else {
+        console.error('Catch 22: Lock state could not be determined...');
+        return lockSide.unknown;
+    }
+}
+
+export const fromZigbee = {
+    heimgard_slm_2_lockState: {
+        cluster: 'closuresDoorLock',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValue = {};
+
+            const {isInteriorLocked, isExteriorLocked, safety_locking} = meta.state;
+            const enforceLockingIfBogus = safety_locking === 'Enabled' ? true : false;
+            if (enforceLockingIfBogus !== undefined) {
+                result.safety_locking = enforceLockingIfBogus === true ? 'Enabled' : 'Disabled';
+            }
+
+            if (msg.data['lockState'] !== undefined) {
+                //Perform a lookup
+                if (isInteriorLocked && isExteriorLocked && msg.data['lockState'] === 2 && enforceLockingIfBogus) {
+                    // In cases where the lockState reports unlocked while there is no history, we should perform a locking action to ensure that it is actually locked. This is to ensure that the state and physical state is correct. This is due to faulty product code.
+                    void tz.lock.convertSet(msg.endpoint, 'state', 'LOCK', null);
+                    return;
+                }
+            }
+            return result;
+        },
+    } satisfies Fz.Converter,
+    heimgard_slm_2_lock: {
+        cluster: 'closuresDoorLock',
+        type: ['commandOperationEventNotification'],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValue = {};
+            const lockStateCode = msg.data['opereventcode'];
+            const lockChangeRequester = utils.getFromLookup(msg.data['opereventsrc'], lockChangeSource);
+            const isLocked = lockStateCode == 1;
+
+            let {isInteriorLocked, isExteriorLocked} = meta.state;
+
+            // Autolocked by device
+            if (lockChangeRequester === 'self') {
+                const targetLock = identifyLockStateFromHistory(meta);
+                if (targetLock === lockSide.interior) {
+                    isInteriorLocked = isLocked;
+                    result.inner_lock_state = 'locked';
+                } else if (targetLock === lockSide.exterior) {
+                    isExteriorLocked = isLocked;
+                    result.lock_state = 'locked';
+                    result.state = lockStateCode == 1 ? 'LOCK' : 'UNLOCK';
+                    meta.state.state = result.state;
+                } else {
+                    void tz.lock.convertSet(msg.endpoint, 'state', 'LOCK', null);
+                    return;
+                }
+            } else {
+                if (lockChangeRequester === 'function_key') {
+                    isInteriorLocked = isLocked;
+                    result.inner_lock_state = isLocked ? 'locked' : 'unlocked';
+                } else {
+                    if (!isLocked) {
+                        result.last_unlock_source = lockChangeRequester;
+                        if (lockChangeRequester === 'function_key' || lockChangeRequester === 'remote') {
+                            result.last_unlock_by_user = 'N/A';
+                        } else {
+                            result.last_unlock_by_user = msg.data['userid'];
+                        }
+                    } else {
+                        // If locked
+                        result.last_lock_source = lockChangeRequester;
+                        result.last_lock_by_user = msg.data['userid'];
+                    }
+
+                    isExteriorLocked = isLocked;
+                    const known_lockstates = {0: 'unknown_lock_failure', 1: 'locked', 2: 'unlocked'};
+                    result.lock_state = utils.getFromLookup(lockStateCode, known_lockstates, 'unknown_lock_failure');
+                    result.state = isLocked ? 'LOCK' : 'UNLOCK';
+                    meta.state.state = result.state;
+                }
+            }
+
+            const newHistoryEntry: LockStateHistory = {
+                time: Date.now(),
+                interiorLockState: isInteriorLocked ? 'locked' : 'unlocked',
+                exteriorLockState: isExteriorLocked ? 'locked' : 'unlocked',
+            };
+            const historyCache = (meta.state.history as LockStateHistory[]) ?? [];
+            historyCache.push(newHistoryEntry);
+            // Keeping only the last 5 entries
+            meta.state.history = historyCache.slice(-5);
+
+            meta.state.isInteriorLocked = isInteriorLocked;
+            meta.state.isExteriorLocked = isExteriorLocked;
+
+            return result;
+        },
+    } satisfies Fz.Converter,
+    heimgard_slm_2_battery_volt: {
+        cluster: 'genPowerCfg',
+        type: ['attributeReport', 'readResponse'],
+        convert: (model, msg, publish, options, meta) => {
+            const result = fz.battery.convert(model, msg, publish, options, meta);
+            if (result['voltage'] !== undefined) {
+                result.voltage = result.voltage / 1000;
+            }
+            return result;
+        },
+    } satisfies Fz.Converter,
+};
+
+export const toZigbee = {
+    antiBogus: {
+        key: ['safety_locking'],
+        convertSet: async (entity, key, value, meta) => {
+            meta.state.safety_locking = value;
+            await entity.read('closuresDoorLock', ['lockState']);
+            return {
+                [key]: value,
+            };
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read('closuresDoorLock', ['lockState']);
+        },
+    } satisfies Tz.Converter,
+};
+
+export const slm_2 = {
+    soundVolume: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+        modernExtend.enumLookup({
+            name: 'soundVolume',
+            cluster: 'closuresDoorLock',
+            attribute: {ID: 0x0024, type: Zcl.DataType.UINT8},
+            description: 'Sound volume',
+            lookup: {
+                off: 0,
+                low: 1,
+                medium: 2,
+                high: 3,
+            },
+            access: 'ALL',
+            ...args,
+        }),
+};


### PR DESCRIPTION
Due to the limited functionality of the device, and no documentation, there is no way to pull correct data at all.
If the function key on the inside is pressed the whole locks status will change, even though the exterior locking is unlocked, the device will for example say that it is locked. This code attempts to work around the issue by keeping a local history of the states and executor.

Sound volume is now mapped against the correct values for this device.
Other functionality is kept, but it does not work for this device (pin lock, user edit etc)
Battery will now show up in overview, but device has to bee reconfigured.

I've converted the code from my local converter at best effort, though I'm unsure how to test it locally for Z2M...
Suggestions are welcome