### PR TITLE
feat: Extend support for custom zigbee frames with `zcl_command`

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -243,8 +243,18 @@ const converters2 = {
             utils.assertObject(value, key);
             const payload = value.payload !== undefined ? value.payload : {};
             utils.assertEndpoint(entity);
-            await entity.zclCommand(value.cluster, value.command, payload, value.options !== undefined ? value.options : {});
-            logger.info(`Invoked ZCL command ${value.cluster}.${value.command} with payload '${JSON.stringify(payload)}'`, NS);
+            await entity.zclCommand(
+                value.cluster,
+                value.command,
+                payload,
+                value.options !== undefined ? value.options : {},
+                value.log_payload ?? {},
+                value.check_status ?? false,
+                value.frametype ?? Zcl.FrameType.SPECIFIC,
+            );
+            if (value.logging ?? false) {
+                logger.info(`Invoked ZCL command ${value.cluster}.${value.command} with payload '${JSON.stringify(payload)}'`, NS);
+            }
         },
     } satisfies Tz.Converter,
     arm_mode: {


### PR DESCRIPTION
The existing implementation is almost a generic "send zigbee frame" function, but falls short.

Notably, it:

 - Does not allow specifying a Zcl.FrameType value
 - Does not allow suppressing normal ACK reporting
 - Does not allow disabling log output in z2m

When working on implementing support for complicated Zigbee devices (Philips Hue, for instance), these limitations hit hard.

This reasonably simple change makes the `zcl_command` significantly more powerful, and should be fully backwards-compatible. 

The one possible exception is that the logging default is reversed. I'm testing devices that need to stream at a rate of 10-60 packets/sec, so being able to disable the log is actually a critical feature, surprisingly.