### PR TITLE
adds publish to Tz.Meta type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -328,6 +328,7 @@ export namespace Tz {
         state: KeyValue;
         endpoint_name: string | undefined;
         membersState?: {[s: string]: KeyValue};
+        publish?: Publish;
     }
     // biome-ignore lint/suspicious/noConfusingVoidType: allow for converters
     export type ConvertSetResult = {state?: KeyValue; membersState?: {[s: string]: KeyValue}} | void;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -328,7 +328,7 @@ export namespace Tz {
         state: KeyValue;
         endpoint_name: string | undefined;
         membersState?: {[s: string]: KeyValue};
-        publish?: Publish;
+        publish: Publish;
     }
     // biome-ignore lint/suspicious/noConfusingVoidType: allow for converters
     export type ConvertSetResult = {state?: KeyValue; membersState?: {[s: string]: KeyValue}} | void;


### PR DESCRIPTION
In order to be able to publish from the context of toZigbee  convertSet 
adds publish to Tz.Meta type

Required to implement a virtual siren state in https://github.com/Koenkk/zigbee-herdsman-converters/pull/8834