### PR TITLE
Modify product model

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -102,7 +102,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE204_u9bfwha0",
             "_TZE204_xalsoe3m",
         ]),
-        model: "BHT-002-GCLZB",
+        model: "BHT-002",
         vendor: "Moes",
         description: "Moes BHT series Thermostat",
         fromZigbee: [legacy.fz.moes_thermostat],


### PR DESCRIPTION
This section of the thermostat is not only suitable for GC models, but also for multiple models including GA, GB, and GC, so this suffix is removed.