### PR TITLE
Tuya Air Quality _TZE200_dwcarsat: Filter more strange values for PM2.5

### DIFF
--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -1939,7 +1939,9 @@ const fromZigbee = {
                 case dataPoints.tuyaSabCO2:
                     if (["_TZE200_dwcarsat", "_TZE204_dwcarsat"].includes(meta.device.manufacturerName)) {
                         // Ignore: https://github.com/Koenkk/zigbee2mqtt/issues/11033#issuecomment-1109808552
-                        if (value === 0xaaac || value === 0xaaab) return;
+                        // There are a lot of "strange" big values, so if the value is bigger than the range of the sensor, discard
+                        // According to the manual of the device, the valid range is 0-1000 ug/m3
+                        if (value > 1000) return;
                         return {pm25: value};
                     }
                     if (meta.device.manufacturerName === "_TZE200_ryfmq5rl") {


### PR DESCRIPTION
My `_TZE200_dwcarsat` shows some strange peaks very out of range:

![image](https://github.com/user-attachments/assets/1526b7a1-2bcb-40b9-aca7-f3c9e90a3dd2)

So I added the two values (43521 and 43522) that I see in the zigbee2mqtt log to the actual rule that filters this kind of values. Maybe its better to simply filter any value bigger than `0xaa00` (43520) or simply the max value of PM2.5 that for this device is 100.