### PR TITLE
Add FLS-PP3 "White" to dresden_elektronik.ts

### DIFF
--- a/src/devices/dresden_elektronik.ts
+++ b/src/devices/dresden_elektronik.ts
@@ -3,7 +3,7 @@ import type {DefinitionWithExtend} from "../lib/types";
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        zigbeeModel: ["FLS-PP3", "FLS-PP3\u0000"],
+        zigbeeModel: ["FLS-PP3", "FLS-PP3\u0000", "FLS-PP3 White\u0000"],
         model: "Mega23M12",
         vendor: "Dresden Elektronik",
         description: "ZigBee Light Link wireless electronic ballast",


### PR DESCRIPTION
It seems that older models of the FLS-PP3 sometimes report as "FLS-PP3 White\u0000".

Here is my database entry:
```text
{"id":8,"type":"Router","ieeeAddr":"0x00212effff017324","nwkAddr":41234,"manufId":4405,"manufName":"dresden elektronik\u0000","powerSource":"Mains (single phase)","modelId":"FLS-PP3 White\u0000","epList":[10,11],"endpoints":{"10":{"profId":49246,"epId":10,"devId":528,"inClusterList":[0,4096,4,3,5,6,8,768],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"FLS-PP3\u0000","manufacturerName":"dresden elektronik\u0000","powerSource":1,"zclVersion":1,"appVersion":2,"stackVersion":3,"hwVersion":1,"dateCode":"20151008\u0000","swBuildId":"020E.201000A0\u0000"}},"lightingColorCtrl":{"attributes":{"colorCapabilities":31,"colorTempPhysicalMin":153,"colorTempPhysicalMax":500,"colorMode":2,"currentX":34531,"currentY":27092,"enhancedCurrentHue":5439,"currentSaturation":251,"colorTemperature":500}},"genOnOff":{"attributes":{"onOff":1}},"genLevelCtrl":{"attributes":{"currentLevel":203}}},"binds":[],"configuredReportings":[],"meta":{}},"11":{"profId":49246,"epId":11,"devId":256,"inClusterList":[0,4096,4,3,5,6,8],"outClusterList":[],"clusters":{"genBasic":{"attributes":{"modelId":"FLS-PP3 White\u0000","manufacturerName":"dresden elektronik\u0000","powerSource":1,"zclVersion":1,"appVersion":2,"stackVersion":3,"hwVersion":1,"dateCode":"20151008\u0000","swBuildId":"020E.201000A0\u0000"}}},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":2,"stackVersion":3,"hwVersion":1,"dateCode":"20151008\u0000","swBuildId":"020E.201000A0\u0000","zclVersion":1,"interviewCompleted":true,"meta":{"configured":332242049},"lastSeen":1740904699267}
```