### PR TITLE
REVERT: #8845 PA-44Z: expose the test property to ring the alarm

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6384,7 +6384,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.smoke(),
             e.battery(),
             tuya.exposes.silence(),
-            tuya.exposes.selfTest(),
+            e.test(),
             e.numeric("smoke_concentration", ea.STATE).withUnit("ppm").withDescription("Parts per million of smoke detected"),
             e.binary("device_fault", ea.STATE, true, false).withDescription("Indicates a fault with the device"),
         ],


### PR DESCRIPTION
Reverting as this approach is not working. 
According to the manufacturer, there should be a datapoint to trigger the alarm via Z2M but I don't have a tuya hub, and copying other devices' config didn't work.