### PR TITLE
Added Philips Hue Fuzo PWM003

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2733,6 +2733,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light()],
     },
     {
+        zigbeeModel: ["PWM003"],
+        model: "PWM003",
+        vendor: "Signify Netherlands B.V.",
+        description: "Hue Fuzo outdoor wall light",
+        extend: [philips.m.light()],
+    },
+    {
         zigbeeModel: ["929003055201"],
         model: "929003055201",
         vendor: "Philips",

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2734,8 +2734,8 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["PWM003"],
-        model: "PWM003",
-        vendor: "Signify Netherlands B.V.",
+        model: "915005732902",
+        vendor: "Philips",
         description: "Hue Fuzo outdoor wall light",
         extend: [philips.m.light()],
     },


### PR DESCRIPTION
1st generation of Philips Hue Fuzo outdoor wall light. I don't have the OEM box anymore so I can't verify Philips article number/product code but I've added the information received from definition generation.