### PR TITLE
fix: Fix duplicate options and toZigbee converters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,6 @@ export {clear as clearGlobalStore} from "./lib/store";
 
 // key: zigbeeModel, value: array of definitions (most of the times 1)
 const externalDefinitionsLookup = new Map<string, DefinitionWithExtend[]>();
-const preparedDefintionsLookup = new Map<DefinitionWithExtend, Definition>();
 export const externalDefinitions: DefinitionWithExtend[] = [];
 
 // expected to be at the beginning of `definitions` array
@@ -404,15 +403,12 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
 }
 
 export function prepareDefinition(definition: DefinitionWithExtend): Definition {
-    if (preparedDefintionsLookup.has(definition)) {
-        return preparedDefintionsLookup.get(definition);
-    }
-
-    const finalDefinition = processExtensions(definition);
+    const finalDefinition = processExtensions({options: [], ...definition});
 
     // When changing the `.push` here, review `should prepare definitions only once` test case as it
     // depends on this.
-    finalDefinition.toZigbee.push(
+    finalDefinition.toZigbee = [
+        ...finalDefinition.toZigbee,
         toZigbee.scene_store,
         toZigbee.scene_recall,
         toZigbee.scene_add,
@@ -424,17 +420,14 @@ export function prepareDefinition(definition: DefinitionWithExtend): Definition 
         toZigbee.command,
         toZigbee.factory_reset,
         toZigbee.zcl_command,
-    );
+    ];
 
     if (definition.externalConverterName) {
         validateDefinition(finalDefinition);
     }
 
     // Add all the options
-    if (!finalDefinition.options) {
-        finalDefinition.options = [];
-    }
-
+    finalDefinition.options = [...finalDefinition.options];
     const optionKeys = finalDefinition.options.map((o) => o.name);
 
     // Add calibration/precision options based on expose
@@ -474,7 +467,6 @@ export function prepareDefinition(definition: DefinitionWithExtend): Definition 
         }
     }
 
-    preparedDefintionsLookup.set(definition, finalDefinition);
     return finalDefinition;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,8 +405,6 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
 export function prepareDefinition(definition: DefinitionWithExtend): Definition {
     const finalDefinition = processExtensions(definition);
 
-    // When changing the `.push` here, review `should prepare definitions only once` test case as it
-    // depends on this.
     finalDefinition.toZigbee = [
         ...finalDefinition.toZigbee,
         toZigbee.scene_store,

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,11 +399,11 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
         return {toZigbee, fromZigbee, exposes, meta, configure, endpoint, onEvent, ota, ...definitionWithoutExtend};
     }
 
-    return definition;
+    return {...definition};
 }
 
 export function prepareDefinition(definition: DefinitionWithExtend): Definition {
-    const finalDefinition = processExtensions({options: [], ...definition});
+    const finalDefinition = processExtensions(definition);
 
     // When changing the `.push` here, review `should prepare definitions only once` test case as it
     // depends on this.
@@ -427,7 +427,7 @@ export function prepareDefinition(definition: DefinitionWithExtend): Definition 
     }
 
     // Add all the options
-    finalDefinition.options = [...finalDefinition.options];
+    finalDefinition.options = [...(finalDefinition.options ?? [])];
     const optionKeys = finalDefinition.options.map((o) => o.name);
 
     // Add calibration/precision options based on expose

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export {clear as clearGlobalStore} from "./lib/store";
 
 // key: zigbeeModel, value: array of definitions (most of the times 1)
 const externalDefinitionsLookup = new Map<string, DefinitionWithExtend[]>();
+const preparedDefintionsLookup = new Map<DefinitionWithExtend, Definition>();
 export const externalDefinitions: DefinitionWithExtend[] = [];
 
 // expected to be at the beginning of `definitions` array
@@ -403,8 +404,14 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
 }
 
 export function prepareDefinition(definition: DefinitionWithExtend): Definition {
+    if (preparedDefintionsLookup.has(definition)) {
+        return preparedDefintionsLookup.get(definition);
+    }
+
     const finalDefinition = processExtensions(definition);
 
+    // When changing the `.push` here, review `should prepare definitions only once` test case as it
+    // depends on this.
     finalDefinition.toZigbee.push(
         toZigbee.scene_store,
         toZigbee.scene_recall,
@@ -467,6 +474,7 @@ export function prepareDefinition(definition: DefinitionWithExtend): Definition 
         }
     }
 
+    preparedDefintionsLookup.set(definition, finalDefinition);
     return finalDefinition;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -326,6 +326,15 @@ describe("ZHC", () => {
         expect((await findByDevice(device)).vendor).toStrictEqual("Aqara");
     });
 
+    it("should prepare definitions only once", async () => {
+        const device = mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_3towulqd", endpoints: []});
+        const definition1 = await findByDevice(device);
+        const definition1TzLength = definition1.toZigbee.length;
+        const definition2 = await findByDevice(device);
+        const definition2TzLength = definition2.toZigbee.length;
+        expect(definition1TzLength).toStrictEqual(definition2TzLength);
+    });
+
     it("adds external converter with same model built-in", async () => {
         const device = mockDevice({modelID: "TS0601", manufacturerName: "_TZE204_sxm7l9xa", endpoints: []}, "EndDevice");
         const extDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE204_unknown", endpoints: []}, "EndDevice");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -330,9 +330,12 @@ describe("ZHC", () => {
         const device = mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_3towulqd", endpoints: []});
         const definition1 = await findByDevice(device);
         const definition1TzLength = definition1.toZigbee.length;
+        const definition1OptionsLength = definition1.toZigbee.length;
         const definition2 = await findByDevice(device);
         const definition2TzLength = definition2.toZigbee.length;
+        const definition2OptionsLength = definition2.toZigbee.length;
         expect(definition1TzLength).toStrictEqual(definition2TzLength);
+        expect(definition1OptionsLength).toStrictEqual(definition2OptionsLength);
     });
 
     it("adds external converter with same model built-in", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -326,7 +326,7 @@ describe("ZHC", () => {
         expect((await findByDevice(device)).vendor).toStrictEqual("Aqara");
     });
 
-    it("should prepare definitions only once", async () => {
+    it("should not add toZigbee converters/options multiple times if findByDevice is called multiple times for the same device", async () => {
         const device = mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_3towulqd", endpoints: []});
         const definition1 = await findByDevice(device);
         const definition1TzLength = definition1.toZigbee.length;


### PR DESCRIPTION
Currently toZigbee converters and options are added on every `findByDevice`, this causes duplicates when you have the same device multiple times.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/26640

The alternative solution is to clone all the arrays to make sure the original object is not mutated (more CPU heavy, since `processExtensions` also runs multiple times). This solution is a bit more memory heavy. 

CC: @Nerivec 

EDIT: With a db of 100 devices, this makes heapUsed grow from 49 -> 57mb, a bit too much, will optimise this.