### PR TITLE
Add new thermostat OWON PCT512

### DIFF
--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -391,7 +391,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "PCT512",
         vendor: "OWON",
         description: "Thermostat",
-        fromZigbee: [fz.thermostat, fz.humidity, fz.occupancy],
+        fromZigbee: [fz.thermostat],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_min_heat_setpoint_limit,
@@ -400,9 +400,8 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
         ],
+        extend: [m.occupancy(), m.humidity()],
         exposes: [
-            e.humidity(),
-            e.occupancy(),
             e
                 .climate()
                 .withSystemMode(["off", "heat"])

--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -390,7 +390,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["PCT512"],
         model: "PCT512",
         vendor: "OWON",
-        description: "Thermostat PCT512",
+        description: "Thermostat",
         fromZigbee: [fz.thermostat, fz.humidity, fz.occupancy],
         toZigbee: [
             tz.thermostat_occupied_heating_setpoint,
@@ -415,29 +415,12 @@ export const definitions: DefinitionWithExtend[] = [
             const binds = ["genBasic", "genIdentify", "genGroups", "genScenes", "genOnOff", "hvacThermostat", "msRelativeHumidity"];
 
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
-            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {
-                min: 0,
-                max: 3600,
-                change: 10,
-            });
-            await reporting.thermostatTemperature(endpoint, {
-                min: 0,
-                max: 3600,
-                change: 10,
-            });
-            await reporting.humidity(endpoint, {
-                min: 0,
-                max: 3600,
-                change: 10,
-            });
-            await reporting.thermostatSystemMode(endpoint, {
-                min: 0,
-                max: 3600,
-            });
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {min: 0, max: 3600, change: 10});
+            await reporting.thermostatTemperature(endpoint, {min: 0, max: 3600, change: 10});
+            await reporting.humidity(endpoint, {min: 0, max: 3600, change: 10});
+            await reporting.thermostatSystemMode(endpoint, {min: 0, max: 3600});
             await reporting.thermostatRunningState(endpoint);
-
             await endpoint.read("hvacThermostat", ["systemMode", "runningState", "occupiedHeatingSetpoint", "localTemp"]);
-
             await endpoint.read("msRelativeHumidity", ["measuredValue"]);
         },
     },

--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -387,6 +387,61 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        zigbeeModel: ["PCT512"],
+        model: "PCT512",
+        vendor: "OWON",
+        description: "Thermostat PCT512",
+        fromZigbee: [fz.thermostat, fz.humidity, fz.occupancy],
+        toZigbee: [
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_min_heat_setpoint_limit,
+            tz.thermostat_max_heat_setpoint_limit,
+            tz.thermostat_local_temperature,
+            tz.thermostat_system_mode,
+            tz.thermostat_running_state,
+        ],
+        exposes: [
+            e.humidity(),
+            e.occupancy(),
+            e
+                .climate()
+                .withSystemMode(["off", "heat"])
+                .withLocalTemperature()
+                .withRunningState(["heat", "idle"])
+                .withSetpoint("occupied_heating_setpoint", 5, 30, 0.5),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            const binds = ["genBasic", "genIdentify", "genGroups", "genScenes", "genOnOff", "hvacThermostat", "msRelativeHumidity"];
+
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint, {
+                min: 0,
+                max: 3600,
+                change: 10,
+            });
+            await reporting.thermostatTemperature(endpoint, {
+                min: 0,
+                max: 3600,
+                change: 10,
+            });
+            await reporting.humidity(endpoint, {
+                min: 0,
+                max: 3600,
+                change: 10,
+            });
+            await reporting.thermostatSystemMode(endpoint, {
+                min: 0,
+                max: 3600,
+            });
+            await reporting.thermostatRunningState(endpoint);
+
+            await endpoint.read("hvacThermostat", ["systemMode", "runningState", "occupiedHeatingSetpoint", "localTemp"]);
+
+            await endpoint.read("msRelativeHumidity", ["measuredValue"]);
+        },
+    },
+    {
         zigbeeModel: ["PIR323-PTH"],
         model: "PIR323-PTH",
         vendor: "OWON",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -88,6 +88,8 @@ export const thermostatRunningStates: KeyValueAny = {
     34: "cool",
     65: "heat",
     66: "cool",
+    32768: "idle",
+    32769: "heat",
 };
 
 export const thermostatAcLouverPositions: KeyValueNumberString = {


### PR DESCRIPTION
- Added the converter for the OWON PCT512 thermostat.
- It has been necessary to add 2 new constants for the idle and heat values: 32768: ‘idle’, 32769: ‘heat’,