### PR TITLE
Orvibo MixSwitch random on/off bugfix and expose power_on_behavior 

### DIFF
--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -352,7 +352,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "T18W3Z",
         vendor: "ORVIBO",
         description: "Neutral smart switch 3 gang",
-        extend: [m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}), m.onOff({endpointNames: ["l1", "l2", "l3"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["l1", "l2", "l3"]}),
+        ],
     },
     {
         zigbeeModel: ["fdd76effa0e146b4bdafa0c203a37192", "c670e231d1374dbc9e3c6a9fffbd0ae6", "75a4bfe8ef9c4350830a25d13e3ab068"],
@@ -436,21 +441,35 @@ export const definitions: DefinitionWithExtend[] = [
         model: "T30W3Z",
         vendor: "ORVIBO",
         description: "Smart light switch - 3 gang",
-        extend: [m.deviceEndpoints({endpoints: {top: 1, center: 2, bottom: 3}}), m.onOff({endpointNames: ["top", "center", "bottom"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {top: 1, center: 2, bottom: 3}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["top", "center", "bottom"]}),
+        ],
     },
     {
         zigbeeModel: ["074b3ffba5a045b7afd94c47079dd553"],
         model: "T21W2Z",
         vendor: "ORVIBO",
         description: "Smart light switch - 2 gang",
-        extend: [m.deviceEndpoints({endpoints: {top: 1, bottom: 2}}), m.onOff({endpointNames: ["top", "bottom"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {top: 1, bottom: 2}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["top", "bottom"]}),
+        ],
     },
     {
         zigbeeModel: ["095db3379e414477ba6c2f7e0c6aa026"],
         model: "T21W1Z",
         vendor: "ORVIBO",
         description: "Smart light switch - 1 gang",
-        extend: [m.onOff()],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.onOff({configureReporting: false, powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ["093199ff04984948b4c78167c8e7f47e", "c8daea86aa9c415aa524365775b1218c", "c8daea86aa9c415aa524365775b1218"],
@@ -475,7 +494,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "R11W2Z",
         vendor: "ORVIBO",
         description: "In wall switch - 2 gang",
-        extend: [m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}), m.onOff({endpointNames: ["l1", "l2"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["l1", "l2"]}),
+        ],
     },
     {
         zigbeeModel: ["9ea4d5d8778d4f7089ac06a3969e784b", "83b9b27d5ffb4830bf35be5b1023623e", "2810c2403b9c4a5db62cc62d1030d95e"],
@@ -562,14 +586,24 @@ export const definitions: DefinitionWithExtend[] = [
         model: "T40W2Z",
         vendor: "ORVIBO",
         description: "MixSwitch 2 gangs",
-        extend: [m.deviceEndpoints({endpoints: {left: 1, right: 2}}), m.onOff({endpointNames: ["left", "right"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {left: 1, right: 2}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["left", "right"]}),
+        ],
     },
     {
         zigbeeModel: ["e8d667cb184b4a2880dd886c23d00976"],
         model: "T40W3Z_v1",
         vendor: "ORVIBO",
         description: "MixSwitch 3 gangs",
-        extend: [m.deviceEndpoints({endpoints: {left: 1, center: 2, right: 3}}), m.onOff({endpointNames: ["left", "center", "right"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {left: 1, center: 2, right: 3}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["left", "center", "right"]}),
+        ],
     },
     {
         zigbeeModel: ["f3be30b8c43c44da85aac622e5b56111", "f58591161f344ccea242688a6de7d25d"],
@@ -618,14 +652,23 @@ export const definitions: DefinitionWithExtend[] = [
         model: "T41W1Z",
         vendor: "ORVIBO",
         description: "MixSwitch 1 gang (without neutral wire)",
-        extend: [m.onOff()],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.onOff({configureReporting: false, powerOnBehavior: false}),
+        ],
     },
     {
         zigbeeModel: ["7c8f476a0f764cd4b994bc73d07c906d"],
         model: "T41W2Z",
         vendor: "ORVIBO",
         description: "MixSwitch 2 gang (without neutral wire)",
-        extend: [m.deviceEndpoints({endpoints: {left: 1, right: 2}}), m.onOff({endpointNames: ["left", "right"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {left: 1, right: 2}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["left", "right"]}),
+        ],
     },
     {
         zigbeeModel: ["cb7ce9fe2cb147e69c5ea700b39b3d5b"],
@@ -646,7 +689,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "R30W3Z",
         vendor: "ORVIBO",
         description: "In-wall switch 3 gang",
-        extend: [m.deviceEndpoints({endpoints: {left: 1, center: 2, right: 3}}), m.onOff({endpointNames: ["left", "center", "right"]})],
+        extend: [
+            clusterManuSpecificOrviboPowerOnBehavior(),
+            orviboSwitchPowerOnBehavior(),
+            m.deviceEndpoints({endpoints: {left: 1, center: 2, right: 3}}),
+            m.onOff({configureReporting: false, powerOnBehavior: false, endpointNames: ["left", "center", "right"]}),
+        ],
     },
     {
         zigbeeModel: ["0e93fa9c36bb417a90ad5d8a184b683a"],

--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -105,9 +105,9 @@ const clusterManuSpecifcOrviboSwitchRewiring = () => {
 };
 const clusterManuSpecificOrviboPowerOnBehavior = () => {
     return m.deviceAddCustomCluster("manuSpecificOrvibo2", {
-        ID: 0xFF00,
+        ID: 0xff00,
         attributes: {
-            power_on_behavior: { ID: 0x0001, type: Zcl.DataType.UINT8 }
+            power_on_behavior: {ID: 0x0001, type: Zcl.DataType.UINT8},
         },
         commands: {},
         commandsResponse: {},
@@ -252,42 +252,42 @@ const orviboSwitchRewiring = (args: OrviboSwitchRewiringArgs): ModernExtend => {
     };
 };
 const orviboSwitchPowerOnBehavior = (): ModernExtend => {
-    const powerOnLookup: {[k: number]: string} = {1: 'off', 2: 'previous'};
-    const powerOnLookup2: {[k: string]: number} = {'off': 1, 'previous': 2};
-    const exposes: Expose[] = [e.power_on_behavior(['off', 'previous'])];
+    const powerOnLookup: {[k: number]: string} = {1: "off", 2: "previous"};
+    const powerOnLookup2: {[k: string]: number} = {off: 1, previous: 2};
+    const exposes: Expose[] = [e.power_on_behavior(["off", "previous"])];
     const fromZigbee: Fz.Converter[] = [
         {
-            cluster: 'manuSpecificOrvibo2',
-            type: ['readResponse'],
+            cluster: "manuSpecificOrvibo2",
+            type: ["readResponse"],
             convert: (model, msg, publish, options, meta) => {
                 const result: KeyValue = {};
-                if (typeof msg.data.power_on_behavior === 'number') {
+                if (typeof msg.data.power_on_behavior === "number") {
                     result.power_on_behavior = powerOnLookup[msg.data.power_on_behavior as number];
                 }
                 return result;
-            }
-        }
+            },
+        },
     ];
     const toZigbee: Tz.Converter[] = [
         {
-            key: ['power_on_behavior'],
-            convertSet:  async (entity, key, value, meta) => {
-                if (key === 'power_on_behavior') {
-                    await entity.write('manuSpecificOrvibo2', {power_on_behavior: powerOnLookup2[value as string]});
+            key: ["power_on_behavior"],
+            convertSet: async (entity, key, value, meta) => {
+                if (key === "power_on_behavior") {
+                    await entity.write("manuSpecificOrvibo2", {power_on_behavior: powerOnLookup2[value as string]});
                 }
             },
             convertGet: async (entity, key, meta) => {
-                if (key === 'power_on_behavior') {
-                    await entity.read('manuSpecificOrvibo2', ['power_on_behavior']);
+                if (key === "power_on_behavior") {
+                    await entity.read("manuSpecificOrvibo2", ["power_on_behavior"]);
                 }
-            }
-        }
+            },
+        },
     ];
     return {
         exposes,
         fromZigbee,
         toZigbee,
-        isModernExtend: true
+        isModernExtend: true,
     };
 };
 
@@ -554,7 +554,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             clusterManuSpecificOrviboPowerOnBehavior(),
             orviboSwitchPowerOnBehavior(),
-            m.onOff({configureReporting: false, powerOnBehavior: false})
+            m.onOff({configureReporting: false, powerOnBehavior: false}),
         ],
     },
     {
@@ -591,7 +591,11 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             clusterManuSpecifcOrviboSwitchRewiring(),
             m.deviceEndpoints({endpoints: {left_up: 1, left_down: 2, center_up: 3, center_down: 4, right_up: 5, right_down: 6}}),
-            m.onOff({powerOnBehavior: false, configureReporting: false, endpointNames: ["left_up", "left_down", "center_up", "center_down", "right_up", "right_down"]}),
+            m.onOff({
+                powerOnBehavior: false,
+                configureReporting: false,
+                endpointNames: ["left_up", "left_down", "center_up", "center_down", "right_up", "right_down"],
+            }),
             orviboSwitchRewiring({
                 endpointNames: ["left_up", "left_down", "center_up", "center_down", "right_up", "right_down"],
                 endpoints: {left_up: 1, left_down: 2, center_up: 3, center_down: 4, right_up: 5, right_down: 6},

--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -107,7 +107,7 @@ const clusterManuSpecificOrviboPowerOnBehavior = () => {
     return m.deviceAddCustomCluster("manuSpecificOrvibo2", {
         ID: 0xff00,
         attributes: {
-            power_on_behavior: {ID: 0x0001, type: Zcl.DataType.UINT8},
+            powerOnBehavior: {ID: 0x0001, type: Zcl.DataType.UINT8},
         },
         commands: {},
         commandsResponse: {},
@@ -261,8 +261,8 @@ const orviboSwitchPowerOnBehavior = (): ModernExtend => {
             type: ["readResponse"],
             convert: (model, msg, publish, options, meta) => {
                 const result: KeyValue = {};
-                if (typeof msg.data.power_on_behavior === "number") {
-                    result.power_on_behavior = powerOnLookup[msg.data.power_on_behavior as number];
+                if (typeof msg.data.powerOnBehavior === "number") {
+                    result.power_on_behavior = powerOnLookup[msg.data.powerOnBehavior as number];
                 }
                 return result;
             },
@@ -273,12 +273,12 @@ const orviboSwitchPowerOnBehavior = (): ModernExtend => {
             key: ["power_on_behavior"],
             convertSet: async (entity, key, value, meta) => {
                 if (key === "power_on_behavior") {
-                    await entity.write("manuSpecificOrvibo2", {power_on_behavior: powerOnLookup2[value as string]});
+                    await entity.write("manuSpecificOrvibo2", {powerOnBehavior: powerOnLookup2[value as string]});
                 }
             },
             convertGet: async (entity, key, meta) => {
                 if (key === "power_on_behavior") {
-                    await entity.read("manuSpecificOrvibo2", ["power_on_behavior"]);
+                    await entity.read("manuSpecificOrvibo2", ["powerOnBehavior"]);
                 }
             },
         },


### PR DESCRIPTION
This PR has 2 improvements:
First is fix for [issue](https://github.com/Koenkk/zigbee2mqtt/issues/26687) is to not configure reporting for onOff. This configuration had 2 effects:
1. Switches start malfunctioning with firmware version 6.1.7 (with 6.1.3 I can confirm they worked properly). In particular turning off and on at random points in time.
2. Switches stop reporting their state periodically. This in particular creates issue when there is power loss event, as Z2M never gets notified that switch changed to off.

Second is exposing power_on_behavior, which is implemented in non-standard way through manufacturer specific cluster 0xFF00.