### PR TITLE
Add valve flow rate to AVATTO TRV06.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5453,6 +5453,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withLocalTemperature(ea.STATE)
                 .withSystemMode(["auto", "heat", "off"], ea.STATE_SET)
                 .withRunningState(["idle", "heat"], ea.STATE)
+                .withPiHeatingDemand()
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET),
             ...tuya.exposes.scheduleAllDays(ea.STATE_SET, "HH:MM/C HH:MM/C HH:MM/C HH:MM/C HH:MM/C HH:MM/C"),
             e
@@ -5504,6 +5505,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [36, "frost_protection", tuya.valueConverter.onOff],
                 [39, "scale_protection", tuya.valueConverter.onOff],
                 [47, "local_temperature_calibration", tuya.valueConverter.localTempCalibration2],
+                [101, "pi_heating_demand", tuya.valueConverter.raw],
             ],
         },
     },


### PR DESCRIPTION
This is as simple as wiring up data point 101; the Smart Life app calls this “flow rate” (IIRC) but it seems to match well to the concept “PI Heating Demand” that zigbee-herdsman-converters already has for other devices.

I haven't checked if this would be somehow settable; the app shows it as a read-only value so I've left it read-only here as well.

Tested with _TZE284_o3x45p96.