### PR TITLE
Create quirky.ts for quirky leak sensor

### DIFF
--- a/src/devices/quirky.ts
+++ b/src/devices/quirky.ts
@@ -1,0 +1,16 @@
+import * as fz from "zigbee-herdsman-converters/converters/fromZigbee";
+import * as exposes from "zigbee-herdsman-converters/lib/exposes";
+const e = exposes.presets;
+
+const definition = {
+    zigbeeModel: ['Overflow'],
+    model: 'Smart_Water_Leak_Sensor_Quirky_Inc',
+    vendor: 'Quirky',
+    description: 'Smart water leak sensor with a long cable and a seperate sensing end and body. It accepts 2 AA batteries.',
+    fromZigbee: [fz.ias_water_leak_alarm_1],
+    toZigbee: [],
+    exposes: [e.water_leak(), e.battery_low()],
+    meta: {},
+};
+
+module.exports = definition;


### PR DESCRIPTION
https://www.wink.com/downloads/help/quirkyge-overflow-water-sensor/user-guide.pdf

I have created and installed the external connector, and it works. This file is identical to the external connector, except that the first two lines were
```
const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
```
which was replaced by
```
import * as fz from "zigbee-herdsman-converters/converters/fromZigbee";
 import * as exposes from "zigbee-herdsman-converters/lib/exposes";
```
in this commit.
<br>

I've also added the image to zigbee2mqtt repository.