### PR TITLE
feat: Generate definition for unsupported Green Power devices

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -529,7 +529,7 @@ export async function findDefinition(device: Zh.Device, generateForUnknown = fal
         }
 
         // Do not add this definition to cache, as device configuration might change.
-        const {definition} = device.type === "GreenPower" ? generateGreenPowerDefinition(device) : await generateDefinition(device);
+        const {definition} = await generateDefinition(device);
 
         return definition;
     }
@@ -569,13 +569,11 @@ export async function findDefinition(device: Zh.Device, generateForUnknown = fal
 }
 
 export async function generateExternalDefinitionSource(device: Zh.Device): Promise<string> {
-    return device.type === "GreenPower"
-        ? generateGreenPowerDefinition(device).externalDefinitionSource
-        : (await generateDefinition(device)).externalDefinitionSource;
+    return (await generateDefinition(device)).externalDefinitionSource;
 }
 
 export async function generateExternalDefinition(device: Zh.Device): Promise<Definition> {
-    const {definition} = await generateDefinition(device);
+    const {definition} = device.type === "GreenPower" ? generateGreenPowerDefinition(device) : await generateDefinition(device);
 
     return prepareDefinition(definition);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import {
     access,
 } from "./lib/exposes";
 import * as exposesLib from "./lib/exposes";
-import {generateDefinition} from "./lib/generateDefinition";
+import {generateDefinition, generateGreenPowerDefinition} from "./lib/generateDefinition";
 import {logger} from "./lib/logger";
 import {
     type Configure,
@@ -529,7 +529,7 @@ export async function findDefinition(device: Zh.Device, generateForUnknown = fal
         }
 
         // Do not add this definition to cache, as device configuration might change.
-        const {definition} = await generateDefinition(device);
+        const {definition} = device.type === "GreenPower" ? generateGreenPowerDefinition(device) : await generateDefinition(device);
 
         return definition;
     }
@@ -569,7 +569,9 @@ export async function findDefinition(device: Zh.Device, generateForUnknown = fal
 }
 
 export async function generateExternalDefinitionSource(device: Zh.Device): Promise<string> {
-    return (await generateDefinition(device)).externalDefinitionSource;
+    return device.type === "GreenPower"
+        ? generateGreenPowerDefinition(device).externalDefinitionSource
+        : (await generateDefinition(device)).externalDefinitionSource;
 }
 
 export async function generateExternalDefinition(device: Zh.Device): Promise<Definition> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import {
     access,
 } from "./lib/exposes";
 import * as exposesLib from "./lib/exposes";
-import {generateDefinition, generateGreenPowerDefinition} from "./lib/generateDefinition";
+import {generateDefinition} from "./lib/generateDefinition";
 import {logger} from "./lib/logger";
 import {
     type Configure,
@@ -573,7 +573,7 @@ export async function generateExternalDefinitionSource(device: Zh.Device): Promi
 }
 
 export async function generateExternalDefinition(device: Zh.Device): Promise<Definition> {
-    const {definition} = device.type === "GreenPower" ? generateGreenPowerDefinition(device) : await generateDefinition(device);
+    const {definition} = await generateDefinition(device);
 
     return prepareDefinition(definition);
 }

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -150,6 +150,10 @@ export default {
 }
 
 export async function generateDefinition(device: Zh.Device): Promise<{externalDefinitionSource: string; definition: DefinitionWithExtend}> {
+    if (device.type === "GreenPower") {
+        return generateGreenPowerDefinition(device);
+    }
+
     // Map cluster to all endpoints that have this cluster.
     const mapClusters = (endpoint: ZHModels.Endpoint, clusters: Cluster[], clusterMap: Map<string, ZHModels.Endpoint[]>) => {
         for (const cluster of clusters) {

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -52,138 +52,11 @@ type Extender = [string[], ExtenderGenerator];
 
 type DefinitionWithZigbeeModel = DefinitionWithExtend & {zigbeeModel: string[]};
 
-function generateSource(definition: DefinitionWithZigbeeModel, generatedExtend: GeneratedExtend[]): string {
-    const imports = [...new Set(generatedExtend.map((e) => e.lib ?? "modernExtend"))];
-    const importsStr = imports.map((e) => `const ${e === "modernExtend" ? "m" : e} = require('zigbee-herdsman-converters/lib/${e}');`).join("\n");
-    return `${importsStr}
-
-const definition = {
-    zigbeeModel: ['${definition.zigbeeModel}'],
-    model: '${definition.model}',
-    vendor: '${definition.vendor}',
-    description: 'Automatically generated definition',
-    extend: [${generatedExtend.map((e) => `${e.lib ?? "m"}.${e.getSource()}`).join(", ")}],
-    meta: ${JSON.stringify(definition.meta || {})},
-};
-
-module.exports = definition;`;
-}
-
-export async function generateDefinition(device: Zh.Device): Promise<{externalDefinitionSource: string; definition: DefinitionWithExtend}> {
-    // Map cluster to all endpoints that have this cluster.
-    const mapClusters = (endpoint: ZHModels.Endpoint, clusters: Cluster[], clusterMap: Map<string, ZHModels.Endpoint[]>) => {
-        for (const cluster of clusters) {
-            if (!clusterMap.has(cluster.name)) {
-                clusterMap.set(cluster.name, []);
-            }
-
-            const endpointsWithCluster = clusterMap.get(cluster.name);
-            endpointsWithCluster.push(endpoint);
-        }
-    };
-
-    const knownInputClusters = inputExtenders.flatMap((ext) => ext[0]);
-    const knownOutputClusters = outputExtenders.flatMap((ext) => ext[0]);
-
-    const inputClusterMap = new Map<string, ZHModels.Endpoint[]>();
-    const outputClusterMap = new Map<string, ZHModels.Endpoint[]>();
-
-    for (const endpoint of device.endpoints) {
-        // Filter clusters to leave only the ones that we can generate extenders for.
-        const inputClusters = endpoint.getInputClusters().filter((c) => knownInputClusters.find((known) => known === c.name));
-        const outputClusters = endpoint.getOutputClusters().filter((c) => knownOutputClusters.find((known) => known === c.name));
-
-        mapClusters(endpoint, inputClusters, inputClusterMap);
-        mapClusters(endpoint, outputClusters, outputClusterMap);
-    }
-    // Generate extenders
-    const usedExtenders: Extender[] = [];
-    const generatedExtend: GeneratedExtend[] = [];
-
-    const addGenerators = async (clusterName: string, endpoints: Zh.Endpoint[], extenders: Extender[]) => {
-        const extender = extenders.find((e) => e[0].includes(clusterName));
-        if (!extender || usedExtenders.includes(extender)) {
-            return;
-        }
-        usedExtenders.push(extender);
-        generatedExtend.push(...(await extender[1](device, endpoints)));
-    };
-
-    for (const [cluster, endpoints] of inputClusterMap) {
-        await addGenerators(cluster, endpoints, inputExtenders);
-    }
-
-    for (const [cluster, endpoints] of outputClusterMap) {
-        await addGenerators(cluster, endpoints, outputExtenders);
-    }
-
-    const extenders = generatedExtend.map((e) => e.getExtend());
-    // Generated definition below will provide this.
-    // biome-ignore lint/complexity/noForEach: ignored using `--suppress`
-    extenders.forEach((extender) => {
-        extender.endpoint = undefined;
-    });
-
-    // Currently multiEndpoint is enabled if device has more then 1 endpoint.
-    // It is possible to better check if device should be considered multiEndpoint
-    // based, for example, on generator arguments(i.e. presence of "endpointNames"),
-    // but this will be enough for now.
-    const endpointsWithoutGreenPower = device.endpoints.filter((e) => e.ID !== 242);
-    const multiEndpoint = endpointsWithoutGreenPower.length > 1;
-
-    if (multiEndpoint) {
-        const endpoints: {[n: string]: number} = {};
-        for (const endpoint of endpointsWithoutGreenPower) {
-            endpoints[endpoint.ID.toString()] = endpoint.ID;
-        }
-        // Add to beginning for better visibility.
-        generatedExtend.unshift(new ExtendGenerator({extend: m.deviceEndpoints, args: {endpoints}, source: "deviceEndpoints"}));
-        extenders.unshift(generatedExtend[0].getExtend());
-    }
-
-    const definition: DefinitionWithExtend = {
-        zigbeeModel: [device.modelID],
-        model: device.modelID ?? "",
-        vendor: device.manufacturerName ?? "",
-        description: "Automatically generated definition",
-        extend: extenders,
-        generated: true,
-    };
-
-    if (multiEndpoint) {
-        definition.meta = {multiEndpoint};
-    }
-
-    const externalDefinitionSource = generateSource(definition, generatedExtend);
-    return {externalDefinitionSource, definition};
-}
-
-function stringifyEps(endpoints: ZHModels.Endpoint[]): string[] {
-    return endpoints.map((e) => e.ID.toString());
-}
-
-// This function checks if provided array of endpoints contain
-// only first device endpoint, which is passed in as `firstEndpoint`.
-function onlyFirstDeviceEnpoint(device: Zh.Device, endpoints: ZHModels.Endpoint[]): boolean {
-    return endpoints.length === 1 && endpoints[0].ID === device.endpoints[0].ID;
-}
-
-// maybeEndpoints returns either `toExtend` if only first device endpoint is provided
-// as `endpoints`, or `endpointNames` with `toExtend`.
-// This allows to drop unnecessary `endpointNames` argument if it is not needed.
-function maybeEndpointArgs<T>(device: Zh.Device, endpoints: Zh.Endpoint[], toExtend?: T): T | undefined {
-    if (onlyFirstDeviceEnpoint(device, endpoints)) {
-        return toExtend;
-    }
-
-    return {endpointNames: stringifyEps(endpoints), ...toExtend};
-}
-
 // If generator will have endpoint argument - generator implementation
 // should not provide it if only the first device endpoint is passed in.
 // If multiple endpoints provided(maybe including the first device endpoint) -
 // they all should be passed as an argument, where possible, to be explicit.
-const inputExtenders: Extender[] = [
+const INPUT_EXTENDERS: Extender[] = [
     [
         ["msTemperatureMeasurement"],
         async (d, eps) => [new ExtendGenerator({extend: m.temperature, args: maybeEndpointArgs(d, eps), source: "temperature"})],
@@ -229,7 +102,7 @@ const inputExtenders: Extender[] = [
     [["genBinaryOutput"], extenderBinaryOutput],
 ];
 
-const outputExtenders: Extender[] = [
+const OUTPUT_EXTENDERS: Extender[] = [
     [["genOnOff"], async (d, eps) => [new ExtendGenerator({extend: m.commandsOnOff, args: maybeEndpointArgs(d, eps), source: "commandsOnOff"})]],
     [
         ["genLevelCtrl"],
@@ -246,6 +119,159 @@ const outputExtenders: Extender[] = [
         ],
     ],
 ];
+
+function generateSource(definition: DefinitionWithZigbeeModel, generatedExtend: GeneratedExtend[]): string {
+    const imports = [...new Set(generatedExtend.map((e) => e.lib ?? "modernExtend"))];
+    const importsStr = imports.map((e) => `const ${e === "modernExtend" ? "m" : e} = require('zigbee-herdsman-converters/lib/${e}');`).join("\n");
+    return `${importsStr}
+
+const definition = {
+    zigbeeModel: ['${definition.zigbeeModel}'],
+    model: '${definition.model}',
+    vendor: '${definition.vendor}',
+    description: 'Automatically generated definition',
+    extend: [${generatedExtend.map((e) => `${e.lib ?? "m"}.${e.getSource()}`).join(", ")}],
+    meta: ${JSON.stringify(definition.meta || {})},
+};
+
+module.exports = definition;`;
+}
+
+function generateGreenPowerSource(definition: DefinitionWithExtend, ieeeAddr: string): string {
+    return `import {genericGreenPower} from 'zigbee-herdsman-converters/lib/modernExtend';
+
+export default {
+    fingerprint: [{modelID: '${definition.model}', ieeeAddr: new RegExp('^${ieeeAddr}$')}],
+    model: '${definition.model}',
+    vendor: '${definition.vendor}',
+    description: 'Automatically generated definition for Green Power',
+    extend: [genericGreenPower()],
+};`;
+}
+
+export async function generateDefinition(device: Zh.Device): Promise<{externalDefinitionSource: string; definition: DefinitionWithExtend}> {
+    // Map cluster to all endpoints that have this cluster.
+    const mapClusters = (endpoint: ZHModels.Endpoint, clusters: Cluster[], clusterMap: Map<string, ZHModels.Endpoint[]>) => {
+        for (const cluster of clusters) {
+            if (!clusterMap.has(cluster.name)) {
+                clusterMap.set(cluster.name, []);
+            }
+
+            const endpointsWithCluster = clusterMap.get(cluster.name);
+            endpointsWithCluster.push(endpoint);
+        }
+    };
+
+    const knownInputClusters = INPUT_EXTENDERS.flatMap((ext) => ext[0]);
+    const knownOutputClusters = OUTPUT_EXTENDERS.flatMap((ext) => ext[0]);
+
+    const inputClusterMap = new Map<string, ZHModels.Endpoint[]>();
+    const outputClusterMap = new Map<string, ZHModels.Endpoint[]>();
+
+    for (const endpoint of device.endpoints) {
+        // Filter clusters to leave only the ones that we can generate extenders for.
+        const inputClusters = endpoint.getInputClusters().filter((c) => knownInputClusters.find((known) => known === c.name));
+        const outputClusters = endpoint.getOutputClusters().filter((c) => knownOutputClusters.find((known) => known === c.name));
+
+        mapClusters(endpoint, inputClusters, inputClusterMap);
+        mapClusters(endpoint, outputClusters, outputClusterMap);
+    }
+    // Generate extenders
+    const usedExtenders: Extender[] = [];
+    const generatedExtend: GeneratedExtend[] = [];
+
+    const addGenerators = async (clusterName: string, endpoints: Zh.Endpoint[], extenders: Extender[]) => {
+        const extender = extenders.find((e) => e[0].includes(clusterName));
+        if (!extender || usedExtenders.includes(extender)) {
+            return;
+        }
+        usedExtenders.push(extender);
+        generatedExtend.push(...(await extender[1](device, endpoints)));
+    };
+
+    for (const [cluster, endpoints] of inputClusterMap) {
+        await addGenerators(cluster, endpoints, INPUT_EXTENDERS);
+    }
+
+    for (const [cluster, endpoints] of outputClusterMap) {
+        await addGenerators(cluster, endpoints, OUTPUT_EXTENDERS);
+    }
+
+    const extenders = generatedExtend.map((e) => e.getExtend());
+    // Generated definition below will provide this.
+    // biome-ignore lint/complexity/noForEach: ignored using `--suppress`
+    extenders.forEach((extender) => {
+        extender.endpoint = undefined;
+    });
+
+    // Currently multiEndpoint is enabled if device has more then 1 endpoint.
+    // It is possible to better check if device should be considered multiEndpoint
+    // based, for example, on generator arguments(i.e. presence of "endpointNames"),
+    // but this will be enough for now.
+    const endpointsWithoutGreenPower = device.endpoints.filter((e) => e.ID !== 242);
+    const multiEndpoint = endpointsWithoutGreenPower.length > 1;
+
+    if (multiEndpoint) {
+        const endpoints: {[n: string]: number} = {};
+        for (const endpoint of endpointsWithoutGreenPower) {
+            endpoints[endpoint.ID.toString()] = endpoint.ID;
+        }
+        // Add to beginning for better visibility.
+        generatedExtend.unshift(new ExtendGenerator({extend: m.deviceEndpoints, args: {endpoints}, source: "deviceEndpoints"}));
+        extenders.unshift(generatedExtend[0].getExtend());
+    }
+
+    const definition: DefinitionWithExtend = {
+        zigbeeModel: [device.modelID],
+        model: device.modelID ?? "",
+        vendor: device.manufacturerName ?? "",
+        description: "Automatically generated definition",
+        extend: extenders,
+        generated: true,
+    };
+
+    if (multiEndpoint) {
+        definition.meta = {multiEndpoint};
+    }
+
+    const externalDefinitionSource = generateSource(definition, generatedExtend);
+    return {externalDefinitionSource, definition};
+}
+
+export function generateGreenPowerDefinition(device: Zh.Device): {externalDefinitionSource: string; definition: DefinitionWithExtend} {
+    const definition: DefinitionWithExtend = {
+        fingerprint: [{modelID: device.modelID, ieeeAddr: new RegExp(`^${device.ieeeAddr}$`)}],
+        model: device.modelID ?? "",
+        vendor: device.manufacturerName ?? "",
+        description: "Automatically generated definition for Green Power",
+        extend: [m.genericGreenPower()],
+        generated: true,
+    };
+
+    const externalDefinitionSource = generateGreenPowerSource(definition, device.ieeeAddr);
+    return {externalDefinitionSource, definition};
+}
+
+function stringifyEps(endpoints: ZHModels.Endpoint[]): string[] {
+    return endpoints.map((e) => e.ID.toString());
+}
+
+// This function checks if provided array of endpoints contain
+// only first device endpoint, which is passed in as `firstEndpoint`.
+function onlyFirstDeviceEnpoint(device: Zh.Device, endpoints: ZHModels.Endpoint[]): boolean {
+    return endpoints.length === 1 && endpoints[0].ID === device.endpoints[0].ID;
+}
+
+// maybeEndpoints returns either `toExtend` if only first device endpoint is provided
+// as `endpoints`, or `endpointNames` with `toExtend`.
+// This allows to drop unnecessary `endpointNames` argument if it is not needed.
+function maybeEndpointArgs<T>(device: Zh.Device, endpoints: Zh.Endpoint[], toExtend?: T): T | undefined {
+    if (onlyFirstDeviceEnpoint(device, endpoints)) {
+        return toExtend;
+    }
+
+    return {endpointNames: stringifyEps(endpoints), ...toExtend};
+}
 
 async function extenderLock(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     // TODO: Support multiple endpoints

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2222,10 +2222,7 @@ export const GPDF_COMMANDS: Record<number, string> = {
 export function genericGreenPower(): ModernExtend {
     const exposes = [
         e.action(Object.values(GPDF_COMMANDS)),
-        // e.numeric("payload", ea.STATE).withDescription("Payload received with the command (hexadecimal)"),
-        e
-            .list("payload", ea.STATE, e.numeric("payload", ea.STATE).withDescription("Byte"))
-            .withDescription("Payload of the command"),
+        e.list("payload", ea.STATE, e.numeric("payload", ea.STATE).withDescription("Byte")).withDescription("Payload of the command"),
     ];
     const fromZigbee: Fz.Converter[] = [
         {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2138,6 +2138,118 @@ export function gasMeter(args?: GasMeterArgs): ModernExtend {
 
 // #region Other extends
 
+/**
+ * Version of the GP spec: 1.1.1
+ */
+export const GPDF_COMMANDS: Record<number, string> = {
+    /*0x00*/ 0: "identify",
+    /*0x10*/ 16: "recall_scene0",
+    /*0x11*/ 17: "recall_scene1",
+    /*0x12*/ 18: "recall_scene2",
+    /*0x13*/ 19: "recall_scene3",
+    /*0x14*/ 20: "recall_scene4",
+    /*0x15*/ 21: "recall_scene5",
+    /*0x16*/ 22: "recall_scene6",
+    /*0x17*/ 23: "recall_scene7",
+    /*0x18*/ 24: "store_scene0",
+    /*0x19*/ 25: "store_scene1",
+    /*0x1a*/ 26: "store_scene2",
+    /*0x1b*/ 27: "store_scene3",
+    /*0x1c*/ 28: "store_scene4",
+    /*0x1d*/ 29: "store_scene5",
+    /*0x1e*/ 30: "store_scene6",
+    /*0x1f*/ 31: "store_scene7",
+    /*0x20*/ 32: "off",
+    /*0x21*/ 33: "on",
+    /*0x22*/ 34: "toggle",
+    /*0x23*/ 35: "release",
+    /*0x30*/ 48: "move_up", // with payload
+    /*0x31*/ 49: "move_down", // with payload
+    /*0x32*/ 50: "step_up", // with payload
+    /*0x33*/ 51: "step_down", // with payload
+    /*0x34*/ 52: "level_control_stop",
+    /*0x35*/ 53: "move_up_with_on_off", // with payload
+    /*0x36*/ 54: "move_down_with_on_off", // with payload
+    /*0x37*/ 55: "step_up_with_on_off", // with payload
+    /*0x38*/ 56: "step_down_with_on_off", // with payload
+    /*0x40*/ 64: "move_hue_stop",
+    /*0x41*/ 65: "move_hue_up", // with payload
+    /*0x42*/ 66: "move_hue_down", // with payload
+    /*0x43*/ 67: "step_hue_up", // with payload
+    /*0x44*/ 68: "step_huw_down", // with payload
+    /*0x45*/ 69: "move_saturation_stop",
+    /*0x46*/ 70: "move_saturation_up", // with payload
+    /*0x47*/ 71: "move_saturation_down", // with payload
+    /*0x48*/ 72: "step_saturation_up", // with payload
+    /*0x49*/ 73: "step_saturation_down", // with payload
+    /*0x4a*/ 74: "move_color", // with payload
+    /*0x4b*/ 75: "step_color", // with payload
+    /*0x50*/ 80: "lock_door",
+    /*0x51*/ 81: "unlock_door",
+    /*0x60*/ 96: "press11",
+    /*0x61*/ 97: "release11",
+    /*0x62*/ 98: "press12",
+    /*0x63*/ 99: "release12",
+    /*0x64*/ 100: "press22",
+    /*0x65*/ 101: "release22",
+    /*0x66*/ 102: "short_press11",
+    /*0x67*/ 103: "short_press12",
+    /*0x68*/ 104: "short_press22",
+    /*0x69*/ 105: "press_8bit_vector", // with payload
+    /*0x6a*/ 106: "release_8bit_vector", // with payload
+    /*0xa0*/ 160: "attribute_reporting", // with payload
+    /*0xa1*/ 161: "manufacture_specific_attr_reporting", // with payload
+    /*0xa2*/ 162: "multi_cluster_reporting", // with payload
+    /*0xa3*/ 163: "manufacturer_specific_mcluster_reporting", // with payload
+    /*0xa4*/ 164: "request_attributes", // with payload
+    /*0xa5*/ 165: "read_attributes_response", // with payload
+    /*0xa6*/ 166: "zcl_tunneling", // with payload
+    /*0xa8*/ 168: "compact_attribute_reporting", // with payload
+    /*0xaf*/ 175: "any_sensor_command_a0_a3", // with payload
+    /*0xe0*/ 224: "commissioning", // with payload
+    /*0xe1*/ 225: "decommissioning",
+    /*0xe2*/ 226: "success",
+    /*0xe3*/ 227: "channel_request", // with payload
+    /*0xe4*/ 228: "application_description", // with payload
+    //-- sent to GPD
+    // /*0xf0*/ 240: "commissioning_reply",
+    // /*0xf1*/ 241: "write_attributes",
+    // /*0xf2*/ 242: "read_attributes",
+    // /*0xf3*/ 243: "channel_configuration",
+    // /*0xf6*/ 246: "zcl_tunneling",
+};
+
+export function genericGreenPower(): ModernExtend {
+    const exposes = [
+        e.action(Object.values(GPDF_COMMANDS)),
+        // e.numeric("payload", ea.STATE).withDescription("Payload received with the command (hexadecimal)"),
+        e
+            .list("payload", ea.STATE, e.numeric("payload", ea.STATE).withDescription("Byte"))
+            .withDescription("Payload of the command"),
+    ];
+    const fromZigbee: Fz.Converter[] = [
+        {
+            cluster: "greenPower",
+            type: ["commandNotification", "commandCommissioningNotification"],
+            convert: (model, msg, publish, options, meta) => {
+                const commandID = msg.data.commandID as number;
+                if (hasAlreadyProcessedMessage(msg, model, msg.data.frameCounter, `${msg.device.ieeeAddr}_${commandID}`)) return;
+                if (commandID >= 0xe0) return; // Skip op commands
+
+                const gpdfCommandStr = GPDF_COMMANDS[commandID];
+                const payloadBuf = msg.data.commandFrame.raw as Buffer | undefined;
+
+                return {
+                    action: gpdfCommandStr ?? `unknown_${commandID}`,
+                    payload: payloadBuf?.length > 0 ? Array.from(payloadBuf) : [],
+                };
+            },
+        },
+    ];
+
+    return {exposes, fromZigbee, isModernExtend: true};
+}
+
 export interface CommandsScenesArgs {
     commands?: string[];
     bind?: boolean;


### PR DESCRIPTION
@Koenkk not sure about the best way to display the payload? Frontend shows the array as a plain string `[1]` as it is right now.

This should also allow partially supporting the Moes ZEU2S that doesn't appear to have a fixed source ID... (otherwise used to identify an actual converter for GP devices). ref: https://github.com/Koenkk/zigbee2mqtt/issues/19405

_Tested with a PTM216Z from enocean by removing its actual converter._