### PR TITLE
Fix color temperature range for Namron 3802966

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -533,7 +533,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "3802966",
         vendor: "Namron",
         description: "LED 4.8W CCT GU10",
-        extend: [m.light({colorTemp: {range: [153, 370]}})],
+        extend: [m.light({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ["89665"],


### PR DESCRIPTION
The original definition for this LED bulb is not correct regarding the colorTemperature range.

The actual range is 200-454 which is also reported by the generated definition.

This PR fixes just this.
Let me know if there is anything else needed in order to get this PR merged.

Thanks!