### PR TITLE
Innr AE 270 T supports powerOnBehavior

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -623,7 +623,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "AE 270 T",
         vendor: "Innr",
         description: "E26/24 bulb 1100lm, dimmable, white spectrum",
-        extend: [m.light({colorTemp: {range: [154, 500]}, turnsOffAtBrightness1: true, powerOnBehavior: false})],
+        extend: [m.light({colorTemp: {range: [154, 500]}, turnsOffAtBrightness1: true})],
         ota: true,
     },
     {


### PR DESCRIPTION
Innr AE 270 T supports powerOnBehavior. It is unclear why this was changed in https://github.com/Koenkk/zigbee-herdsman-converters/pull/8493