### PR TITLE
fix: Allow scheduling OTA on device request

### DIFF
--- a/test/ota.test.ts
+++ b/test/ota.test.ts
@@ -49,6 +49,10 @@ export function defuseRejection<T>(promise: Promise<T>): Promise<T> {
     return promise;
 }
 
+function fixVitestExplorerPath(filepath: string): string {
+    return path.resolve(filepath).replace(/test(\/|\\)test/, "test");
+}
+
 const ZIGBEE_OTA_MASTER_URL = "https://github.com/Koenkk/zigbee-OTA/raw/master/";
 const BASE_IMAGES_DIRNAME = "images";
 const PREV_IMAGES_DIRNAME = "images1";
@@ -116,8 +120,12 @@ describe("OTA", () => {
 
     const getLocalPath = (fromUrl: string): string[] => fromUrl.split("/").slice(-2);
     let fetchReturnedStatus: {ok: boolean; status: number; body: unknown} = {ok: true, status: 200, body: 1 /* just needs to not be falsy */};
-    const mockGetLatestManifest = vi.fn(() => JSON.parse(readFileSync(TEST_BASE_MANIFEST_INDEX_FILEPATH, "utf8")) as Ota.ZigbeeOTAImageMeta[]);
-    const mockGetPreviousManifest = vi.fn(() => JSON.parse(readFileSync(TEST_PREV_MANIFEST_INDEX_FILEPATH, "utf8")) as Ota.ZigbeeOTAImageMeta[]);
+    const mockGetLatestManifest = vi.fn(
+        () => JSON.parse(readFileSync(fixVitestExplorerPath(TEST_BASE_MANIFEST_INDEX_FILEPATH), "utf8")) as Ota.ZigbeeOTAImageMeta[],
+    );
+    const mockGetPreviousManifest = vi.fn(
+        () => JSON.parse(readFileSync(fixVitestExplorerPath(TEST_PREV_MANIFEST_INDEX_FILEPATH), "utf8")) as Ota.ZigbeeOTAImageMeta[],
+    );
     const mockGetFirmwareFile = vi.fn((urlStr: string) => {
         const dirPath = urlStr.startsWith(`${ZIGBEE_OTA_MASTER_URL}${BASE_IMAGES_DIRNAME}/`) ? TEST_BASE_IMAGES_DIRPATH : TEST_PREV_IMAGES_DIRPATH;
         const filePaths = getLocalPath(urlStr);
@@ -125,7 +133,7 @@ describe("OTA", () => {
 
         console.log(`Getting image: ${filePath} using ${urlStr}`);
 
-        return readFileSync(filePath);
+        return readFileSync(fixVitestExplorerPath(filePath));
     });
     const fetchOverride = (urlStr: string | URL | Request) => {
         if (urlStr === ZIGBEE_OTA_LATEST_URL) {
@@ -489,8 +497,8 @@ describe("OTA", () => {
     });
 
     it("checks all test links work", async () => {
-        expect(existsSync(TEST_BASE_MANIFEST_INDEX_FILEPATH)).toStrictEqual(true);
-        expect(existsSync(TEST_PREV_MANIFEST_INDEX_FILEPATH)).toStrictEqual(true);
+        expect(existsSync(fixVitestExplorerPath(TEST_BASE_MANIFEST_INDEX_FILEPATH))).toStrictEqual(true);
+        expect(existsSync(fixVitestExplorerPath(TEST_PREV_MANIFEST_INDEX_FILEPATH))).toStrictEqual(true);
 
         const baseManifestRsp = fetchOverride(ZIGBEE_OTA_LATEST_URL);
         // biome-ignore lint/style/noNonNullAssertion: ignored using `--suppress`
@@ -1176,6 +1184,77 @@ describe("OTA", () => {
             expect(mockEndpointWrite).toHaveBeenCalledWith("genScenes", {currentGroup: 49502});
         });
 
+        it("fails queryNextImageRequest", async () => {
+            failQueryNextImageRequest = true;
+            const [device, image] = await getGammaTroniquesDevice(0);
+
+            const resultP = defuseRejection(update(device as unknown as Zh.Device, {}, true, vi.fn()));
+
+            await vi.runAllTimersAsync();
+
+            await expect(resultP).rejects.toThrow(`Device didn't respond to OTA request`);
+        });
+
+        it("fails to find an image", async () => {
+            const [device, image] = await getGammaTroniquesDevice(0);
+            const commandResponseSpy = vi.spyOn(device.endpoints[0], "commandResponse");
+
+            const resultP = defuseRejection(update(device as unknown as Zh.Device, {}, true, vi.fn()));
+
+            await vi.runAllTimersAsync();
+
+            await expect(resultP).resolves.toStrictEqual(undefined);
+            expect(commandResponseSpy).toHaveBeenCalledTimes(2);
+            expect(commandResponseSpy).toHaveBeenNthCalledWith(
+                2,
+                "genOta",
+                "queryNextImageResponse",
+                {status: Zcl.Status.NO_IMAGE_AVAILABLE},
+                undefined,
+                expect.any(Number),
+            );
+        });
+
+        it("fails to find an upgrade image", async () => {
+            const [device, image] = await getGammaTroniquesDevice(0);
+            const commandResponseSpy = vi.spyOn(device.endpoints[0], "commandResponse");
+
+            const resultP = update(device as unknown as Zh.Device, {}, false, vi.fn());
+
+            await vi.runAllTimersAsync();
+
+            await expect(resultP).resolves.toStrictEqual(undefined);
+            expect(commandResponseSpy).toHaveBeenCalledTimes(2);
+            expect(commandResponseSpy).toHaveBeenNthCalledWith(
+                2,
+                "genOta",
+                "queryNextImageResponse",
+                {status: Zcl.Status.NO_IMAGE_AVAILABLE},
+                undefined,
+                expect.any(Number),
+            );
+        });
+
+        it("fails to find a downgrade image", async () => {
+            const [device, image] = await getInovelliDevice(-10);
+            const commandResponseSpy = vi.spyOn(device.endpoints[0], "commandResponse");
+
+            const resultP = defuseRejection(update(device as unknown as Zh.Device, {}, true, vi.fn()));
+
+            await vi.runAllTimersAsync();
+
+            await expect(resultP).resolves.toStrictEqual(undefined);
+            expect(commandResponseSpy).toHaveBeenCalledTimes(2);
+            expect(commandResponseSpy).toHaveBeenNthCalledWith(
+                2,
+                "genOta",
+                "queryNextImageResponse",
+                {status: Zcl.Status.NO_IMAGE_AVAILABLE},
+                undefined,
+                expect.any(Number),
+            );
+        });
+
         describe.skip("runs an update", () => {
             const consoleDebugOriginal = console.debug;
             // XXX: some logging for local testing since debug disabled
@@ -1443,7 +1522,7 @@ describe("OTA", () => {
                 const metas = getMetas(INOVELLI_BASE_URL, mockGetLatestManifest())!;
                 const filePaths = getLocalPath(INOVELLI_BASE_URL);
                 const filePath = path.join(TEST_BASE_IMAGES_DIRPATH, ...filePaths);
-                let firmwareFile = readFileSync(filePath);
+                let firmwareFile = readFileSync(fixVitestExplorerPath(filePath));
                 firmwareFile = firmwareFile.subarray(0, -1024);
                 // bypass checksum validation to get to proper codepath
                 metas.sha512 = crypto.createHash("sha512").update(firmwareFile).digest("hex");
@@ -1469,7 +1548,7 @@ describe("OTA", () => {
                 const metas = getMetas(INOVELLI_BASE_URL, mockGetLatestManifest())!;
                 const filePaths = getLocalPath(INOVELLI_BASE_URL);
                 const filePath = path.join(TEST_BASE_IMAGES_DIRPATH, ...filePaths);
-                let firmwareFile = readFileSync(filePath);
+                let firmwareFile = readFileSync(fixVitestExplorerPath(filePath));
                 firmwareFile = firmwareFile.subarray(0, -1024);
                 // bypass checksum validation to get to proper codepath
                 metas.sha512 = crypto.createHash("sha512").update(firmwareFile).digest("hex");
@@ -1496,36 +1575,6 @@ describe("OTA", () => {
                 await vi.runAllTimersAsync();
 
                 await expect(resultP).rejects.toThrow("File checksum validation failed");
-            });
-
-            it("fails to find an image", async () => {
-                const [device, image] = await getGammaTroniquesDevice(0);
-
-                const resultP = defuseRejection(update(device as unknown as Zh.Device, {}, true, mockOnProgress));
-
-                await vi.runAllTimersAsync();
-
-                await expect(resultP).rejects.toThrow(expect.objectContaining({message: expect.stringContaining("No image currently available")}));
-            });
-
-            it("fails to find an upgrade image", async () => {
-                const [device, image] = await getGammaTroniquesDevice(0);
-
-                const resultP = defuseRejection(update(device as unknown as Zh.Device, {}, false, mockOnProgress));
-
-                await vi.runAllTimersAsync();
-
-                await expect(resultP).rejects.toThrow("No new image available");
-            });
-
-            it("fails to find a downgrade image", async () => {
-                const [device, image] = await getInovelliDevice(-10);
-
-                const resultP = defuseRejection(update(device as unknown as Zh.Device, {}, true, mockOnProgress));
-
-                await vi.runAllTimersAsync();
-
-                await expect(resultP).rejects.toThrow("No previous image available");
             });
 
             it("fails to find an image due to hardware version restrictions unmet", async () => {
@@ -1560,17 +1609,6 @@ describe("OTA", () => {
                 await vi.runAllTimersAsync();
 
                 await expect(resultP).rejects.toThrow(expect.objectContaining({message: expect.stringContaining("Hardware version mismatch")}));
-            });
-
-            it("fails queryNextImageRequest", async () => {
-                failQueryNextImageRequest = true;
-                const [device, image] = await getGammaTroniquesDevice(0);
-
-                const resultP = defuseRejection(update(device as unknown as Zh.Device, {}, true, mockOnProgress));
-
-                await vi.runAllTimersAsync();
-
-                await expect(resultP).rejects.toThrow(`Device didn't respond to OTA request`);
             });
 
             it("sends default response when upgradeEndResult != SUCCESS", async () => {

--- a/test/ota.test.ts
+++ b/test/ota.test.ts
@@ -1096,6 +1096,7 @@ describe("OTA", () => {
 
     describe("Updating", () => {
         it("fails to get latest manifest", async () => {
+            const consoleInfoSpy = vi.spyOn(console, "info");
             fetchReturnedStatus.ok = false;
             fetchReturnedStatus.status = 429;
             const [device, image] = await getBoschDevice(-1);
@@ -1103,10 +1104,14 @@ describe("OTA", () => {
 
             await vi.runAllTimersAsync();
 
-            await expect(result).rejects.toThrow(`Invalid response from ${ZIGBEE_OTA_LATEST_URL} status=429.`);
+            await expect(result).resolves.toStrictEqual(undefined);
+            expect(consoleInfoSpy).toHaveBeenCalledWith(
+                expect.stringContaining(`No image currently available (Invalid response from ${ZIGBEE_OTA_LATEST_URL} status=429.)`),
+            );
         });
 
         it("fails to get previous manifest", async () => {
+            const consoleInfoSpy = vi.spyOn(console, "info");
             fetchReturnedStatus.ok = false;
             fetchReturnedStatus.status = 403;
             const [device, image] = await getInovelliDevice(-1);
@@ -1114,10 +1119,14 @@ describe("OTA", () => {
 
             await vi.runAllTimersAsync();
 
-            await expect(result).rejects.toThrow(`Invalid response from ${ZIGBEE_OTA_PREVIOUS_URL} status=403.`);
+            await expect(result).resolves.toStrictEqual(undefined);
+            expect(consoleInfoSpy).toHaveBeenCalledWith(
+                expect.stringContaining(`No image currently available (Invalid response from ${ZIGBEE_OTA_PREVIOUS_URL} status=403.)`),
+            );
         });
 
         it("fails to get firmware file from URL", async () => {
+            const consoleInfoSpy = vi.spyOn(console, "info");
             const [device, image] = await getInnrDevice(-1);
 
             // first call is to manifest, let that resolve
@@ -1139,10 +1148,14 @@ describe("OTA", () => {
 
             await vi.runAllTimersAsync();
 
-            await expect(result).rejects.toThrow(`Invalid response from ${INNR_BASE_URL} status=200.`);
+            await expect(result).resolves.toStrictEqual(undefined);
+            expect(consoleInfoSpy).toHaveBeenCalledWith(
+                expect.stringContaining(`No image currently available (Invalid response from ${INNR_BASE_URL} status=200.)`),
+            );
         });
 
         it("executes workaround for Securifi modelID=PP-WHT-US to trigger OTA with genScenes cluster", async () => {
+            const consoleInfoSpy = vi.spyOn(console, "info");
             // same version, short-circuit since tested logic already done
             const [device, image] = await getSecurifiDevice(0);
             const mockEndpointWrite = vi.fn();
@@ -1157,7 +1170,8 @@ describe("OTA", () => {
 
             await vi.runAllTimersAsync();
 
-            await expect(result).rejects.toThrow("No new image available");
+            await expect(result).resolves.toStrictEqual(undefined);
+            expect(consoleInfoSpy).toHaveBeenCalledWith(expect.stringContaining("No image currently available (No new image available)"));
             expect(mockEndpointWrite).toHaveBeenCalledTimes(1);
             expect(mockEndpointWrite).toHaveBeenCalledWith("genScenes", {currentGroup: 49502});
         });


### PR DESCRIPTION
### Changes

- No longer throw when no image is available when `update` is triggered, instead return `undefined` (zigbee2mqtt will deal with the result).
- When no image is available on `update`, automatically send `NO_IMAGE_AVAILABLE` response to device.
- Add parameters to `update` function to allow more specific triggering from zigbee2mqtt (i.e. on a device's request).
