### PR TITLE
Sonoff TRVZB: Fix rounding of externalTemperatureInput

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1312,6 +1312,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
                 scale: 100,
+                precision: 1,
             }),
             m.numeric({
                 name: "idle_steps",


### PR DESCRIPTION
As described in https://github.com/Koenkk/zigbee2mqtt/issues/26846, the converter for the Sonoff TRVZB's `externalTemperatureInput` attribute is prone to 
floating-point precision errors. A simple `Math.round` call is enough to solve this, and specifying `precision: 1` will do just that under the hood.

After the fix, it's now possible to set the value to `19.4` and it won't change to `19.3`.