### PR TITLE
feat(add): 1402790 (manuf: Namron)

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -1636,4 +1636,23 @@ export const definitions: DefinitionWithExtend[] = [
             e.text("vacation_end_date", ea.ALL).withDescription("End date").withDescription("Supports dates starting with day or year with '. - /'"),
         ],
     },
+    {
+        zigbeeModel: ["1402790"],
+        model: "1402790",
+        vendor: "NAMRON AS",
+        description: "Stove guard for safe cooking",
+        extend: [
+            m.deviceEndpoints({endpoints: {main_switch: 1, short_override: 2}}),
+            m.onOff({powerOnBehavior: false, endpointNames: ["main_switch"], description: "Main relay switch"}),
+            m.onOff({powerOnBehavior: false, endpointNames: ["short_override"], description: "Short override switch"}),
+            m.electricityMeter({
+                endpointNames: ["main_switch"],
+                power: {multiplier: 1, divisor: 1},
+                voltage: false,
+                current: false,
+            }),
+            m.battery(),
+            m.temperature({reporting: undefined}),
+        ],
+    },
 ];

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -1639,7 +1639,7 @@ export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["1402790"],
         model: "1402790",
-        vendor: "NAMRON AS",
+        vendor: "Namron",
         description: "Stove guard for safe cooking",
         extend: [
             m.deviceEndpoints({endpoints: {main_switch: 1, short_override: 2}}),


### PR DESCRIPTION
Add support for 1402790 form manufacturer Namron
Device similar to Fire Fence Stove Guard.

Picture should be identical to https://github.com/Koenkk/zigbee2mqtt.io/pull/3553.
Question for maintainer - does I require to commit same image again under different name or there exist any mechanism to logically symlink these?