### PR TITLE
Add Philips Hue Being Ceiling Light

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2327,7 +2327,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "929003777301",
         vendor: "Philips",
         description: "Philips Hue Being Ceiling Light",
-        extend: [philips.m.light({"colorTemp":{"range":[153,454]}})],
+        extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ["RDM001", "9290030171", "RDM004"],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2326,7 +2326,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["929003777301"],
         model: "929003777301",
         vendor: "Philips",
-        description: "Philips Hue Being Ceiling Light",
+        description: "Hue Being ceiling light",
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2323,6 +2323,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: undefined}, color: true})],
     },
     {
+        zigbeeModel: ["929003777301"],
+        model: "929003777301",
+        vendor: "Philips",
+        description: "Philips Hue Being Ceiling Light",
+        extend: [philips.m.light({"colorTemp":{"range":[153,454]}})],
+    },
+    {
         zigbeeModel: ["RDM001", "9290030171", "RDM004"],
         model: "929003017102",
         vendor: "Philips",


### PR DESCRIPTION
Device: https://www.philips-hue.com/en-us/p/hue-white-ambiance-being-ceiling-light-black/046677588335

Database entry:
```
{"id":39,"type":"Router","ieeeAddr":"0x001788010e354fdf","nwkAddr":61901,"manufId":4107,"manufName":"Signify Netherlands B.V.","powerSource":"Mains (single phase)","modelId":"929003777301","epList":[11,242],"endpoints":{"11":{"profId":260,"epId":11,"devId":268,"inClusterList":[0,3,4,5,6,8,4096,768],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"929003777301","manufacturerName":"Signify Netherlands B.V.","powerSource":1,"zclVersion":2,"appVersion":2,"stackVersion":1,"hwVersion":0,"dateCode":"20210305","swBuildId":"1.82.10"}},"lightingColorCtrl":{"attributes":{"colorCapabilities":16,"colorTempPhysicalMin":153,"colorTempPhysicalMax":454,"colorMode":2,"colorTemperature":454,"startUpColorTemperature":366}},"genLevelCtrl":{"attributes":{"currentLevel":3}},"genOnOff":{"attributes":{"onOff":1,"startUpOnOff":1}}},"binds":[],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":2,"stackVersion":1,"hwVersion":0,"dateCode":"20210305","swBuildId":"1.82.10","zclVersion":2,"interviewCompleted":true,"meta":{"configured":332242049},"lastSeen":1743121009110}
```