### PR TITLE
fix: enable onOffCountdown for TS011F_with_threshold

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10404,6 +10404,7 @@ export const definitions: DefinitionWithExtend[] = [
                 electricalMeasurementsFzConverter: fzLocal.TS011F_electrical_measurement,
                 powerOutageMemory: true,
                 indicatorMode: true,
+                onOffCountdown: true,
             }),
         ],
         fromZigbee: [fz.temperature, fzLocal.TS011F_threshold],


### PR DESCRIPTION
I have 2 `_TZ3000_cayepv1a` and countdown feature is working properly so enabling it for everyone. 
* If the state is off and set the countdown it will power on with a specific delay
* If the state is on and set the countdown it will power off with a specific delay

![image](https://github.com/user-attachments/assets/5b49baf3-173d-4f3b-a6d6-db06ad5718fc)


Unfortunately I don't own any of the other devices and I am not sure if they support this feature.

This is my first PR here so please let know if there are any other testing steps I should be making.
