### PR TITLE
introduce .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# fix: Migrate from eslint/prettier to Biome (#8859)
+009890b0d5cce8ff27ac1f2770ec31543e96b185
+# fix: Implement prettier (#7702)
+607a13e9a112abbf1a8d34fcabee8f82a07f80a8


### PR DESCRIPTION
Migration commit is making very hard to track changes so it's useful if it gets removed from blame.
For more details check [here](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view)
