### PR TITLE
Add support for Tuya model ZTH08, TS0601 _TZE204_d7lpruvi

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1165,6 +1165,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE204_9yapgbuv",
             "_TZE204_upagmta9",
             "_TZE200_cirvgep4",
+            "_TZE204_d7lpruvi",
             "_TZE200_upagmta9",
             "_TZE204_yjjdcqsq",
             "_TZE204_jygvp6fk",
@@ -1197,6 +1198,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Tuya", "ZTH02", "Temperature and humidity sensor", ["_TZE200_9yapgbuv", "_TZE204_9yapgbuv"]),
             tuya.whitelabel("Tuya", "ZTH05", "Temperature and humidity sensor", ["_TZE204_upagmta9", "_TZE200_upagmta9"]),
             tuya.whitelabel("Tuya", "ZTH08-E", "Temperature and humidity sensor", ["_TZE200_cirvgep4", "_TZE204_cirvgep4"]),
+            tuya.whitelabel("Tuya", "ZTH08", "Temperature and humidity sensor", ["_TZE204_d7lpruvi", "_TZE204_d7lpruvi"]),
         ],
     },
     {


### PR DESCRIPTION
Another variant of https://www.zigbee2mqtt.io/devices/ZTH08-E.html
The model number in seller/manufacture's description is `ZTH08`.
Tested with my own device, everything works identically to other variant that I also have.

Fix https://github.com/Koenkk/zigbee2mqtt/issues/26883