### PR TITLE
fix: Schneider S520567: expose tilt

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -575,7 +575,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fz.cover_position_tilt],
         toZigbee: [tz.cover_position_tilt, tz.cover_state, tzLocal.lift_duration],
         exposes: [
-            e.cover_position(),
+            e.cover_position_tilt(),
             e.numeric("lift_duration", ea.STATE_SET).withUnit("s").withValueMin(0).withValueMax(300).withDescription("Duration of lift"),
         ],
         meta: {coverInverted: true},


### PR DESCRIPTION
My Schneider S520567 is connected to outdoor Venetian blind. The device properly report the tilt value of my blind. However, there was no way to control it.

This patch has a drawback. I also use the same device reference for normal shutters. This patch expose a tilt control while the shutter does not support it. I assume I have to expose a property to enable/disable the control of the tilt. I would be glad to have some guidance about how to do that.

