### PR TITLE
add custom cluster heimanSpecificAirQuality

### DIFF
--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -2,6 +2,7 @@ import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
 import * as exposes from "../lib/exposes";
+import {addCustomClusterHeimanSpecificAirQuality} from "../lib/heiman";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
@@ -427,7 +428,10 @@ export const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "genOnOff", "genLevelCtrl", "lightingColorCtrl"]);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint, {
+                min: constants.repInterval.MINUTES_5,
+                max: constants.repInterval.HOUR,
+            });
         },
     },
     {
@@ -441,7 +445,10 @@ export const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "genOnOff", "genLevelCtrl", "lightingColorCtrl"]);
-            await reporting.batteryPercentageRemaining(endpoint, {min: constants.repInterval.MINUTES_5, max: constants.repInterval.HOUR});
+            await reporting.batteryPercentageRemaining(endpoint, {
+                min: constants.repInterval.MINUTES_5,
+                max: constants.repInterval.HOUR,
+            });
         },
     },
     {
@@ -520,6 +527,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "HS2AQ-EM",
         vendor: "HEIMAN",
         description: "Air quality monitor",
+        extend: [addCustomClusterHeimanSpecificAirQuality()],
         fromZigbee: [fz.battery, fz.temperature, fz.humidity, fz.pm25, fz.heiman_hcho, fz.heiman_air_quality],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {
@@ -580,7 +588,11 @@ export const definitions: DefinitionWithExtend[] = [
             // So, we need to write time during configure
             const time = Math.round((new Date().getTime() - constants.OneJanuary2000) / 1000);
             // Time-master + synchronised
-            const values = {timeStatus: 3, time: time, timeZone: new Date().getTimezoneOffset() * -1 * 60};
+            const values = {
+                timeStatus: 3,
+                time: time,
+                timeZone: new Date().getTimezoneOffset() * -1 * 60,
+            };
             await endpoint.write("genTime", values);
         },
         exposes: [
@@ -751,9 +763,21 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["msRelativeHumidity", "genPowerCfg", "msTemperatureMeasurement", "msCO2"]);
             await reporting.batteryPercentageRemaining(endpoint);
-            await reporting.temperature(endpoint, {min: 1, max: constants.repInterval.MINUTES_5, change: 10}); // 0.1 degree change
-            await reporting.humidity(endpoint, {min: 1, max: constants.repInterval.MINUTES_5, change: 10}); // 0.1 % change
-            await reporting.co2(endpoint, {min: 5, max: constants.repInterval.MINUTES_5, change: 0.00005}); // 50 ppm change
+            await reporting.temperature(endpoint, {
+                min: 1,
+                max: constants.repInterval.MINUTES_5,
+                change: 10,
+            }); // 0.1 degree change
+            await reporting.humidity(endpoint, {
+                min: 1,
+                max: constants.repInterval.MINUTES_5,
+                change: 10,
+            }); // 0.1 % change
+            await reporting.co2(endpoint, {
+                min: 5,
+                max: constants.repInterval.MINUTES_5,
+                change: 0.00005,
+            }); // 50 ppm change
         },
         exposes: [e.co2(), e.battery(), e.humidity(), e.temperature()],
     },
@@ -778,8 +802,14 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "HEIMAN",
         description: "Motion sensor",
         extend: [
-            m.battery({voltageToPercentage: {min: 2500, max: 3000}, voltage: true}),
-            m.iasZoneAlarm({zoneType: "occupancy", zoneAttributes: ["alarm_1", "tamper", "battery_low"]}),
+            m.battery({
+                voltageToPercentage: {min: 2500, max: 3000},
+                voltage: true,
+            }),
+            m.iasZoneAlarm({
+                zoneType: "occupancy",
+                zoneAttributes: ["alarm_1", "tamper", "battery_low"],
+            }),
         ],
     },
 ];

--- a/src/lib/heiman.ts
+++ b/src/lib/heiman.ts
@@ -1,0 +1,49 @@
+import {Zcl} from "zigbee-herdsman";
+
+import * as m from "../lib/modernExtend";
+import type {ModernExtend} from "../lib/types";
+
+export const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.HEIMAN_TECHNOLOGY_CO_LTD};
+
+export function addCustomClusterHeimanSpecificAirQuality(): ModernExtend {
+    return m.deviceAddCustomCluster("heimanSpecificAirQuality", {
+        ...manufacturerOptions,
+        // from HS2AQ-3.0海曼智能空气质量检测仪API文档-V01
+        ID: 0xfc81,
+        attributes: {
+            language: {ID: 0xf000, type: Zcl.DataType.UINT8},
+            unitOfMeasure: {ID: 0xf001, type: Zcl.DataType.UINT8},
+            // (0 is not charged, 1 is charging, 2 is fully charged)
+            batteryState: {ID: 0xf002, type: Zcl.DataType.UINT8},
+            pm10measuredValue: {ID: 0xf003, type: Zcl.DataType.UINT16},
+            tvocMeasuredValue: {ID: 0xf004, type: Zcl.DataType.UINT16},
+            aqiMeasuredValue: {ID: 0xf005, type: Zcl.DataType.UINT16},
+            temperatureMeasuredMax: {ID: 0xf006, type: Zcl.DataType.INT16},
+            temperatureMeasuredMin: {ID: 0xf007, type: Zcl.DataType.INT16},
+            humidityMeasuredMax: {ID: 0xf008, type: Zcl.DataType.UINT16},
+            humidityMeasuredMin: {ID: 0xf009, type: Zcl.DataType.UINT16},
+            alarmEnable: {ID: 0xf00a, type: Zcl.DataType.UINT16},
+        },
+        commands: {
+            setLanguage: {
+                ID: 0x011b,
+                parameters: [
+                    // (1: English 0: Chinese)
+                    {name: "languageCode", type: Zcl.DataType.UINT8},
+                ],
+            },
+            setUnitOfTemperature: {
+                ID: 0x011c,
+                parameters: [
+                    // (0: ℉ 1: ℃)
+                    {name: "unitsCode", type: Zcl.DataType.UINT8},
+                ],
+            },
+            getTime: {
+                ID: 0x011d,
+                parameters: [],
+            },
+        },
+        commandsResponse: {},
+    });
+}


### PR DESCRIPTION
Adds custom cluster heimanSpecificAirQuality. This is in association with issue http://github.com/Koenkk/zigbee2mqtt/issues/26876 in preparation for adding an Ikea custom cluster that uses a conflicting cluster ID. There will be another PR in zigbee-herdsman to remove the heimanSpecificAirQuality cluster from there.

There were a few questions I had about the changes. If there's more to be done here let me know and I'll be happy to address it. Any feedback is welcome!