### PR TITLE
fix: Tuya ZY-M100-S_2: fix illuminance values

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9067,9 +9067,9 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         meta: {
             tuyaDatapoints: [
-                [1, "presence", tuya.valueConverter.trueFalse1],
+                [1, "presence", tuya.valueConverterBasic.lookup({True: 0, False: 1})],
                 [9, "target_distance", tuya.valueConverter.divideBy100],
-                [104, "illuminance", tuya.valueConverter.raw],
+                [12, "illuminance", tuya.valueConverter.raw],
                 [2, "radar_sensitivity", tuya.valueConverter.raw],
                 [4, "maximum_range", tuya.valueConverter.divideBy100],
                 [3, "minimum_range", tuya.valueConverter.divideBy100],


### PR DESCRIPTION
Amended the definition for the ZY-M100-S_2 device (TS0601/_TZE284_iadro9bf) to correct the datapoint for illuminance and also convert the value for presence detection from FALSE to TRUE to provide correct handling in Home Assistant during sensor detection events.