### PR TITLE
fix(ignore): naming style in easyiot converter

### DIFF
--- a/src/devices/easyiot.ts
+++ b/src/devices/easyiot.ts
@@ -82,7 +82,7 @@ const tzLocal = {
                 "tunneling",
                 "transferData",
                 {
-                    tunnelID: 0x0000,
+                    tunnelId: 0x0000,
                     data: Buffer.from(value as string, "hex"),
                 },
                 {disableDefaultResponse: true},
@@ -112,7 +112,7 @@ const tzLocal = {
                 "tunneling",
                 "transferData",
                 {
-                    tunnelID: 0x0000,
+                    tunnelId: 0x0000,
                     data: protocolFrame,
                 },
                 {disableDefaultResponse: true},
@@ -139,7 +139,7 @@ const tzLocal = {
                 "tunneling",
                 "transferData",
                 {
-                    tunnelID: 0x0001,
+                    tunnelId: 0x0001,
                     data: protocolFrame,
                 },
                 {disableDefaultResponse: true},
@@ -166,7 +166,7 @@ const tzLocal = {
                 "tunneling",
                 "transferData",
                 {
-                    tunnelID: 0x0001,
+                    tunnelId: 0x0001,
                     data: protocolFrame,
                 },
                 {disableDefaultResponse: true},


### PR DESCRIPTION
Fixes for naming style in easyiot.ts due to changes in clusters definition

Relates to changes of cluster definitions in zigbee-herdsman:
https://github.com/Koenkk/zigbee-herdsman/pull/1381