### PR TITLE
Add battery voltage to pvvx/ZigbeeTLc devices

### DIFF
--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -137,7 +137,9 @@ export const definitions = [
             extend.tempCalibration,
             extend.humidityCalibration,
             extend.measurementInterval,
-            m.battery(),
+            m.battery({
+                voltage: true,
+            }),
         ],
         ota: true,
     },
@@ -164,7 +166,9 @@ export const definitions = [
             extend.tempCalibration,
             extend.humidityCalibration,
             extend.measurementInterval,
-            m.battery(),
+            m.battery({
+                voltage: true,
+            }),
         ],
         ota: true,
     },
@@ -194,7 +198,9 @@ export const definitions = [
             extend.tempCalibration,
             extend.humidityCalibration,
             extend.measurementInterval,
-            m.battery(),
+            m.battery({
+                voltage: true,
+            }),
         ],
         ota: true,
     },


### PR DESCRIPTION
The pvvx/ZigbeeTLc firmware does also support the battery voltage.

<img width="455" alt="image" src="https://github.com/user-attachments/assets/5f36e23b-6032-460c-ac7c-53d39ec44e7d" />
