### PR TITLE
Add switch type configuration for Nodon SIN-4-RS-20 roller shutter module

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -125,11 +125,11 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchType: (cluster: string = "genOnOff", endpointName?: string, args?: Partial<m.EnumLookupArgs>) => {
+    switchType: (cluster = "genOnOff", endpointName?: string, args?: Partial<m.EnumLookupArgs>) => {
         const resultName = "switch_type";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
         const resultDescription = "Select the switch type wired to the device.";
-    
+
         const result: ModernExtend = m.enumLookup({
             name: resultName,
             lookup: resultLookup,
@@ -140,18 +140,16 @@ const nodonModernExtend = {
             endpoint: endpointName,
             ...args,
         });
-    
+
         result.exposes = [
             (device, options) => {
                 if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
-                    return [e.enum(resultName, ea.ALL, Object.keys(resultLookup))
-                        .withDescription(resultDescription)
-                        .withEndpoint(endpointName)];
+                    return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription).withEndpoint(endpointName)];
                 }
                 return [];
             },
         ];
-    
+
         return result;
     },
     trvMode: (args?: Partial<m.EnumLookupArgs>) =>

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -125,11 +125,11 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchType: (cluster: string = "genOnOff", args?: Partial<m.EnumLookupArgs>) => {
+    switchType: (cluster = "genOnOff", args?: Partial<m.EnumLookupArgs>) => {
         const resultName = "switch_type";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
         const resultDescription = "Select the switch type wire to the device.";
-    
+
         const result: ModernExtend = m.enumLookup({
             name: resultName,
             lookup: resultLookup,

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -139,7 +139,7 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
             ...args,
         });
-    
+
         result.exposes = [
             (device, options) => {
                 if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
@@ -148,7 +148,7 @@ const nodonModernExtend = {
                 return [];
             },
         ];
-    
+
         return result;
     },
     trvMode: (args?: Partial<m.EnumLookupArgs>) =>

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -125,11 +125,11 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchType: (cluster = "genOnOff", args?: Partial<m.EnumLookupArgs>) => {
+    switchType: (cluster: string = "genOnOff", endpointName?: string, args?: Partial<m.EnumLookupArgs>) => {
         const resultName = "switch_type";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
-        const resultDescription = "Select the switch type wire to the device.";
-
+        const resultDescription = "Select the switch type wired to the device.";
+    
         const result: ModernExtend = m.enumLookup({
             name: resultName,
             lookup: resultLookup,
@@ -137,18 +137,21 @@ const nodonModernExtend = {
             attribute: {ID: 0x1001, type: Zcl.DataType.ENUM8},
             description: resultDescription,
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
+            endpoint: endpointName,
             ...args,
         });
-
+    
         result.exposes = [
             (device, options) => {
                 if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
-                    return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription)];
+                    return [e.enum(resultName, ea.ALL, Object.keys(resultLookup))
+                        .withDescription(resultDescription)
+                        .withEndpoint(endpointName)];
                 }
                 return [];
             },
         ];
-
+    
         return result;
     },
     trvMode: (args?: Partial<m.EnumLookupArgs>) =>
@@ -270,8 +273,8 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             m.onOff({endpointNames: ["l1", "l2"]}),
-            nodonModernExtend.switchType({endpointName: "l1"}),
-            nodonModernExtend.switchType({endpointName: "l2"}),
+            nodonModernExtend.switchType("genOnOff", "l1"),
+            nodonModernExtend.switchType("genOnOff", "l2"),
         ],
         ota: true,
     },
@@ -283,8 +286,8 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             m.onOff({endpointNames: ["l1", "l2"]}),
-            nodonModernExtend.switchType({endpointName: "l1"}),
-            nodonModernExtend.switchType({endpointName: "l2"}),
+            nodonModernExtend.switchType("genOnOff", "l1"),
+            nodonModernExtend.switchType("genOnOff", "l2"),
         ],
         ota: true,
     },

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -125,11 +125,11 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchType: (cluster: string = "genOnOff", endpointName?: string, args?: Partial<m.EnumLookupArgs>) => {
+    switchType: (cluster = "genOnOff", endpointName?: string, args?: Partial<m.EnumLookupArgs>) => {
         const resultName = "switch_type";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
         const resultDescription = "Select the switch type wired to the device.";
-    
+
         const enumLookupResult: ModernExtend = m.enumLookup({
             name: resultName,
             lookup: resultLookup,
@@ -139,14 +139,13 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
             ...args,
         });
-    
+
         const result = endpointName ? m.withEndpoint(endpointName, enumLookupResult) : enumLookupResult;
-    
+
         result.exposes = [
             (device, options) => {
                 if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
-                    const expose = e.enum(resultName, ea.ALL, Object.keys(resultLookup))
-                        .withDescription(resultDescription);
+                    const expose = e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription);
                     if (endpointName) {
                         expose.withEndpoint(endpointName);
                     }
@@ -155,7 +154,7 @@ const nodonModernExtend = {
                 return [];
             },
         ];
-    
+
         return result;
     },
     trvMode: (args?: Partial<m.EnumLookupArgs>) =>

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -125,31 +125,37 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchType: (cluster = "genOnOff", endpointName?: string, args?: Partial<m.EnumLookupArgs>) => {
+    switchType: (cluster: string = "genOnOff", endpointName?: string, args?: Partial<m.EnumLookupArgs>) => {
         const resultName = "switch_type";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
         const resultDescription = "Select the switch type wired to the device.";
-
-        const result: ModernExtend = m.enumLookup({
+    
+        const enumLookupResult: ModernExtend = m.enumLookup({
             name: resultName,
             lookup: resultLookup,
             cluster: cluster,
             attribute: {ID: 0x1001, type: Zcl.DataType.ENUM8},
             description: resultDescription,
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
-            endpoint: endpointName,
             ...args,
         });
-
+    
+        const result = endpointName ? m.withEndpoint(endpointName, enumLookupResult) : enumLookupResult;
+    
         result.exposes = [
             (device, options) => {
                 if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
-                    return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription).withEndpoint(endpointName)];
+                    const expose = e.enum(resultName, ea.ALL, Object.keys(resultLookup))
+                        .withDescription(resultDescription);
+                    if (endpointName) {
+                        expose.withEndpoint(endpointName);
+                    }
+                    return [expose];
                 }
                 return [];
             },
         ];
-
+    
         return result;
     },
     trvMode: (args?: Partial<m.EnumLookupArgs>) =>

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -125,22 +125,21 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchType: (args?: Partial<m.EnumLookupArgs>) => {
+    switchType: (cluster: string = "genOnOff", args?: Partial<m.EnumLookupArgs>) => {
         const resultName = "switch_type";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
         const resultDescription = "Select the switch type wire to the device.";
-
+    
         const result: ModernExtend = m.enumLookup({
             name: resultName,
             lookup: resultLookup,
-            cluster: "genOnOff",
+            cluster: cluster,
             attribute: {ID: 0x1001, type: Zcl.DataType.ENUM8},
             description: resultDescription,
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NODON},
             ...args,
         });
-
-        // NOTE: make exposes dynamic based on fw version
+    
         result.exposes = [
             (device, options) => {
                 if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
@@ -149,7 +148,7 @@ const nodonModernExtend = {
                 return [];
             },
         ];
-
+    
         return result;
     },
     trvMode: (args?: Partial<m.EnumLookupArgs>) =>
@@ -215,6 +214,7 @@ export const definitions: DefinitionWithExtend[] = [
             nodonModernExtend.calibrationVerticalRunTimeDowm(),
             nodonModernExtend.calibrationRotationRunTimeUp(),
             nodonModernExtend.calibrationRotationRunTimeDown(),
+            nodonModernExtend.switchType("closuresWindowCovering"),
         ],
         ota: true,
     },
@@ -229,6 +229,7 @@ export const definitions: DefinitionWithExtend[] = [
             nodonModernExtend.calibrationVerticalRunTimeDowm(),
             nodonModernExtend.calibrationRotationRunTimeUp(),
             nodonModernExtend.calibrationRotationRunTimeDown(),
+            nodonModernExtend.switchType("closuresWindowCovering"),
         ],
         ota: true,
     },


### PR DESCRIPTION
This PR adds support for configuring the switch type on the Nodon SIN-4-RS-20 roller shutter module. Unlike the SIN-4-1-20 light module, where the switch type setting resides in the `genOnOff` cluster, the SIN-4-RS-20 uses the `closuresWindowCovering` cluster.

To implement this:
1. I Updated the `switchType` function in `nodonModernExtend` to accept a `cluster` parameter, defaulting to `"genOnOff"`. This allows reuse across devices with different clusters while maintaining backward compatibility.
2. I Added `nodonModernExtend.switchType("closuresWindowCovering")` to the `extend` array in the SIN-4-RS-20 definition, enabling the feature for this model.

The implementation assumes the switch type attribute ID (`0x1001`) is the same in both clusters, as it's manufacturer-specific (NodOn, `0x128b`). I was able to verify this using three of my own SIN-4-RS-20 modules running Firmware 3.5.0. Please note I only tested the non-pro variant, but as the pro and non-pro share all of their other config, I added it to the pro variant as well. I had to rework this due to some build issues.