### PR TITLE
Add _TZE200_uiyqstza to lidl.ts

### DIFF
--- a/src/devices/lidl.ts
+++ b/src/devices/lidl.ts
@@ -542,7 +542,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [tuya.modernExtend.tuyaLight({colorTemp: {range: [153, 500]}, color: {modes: ["hs", "xy"]}})],
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_chyvmhay"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_chyvmhay", "_TZE200_uiyqstza"]),
         model: "368308_2010",
         vendor: "Lidl",
         description: "Silvercrest radiator valve with thermostat",


### PR DESCRIPTION
[lidl_custom.mjs.txt](https://github.com/user-attachments/files/19619122/lidl_custom.mjs.txt)
Tested with attached external converter and works.

The converter mostly works. Errors that I get:
```
error 2025-04-06 02:43:36z2m: No converter available for 'get' 'away_setting' ([object Object])
error 2025-04-06 02:44:37z2m: No converter available for 'get' 'monday' ([object Object])
```
After a while, the device seems to go offline in spite of setting schedules, because, After succesfully setting Mon, Tue, Wed, I started getting this:
```
error 2025-04-06 03:22:05z2m: Publish 'set' 'thursday' to 'Thermostat_Living_Front_Zigbee' failed: 'Error: ZCL command 0xa4c138f2269496c6/1 manuSpecificTuya.dataRequest({"seq":49,"dpValues":[{"dp":112,"datatype":0,"data":[4,41,24,33,32,41,48,33,92,34,1,34,1,34,1,34,1,34]}]}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Data request failed with error: 'MAC transaction expired' (240))'
error 2025-04-06 03:23:41z2m: Publish 'set' 'friday' to 'Thermostat_Living_Front_Zigbee' failed: 'Error: ZCL command 0xa4c138f2269496c6/1 manuSpecificTuya.dataRequest({"seq":50,"dpValues":[{"dp":113,"datatype":0,"data":[5,41,24,33,32,41,48,34,1,34,1,34,1,34,1,34,1,34]}]}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Data request failed with error: 'MAC transaction expired' (240))'
``` 
At this point, if I change the setting `Current heating setpoint auto` (and I confirm visually on the device that it works), I can go on to set the schedules for additional days (even Thu and Fri, which had generated an error).

So it seems that this action somehow woke the device, and setting a schedule does not prevent it from going to sleep.
