### PR TITLE
fix: semver validation before comparison

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -1,6 +1,6 @@
 import {Zcl} from "zigbee-herdsman";
 
-import * as semver from "semver";
+import {gt as semverGt, valid as semverValid} from "semver";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -109,7 +109,7 @@ const nodonModernExtend = {
         // NOTE: make exposes dynamic based on fw version
         result.exposes = [
             (device, options) => {
-                if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
+                if (semverValid(device?.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
                     return [
                         e
                             .numeric(resultName, ea.ALL)
@@ -143,7 +143,7 @@ const nodonModernExtend = {
         // NOTE: make exposes dynamic based on fw version
         result.exposes = [
             (device, options) => {
-                if (device && semver.gt(device.softwareBuildID, "3.4.0")) {
+                if (semverValid(device?.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
                     return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription)];
                 }
                 return [];

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -109,7 +109,7 @@ const nodonModernExtend = {
         // NOTE: make exposes dynamic based on fw version
         result.exposes = [
             (device, options) => {
-                if (semverValid(device?.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
+                if (device?.softwareBuildID && semverValid(device.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
                     return [
                         e
                             .numeric(resultName, ea.ALL)
@@ -143,7 +143,7 @@ const nodonModernExtend = {
         // NOTE: make exposes dynamic based on fw version
         result.exposes = [
             (device, options) => {
-                if (semverValid(device?.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
+                if (device?.softwareBuildID && semverValid(device.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
                     return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription)];
                 }
                 return [];

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -1,4 +1,4 @@
-import * as semver from "semver";
+import {gte as semverGte, valid as semverValid} from "semver";
 
 import {Zcl} from "zigbee-herdsman";
 
@@ -344,8 +344,8 @@ const ubisys = {
                 // ubisys switched to writeStructure a while ago, change log only goes back to 1.9.x
                 // and it happened before that but to be safe we will only use writeStrucutre on 1.9.0 and up
                 let useWriteStruct = false;
-                if (meta.device.softwareBuildID !== undefined) {
-                    useWriteStruct = semver.gte(meta.device.softwareBuildID, "1.9.0", true);
+                if (semverValid(meta.device.softwareBuildID, true)) {
+                    useWriteStruct = semverGte(meta.device.softwareBuildID, "1.9.0", true);
                 }
                 if (useWriteStruct) {
                     logger.debug(`ubisys: using writeStructure for '${meta.options.friendly_name}'.`, NS);

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -344,7 +344,7 @@ const ubisys = {
                 // ubisys switched to writeStructure a while ago, change log only goes back to 1.9.x
                 // and it happened before that but to be safe we will only use writeStrucutre on 1.9.0 and up
                 let useWriteStruct = false;
-                if (semverValid(meta.device.softwareBuildID, true)) {
+                if (meta.device.softwareBuildID && semverValid(meta.device.softwareBuildID, true)) {
                     useWriteStruct = semverGte(meta.device.softwareBuildID, "1.9.0", true);
                 }
                 if (useWriteStruct) {

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -103,7 +103,7 @@ export function ikeaLight(args?: Omit<m.LightArgs, "colorTemp"> & {colorTemp?: t
         ...result.meta,
         noOffTransitionWhenOff: (entity) => {
             const softwareBuildID = entity.getDevice().softwareBuildID;
-            return softwareBuildID && semverValid(softwareBuildID, true) && semverGt(softwareBuildID, "1.0.021", true);
+            return softwareBuildID && semverValid(softwareBuildID, true) && semverGt(softwareBuildID, "1.0.012", true);
         },
     };
 

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -103,7 +103,7 @@ export function ikeaLight(args?: Omit<m.LightArgs, "colorTemp"> & {colorTemp?: t
         ...result.meta,
         noOffTransitionWhenOff: (entity) => {
             const softwareBuildID = entity.getDevice().softwareBuildID;
-            return semverValid(softwareBuildID, true) && semverGt(softwareBuildID, "1.0.021", true);
+            return softwareBuildID && semverValid(softwareBuildID, true) && semverGt(softwareBuildID, "1.0.021", true);
         },
     };
 
@@ -132,7 +132,7 @@ export function ikeaBattery(): ModernExtend {
                     // batteryPercentageRemaining of 100 when the battery is full (should be 200).
                     let dividePercentage = true;
 
-                    if (semverValid(meta.device.softwareBuildID, true)) {
+                    if (meta.device.softwareBuildID && semverValid(meta.device.softwareBuildID, true)) {
                         if (model.model === "E2103") {
                             if (semverLt(meta.device.softwareBuildID, "24.4.13", true)) {
                                 dividePercentage = false;
@@ -181,7 +181,7 @@ export function ikeaConfigureStyrbar(): ModernExtend {
     const configure: Configure[] = [
         async (device, coordinatorEndpoint, definition) => {
             // https://github.com/Koenkk/zigbee2mqtt/issues/15725
-            if (semverValid(device.softwareBuildID, true) && semverGte(device.softwareBuildID, "2.4.0", true)) {
+            if (device.softwareBuildID && semverValid(device.softwareBuildID, true) && semverGte(device.softwareBuildID, "2.4.0", true)) {
                 const endpoint = device.getEndpoint(1);
                 await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "genLevelCtrl", "genScenes"]);
             }

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -1,4 +1,4 @@
-import * as semver from "semver";
+import {gt as semverGt, gte as semverGte, lt as semverLt, valid as semverValid} from "semver";
 
 import {Zcl} from "zigbee-herdsman";
 
@@ -103,7 +103,7 @@ export function ikeaLight(args?: Omit<m.LightArgs, "colorTemp"> & {colorTemp?: t
         ...result.meta,
         noOffTransitionWhenOff: (entity) => {
             const softwareBuildID = entity.getDevice().softwareBuildID;
-            return softwareBuildID && !softwareBuildID.includes("-") && semver.gt(softwareBuildID ?? "0.0.0", "1.0.021", true);
+            return semverValid(softwareBuildID, true) && semverGt(softwareBuildID, "1.0.021", true);
         },
     };
 
@@ -131,17 +131,20 @@ export function ikeaBattery(): ModernExtend {
                     // Some devices do not comply to the ZCL and report a
                     // batteryPercentageRemaining of 100 when the battery is full (should be 200).
                     let dividePercentage = true;
-                    if (model.model === "E2103") {
-                        if (semver.lt(meta.device.softwareBuildID, "24.4.13", true)) {
-                            dividePercentage = false;
-                        }
-                    } else {
-                        // IKEA corrected this on newer remote fw version, but many people are still
-                        // 2.2.010 which is the last version supporting group bindings. We try to be
-                        // smart and pick the correct one for IKEA remotes.
-                        // If softwareBuildID is below 2.4.0 it should not be divided
-                        if (semver.lt(meta.device.softwareBuildID, "2.4.0", true)) {
-                            dividePercentage = false;
+
+                    if (semverValid(meta.device.softwareBuildID, true)) {
+                        if (model.model === "E2103") {
+                            if (semverLt(meta.device.softwareBuildID, "24.4.13", true)) {
+                                dividePercentage = false;
+                            }
+                        } else {
+                            // IKEA corrected this on newer remote fw version, but many people are still
+                            // 2.2.010 which is the last version supporting group bindings. We try to be
+                            // smart and pick the correct one for IKEA remotes.
+                            // If softwareBuildID is below 2.4.0 it should not be divided
+                            if (semverLt(meta.device.softwareBuildID, "2.4.0", true)) {
+                                dividePercentage = false;
+                            }
                         }
                     }
 
@@ -178,7 +181,7 @@ export function ikeaConfigureStyrbar(): ModernExtend {
     const configure: Configure[] = [
         async (device, coordinatorEndpoint, definition) => {
             // https://github.com/Koenkk/zigbee2mqtt/issues/15725
-            if (semver.gte(device.softwareBuildID, "2.4.0", true)) {
+            if (semverValid(device.softwareBuildID, true) && semverGte(device.softwareBuildID, "2.4.0", true)) {
                 const endpoint = device.getEndpoint(1);
                 await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "genLevelCtrl", "genScenes"]);
             }


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/27014

Just to be sure, I confirmed a few scenario:
```ts
        expect(semverValid(undefined)).toStrictEqual(null);
        expect(semverValid(null)).toStrictEqual(null);
        expect(semverValid("")).toStrictEqual(null);
        expect(semverValid("nogood")).toStrictEqual(null);
        expect(semverValid("a.b.c")).toStrictEqual(null);
        expect(semverValid("123")).toStrictEqual(null);
        expect(semverValid("1-2.3")).toStrictEqual(null);
        expect(semverValid("1.2.3-")).toStrictEqual(null);
        expect(semverValid("1.2.3\u0000")).toStrictEqual(null);
        expect(semverValid("1.2.3.0")).toStrictEqual(null);
        expect(semverValid("1.2.3")).toStrictEqual("1.2.3");
        expect(semverValid("v1.2.3")).toStrictEqual("1.2.3");
        expect(semverValid("1.2.3alpha4")).toStrictEqual(null);
        expect(semverValid("1.2.3alpha4", true)).toStrictEqual("1.2.3-alpha4");
        expect(semverGt("1.2.3alpha4", "1.2.2", true)).toStrictEqual(true);
        expect(semverValid("1.1.1.0-5.7.2.0", true)).toStrictEqual(null);
```