### PR TITLE
feat: add Aqara WS-K02E Switch H2 US (double rocker)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4529,4 +4529,33 @@ export const definitions: DefinitionWithExtend[] = [
             lumiSwitchMode(),
         ],
     },
+    {
+        zigbeeModel: ["lumi.switch.agl004"],
+        model: "WS-K02E",
+        vendor: "Aqara",
+        description: "Light Switch H2 US (double rocker)",
+        fromZigbee: [fz.on_off, lumi.fromZigbee.lumi_action_multistate, lumi.fromZigbee.lumi_specific],
+        extend: [
+            lumiZigbeeOTA(),
+            lumiPreventReset(),
+            m.deviceEndpoints({endpoints: {top: 1, center: 2, bottom: 3, wireless: 4}}),
+            m.bindCluster({endpointNames: ["top", "wireless"], cluster: "manuSpecificLumi", clusterType: "input"}),
+            m.bindCluster({endpointNames: ["top"], cluster: "genOnOff", clusterType: "input"}),
+            lumiPower(),
+            lumiOnOff({
+                operationMode: true,
+                powerOutageMemory: "enum",
+                lockRelay: true,
+                endpointNames: ["top"],
+            }),
+            lumiAction({
+                actionLookup: {hold: 0, single: 1, double: 2, release: 255},
+                endpointNames: ["top", "wireless"],
+            }),
+            lumiMultiClick({description: "Multi-click mode for wireless button", endpointName: "wireless"}),
+            lumiLedDisabledNight(),
+            lumiFlipIndicatorLight(),
+            lumiSwitchMode(),
+        ],
+    },
 ];


### PR DESCRIPTION
Added and tested new Aqara H2 with double rockers. Modeled after #9054 with similar results. 
* Wireless button LED not working. 
* MultiClick on wireless fails: 
  ```z2m: Publish 'set' 'multi_click' to 'office/light_switch' failed: 'Error: ZCL command 0x54ef4410011aff5e/2 manuSpecificLumi.write({"646":{"value":2,"type":32}}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"manufacturerCode":4447,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')' ```