### PR TITLE
Update PMM-300Z2 and PMM-300Z3

### DIFF
--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -197,6 +197,7 @@ const tzLocal = {
         convertSet: async (entity, key, value, meta) => {
             const lookup = {Auto: 0, "Manual(Forward)": 1, "Manual(Reverse)": 2};
             await entity.write("seMetering", {"0x9001": {value: utils.getFromLookup(value, lookup), type: 0x20}});
+            return {state: {[key]: value}};
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("seMetering", [0x9001]);

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -286,7 +286,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.humidity(endpoint, {min: 20, max: 300, change: 40});
         },
         exposes: [e.battery(), e.battery_voltage(), e.temperature(), e.humidity(), e.occupancy()],
-        extend: [m.illuminance()],
+        extend: [m.illuminance({scale: (value) => value})],
     },
     {
         zigbeeModel: ["SBM300Z1"],

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -663,16 +663,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "SiHAS energy monitor",
         fromZigbee: [fzLocal.ct_direction],
         toZigbee: [tzLocal.ct_direction],
-        extend: [
-            m.electricityMeter({
-                power: {cluster: "metering", min: 30},
-                current: {min: 30, max: 600, change: 1},
-                voltage: {min: 60},
-                acFrequency: {multiplier: 1, divisor: 10, min: 60},
-                powerFactor: true,
-            }),
-            m.temperature({reporting: {min: 60, max: 3600, change: 100}}),
-        ],
+        extend: [m.electricityMeter({power: {cluster: "metering"}, acFrequency: {multiplier: 1, divisor: 10}, powerFactor: true}), m.temperature()],
         // Produced_energy and ct_direction is supported in version 8 and above.
         exposes: (device, options) => {
             const exposes = [];
@@ -716,16 +707,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "ShinaSystem",
         ota: true,
         description: "SiHAS 3phase energy monitor",
-        extend: [
-            m.electricityMeter({
-                power: {cluster: "metering", min: 30},
-                current: {min: 30, max: 600, change: 1},
-                voltage: {min: 60},
-                acFrequency: {multiplier: 1, divisor: 10, min: 60},
-                powerFactor: true,
-            }),
-            m.temperature({reporting: {min: 60, max: 3600, change: 100}}),
-        ],
+        extend: [m.electricityMeter({power: {cluster: "metering"}, acFrequency: {multiplier: 1, divisor: 10}, powerFactor: true}), m.temperature()],
         // Produced_energy is supported in version 9 and above.
         exposes: (device, options) => {
             const exposes = [];

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -195,8 +195,8 @@ const tzLocal = {
     ct_direction: {
         key: ["ct_direction"],
         convertSet: async (entity, key, value, meta) => {
-            const lookup = {"Auto": 0, "Manual(Forward)": 1, "Manual(Reverse)": 2};
-            await entity.write("seMetering", {'0x9001': {value: utils.getFromLookup(value, lookup), type: 0x20}});
+            const lookup = {Auto: 0, "Manual(Forward)": 1, "Manual(Reverse)": 2};
+            await entity.write("seMetering", {"0x9001": {value: utils.getFromLookup(value, lookup), type: 0x20}});
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("seMetering", [0x9001]);
@@ -678,15 +678,17 @@ export const definitions: DefinitionWithExtend[] = [
             const exposes = [];
             if (device?.applicationVersion >= 8) {
                 exposes.push(e.produced_energy().withAccess(ea.STATE_GET));
-                exposes.push(e.enum("ct_direction", ea.ALL, ["Auto", "Manual(Forward)", "Manual(Reverse)"])
-                              .withDescription(
-                                "Auto (Default):" +
+                exposes.push(
+                    e
+                        .enum("ct_direction", ea.ALL, ["Auto", "Manual(Forward)", "Manual(Reverse)"])
+                        .withDescription(
+                            "Auto (Default):" +
                                 " All measured power and energy values are treated as positive regardless of CT installation direction," +
                                 " And there is only energy consumption, not produced energy. " +
                                 "And Manual additionally displays produced energy(e.g. when solar power is installed, set it manually)." +
-                                " And it displays energy consumption and production according to the manual forward/reverse settings."
-                              )
-                            );
+                                " And it displays energy consumption and production according to the manual forward/reverse settings.",
+                        ),
+                );
             }
             return exposes;
         },


### PR DESCRIPTION
- PMM-300Z2(Single-phase power meters) : Produced_energy and ct_direction is supported in version 8 and above.
- PMM-300Z3(Three-phase power meters): Produced_energy is supported in version 9 and above