### PR TITLE
fix: latest philips hue ensis black models

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -567,7 +567,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ["4090330P9_01", "4090330P9_02", "929003052501_01", "929003052501_02"],
+        zigbeeModel: ["4090330P9_01", "4090330P9_02", "929003052501_01", "929003052501_02", "929003785001_01", "929003785001_02"],
         model: "4090330P9",
         vendor: "Philips",
         description: "Hue Ensis (black)",


### PR DESCRIPTION
Added my new light to zigbee2mqtt and it came up as unsupported. Following the changes and comments in #3403 which are directly related. Philips Hue site confirms the number on its product page: https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-ensis-pendant-light/046677588366 (`Material number (12NC)`)

LMK if there's anything else I need to do or can help out with getting this merged!