### PR TITLE
fix: correct endpoints for lumi.switch.agl004

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4538,7 +4538,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             lumiZigbeeOTA(),
             lumiPreventReset(),
-            m.deviceEndpoints({endpoints: {top: 1, center: 2, bottom: 3, wireless: 4}}),
+            m.deviceEndpoints({endpoints: {top: 1, wireless: 2}}),
             m.bindCluster({endpointNames: ["top", "wireless"], cluster: "manuSpecificLumi", clusterType: "input"}),
             m.bindCluster({endpointNames: ["top"], cluster: "genOnOff", clusterType: "input"}),
             lumiPower(),


### PR DESCRIPTION
Incorrectly specified 4 endpoints instead of 2.