### PR TITLE
fix: latest philips hue perifo spotlight and linear light bar

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3777,7 +3777,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ["929003115701"],
+        zigbeeModel: ["929003115701", "929003617901"],
         model: "929003115701",
         vendor: "Philips",
         description: "Hue Perifo cylinder spotlight (black)",
@@ -3791,7 +3791,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ["929003116101"],
+        zigbeeModel: ["929003116101", "929003618201"],
         model: "929003116101",
         vendor: "Philips",
         description: "Hue Perifo linear light bar (black)",


### PR DESCRIPTION
follow-up to #9149

also add support for:
- Perifo linear light bar (black) ([ref](https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-perifo-linear-light-bar/046677583392) - `929003618201`)
- Perifo cylinder spotlight (black) ([ref](https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-perifo-cylinder-spotlight/046677583309) - `929003617901`)

Note: model #s are available on both web pages provided