### PR TITLE
fix: do not throw when exposes function throws

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -386,7 +386,13 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
 
                 for (const item of allExposes) {
                     if (typeof item === "function") {
-                        result.push(...item(device, options));
+                        try {
+                            const deviceExposes = item(device, options);
+
+                            result.push(...deviceExposes);
+                        } catch (error) {
+                            logger.error(`Failed to process exposes for '${device.ieeeAddr}' (${(error as Error).stack})`, NS);
+                        }
                     } else {
                         result.push(item);
                     }


### PR DESCRIPTION
Prevent another https://github.com/Koenkk/zigbee2mqtt/issues/27014
This will of course break the proper list of exposes for a specific device model (if one ever throws), but better that than Z2M being completely unusable...