### PR TITLE
Add new device in muller_licht.ts: Tint Cano ceiling light 404122/404123

### DIFF
--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -296,9 +296,9 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: [{manufacturerName: "MLI", modelID: "Ceiling light"}],
-        model: '404122/404123',
-        vendor: 'Müller Licht',
-        description: 'Tint smart ceiling light Cano black/silver, white+color (1800-6500K+RGB), 21w',
-        extend: [mullerLichtLight({"colorTemp":{"range":[153,555]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        model: "404122/404123",
+        vendor: "Müller Licht",
+        description: "Tint smart ceiling light Cano black/silver, white+color (1800-6500K+RGB), 21w",
+        extend: [mullerLichtLight({colorTemp: {range: [153, 555]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
 ];

--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -294,4 +294,11 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Tint spotlight GU10 white+color",
         extend: [mullerLichtLight({colorTemp: {range: [153, 555]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
+    {
+        fingerprint: [{manufacturerName: "MLI", modelID: "Ceiling light"}],
+        model: '404122/404123',
+        vendor: 'Müller Licht',
+        description: 'Tint smart ceiling light Cano black/silver, white+color (1800-6500K+RGB), 21w',
+        extend: [mullerLichtLight({"colorTemp":{"range":[153,555]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+    },
 ];


### PR DESCRIPTION
In Reference to issue #25243

🔗 [https://github.com/Koenkk/zigbee2mqtt/issues/25243](https://github.com/Koenkk/zigbee2mqtt/issues/25243)

There are two versions of this ceiling light: one with a black design and one with a silver design. From a Zigbee perspective, both devices appear identical.