### PR TITLE
Add LEDVANCE BIOLUX HCL LED Panel 600mm

### DIFF
--- a/src/devices/ledvance.ts
+++ b/src/devices/ledvance.ts
@@ -60,7 +60,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [ledvanceLight({colorTemp: {range: [153, 370]}})],
     },
     {
-        zigbeeModel: ["PL HCL600 01"],
+        zigbeeModel: ["PL_HCL600_01"],
         model: "4058075364547",
         vendor: "LEDVANCE",
         description: "Biolux HCL Panel 600 Zigbee tunable white",

--- a/src/devices/ledvance.ts
+++ b/src/devices/ledvance.ts
@@ -60,6 +60,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [ledvanceLight({colorTemp: {range: [153, 370]}})],
     },
     {
+        zigbeeModel: ["PL HCL600 01"],
+        model: "4058075364547",
+        vendor: "LEDVANCE",
+        description: "Biolux HCL Panel 600 Zigbee tunable white",
+        extend: [ledvanceLight({colorTemp: {range: [153, 370]}})],
+    },
+    {
         zigbeeModel: ["A60 RGBW Value II"],
         model: "AC25697",
         vendor: "LEDVANCE",


### PR DESCRIPTION
This PR adds this Panel:
https://www.ledvance.com/en-int/renewable-energy/products/light-management-components/vivares-components-by-ledvance/programmable-single-and-multi-room-solutions/radio-based-lighting-control/wireless-light-management-system-which-is-following-the-course-of-natural-daylight-by-high-specified-artificial-light/recessed-panel-luminaires--tunable-white--110-lmw--tool-free-installation--zigbee-30-c317004?productId=227899

Exposure to Home assistant also works, giving the full dim and colour temperature range (2700k to 6500k)