### PR TITLE
Update ikea.ts

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -391,11 +391,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2110R3",
         vendor: "IKEA",
         description: "TRADFRI bulb GU10, color/white spectrum, 345 lm",
-        extend: [
-            addCustomClusterManuSpecificIkeaUnknown(),
-            ikeaLight({colorTemp: {range: [250, 454], viaColor: true}, color: true}),
-            m.identify(),
-        ],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: {range: [250, 454], viaColor: true}, color: true}), m.identify()],
     },
     // #endregion GU10
     // #region light panels

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -363,10 +363,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight(), m.identify()],
     },
     {
-        zigbeeModel: ["TRADFRI bulb GU10 CWS 345lm", "TRADFRI bulb GU10 CWS 380lm"],
+        zigbeeModel: ["TRADFRI bulb GU10 CWS 380lm"],
         model: "LED1923R5",
         vendor: "IKEA",
-        description: "TRADFRI bulb GU10, color/white spectrum, 345/380 lm",
+        description: "TRADFRI bulb GU10, color/white spectrum, 380 lm",
         extend: [
             addCustomClusterManuSpecificIkeaUnknown(),
             ikeaLight({colorTemp: {range: [153, 500], viaColor: true}, color: true}), // light is pure RGB (XY), advertise 2000K-6500K
@@ -385,6 +385,13 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "IKEA",
         description: "TRADFRI bulb GU10, white spectrum, 345/380 lm",
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+    },
+    {
+        zigbeeModel: ["TRADFRI bulb GU10 CWS 345lm"],
+        model: "LED2110R3",
+        vendor: "IKEA",
+        description: "TRADFRI bulb GU10, color/white spectrum, 345 lm",
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: {range: [250, 454]}, color: true}), m.identify()],
     },
     // #endregion GU10
     // #region light panels

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -391,7 +391,11 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2110R3",
         vendor: "IKEA",
         description: "TRADFRI bulb GU10, color/white spectrum, 345 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: {range: [250, 454]}, color: true}), m.identify()],
+        extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
+            ikeaLight({colorTemp: {range: [250, 454], viaColor: true}, color: true}),
+            m.identify(),
+        ],
     },
     // #endregion GU10
     // #region light panels


### PR DESCRIPTION
Add model LED2110R3. It looks slightly different from LED1923R5

from database.db

{"id":2,"type":"Router","ieeeAddr":"0x403059fffed50144","nwkAddr":51334,"manufId":4476,"manufName":"IKEA of Sweden","powerSource":"Mains (single phase)","modelId":"TRADFRI bulb GU10 CWS 345lm","epList":[1,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":269,"inClusterList":[0,3,4,5,6,8,768,4096,64636],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"TRADFRI bulb GU10 CWS 345lm","manufacturerName":"IKEA of Sweden","powerSource":1,"zclVersion":8,"appVersion":1,"stackVersion":113,"hwVersion":1,"dateCode":"20230913","swBuildId":"1.0.38"}},"lightingColorCtrl":{"attributes":{"colorCapabilities":31,"colorTempPhysicalMin":250,"colorTempPhysicalMax":454}},"genLevelCtrl":{"attributes":{"currentLevel":254,"onLevel":255}}},"binds":[],"configuredReportings":[],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[33],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":1,"stackVersion":113,"hwVersion":1,"dateCode":"20230913","swBuildId":"1.0.38","zclVersion":8,"interviewCompleted":true,"meta":{"configured":332242049},"lastSeen":1744921468208}