### PR TITLE
Add endpoint name postfix to color cluster state.

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -725,10 +725,14 @@ export const color_colortemp: Fz.Converter = {
             result[color_options] = {execute_if_off: (msg.data.options & (1 << 0)) > 0};
         }
 
+        // Use postfixWithEndpointName with an empty value to get just the postfix that
+        // needs to be added to the result key.
+        const epPostfix = postfixWithEndpointName("", msg, model, meta);
+
         // handle color property sync
         // NOTE: this should the last thing we do, as we need to have processed all attributes,
         //       we use assign here so we do not lose other attributes.
-        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options));
+        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, epPostfix));
     },
 };
 export const meter_identification: Fz.Converter = {
@@ -2106,34 +2110,41 @@ export const tuya_led_controller: Fz.Converter = {
 
         if (msg.data.colorTemperature !== undefined) {
             const value = Number(msg.data.colorTemperature);
-            result.color_temp = mapNumberRange(value, 0, 255, 500, 153);
+            const color_temp = postfixWithEndpointName("color_temp", msg, model, meta);
+            result[color_temp] = mapNumberRange(value, 0, 255, 500, 153);
         }
 
         if (msg.data.tuyaBrightness !== undefined) {
-            result.brightness = msg.data.tuyaBrightness;
+            const brightness = postfixWithEndpointName("brightness", msg, model, meta);
+            result[brightness] = msg.data.tuyaBrightness;
         }
 
         if (msg.data.tuyaRgbMode !== undefined) {
+            const color_mode = postfixWithEndpointName("color_mode", msg, model, meta);
             if (msg.data.tuyaRgbMode === 1) {
-                result.color_mode = constants.colorModeLookup[0];
+                result[color_mode] = constants.colorModeLookup[0];
             } else {
-                result.color_mode = constants.colorModeLookup[2];
+                result[color_mode] = constants.colorModeLookup[2];
             }
         }
 
-        result.color = {};
+        const color = postfixWithEndpointName("color", msg, model, meta);
+        result[color] = {};
 
         if (msg.data.currentHue !== undefined) {
-            result.color.hue = mapNumberRange(msg.data.currentHue, 0, 254, 0, 360);
-            result.color.h = result.color.hue;
+            result[color].hue = mapNumberRange(msg.data.currentHue, 0, 254, 0, 360);
+            result[color].h = result[color].hue;
         }
 
         if (msg.data.currentSaturation !== undefined) {
-            result.color.saturation = mapNumberRange(msg.data.currentSaturation, 0, 254, 0, 100);
-            result.color.s = result.color.saturation;
+            result[color].saturation = mapNumberRange(msg.data.currentSaturation, 0, 254, 0, 100);
+            result[color].s = result[color].saturation;
         }
 
-        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options));
+        // Use postfixWithEndpointName with an empty value to get just the postfix that
+        // can be added to the result keys.
+        const epPostfix = postfixWithEndpointName("", msg, model, meta);
+        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, epPostfix));
     },
 };
 export const wiser_device_info: Fz.Converter = {

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -683,7 +683,13 @@ export class Color {
  * @returns state with color, color_temp, and color_mode set and synchronized from newState's attributes
  *          (other attributes are not included make sure to merge yourself)
  */
-export function syncColorState(newState: KeyValueAny, oldState: KeyValueAny, endpoint: Zh.Endpoint | Zh.Group, options: KeyValue, epPostfix?: String): KeyValueAny {
+export function syncColorState(
+    newState: KeyValueAny,
+    oldState: KeyValueAny,
+    endpoint: Zh.Endpoint | Zh.Group,
+    options: KeyValue,
+    epPostfix?: string,
+): KeyValueAny {
     const colorTargets = [];
     const colorSync = options && options.color_sync !== undefined ? options.color_sync : true;
     const result: KeyValueAny = {};
@@ -691,10 +697,10 @@ export function syncColorState(newState: KeyValueAny, oldState: KeyValueAny, end
 
     const keyPostfix = epPostfix ? epPostfix : "";
     const keys = {
-        "color": `color${keyPostfix}`,
-        "color_mode": `color_mode${keyPostfix}`,
-        "color_temp": `color_temp${keyPostfix}`,
-    }
+        color: `color${keyPostfix}`,
+        color_mode: `color_mode${keyPostfix}`,
+        color_temp: `color_temp${keyPostfix}`,
+    };
 
     // check if color sync is enabled
     if (!colorSync) {

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -679,21 +679,29 @@ export class Color {
  * @param oldState - state from the cache with all the old attributes set
  * @param endpoint - with lightingColorCtrl cluster
  * @param options - meta.options for the device or group
+ * @param epPostfix - postfix from the end point name. This string will be appended to the result keys unconditionally.
  * @returns state with color, color_temp, and color_mode set and synchronized from newState's attributes
  *          (other attributes are not included make sure to merge yourself)
  */
-export function syncColorState(newState: KeyValueAny, oldState: KeyValueAny, endpoint: Zh.Endpoint | Zh.Group, options: KeyValue): KeyValueAny {
+export function syncColorState(newState: KeyValueAny, oldState: KeyValueAny, endpoint: Zh.Endpoint | Zh.Group, options: KeyValue, epPostfix?: String): KeyValueAny {
     const colorTargets = [];
     const colorSync = options && options.color_sync !== undefined ? options.color_sync : true;
     const result: KeyValueAny = {};
     const [colorTempMin, colorTempMax] = findColorTempRange(endpoint);
 
+    const keyPostfix = epPostfix ? epPostfix : "";
+    const keys = {
+        "color": `color${keyPostfix}`,
+        "color_mode": `color_mode${keyPostfix}`,
+        "color_temp": `color_temp${keyPostfix}`,
+    }
+
     // check if color sync is enabled
     if (!colorSync) {
         // copy newState.{color_mode,color,color_temp}
-        if (newState.color_mode !== undefined) result.color_mode = newState.color_mode;
-        if (newState.color !== undefined) result.color = newState.color;
-        if (newState.color_temp !== undefined) result.color_temp = newState.color_temp;
+        if (newState[keys.color_mode] !== undefined) result[keys.color_mode] = newState[keys.color_mode];
+        if (newState[keys.color] !== undefined) result[keys.color] = newState[keys.color];
+        if (newState[keys.color_temp] !== undefined) result[keys.color_temp] = newState[keys.color_temp];
         return result;
     }
 
@@ -704,97 +712,97 @@ export function syncColorState(newState: KeyValueAny, oldState: KeyValueAny, end
     if (oldState === undefined) oldState = {};
 
     // figure out current color_mode
-    if (newState.color_mode !== undefined) {
-        result.color_mode = newState.color_mode;
-    } else if (oldState.color_mode !== undefined) {
-        result.color_mode = oldState.color_mode;
+    if (newState[keys.color_mode] !== undefined) {
+        result[keys.color_mode] = newState[keys.color_mode];
+    } else if (oldState[keys.color_mode] !== undefined) {
+        result[keys.color_mode] = oldState[keys.color_mode];
     } else {
-        if (newState.color_temp !== undefined) {
-            result.color_mode = "color_temp";
+        if (newState[keys.color_temp] !== undefined) {
+            result[keys.color_mode] = "color_temp";
         }
-        if (newState.color !== undefined) {
-            result.color_mode = newState.color.hue !== undefined ? "hs" : "xy";
+        if (newState[keys.color] !== undefined) {
+            result[keys.color_mode] = newState[keys.color].hue !== undefined ? "hs" : "xy";
         }
     }
 
     // figure out target attributes
-    if (oldState.color_temp !== undefined || newState.color_temp !== undefined) {
+    if (oldState[keys.color_temp] !== undefined || newState[keys.color_temp] !== undefined) {
         colorTargets.push("color_temp");
     }
     if (
-        (oldState.color !== undefined && oldState.color.hue !== undefined && oldState.color.saturation !== undefined) ||
-        (newState.color !== undefined && newState.color.hue !== undefined && newState.color.saturation !== undefined)
+        (oldState[keys.color] !== undefined && oldState[keys.color].hue !== undefined && oldState[keys.color].saturation !== undefined) ||
+        (newState[keys.color] !== undefined && newState[keys.color].hue !== undefined && newState[keys.color].saturation !== undefined)
     ) {
         colorTargets.push("hs");
     }
     if (
-        (oldState.color !== undefined && oldState.color.x !== undefined && oldState.color.y !== undefined) ||
-        (newState.color !== undefined && newState.color.x !== undefined && newState.color.y !== undefined)
+        (oldState[keys.color] !== undefined && oldState[keys.color].x !== undefined && oldState[keys.color].y !== undefined) ||
+        (newState[keys.color] !== undefined && newState[keys.color].x !== undefined && newState[keys.color].y !== undefined)
     ) {
         colorTargets.push("xy");
     }
 
     // sync color attributes
-    result.color = {};
-    switch (result.color_mode) {
+    result[keys.color] = {};
+    switch (result[keys.color_mode]) {
         case "hs":
-            if (newState.color !== undefined && newState.color.hue !== undefined) {
-                Object.assign(result.color, {hue: newState.color.hue});
-            } else if (oldState.color !== undefined && oldState.color.hue !== undefined) {
-                Object.assign(result.color, {hue: oldState.color.hue});
+            if (newState[keys.color] !== undefined && newState[keys.color].hue !== undefined) {
+                Object.assign(result[keys.color], {hue: newState[keys.color].hue});
+            } else if (oldState[keys.color] !== undefined && oldState[keys.color].hue !== undefined) {
+                Object.assign(result[keys.color], {hue: oldState[keys.color].hue});
             }
-            if (newState.color !== undefined && newState.color.saturation !== undefined) {
-                Object.assign(result.color, {saturation: newState.color.saturation});
-            } else if (oldState.color !== undefined && oldState.color.saturation !== undefined) {
-                Object.assign(result.color, {saturation: oldState.color.saturation});
+            if (newState[keys.color] !== undefined && newState[keys.color].saturation !== undefined) {
+                Object.assign(result[keys.color], {saturation: newState[keys.color].saturation});
+            } else if (oldState[keys.color] !== undefined && oldState[keys.color].saturation !== undefined) {
+                Object.assign(result[keys.color], {saturation: oldState[keys.color].saturation});
             }
 
-            if (result.color.hue !== undefined && result.color.saturation !== undefined) {
-                const hsv = new ColorHSV(result.color.hue, result.color.saturation);
+            if (result[keys.color].hue !== undefined && result[keys.color].saturation !== undefined) {
+                const hsv = new ColorHSV(result[keys.color].hue, result[keys.color].saturation);
                 if (colorTargets.includes("color_temp")) {
-                    result.color_temp = clampColorTemp(precisionRound(hsv.toMireds(), 0), colorTempMin, colorTempMax);
+                    result[keys.color_temp] = clampColorTemp(precisionRound(hsv.toMireds(), 0), colorTempMin, colorTempMax);
                 }
                 if (colorTargets.includes("xy")) {
-                    Object.assign(result.color, hsv.toXY().rounded(4).toObject());
+                    Object.assign(result[keys.color], hsv.toXY().rounded(4).toObject());
                 }
             }
             break;
         case "xy":
-            if (newState.color !== undefined && newState.color.x !== undefined) {
-                Object.assign(result.color, {x: newState.color.x});
-            } else if (oldState.color !== undefined && oldState.color.x !== undefined) {
-                Object.assign(result.color, {x: oldState.color.x});
+            if (newState[keys.color] !== undefined && newState[keys.color].x !== undefined) {
+                Object.assign(result[keys.color], {x: newState[keys.color].x});
+            } else if (oldState[keys.color] !== undefined && oldState[keys.color].x !== undefined) {
+                Object.assign(result[keys.color], {x: oldState[keys.color].x});
             }
-            if (newState.color !== undefined && newState.color.y !== undefined) {
-                Object.assign(result.color, {y: newState.color.y});
-            } else if (oldState.color !== undefined && oldState.color.y !== undefined) {
-                Object.assign(result.color, {y: oldState.color.y});
+            if (newState[keys.color] !== undefined && newState[keys.color].y !== undefined) {
+                Object.assign(result[keys.color], {y: newState[keys.color].y});
+            } else if (oldState[keys.color] !== undefined && oldState[keys.color].y !== undefined) {
+                Object.assign(result[keys.color], {y: oldState[keys.color].y});
             }
 
-            if (result.color.x !== undefined && result.color.y !== undefined) {
-                const xy = new ColorXY(result.color.x, result.color.y);
+            if (result[keys.color].x !== undefined && result[keys.color].y !== undefined) {
+                const xy = new ColorXY(result[keys.color].x, result[keys.color].y);
                 if (colorTargets.includes("color_temp")) {
-                    result.color_temp = clampColorTemp(precisionRound(xy.toMireds(), 0), colorTempMin, colorTempMax);
+                    result[keys.color_temp] = clampColorTemp(precisionRound(xy.toMireds(), 0), colorTempMin, colorTempMax);
                 }
                 if (colorTargets.includes("hs")) {
-                    Object.assign(result.color, xy.toHSV().rounded(0).toObject(false, false));
+                    Object.assign(result[keys.color], xy.toHSV().rounded(0).toObject(false, false));
                 }
             }
             break;
         case "color_temp":
-            if (newState.color_temp !== undefined) {
-                result.color_temp = newState.color_temp;
-            } else if (oldState.color_temp !== undefined) {
-                result.color_temp = oldState.color_temp;
+            if (newState[keys.color_temp] !== undefined) {
+                result[keys.color_temp] = newState[keys.color_temp];
+            } else if (oldState[keys.color_temp] !== undefined) {
+                result[keys.color_temp] = oldState[keys.color_temp];
             }
 
-            if (result.color_temp !== undefined) {
-                const xy = ColorXY.fromMireds(result.color_temp);
+            if (result[keys.color_temp] !== undefined) {
+                const xy = ColorXY.fromMireds(result[keys.color_temp]);
                 if (colorTargets.includes("xy")) {
-                    Object.assign(result.color, xy.rounded(4).toObject());
+                    Object.assign(result[keys.color], xy.rounded(4).toObject());
                 }
                 if (colorTargets.includes("hs")) {
-                    Object.assign(result.color, xy.toHSV().rounded(0).toObject(false, false));
+                    Object.assign(result[keys.color], xy.toHSV().rounded(0).toObject(false, false));
                 }
             }
             break;
@@ -802,7 +810,7 @@ export function syncColorState(newState: KeyValueAny, oldState: KeyValueAny, end
 
     // drop empty result.color
     // biome-ignore lint/performance/noDelete: ignored using `--suppress`
-    if (Object.keys(result.color).length === 0) delete result.color;
+    if (Object.keys(result[keys.color]).length === 0) delete result[keys.color];
 
     return result;
 }


### PR DESCRIPTION
The state reported for color cluster do not currently postfix their keys with the name of the endpoint they are retrived from. This causes states reported from multiple endpoints to overwrite each other.

This patch adds the endpoint name postfixes to the keys of color cluster attributes.

This is a follow up to #9196 which fixed the issue for color_temp only and covers other attributes of the color control cluster in both color_colortemp and in tuya_led_controller.