### PR TITLE
Add Ion Industries dimmer TZE200_0hb4rdnp support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2213,6 +2213,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE204_vevc4c6g",
             "_TZE200_0nauxa0p",
             "_TZE200_ykgar0ow",
+            "_TZE200_0hb4rdnp",
         ]),
         model: "TS0601_dimmer_1_gang_1",
         vendor: "Tuya",
@@ -2227,7 +2228,7 @@ export const definitions: DefinitionWithExtend[] = [
                 e.power_on_behavior().withAccess(ea.STATE_SET),
             ];
 
-            if (!device || !["_TZE200_ykgar0ow"].includes(device.manufacturerName)) {
+            if (!device || !["_TZE200_ykgar0ow", "_TZE200_0hb4rdnp"].includes(device.manufacturerName)) {
                 exps.push(tuya.exposes.lightType(), tuya.exposes.backlightModeOffNormalInverted().withAccess(ea.STATE_SET));
             }
 
@@ -2262,6 +2263,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Mercator Ikuü", "SSWRM-ZB", "Rotary dimmer mechanism", ["_TZE200_a0syesf5"]),
             tuya.whitelabel("Lonsonho", "EDM-1ZBB-EU", "Smart Dimmer Switch", ["_TZE200_0nauxa0p"]),
             tuya.whitelabel("ION Industries", "ID200W-ZIGB", "LED Zigbee Dimmer", ["_TZE200_ykgar0ow"]),
+            tuya.whitelabel("ION Industries", "90.500.090", "Zigbee Dimmer Master/Slave set", ["_TZE200_0hb4rdnp"]),
         ],
     },
     {


### PR DESCRIPTION
[TZE200_0hb4rdnp](https://www.elektramat.nl/ion-industries-universele-led-zigbee-dimmer-set-master-slave-0-3-200w-90-500-090/) dimmer is essentially the same as [_TZE200_ykgar0ow](https://www.elektramat.nl/ion-industries-universele-led-zigbee-hue-compatible-draaidimmer-0-3-200w-id200w-zigb/) with an additional slave module.

The only issue I encountered while testing it locally: 
Reporting of the current state back to z2m does not work in case the dimmer is used in "no-neutral" mode. With the neutral wire connected, physical interactions with the knob are reflected in z2m state correctly.