### PR TITLE
Detect CK-BL702-AL-01(7009_Z102LG04-1) as Tuya CK-BL702-AL-01

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1556,7 +1556,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["CK-BL702-AL-01(7009_Z102LG03-1)", "CK-BL702-AL-01(7009_Z102LG04-2)"],
+        zigbeeModel: ["CK-BL702-AL-01(7009_Z102LG03-1)", "CK-BL702-AL-01(7009_Z102LG04-1)", "CK-BL702-AL-01(7009_Z102LG04-2)"],
         model: "CK-BL702-AL-01",
         vendor: "Tuya",
         description: "Zigbee LED bulb",


### PR DESCRIPTION
Similar to https://github.com/Koenkk/zigbee-herdsman-converters/commit/29653044f43b6c54f6a6c7c6ebab5ec45c05045a

I haven't tested it as I don't know an easy way to patch converters in HAOS environment. But given it works fine without support and model is the same, I believe it should be ok.

This is GX53 variant of Tuya RGBWW light bulb.

Reference picture:
![tuya-gx53](https://github.com/user-attachments/assets/434bf584-a7ed-4d3b-a43e-0446f4c2ad9c)
