### PR TITLE
Added ZG-101Z/D device mode

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8806,8 +8806,11 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZG-101Z/D",
         vendor: "Tuya",
         description: "Smart knob",
-        fromZigbee: [fz.tuya_multi_action, fz.battery],
-        exposes: [e.action(["rotate_left", "rotate_right"])],
+        fromZigbee: [fz.tuya_multi_action, fz.battery, fz.tuya_operation_mode],
+        exposes: [
+            e.action(["rotate_left", "rotate_right"]),
+            e.enum("operation_mode", ea.ALL, ["command", "event"]).withDescription('Operation mode: "command" - for group control, "event" - for clicks'),
+        ],
         extend: [m.battery(), tuya.modernExtend.tuyaMagicPacket()],
     },
     {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8809,7 +8809,9 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fz.tuya_multi_action, fz.battery, fz.tuya_operation_mode],
         exposes: [
             e.action(["rotate_left", "rotate_right"]),
-            e.enum("operation_mode", ea.ALL, ["command", "event"]).withDescription('Operation mode: "command" - for group control, "event" - for clicks'),
+            e
+                .enum("operation_mode", ea.ALL, ["command", "event"])
+                .withDescription('Operation mode: "command" - for group control, "event" - for clicks'),
         ],
         extend: [m.battery(), tuya.modernExtend.tuyaMagicPacket()],
     },


### PR DESCRIPTION
Not sure why this was excluded as the ZG-101Z/D does supports command, event switching

```json
{
    "battery": 100,
    "last_seen": "2025-04-21T15:06:41+07:00",
    "linkquality": 112,
    "operation_mode": "command",
    "voltage": 3000
}
```

```json
{"id":30,"type":"EndDevice","ieeeAddr":"0xa4c13850fab9ccdd","nwkAddr":36405,"manufId":4742,"manufName":"_TZ3000_abrsvsou","powerSource":"Battery","modelId":"TS004F","epList":[1],"endpoints":{"1":{"profId":260,"epId":1,"devId":260,"inClusterList":[0,1,3,4,6,4096],"outClusterList":[25,10,3,4,5,6,8,4096],"clusters":{"genBasic":{"attributes":{"manufacturerName":"_TZ3000_abrsvsou","zclVersion":3,"appVersion":145,"modelId":"TS004F","powerSource":3}},"genOnOff":{"attributes":{"tuyaOperationMode":0}},"genPowerCfg":{"attributes":{"batteryPercentageRemaining":200,"batteryVoltage":30}}},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":145,"stackVersion":2,"hwVersion":1,"swBuildId":"0122052017","zclVersion":3,"interviewCompleted":true,"meta":{"configured":332242049},"lastSeen":1745222683508}
```