### PR TITLE
fix modern extends numeric/binary not configuring attributes (Koenkk/zigbee2mqtt#27173)

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -189,8 +189,8 @@ export async function setupAttributes(
 export function setupConfigureForReporting(
     cluster: string | number,
     attribute: ReportingConfigAttribute,
-    config: ReportingConfigWithoutAttribute,
-    access: Access,
+    config?: false | ReportingConfigWithoutAttribute,
+    access?: Access,
     endpointNames?: string[],
 ) {
     const configureReporting = !!config;
@@ -2490,10 +2490,7 @@ export function numeric(args: NumericArgs): ModernExtend {
         },
     ];
 
-    const configure: Configure[] = [];
-    if (reporting) {
-        configure.push(setupConfigureForReporting(cluster, attribute, reporting, access, endpoints));
-    }
+    const configure: Configure[] = [setupConfigureForReporting(cluster, attribute, reporting, access, endpoints)];
 
     return {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
 }
@@ -2558,10 +2555,7 @@ export function binary(args: BinaryArgs): ModernExtend {
         },
     ];
 
-    const configure: Configure[] = [];
-    if (reporting) {
-        configure.push(setupConfigureForReporting(cluster, attribute, reporting, access));
-    }
+    const configure: Configure[] = [setupConfigureForReporting(cluster, attribute, reporting, access)];
 
     return {exposes: [expose], fromZigbee, toZigbee, configure, isModernExtend: true};
 }


### PR DESCRIPTION
Fix for `numeric` and `binary` functions not reading attributes during configuration See issue:

Koenkk/zigbee2mqtt#27173

Note that the `numeric` and `binary` function signatures uses:

```
    reporting?: false | ReportingConfigWithoutAttribute;
``` 

So it seems that some functions use `undefined` to reflect no reporting arg and some use `false`.

I modified `setupConfigureForReporting` to to accept `false | undefined`, but another option would be:

```
const configure: Configure[] = [setupConfigureForReporting(cluster, attribute, reporting === false ? undefined : reporting, access, endpoints)];
```
In `numeric`/`binary`.