### PR TITLE
fix: sonoff ZBM5-1C-120 state

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1648,7 +1648,7 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [],
         ota: true,
         extend: [
-            m.deviceEndpoints({endpoints: {l1: 1}}),
+            m.deviceEndpoints({endpoints: {l1: 1}, multiEndpointSkip: ["state", "power_on_behavior"]}),
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1"]}),
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),


### PR DESCRIPTION
### Problem

The Sonoff ZBM5-1C-120 1-gang switch device in z2m has two on/off states which are state and state_l1. Those two states are not synchronized. The _state_ was updated only by changing state in z2m but the _state_l1_ was updated only when physically pushing the button in the switch.

Example state when pushed the button:
```
{
    "detach_relay_mode": {
        "detach_relay_outlet1": "DISABLE",
        "detach_relay_outlet2": "DISABLE",
        "detach_relay_outlet3": "DISABLE"
    },
    "device_work_mode": "Zigbee end device",
    "linkquality": 47,
    "network_indicator": false,
    "power_on_behavior": "off",
    "power_on_behavior_l1": "off",
    "state": "OFF",
    "state_l1": "ON",
}
```

### Solution

Modified the configuration to not suffix state with the endpoint name (_l1).

### Testing

Tested by re-pairing ZBM5-1C-120 device. The device now correctly has only one on/off _state_ which function properly when physically pushing the button and changing state via z2m.

Related issue: https://github.com/Koenkk/zigbee2mqtt/issues/27217