### PR TITLE
feat(devices): add Tuya TLC2206 water level sensor (_TZE200_lvkk0hdg)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15815,6 +15815,60 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE200_lvkk0hdg"}],
+        model: "TLC2206",
+        vendor: "Tuya",
+        description: "Water level sensor",
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        onEvent: tuya.onEventSetLocalTime,
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.numeric("liquid_level_percent", ea.STATE).withUnit("%").withDescription("Liquid level ratio"),
+            e.numeric("liquid_depth", ea.STATE).withUnit("cm").withDescription("Liquid depth"),
+            e.enum("liquid_state", ea.STATE, ["low", "normal", "high"]).withDescription("Liquid level status"),
+            e
+                .numeric("max_set", ea.STATE_SET)
+                .withUnit("%")
+                .withDescription("Liquid max percentage")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(1),
+            e
+                .numeric("mini_set", ea.STATE_SET)
+                .withUnit("%")
+                .withDescription("Liquid minimal percentage")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(1),
+            e
+                .numeric("installation_height", ea.STATE_SET)
+                .withUnit("mm")
+                .withDescription("Height from sensor to tank bottom")
+                .withValueMin(10)
+                .withValueMax(4000)
+                .withValueStep(1),
+            e
+                .numeric("liquid_depth_max", ea.STATE_SET)
+                .withUnit("mm")
+                .withDescription("Height from sensor to liquid level")
+                .withValueMin(10)
+                .withValueMax(4000)
+                .withValueStep(5),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "liquid_state", tuya.valueConverterBasic.lookup({low: tuya.enum(1), normal: tuya.enum(0), high: tuya.enum(2)})],
+                [2, "liquid_depth", tuya.valueConverter.raw], // mm
+                [22, "liquid_level_percent", tuya.valueConverter.raw],
+                [7, "max_set", tuya.valueConverter.raw],
+                [8, "mini_set", tuya.valueConverter.raw],
+                [19, "installation_height", tuya.valueConverter.raw],
+                [21, "liquid_depth_max", tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_q12rv9gj"]),
         model: "HHST001",
         vendor: "HeatHUB",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15835,7 +15835,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withValueMax(100)
                 .withValueStep(1),
             e
-                .numeric("mini_set", ea.STATE_SET)
+                .numeric("min_set", ea.STATE_SET)
                 .withUnit("%")
                 .withDescription("Liquid minimal percentage")
                 .withValueMin(0)

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15862,7 +15862,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [2, "liquid_depth", tuya.valueConverter.raw], // mm
                 [22, "liquid_level_percent", tuya.valueConverter.raw],
                 [7, "max_set", tuya.valueConverter.raw],
-                [8, "mini_set", tuya.valueConverter.raw],
+                [8, "min_set", tuya.valueConverter.raw],
                 [19, "installation_height", tuya.valueConverter.raw],
                 [21, "liquid_depth_max", tuya.valueConverter.raw],
             ],


### PR DESCRIPTION
### Add support for Tuya/EPT TECH TLC2206 Water Level Sensor

**Zigbee model:** TS0601  
**Manufacturer:** _TZE200_lvkk0hdg  
**Brand:** EPT TECH  
**Device:** SMART TLC2206 - Tank Level Monitor

This device exposes:
- `liquid_level_percent` (%)
- `liquid_depth` (cm)
- `liquid_state` (low/normal/high)
- configuration settings:
  - `max_set`, `mini_set` (%)
  - `installation_height`, `liquid_depth_max` (mm)

All datapoints verified and tested in Zigbee2MQTT with external converter.

> 🔍 **Note:** While this device is functionally similar to `_TZE284_kyyu8rbj`, it reports `installation_height` and `liquid_depth_max` in **millimeters (mm)**, not meters (m) like the existing `ME201WZ` definition. Therefore, a separate converter with raw value handling and distinct fingerprint is required.

### Images

*Photo of the physical product:*
![TZE200_lvkk0hdg_512x512](https://github.com/user-attachments/assets/2b1b70f6-db4b-4f4b-b1cf-530a109e8c08)


*Screenshot from Zigbee2MQTT UI:*
![TZE200_lvkk0hdg-screenshot](https://github.com/user-attachments/assets/e95350d7-b879-4b5a-8373-31dc09d0606c)


Let me know if anything needs adjustment. Thanks!
