### PR TITLE
fix: trigger IKEA unfreeze on color changes too

### DIFF
--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -891,7 +891,7 @@ const willFreeze = (payload: KeyValue, transition: number, value: unknown) =>
 // https://github.com/Koenkk/zigbee2mqtt/issues/18574
 //
 // These are keys for whom we need to unfreeze the light before issuing a corresponding command to said light
-const keysNeedingUnfreeze = new Set(["state", "brightness", "brightness_percent", "color_temp", "color_temp_percent"]);
+const keysNeedingUnfreeze = new Set(["state", "brightness", "brightness_percent", "color", "color_temp", "color_temp_percent"]);
 
 const ikea_bulb_unfreeze = (next: Tz.Converter["convertSet"]) => {
     const converter: Tz.Converter["convertSet"] = async (entity, key, value, meta) => {


### PR DESCRIPTION
All color changes with transition also freeze the lights, not just temperature changes.

See: https://github.com/Koenkk/zigbee2mqtt/issues/18574
See: https://github.com/Koenkk/zigbee-herdsman-converters/pull/8637

cc @Koenkk @bobrippling 