### PR TITLE
Fix the issue where the "illuminance" parameter does not display for the "zy-m100-s_2" device.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9250,32 +9250,32 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [9, "target_distance", tuya.valueConverter.divideBy100],
-				[
-					12,
-					null,
-					{
-						from: (v: number, meta: Fz.Meta, options?: KeyValue) => {
-                            if (["_TZE204_iadro9bf","_TZE284_iadro9bf"].includes(meta.device.manufacturerName)) {
+                [
+                    12,
+                    null,
+                    {
+                        from: (v: number, meta: Fz.Meta, options?: KeyValue) => {
+                            if (["_TZE204_iadro9bf", "_TZE284_iadro9bf"].includes(meta.device.manufacturerName)) {
                                 return {
-									illuminance: v
-								}
+                                    illuminance: v,
+                                };
                             }
                         },
-					}
-				],
-				[
-					104,
-					null,
-					{
-						from: (v: number, meta: Fz.Meta, options?: KeyValue) => {
-				            if (!["_TZE204_iadro9bf","_TZE284_iadro9bf"].includes(meta.device.manufacturerName)) {
-				                return {
-									illuminance: v
-								}
-				            }
-				        },
-					}
-				],
+                    },
+                ],
+                [
+                    104,
+                    null,
+                    {
+                        from: (v: number, meta: Fz.Meta, options?: KeyValue) => {
+                            if (!["_TZE204_iadro9bf", "_TZE284_iadro9bf"].includes(meta.device.manufacturerName)) {
+                                return {
+                                    illuminance: v,
+                                };
+                            }
+                        },
+                    },
+                ],
                 [2, "radar_sensitivity", tuya.valueConverter.raw],
                 [4, "maximum_range", tuya.valueConverter.divideBy100],
                 [3, "minimum_range", tuya.valueConverter.divideBy100],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9250,8 +9250,32 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [9, "target_distance", tuya.valueConverter.divideBy100],
-                [12, "illuminance", tuya.valueConverter.raw], // _TZE284_iadro9bf
-                [104, "illuminance", tuya.valueConverter.raw],
+				[
+					12,
+					null,
+					{
+						from: (v: number, meta: Fz.Meta, options?: KeyValue) => {
+                            if (["_TZE204_iadro9bf","_TZE284_iadro9bf"].includes(meta.device.manufacturerName)) {
+                                return {
+									illuminance: v
+								}
+                            }
+                        },
+					}
+				],
+				[
+					104,
+					null,
+					{
+						from: (v: number, meta: Fz.Meta, options?: KeyValue) => {
+				            if (!["_TZE204_iadro9bf","_TZE284_iadro9bf"].includes(meta.device.manufacturerName)) {
+				                return {
+									illuminance: v
+								}
+				            }
+				        },
+					}
+				],
                 [2, "radar_sensitivity", tuya.valueConverter.raw],
                 [4, "maximum_range", tuya.valueConverter.divideBy100],
                 [3, "minimum_range", tuya.valueConverter.divideBy100],


### PR DESCRIPTION
The main problem is that someone added compatibility for two models: "_TZE204_iadro9bf" and "_TZE284_iadro9bf". However, when I contacted the manufacturer of "zy-m100-s_2", they stated that these two models do not exist—someone likely added them arbitrarily because the DP points seemed similar. I suggest that a new converter should be developed for these two models.