### PR TITLE
feat(devices): mark EPT TECH TLC2206 as mains-powered

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15965,10 +15965,11 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE200_lvkk0hdg", powerSource: "Mains (single phase)"}],
+        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE200_lvkk0hdg"}],
         model: "TLC2206",
         vendor: "Tuya",
         description: "Water level sensor",
+        extend: [m.forcePowerSource({powerSource: "Mains (single phase)"})],
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         onEvent: tuya.onEventSetLocalTime,

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15965,7 +15965,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE200_lvkk0hdg"}],
+        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE200_lvkk0hdg", powerSource: "Mains (single phase)"}],
         model: "TLC2206",
         vendor: "Tuya",
         description: "Water level sensor",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15997,7 +15997,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Height from sensor to tank bottom")
                 .withValueMin(10)
                 .withValueMax(4000)
-                .withValueStep(1),
+                .withValueStep(5),
             e
                 .numeric("liquid_depth_max", ea.STATE_SET)
                 .withUnit("mm")


### PR DESCRIPTION
Adds a previously undefined powerSource fingerprint option to mark the EPT TECH TLC2206 as mains-powered (single phase), ensuring the Zigbee2MQTT UI displays “Mains” instead of a battery status.