### PR TITLE
Convert Inovelli UI LED1-7 to API 0-6 for individualLedEffect

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1403,7 +1403,7 @@ const tzLocal = {
                 "individualLedEffect",
                 {
                     // @ts-expect-error ignore
-                    led: Math.min(Math.max(0, Number.parseInt(values.led)), 7),
+                    led: Math.min(Math.max(1, Number.parseInt(values.led)), 7) - 1,
                     // @ts-expect-error ignore
                     effect: individualLedEffects[values.effect],
                     // @ts-expect-error ignore


### PR DESCRIPTION
This is the fix for issue #27319 which is caused because the UI numbers the LEDs from 1 - 7, but the Individual LED Effect call expects the LEDs to be numbered 0 - 6.