### PR TITLE
Superled 70012 does not support effect

### DIFF
--- a/src/devices/superled.ts
+++ b/src/devices/superled.ts
@@ -7,6 +7,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "70012",
         vendor: "SuperLED",
         description: "SÄVY NUPPI, Zigbee LED-dimmer, triac, 5-200W",
-        extend: [m.light({powerOnBehavior: false})],
+        extend: [m.light({powerOnBehavior: false, effect: false})],
     },
 ];


### PR DESCRIPTION
Hi,

I remove the effect from superled dimmer, as it complains it's not supported command.

Will it be removed from the docs by some script automation, or should I edit and create PR for [this](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/70012.md) separately?