### PR TITLE
Added additional model number for Philips Hue outdoor pedestal

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -770,7 +770,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: undefined}, color: true})],
     },
     {
-        zigbeeModel: ["1743430P7"],
+        zigbeeModel: ["1743430P7", "1745430A7"],
         model: "1743430P7",
         vendor: "Philips",
         description: "Hue Impress outdoor Pedestal",


### PR DESCRIPTION
Added additional model number for the philips hue outdoor pedestal lights.

```python 
import * as philips from 'zigbee-herdsman-converters/lib/philips';

export default {
    zigbeeModel: ['1745430A7'],
    model: '1745430A7',
    vendor: 'Philips',
    description: 'Automatically generated definition',
    extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
    meta: {},
};
```