### PR TITLE
Bosch BMCT-SLZ (Light/Shutter Control Unit II): Enable ota updates

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1838,6 +1838,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             boschExtend.bmct(),
         ],
+        ota: true,
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
             await reporting.bind(endpoint1, coordinatorEndpoint, ["genIdentify", "closuresWindowCovering", "boschSpecific"]);


### PR DESCRIPTION
Thanks to some members of the community (@docgalaxyblock and Benjamin), I was able to provide the latest firmware for the Bosch BMCT-SLZ (Light/Shutter Control Unit II), see https://github.com/Koenkk/zigbee-OTA/pull/766 . As there were no previous firmware updates provided by the `zigbee-OTA` repository, it's necessary to change the converter here.

This pull request makes the necessary change.