### PR TITLE
Fix Sonoff S60ZBTPF plug power meter data

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1491,7 +1491,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S60ZBTPF",
         vendor: "SONOFF",
         description: "Zigbee smart plug",
-        extend: [m.onOff()],
+        extend: [m.onOff(), m.electricityMeter()],
     },
     {
         zigbeeModel: ["S60ZBTPG"],


### PR DESCRIPTION
In the original support for the Sonoff S60ZBTPF plug, power consumption monitoring of the device is not included. I simply added that data, and it now correctly displays voltage, power, and current.