### PR TITLE
Add Nedis ZBSC10WT whitelabel

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3302,6 +3302,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Moes", "ZSS-S01-TH", "Temperature and humidity sensor", ["_TZ3000_f2bw0b6k"]),
             tuya.whitelabel("Danfoss", "014G2480", "Temperature and humidity sensor", ["_TZ3000_mxzo5rhf"]),
             tuya.whitelabel("Tuya", "HS09", "Hanging temperature humidity sensor", ["_TZ3000_1twfmkcc"]),
+            tuya.whitelabel("Nedis", "ZBSC10WT", "Temperature and humidity sensor", ["_TZ3000_fie1dpkm"]),
         ],
     },
     {


### PR DESCRIPTION
Added [Nedis ZBSC10WT](https://nedis.com/en-us/product/household-and-living/climate/humidity-control/550726063/smartlife-climate-sensor-zigbee-30-battery-powered-android-ios-white?_ga=undefined) sensor.