### PR TITLE
Fix Detect '_TZ3000_nuenzetq' as 'Tuya ZG-2002-RF'

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4060,6 +4060,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("pcblab.io", "RR620ZB", "2 gang Zigbee switch module", ["_TZ3000_4xfqlgqo"]),
             tuya.whitelabel("Nous", "L13Z", "2 gang switch", ["_TZ3000_ruxexjfz", "_TZ3000_hojntt34"]),
             tuya.whitelabel("Tuya", "ZG-2002-RF", "Three mode Zigbee Switch", ["_TZ3000_lugaswf8"]),
+            tuya.whitelabel("Tuya", "ZG-2002-RF", "Three mode Zigbee Switch", ["_TZ3000_nuenzetq"]),
             tuya.whitelabel("Mercator Ikuü", "SSW02", "2 gang switch", ["_TZ3000_fbjdkph9"]),
             tuya.whitelabel("Aubess", "TMZ02", "2 gang switch", ["_TZ3000_lmlsduws"]),
         ],


### PR DESCRIPTION
Fix Detect '_TZ3000_nuenzetq' as 'Tuya ZG-2002-RF'
(fix https://github.com/Koenkk/zigbee2mqtt/issues/25668)

First pull request... Check my code ! Hope I do it the right way !