### PR TITLE
Fix: typo in modernExtend and fromZigbee

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1499,7 +1499,7 @@ export const command_step_color_temperature: Fz.Converter = {
         return payload;
     },
 };
-export const command_ehanced_move_to_hue_and_saturation: Fz.Converter = {
+export const command_enhanced_move_to_hue_and_saturation: Fz.Converter = {
     cluster: "lightingColorCtrl",
     type: "commandEnhancedMoveToHueAndSaturation",
     convert: (model, msg, publish, options, meta) => {

--- a/src/devices/calex.ts
+++ b/src/devices/calex.ts
@@ -33,7 +33,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_move_to_color_temp,
             fz.command_move,
             fz.command_stop,
-            fz.command_ehanced_move_to_hue_and_saturation,
+            fz.command_enhanced_move_to_hue_and_saturation,
         ],
         exposes: [
             e.action([

--- a/src/devices/iluminize.ts
+++ b/src/devices/iluminize.ts
@@ -204,7 +204,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_stop,
             fz.command_move,
             fz.command_color_loop_set,
-            fz.command_ehanced_move_to_hue_and_saturation,
+            fz.command_enhanced_move_to_hue_and_saturation,
         ],
         exposes: [
             e.battery(),

--- a/src/devices/paul_neuhaus.ts
+++ b/src/devices/paul_neuhaus.ts
@@ -21,7 +21,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_move_to_color,
             fz.command_move,
             fz.command_color_loop_set,
-            fz.command_ehanced_move_to_hue_and_saturation,
+            fz.command_enhanced_move_to_hue_and_saturation,
             fz.tint_scene,
             fz.command_recall,
         ],
@@ -105,7 +105,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Q RGBW remote controller",
         fromZigbee: [
             fz.command_step,
-            fz.command_ehanced_move_to_hue_and_saturation,
+            fz.command_enhanced_move_to_hue_and_saturation,
             fz.command_move_to_color_temp,
             fz.command_on,
             fz.command_off,

--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -260,7 +260,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_stop,
             fz.command_move,
             fz.command_color_loop_set,
-            fz.command_ehanced_move_to_hue_and_saturation,
+            fz.command_enhanced_move_to_hue_and_saturation,
             fz.tint_scene,
         ],
         toZigbee: [],

--- a/src/devices/robb.ts
+++ b/src/devices/robb.ts
@@ -349,7 +349,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_stop,
             fz.command_move,
             fz.command_color_loop_set,
-            fz.command_ehanced_move_to_hue_and_saturation,
+            fz.command_enhanced_move_to_hue_and_saturation,
         ],
         toZigbee: [],
         exposes: [

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -1232,7 +1232,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_move_to_color,
             fz.command_move_to_color_temp,
             fz.command_color_loop_set,
-            fz.command_ehanced_move_to_hue_and_saturation,
+            fz.command_enhanced_move_to_hue_and_saturation,
         ],
         exposes: [
             e.battery(),

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1225,7 +1225,7 @@ export function commandsColorCtrl(args?: CommandsColorCtrl): ModernExtend {
     const fromZigbee: Fz.Converter[] = [
         fz.command_move_color_temperature,
         fz.command_step_color_temperature,
-        fz.command_ehanced_move_to_hue_and_saturation,
+        fz.command_enhanced_move_to_hue_and_saturation,
         fz.command_move_to_hue_and_saturation,
         fz.command_step_hue,
         fz.command_step_saturation,


### PR DESCRIPTION
While searching in modernExtend I found a small error. I may be wrong and it might be correct. I also corrected fromZigbee as well