### PR TITLE
Update Philips 4034031P7

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -410,7 +410,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "4034031P7",
         vendor: "Philips",
         description: "Hue Fair",
-        extend: [philips.m.light({colorTemp: {range: undefined}})],
+        extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ["4034031P6"],


### PR DESCRIPTION
Defined the colorTemp range. I just shared the database entry as well.


{"id":3,"type":"Router","ieeeAddr":"0x0017880106fe916d","nwkAddr":56280,"manufId":4107,"manufName":"Signify Netherlands B.V.","powerSource":"Mains (single phase)","modelId":"LTC002","epList":[11,242],"endpoints":{"11":{"profId":49246,"epId":11,"devId":544,"inClusterList":[0,3,4,5,6,8,4096,64515,64516,768],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"LTC002","manufacturerName":"Signify Netherlands B.V.","powerSource":1,"zclVersion":1,"appVersion":2,"stackVersion":1,"hwVersion":2,"dateCode":"20240329","swBuildId":"1.116.3"}},"lightingColorCtrl":{"attributes":{"colorCapabilities":16,"colorTempPhysicalMin":153,"colorTempPhysicalMax":454,"colorMode":2,"colorTemperature":454,"startUpColorTemperature":366}},"genOnOff":{"attributes":{"onOff":1,"startUpOnOff":255}},"genLevelCtrl":{"attributes":{"currentLevel":119}}},"binds":[],"configuredReportings":[],"meta":{"onLevelSupported":false}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[33],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":2,"stackVersion":1,"hwVersion":2,"dateCode":"20240329","swBuildId":"1.116.3","zclVersion":1,"interviewCompleted":true,"interviewState":"SUCCESSFUL","meta":{"configured":332242049},"lastSeen":1747513719279}