### PR TITLE
fix: tuya/MG-ZG01W: remove endpoint l1 to simplify definition

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2957,7 +2957,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "MG-ZG01W",
         vendor: "Tuya",
         description: "1 gang switch with power meter",
-        exposes: [e.switch().withEndpoint("l1").setAccess("state", ea.STATE_SET), e.voltage(), e.current(), e.power()],
+        exposes: [tuya.exposes.switch(), e.voltage(), e.current(), e.power()],
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
@@ -2968,9 +2968,6 @@ export const definitions: DefinitionWithExtend[] = [
                 [22, "power", tuya.valueConverter.divideBy10],
                 [23, "voltage", tuya.valueConverter.divideBy10],
             ],
-        },
-        endpoint: (device) => {
-            return {l1: 1};
         },
     },
     {


### PR DESCRIPTION
The switch only has 1 input so it's probably not useful to set up an endpoint.

This should also fix the case where `state` and `state_l1` can sometimes get out-of-sync.