### PR TITLE
Legrand 067797 instead of BTicino 4411C

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -698,4 +698,27 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.onOff(endpoint);
         },
     },
+    {
+        zigbeeModel: [" Dimmer switch with neutral\u0000\u0000\u0000\u0000"],
+        model: "067797",
+        vendor: "Legrand",
+        description: "Dimmer switch with neutral",
+        ota: true,
+        fromZigbee: [fz.identify, fz.lighting_ballast_configuration, fzLegrand.cluster_fc01],
+        toZigbee: [tz.on_off, tzLegrand.led_mode, tz.legrand_device_mode, tzLegrand.identify, tz.ballast_config],
+        exposes: [
+            e.numeric("ballast_minimum_level", ea.ALL).withValueMin(1).withValueMax(254).withDescription("Specifies the minimum brightness value"),
+            e.numeric("ballast_maximum_level", ea.ALL).withValueMin(1).withValueMax(254).withDescription("Specifies the maximum brightness value"),
+            e.binary("device_mode", ea.ALL, "dimmer_on", "dimmer_off").withDescription("Allow the device to change brightness"),
+            eLegrand.identify(),
+            eLegrand.ledInDark(),
+            eLegrand.ledIfOn(),
+        ],
+        extend: [m.light({configureReporting: true})],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genBinaryInput", "genOnOff", "lightingBallastCfg"]);
+            await reporting.onOff(endpoint);
+        },
+    },
 ];

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -699,7 +699,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: [" Dimmer switch with neutral\u0000\u0000\u0000\u0000"],
+        fingerprint: [{modelID: " Dimmer switch with neutral\u0000\u0000\u0000\u0000", ieeeAddr: /^0x0004............$/}],
         model: "067797",
         vendor: "Legrand",
         description: "Dimmer switch with neutral",

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -699,7 +699,13 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: " Dimmer switch with neutral\u0000\u0000\u0000\u0000", ieeeAddr: /^0x0004............$/}],
+        fingerprint: [
+            {
+                modelID: " Dimmer switch with neutral\u0000\u0000\u0000\u0000",
+                manufacturerName:
+                    " Legrand\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            },
+        ],
         model: "067797",
         vendor: "Legrand",
         description: "Dimmer switch with neutral",


### PR DESCRIPTION
I opened [a discussion on the subject](https://github.com/Koenkk/zigbee2mqtt/discussions/27264), but I didn't find an answer; so I created the corresponding file in external converter and it seems OK, I also created a [PR for the image to be published](https://github.com/Koenkk/zigbee2mqtt.io/pull/3798)

don't hesitate to tell me if this isn't the right method, maybe it's better to use whitelabel, but I haven't succeeded. 