### PR TITLE
Add new revision of ZTH08 (TS0601 Temperature and Humidity Sensor)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1093,6 +1093,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE204_cirvgep4",
             "_TZE284_yjjdcqsq",
             "_TZE284_hdyjyqjm",
+            "_TZE284_d7lpruvi",
         ]),
         model: "TS0601_temperature_humidity_sensor_2",
         vendor: "Tuya",
@@ -1120,7 +1121,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Tuya", "ZTH02", "Temperature and humidity sensor", ["_TZE200_9yapgbuv", "_TZE204_9yapgbuv"]),
             tuya.whitelabel("Tuya", "ZTH05", "Temperature and humidity sensor", ["_TZE204_upagmta9", "_TZE200_upagmta9"]),
             tuya.whitelabel("Tuya", "ZTH08-E", "Temperature and humidity sensor", ["_TZE200_cirvgep4", "_TZE204_cirvgep4"]),
-            tuya.whitelabel("Tuya", "ZTH08", "Temperature and humidity sensor", ["_TZE204_d7lpruvi", "_TZE204_d7lpruvi", "_TZE284_hdyjyqjm"]),
+            tuya.whitelabel("Tuya", "ZTH08", "Temperature and humidity sensor", ["_TZE204_d7lpruvi", "_TZE284_d7lpruvi", "_TZE284_hdyjyqjm"]),
         ],
     },
     {


### PR DESCRIPTION
Added **_TZE284_d7lpruvi**, the identifier for the new revision of the **ZTH08 (TS0601 Temperature and Humidity Sensor)**, in the code sections where "_TZE204_d7lpruvi" (the identifier for the previous revision of the TS0601 Temperature and Humidity Sensor) was mentioned.
Also, "_TZE204_d7lpruvi" was repeated twice in line 1123.