### PR TITLE
feat(add): LCV002

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4039,6 +4039,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
+    	zigbeeModel: ["LCV002"],
+    	model: "LCV002",
+    	vendor: "Philips",
+    	description: "Hue Lightguide E26 Edison ST23 500lm",
+    	extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: { modes: ["xy", "hs"], enhancedHue: true}})],
+    },
+    {
         zigbeeModel: ["LCO003"],
         model: "929003151601",
         vendor: "Philips",

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4039,11 +4039,11 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
-    	zigbeeModel: ["LCV002"],
-    	model: "LCV002",
-    	vendor: "Philips",
-    	description: "Hue Lightguide E26 Edison ST23 500lm",
-    	extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: { modes: ["xy", "hs"], enhancedHue: true}})],
+        zigbeeModel: ["LCV002"],
+        model: "LCV002",
+        vendor: "Philips",
+        description: "Hue Lightguide E26 Edison ST23 500lm",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["LCO003"],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4040,7 +4040,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["LCV002"],
-        model: "LCV002",
+        model: "046677577520",
         vendor: "Philips",
         description: "Hue Lightguide E26 Edison ST23 500lm",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],


### PR DESCRIPTION
Added https://www.philips-hue.com/en-us/p/bulb-st23-e26-smart-bulb/046677577520.

Zigbee model and model are both reported as LCV002, not sure if the EAN/UPC (046677577520) should be used as the model.