### PR TITLE
Support _TZ3210_2uk4z8ce as ZP-LZ-FR2U

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -23,7 +23,7 @@ const exposesLocal = {
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_cymsnfvf", "_TZ3000_2xlvlnez"]),
+        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_cymsnfvf", "_TZ3000_2xlvlnez", "_TZ3210_2uk4z8ce"]),
         model: "ZP-LZ-FR2U",
         vendor: "Moes",
         description: "Zigbee 3.0 dual USB wireless socket plug",


### PR DESCRIPTION
Hi, I just got these Zigbee Plugs with two USB Ports from aliexpress:
https://de.aliexpress.com/item/4001147597990.html

They showed up as a simple tuya sockets with only one OnOff and with no way to switch the USB ports on (can't even do that manually with the button). I found out they have the same functionality as the ZP-LZ-FR2U and also look exactly the same, they don't have a model number written anywhere though. There is a similar one (ZK-EU-2U) but the ones I have definately have power_outage_memory.

I copied the ZP-LZ-FR2U definition into an external converter, adjusted the fingerprint and it worked perfectly.
The vendor isn't Moes though I think.

![grafik](https://github.com/user-attachments/assets/03916eaa-b425-4374-810f-f82bfbae54b2)
