### PR TITLE
Add LKTMZL02-z (LKTMZL02 with ZigbeeTLC custom firmware)

### DIFF
--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -261,6 +261,26 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         ota: true,
     },
+    {
+        zigbeeModel: ["LKTMZL02-z"],
+        // LKTMZL02 with ZigbeeTLc firmware
+        model: "LKTMZL02-z",
+        vendor: "Tuya",
+        description: "Temperature & Humidity Sensor (pvxx/ZigbeeTLc)",
+        extend: [
+            m.temperature({reporting: {min: "10_SECONDS", max: "1_HOUR", change: 10}}),
+            m.humidity(),
+            extend.enableDisplay,
+            extend.temperatureDisplayMode,
+            extend.temperatureCalibration,
+            extend.humidityCalibration,
+            extend.measurementInterval,
+            m.battery({
+                voltage: true,
+            }),
+        ],
+        ota: true,
+    },
     /*
         ZigbeeTLc devices supporting:
         - Temperature (+calibration)


### PR DESCRIPTION
OTA image of this device was already added but the converter is still missing.
https://github.com/Koenkk/zigbee-OTA/blob/master/images/pvvx/1141-021f-01273001-LKTMZL02Z.zigbee