### PR TITLE
fix(detect): Detect `_TZE284_n4ttsck2` as ONENUO 288WZ smoke detector

### DIFF
--- a/src/devices/onenuo.ts
+++ b/src/devices/onenuo.ts
@@ -7,7 +7,7 @@ const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_kgaxpvxr"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_kgaxpvxr", "_TZE284_n4ttsck2"]),
         model: "288WZ",
         vendor: "ONENUO",
         description: "Smoke detector",


### PR DESCRIPTION
## Summary
- Added fingerprint `_TZE284_n4ttsck2` to ONENUO 288WZ smoke detector

## Test plan
- [ ] Device pairs successfully with the new fingerprint
- [ ] All smoke detector functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)