### PR TITLE
Added support for another Hue Tento ceiling light variation (square instead of round)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4005,7 +4005,7 @@ export const definitions: DefinitionWithExtend[] = [
             {model: "929003823601", vendor: "Philips", description: "Hue Tento WCA 29,1 cm (Black)", fingerprint: [{modelID: "929003823601"}]},
             {model: "929003823801", vendor: "Philips", description: "Hue Tento WCA 42,1 cm (Black)", fingerprint: [{modelID: "929003823801"}]},
             {model: "929003824001", vendor: "Philips", description: "Hue Tento WCA 54,2 cm (Black)", fingerprint: [{modelID: "929003824001"}]},
-            {model: "929003846601", vendor: "Philips", description: "Hue Tento WCA 39,5 cm (White)", fingerprint: [{modelID: "929003846601"}]},
+            {model: "929003846601", vendor: "Philips", description: "Hue Tento WCA 39,5x39,5 cm (White)", fingerprint: [{modelID: "929003846601"}]},
         ],
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3995,7 +3995,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 438]}})],
     },
     {
-        zigbeeModel: ["929003823501", "929003823701", "929003823901", "929003823601", "929003823801", "929003824001"],
+        zigbeeModel: ["929003823501", "929003823701", "929003823901", "929003823601", "929003823801", "929003824001", "929003846601"],
         model: "929003823501",
         vendor: "Philips",
         description: "Hue Tento WCA 29,1cm (White)",
@@ -4005,6 +4005,7 @@ export const definitions: DefinitionWithExtend[] = [
             {model: "929003823601", vendor: "Philips", description: "Hue Tento WCA 29,1 cm (Black)", fingerprint: [{modelID: "929003823601"}]},
             {model: "929003823801", vendor: "Philips", description: "Hue Tento WCA 42,1 cm (Black)", fingerprint: [{modelID: "929003823801"}]},
             {model: "929003824001", vendor: "Philips", description: "Hue Tento WCA 54,2 cm (Black)", fingerprint: [{modelID: "929003824001"}]},
+            {model: "929003846601", vendor: "Philips", description: "Hue Tento WCA 39,5 cm (White)", fingerprint: [{modelID: "929003846601"}]},
         ],
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },


### PR DESCRIPTION
https://www.philips-hue.com/nl-nl/p/hue-white-and-color-ambiance-tento-vierkant-plafondpaneel-middel/8720169350977#specifications

Also see https://github.com/Koenkk/zigbee2mqtt.io/pull/3817