### PR TITLE
Add device IMOU ZTM1-EN

### DIFF
--- a/src/devices/imou.ts
+++ b/src/devices/imou.ts
@@ -39,4 +39,11 @@ export const definitions: DefinitionWithExtend[] = [
             m.iasZoneAlarm({zoneType: "gas", zoneAttributes: ["alarm_1", "alarm_2", "tamper", "test"], alarmTimeout: true}),
         ],
     },
+    {
+        zigbeeModel: ["ZTM1-EN"],
+        model: "ZTM1-EN",
+        vendor: "IMOU",
+        description: "Temperature and humidity sensor",
+        extend: [m.battery(), m.temperature(), m.humidity()],
+    },
 ];


### PR DESCRIPTION
Add support for device IMOU ZTM1-EN.

Image PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/3818

Note: Device exports 2 endpoints (0x01 and 0x02) where 0x02 is a complete duplicate of 0x01. This is the auto generated definition:

```javascript
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['ZTM1-EN'],
    model: 'ZTM1-EN',
    vendor: 'MultIR',
    description: 'Automatically generated definition',
    extend: [m.deviceEndpoints({"endpoints":{"1":1,"2":2}}), m.battery(), m.temperature({"endpointNames":["1","2"]}), m.humidity({"endpointNames":["1","2"]})],
    meta: {"multiEndpoint":true},
};
```

I removed the multi-endpoint bits, and now only one temperature, humidity and battery values are exposed in device state, but I don't know if there is better way to completely ignore endpoint 0x02 (right now it looks like it does not skip binds and attribute report configs for endpoint 0x02).