### PR TITLE
fix: #9413 added execute_if_off for hue color lights

### DIFF
--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -60,7 +60,12 @@ const philipsModernExtend = {
         args = {hueEffect: true, turnsOffAtBrightness1: true, ota: true, ...args};
         if (args.hueEffect || args.gradient) args.effect = false;
         if (args.color) args.color = {modes: ["xy", "hs"], ...(isObject(args.color) ? args.color : {})};
+        if (args.color || args.colorTemp !== undefined)
+            args.levelConfig = {
+                disabledFeatures: ["on_off_transition_time", "on_transition_time", "off_transition_time", "on_level", "current_level_startup"],
+            };
         const result = modernExtend.light(args);
+        if (args.color || args.colorTemp !== undefined) result.exposes.push(...exposeEndpoints(e.light_color_options(), args.endpointNames));
         result.toZigbee.push(philipsTz.hue_power_on_behavior, philipsTz.hue_power_on_error);
         if (args.hueEffect || args.gradient) {
             result.toZigbee.push(philipsTz.effect);

--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -378,6 +378,7 @@ export default {
                 "saturation_move",
                 "hue_step",
                 "saturation_step",
+                "level_config",
                 "power_on_behavior",
                 "hue_power_on_behavior",
                 "hue_power_on_brightness",
@@ -385,7 +386,12 @@ export default {
                 "hue_power_on_color",
                 "effect",
             ],
-            exposes: ["effect", "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs)", "power_on_behavior"],
+            exposes: [
+                "color_options",
+                "effect",
+                "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs,level_config)",
+                "power_on_behavior",
+            ],
             bind: {},
             read: {
                 1: [

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -259,6 +259,7 @@ describe("ModernExtend", () => {
                 "saturation_move",
                 "hue_step",
                 "saturation_step",
+                "level_config",
                 "power_on_behavior",
                 "hue_power_on_behavior",
                 "hue_power_on_brightness",
@@ -269,10 +270,11 @@ describe("ModernExtend", () => {
                 "gradient",
             ],
             exposes: [
+                "color_options",
                 "effect",
                 "gradient",
                 "gradient_scene",
-                "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs)",
+                "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs,level_config)",
 
                 "power_on_behavior",
             ],


### PR DESCRIPTION
Only add to lights that support color (or colorTemp for levelConfig), as this was all I could test.

I was already using execute_if_off and that seems to work, I could not get any other levelConfig to work. I tried with a colorTemp only build and with a color build.