### PR TITLE
Add support of Thaleos TRV06-AT

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5613,6 +5613,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("AVATTO", "TRV06_1", "Thermostatic radiator valve", ["_TZE200_hvaxb2tc", "_TZE284_o3x45p96"]),
             tuya.whitelabel("EARU", "TRV06", "Smart thermostat module", ["_TZE200_yqgbrdyo", "_TZE200_rxq4iti9"]),
             tuya.whitelabel("AVATTO", "AVATTO_TRV06", "Thermostatic radiator valve", ["_TZE284_c6wv4xyo", "_TZE204_o3x45p96"]),
+            tuya.whitelabel("THALEOS", "TRV06-AT", "Thermostatic radiator valve", ["_TZE200_ow09xlxm"]),
         ],
         onEvent: tuya.onEventSetTime,
         configure: tuya.configureMagicPacket,


### PR DESCRIPTION
<img width="588" alt="image" src="https://github.com/user-attachments/assets/d985d62f-aba6-49ad-afe6-c84bfb810a1a" />

from https://thaleos.com/wp-content/uploads/2024/05/Tete-thermostatique-4.pdf

Related to https://github.com/zigpy/zha-device-handlers/issues/3446