### PR TITLE
Revert "feat: Hue: add `execute_if_off` for colour lights (#9426)"

### DIFF
--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -60,12 +60,7 @@ const philipsModernExtend = {
         args = {hueEffect: true, turnsOffAtBrightness1: true, ota: true, ...args};
         if (args.hueEffect || args.gradient) args.effect = false;
         if (args.color) args.color = {modes: ["xy", "hs"], ...(isObject(args.color) ? args.color : {})};
-        if (args.color || args.colorTemp !== undefined)
-            args.levelConfig = {
-                disabledFeatures: ["on_off_transition_time", "on_transition_time", "off_transition_time", "on_level", "current_level_startup"],
-            };
         const result = modernExtend.light(args);
-        if (args.color || args.colorTemp !== undefined) result.exposes.push(...exposeEndpoints(e.light_color_options(), args.endpointNames));
         result.toZigbee.push(philipsTz.hue_power_on_behavior, philipsTz.hue_power_on_error);
         if (args.hueEffect || args.gradient) {
             result.toZigbee.push(philipsTz.effect);

--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -378,7 +378,6 @@ export default {
                 "saturation_move",
                 "hue_step",
                 "saturation_step",
-                "level_config",
                 "power_on_behavior",
                 "hue_power_on_behavior",
                 "hue_power_on_brightness",
@@ -386,12 +385,7 @@ export default {
                 "hue_power_on_color",
                 "effect",
             ],
-            exposes: [
-                "color_options",
-                "effect",
-                "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs,level_config)",
-                "power_on_behavior",
-            ],
+            exposes: ["effect", "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs)", "power_on_behavior"],
             bind: {},
             read: {
                 1: [

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -259,7 +259,6 @@ describe("ModernExtend", () => {
                 "saturation_move",
                 "hue_step",
                 "saturation_step",
-                "level_config",
                 "power_on_behavior",
                 "hue_power_on_behavior",
                 "hue_power_on_brightness",
@@ -270,11 +269,10 @@ describe("ModernExtend", () => {
                 "gradient",
             ],
             exposes: [
-                "color_options",
                 "effect",
                 "gradient",
                 "gradient_scene",
-                "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs,level_config)",
+                "light(state,brightness,color_temp,color_temp_startup,color_xy,color_hs)",
 
                 "power_on_behavior",
             ],


### PR DESCRIPTION
This reverts commit afdfbe4449893c129fedb9a3a23ac93ab1f305dc.

See the discussion on #9426 also [zigbee2mqtt#27568
](https://github.com/Koenkk/zigbee2mqtt/issues/27568)
tl;dr: everything i have access to WS or Color wise seems to support this, but others report getting UNSUPPORTED_ATTRIBUTE, I'm not sure how to filter which do and do not support this. The converters were already there so people can still set these using mqtt as before.