### PR TITLE
Detect Girier JR-ZPM01 as Tuya TS011F_plug_1

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6534,6 +6534,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Nous", "A6Z", "Outdoor smart socket", ["_TZ3000_266azbg3"]),
             tuya.whitelabel("Nedis", "ZBPO130FWT", "Outdoor smart plug (with power monitoring)", ["_TZ3000_3ias4w4o"]),
             tuya.whitelabel("Nous", "A9Z", "Smart ZigBee Socket", ["_TZ3210_ddigca5n"]),
+            tuya.whitelabel("Girier", "JR-ZPM01", "Smart Plug", ["_TZ3000_ww6drja5"]),
         ],
         ota: true,
         extend: [


### PR DESCRIPTION
Currently this plug(Girier JR-ZPM01) is detected as "Tuya TS011F_plug_3", but power monitoring is working without polling. So correct should be "Tuya TS011F_plug_1" ?


https://www.aliexpress.com/item/1005006243517488.html