### PR TITLE
Recognize "hold", "double" and "release" actions of Aqara Dimmer Switch H2 EU (Aqara KD-R01D)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4467,7 +4467,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.light({powerOnBehavior: false}),
             lumiKnobRotation({withButtonState: false}),
             lumiOperationMode({description: "Decoupled mode for knob"}),
-            lumiAction({actionLookup: {single: 1}}),
+            lumiAction({actionLookup: {hold: 0, single: 1, double: 2, release: 255}}),
             m.enumLookup({
                 name: "sensitivity",
                 lookup: {low: 720, medium: 360, high: 180},


### PR DESCRIPTION
Some actions were missing from this dimmer switch. Sadly an Aqara hub is required to set it to multi-function mode. But after that these actions could be captured.