### PR TITLE
Fix Aqara S04D threshold scale

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4684,7 +4684,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueMin: 0.2,
                 valueMax: 3,
                 valueStep: 0.1,
-                scale: 10,
+                scale: 100,
                 unit: "°C",
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0164, type: Zcl.DataType.UINT16},
@@ -4714,7 +4714,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.numeric({
                 name: "humi_threshold",
                 valueMin: 2,
-                valueMax: 10,
+                valueMax: 100,
                 valueStep: 0.5,
                 scale: 10,
                 unit: "%",


### PR DESCRIPTION
As https://github.com/Koenkk/zigbee2mqtt/issues/27262#issuecomment-2934069964 the scale appears wrong on the threshold attribute so you are unable to set them properly which results in errors in HA.
Certainly more issues with this converter but this resolves that one.