### PR TITLE
Add Support of "On level" Setting for Aqara Ceiling light L1-350 (ZNXDD01LM)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -170,6 +170,18 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Aqara",
         description: "Ceiling light L1-350",
         extend: [lumiLight({colorTemp: true, powerOutageMemory: "switch"}), lumiZigbeeOTA()],
+        exposes: [
+            e
+                .composite("level_config", "level_config", ea.ALL)
+                .withFeature(
+                    e
+                        .numeric("on_level", ea.ALL)
+                        .withValueMin(1)
+                        .withValueMax(254)
+                        .withPreset("previous", 255, "Use previous value")
+                        .withDescription("Specifies the level that shall be applied, when an on/toggle command causes the light to turn on."),
+                ),
+        ],
     },
     {
         zigbeeModel: ["lumi.light.cwac02", "lumi.light.acn014"],


### PR DESCRIPTION
Add support of "On level" setting for Aqara Ceiling light L1-350 (ZNXDD01LM)

Working external converter:
```
import * as fz from "zigbee-herdsman-converters/converters/fromZigbee";
import * as tz from "zigbee-herdsman-converters/converters/toZigbee";
import * as exposes from "zigbee-herdsman-converters/lib/exposes";
import * as lumi from "zigbee-herdsman-converters/lib/lumi";
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

const e = exposes.presets;
const ea = exposes.access;

const {
    lumiZigbeeOTA,
    lumiLight,
} = lumi.modernExtend;

const NS = "zhc:lumi";
const {manufacturerCode} = lumi;

export default {
    zigbeeModel: ["lumi.light.acn003"],
    model: "ZNXDD01LM",
    vendor: "Aqara",
    description: "Ceiling light L1-350",
    extend: [lumiLight({colorTemp: true, powerOutageMemory: "switch"}), lumiZigbeeOTA()],
    exposes: [
        e
            .composite("level_config", "level_config", ea.ALL)
            .withFeature(
                e
                    .numeric("on_level", ea.ALL)
                    .withValueMin(1)
                    .withValueMax(254)
                    .withPreset("previous", 255, "Use previous value")
                    .withDescription("Specifies the level that shall be applied, when an on/toggle command causes the light to turn on."),
            ),
    ],
};
```