### PR TITLE
Update candeo.ts

### DIFF
--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -25,18 +25,16 @@ const luxScale: m.ScaleFunction = (value: number, type: "from" | "to") => {
     if (type === "from") {
         result = 10 ** ((result - 1) / 10000);
         if (result > 0 && result <= 2200) {
-            result = -7.969192 + (0.0151988 * result)
+            result = -7.969192 + 0.0151988 * result;
+        } else if (result > 2200 && result <= 2500) {
+            result = -1069.189434 + 0.4950663 * result;
+        } else if (result > 2500) {
+            result = 78029.21628 - 61.73575 * result + 0.01223567 * result ** 2;
         }
-        else if (result > 2200 && result <= 2500) {
-            result = -1069.189434 + (0.4950663 * result)
-        }
-        else if (result > 2500) {
-            result = (78029.21628 - (61.73575 * result)) + (0.01223567 * (result ** 2))
-        }
-        result = result < 1 ? 1 : result
+        result = result < 1 ? 1 : result;
     }
-    return result; 
-}
+    return result;
+};
 
 const fzLocal = {
     switch_type: {


### PR DESCRIPTION
Add lux calibration scale function to Candeo C-ZB-SEMO Motion Sensor.

Aligns lux readings against a calibrated source device.

@Koenkk we're not sure if we got the JS -> TS changes correct, please can you double check for us when you have a moment?

Our working JS external converter is:

```
const m = require('zigbee-herdsman-converters/lib/modernExtend');

function luxScale(value, type) {
    let result = value;
    if (type === "from") {
        result = 10 ** ((result - 1) / 10000);
        if (result > 0 && result <= 2200) {
            result = -7.969192 + (0.0151988 * result)
        }
        else if (result > 2200 && result <= 2500) {
            result = -1069.189434 + (0.4950663 * result)
        }
        else if (result > 2500) {
            result = (78029.21628 - (61.73575 * result)) + (0.01223567 * (result ** 2))
        }
        result = result < 1 ? 1 : result
    }
    return result; 
}

const definition = {
    fingerprint: [
        { modelID: 'C-ZB-SEMO', manufacturerName: 'Candeo' }
    ],
    model: 'C-ZB-SEMO',
    vendor: 'Candeo',
    description: 'Candeo C-ZB-SEMO Motion Sensor',
    extend: [
        m.battery(),
        m.illuminance({reporting: {min: 1, max: 65535, change: 1}, scale: luxScale}),
        m.iasZoneAlarm({zoneType: "occupancy", zoneAttributes: ["alarm_1"]}),
    ],
};

module.exports = definition;
```