### PR TITLE
New model for Tuya TS0603 - Garage door opener

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8783,7 +8783,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS0603", ["_TZE608_c75zqghm", "_TZE608_fmemczv1"]),
+        fingerprint: tuya.fingerprint("TS0603", ["_TZE608_c75zqghm", "_TZE608_fmemczv1", "_TZE608_xkr8gep3"]),
         model: "TS0603",
         vendor: "Tuya",
         meta: {


### PR DESCRIPTION
I have bought a new gate opener (QS-Zigbee-S10-C03) from AliExpress which is the same thing as previous ones but reports a different model.

https://www.aliexpress.com/item/1005009103445839.html

Please let me know if something else should be added :)

Thank you

<img width="615" alt="image" src="https://github.com/user-attachments/assets/d606af99-2816-4ab1-8bfb-9dfa49b93360" />
