### PR TITLE
Sprut.device Bed.box Implementation

### DIFF
--- a/src/devices/sprut.ts
+++ b/src/devices/sprut.ts
@@ -104,6 +104,11 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.onOff({
                 powerOnBehavior: false,
+                endpointNames: ["light"],
+                description: "Backlight",
+            }),
+            m.onOff({
+                powerOnBehavior: false,
                 endpointNames: ["flat"],
                 description: "Flat mode",
             }),


### PR DESCRIPTION
This is a fix for https://github.com/Koenkk/zigbee-herdsman-converters/pull/9489

I just noticed that I missed the lighting control support.

Thanks!