### PR TITLE
Added external converter for the iLightsin (Amelech) HSSA17-Z-MID zhaga

### DIFF
--- a/src/devices/ilightsin.ts
+++ b/src/devices/ilightsin.ts
@@ -9,4 +9,17 @@ export const definitions: DefinitionWithExtend[] = [
         description: "1-10V dimming LED controller",
         extend: [m.light()],
     },
+    {
+    zigbeeModel: ['13D'],
+    model: '13D',
+    vendor: 'Light',
+    description: 'iLightsin HSSA18-Z-MID zhaga module',
+    extend: [
+      m.deviceEndpoints({"endpoints":{"1":1,"33":33,"34":34}}),
+      m.light(),
+      m.illuminance({"endpointNames":["33"]}),
+      m.occupancy({"endpointNames":["34"]}),
+      m.iasZoneAlarm({"zoneType":"generic","zoneAttributes":["alarm_1","alarm_2","tamper","battery_low"]})],     
+    meta: {"multiEndpoint":true},
+    },
 ];


### PR DESCRIPTION
External converter for the iLightsin HSSA17-Z-MID module.

The device is 
 * 1-10V dimmable
 * Has illuminance value in lux
 * Has microwave motion sensor