### PR TITLE
Adapted battery threshold for Aqara Smoke Alarm JY-GZ-01AQ

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2268,7 +2268,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.battery_voltage(),
             e.power_outage_count(false),
         ],
-        meta: {battery: {voltageToPercentage: {min: 2850, max: 3000}}},
+        meta: {battery: {voltageToPercentage: {min: 2475, max: 3000}}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.write("manuSpecificLumi", {331: {value: 1, type: 0x20}}, {manufacturerCode: manufacturerCode});


### PR DESCRIPTION
This change takes care of battery characteristics and far too early battery warnings.
see details: https://github.com/Koenkk/zigbee2mqtt/issues/27374#issuecomment-2984798162