### PR TITLE
Add NimlyPRO24 to Onesti Nimly devices

### DIFF
--- a/src/devices/onesti.ts
+++ b/src/devices/onesti.ts
@@ -103,7 +103,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["NimlyPRO", "NimlyCode", "NimlyTouch", "NimlyIn"],
+        zigbeeModel: ["NimlyPRO", "NimlyCode", "NimlyTouch", "NimlyIn", "NimlyPRO24"],
         model: "Nimly",
         vendor: "Onesti Products AS",
         description: "Zigbee module for Nimly Doorlock series",


### PR DESCRIPTION
The new Nimly Pro Touch uses the nodel "NimlyPRO24" which makes Zigbee2MQTT report it as unsupported.

This just adds the NimlyPRO24 to the list. 

![image](https://github.com/user-attachments/assets/e5275f67-db67-4d3e-8cf7-135e31de38a6)
