### PR TITLE
Update amina.ts

### DIFF
--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -103,7 +103,7 @@ const tzLocal = {
         },
 
         convertGet: async (entity, key, meta) => {
-            await entity.read("genLevelCtrl", ["currentLevel"], manufacturerOptions);
+            await entity.read("genLevelCtrl", ["currentLevel"]);
         },
     } satisfies Tz.Converter,
 


### PR DESCRIPTION
Amina S problem reading charge_limit #27748
issue in wrong location: https://github.com/Koenkk/zigbee2mqtt/issues/27748

Existing code used manufacturerOptions. That is not needed.
await [entity.read](http://entity.read/)("genLevelCtrl", ["currentLevel"], manufacturerOptions);

change that to
await [entity.read](http://entity.read/)("genLevelCtrl", ["currentLevel"]);