### PR TITLE
Update candeo.ts

### DIFF
--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -9,7 +9,7 @@ const e = exposes.presets;
 const ea = exposes.access;
 
 const manufacturerSpecificSwitchTypeClusterCode = 0x1224;
-const manufacturerSpecificRotaryRemoteControlClusterCode = 0xFF03;
+const manufacturerSpecificRotaryRemoteControlClusterCode = 0xff03;
 const switchTypeAttribute = 0x8803;
 const dataType = 0x20;
 const valueMap: {[key: number]: string} = {
@@ -57,8 +57,8 @@ const fzLocal = {
         type: ["commandRotaryRemoteControl"],
         convert: (model, msg, publish, options, meta) => {
             if (utils.hasAlreadyProcessedMessage(msg, model)) return;
-            const messageTypes: {[key: number]: string} = { 
-                1: "button_press", 
+            const messageTypes: {[key: number]: string} = {
+                1: "button_press",
                 3: "ring_rotation",
             };
             const messageType = msg.data.field1;
@@ -67,27 +67,27 @@ const fzLocal = {
                 if (messageTypes[messageType] === "button_press") {
                     const buttonNumber = msg.data.field3;
                     const buttonAction = msg.data.field4;
-                    const buttonNumbers: {[key: number]: string} = { 
-                        1: "button_1_", 
-                        2: "button_2_", 
-                        4: "button_3_", 
-                        8: "button_4_", 
+                    const buttonNumbers: {[key: number]: string} = {
+                        1: "button_1_",
+                        2: "button_2_",
+                        4: "button_3_",
+                        8: "button_4_",
                         16: "centre_button_",
                     };
                     const buttonActions: {[key: number]: string} = {
-                        1: "click", 
-                        2: "double_click", 
-                        3: "hold", 
+                        1: "click",
+                        2: "double_click",
+                        3: "hold",
                         4: "release",
                     };
-                    if (buttonNumber in buttonNumbers && buttonAction in buttonActions) {                     
+                    if (buttonNumber in buttonNumbers && buttonAction in buttonActions) {
                         rotary_remote_control_actions.push(buttonNumbers[buttonNumber] + buttonActions[buttonAction]);
                     }
                 } else if (messageTypes[messageType] === "ring_rotation") {
                     const ringAction = msg.data.field3;
                     const ringActions: {[key: number]: string} = {
-                        1: "started_", 
-                        2: "stopped_", 
+                        1: "started_",
+                        2: "stopped_",
                         3: "continued_",
                     };
                     if (ringAction in ringActions) {
@@ -99,34 +99,34 @@ const fzLocal = {
                             globalStore.putValue(msg.endpoint, "previous_rotation_event", "stopped_");
                         } else {
                             const ringDirection = msg.data.field2;
-                            const ringDirections: {[key: number]: string} = { 
-                                1: "rotating_right", 
-                                2: "rotating_left", 
+                            const ringDirections: {[key: number]: string} = {
+                                1: "rotating_right",
+                                2: "rotating_left",
                             };
                             if (ringDirection in ringDirections) {
                                 const previous_rotation_event = globalStore.getValue(msg.endpoint, "previous_rotation_event");
                                 if (previous_rotation_event !== undefined) {
                                     const ringClicks = msg.data.field4;
                                     if (previous_rotation_event === "stopped_") {
-                                        rotary_remote_control_actions.push(`started_${ringDirections[ringDirection]}`);                                        
+                                        rotary_remote_control_actions.push(`started_${ringDirections[ringDirection]}`);
                                         globalStore.putValue(msg.endpoint, "previous_rotation_event", "started_");
                                         if (ringClicks > 1) {
                                             for (let i = 1; i < ringClicks; i++) {
                                                 rotary_remote_control_actions.push(`continued_${ringDirections[ringDirection]}`);
                                             }
-                                            globalStore.putValue(msg.endpoint, "previous_rotation_event", "continued_");  
+                                            globalStore.putValue(msg.endpoint, "previous_rotation_event", "continued_");
                                         }
                                     } else if (previous_rotation_event === "started_" || previous_rotation_event === "continued_") {
                                         rotary_remote_control_actions.push(`continued_${ringDirections[ringDirection]}`);
                                         if (ringClicks > 1) {
-                                            for (let i = 1; i < ringClicks; i++) {   
+                                            for (let i = 1; i < ringClicks; i++) {
                                                 rotary_remote_control_actions.push(`continued_${ringDirections[ringDirection]}`);
-                                            }                                            
+                                            }
                                         }
                                         globalStore.putValue(msg.endpoint, "previous_rotation_event", "continued_");
                                     }
-                                }                                
-                                globalStore.putValue(msg.endpoint, "previous_direction", ringDirections[ringDirection]);                                
+                                }
+                                globalStore.putValue(msg.endpoint, "previous_direction", ringDirections[ringDirection]);
                             }
                         }
                     }
@@ -474,18 +474,16 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: [
-            { modelID: "C-ZB-SR5BR", manufacturerName: "Candeo" }
-        ],
+        fingerprint: [{modelID: "C-ZB-SR5BR", manufacturerName: "Candeo"}],
         model: "C-ZB-SR5BR",
         vendor: "Candeo",
         description: "Zigbee scene switch remote - 5 button rotary",
-        extend: [        
+        extend: [
             m.battery(),
             m.deviceAddCustomCluster("candeoRotaryRemoteControl", {
                 ID: manufacturerSpecificRotaryRemoteControlClusterCode,
                 attributes: {},
-                commands: { 
+                commands: {
                     rotaryRemoteControl: {
                         ID: 0x01,
                         parameters: [
@@ -499,15 +497,40 @@ export const definitions: DefinitionWithExtend[] = [
                 commandsResponse: {},
             }),
         ],
-        fromZigbee: [
-            fzLocal.rotary_remote_control,
-            fz.ignore_genOta,
-        ],
-        exposes: [e.action(["button_1_click", "button_1_double_click", "button_1_hold", "button_1_release", "button_2_click", "button_2_double_click", "button_2_hold", "button_2_release", "button_3_click", "button_3_double_click", "button_3_hold", "button_3_release", "button_4_click", "button_4_double_click", "button_4_hold", "button_4_release", "centre_button_click", "centre_button_double_click", "centre_button_hold", "centre_button_release", "started_rotating_left", "continued_rotating_left", "stopped_rotating_left", "started_rotating_right", "continued_rotating_right", "stopped_rotating_right"])
+        fromZigbee: [fzLocal.rotary_remote_control, fz.ignore_genOta],
+        exposes: [
+            e.action([
+                "button_1_click",
+                "button_1_double_click",
+                "button_1_hold",
+                "button_1_release",
+                "button_2_click",
+                "button_2_double_click",
+                "button_2_hold",
+                "button_2_release",
+                "button_3_click",
+                "button_3_double_click",
+                "button_3_hold",
+                "button_3_release",
+                "button_4_click",
+                "button_4_double_click",
+                "button_4_hold",
+                "button_4_release",
+                "centre_button_click",
+                "centre_button_double_click",
+                "centre_button_hold",
+                "centre_button_release",
+                "started_rotating_left",
+                "continued_rotating_left",
+                "stopped_rotating_left",
+                "started_rotating_right",
+                "continued_rotating_right",
+                "stopped_rotating_right",
+            ]),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint1 = device.getEndpoint(1);        
+            const endpoint1 = device.getEndpoint(1);
             await endpoint1.bind(manufacturerSpecificRotaryRemoteControlClusterCode, coordinatorEndpoint);
         },
-    }
+    },
 ];


### PR DESCRIPTION
Adds support for the Candeo C-ZB-SR5BR Scene Switch Remote - 5 Button Rotary

Supports click, double click, hold and release events for all 5 buttons
Supports started / continued / stopped rotating events for left and right rotary movement



@Koenkk this converter works well with our device, we used deviceAddCustomCluster in order to custom process the Cluster Commands into appropriate button and rotation actions.

If there's a better way to write the code please let us know!