### PR TITLE
fix: TS0505B_1 transition fixes

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -647,7 +647,7 @@ const tzLocal = {
         ...tz.light_onoff_brightness,
         convertSet: async (entity, key, value, meta) => {
             // This light has two issues:
-            // 1. If passing transition = 0, it will behave as if transition = 1.
+            // 1. If passing transition = 0, it will behave as if transition = 1s.
             // 2. If turning off with a transition, and turning on during the transition, it will turn off
             //    at the end of the first transition timer, despite order to turn on
 

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -658,15 +658,15 @@ const tzLocal = {
             if (transitionSeconds === 0) {
                 const {message} = meta;
                 const wantedState = message.state != null ? (typeof message.state === "string" ? message.state.toLowerCase() : null) : undefined;
-                newMeta = {...meta, message: {...message}}; // Clone meta.message to avoid modifying the original
+                newMeta = {...meta}; // Clone meta to avoid modifying the original
                 if (wantedState === "off") {
                     // Erase transition because that way we get actual instant turn off
-                    newMeta.message.transition = null;
+                    newMeta.message = {state: "OFF"};
                 } else {
                     // Best we can do is set the transition to 0.1 seconds
                     // That is the same thing as is done for TS0505B_2
                     transitionSeconds = 0.1;
-                    newMeta.message.transition = transitionSeconds; // Will get re-parsed by original light_onoff_brightness
+                    newMeta.message = {...message, transition: transitionSeconds}; // Will get re-parsed by original light_onoff_brightness
                 }
             }
 

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -643,7 +643,7 @@ const tzLocal = {
         },
     } satisfies Tz.Converter,
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-    TS0505B_1_transitionFixes: {
+    TS0505B_1_transitionFixesOnOffBrightness: {
         ...tz.light_onoff_brightness,
         convertSet: async (entity, key, value, meta) => {
             // This light has two issues:
@@ -651,24 +651,41 @@ const tzLocal = {
             // 2. If turning off with a transition, and turning on during the transition, it will turn off
             //    at the end of the first transition timer, despite order to turn on
 
-            // Workaround for issue 1: best we can do is set the transition to 0.1 seconds
-            // That is the same thing as is done for TS0505B_2
+            // Workaround for issue 1: patch transition in input message
             const transition = utils.getTransition(entity, "brightness", meta);
-            const transitionSeconds = (transition.time || 1) / 10;
-            meta.message.transition = transitionSeconds; // Will get re-parsed by original light_onoff_brightness
+            const transitionSeconds = transition.time / 10;
+            let newMeta = meta;
+            if (transitionSeconds === 0) {
+                const {message} = meta;
+                const wantedState = message.state != null ? (typeof message.state === "string" ? message.state.toLowerCase() : null) : undefined;
+                newMeta = {...meta, message: {...message}}; // Clone meta.message to avoid modifying the original
+                if (wantedState === "off") {
+                    // Erase transition because that way we get actual instant turn off
+                    newMeta.message.transition = null;
+                } else {
+                    // Best we can do is set the transition to 0.1 seconds
+                    // That is the same thing as is done for TS0505B_2
+                    newMeta.message.transition = transitionSeconds; // Will get re-parsed by original light_onoff_brightness
+                }
+            }
 
-            const ret = await tz.light_onoff_brightness.convertSet(entity, key, value, meta);
+            const ret = await tz.light_onoff_brightness.convertSet(entity, key, value, newMeta);
 
             // Workaround for issue 2:
             // Get the current state of the light after transition time + 0.1s
             // This won't fix the light's state, but at least it will make us aware that it's off,
             // allowing user apps to turn it on again if needed.
             // This could probably be improved by actually turning it on again if necessary.
-            setTimeout(() => {
-                tz.on_off.convertGet(entity, "state", meta).catch((error) => {
-                    logger.warning(`Error getting state of TS0505B_1 after transition: ${error.message}`, NS);
-                });
-            }, transitionSeconds + 0.1);
+            if (transitionSeconds !== 0) {
+                setTimeout(
+                    () => {
+                        tz.on_off.convertGet(entity, "state", meta).catch((error) => {
+                            logger.warning(`Error getting state of TS0505B_1 after transition: ${error.message}`, NS);
+                        });
+                    },
+                    transitionSeconds * 1000 + 100,
+                );
+            }
 
             return ret;
         },
@@ -1799,7 +1816,7 @@ export const definitions: DefinitionWithExtend[] = [
                 color: true,
             }),
         ],
-        toZigbee: [tzLocal.TS0505B_1_transitionFixes],
+        toZigbee: [tzLocal.TS0505B_1_transitionFixesOnOffBrightness],
         configure: (device, coordinatorEndpoint) => {
             device.getEndpoint(1).saveClusterAttributeKeyValue("lightingColorCtrl", {
                 colorCapabilities: 29,

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -653,7 +653,7 @@ const tzLocal = {
 
             // Workaround for issue 1: patch transition in input message
             const transition = utils.getTransition(entity, "brightness", meta);
-            const transitionSeconds = transition.time / 10;
+            let transitionSeconds = transition.time / 10;
             let newMeta = meta;
             if (transitionSeconds === 0) {
                 const {message} = meta;
@@ -665,6 +665,7 @@ const tzLocal = {
                 } else {
                     // Best we can do is set the transition to 0.1 seconds
                     // That is the same thing as is done for TS0505B_2
+                    transitionSeconds = 0.1;
                     newMeta.message.transition = transitionSeconds; // Will get re-parsed by original light_onoff_brightness
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/27894
Helps https://github.com/Koenkk/zigbee2mqtt/issues/27498

This light has two issues:
1. If passing transition = 0, it will behave as if transition = 1.
2. If turning off with a transition, and turning on during the transition, it will turn off at the end of the first transition timer, despite order to turn on

Workaround for issue 1:
- If we're trying to turn off, we can just remove the transition: 0 key and it will just use `on_off`, which is instant
- Otherwise best we can do is set the transition to 0.1 seconds, which will be as instant as it gets (That is the same thing as is done for TS0505B_2)
This PR currently only does this for the turn_on/turn_off case, but not when just changing color.

Workaround for issue 2:
- Get the current state of the light after transition time + 0.1s.

This won't get the light to the "desired" state, but at least it will make us aware that it's off, allowing user apps to turn it on again if needed.
This could probably be improved by actually turning it on again if necessary, but it's unclear to me if I can track "necessary" with certainty, or how I could trigger another change in a way that would make z2m aware of the associated state changes.
Right now my life will be easy enough with just knowing the actual state but with guidance I could maybe adapt this to make it re-apply actually-wanted state.