### PR TITLE
fix(bht002): set tempature steps for specific model

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -235,7 +235,7 @@ export const definitions: DefinitionWithExtend[] = [
                     .climate()
                     .withSetpoint("current_heating_setpoint", 5, 45, heatingStepSize, ea.STATE_SET)
                     .withLocalTemperature(ea.STATE)
-                    .withLocalTemperatureCalibration(-30, 30, 0.1, ea.STATE_SET)
+                    .withLocalTemperatureCalibration(-30, 30, device?.manufacturerName === "_TZE204_aoclfnxz" ? 1 : 0.1, ea.STATE_SET)
                     .withSystemMode(["off", "heat"], ea.STATE_SET)
                     .withRunningState(runningStates, ea.STATE)
                     .withPreset(["hold", "program"]),


### PR DESCRIPTION
as reported in https://github.com/Koenkk/zigbee2mqtt/issues/26794 one device model (_TZE204_aoclfnxz) doesn't support decimal steps when setting the local_temperature_calibration