### PR TITLE
Support of new Tuya switches

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -17578,7 +17578,35 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ezqbvrqz", "_TZ3002_ymv5vytn"]),
+        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_qvmiyxuk"]),
+        model: "TS0001_1_gang_switch",
+        vendor: "Tuya",
+        description: "1 gang switch with backlight",
+
+        fromZigbee: [fz.ignore_basic_report],
+        extend: [
+            tuya.modernExtend.tuyaOnOff({
+                powerOnBehavior2: true,
+                backlightModeOffOn: true,
+                onOffCountdown: true,
+            }),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+        },
+
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tuya.valueConverter.onOff], // Switch
+                [7, "countdown", tuya.valueConverter.countdown], // Countdown
+                [14, "power_on_behavior", tuya.valueConverter.powerOnBehavior], // Power on behavior
+                [16, "backlight_mode", tuya.valueConverter.onOff], // Backlight
+            ],
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ezqbvrqz", "_TZ3002_ymv5vytn", "_TZ3002_6ahhkwyh"]),
         model: "TS0726_2_gang_scene_switch",
         vendor: "Tuya",
         description: "2 gang switch with scene and backlight",
@@ -17606,7 +17634,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_noru9tix", "_TZ3002_rbnycsav"]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_noru9tix", "_TZ3002_rbnycsav", "_TZ3002_kq3kqwjt"]),
         model: "TS0726_3_gang_scene_switch",
         vendor: "Tuya",
         description: "3 gang switch with scene and backlight",
@@ -17634,7 +17662,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_rsylfthg"]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_rsylfthg", "_TZ3002_umdkr64x"]),
         model: "TS0726_4_gang_scene_switch",
         vendor: "Tuya",
         description: "4 gang switch with scene and backlight",


### PR DESCRIPTION
Adding support for one new 1 gang switch with backlight and mapping 3 switches to existing definitions: 

_TZ3000_qvmiyxuk - new 1-gang with backlight
_TZ3002_6ahhkwyh works as _TZ3002_ymv5vytn
_TZ3002_kq3kqwjt works as _TZ3000_noru9tix
_TZ3002_umdkr64x works as _TZ3002_phu8ygaw