### PR TITLE
Fix tamper and battery values for Develco (Frient) KEPZB-110

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -964,7 +964,7 @@ export const ias_no_alarm: Fz.Converter = {
     cluster: "ssIasZone",
     type: ["attributeReport", "commandStatusChangeNotification"],
     convert: (model, msg, publish, options, meta) => {
-        const zoneStatus = msg.data.zoneStatus;
+        const zoneStatus = msg.data.zoneStatus ?? msg.data.zonestatus;
         if (zoneStatus !== undefined) {
             return {
                 tamper: (zoneStatus & (1 << 2)) > 0,


### PR DESCRIPTION
This fixes the reading of the "tamper" and "battery_low" booleans, which are currently always null.

I tested it with my own Frient KEPZB-110.