### PR TITLE
Add support for Tuya 1-gang smart scene switch with backlight

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -17578,6 +17578,29 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_5kxl9esg"]),
+        model: "TS0726_1_gang_scene_switch",
+        vendor: "Tuya",
+        description: "1 gang switch with scene and backlight",
+        fromZigbee: [fz.ignore_basic_report, fzLocal.TS0726_action],
+        exposes: [e.action(["scene_1"])],
+        extend: [
+            tuya.modernExtend.tuyaOnOff({
+                switchMode: true,
+                powerOnBehavior2: true,
+                backlightModeOffOn: true,
+                indicatorModeNoneRelayPos: true,
+                onOffCountdown: true,
+                endpoints: ["l1"],
+            }),
+        ],
+        endpoint: (device) => ({l1: 1}),
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ezqbvrqz", "_TZ3002_ymv5vytn"]),
         model: "TS0726_2_gang_scene_switch",
         vendor: "Tuya",


### PR DESCRIPTION
I finally got the 1-gang version and the support is now added.

Previous PR for 2, 3, 4 gangs:
https://github.com/Koenkk/zigbee-herdsman-converters/pull/9158
https://github.com/Koenkk/zigbee-herdsman-converters/pull/9472
