### PR TITLE
fix(ignore): Add dummy device type

### DIFF
--- a/src/devices/bitron.ts
+++ b/src/devices/bitron.ts
@@ -6,6 +6,7 @@ import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend, Fz, KeyValueAny, Tz} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -242,7 +243,9 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         exposes: (device, options) => {
             const dynExposes = [];
-            let ctrlSeqeOfOper = device?.getEndpoint(1).getClusterAttributeValue("hvacThermostat", "ctrlSeqeOfOper") ?? null;
+            let ctrlSeqeOfOper = !utils.isDummyDevice(device)
+                ? device.getEndpoint(1).getClusterAttributeValue("hvacThermostat", "ctrlSeqeOfOper")
+                : null;
             const modes = [];
 
             if (typeof ctrlSeqeOfOper === "string") ctrlSeqeOfOper = Number.parseInt(ctrlSeqeOfOper) ?? null;

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1923,7 +1923,7 @@ export const definitions: DefinitionWithExtend[] = [
                     .withValueStep(0.1),
             ];
 
-            if (device) {
+            if (!utils.isDummyDevice(device)) {
                 const deviceModeKey = device.getEndpoint(1).getClusterAttributeValue("boschSpecific", "deviceMode");
                 const deviceMode = Object.keys(stateDeviceMode).find((key) => stateDeviceMode[key] === deviceModeKey);
 

--- a/src/devices/busch_jaeger.ts
+++ b/src/devices/busch_jaeger.ts
@@ -43,7 +43,7 @@ export const definitions: DefinitionWithExtend[] = [
             // If endpoint 0x12 (18) is present this means the following two things:
             //  1. The device is connected to a relay or dimmer and needs to be exposed as a dimmable light
             //  2. The top rocker will not be usable (not emit any events) as it's hardwired to the relay/dimmer
-            if (!device || device.getEndpoint(0x12) != null) {
+            if (utils.isDummyDevice(device) || device.getEndpoint(0x12) != null) {
                 expose.push(e.light_brightness().withEndpoint("relay"));
             }
             // Not all devices support all actions (depends on number of rocker rows and if relay/dimmer is installed),

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -6,7 +6,8 @@ import * as exposes from "../lib/exposes";
 import * as legacy from "../lib/legacy";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Expose, Fz, KeyValue, KeyValueAny, Tz, Zh} from "../lib/types";
+import type {DefinitionWithExtend, DummyDevice, Expose, Fz, KeyValue, KeyValueAny, Tz, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
 import {calibrateAndPrecisionRoundOptions, getFromLookup, getKey, isEndpoint, postfixWithEndpointName} from "../lib/utils";
 
 const e = exposes.presets;
@@ -145,8 +146,8 @@ const fzLocal = {
     } satisfies Fz.Converter,
 };
 
-function ptvoGetMetaOption(device: Zh.Device, key: string, defaultValue: unknown) {
-    if (device != null) {
+function ptvoGetMetaOption(device: Zh.Device | DummyDevice, key: string, defaultValue: unknown) {
+    if (!utils.isDummyDevice(device)) {
         const value = device.meta[key];
         if (value === undefined) {
             return defaultValue;
@@ -340,8 +341,8 @@ export const definitions: DefinitionWithExtend[] = [
             const expose: Expose[] = [];
             const exposeDeviceOptions: KeyValue = {};
             const deviceConfig = ptvoGetMetaOption(device, "device_config", "");
-            if (deviceConfig === "") {
-                if (device?.endpoints) {
+            if (deviceConfig === "" || utils.isDummyDevice(device)) {
+                if (!utils.isDummyDevice(device)) {
                     for (const endpoint of device.endpoints) {
                         const exposeEpOptions: KeyValue = {};
                         ptvoAddStandardExposes(endpoint, expose, exposeEpOptions, exposeDeviceOptions);

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -7,6 +7,7 @@ import * as exposes from "../lib/exposes";
 import * as reporting from "../lib/reporting";
 import * as globalStore from "../lib/store";
 import type {DefinitionWithExtend, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -74,7 +75,7 @@ export const definitions: DefinitionWithExtend[] = [
             tz.danfoss_thermostat_occupied_heating_setpoint_scheduled,
         ],
         exposes: (device, options) => {
-            const maxSetpoint = ["TRV001", "TRV003"].includes(device?.modelID) ? 32 : 35;
+            const maxSetpoint = !utils.isDummyDevice(device) && ["TRV001", "TRV003"].includes(device.modelID) ? 32 : 35;
             return [
                 e.battery(),
                 e.keypad_lockout(),

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -619,12 +619,12 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: (device, options) => {
             const dynExposes = [];
             dynExposes.push(e.occupancy());
-            if (Number(device?.softwareBuildID?.split(".")[0]) >= 3) {
+            if (utils.isDummyDevice(device) || Number(device.softwareBuildID?.split(".")[0]) >= 3) {
                 dynExposes.push(e.numeric("occupancy_timeout", ea.ALL).withUnit("s").withValueMin(5).withValueMax(65535));
             }
             dynExposes.push(e.tamper());
             dynExposes.push(e.battery_low());
-            if (Number(device?.softwareBuildID?.split(".")[0]) >= 4) {
+            if (utils.isDummyDevice(device) || Number(device?.softwareBuildID?.split(".")[0]) >= 4) {
                 dynExposes.push(
                     e.enum("led_control", ea.ALL, ["off", "fault_only", "motion_only", "both"]).withDescription("Control LED indicator usage."),
                 );
@@ -682,7 +682,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [develco.tz.led_control, develco.tz.ias_occupancy_timeout],
         exposes: (device, options) => {
             const dynExposes = [];
-            if (Number(device?.softwareBuildID?.split(".")[0]) >= 2) {
+            if (utils.isDummyDevice(device) || Number(device?.softwareBuildID?.split(".")[0]) >= 2) {
                 dynExposes.push(e.numeric("occupancy_timeout", ea.ALL).withUnit("s").withValueMin(5).withValueMax(65535));
                 dynExposes.push(
                     e.enum("led_control", ea.ALL, ["off", "fault_only", "motion_only", "both"]).withDescription("Control LED indicator usage."),

--- a/src/devices/gmmts.ts
+++ b/src/devices/gmmts.ts
@@ -10,6 +10,7 @@ import {logger} from "../lib/logger";
 import * as reporting from "../lib/reporting";
 import * as globalStore from "../lib/store";
 import type {DefinitionWithExtend, Expose, Fz, KeyValue, Tz, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const ea = exposes.access;
 const e = exposes.presets;
@@ -1991,7 +1992,7 @@ export const definitions: DefinitionWithExtend[] = [
             let currentProducer = "";
             let translation = "";
 
-            if (device == null) {
+            if (utils.isDummyDevice(device)) {
                 return exposes;
             }
 

--- a/src/devices/imhotepcreation.ts
+++ b/src/devices/imhotepcreation.ts
@@ -4,6 +4,7 @@ import * as constants from "../lib/constants";
 import * as exposes from "../lib/exposes";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -115,7 +116,7 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: (device, options) => {
             const features = [];
 
-            if (typeof device !== "undefined" && device != null && device.endpoints) {
+            if (!utils.isDummyDevice(device)) {
                 for (let i = 1; i <= 16; i++) {
                     const endpoint = device?.getEndpoint(i);
                     if (endpoint !== undefined) {

--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1768,7 +1768,7 @@ export const definitions: DefinitionWithExtend[] = [
             // docs generation
             // biome-ignore lint/suspicious/noImplicitAnyLet: ignored using `--suppress`
             let exposes;
-            if (device == null && options == null) {
+            if (utils.isDummyDevice(device)) {
                 exposes = exposedData
                     .map((e) => e.exposes)
                     .filter(

--- a/src/devices/ls.ts
+++ b/src/devices/ls.ts
@@ -1,6 +1,7 @@
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import type {DefinitionWithExtend} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 
@@ -14,7 +15,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: m.light({colorTemp: {range: [153, 454]}, color: true}).toZigbee,
         configure: m.light({colorTemp: {range: [153, 454]}, color: true}).configure[0],
         exposes: (device, options) => {
-            if (!device) return [e.light_brightness_colortemp_colorxy([153, 454])];
+            if (utils.isDummyDevice(device)) return [e.light_brightness_colortemp_colorxy([153, 454])];
             return [
                 ...device.endpoints
                     .filter((ep) => ep.ID !== 242)

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -224,8 +224,8 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         whiteLabel: [tuya.whitelabel("Moes", "BHT-002/BHT-006", "Smart heating thermostat", ["_TZE204_aoclfnxz"])],
         exposes: (device, options) => {
-            const heatingStepSize = device?.manufacturerName === "_TZE204_5toc8efa" ? 0.5 : 1;
-            const runningStates = device?.manufacturerName === "_TZE200_aoclfnxz" ? ["idle", "heat"] : ["idle", "heat", "cool"];
+            const heatingStepSize = device.manufacturerName === "_TZE204_5toc8efa" ? 0.5 : 1;
+            const runningStates = device.manufacturerName === "_TZE200_aoclfnxz" ? ["idle", "heat"] : ["idle", "heat", "cool"];
             return [
                 e.child_lock(),
                 e.deadzone_temperature(),
@@ -235,7 +235,7 @@ export const definitions: DefinitionWithExtend[] = [
                     .climate()
                     .withSetpoint("current_heating_setpoint", 5, 45, heatingStepSize, ea.STATE_SET)
                     .withLocalTemperature(ea.STATE)
-                    .withLocalTemperatureCalibration(-30, 30, device?.manufacturerName === "_TZE204_aoclfnxz" ? 1 : 0.1, ea.STATE_SET)
+                    .withLocalTemperatureCalibration(-30, 30, device.manufacturerName === "_TZE204_aoclfnxz" ? 1 : 0.1, ea.STATE_SET)
                     .withSystemMode(["off", "heat"], ea.STATE_SET)
                     .withRunningState(runningStates, ea.STATE)
                     .withPreset(["hold", "program"]),
@@ -523,7 +523,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tzZosung.zosung_ir_code_to_send, tzZosung.zosung_learn_ir_code],
         exposes: (device, options) => {
             const exposes: Expose[] = [ez.learn_ir_code(), ez.learned_ir_code(), ez.ir_code_to_send()];
-            if (device?.manufacturerName !== "") {
+            if (device.manufacturerName !== "") {
                 exposes.push(e.battery(), e.battery_voltage());
             }
             return exposes;

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -8,6 +8,7 @@ import * as m from "../lib/modernExtend";
 import {nodonPilotWire} from "../lib/nodon";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend, ModernExtend} from "../lib/types";
+import {isDummyDevice} from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -108,7 +109,12 @@ const nodonModernExtend = {
         // NOTE: make exposes dynamic based on fw version
         result.exposes = [
             (device, options) => {
-                if (device?.softwareBuildID && semverValid(device.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
+                if (
+                    !isDummyDevice(device) &&
+                    device.softwareBuildID &&
+                    semverValid(device.softwareBuildID) &&
+                    semverGt(device.softwareBuildID, "3.4.0")
+                ) {
                     return [
                         e
                             .numeric(resultName, ea.ALL)
@@ -142,7 +148,12 @@ const nodonModernExtend = {
         // NOTE: make exposes dynamic based on fw version
         result.exposes = [
             (device, options) => {
-                if (device?.softwareBuildID && semverValid(device.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
+                if (
+                    !isDummyDevice(device) &&
+                    device.softwareBuildID &&
+                    semverValid(device.softwareBuildID) &&
+                    semverGt(device.softwareBuildID, "3.4.0")
+                ) {
                     return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription)];
                 }
                 return [];
@@ -169,7 +180,12 @@ const nodonModernExtend = {
         // NOTE: make exposes dynamic based on fw version
         result.exposes = [
             (device, options) => {
-                if (device?.softwareBuildID && semverValid(device.softwareBuildID) && semverGt(device.softwareBuildID, "3.4.0")) {
+                if (
+                    !isDummyDevice(device) &&
+                    device.softwareBuildID &&
+                    semverValid(device.softwareBuildID) &&
+                    semverGt(device.softwareBuildID, "3.4.0")
+                ) {
                     return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription)];
                 }
                 return [];

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -6,6 +6,7 @@ import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as globalStore from "../lib/store";
 import type {DefinitionWithExtend, KeyValue, OnEventData, OnEventType, Zh} from "../lib/types";
+import {isDummyDevice} from "../lib/utils";
 
 const NS = "zhc:profalux";
 const e = exposes.presets;
@@ -64,16 +65,13 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tz.cover_state, tz.cover_position_tilt],
         options: [],
         exposes: (device, options) => {
-            const endpoint = device?.getEndpoint(2);
             // Motor can be configured using the associated remote:
             //  0: default hard cover         : 2xF Up + Down on the associated remote
             //  1: cover using tilt (aka BSO) : 2xF Stop + Up
             //  2: soft cover (aka store)     : 2xF Stop + Down
-
-            if ((device == null && options == null) || endpoint.getClusterAttributeValue("manuSpecificProfalux1", "motorCoverType") === 1) {
-                return [e.cover_position_tilt()];
-            }
-            return [e.cover_position()];
+            return isDummyDevice(device) || device?.getEndpoint(2).getClusterAttributeValue("manuSpecificProfalux1", "motorCoverType") === 1
+                ? [e.cover_position_tilt()]
+                : [e.cover_position()];
         },
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(2);

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -703,7 +703,7 @@ export const definitions: DefinitionWithExtend[] = [
         // Produced_energy and ct_direction is supported in version 8 and above.
         exposes: (device, options) => {
             const exposes = [];
-            if (device?.applicationVersion >= 8) {
+            if (utils.isDummyDevice(device) || device.applicationVersion >= 8) {
                 exposes.push(e.produced_energy().withAccess(ea.STATE_GET));
                 exposes.push(
                     e
@@ -747,7 +747,7 @@ export const definitions: DefinitionWithExtend[] = [
         // Produced_energy is supported in version 9 and above.
         exposes: (device, options) => {
             const exposes = [];
-            if (device?.applicationVersion >= 9) {
+            if (utils.isDummyDevice(device) || device.applicationVersion >= 9) {
                 exposes.push(e.produced_energy().withAccess(ea.STATE_GET));
             }
             return exposes;

--- a/src/devices/siglis.ts
+++ b/src/devices/siglis.ts
@@ -2,7 +2,7 @@ import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz, KeyValue, Tz, Zh} from "../lib/types";
+import type {DefinitionWithExtend, DummyDevice, Fz, KeyValue, Tz, Zh} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
@@ -91,7 +91,7 @@ const buttonEventExposes = e.action([
     "button_4_release",
 ]);
 
-function checkOption(device: Zh.Device, options: KeyValue, key: string) {
+function checkOption(device: Zh.Device | DummyDevice, options: KeyValue, key: string) {
     if (options != null && options[key] != null) {
         if (options[key] === "true") {
             return true;
@@ -104,8 +104,8 @@ function checkOption(device: Zh.Device, options: KeyValue, key: string) {
     return checkMetaOption(device, key);
 }
 
-function checkMetaOption(device: Zh.Device, key: string) {
-    if (device != null) {
+function checkMetaOption(device: Zh.Device | DummyDevice, key: string) {
+    if (!utils.isDummyDevice(device)) {
         const enabled = device.meta[key];
         if (enabled === undefined) {
             return false;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -938,7 +938,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
         configure: async (device, coordinatorEndpoint) => {
-            if (device?.manufacturerName === "_TZ3210_up3pngle") {
+            if (device.manufacturerName === "_TZ3210_up3pngle") {
                 // Required for this version
                 // https://github.com/Koenkk/zigbee-herdsman-converters/pull/8004
                 const endpoint = device.getEndpoint(1);
@@ -2914,9 +2914,9 @@ export const definitions: DefinitionWithExtend[] = [
                 e.enum("moving", ea.STATE, ["UP", "STOP", "DOWN"]),
                 e.binary("motor_reversal", ea.ALL, "ON", "OFF"),
             ];
-            if (["_TZ3000_yruungrl"].includes(device?.manufacturerName)) {
+            if (["_TZ3000_yruungrl"].includes(device.manufacturerName)) {
                 exps.push(e.binary("calibration", ea.ALL, "ON", "OFF"), e.numeric("calibration_time", ea.ALL).withUnit("s"));
-            } else if (["_TZ3000_cet6ch1r", "_TZ3000_5iixzdo7"].includes(device?.manufacturerName)) {
+            } else if (["_TZ3000_cet6ch1r", "_TZ3000_5iixzdo7"].includes(device.manufacturerName)) {
                 exps.push(
                     e.binary("calibration_to_open", ea.ALL, "ON", "OFF"),
                     e.binary("calibration_to_close", ea.ALL, "ON", "OFF"),
@@ -2926,12 +2926,12 @@ export const definitions: DefinitionWithExtend[] = [
             } else {
                 exps.push(e.binary("calibration", ea.ALL, "ON", "OFF"), e.numeric("calibration_time", ea.STATE).withUnit("s"));
             }
-            if (!["_TZ3210_xbpt8ewc", "_TZ3000_e3vhyirx", "_TZ3000_5iixzdo7", "_TZ3000_yruungrl"].includes(device?.manufacturerName)) {
+            if (!["_TZ3210_xbpt8ewc", "_TZ3000_e3vhyirx", "_TZ3000_5iixzdo7", "_TZ3000_yruungrl"].includes(device.manufacturerName)) {
                 exps.push(tuya.exposes.indicatorMode(), tuya.exposes.backlightModeOffOn());
             }
-            if (["_TZ3000_5iixzdo7"].includes(device?.manufacturerName)) {
+            if (["_TZ3000_5iixzdo7"].includes(device.manufacturerName)) {
                 exps.push(tuya.exposes.switchTypeCurtain());
-            } else if (["_TZ3000_yruungrl"].includes(device?.manufacturerName)) {
+            } else if (["_TZ3000_yruungrl"].includes(device.manufacturerName)) {
                 exps.push(
                     e.enum("switch_type_curtain", ea.ALL, ["flip-switch", "sync-switch", "button-switch"]).withDescription("External switch type"),
                 );
@@ -10621,7 +10621,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tz.TS110E_onoff_brightness, tz.TS110E_options, tuya.tz.power_on_behavior_1, tz.light_brightness_move, tzLocal.ts110eCountdown],
         exposes: (device, options) => {
             // https://github.com/Koenkk/zigbee2mqtt/issues/26791#issuecomment-2765734859
-            const countdownValueStep = device?.manufacturerName === "_TZ3210_ngqk6jia" ? 30 : 1;
+            const countdownValueStep = device.manufacturerName === "_TZ3210_ngqk6jia" ? 30 : 1;
             return [
                 e.light_brightness().withMinBrightness().withMaxBrightness(),
                 tuya.exposes.lightType().withAccess(ea.ALL),
@@ -11068,7 +11068,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tzLocal.TS011F_threshold],
         exposes: (device, options) => {
             const exposes: Expose[] = [];
-            if (!["_TZ3000_303avxxt", "_TZ3000_zjchz7pd"].includes(device?.manufacturerName)) {
+            if (!["_TZ3000_303avxxt", "_TZ3000_zjchz7pd"].includes(device.manufacturerName)) {
                 exposes.push(
                     e.temperature(),
                     e

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -990,7 +990,9 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         exposes: (device, options) => {
             const coverExpose = e.cover();
-            const coverType = device?.getEndpoint(1).getClusterAttributeValue("closuresWindowCovering", "windowCoveringType") ?? undefined;
+            const coverType = !utils.isDummyDevice(device)
+                ? device.getEndpoint(1).getClusterAttributeValue("closuresWindowCovering", "windowCoveringType")
+                : undefined;
             switch (
                 coverType // cf. Ubisys J1 Technical Reference Manual, chapter 7.2.5.1 Calibration
             ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,7 +381,7 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
         if (allExposesIsExposeOnly(allExposes)) {
             exposes = allExposes;
         } else {
-            exposes = (device: Zh.Device | undefined, options: KeyValue | undefined) => {
+            exposes = (device, options) => {
                 const result: Expose[] = [];
 
                 for (const item of allExposes) {
@@ -391,7 +391,8 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
 
                             result.push(...deviceExposes);
                         } catch (error) {
-                            logger.error(`Failed to process exposes for '${device.ieeeAddr}' (${(error as Error).stack})`, NS);
+                            const ieeeAddr = utils.isDummyDevice(device) ? "dummy-device" : device.ieeeAddr;
+                            logger.error(`Failed to process exposes for '${ieeeAddr}' (${(error as Error).stack})`, NS);
                         }
                     } else {
                         result.push(item);
@@ -435,7 +436,7 @@ export function prepareDefinition(definition: DefinitionWithExtend): Definition 
     const optionKeys = finalDefinition.options.map((o) => o.name);
 
     // Add calibration/precision options based on expose
-    for (const expose of Array.isArray(finalDefinition.exposes) ? finalDefinition.exposes : finalDefinition.exposes(undefined, undefined)) {
+    for (const expose of Array.isArray(finalDefinition.exposes) ? finalDefinition.exposes : finalDefinition.exposes({isDummyDevice: true}, {})) {
         if (
             !optionKeys.includes(expose.name) &&
             utils.isNumericExpose(expose) &&

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -1,6 +1,6 @@
 import {Zcl} from "zigbee-herdsman";
 
-import type {Fz, KeyValueAny, KeyValueString, OnEvent, Tz, Zh} from "../lib/types";
+import type {DummyDevice, Fz, KeyValueAny, KeyValueString, OnEvent, Tz, Zh} from "../lib/types";
 import * as utils from "../lib/utils";
 import * as exposes from "./exposes";
 import {logger} from "./logger";
@@ -76,10 +76,12 @@ export const eLegrand = {
     ledIfOn: () => {
         return e.binary("led_if_on", ea.ALL, "ON", "OFF").withDescription("Enables the LED on activity").withCategory("config");
     },
-    getCover: (device: Zh.Device) => {
+    getCover: (device: Zh.Device | DummyDevice) => {
         const c = e.cover_position();
 
-        const calMode = Number(device?.getEndpoint(1)?.clusters?.closuresWindowCovering?.attributes?.calibrationMode);
+        const calMode = !utils.isDummyDevice(device)
+            ? Number(device.getEndpoint(1)?.clusters?.closuresWindowCovering?.attributes?.calibrationMode)
+            : 0;
         const showTilt = calMode ? shutterCalibrationModes[calMode]?.supportsTilt === true : false;
 
         if (showTilt) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -256,7 +256,13 @@ export interface OnEventData {
     data?: KeyValueAny;
 }
 
-export type DefinitionExposesFunction = (device: Zh.Device | undefined, options: KeyValue | undefined) => Expose[];
+// Special type for the zigbee2mqtt.io device page docgen
+export type DummyDevice = {
+    manufacturerName?: string;
+    isDummyDevice: true;
+};
+
+export type DefinitionExposesFunction = (device: Zh.Device | DummyDevice, options: KeyValue) => Expose[];
 
 export type DefinitionExposes = Expose[] | DefinitionExposesFunction;
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,6 +8,7 @@ import type {
     BatteryNonLinearVoltage,
     Configure,
     Definition,
+    DummyDevice,
     Expose,
     Fz,
     KeyValue,
@@ -702,6 +703,10 @@ export function isEndpoint(obj: Zh.Endpoint | Zh.Group | Zh.Device): obj is Zh.E
 
 export function isDevice(obj: Zh.Endpoint | Zh.Group | Zh.Device): obj is Zh.Device {
     return obj.constructor.name.toLowerCase() === "device";
+}
+
+export function isDummyDevice(obj: Zh.Device | DummyDevice): obj is DummyDevice {
+    return "isDummyDevice" in obj;
 }
 
 export function isGroup(obj: Zh.Endpoint | Zh.Group | Zh.Device): obj is Zh.Group {

--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -1,5 +1,5 @@
 import baseDefinitions from "../src/devices/index";
-import {type Definition, prepareDefinition} from "../src/index";
+import {type Definition, type Expose, prepareDefinition} from "../src/index";
 import {access, Numeric} from "../src/lib/exposes";
 import * as sunricher from "../src/lib/sunricher";
 import {tz} from "../src/lib/tuya";
@@ -7,6 +7,10 @@ import {COLORTEMP_RANGE_MISSING_ALLOWED} from "./colortemp_range_missing_allowed
 
 describe("Check definitions", () => {
     const definitions: Definition[] = [];
+
+    function definitionExposes(definition: Definition): Expose[] {
+        return typeof definition.exposes === "function" ? definition.exposes({isDummyDevice: true}, {}) : definition.exposes;
+    }
 
     beforeAll(() => {
         for (const def of baseDefinitions) {
@@ -23,7 +27,7 @@ describe("Check definitions", () => {
             if (definition.toZigbee.includes(sunricher.tz.setModel)) return;
 
             const toCheck = [];
-            const exposes = typeof definition.exposes === "function" ? definition.exposes(undefined, undefined) : definition.exposes;
+            const exposes = definitionExposes(definition);
 
             for (const expose of exposes) {
                 if (expose.access !== undefined) {
@@ -57,7 +61,7 @@ describe("Check definitions", () => {
 
     it("Exposes properties are unique", () => {
         for (const definition of definitions) {
-            const exposes = typeof definition.exposes === "function" ? definition.exposes(undefined, undefined) : definition.exposes;
+            const exposes = definitionExposes(definition);
             const found: string[] = [];
 
             for (const expose of exposes) {
@@ -90,7 +94,7 @@ describe("Check definitions", () => {
 
     it("Check if all exposes have a color temp range", () => {
         for (const definition of definitions) {
-            const exposes = typeof definition.exposes === "function" ? definition.exposes(undefined, undefined) : definition.exposes;
+            const exposes = definitionExposes(definition);
 
             for (const expose of exposes.filter((e) => e.type === "light")) {
                 const colorTemp = expose.features.find((f) => f.name === "color_temp");
@@ -112,7 +116,7 @@ describe("Check definitions", () => {
     it("Number exposes with set access should have a range", () => {
         for (const definition of definitions) {
             if (definition.exposes) {
-                const exposes = typeof definition.exposes === "function" ? definition.exposes(undefined, undefined) : definition.exposes;
+                const exposes = definitionExposes(definition);
 
                 for (const expose of exposes) {
                     if (expose.type === "numeric" && expose.access & access.SET) {


### PR DESCRIPTION
Add a dummy device to allow for a more accurate device page to be generated, currently mainly focuses on Tuya dynamic exposes which use the `device.manufacturerName`.

Fixes https://github.com/Koenkk/zigbee2mqtt.io/pull/3910