### PR TITLE
Add support for Tuya Smartica HY607W 3A thermostat (_TZE200_khah2lkr)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -908,7 +908,7 @@ const fzLocal = {
 
 const modeLookup = {
     from: (v: number) => {
-        const map = {
+        const map: { [key: number]: string } = {
             0: "manual",
             1: "auto",
             3: "hybrid",
@@ -916,7 +916,7 @@ const modeLookup = {
         return map[v] !== undefined ? map[v] : `unknown (${v})`;
     },
     to: (v: string) => {
-        const map = {
+        const map: { [key: string]: number } = {
             manual: 0,
             auto: 1,
             hybrid: 3,


### PR DESCRIPTION
This adds support for Tuya Smartica HY607W 3A thermostat (_TZE200_khah2lkr), tested with Zigbee2MQTT 1.38.0. Includes support for target temperature, current temperature, on/off state, and mode switching to manual via DP 128. Uses custom external converter format.

It's based from https://github.com/Koenkk/zigbee-herdsman-converters/pull/9595.