### PR TITLE
Add Ecodim ED-10032 LED filament lamp

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3374,6 +3374,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("MiBoxer", "E2-ZR", "2 in 1 LED controller", ["_TZB210_ayx58ft5", "_TZB210_eiwanbeb"]),
             tuya.whitelabel("MiBoxer", "PZ2", "2 in 1 LED controller", ["_TZB210_0bkzabht"]),
             tuya.whitelabel("Lidl", "14156408L", "Livarno Lux smart LED ceiling light", ["_TZ3210_c2iwpxf1"]),
+            tuya.whitelabel("EcoDim", "ED-10032", "Zigbee LED filament lamp dimmable E27, bulb A60, Smokey 2000K-4000K", ["_TZ3210_09hzmirw"]),
         ],
         extend: [
             tuya.modernExtend.tuyaLight({


### PR DESCRIPTION
Generated definition for reference: 

```js
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['TS0502B'],
    model: 'TS0502B',
    vendor: '_TZ3210_09hzmirw',
    description: 'Automatically generated definition',
    extend: [m.light({"colorTemp":{"range":[153,500]}})],
    meta: {},
};
```

This lamp is a tuya whitelabel: https://www.ecodim.nl/nl/ed-10032.html

Docs PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/3946