### PR TITLE
Add support for SLC SmartOne Zigbee Remote control Zigbee IP20 (S57007)

### DIFF
--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -94,6 +94,11 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S57007",
         vendor: "The Light Group",
         description: "SLC SmartOne Zigbee remote control Zigbee IP20",
-        extend: [m.deviceEndpoints({endpoints: {"1": 1, "2": 2}), m.battery(), m.commandsOnOff({endpointNames: ["1", "2"]}), m.commandsScenes({endpointNames: ["1", "2"]})],
+        extend: [
+            m.deviceEndpoints({endpoints: {"1": 1, "2": 2}}),
+            m.battery(),
+            m.commandsOnOff({endpointNames: ["1", "2"]}),
+            m.commandsScenes({endpointNames: ["1", "2"]}),
+        ],
     },
 ];

--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -94,11 +94,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S57007",
         vendor: "The Light Group",
         description: "SLC SmartOne Zigbee remote control Zigbee IP20",
-        extend: [
-            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}),
-            m.battery(),
-            m.commandsOnOff(),
-            m.commandsScenes(),
-        ],
+        extend: [m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}), m.battery(), m.commandsOnOff(), m.commandsScenes()],
     },
 ];

--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -92,9 +92,8 @@ export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["S57007"],
         model: "S57007",
-        vendor: "The Light Group AS",
-        description: "SLC SmartOne Zigbee Remote control Zigbee IP20",
-        extend: [m.battery(), m.commandsOnOff(), m.commandsScenes()],
-        meta: {multiEndpoint: true},
+        vendor: "The Light Group",
+        description: "SLC SmartOne Zigbee remote control Zigbee IP20",
+        extend: [m.deviceEndpoints({endpoints: {"1": 1, "2": 2}), m.battery(), m.commandsOnOff({endpointNames: ["1", "2"]}), m.commandsScenes({endpointNames: ["1", "2"]})],
     },
 ];

--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -95,10 +95,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "The Light Group",
         description: "SLC SmartOne Zigbee remote control Zigbee IP20",
         extend: [
-            m.deviceEndpoints({endpoints: {"1": 1, "2": 2}}),
+            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}),
             m.battery(),
-            m.commandsOnOff({endpointNames: ["1", "2"]}),
-            m.commandsScenes({endpointNames: ["1", "2"]}),
+            m.commandsOnOff(),
+            m.commandsScenes(),
         ],
     },
 ];

--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -94,6 +94,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S57007",
         vendor: "The Light Group",
         description: "SLC SmartOne Zigbee remote control Zigbee IP20",
-        extend: [m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}), m.battery(), m.commandsOnOff(), m.commandsScenes()],
+        extend: [m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}), m.battery(), m.commandsOnOff({endpointNames: ["1", "2", "3"]}), m.commandsScenes({endpointNames: ["1", "2", "3"]})],
     },
 ];

--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -89,4 +89,13 @@ export const definitions: DefinitionWithExtend[] = [
         description: "SLC SmartOne TW led dimmable driver 24V/75W",
         extend: [m.light({colorTemp: {range: [160, 450]}})],
     },
+    {
+        zigbeeModel: ['S57007'],
+        model: 'S57007',
+        vendor: 'The Light Group AS',
+        description: 'SLC SmartOne Zigbee Remote control Zigbee IP20',
+        extend: [m.battery(), m.commandsOnOff(), m.commandsScenes()],
+        meta: {"multiEndpoint":true},
+    },
+
 ];

--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -90,12 +90,11 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: [160, 450]}})],
     },
     {
-        zigbeeModel: ['S57007'],
-        model: 'S57007',
-        vendor: 'The Light Group AS',
-        description: 'SLC SmartOne Zigbee Remote control Zigbee IP20',
+        zigbeeModel: ["S57007"],
+        model: "S57007",
+        vendor: "The Light Group AS",
+        description: "SLC SmartOne Zigbee Remote control Zigbee IP20",
         extend: [m.battery(), m.commandsOnOff(), m.commandsScenes()],
-        meta: {"multiEndpoint":true},
+        meta: {multiEndpoint: true},
     },
-
 ];

--- a/src/devices/the_light_group.ts
+++ b/src/devices/the_light_group.ts
@@ -94,6 +94,11 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S57007",
         vendor: "The Light Group",
         description: "SLC SmartOne Zigbee remote control Zigbee IP20",
-        extend: [m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}), m.battery(), m.commandsOnOff({endpointNames: ["1", "2", "3"]}), m.commandsScenes({endpointNames: ["1", "2", "3"]})],
+        extend: [
+            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}),
+            m.battery(),
+            m.commandsOnOff({endpointNames: ["1", "2", "3"]}),
+            m.commandsScenes({endpointNames: ["1", "2", "3"]}),
+        ],
     },
 ];


### PR DESCRIPTION
PR to add "The Light Group" remote "[SLC SmartOne Zigbee Remote control Zigbee IP20 (S57007)](https://tlg.no/products/slc-smartone-zigbee-remote-control-zigbee-ip20)"

{
  zigbeeModel: ['S57007'],
        model: 'S57007',
        vendor: 'The Light Group AS',
        description: 'SLC SmartOne Zigbee Remote control Zigbee IP20',
        extend: [m.battery(), m.commandsOnOff(), m.commandsScenes()],
        meta: {"multiEndpoint":true},
}