### PR TITLE
Add support for Envilar 5463

### DIFF
--- a/src/devices/envilar.ts
+++ b/src/devices/envilar.ts
@@ -73,4 +73,11 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee CV dimmable LED driver",
         extend: [m.light()],
     },
+    {
+        zigbeeModel: ["5463"],
+        model: "5463",
+        vendor: "Envilar",
+        description: "Zigbee CCT dimmable LED driver",
+        extend: [m.light({colorTemp: {range: [160, 450]}}), m.identify()],
+    },
 ];


### PR DESCRIPTION
This PR adds support for the Envilar 5463 CCT dimmable LED driver.
I will create PR for the device's image to the zigbee2mqtt.io repository