### PR TITLE
Drop "Z-Wave" mention for Eco-DIm.07/Eco-Dim.10

### DIFF
--- a/src/devices/ecodim.ts
+++ b/src/devices/ecodim.ts
@@ -65,7 +65,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         model: "Eco-Dim.07/Eco-Dim.10",
         vendor: "EcoDim",
-        description: "Zigbee & Z-wave dimmer",
+        description: "Zigbee LED dimmer",
         ota: true,
         extend: [m.light({configureReporting: true})],
     },


### PR DESCRIPTION
Noticed in HA:

<img width="345" height="232" alt="image" src="https://github.com/user-attachments/assets/7ef68d98-f9e4-419d-81ac-b150ee303387" />

But the device does not support Z-Wave at all... Especially not in the Zibee2Mqtt context 🤣 

Manufacturer does sell Z-Wave (and WiFi, and Matter) variants as well, but it's not a multi-protocol device - they're distinct versions: 
https://www.ecodim.nl/nl/search/Eco-Dim-dot-07/
https://www.ecodim.nl/nl/search/Eco-Dim-dot-10/

So it is safe to only report as a Zigbee dimmer 😉 

