### PR TITLE
feat(devices): Add Yale Assure Lock 2 variant, YRD450-F

### DIFF
--- a/src/devices/yale.ts
+++ b/src/devices/yale.ts
@@ -393,7 +393,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [lockExtend()],
     },
     {
-        zigbeeModel: ["YRD450 TS"],
+        zigbeeModel: ["YRD450 TS", "YRD450-F TS"],
         model: "YRD450-BLE",
         vendor: "Yale",
         description: "Assure lock 2",


### PR DESCRIPTION
Adding YRD450-F TS model as a YRD450-BLE variant (Yale Assure Lock 2).