### PR TITLE
Fix TS0726_1_gang_scene_switch for the scene action

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -17670,6 +17670,10 @@ export const definitions: DefinitionWithExtend[] = [
                 onOffCountdown: true,
             }),
         ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+        },
     },
     {
         fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ezqbvrqz", "_TZ3002_ymv5vytn", "_TZ3002_6ahhkwyh"]),


### PR DESCRIPTION
Without `configureMagicPacket`, scene action cannot be triggered by pressing the button in scene mode.