### PR TITLE
Bosch Light/shutter control unit II supports power monitoring

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1819,7 +1819,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Light/shutter control unit II",
         extend: [
             m.deviceEndpoints({endpoints: {left: 2, right: 3}}),
-            m.electricityMeter({ voltage: false, current: false }),
+            m.electricityMeter({voltage: false, current: false}),
             m.deviceAddCustomCluster("boschSpecific", {
                 ID: 0xfca0,
                 manufacturerCode: Zcl.ManufacturerCode.ROBERT_BOSCH_GMBH,

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1819,6 +1819,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Light/shutter control unit II",
         extend: [
             m.deviceEndpoints({endpoints: {left: 2, right: 3}}),
+            m.electricityMeter({ voltage: false, current: false }),
             m.deviceAddCustomCluster("boschSpecific", {
                 ID: 0xfca0,
                 manufacturerCode: Zcl.ManufacturerCode.ROBERT_BOSCH_GMBH,


### PR DESCRIPTION
Add electricityMeter to Bosch Light/shutter control unit II definition