### PR TITLE
fix: specify illuminance unit as "lx" for ZG-223Z

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18061,7 +18061,7 @@ export const definitions: DefinitionWithExtend[] = [
         configure: tuya.configureMagicPacket,
         exposes: [
             e.enum("rainwater", ea.STATE, ["none", "raining"]).withDescription("Sensor rainwater status"),
-            e.illuminance().withUnit("x"),
+            e.illuminance().withUnit("lx"),
             e
                 .numeric("sensitivity", ea.STATE_SET)
                 .withValueMin(0)


### PR DESCRIPTION
The `illuminance` exposure for the ZG-223Z device in `tuya.ts` had incorrect unit 'x'. This update corrects that via `.withUnit("lx")