### PR TITLE
fix: set calibration option step at 0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     ],
     "scripts": {
         "check": "biome check --error-on-warnings",
+        "check:w": "biome check --error-on-warnings --write",
         "test": "vitest run --config ./test/vitest.config.mts",
         "test:coverage": "vitest run --config ./test/vitest.config.mts --coverage",
         "bench": "vitest bench --run --config ./test/vitest.config.mts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,7 @@ export function prepareDefinition(definition: DefinitionWithExtend): Definition 
 
             const type = utils.calibrateAndPrecisionRoundOptionsIsPercentual(expose.name) ? "percentual" : "absolute";
 
-            finalDefinition.options.push(exposesLib.options.calibration(expose.name, type));
+            finalDefinition.options.push(exposesLib.options.calibration(expose.name, type).withValueStep(0.1));
 
             if (utils.calibrateAndPrecisionRoundOptionsDefaultPrecision[expose.name] !== 0) {
                 finalDefinition.options.push(exposesLib.options.precision(expose.name));


### PR DESCRIPTION
This will set frontend inputs to `step=0.1` which should fit better for most use cases (temp/hum). 
Note: a direct MQTT request allows any decimal precision. This only affects the published schema (what frontends use to display fields).

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/26455