### PR TITLE
lixee/zlinky: fix default value for measurement_poll_chunk in description

### DIFF
--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1805,7 +1805,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .numeric("measurement_poll_chunk", ea.SET)
                 .withValueMin(1)
                 .withDescription(
-                    "During the poll, request multiple exposes to the Zlinky at once for reducing Zigbee network overload. Too much request at once could exceed device limit. Requires Z2M restart. Default: 1",
+                    "During the poll, request multiple exposes to the Zlinky at once for reducing Zigbee network overload. Too much request at once could exceed device limit. Requires Z2M restart. Default: 4",
                 ),
             e
                 .text("tic_command_whitelist", ea.SET)


### PR DESCRIPTION
Hi,
In 622631f9e4edd64590959db1479f6bee0f7f0d7b, the default changed from 2 to 4 but the description was not updated accordingly.