### PR TITLE
chore: import vitest instead of relying on globals

### DIFF
--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+import {beforeAll, describe, it} from "vitest";
 import baseDefinitions from "../src/devices/index";
 import {type Definition, type Expose, prepareDefinition} from "../src/index";
 import {access, Numeric} from "../src/lib/exposes";

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, test} from "vitest";
 import {Color, ColorHSV, ColorRGB, ColorXY} from "../src/lib/color";
 
 describe("lib/color", () => {

--- a/test/findByDevice.bench.ts
+++ b/test/findByDevice.bench.ts
@@ -1,5 +1,4 @@
-import {bench} from "vitest";
-
+import {bench, describe} from "vitest";
 import {findByDevice} from "../src/index";
 import {mockDevice} from "./utils";
 

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import {fromZigbee} from "../src/index";
 
 describe("converters/fromZigbee", () => {

--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -1,7 +1,6 @@
+import {describe, expect, test} from "vitest";
 import type {Models as ZHModels} from "zigbee-herdsman";
-
 import {Zcl} from "zigbee-herdsman";
-
 import {findByDevice, generateExternalDefinitionSource} from "../src";
 import * as fz from "../src/converters/fromZigbee";
 import {repInterval} from "../src/lib/constants";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,7 @@
+import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
+import {describe, expect, it, vi} from "vitest";
 import {
     addExternalDefinition,
     type Definition,

--- a/test/lumi.test.ts
+++ b/test/lumi.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import {fromZigbee, type TrvScheduleConfig, trv} from "../src/lib/lumi";
 
 describe("lib/lumi", () => {

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, test} from "vitest";
 import * as fz from "../src/converters/fromZigbee";
 import {repInterval} from "../src/lib/constants";
 import {fromZigbee as lumiFz} from "../src/lib/lumi";

--- a/test/ota.test.ts
+++ b/test/ota.test.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import {existsSync, readFileSync} from "node:fs";
 import path from "node:path";
 import {EventEmitter} from "node:stream";
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {Zcl} from "zigbee-herdsman";
 import ZclTransactionSequenceNumber from "zigbee-herdsman/dist/controller/helpers/zclTransactionSequenceNumber";
 import {Waitress} from "zigbee-herdsman/dist/utils/waitress";

--- a/test/philips.test.ts
+++ b/test/philips.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, test} from "vitest";
 import {decodeGradientColors, encodeGradientColors} from "../src/lib/philips";
 
 describe("lib/philips", () => {

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -1,7 +1,6 @@
 import type {Mock} from "vitest";
-
+import {beforeEach, describe, expect, it, vi} from "vitest";
 import type {Models as ZHModels} from "zigbee-herdsman";
-
 import {findByDevice} from "../src/index";
 import type {Definition, Fz, KeyValueAny, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";

--- a/test/toZigbee_colortemp_move.test.ts
+++ b/test/toZigbee_colortemp_move.test.ts
@@ -1,5 +1,4 @@
 import {beforeEach, describe, expect, test, vi} from "vitest";
-
 import * as zhc from "../src";
 import type {Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../tsconfig",
     "include": ["./**/*", "vitest.config.mts"],
     "compilerOptions": {
-        "types": ["vitest/globals"],
         "rootDir": "..",
         "noEmit": true
     },

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -1,4 +1,5 @@
 import type {Fz} from "src/lib/types";
+import {describe, expect, it} from "vitest";
 import {findByDevice, type Tz} from "../src/index";
 import * as tuya from "../src/lib/tuya";
 import {mockDevice} from "./utils";

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,7 +1,6 @@
+import {beforeEach, describe, expect, it} from "vitest";
 import type {Device} from "zigbee-herdsman/dist/controller/model";
-
 import type {Tz} from "../src/lib/types";
-
 import {batteryVoltageToPercentage, getFromLookup, getTransition, mapNumberRange, toNumber} from "../src/lib/utils";
 import {mockDevice} from "./utils";
 


### PR DESCRIPTION
Same as https://github.com/Koenkk/zigbee-herdsman/pull/1464