### PR TITLE
fix!: Add `device` argument to `postProcessConvertedFromZigbeeMessage`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -475,10 +475,10 @@ export function prepareDefinition(definition: DefinitionWithExtend): Definition 
     return finalDefinition;
 }
 
-export function postProcessConvertedFromZigbeeMessage(definition: Definition, payload: KeyValue, options: KeyValue): void {
+export function postProcessConvertedFromZigbeeMessage(definition: Definition, payload: KeyValue, options: KeyValue, device: Zh.Device): void {
     // Apply calibration/precision options
     for (const [key, value] of Object.entries(payload)) {
-        const definitionExposes = Array.isArray(definition.exposes) ? definition.exposes : definition.exposes({isDummyDevice: true}, {});
+        const definitionExposes = Array.isArray(definition.exposes) ? definition.exposes : definition.exposes(device, {});
         const expose = definitionExposes.find((e) => e.property === key);
 
         if (expose?.name && expose.name in utils.calibrateAndPrecisionRoundOptionsDefaultPrecision && value !== "" && utils.isNumber(value)) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -537,7 +537,8 @@ describe("ZHC", () => {
     });
 
     it("computes calibration/precision", async () => {
-        const ts0601Soil = await findByDevice(mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_myd45weu", endpoints: []}));
+        const ts0601SoilDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_myd45weu", endpoints: []});
+        const ts0601Soil = await findByDevice(ts0601SoilDevice);
         expect(ts0601Soil.options.map((t) => t.name)).toStrictEqual([
             "temperature_calibration",
             "temperature_precision",
@@ -546,18 +547,20 @@ describe("ZHC", () => {
         ]);
         const payload1 = {temperature: 1.193};
         const options1 = {temperature_calibration: 2.5, temperature_precision: 1};
-        postProcessConvertedFromZigbeeMessage(ts0601Soil, payload1, options1);
+        postProcessConvertedFromZigbeeMessage(ts0601Soil, payload1, options1, ts0601SoilDevice);
         expect(payload1).toStrictEqual({temperature: 3.7});
 
         // For multi endpoint property
-        const AUA1ZBDSS = await findByDevice(mockDevice({modelID: "DoubleSocket50AU", endpoints: []}));
+        const AUA1ZBDSSDevice = mockDevice({modelID: "DoubleSocket50AU", endpoints: []});
+        const AUA1ZBDSS = await findByDevice(AUA1ZBDSSDevice);
         expect(AUA1ZBDSS.options.map((t) => t.name)).toStrictEqual(["power_calibration", "power_precision", "transition", "state_action"]);
         const payload2 = {power_left: 5.31};
         const options2 = {power_calibration: 100, power_precision: 0}; // calibration for power is percentual
-        postProcessConvertedFromZigbeeMessage(AUA1ZBDSS, payload2, options2);
+        postProcessConvertedFromZigbeeMessage(AUA1ZBDSS, payload2, options2, AUA1ZBDSSDevice);
         expect(payload2).toStrictEqual({power_left: 11});
 
-        const ts011fPlug1 = await findByDevice(mockDevice({modelID: "TS011F", endpoints: []}));
+        const ts0111fPlug1Device = mockDevice({modelID: "TS011F", endpoints: []});
+        const ts011fPlug1 = await findByDevice(ts0111fPlug1Device);
         expect(ts011fPlug1.options.map((t) => t.name)).toStrictEqual([
             "power_calibration",
             "power_precision",
@@ -571,7 +574,7 @@ describe("ZHC", () => {
         ]);
         const payload3 = {current: 0.0585};
         const options3 = {current_calibration: -50};
-        postProcessConvertedFromZigbeeMessage(ts011fPlug1, payload3, options3);
+        postProcessConvertedFromZigbeeMessage(ts011fPlug1, payload3, options3, ts0111fPlug1Device);
         expect(payload3).toStrictEqual({current: 0.03});
     });
 


### PR DESCRIPTION
To prevent passing a dummy device to the expose method.

This is a **breaking change**, clients should now pass `device` argument to `postProcessConvertedFromZigbeeMessage()`