### PR TITLE
fix: Don't throw `Failed to apply calibration to` when value is an empty string

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -165,7 +165,8 @@ export function calibrateAndPrecisionRoundOptionsIsPercentual(type: string) {
 export function calibrateAndPrecisionRoundOptions(number: number, options: KeyValue, type: string) {
     // Calibrate
     const calibrateKey = `${type}_calibration`;
-    let calibrationOffset = toNumber(options?.[calibrateKey] != null ? options[calibrateKey] : 0, calibrateKey);
+    const calibrateValue = options?.[calibrateKey];
+    let calibrationOffset = toNumber(calibrateValue != null && calibrateValue !== "" ? calibrateValue : 0, calibrateKey);
     if (calibrateAndPrecisionRoundOptionsIsPercentual(type)) {
         // linear calibration because measured value is zero based
         // +/- percent
@@ -176,8 +177,9 @@ export function calibrateAndPrecisionRoundOptions(number: number, options: KeyVa
 
     // Precision round
     const precisionKey = `${type}_precision`;
+    const precisionValue = options?.[precisionKey];
     const defaultValue = calibrateAndPrecisionRoundOptionsDefaultPrecision[type] || 0;
-    const precision = toNumber(options?.[precisionKey] != null ? options[precisionKey] : defaultValue, precisionKey);
+    const precision = toNumber(precisionValue != null && precisionValue !== "" ? precisionValue : defaultValue, precisionKey);
     return precisionRound(number, precision);
 }
 


### PR DESCRIPTION
When there is a `""` value for calibration or precision in the `configuration.yaml` an error is thrown, e.g.: `Failed to apply calibration to 'current': 'current_calibration' is not a number, got string ()`. It seems these values are set by the frontend in some cases, therefore I would propose to ignore these and fallback to the default calibration or precision value.


Example config:
```yaml
devices:
  '0xa4c138b3497171b4':
    current_calibration: ''
```

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/21724