### PR TITLE
Allow MQTT messages to pass a null state to indicate no state change

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1140,7 +1140,7 @@ export const light_onoff_brightness: Tz.Converter = {
         const {message} = meta;
         const transition = utils.getTransition(entity, "brightness", meta);
         const turnsOffAtBrightness1 = utils.getMetaValue(entity, meta.mapped, "turnsOffAtBrightness1", "allEqual", false);
-        let state = message.state != null ? (typeof message.state === "string" ? message.state.toLowerCase() : null) : undefined;
+        let state = message.state !== undefined ? (typeof message.state === "string" ? message.state.toLowerCase() : null) : undefined;
         let brightness: number;
         if (message.brightness != null) {
             brightness = Number(message.brightness);


### PR DESCRIPTION
The comment at lines 1168-1170 implies that setting state to null in your MQTT message should cause the converter to send MoveToLevel rather than MoveToLevelWithOnOff:

> Infer state from desired brightness if unset. Ideally we'd want to keep it as it is, but this code has always used 'MoveToLevelWithOnOff' so that'd break backwards compatibility. To keep the state, the user has to explicitly set it to null.

I believe this functionality was broken by https://github.com/Koenkk/zigbee-herdsman-converters/pull/9284, which changed the way a null state was treated. There are various places in this function that treat a null state differently than an undefined state -- all of them look reasonable with the new logic.

The ability to send moveToLevel is important because it allows (in conjunction with configuring the Zigbee light with the ExecuteIfOff bit) you to control the level the device will use when it turns on next.