### PR TITLE
Add MoveToLevel support to the Inovelli converter

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1735,20 +1735,23 @@ const tzLocal = {
             globalStore.putValue(entity, "brightness", brightness);
             await entity.command(
                 "genLevelCtrl",
-                "moveToLevelWithOnOff",
+                state === undefined ? "moveToLevel" : "moveToLevelWithOnOff",
                 {
                     level: Number(brightness),
                     transtime: !transition.specified ? 0xffff : transition.time,
                 },
                 utils.getOptions(meta.mapped, entity),
             );
-
-            return {
+            const result = {
                 state: {
-                    state: brightness === 0 ? "OFF" : "ON",
+                    state: {},
                     brightness: Number(brightness),
                 },
             };
+            if (state !== undefined) {
+                result.state.state = brightness === 0 ? "OFF" : "ON";
+            }
+            return result;
         },
         convertGet: async (entity, key, meta) => {
             if (key === "brightness") {


### PR DESCRIPTION
Issuing MoveToLevel (rather than MoveToLevelWithOnOff) is supported by the base toZigbee converter, but not the Inovelli-specific converter. This change adds that support, largely copying the logic from toZigbee.ts (with some minor changes).

I tested that after this change, the code issues the expected command and that the device responds correctly to it. However, at present, the switch ignores MoveToLevel commands sent while the switch is off. This is expected because Z2M does not have have the functionality to send ExecuteIfOff to these devices. I haven't yet determined whether this missing functionality is because no one needed it, or whether the devices don't support ExecuteIfOff.