### PR TITLE
Added Temperature & humidity sensor Model: TS0203, Manufacturer: Zbeacon

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3567,6 +3567,27 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0203", ["Zbeacon"]),
+        model: "TH02Z",
+        vendor: "Tuya",
+        description: "Temperature & humidity sensor",
+        fromZigbee: [fzLocal.TS0201_battery, fz.temperature, fz.humidity],
+        toZigbee: [],
+        exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
+        configure: tuya.configureMagicPacket,
+        meta: {
+            battery: {
+                // These sensors do send a Battery Percentage Remaining (0x0021)
+                // value, but is usually incorrect. For example, a coin battery tested
+                // with a load tester may show 80%, but report 2.5V / 1%. This voltage
+                // calculation matches what ZHA does by default.
+                // https://github.com/Koenkk/zigbee2mqtt/discussions/17337
+                // https://github.com/zigpy/zha-device-handlers/blob/c6ed94a52a469e72b32ece2a92d528060c7fd034/zhaquirks/__init__.py#L195-L228
+                voltageToPercentage: "3V_1500_2800",
+            },
+        },
+    },
+    {
         fingerprint: [
             ...tuya.fingerprint("TS0201", ["_TZ3000_dowj6gyi", "_TZ3000_8ybe88nf", "_TZ3000_akqdg6g7"]),
             {manufacturerName: "_TZ3000_zl1kmjqx"},


### PR DESCRIPTION
I added support for Temperature & humidity sensor:
Model: TS0203
Manufacturer: Zbeacon
Perhaps it's possible combine it with another similar devices. I only copy parts of code and changed deviceID

<img width="1416" height="916" alt="image" src="https://github.com/user-attachments/assets/051e0c92-0122-464a-bdaf-879dd0bd3cd5" />

Product: [link ](https://www.aliexpress.com/item/1005009462506113.html?spm=a2g0o.order_list.order_list_main.29.364e1802TpK78t)
