### PR TITLE
Fix detection of Tuya Smart knob ZG-101Z/D with 2.6.0

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9473,7 +9473,7 @@ export const definitions: DefinitionWithExtend[] = [
                 applicationVersion: 145,
                 priority: 1,
             },
-        {modelID: "TS004F", manufacturerName: "_TZ3000_gwkzibhs"},
+            {modelID: "TS004F", manufacturerName: "_TZ3000_gwkzibhs"},
         ],
         model: "ZG-101Z/D",
         vendor: "Tuya",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9399,7 +9399,6 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["ZG-101ZD"],
         fingerprint: tuya.fingerprint("TS004F", [
             "_TZ3000_4fjiwweb",
             "_TZ3000_uri7ongn",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9407,7 +9407,6 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_qja6nq5z",
             "_TZ3000_402vrq2i",
             "_TZ3000_abrsvsou",
-            "_TZ3000_gwkzibhs",
         ]),
         model: "ERS-10TZBVK-AA",
         vendor: "Tuya",
@@ -9422,10 +9421,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.tuya_operation_mode,
             fz.battery,
         ],
-        whiteLabel: [
-            tuya.whitelabel("Tuya", "ZG-101Z_D_1", "Smart knob", ["_TZ3000_402vrq2i"]),
-            tuya.whitelabel("HOBEIAN", "ZG-101ZD", "Smart knob", ["_TZ3000_gwkzibhs"]),
-        ],
+        whiteLabel: [tuya.whitelabel("Tuya", "ZG-101Z_D_1", "Smart knob", ["_TZ3000_402vrq2i"])],
         toZigbee: [tz.tuya_operation_mode],
         exposes: [
             e.action([
@@ -9470,6 +9466,7 @@ export const definitions: DefinitionWithExtend[] = [
     {
         // Only the ones with applicationVersion 145 should be detected as this, e.g. applicationVersion 66 should be detected as ERS-10TZBVK-AA.
         // https://github.com/Koenkk/zigbee2mqtt/issues/25053
+        zigbeeModel: ["ZG-101ZD"],
         fingerprint: [
             {
                 modelID: "TS004F",
@@ -9477,6 +9474,7 @@ export const definitions: DefinitionWithExtend[] = [
                 applicationVersion: 145,
                 priority: 1,
             },
+        {modelID: "TS004F", manufacturerName: "_TZ3000_gwkzibhs"},
         ],
         model: "ZG-101Z/D",
         vendor: "Tuya",


### PR DESCRIPTION
@Koenkk I'm trying to fix this (https://github.com/Koenkk/zigbee2mqtt/issues/28149) but I have to move `zigbeeModel: ["ZG-101ZD"]`from `ERS-10TZBVK-AA` to `ZG-101ZD` because of this:         

         // Only the ones with applicationVersion 145 should be detected as this, e.g. applicationVersion 66 should be detected as ERS-10TZBVK-AA.
        // https://github.com/Koenkk/zigbee2mqtt/issues/25053

I think that way turns back works fine but I wanna your look on this. Does have a way that I can do this without move zigbeeModel to another part of the code? I don't know if I make myself clear because I didn't the commit that cause this wrong detection but I'm trying to help.

Thanks.