### PR TITLE
Update adurosmart.ts - ERIA tunable white candle E12

### DIFF
--- a/src/devices/adurosmart.ts
+++ b/src/devices/adurosmart.ts
@@ -117,10 +117,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"]}})],
     },
     {
-        zigbeeModel: ['AD-E1XCTW3001'],
-        model: 'E1XCTW3001',
-        vendor: 'AduroSmart',
-        description: 'ERIA tunable-white candle bulb (E12)',
+        zigbeeModel: ["AD-E1XCTW3001"],
+        model: "E1XCTW3001",
+        vendor: "AduroSmart",
+        description: "ERIA tunable-white candle bulb (E12)",
         extend: [m.light({colorTemp: {range: [153, 500]}})],
     },
     {


### PR DESCRIPTION
Definition for ERIA tunable-white candle bulb (E12) - shown here:

https://www.amazon.com/dp/B0DTBVMS7X?ref=ppx_yo2ov_dt_b_fed_asin_title