### PR TITLE
Inovelli VZM31: Temporarily remove fanTimerMode

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1156,7 +1156,8 @@ const VZM30_ATTRIBUTES: {[s: string]: Attribute} = {
 };
 
 const VZM31_ATTRIBUTES: {[s: string]: Attribute} = {
-    ...COMMON_DIMMER_ATTRIBUTES,
+    // Temporarily exclude fanTimerMode from the VZM31. While the specifications indicate that this attribute should be present, it's missing in the current firmware (2.18). This can be removed once the firmware bug is corrected.
+    ...Object.fromEntries(Object.entries(COMMON_DIMMER_ATTRIBUTES).filter(([key]) => key !== "fanTimerMode")),
     ...COMMON_DIMMER_ON_OFF_ATTRIBUTES,
     ...COMMON_DIMMABLE_LIGHT_ATTRIBUTES,
     relayClick: {


### PR DESCRIPTION
In https://github.com/Koenkk/zigbee-herdsman-converters/pull/9597, we made `fanTimerMode` available to all of the other Inovelli devices that were supposed to support it. VZM31 claims to support it but it's missing in the current firmware. Let's temporarily pull it out and then revert this change once they release a firmware update that adds support for it.