### PR TITLE
Extend the  converter to allow passing in a payload object directly to the on_off converter

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -41,7 +41,9 @@ export const on_off: Tz.Converter = {
             if (typeof offWaitTime !== "number") {
                 throw Error("The off_wait_time value must be a number!");
             }
-            const payload = meta.payload ? meta.payload : {ctrlbits: 0, ontime: Math.round(onTime * 10), offwaittime: Math.round(offWaitTime * 10)};
+            const payload = meta.converterOptions
+                ? meta.converterOptions
+                : {ctrlbits: 0, ontime: Math.round(onTime * 10), offwaittime: Math.round(offWaitTime * 10)};
             await entity.command("genOnOff", "onWithTimedOff", payload, utils.getOptions(meta.mapped, entity));
         } else {
             await entity.command("genOnOff", state, {}, utils.getOptions(meta.mapped, entity));

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1681,7 +1681,7 @@ const tzLocal = {
                     ...meta.message,
                     transition: !transition.specified ? 0xffff : transition.time,
                 },
-                payload: {
+                converterOptions: {
                     ctrlbits: 0,
                     ontime: meta.message.on_time != null ? Math.round((meta.message.on_time as number) * 10) : 0xffff,
                     offwaittime: meta.message.off_wait_time != null ? Math.round((meta.message.off_wait_time as number) * 10) : 0xffff,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -337,7 +337,7 @@ export namespace Tz {
         endpoint_name: string | undefined;
         membersState?: {[s: string]: KeyValue};
         publish: Publish;
-        payload?: KeyValue;
+        converterOptions?: KeyValue;
     }
     // biome-ignore lint/suspicious/noConfusingVoidType: ignored using `--suppress`
     export type ConvertSetResult = {state?: KeyValue; membersState?: {[s: string]: KeyValue}} | void;


### PR DESCRIPTION
This modified converter is used so that devices like Inovelli that need to pass in a specific value `0xffff` to the `ontime` and `offwaittime` variables don't need to copy and implement their own converter.

Resolves https://github.com/Koenkk/zigbee2mqtt/issues/28023