### PR TITLE
fix!: Replace all `Fz.Message.meta` properties with `zclFrame`

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -4356,7 +4356,7 @@ export const CCTSwitch_D0001_levelctrl: Fz.Converter = {
             }
 
             if (clk !== "memory") {
-                globalStore.putValue(msg.endpoint, "last_seq", msg.meta.zclTransactionSequenceNumber);
+                globalStore.putValue(msg.endpoint, "last_seq", msg.meta.zclFrame.header.transactionSequenceNumber);
                 globalStore.putValue(msg.endpoint, "last_clk", clk);
                 payload.action = cmd;
             }
@@ -4400,7 +4400,7 @@ export const CCTSwitch_D0001_lighting: Fz.Converter = {
             const lastClk = globalStore.getValue(msg.endpoint, "last_clk");
             const lastSeq = globalStore.getValue(msg.endpoint, "last_seq");
 
-            const seq = msg.meta.zclTransactionSequenceNumber;
+            const seq = msg.meta.zclFrame.header.transactionSequenceNumber;
             let clk = "colortemp";
             payload.color_temp = msg.data.colortemp;
             payload.transition = Number.parseFloat(msg.data.transtime) / 10.0;
@@ -4430,7 +4430,7 @@ export const CCTSwitch_D0001_lighting: Fz.Converter = {
             }
 
             if (clk != null) {
-                globalStore.putValue(msg.endpoint, "last_seq", msg.meta.zclTransactionSequenceNumber);
+                globalStore.putValue(msg.endpoint, "last_seq", msg.meta.zclFrame.header.transactionSequenceNumber);
                 globalStore.putValue(msg.endpoint, "last_clk", clk);
             }
         }
@@ -4703,7 +4703,7 @@ export const wiser_smart_thermostat_client: Fz.Converter = {
             const lookup: KeyValueAny = {manual: 1, schedule: 2, energy_saver: 3, holiday: 6};
             const zonemodeNum = meta.state.zone_mode ? lookup[meta.state.zone_mode] : 1;
             response[0xe010] = {value: zonemodeNum, type: 0x30};
-            await msg.endpoint.readResponse(msg.cluster, msg.meta.zclTransactionSequenceNumber, response, {srcEndpoint: 11});
+            await msg.endpoint.readResponse(msg.cluster, msg.meta.zclFrame.header.transactionSequenceNumber, response, {srcEndpoint: 11});
         }
     },
 };
@@ -5157,7 +5157,7 @@ export const command_arm_with_transaction: Fz.Converter = {
     convert: (model, msg, publish, options, meta) => {
         const payload = command_arm.convert(model, msg, publish, options, meta) as KeyValueAny;
         if (!payload) return;
-        payload.action_transaction = msg.meta.zclTransactionSequenceNumber;
+        payload.action_transaction = msg.meta.zclFrame.header.transactionSequenceNumber;
         return payload;
     },
 };

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -326,7 +326,7 @@ const boschExtend = {
                             dstEnd: {attribute: 0x0004, status: Zcl.Status.SUCCESS, value: 0x00},
                             dstShift: {attribute: 0x0005, status: Zcl.Status.SUCCESS, value: 0x00},
                         };
-                        await msg.endpoint.readResponse(msg.cluster, msg.meta.zclTransactionSequenceNumber, response);
+                        await msg.endpoint.readResponse(msg.cluster, msg.meta.zclFrame.header.transactionSequenceNumber, response);
                     }
                 },
             },

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -709,7 +709,7 @@ export function iasArmCommandDefaultResponse(): ModernExtend {
             // Since arm command has a response zigbee-herdsman doesn't send a default response.
             // This causes the remote to repeat the arm command, so send a default response here.
             msg.endpoint
-                .defaultResponse(0, 0, 1281, msg.meta.zclTransactionSequenceNumber)
+                .defaultResponse(0, 0, 1281, msg.meta.zclFrame.header.transactionSequenceNumber)
                 .catch((error) => logger.error(`Failed to send default response to '${msg.device.ieeeAddr}' (${error})`, NS));
         },
     };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,5 @@
 import type {Models as ZHModels} from "zigbee-herdsman";
-import type {Header as ZHZclHeader} from "zigbee-herdsman/dist/zspec/zcl";
-import type {FrameControl} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
+import type {Frame as ZHZclFrame, Header as ZHZclHeader} from "zigbee-herdsman/dist/zspec/zcl";
 
 import type * as exposes from "./exposes";
 
@@ -289,7 +288,7 @@ export namespace Fz {
         data: any;
         endpoint: Zh.Endpoint;
         device: Zh.Device;
-        meta: {zclTransactionSequenceNumber?: number; manufacturerCode?: number; frameControl?: FrameControl};
+        meta: {zclFrame: ZHZclFrame};
         groupID: number;
         type: string;
         cluster: string | number;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -82,7 +82,7 @@ export function mapNumberRange(value: number, fromLow: number, fromHigh: number,
 const transactionStore: {[s: string]: number[]} = {};
 export function hasAlreadyProcessedMessage(msg: Fz.Message, model: Definition, id: number = null, key: string = null) {
     if (model.meta?.publishDuplicateTransaction) return false;
-    const currentID = id !== null ? id : msg.meta.zclTransactionSequenceNumber;
+    const currentID = id !== null ? id : msg.meta.zclFrame.header.transactionSequenceNumber;
     // biome-ignore lint/style/noParameterAssign: ignored using `--suppress`
     key = key || `${msg.device.ieeeAddr}-${msg.endpoint.ID}`;
     if (transactionStore[key]?.includes(currentID)) return true;


### PR DESCRIPTION
See https://github.com/Koenkk/zigbee-herdsman/pull/1473

This is a **breaking change** as the `Fz.Message.meta` only accepts a `zclFrame` now.