### PR TITLE
Add support for Heiman HS2SA-1 Photoelectric Smoke Alarm sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7054,6 +7054,32 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_ai4rqhky"]),
+        model: "HS2SA-1",
+        vendor: "Heiman",
+        description: "Photoelectric Smoke Alarm",
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        onEvent: tuya.onEventSetTime,
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.smoke(),
+            e.battery(),
+            tuya.exposes.batteryState(),
+            e.binary("silence", ea.STATE_SET, "ON", "OFF"),
+            e.enum("self_test", ea.STATE, ["checking", "check_success", "check_failure"]),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "smoke", tuya.valueConverter.trueFalse0],
+                [9, "self_test", tuya.valueConverterBasic.lookup({checking: 0, check_success: 1, check_failure: 2})],
+                [14, "battery_state", tuya.valueConverter.batteryState],
+                [15, "battery", tuya.valueConverter.raw],
+                [16, "silence", tuya.valueConverter.onOff],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_m9skfctm", "_TZE200_rccxox8p", "_TZE284_rccxox8p"]),
         model: "PA-44Z",
         vendor: "Tuya",


### PR DESCRIPTION
Tuya based smoke alarm.

https://www.heimantech.com/product/?type=detail&id=139

```
export default {
    zigbeeModel: ['TS0601'],
    model: 'TS0601',
    vendor: '_TZE284_ai4rqhky',
    description: 'Automatically generated definition',
    extend: [],
    meta: {},
};
```
<img width="915" height="916" alt="image" src="https://github.com/user-attachments/assets/19f14595-dd33-41f7-b0bd-83c587eb0771" />

Issue [https://github.com/Koenkk/zigbee2mqtt/issues/24346](url) is also solved.