### PR TITLE
fix: adjust to new typing from ZH, fix discovered issues

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -368,7 +368,7 @@ export const lock: Tz.Converter = {
 export const lock_auto_relock_time: Tz.Converter = {
     key: ["auto_relock_time"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("closuresDoorLock", {autoRelockTime: value}, utils.getOptions(meta.mapped, entity));
+        await entity.write("closuresDoorLock", {autoRelockTime: value as number}, utils.getOptions(meta.mapped, entity));
         return {state: {auto_relock_time: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -566,7 +566,7 @@ export const warning: Tz.Converter = {
 export const ias_max_duration: Tz.Converter = {
     key: ["max_duration"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("ssIasWd", {maxDuration: value});
+        await entity.write("ssIasWd", {maxDuration: value as number});
         return {state: {max_duration: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -807,7 +807,14 @@ export const level_config: Tz.Converter = {
         }
     },
     convertGet: async (entity, key, meta) => {
-        for (const attribute of ["onOffTransitionTime", "onTransitionTime", "offTransitionTime", "startUpCurrentLevel", "onLevel", "options"]) {
+        for (const attribute of [
+            "onOffTransitionTime",
+            "onTransitionTime",
+            "offTransitionTime",
+            "startUpCurrentLevel",
+            "onLevel",
+            "options",
+        ] as const) {
             try {
                 await entity.read("genLevelCtrl", [attribute]);
             } catch {
@@ -829,37 +836,36 @@ export const ballast_config: Tz.Converter = {
             }
         }
         if (key === "ballast_minimum_level") {
-            await entity.write("lightingBallastCfg", {minLevel: value});
+            await entity.write("lightingBallastCfg", {minLevel: value as number});
         }
         if (key === "ballast_maximum_level") {
-            await entity.write("lightingBallastCfg", {maxLevel: value});
+            await entity.write("lightingBallastCfg", {maxLevel: value as number});
         }
         if (key === "ballast_power_on_level") {
-            await entity.write("lightingBallastCfg", {powerOnLevel: value});
+            await entity.write("lightingBallastCfg", {powerOnLevel: value as number});
         }
         return {state: {[key]: value}};
     },
     convertGet: async (entity, key, meta) => {
         let result = {};
         for (const attrName of [
-            "ballast_status",
-            "min_level",
-            "max_level",
-            "power_on_level",
-            "power_on_fade_time",
-            "intrinsic_ballast_factor",
-            "ballast_factor_adjustment",
-            "lamp_quantity",
-            "lamp_type",
-            "lamp_manufacturer",
-            "lamp_rated_hours",
-            "lamp_burn_hours",
-            "lamp_alarm_mode",
-            "lamp_burn_hours_trip_point",
-        ]) {
+            "ballastStatus",
+            "minLevel",
+            "maxLevel",
+            "powerOnLevel",
+            "powerOnFadeTime",
+            "intrinsicBallastFactor",
+            "ballastFactorAdjustment",
+            "lampQuantity",
+            "lampType",
+            "lampManufacturer",
+            "lampRatedHours",
+            "lampBurnHours",
+            "lampAlarmMode",
+            "lampBurnHoursTripPoint",
+        ] as const) {
             try {
-                // @ts-expect-error ignore
-                result = {...result, ...(await entity.read("lightingBallastCfg", [utils.toCamelCase(attrName)]))};
+                result = {...result, ...(await entity.read("lightingBallastCfg", [attrName]))};
             } catch {
                 // continue regardless of error
             }
@@ -1215,7 +1221,6 @@ export const light_onoff_brightness: Tz.Converter = {
                     try {
                         const attributeRead = await entity.read("genLevelCtrl", ["onLevel"]);
                         if (attributeRead !== undefined) {
-                            // @ts-expect-error ignore
                             onLevel = attributeRead.onLevel;
                         }
                     } catch {
@@ -1305,7 +1310,11 @@ export const light_colortemp_startup: Tz.Converter = {
             value = light.clampColorTemp(value, colorTempMin, colorTempMax);
         }
 
-        await entity.write("lightingColorCtrl", {startUpColorTemperature: value}, utils.getOptions(meta.mapped, entity));
+        await entity.write(
+            "lightingColorCtrl",
+            {startUpColorTemperature: value as number /* type failure? */},
+            utils.getOptions(meta.mapped, entity),
+        );
         return {state: {color_temp_startup: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -1383,7 +1392,7 @@ export const effect: Tz.Converter = {
 export const thermostat_remote_sensing: Tz.Converter = {
     key: ["remote_sensing"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {remoteSensing: value});
+        await entity.write("hvacThermostat", {remoteSensing: value as number});
     },
     convertGet: async (entity, key, meta) => {
         await entity.read("hvacThermostat", ["remoteSensing"]);
@@ -1531,7 +1540,7 @@ export const thermostat_system_mode: Tz.Converter = {
     convertSet: async (entity, key, value, meta) => {
         let systemMode = utils.getKey(constants.thermostatSystemModes, value, undefined, Number);
         if (systemMode === undefined) {
-            systemMode = utils.getKey(legacy.thermostatSystemModes, value, value, Number);
+            systemMode = utils.getKey(legacy.thermostatSystemModes, value, value as number, Number);
         }
         await entity.write("hvacThermostat", {systemMode});
         return {state: {system_mode: value}};
@@ -1545,7 +1554,7 @@ export const acova_thermostat_system_mode: Tz.Converter = {
     convertSet: async (entity, key, value, meta) => {
         let systemMode = utils.getKey(constants.acovaThermostatSystemModes, value, undefined, Number);
         if (systemMode === undefined) {
-            systemMode = utils.getKey(legacy.thermostatSystemModes, value, value, Number);
+            systemMode = utils.getKey(legacy.thermostatSystemModes, value, value as number, Number);
         }
         await entity.write("hvacThermostat", {systemMode});
         return {state: {system_mode: value}};
@@ -1560,7 +1569,7 @@ export const thermostat_control_sequence_of_operation: Tz.Converter = {
         utils.assertEndpoint(entity);
         let val = utils.getKey(constants.thermostatControlSequenceOfOperations, value, undefined, Number);
         if (val === undefined) {
-            val = utils.getKey(constants.thermostatControlSequenceOfOperations, value, value, Number);
+            val = utils.getKey(constants.thermostatControlSequenceOfOperations, value, value as number, Number);
         }
         const attributes = {ctrlSeqeOfOper: val};
         await entity.write("hvacThermostat", attributes);
@@ -1592,7 +1601,7 @@ export const thermostat_programming_operation_mode: Tz.Converter = {
 export const thermostat_temperature_display_mode: Tz.Converter = {
     key: ["temperature_display_mode"],
     convertSet: async (entity, key, value, meta) => {
-        const tempDisplayMode = utils.getKey(constants.temperatureDisplayMode, value, value, Number);
+        const tempDisplayMode = utils.getKey(constants.temperatureDisplayMode, value, value as number, Number);
         await entity.write("hvacUserInterfaceCfg", {tempDisplayMode});
         return {state: {temperature_display_mode: value}};
     },
@@ -1603,7 +1612,7 @@ export const thermostat_temperature_display_mode: Tz.Converter = {
 export const thermostat_keypad_lockout: Tz.Converter = {
     key: ["keypad_lockout"],
     convertSet: async (entity, key, value, meta) => {
-        const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value, Number);
+        const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value as number, Number);
         await entity.write("hvacUserInterfaceCfg", {keypadLockout});
         return {state: {keypad_lockout: value}};
     },
@@ -1614,8 +1623,7 @@ export const thermostat_keypad_lockout: Tz.Converter = {
 export const thermostat_temperature_setpoint_hold: Tz.Converter = {
     key: ["temperature_setpoint_hold"],
     convertSet: async (entity, key, value, meta) => {
-        const tempSetpointHold = value;
-        await entity.write("hvacThermostat", {tempSetpointHold});
+        await entity.write("hvacThermostat", {tempSetpointHold: value as number});
     },
     convertGet: async (entity, key, meta) => {
         await entity.read("hvacThermostat", ["tempSetpointHold"]);
@@ -1624,8 +1632,7 @@ export const thermostat_temperature_setpoint_hold: Tz.Converter = {
 export const thermostat_temperature_setpoint_hold_duration: Tz.Converter = {
     key: ["temperature_setpoint_hold_duration"],
     convertSet: async (entity, key, value, meta) => {
-        const tempSetpointHoldDuration = value;
-        await entity.write("hvacThermostat", {tempSetpointHoldDuration});
+        await entity.write("hvacThermostat", {tempSetpointHoldDuration: value as number});
     },
     convertGet: async (entity, key, meta) => {
         await entity.read("hvacThermostat", ["tempSetpointHoldDuration"]);
@@ -1881,7 +1888,7 @@ export const thermostat_ac_louver_position: Tz.Converter = {
     convertSet: async (entity, key, value, meta) => {
         let acLouverPosition = utils.getKey(constants.thermostatAcLouverPositions, value, undefined, Number);
         if (acLouverPosition === undefined) {
-            acLouverPosition = utils.getKey(constants.thermostatAcLouverPositions, value, value, Number);
+            acLouverPosition = utils.getKey(constants.thermostatAcLouverPositions, value, value as number, Number);
         }
         await entity.write("hvacThermostat", {acLouverPosition});
         return {state: {ac_louver_position: value}};
@@ -2036,7 +2043,7 @@ export const humidity: Tz.Converter = {
 export const elko_power_status: Tz.Converter = {
     key: ["system_mode"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {elkoPowerStatus: value === "heat"});
+        await entity.write("hvacThermostat", {elkoPowerStatus: value === "heat" ? 1 : 0});
         return {state: {system_mode: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2297,7 +2304,7 @@ export const livolo_cover_options: Tz.Converter = {
                      (must be one of 'FORWARD' or 'REVERSE')`);
             }
 
-            const payload = {4865: {value: [direction, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]}};
+            const payload = {4865: {value: [direction, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], type: Zcl.BuffaloZclDataType.LIST_UINT8}};
             await entity.write("genPowerCfg", payload, options);
         }
 
@@ -2305,7 +2312,7 @@ export const livolo_cover_options: Tz.Converter = {
             if (value.motor_speed < 20 || value.motor_speed > 40) {
                 throw new Error("livolo_cover_options: Motor speed is out of range (20-40)");
             }
-            const payload = {4609: {value: [value.motor_speed, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]}};
+            const payload = {4609: {value: [value.motor_speed, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], type: Zcl.BuffaloZclDataType.LIST_UINT8}};
             await entity.write("genPowerCfg", payload, options);
         }
     },
@@ -2436,7 +2443,7 @@ export const danfoss_mounted_mode_active: Tz.Converter = {
 export const danfoss_mounted_mode_control: Tz.Converter = {
     key: ["mounted_mode_control"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossMountedModeControl: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossMountedModeControl: value as number}, manufacturerOptions.danfoss);
         return {state: {mounted_mode_control: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2446,7 +2453,7 @@ export const danfoss_mounted_mode_control: Tz.Converter = {
 export const danfoss_thermostat_vertical_orientation: Tz.Converter = {
     key: ["thermostat_vertical_orientation"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossThermostatOrientation: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossThermostatOrientation: value as number}, manufacturerOptions.danfoss);
         return {state: {thermostat_vertical_orientation: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2456,7 +2463,7 @@ export const danfoss_thermostat_vertical_orientation: Tz.Converter = {
 export const danfoss_external_measured_room_sensor: Tz.Converter = {
     key: ["external_measured_room_sensor"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossExternalMeasuredRoomSensor: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossExternalMeasuredRoomSensor: value as number}, manufacturerOptions.danfoss);
         return {state: {external_measured_room_sensor: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2466,7 +2473,7 @@ export const danfoss_external_measured_room_sensor: Tz.Converter = {
 export const danfoss_radiator_covered: Tz.Converter = {
     key: ["radiator_covered"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossRadiatorCovered: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossRadiatorCovered: value as number}, manufacturerOptions.danfoss);
         return {state: {radiator_covered: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2476,7 +2483,7 @@ export const danfoss_radiator_covered: Tz.Converter = {
 export const danfoss_viewing_direction: Tz.Converter = {
     key: ["viewing_direction"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacUserInterfaceCfg", {danfossViewingDirection: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacUserInterfaceCfg", {danfossViewingDirection: value as number}, manufacturerOptions.danfoss);
         return {state: {viewing_direction: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2486,7 +2493,7 @@ export const danfoss_viewing_direction: Tz.Converter = {
 export const danfoss_algorithm_scale_factor: Tz.Converter = {
     key: ["algorithm_scale_factor"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossAlgorithmScaleFactor: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossAlgorithmScaleFactor: value as number}, manufacturerOptions.danfoss);
         return {state: {algorithm_scale_factor: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2496,7 +2503,7 @@ export const danfoss_algorithm_scale_factor: Tz.Converter = {
 export const danfoss_heat_available: Tz.Converter = {
     key: ["heat_available"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossHeatAvailable: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossHeatAvailable: value as number}, manufacturerOptions.danfoss);
         return {state: {heat_available: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2523,7 +2530,7 @@ export const danfoss_day_of_week: Tz.Converter = {
 export const danfoss_trigger_time: Tz.Converter = {
     key: ["trigger_time"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossTriggerTime: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossTriggerTime: value as number}, manufacturerOptions.danfoss);
         return {state: {trigger_time: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2533,7 +2540,7 @@ export const danfoss_trigger_time: Tz.Converter = {
 export const danfoss_window_open_feature: Tz.Converter = {
     key: ["window_open_feature"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossWindowOpenFeatureEnable: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossWindowOpenFeatureEnable: value as number}, manufacturerOptions.danfoss);
         return {state: {window_open_feature: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2549,7 +2556,7 @@ export const danfoss_window_open_internal: Tz.Converter = {
 export const danfoss_window_open_external: Tz.Converter = {
     key: ["window_open_external"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossWindowOpenExternal: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossWindowOpenExternal: value as number}, manufacturerOptions.danfoss);
         return {state: {window_open_external: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2559,7 +2566,7 @@ export const danfoss_window_open_external: Tz.Converter = {
 export const danfoss_load_balancing_enable: Tz.Converter = {
     key: ["load_balancing_enable"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossLoadBalancingEnable: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossLoadBalancingEnable: value as number}, manufacturerOptions.danfoss);
         return {state: {load_balancing_enable: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2569,7 +2576,7 @@ export const danfoss_load_balancing_enable: Tz.Converter = {
 export const danfoss_load_room_mean: Tz.Converter = {
     key: ["load_room_mean"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossLoadRoomMean: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossLoadRoomMean: value as number}, manufacturerOptions.danfoss);
         return {state: {load_room_mean: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -2597,7 +2604,7 @@ export const danfoss_adaptation_status: Tz.Converter = {
 export const danfoss_adaptation_settings: Tz.Converter = {
     key: ["adaptation_run_settings"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("hvacThermostat", {danfossAdaptionRunSettings: value}, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossAdaptionRunSettings: value as number}, manufacturerOptions.danfoss);
         return {state: {adaptation_run_settings: value}};
     },
 
@@ -2608,8 +2615,11 @@ export const danfoss_adaptation_settings: Tz.Converter = {
 export const danfoss_adaptation_control: Tz.Converter = {
     key: ["adaptation_run_control"],
     convertSet: async (entity, key, value, meta) => {
-        const payload = {danfossAdaptionRunControl: utils.getKey(constants.danfossAdaptionRunControl, value, value, Number)};
-        await entity.write("hvacThermostat", payload, manufacturerOptions.danfoss);
+        await entity.write(
+            "hvacThermostat",
+            {danfossAdaptionRunControl: utils.getKey(constants.danfossAdaptionRunControl, value, value as number, Number)},
+            manufacturerOptions.danfoss,
+        );
         return {state: {adaptation_run_control: value}};
     },
 
@@ -2620,8 +2630,7 @@ export const danfoss_adaptation_control: Tz.Converter = {
 export const danfoss_regulation_setpoint_offset: Tz.Converter = {
     key: ["regulation_setpoint_offset"],
     convertSet: async (entity, key, value, meta) => {
-        const payload = {danfossRegulationSetpointOffset: value};
-        await entity.write("hvacThermostat", payload, manufacturerOptions.danfoss);
+        await entity.write("hvacThermostat", {danfossRegulationSetpointOffset: value as number}, manufacturerOptions.danfoss);
         return {state: {regulation_setpoint_offset: value}};
     },
 
@@ -2698,7 +2707,7 @@ export const danfoss_system_status_code: Tz.Converter = {
 export const danfoss_heat_supply_request: Tz.Converter = {
     key: ["heat_supply_request"],
     convertGet: async (entity, key, meta) => {
-        await entity.read("haDiagnostic", ["danfossHeatsupplyRequest"], manufacturerOptions.danfoss);
+        await entity.read("haDiagnostic", ["danfossHeatSupplyRequest"], manufacturerOptions.danfoss);
     },
 };
 export const danfoss_system_status_water: Tz.Converter = {
@@ -3759,11 +3768,9 @@ export const scene_store: Tz.Converter = {
                     utils.saveSceneState(member, sceneid, groupid, meta.membersState[member.getDevice().ieeeAddr], scenename);
                 }
             }
-            // @ts-expect-error ignore
         } else if (response.status === 0) {
             utils.saveSceneState(entity, sceneid, groupid, meta.state, scenename);
         } else {
-            // @ts-expect-error ignore
             throw new Error(`Scene add not successful ('${Zcl.Status[response.status]}')`);
         }
         logger.info("Successfully stored scene", NS);
@@ -3992,11 +3999,9 @@ export const scene_remove: Tz.Converter = {
                     utils.deleteSceneState(member, sceneid, groupid);
                 }
             }
-            // @ts-expect-error ignore
         } else if (response.status === 0) {
             utils.deleteSceneState(entity, sceneid, groupid);
         } else {
-            // @ts-expect-error ignore
             throw new Error(`Scene remove not successful ('${Zcl.Status[response.status]}')`);
         }
         logger.info("Successfully removed scene", NS);
@@ -4072,7 +4077,7 @@ export const TS0003_curtain_switch: Tz.Converter = {
 export const ts0216_duration: Tz.Converter = {
     key: ["duration"],
     convertSet: async (entity, key, value, meta) => {
-        await entity.write("ssIasWd", {maxDuration: value});
+        await entity.write("ssIasWd", {maxDuration: value as number});
     },
     convertGet: async (entity, key, meta) => {
         await entity.read("ssIasWd", ["maxDuration"]);
@@ -4193,7 +4198,7 @@ export const TS0210_sensitivity: Tz.Converter = {
     convertSet: async (entity, key, value, meta) => {
         // biome-ignore lint/style/noParameterAssign: ignored using `--suppress`
         value = utils.toNumber(value, "sensitivity");
-        await entity.write("ssIasZone", {currentZoneSensitivityLevel: value});
+        await entity.write("ssIasZone", {currentZoneSensitivityLevel: value as number});
         return {state: {sensitivity: value}};
     },
 };
@@ -4207,7 +4212,7 @@ export const viessmann_window_open_force: Tz.Converter = {
     key: ["window_open_force"],
     convertSet: async (entity, key, value, meta) => {
         if (typeof value === "boolean") {
-            await entity.write("hvacThermostat", {viessmannWindowOpenForce: value}, manufacturerOptions.viessmann);
+            await entity.write("hvacThermostat", {viessmannWindowOpenForce: value ? 1 : 0}, manufacturerOptions.viessmann);
             return {state: {window_open_force: value}};
         }
         logger.error("window_open_force must be a boolean!", NS);
@@ -4338,8 +4343,11 @@ export const schneider_dimmer_mode: Tz.Converter = {
 export const wiser_dimmer_mode: Tz.Converter = {
     key: ["dimmer_mode"],
     convertSet: async (entity, key, value, meta) => {
-        const controlMode = utils.getKey(constants.wiserDimmerControlMode, value, value, Number);
-        await entity.write("lightingBallastCfg", {wiserControlMode: controlMode}, {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC});
+        await entity.write(
+            "lightingBallastCfg",
+            {wiserControlMode: utils.getKey(constants.wiserDimmerControlMode, value, value as number, Number)},
+            {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC},
+        );
         return {state: {dimmer_mode: value}};
     },
     convertGet: async (entity, key, meta) => {
@@ -4394,7 +4402,7 @@ export const schneider_thermostat_keypad_lockout: Tz.Converter = {
     key: ["keypad_lockout"],
     convertSet: async (entity, key, value, meta) => {
         utils.assertEndpoint(entity);
-        const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value, Number);
+        const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value as number, Number);
         await entity.write("hvacUserInterfaceCfg", {keypadLockout});
         entity.saveClusterAttributeKeyValue("hvacUserInterfaceCfg", {keypadLockout});
         return {state: {keypad_lockout: value}};
@@ -4487,17 +4495,19 @@ export const wiser_sed_thermostat_local_temperature_calibration: Tz.Converter = 
 export const wiser_sed_thermostat_keypad_lockout: Tz.Converter = {
     key: ["keypad_lockout"],
     convertSet: async (entity, key, value, meta) => {
-        const keypadLockout = utils.getKey(constants.keypadLockoutMode, value, value, Number);
-        await entity.write("hvacUserInterfaceCfg", {keypadLockout}, {srcEndpoint: 11, disableDefaultResponse: true});
+        await entity.write(
+            "hvacUserInterfaceCfg",
+            {keypadLockout: utils.getKey(constants.keypadLockoutMode, value, value as number, Number)},
+            {srcEndpoint: 11, disableDefaultResponse: true},
+        );
         return {state: {keypad_lockout: value}};
     },
 };
 export const sihas_set_people: Tz.Converter = {
     key: ["people"],
     convertSet: async (entity, key, value, meta) => {
-        const payload = {presentValue: value};
         const endpoint = meta.device.endpoints.find((e) => e.supportsInputCluster("genAnalogInput"));
-        await endpoint.write("genAnalogInput", payload);
+        await endpoint.write("genAnalogInput", {presentValue: value as number});
     },
     convertGet: async (entity, key, meta) => {
         const endpoint = meta.device.endpoints.find((e) => e.supportsInputCluster("genAnalogInput"));

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -2242,7 +2242,12 @@ export const livolo_cover_state: Tz.Converter = {
             default:
                 throw new Error(`Value '${value}' is not a valid cover position (must be one of 'OPEN' or 'CLOSE')`);
         }
-        await entity.writeStructured("genPowerCfg", [payload], options);
+        await entity.writeStructured(
+            "genPowerCfg",
+            // @ts-expect-error workaround write custom payload
+            [payload],
+            options,
+        );
         return {
             state: {
                 moving: true,
@@ -2304,16 +2309,26 @@ export const livolo_cover_options: Tz.Converter = {
                      (must be one of 'FORWARD' or 'REVERSE')`);
             }
 
-            const payload = {4865: {value: [direction, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], type: Zcl.BuffaloZclDataType.LIST_UINT8}};
-            await entity.write("genPowerCfg", payload, options);
+            const payload = {4865: {value: [direction, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]}};
+            await entity.write(
+                "genPowerCfg",
+                // @ts-expect-error workaround write custom payload
+                payload,
+                options,
+            );
         }
 
         if (value.motor_speed != null) {
             if (value.motor_speed < 20 || value.motor_speed > 40) {
                 throw new Error("livolo_cover_options: Motor speed is out of range (20-40)");
             }
-            const payload = {4609: {value: [value.motor_speed, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], type: Zcl.BuffaloZclDataType.LIST_UINT8}};
-            await entity.write("genPowerCfg", payload, options);
+            const payload = {4609: {value: [value.motor_speed, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]}};
+            await entity.write(
+                "genPowerCfg",
+                // @ts-expect-error workaround write custom payload
+                payload,
+                options,
+            );
         }
     },
 };

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -3676,16 +3676,16 @@ export const diyruz_zintercom_config: Tz.Converter = {
     },
     convertGet: async (entity, key, meta) => {
         const payloads = {
-            mode: ["closuresDoorLock", 0x0051],
-            sound: ["closuresDoorLock", 0x0052],
-            time_ring: ["closuresDoorLock", 0x0053],
-            time_talk: ["closuresDoorLock", 0x0054],
-            time_open: ["closuresDoorLock", 0x0055],
-            time_bell: ["closuresDoorLock", 0x0057],
-            time_report: ["closuresDoorLock", 0x0056],
+            mode: 0x0051,
+            sound: 0x0052,
+            time_ring: 0x0053,
+            time_talk: 0x0054,
+            time_open: 0x0055,
+            time_bell: 0x0057,
+            time_report: 0x0056,
         };
         const v = utils.getFromLookup(key, payloads);
-        await entity.read(v[0], [v[1]]);
+        await entity.read("closuresDoorLock", [v]);
     },
 };
 export const power_source: Tz.Converter = {

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1,4 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
+import type {TClusterCommandPayload} from "zigbee-herdsman/dist/zspec/zcl/definition/clusters-types";
 import * as libColor from "../lib/color";
 import * as constants from "../lib/constants";
 import * as exposes from "../lib/exposes";
@@ -41,7 +42,8 @@ export const on_off: Tz.Converter = {
                 throw Error("The off_wait_time value must be a number!");
             }
             const payload = meta.converterOptions
-                ? meta.converterOptions
+                ? // TODO: better typing? currently used in a single place??
+                  (meta.converterOptions as TClusterCommandPayload<"genOnOff", "onWithTimedOff">)
                 : {ctrlbits: 0, ontime: Math.round(onTime * 10), offwaittime: Math.round(offWaitTime * 10)};
             await entity.command("genOnOff", "onWithTimedOff", payload, utils.getOptions(meta.mapped, entity));
         } else {

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -90,16 +90,6 @@ export const light_color: Tz.Converter = {
             const colorx = utils.mapNumberRange(xy.x, 0, 1, 0, 65535);
             const colory = utils.mapNumberRange(xy.y, 0, 1, 0, 65535);
 
-            // XXX: should this be skipped entirely in this codepath?
-            if (utils.isObject(value) && value.brightness != null) {
-                await entity.command(
-                    "genLevelCtrl",
-                    "moveToLevelWithOnOff",
-                    {level: Number(value.brightness), transtime},
-                    utils.getOptions(meta.mapped, entity),
-                );
-            }
-
             await entity.command("lightingColorCtrl", "moveToColor", {transtime, colorx, colory}, utils.getOptions(meta.mapped, entity));
         } else if (newColor.isHSV()) {
             const hsv = newColor.hsv;
@@ -157,7 +147,7 @@ export const light_color: Tz.Converter = {
                 await entity.command("lightingColorCtrl", "moveToSaturation", {transtime, saturation}, utils.getOptions(meta.mapped, entity));
             }
         } else {
-            // TODO: throw?
+            throw new Error("Invalid color");
         }
 
         return {state: libColor.syncColorState(newState, meta.state, entity, meta.options)};

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1520,11 +1520,9 @@ export const thermostat_weekly_schedule: Tz.Converter = {
         // map array of desired modes to bitmask
         let mode = 0;
 
-        for (let m of modes) {
+        for (const m of modes) {
             // lookup mode bit
-            // TODO: fallback is string, but need number?
-            m = utils.getKey(constants.thermostatScheduleMode, m.toLowerCase(), m, Number);
-            mode |= 1 << m;
+            mode |= 1 << utils.getKey(constants.thermostatScheduleMode, m, 0, Number);
         }
 
         // map array of days to desired dayofweek bitmask

--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -224,7 +224,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
 
-            m.numeric<"aminaControlCluster", true>({
+            m.numeric<"aminaControlCluster", AminaControlCluster>({
                 name: "total_active_energy",
                 cluster: "aminaControlCluster",
                 attribute: "totalActiveEnergy",
@@ -236,7 +236,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
 
-            m.numeric<"aminaControlCluster", true>({
+            m.numeric<"aminaControlCluster", AminaControlCluster>({
                 name: "last_session_energy",
                 cluster: "aminaControlCluster",
                 attribute: "lastSessionEnergy",
@@ -248,7 +248,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
 
-            m.binary<"aminaControlCluster", true>({
+            m.binary<"aminaControlCluster", AminaControlCluster>({
                 name: "ev_connected",
                 cluster: "aminaControlCluster",
                 attribute: "evConnected",
@@ -258,7 +258,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE",
             }),
 
-            m.binary<"aminaControlCluster", true>({
+            m.binary<"aminaControlCluster", AminaControlCluster>({
                 name: "charging",
                 cluster: "aminaControlCluster",
                 attribute: "charging",
@@ -268,7 +268,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE",
             }),
 
-            m.binary<"aminaControlCluster", true>({
+            m.binary<"aminaControlCluster", AminaControlCluster>({
                 name: "derated",
                 cluster: "aminaControlCluster",
                 attribute: "derated",
@@ -278,7 +278,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE",
             }),
 
-            m.binary<"aminaControlCluster", true>({
+            m.binary<"aminaControlCluster", AminaControlCluster>({
                 name: "alarm_active",
                 cluster: "aminaControlCluster",
                 attribute: "alarmActive",
@@ -294,7 +294,7 @@ export const definitions: DefinitionWithExtend[] = [
                 threePhase: true,
             }),
 
-            m.binary<"aminaControlCluster", true>({
+            m.binary<"aminaControlCluster", AminaControlCluster>({
                 name: "single_phase",
                 cluster: "aminaControlCluster",
                 attribute: "singlePhase",
@@ -304,7 +304,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.binary<"aminaControlCluster", true>({
+            m.binary<"aminaControlCluster", AminaControlCluster>({
                 name: "enable_offline",
                 cluster: "aminaControlCluster",
                 attribute: "enableOffline",
@@ -314,7 +314,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.numeric<"aminaControlCluster", true>({
+            m.numeric<"aminaControlCluster", AminaControlCluster>({
                 name: "time_to_offline",
                 cluster: "aminaControlCluster",
                 attribute: "timeToOffline",
@@ -326,7 +326,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.numeric<"aminaControlCluster", true>({
+            m.numeric<"aminaControlCluster", AminaControlCluster>({
                 name: "offline_current",
                 cluster: "aminaControlCluster",
                 attribute: "offlineCurrent",
@@ -338,7 +338,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.binary<"aminaControlCluster", true>({
+            m.binary<"aminaControlCluster", AminaControlCluster>({
                 name: "offline_single_phase",
                 cluster: "aminaControlCluster",
                 attribute: "offlineSinglePhase",

--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -205,7 +205,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
 
-            m.numeric({
+            m.numeric<"aminaControlCluster", true>({
                 name: "total_active_energy",
                 cluster: "aminaControlCluster",
                 attribute: "totalActiveEnergy",
@@ -217,7 +217,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
 
-            m.numeric({
+            m.numeric<"aminaControlCluster", true>({
                 name: "last_session_energy",
                 cluster: "aminaControlCluster",
                 attribute: "lastSessionEnergy",
@@ -229,7 +229,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
 
-            m.binary({
+            m.binary<"aminaControlCluster", true>({
                 name: "ev_connected",
                 cluster: "aminaControlCluster",
                 attribute: "evConnected",
@@ -239,7 +239,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE",
             }),
 
-            m.binary({
+            m.binary<"aminaControlCluster", true>({
                 name: "charging",
                 cluster: "aminaControlCluster",
                 attribute: "charging",
@@ -249,7 +249,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE",
             }),
 
-            m.binary({
+            m.binary<"aminaControlCluster", true>({
                 name: "derated",
                 cluster: "aminaControlCluster",
                 attribute: "derated",
@@ -259,7 +259,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE",
             }),
 
-            m.binary({
+            m.binary<"aminaControlCluster", true>({
                 name: "alarm_active",
                 cluster: "aminaControlCluster",
                 attribute: "alarmActive",
@@ -275,7 +275,7 @@ export const definitions: DefinitionWithExtend[] = [
                 threePhase: true,
             }),
 
-            m.binary({
+            m.binary<"aminaControlCluster", true>({
                 name: "single_phase",
                 cluster: "aminaControlCluster",
                 attribute: "singlePhase",
@@ -285,7 +285,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.binary({
+            m.binary<"aminaControlCluster", true>({
                 name: "enable_offline",
                 cluster: "aminaControlCluster",
                 attribute: "enableOffline",
@@ -295,7 +295,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.numeric({
+            m.numeric<"aminaControlCluster", true>({
                 name: "time_to_offline",
                 cluster: "aminaControlCluster",
                 attribute: "timeToOffline",
@@ -307,7 +307,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.numeric({
+            m.numeric<"aminaControlCluster", true>({
                 name: "offline_current",
                 cluster: "aminaControlCluster",
                 attribute: "offlineCurrent",
@@ -319,7 +319,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
             }),
 
-            m.binary({
+            m.binary<"aminaControlCluster", true>({
                 name: "offline_single_phase",
                 cluster: "aminaControlCluster",
                 attribute: "offlineSinglePhase",

--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -139,7 +139,7 @@ const tzLocal = {
     charge_limit: {
         key: ["charge_limit"],
         convertSet: async (entity, key, value, meta) => {
-            const payload = {level: value, transtime: 0};
+            const payload = {level: value as number, transtime: 0};
             await entity.command("genLevelCtrl", "moveToLevel", payload, utils.getOptions(meta.mapped, entity));
         },
 

--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as constants from "../lib/constants";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
@@ -15,7 +14,7 @@ const ea = exposes.access;
 
 const manufacturerOptions = {manufacturerCode: 0x143b};
 
-interface AminaControlCluster extends TCustomCluster {
+interface AminaControlCluster {
     attributes: {
         alarms: number;
         evStatus: number;

--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -173,6 +173,10 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             e.text("ev_status", ea.STATE_GET).withDescription("Current charging status"),
             e.list("alarms", ea.STATE_GET, e.enum("alarm", ea.STATE_GET, aminaAlarms)).withDescription("List of active alarms"),
+            e.binary("ev_connected", ea.STATE, true, false).withDescription("An EV is connected to the charger"),
+            e.binary("charging", ea.STATE, true, false).withDescription("Power is being delivered to the EV"),
+            e.binary("derated", ea.STATE, true, false).withDescription("Charging derated due to high temperature"),
+            e.binary("alarm_active", ea.STATE, true, false).withDescription("An active alarm is present"),
         ],
         extend: [
             m.deviceAddCustomCluster("aminaControlCluster", {
@@ -245,46 +249,6 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 precision: 2,
                 access: "STATE_GET",
-            }),
-
-            m.binary<"aminaControlCluster", AminaControlCluster>({
-                name: "ev_connected",
-                cluster: "aminaControlCluster",
-                attribute: "evConnected",
-                description: "An EV is connected to the charger",
-                valueOn: [true, 1],
-                valueOff: [false, 0],
-                access: "STATE",
-            }),
-
-            m.binary<"aminaControlCluster", AminaControlCluster>({
-                name: "charging",
-                cluster: "aminaControlCluster",
-                attribute: "charging",
-                description: "Power is being delivered to the EV",
-                valueOn: [true, 1],
-                valueOff: [false, 0],
-                access: "STATE",
-            }),
-
-            m.binary<"aminaControlCluster", AminaControlCluster>({
-                name: "derated",
-                cluster: "aminaControlCluster",
-                attribute: "derated",
-                description: "Charging derated due to high temperature",
-                valueOn: [true, 1],
-                valueOff: [false, 0],
-                access: "STATE",
-            }),
-
-            m.binary<"aminaControlCluster", AminaControlCluster>({
-                name: "alarm_active",
-                cluster: "aminaControlCluster",
-                attribute: "alarmActive",
-                description: "An active alarm is present",
-                valueOn: [true, 1],
-                valueOff: [false, 0],
-                access: "STATE",
             }),
 
             m.electricityMeter({

--- a/src/devices/aurora_lighting.ts
+++ b/src/devices/aurora_lighting.ts
@@ -75,6 +75,7 @@ const batteryRotaryDimmer = (...endpointsIds: number[]) => ({
                 for (const c of endpoint.configuredReportings) {
                     await endpoint.configureReporting(c.cluster.name, [
                         {
+                            // @ts-expect-error dynamic, assumed correct since already applied
                             attribute: c.attribute.name,
                             minimumReportInterval: c.minimumReportInterval,
                             maximumReportInterval: c.maximumReportInterval,

--- a/src/devices/aurora_lighting.ts
+++ b/src/devices/aurora_lighting.ts
@@ -18,7 +18,7 @@ const tzLocal = {
             const state = value.toLowerCase();
             utils.validateValue(state, ["toggle", "off", "on"]);
             const endpoint = meta.device.getEndpoint(3);
-            await endpoint.command("genOnOff", state, {});
+            await endpoint.command("genOnOff", state as "toggle" | "off" | "on", {});
             return {state: {backlight_led: state.toUpperCase()}};
         },
     } satisfies Tz.Converter,
@@ -26,7 +26,7 @@ const tzLocal = {
         key: ["brightness"],
         options: [exposes.options.transition()],
         convertSet: async (entity, key, value, meta) => {
-            await entity.command("genLevelCtrl", "moveToLevel", {level: value, transtime: 0}, utils.getOptions(meta.mapped, entity));
+            await entity.command("genLevelCtrl", "moveToLevel", {level: value as number, transtime: 0}, utils.getOptions(meta.mapped, entity));
             return {state: {brightness: value}};
         },
         convertGet: async (entity, key, meta) => {

--- a/src/devices/bacchus.ts
+++ b/src/devices/bacchus.ts
@@ -68,7 +68,7 @@ function timeHHMM(args: m.TextArgs<"genTime">): ModernExtend {
     return {...mExtend, fromZigbee, toZigbee, configure, isModernExtend: true};
 }
 
-function binaryWithOnOffCommand<Cl extends string | number>(args: m.BinaryArgs<Cl>): ModernExtend {
+function binaryWithOnOffCommand(args: m.BinaryArgs<"genOnOff", undefined>): ModernExtend {
     const {name, cluster, attribute, zigbeeCommandOptions, endpointName, reporting} = args;
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];

--- a/src/devices/bacchus.ts
+++ b/src/devices/bacchus.ts
@@ -82,7 +82,9 @@ function binaryWithOnOffCommand(args: m.BinaryArgs<"genOnOff", undefined>): Mode
                     ? async (entity, key, value, meta) => {
                           const state = isString(meta.message[key]) ? meta.message[key].toLowerCase() : null;
                           validateValue(state, ["toggle", "off", "on"]);
-                          await m.determineEndpoint(entity, meta, cluster).command(cluster, state, {}, zigbeeCommandOptions);
+                          await m
+                              .determineEndpoint(entity, meta, cluster)
+                              .command(cluster, state as "toggle" | "off" | "on", {}, zigbeeCommandOptions);
                           await m.determineEndpoint(entity, meta, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
                           return {state: {[key]: value}};
                       }

--- a/src/devices/bacchus.ts
+++ b/src/devices/bacchus.ts
@@ -8,8 +8,8 @@ import {assertNumber, getEndpointName, isString, precisionRound, validateValue} 
 
 const defaultReporting = {min: 0, max: 3600, change: 0};
 const electicityReporting = {min: 0, max: 30, change: 1};
-const defaultReportingOnOff = {min: 0, max: 3600, change: 0, attribute: "onOff"};
-const defaultReportingOOS = {min: 0, max: 3600, change: 0, attribute: "outOfService"};
+const defaultReportingOnOff = {min: 0, max: 3600, change: 0, attribute: "onOff" as const};
+const defaultReportingOOS = {min: 0, max: 3600, change: 0, attribute: "outOfService" as const};
 
 const time_to_str_min = (time: number) => {
     const date = new Date(null);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -155,6 +155,12 @@ interface BoschSpecificBmct extends TCustomCluster {
     commandResponses: never;
 }
 
+interface BoschSpecificBwa1 extends TCustomCluster {
+    attributes: {alarmOnMotion: number};
+    commands: never;
+    commandResponses: never;
+}
+
 const boschExtend = {
     hvacThermostatCluster: () =>
         m.deviceAddCustomCluster("hvacThermostat", {
@@ -228,7 +234,7 @@ const boschExtend = {
             commandsResponse: {},
         }),
     operatingMode: () =>
-        m.enumLookup<"hvacThermostat", true>({
+        m.enumLookup<"hvacThermostat", BoschHvacThermostat>({
             name: "operating_mode",
             cluster: "hvacThermostat",
             attribute: "operatingMode",
@@ -238,7 +244,7 @@ const boschExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     windowDetection: () =>
-        m.binary<"hvacThermostat", true>({
+        m.binary<"hvacThermostat", BoschHvacThermostat>({
             name: "window_detection",
             cluster: "hvacThermostat",
             attribute: "windowDetection",
@@ -248,7 +254,7 @@ const boschExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     boostHeating: () =>
-        m.binary<"hvacThermostat", true>({
+        m.binary<"hvacThermostat", BoschHvacThermostat>({
             name: "boost_heating",
             cluster: "hvacThermostat",
             attribute: "boostHeating",
@@ -268,7 +274,7 @@ const boschExtend = {
             valueOff: ["UNLOCK", 0x00],
         }),
     displayOntime: () =>
-        m.numeric<"hvacUserInterfaceCfg", true>({
+        m.numeric<"hvacUserInterfaceCfg", BoschHvacUserInterfaceCfg>({
             name: "display_ontime",
             cluster: "hvacUserInterfaceCfg",
             attribute: "displayOntime",
@@ -279,7 +285,7 @@ const boschExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     displayBrightness: () =>
-        m.numeric<"hvacUserInterfaceCfg", true>({
+        m.numeric<"hvacUserInterfaceCfg", BoschHvacUserInterfaceCfg>({
             name: "display_brightness",
             cluster: "hvacUserInterfaceCfg",
             attribute: "displayBrightness",
@@ -1315,7 +1321,7 @@ export const definitions: DefinitionWithExtend[] = [
                 percentage: true,
                 lowStatus: true,
             }),
-            m.binary<"boschSpecific", true>({
+            m.binary<"boschSpecific", BoschSpecificBwa1>({
                 name: "alarm_on_motion",
                 cluster: "boschSpecific",
                 attribute: "alarmOnMotion",
@@ -1331,15 +1337,10 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
         configure: async (device, coordinatorEndpoint) => {
-            interface BoschSpecific extends TCustomCluster {
-                attributes: {alarmOnMotion: number};
-                commands: never;
-                commandResponses: never;
-            }
             const endpoint = device.getEndpoint(1);
             await endpoint.read("genPowerCfg", ["batteryPercentageRemaining"]);
             await endpoint.read("ssIasZone", ["zoneStatus"]);
-            await endpoint.read<"boschSpecific", BoschSpecific>("boschSpecific", ["alarmOnMotion"], manufacturerOptions);
+            await endpoint.read<"boschSpecific", BoschSpecificBwa1>("boschSpecific", ["alarmOnMotion"], manufacturerOptions);
         },
     },
     {
@@ -1490,7 +1491,7 @@ export const definitions: DefinitionWithExtend[] = [
             boschExtend.operatingMode(),
             boschExtend.windowDetection(),
             boschExtend.boostHeating(),
-            m.numeric<"hvacThermostat", true>({
+            m.numeric<"hvacThermostat", BoschHvacThermostat>({
                 name: "remote_temperature",
                 cluster: "hvacThermostat",
                 attribute: "remoteTemperature",
@@ -1514,7 +1515,7 @@ export const definitions: DefinitionWithExtend[] = [
             boschExtend.childLock(),
             boschExtend.displayOntime(),
             boschExtend.displayBrightness(),
-            m.enumLookup<"hvacUserInterfaceCfg", true>({
+            m.enumLookup<"hvacUserInterfaceCfg", BoschHvacUserInterfaceCfg>({
                 name: "display_orientation",
                 cluster: "hvacUserInterfaceCfg",
                 attribute: "displayOrientation",
@@ -1522,7 +1523,7 @@ export const definitions: DefinitionWithExtend[] = [
                 lookup: {normal: 0x00, flipped: 0x01},
                 zigbeeCommandOptions: manufacturerOptions,
             }),
-            m.enumLookup<"hvacUserInterfaceCfg", true>({
+            m.enumLookup<"hvacUserInterfaceCfg", BoschHvacUserInterfaceCfg>({
                 name: "displayed_temperature",
                 cluster: "hvacUserInterfaceCfg",
                 attribute: "displayedTemperature",
@@ -1530,7 +1531,7 @@ export const definitions: DefinitionWithExtend[] = [
                 lookup: {target: 0x00, measured: 0x01},
                 zigbeeCommandOptions: manufacturerOptions,
             }),
-            m.enumLookup<"hvacThermostat", true>({
+            m.enumLookup<"hvacThermostat", BoschHvacThermostat>({
                 name: "valve_adapt_status",
                 cluster: "hvacThermostat",
                 attribute: "valveAdaptStatus",

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1,5 +1,5 @@
 import {Zcl, ZSpec} from "zigbee-herdsman";
-
+import type {ClusterOrRawAttributeKeys, PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -259,7 +259,11 @@ const boschExtend = {
                     return {state: {valve_adapt_process: value}};
                 },
                 convertGet: async (entity, key, meta) => {
-                    await entity.read("hvacThermostat", ["valveAdaptStatus"], manufacturerOptions);
+                    await entity.read(
+                        "hvacThermostat",
+                        ["valveAdaptStatus"] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">,
+                        manufacturerOptions,
+                    );
                 },
             },
         ];
@@ -293,18 +297,30 @@ const boschExtend = {
                     if (key === "pi_heating_demand") {
                         let demand = utils.toNumber(value, key);
                         demand = utils.numberWithinRange(demand, 0, 100);
-                        await entity.write("hvacThermostat", {heatingDemand: demand}, manufacturerOptions);
+                        await entity.write(
+                            "hvacThermostat",
+                            {heatingDemand: demand} as PartialClusterOrRawWriteAttributes<"hvacThermostat">,
+                            manufacturerOptions,
+                        );
                         return {state: {pi_heating_demand: demand}};
                     }
                 },
                 convertGet: async (entity, key, meta) => {
-                    await entity.read("hvacThermostat", ["heatingDemand"], manufacturerOptions);
+                    await entity.read(
+                        "hvacThermostat",
+                        ["heatingDemand"] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">,
+                        manufacturerOptions,
+                    );
                 },
             },
             {
                 key: ["running_state"],
                 convertGet: async (entity, key, meta) => {
-                    await entity.read("hvacThermostat", ["heatingDemand"], manufacturerOptions);
+                    await entity.read(
+                        "hvacThermostat",
+                        ["heatingDemand"] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">,
+                        manufacturerOptions,
+                    );
                 },
             },
         ];
@@ -1479,13 +1495,25 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.read("hvacThermostat", ["localTemperatureCalibration", "setpointChangeSource"]);
             await endpoint.read(
                 "hvacThermostat",
-                ["operatingMode", "heatingDemand", "valveAdaptStatus", "remoteTemperature", "windowDetection", "boostHeating"],
+                [
+                    "operatingMode",
+                    "heatingDemand",
+                    "valveAdaptStatus",
+                    "remoteTemperature",
+                    "windowDetection",
+                    "boostHeating",
+                ] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">,
                 manufacturerOptions,
             );
             await endpoint.read("hvacUserInterfaceCfg", ["keypadLockout"]);
             await endpoint.read(
                 "hvacUserInterfaceCfg",
-                ["displayOrientation", "displayedTemperature", "displayOntime", "displayBrightness"],
+                [
+                    "displayOrientation",
+                    "displayedTemperature",
+                    "displayOntime",
+                    "displayBrightness",
+                ] as unknown as ClusterOrRawAttributeKeys<"hvacUserInterfaceCfg">,
                 manufacturerOptions,
             );
         },
@@ -1560,9 +1588,17 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.thermostatKeypadLockMode(endpoint);
             await endpoint.read("genPowerCfg", ["batteryVoltage"]);
             await endpoint.read("hvacThermostat", ["localTemperatureCalibration"]);
-            await endpoint.read("hvacThermostat", ["operatingMode", "windowDetection", "boostHeating"], manufacturerOptions);
+            await endpoint.read(
+                "hvacThermostat",
+                ["operatingMode", "windowDetection", "boostHeating"] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">,
+                manufacturerOptions,
+            );
             await endpoint.read("hvacUserInterfaceCfg", ["keypadLockout"]);
-            await endpoint.read("hvacUserInterfaceCfg", ["displayOntime", "displayBrightness"], manufacturerOptions);
+            await endpoint.read(
+                "hvacUserInterfaceCfg",
+                ["displayOntime", "displayBrightness"] as unknown as ClusterOrRawAttributeKeys<"hvacUserInterfaceCfg">,
+                manufacturerOptions,
+            );
         },
     },
     {
@@ -1622,9 +1658,17 @@ export const definitions: DefinitionWithExtend[] = [
             });
             await reporting.thermostatKeypadLockMode(endpoint);
             await endpoint.read("hvacThermostat", ["localTemperatureCalibration"]);
-            await endpoint.read("hvacThermostat", ["operatingMode", "windowDetection", "boostHeating"], manufacturerOptions);
+            await endpoint.read(
+                "hvacThermostat",
+                ["operatingMode", "windowDetection", "boostHeating"] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">,
+                manufacturerOptions,
+            );
             await endpoint.read("hvacUserInterfaceCfg", ["keypadLockout"]);
-            await endpoint.read("hvacUserInterfaceCfg", ["displayOntime", "displayBrightness"], manufacturerOptions);
+            await endpoint.read(
+                "hvacUserInterfaceCfg",
+                ["displayOntime", "displayBrightness"] as unknown as ClusterOrRawAttributeKeys<"hvacUserInterfaceCfg">,
+                manufacturerOptions,
+            );
         },
     },
     {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1,5 +1,4 @@
 import {Zcl, ZSpec} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -76,7 +75,7 @@ const labelConfirmation = `Specifies LED color (rgb) and pattern of the confirma
 8: Number of Repetitions (01=1 to ff=255)
 Example: 30ff00000102010001`;
 
-interface BoschHvacThermostat extends TCustomCluster {
+interface BoschHvacThermostat {
     attributes: {
         operatingMode: number;
         heatingDemand: number;
@@ -91,7 +90,7 @@ interface BoschHvacThermostat extends TCustomCluster {
     commandResponses: never;
 }
 
-interface BoschHvacUserInterfaceCfg extends TCustomCluster {
+interface BoschHvacUserInterfaceCfg {
     attributes: {
         displayOrientation: number;
         displayedTemperature: number;
@@ -102,7 +101,7 @@ interface BoschHvacUserInterfaceCfg extends TCustomCluster {
     commandResponses: never;
 }
 
-interface TwinguardSmokeDetector extends TCustomCluster {
+interface TwinguardSmokeDetector {
     attributes: {
         sensitivity: number;
     };
@@ -111,7 +110,7 @@ interface TwinguardSmokeDetector extends TCustomCluster {
     };
     commandResponses: never;
 }
-interface TwinguardOptions extends TCustomCluster {
+interface TwinguardOptions {
     attributes: {
         unknown1: number;
         // biome-ignore lint/style/useNamingConvention: TODO
@@ -122,7 +121,7 @@ interface TwinguardOptions extends TCustomCluster {
     };
     commandResponses: never;
 }
-interface TwinguardSetup extends TCustomCluster {
+interface TwinguardSetup {
     attributes: {
         unknown1: number;
         unknown2: number;
@@ -131,7 +130,7 @@ interface TwinguardSetup extends TCustomCluster {
     commands: {pairingCompleted: Record<string, never>};
     commandResponses: never;
 }
-interface TwinguardAlarm extends TCustomCluster {
+interface TwinguardAlarm {
     attributes: {
         // biome-ignore lint/style/useNamingConvention: TODO
         alarm_status: number;
@@ -140,7 +139,7 @@ interface TwinguardAlarm extends TCustomCluster {
     commandResponses: never;
 }
 
-interface BoschSpecificBmct extends TCustomCluster {
+interface BoschSpecificBmct {
     attributes: {
         deviceMode: number;
         switchType: number;
@@ -155,7 +154,7 @@ interface BoschSpecificBmct extends TCustomCluster {
     commandResponses: never;
 }
 
-interface BoschSpecificBwa1 extends TCustomCluster {
+interface BoschSpecificBwa1 {
     attributes: {alarmOnMotion: number};
     commands: never;
     commandResponses: never;

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1030,8 +1030,9 @@ const tzLocal = {
             const buffer = Buffer.from(value as string, "hex");
             if (buffer.length !== 9) throw new Error(`Invalid configuration length: ${buffer.length} (should be 9)`);
 
-            const payload: {[key: number | string]: KeyValue} = {};
-            payload[buttonMap[key as keyof typeof buttonMap]] = {value: buffer, type: 65};
+            const payload = {
+                [buttonMap[key as keyof typeof buttonMap]]: {value: buffer, type: 65},
+            };
             await entity.write("boschSpecific", payload, manufacturerOptions);
 
             const result: {[key: number | string]: string} = {};

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -149,7 +149,7 @@ const boschExtend = {
             commandsResponse: {},
         }),
     operatingMode: () =>
-        m.enumLookup({
+        m.enumLookup<"hvacThermostat", true>({
             name: "operating_mode",
             cluster: "hvacThermostat",
             attribute: "operatingMode",
@@ -159,7 +159,7 @@ const boschExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     windowDetection: () =>
-        m.binary({
+        m.binary<"hvacThermostat", true>({
             name: "window_detection",
             cluster: "hvacThermostat",
             attribute: "windowDetection",
@@ -169,7 +169,7 @@ const boschExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     boostHeating: () =>
-        m.binary({
+        m.binary<"hvacThermostat", true>({
             name: "boost_heating",
             cluster: "hvacThermostat",
             attribute: "boostHeating",
@@ -189,7 +189,7 @@ const boschExtend = {
             valueOff: ["UNLOCK", 0x00],
         }),
     displayOntime: () =>
-        m.numeric({
+        m.numeric<"hvacUserInterfaceCfg", true>({
             name: "display_ontime",
             cluster: "hvacUserInterfaceCfg",
             attribute: "displayOntime",
@@ -200,7 +200,7 @@ const boschExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     displayBrightness: () =>
-        m.numeric({
+        m.numeric<"hvacUserInterfaceCfg", true>({
             name: "display_brightness",
             cluster: "hvacUserInterfaceCfg",
             attribute: "displayBrightness",
@@ -1218,7 +1218,7 @@ export const definitions: DefinitionWithExtend[] = [
                 percentage: true,
                 lowStatus: true,
             }),
-            m.binary({
+            m.binary<"boschSpecific", true>({
                 name: "alarm_on_motion",
                 cluster: "boschSpecific",
                 attribute: "alarmOnMotion",
@@ -1388,7 +1388,7 @@ export const definitions: DefinitionWithExtend[] = [
             boschExtend.operatingMode(),
             boschExtend.windowDetection(),
             boschExtend.boostHeating(),
-            m.numeric({
+            m.numeric<"hvacThermostat", true>({
                 name: "remote_temperature",
                 cluster: "hvacThermostat",
                 attribute: "remoteTemperature",
@@ -1412,7 +1412,7 @@ export const definitions: DefinitionWithExtend[] = [
             boschExtend.childLock(),
             boschExtend.displayOntime(),
             boschExtend.displayBrightness(),
-            m.enumLookup({
+            m.enumLookup<"hvacUserInterfaceCfg", true>({
                 name: "display_orientation",
                 cluster: "hvacUserInterfaceCfg",
                 attribute: "displayOrientation",
@@ -1420,7 +1420,7 @@ export const definitions: DefinitionWithExtend[] = [
                 lookup: {normal: 0x00, flipped: 0x01},
                 zigbeeCommandOptions: manufacturerOptions,
             }),
-            m.enumLookup({
+            m.enumLookup<"hvacUserInterfaceCfg", true>({
                 name: "displayed_temperature",
                 cluster: "hvacUserInterfaceCfg",
                 attribute: "displayedTemperature",
@@ -1428,7 +1428,7 @@ export const definitions: DefinitionWithExtend[] = [
                 lookup: {target: 0x00, measured: 0x01},
                 zigbeeCommandOptions: manufacturerOptions,
             }),
-            m.enumLookup({
+            m.enumLookup<"hvacThermostat", true>({
                 name: "valve_adapt_status",
                 cluster: "hvacThermostat",
                 attribute: "valveAdaptStatus",

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -583,7 +583,7 @@ const boschExtend = {
         };
     },
     broadcastAlarm: (): ModernExtend => {
-        const sirenState: KeyValue = {
+        const sirenState = {
             smoke_off: 0x0000,
             smoke_on: 0x3c00,
             burglar_off: 0x0001,
@@ -602,10 +602,10 @@ const boschExtend = {
                     if (key === "broadcast_alarm") {
                         const index = utils.getFromLookup(value, sirenState);
                         utils.assertEndpoint(entity);
-                        await entity.zclCommandBroadcast(
+                        await entity.zclCommandBroadcast<"ssIasZone", "boschSmokeAlarmSiren", BoschSmokeAlarmSiren>(
                             255,
                             ZSpec.BroadcastAddress.SLEEPY,
-                            Zcl.Clusters.ssIasZone.ID,
+                            "ssIasZone",
                             "boschSmokeAlarmSiren",
                             {data: index},
                             manufacturerOptions,

--- a/src/devices/centralite.ts
+++ b/src/devices/centralite.ts
@@ -333,7 +333,7 @@ export const definitions: DefinitionWithExtend[] = [
 
             const payload = [
                 {
-                    attribute: "measuredValue",
+                    attribute: "measuredValue" as const,
                     minimumReportInterval: 10,
                     maximumReportInterval: constants.repInterval.HOUR,
                     reportableChange: 10,

--- a/src/devices/ctm.ts
+++ b/src/devices/ctm.ts
@@ -419,7 +419,7 @@ const tzLocal = {
         key: ["device_enabled"],
         convertSet: async (entity, key, value, meta) => {
             utils.assertString(value, "device_enabled");
-            await entity.command("genOnOff", value.toLowerCase(), {}, utils.getOptions(meta.mapped, entity));
+            await entity.command("genOnOff", value.toLowerCase() as "off" | "on", {}, utils.getOptions(meta.mapped, entity));
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("genOnOff", ["onOff"]);
@@ -428,7 +428,7 @@ const tzLocal = {
     ctm_mbd_brightness: {
         key: ["brightness"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.command("genLevelCtrl", "moveToLevel", {level: value, transtime: 1}, utils.getOptions(meta.mapped, entity));
+            await entity.command("genLevelCtrl", "moveToLevel", {level: value as number, transtime: 1}, utils.getOptions(meta.mapped, entity));
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("genLevelCtrl", ["currentLevel"]);

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -578,10 +578,9 @@ export const definitions: DefinitionWithExtend[] = [
                 const controlEp = device.getEndpoint(1);
                 if (controlEp != null) {
                     try {
-                        let deviceConfig = await controlEp.read("genBasic", [32768]);
+                        const deviceConfig = await controlEp.read("genBasic", [32768]);
                         if (deviceConfig) {
-                            deviceConfig = deviceConfig["32768"];
-                            ptvoSetMetaOption(device, "device_config", deviceConfig);
+                            ptvoSetMetaOption(device, "device_config", deviceConfig[32768]);
                             device.save();
                         }
                     } catch {

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -283,7 +283,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(8);
-            const payload = [{attribute: "zclVersion", minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];
+            const payload = [{attribute: "zclVersion" as const, minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBasic"]);
             await endpoint.configureReporting("genBasic", payload);
         },

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -893,6 +892,7 @@ export const definitions: DefinitionWithExtend[] = [
                         "danfossRoomFloorSensorMode",
                         "danfossFloorMinSetpoint",
                         "danfossFloorMaxSetpoint",
+                        // TODO: ???
                         "schedule_type_used",
                         "icon2_pre_heat",
                         "icon2_pre_heat_status",
@@ -935,7 +935,7 @@ export const definitions: DefinitionWithExtend[] = [
                     "haDiagnostic",
                     [
                         "danfossSystemStatusCode",
-                        "danfossHeatsupplyRequest",
+                        "danfossHeatSupplyRequest",
                         "danfossSystemStatusWater",
                         "danfossMultimasterRole",
                         "danfossIconApplication",

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -886,19 +886,7 @@ export const definitions: DefinitionWithExtend[] = [
                     "maxHeatSetpointLimit",
                     "systemMode",
                 ]);
-                await endpoint.read(
-                    "hvacThermostat",
-                    [
-                        "danfossRoomFloorSensorMode",
-                        "danfossFloorMinSetpoint",
-                        "danfossFloorMaxSetpoint",
-                        // TODO: ???
-                        "schedule_type_used",
-                        "icon2_pre_heat",
-                        "icon2_pre_heat_status",
-                    ],
-                    options,
-                );
+                await endpoint.read("hvacThermostat", ["danfossRoomFloorSensorMode", "danfossFloorMinSetpoint", "danfossFloorMaxSetpoint"], options);
                 await endpoint.read("hvacUserInterfaceCfg", ["keypadLockout"]);
                 await endpoint.read("msTemperatureMeasurement", ["measuredValue"]);
                 await endpoint.read("msRelativeHumidity", ["measuredValue"]);

--- a/src/devices/dawon_dns.ts
+++ b/src/devices/dawon_dns.ts
@@ -226,7 +226,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["ssIasZone"]);
             const payload = [
                 {
-                    attribute: "zoneState",
+                    attribute: "zoneState" as const,
                     minimumReportInterval: 0,
                     maximumReportInterval: 3600,
                     reportableChange: 0,

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -1,9 +1,8 @@
 import {Zcl} from "zigbee-herdsman";
-import type {ClusterOrRawAttributeKeys, PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
-import {develcoModernExtend} from "../lib/develco";
+import {type DevelcoGenBasic, develcoModernExtend} from "../lib/develco";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
@@ -194,16 +193,12 @@ const develco = {
         led_control: {
             key: ["led_control"],
             convertSet: async (entity, key, value, meta) => {
-                const ledControl = utils.getKey(develcoLedControlMap, value, value, Number);
-                await entity.write(
-                    "genBasic",
-                    {develcoLedControl: ledControl} as PartialClusterOrRawWriteAttributes<"genBasic">,
-                    manufacturerOptions,
-                );
+                const ledControl = utils.getKey(develcoLedControlMap, value, value as number, Number);
+                await entity.write<"genBasic", DevelcoGenBasic>("genBasic", {develcoLedControl: ledControl}, manufacturerOptions);
                 return {state: {led_control: value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("genBasic", ["develcoLedControl"] as unknown as ClusterOrRawAttributeKeys<"genBasic">, manufacturerOptions);
+                await entity.read<"genBasic", DevelcoGenBasic>("genBasic", ["develcoLedControl"], manufacturerOptions);
             },
         } satisfies Tz.Converter,
         ias_occupancy_timeout: {
@@ -664,7 +659,7 @@ export const definitions: DefinitionWithExtend[] = [
                 await endpoint35.read("ssIasZone", ["develcoAlarmOffDelay"], manufacturerOptions);
             }
             if (Number(device?.softwareBuildID?.split(".")[0]) >= 4) {
-                await endpoint35.read("genBasic", ["develcoLedControl"] as unknown as ClusterOrRawAttributeKeys<"genBasic">, manufacturerOptions);
+                await endpoint35.read<"genBasic", DevelcoGenBasic>("genBasic", ["develcoLedControl"], manufacturerOptions);
             }
         },
     },
@@ -720,7 +715,7 @@ export const definitions: DefinitionWithExtend[] = [
             if (device?.softwareBuildID && Number(device.softwareBuildID.split(".")[0]) >= 2) {
                 const endpoint35 = device.getEndpoint(35);
                 await endpoint35.read("ssIasZone", ["develcoAlarmOffDelay"], manufacturerOptions);
-                await endpoint35.read("genBasic", ["develcoLedControl"] as unknown as ClusterOrRawAttributeKeys<"genBasic">, manufacturerOptions);
+                await endpoint35.read<"genBasic", DevelcoGenBasic>("genBasic", ["develcoLedControl"], manufacturerOptions);
             }
         },
     },

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -166,7 +166,7 @@ const develco = {
         pulse_configuration: {
             key: ["pulse_configuration"],
             convertSet: async (entity, key, value, meta) => {
-                await entity.write("seMetering", {develcoPulseConfiguration: value}, manufacturerOptions);
+                await entity.write("seMetering", {develcoPulseConfiguration: value as number}, manufacturerOptions);
                 return {state: {pulse_configuration: value}};
             },
             convertGet: async (entity, key, meta) => {
@@ -187,7 +187,7 @@ const develco = {
         current_summation: {
             key: ["current_summation"],
             convertSet: async (entity, key, value, meta) => {
-                await entity.write("seMetering", {develcoCurrentSummation: value}, manufacturerOptions);
+                await entity.write("seMetering", {develcoCurrentSummation: value as number}, manufacturerOptions);
                 return {state: {current_summation: value}};
             },
         } satisfies Tz.Converter,

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {ClusterOrRawAttributeKeys, PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -195,11 +195,15 @@ const develco = {
             key: ["led_control"],
             convertSet: async (entity, key, value, meta) => {
                 const ledControl = utils.getKey(develcoLedControlMap, value, value, Number);
-                await entity.write("genBasic", {develcoLedControl: ledControl}, manufacturerOptions);
+                await entity.write(
+                    "genBasic",
+                    {develcoLedControl: ledControl} as PartialClusterOrRawWriteAttributes<"genBasic">,
+                    manufacturerOptions,
+                );
                 return {state: {led_control: value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("genBasic", ["develcoLedControl"], manufacturerOptions);
+                await entity.read("genBasic", ["develcoLedControl"] as unknown as ClusterOrRawAttributeKeys<"genBasic">, manufacturerOptions);
             },
         } satisfies Tz.Converter,
         ias_occupancy_timeout: {
@@ -660,7 +664,7 @@ export const definitions: DefinitionWithExtend[] = [
                 await endpoint35.read("ssIasZone", ["develcoAlarmOffDelay"], manufacturerOptions);
             }
             if (Number(device?.softwareBuildID?.split(".")[0]) >= 4) {
-                await endpoint35.read("genBasic", ["develcoLedControl"], manufacturerOptions);
+                await endpoint35.read("genBasic", ["develcoLedControl"] as unknown as ClusterOrRawAttributeKeys<"genBasic">, manufacturerOptions);
             }
         },
     },
@@ -716,7 +720,7 @@ export const definitions: DefinitionWithExtend[] = [
             if (device?.softwareBuildID && Number(device.softwareBuildID.split(".")[0]) >= 2) {
                 const endpoint35 = device.getEndpoint(35);
                 await endpoint35.read("ssIasZone", ["develcoAlarmOffDelay"], manufacturerOptions);
-                await endpoint35.read("genBasic", ["develcoLedControl"], manufacturerOptions);
+                await endpoint35.read("genBasic", ["develcoLedControl"] as unknown as ClusterOrRawAttributeKeys<"genBasic">, manufacturerOptions);
             }
         },
     },

--- a/src/devices/diyruz.ts
+++ b/src/devices/diyruz.ts
@@ -99,13 +99,13 @@ export const definitions: DefinitionWithExtend[] = [
                 // Legacy PM2 firmwares
                 const payload = [
                     {
-                        attribute: "batteryPercentageRemaining",
+                        attribute: "batteryPercentageRemaining" as const,
                         minimumReportInterval: 0,
                         maximumReportInterval: 3600,
                         reportableChange: 0,
                     },
                     {
-                        attribute: "batteryVoltage",
+                        attribute: "batteryVoltage" as const,
                         minimumReportInterval: 0,
                         maximumReportInterval: 3600,
                         reportableChange: 0,
@@ -169,13 +169,13 @@ export const definitions: DefinitionWithExtend[] = [
                 // Legacy PM2 firmwares
                 const payload = [
                     {
-                        attribute: "batteryPercentageRemaining",
+                        attribute: "batteryPercentageRemaining" as const,
                         minimumReportInterval: 0,
                         maximumReportInterval: 3600,
                         reportableChange: 0,
                     },
                     {
-                        attribute: "batteryVoltage",
+                        attribute: "batteryVoltage" as const,
                         minimumReportInterval: 0,
                         maximumReportInterval: 3600,
                         reportableChange: 0,
@@ -312,7 +312,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tz.diyruz_airsense_config],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            const clusters = ["msTemperatureMeasurement", "msRelativeHumidity", "msPressureMeasurement", "msCO2"];
+            const clusters = ["msTemperatureMeasurement", "msRelativeHumidity", "msPressureMeasurement", "msCO2"] as const;
             await reporting.bind(endpoint, coordinatorEndpoint, clusters);
             for (const cluster of clusters) {
                 await endpoint.configureReporting(cluster, [
@@ -346,8 +346,8 @@ export const definitions: DefinitionWithExtend[] = [
             const firstEndpoint = device.getEndpoint(1);
             await reporting.bind(firstEndpoint, coordinatorEndpoint, ["closuresDoorLock", "genPowerCfg"]);
             const payload1 = [
-                {attribute: "batteryPercentageRemaining", minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},
-                {attribute: "batteryVoltage", minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},
+                {attribute: "batteryPercentageRemaining" as const, minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},
+                {attribute: "batteryVoltage" as const, minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},
             ];
             await firstEndpoint.configureReporting("genPowerCfg", payload1);
             const payload2 = [{attribute: {ID: 0x0050, type: 0x30}, minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];

--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-
 import * as fz from "../converters/fromZigbee";
 import {modernExtend as ewelinkModernExtend} from "../lib/ewelink";
 import * as exposes from "../lib/exposes";
@@ -8,6 +7,7 @@ import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend, Fz} from "../lib/types";
+import type {SonoffEwelink} from "./sonoff";
 
 const e = exposes.presets;
 
@@ -203,13 +203,9 @@ export const definitions: DefinitionWithExtend[] = [
         onEvent: async (event) => {
             if (event.type === "deviceInterview") {
                 const endpoint = event.data.device.getEndpoint(1);
-                const payloadValue = [];
-                payloadValue[0] = 0x02;
-                payloadValue[1] = 0x0e;
-                payloadValue[2] = 0x00;
                 // Query the maximum level supported for speed adjustment.
-                await endpoint.command("customClusterEwelink", "protocolData", {
-                    data: payloadValue,
+                await endpoint.command<"customClusterEwelink", "protocolData", SonoffEwelink>("customClusterEwelink", "protocolData", {
+                    data: [0x02, 0x0e, 0x00],
                 });
             }
         },

--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -197,7 +197,7 @@ export const definitions: DefinitionWithExtend[] = [
             ewelinkModernExtend.ewelinkMotorSpeed("customClusterEwelink", "protocolData", 0x00, 0x0e),
         ],
         configure: async (device, coordinatorEndpoint) => {
-            const windowCoveringAttributes = [{attribute: "currentPositionLiftPercentage", min: 0, max: 3600, change: 10}];
+            const windowCoveringAttributes = [{attribute: "currentPositionLiftPercentage" as const, min: 0, max: 3600, change: 10}];
             await m.setupAttributes(device, coordinatorEndpoint, "closuresWindowCovering", windowCoveringAttributes);
         },
         onEvent: async (event) => {
@@ -249,7 +249,7 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["customClusterEwelink"]);
 
-            const windowCoveringAttributes = [{attribute: "currentPositionLiftPercentage", min: 0, max: 3600, change: 10}];
+            const windowCoveringAttributes = [{attribute: "currentPositionLiftPercentage" as const, min: 0, max: 3600, change: 10}];
             await m.setupAttributes(device, coordinatorEndpoint, "closuresWindowCovering", windowCoveringAttributes);
         },
         ota: true,
@@ -288,7 +288,7 @@ export const definitions: DefinitionWithExtend[] = [
             ewelinkModernExtend.ewelinkMotorClbByPosition("customClusterEwelink", "protocolData"),
         ],
         configure: async (device, coordinatorEndpoint) => {
-            const windowCoveringAttributes = [{attribute: "currentPositionLiftPercentage", min: 0, max: 3600, change: 10}];
+            const windowCoveringAttributes = [{attribute: "currentPositionLiftPercentage" as const, min: 0, max: 3600, change: 10}];
             await m.setupAttributes(device, coordinatorEndpoint, "closuresWindowCovering", windowCoveringAttributes);
         },
         ota: true,

--- a/src/devices/gmmts.ts
+++ b/src/devices/gmmts.ts
@@ -1,6 +1,7 @@
 import {Buffer} from "node:buffer";
 import type {Models as ZHModels} from "zigbee-herdsman";
 import {Zcl} from "zigbee-herdsman";
+import type {PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import {repInterval} from "../lib/constants";
 import * as exposes from "../lib/exposes";
@@ -1912,7 +1913,9 @@ function genereateTzLocal() {
                 if (Number(value) < 0 || Number(value) > 65535) {
                     throw new Error("Value must be between 0 and 65535");
                 }
-                await entity.write(item.clust, {[item.attr]: value}, {manufacturerCode: null});
+                await entity.write(item.clust, {[item.attr]: value} as PartialClusterOrRawWriteAttributes<typeof item.clust>, {
+                    manufacturerCode: null,
+                });
             };
         }
         tzLocal.push(tz);

--- a/src/devices/gmmts.ts
+++ b/src/devices/gmmts.ts
@@ -1,7 +1,6 @@
 import {Buffer} from "node:buffer";
 import type {Models as ZHModels} from "zigbee-herdsman";
 import {Zcl} from "zigbee-herdsman";
-import type {PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import {repInterval} from "../lib/constants";
 import * as exposes from "../lib/exposes";
@@ -1913,9 +1912,7 @@ function genereateTzLocal() {
                 if (Number(value) < 0 || Number(value) > 65535) {
                     throw new Error("Value must be between 0 and 65535");
                 }
-                await entity.write(item.clust, {[item.attr]: value} as PartialClusterOrRawWriteAttributes<typeof item.clust>, {
-                    manufacturerCode: null,
-                });
+                await entity.write(item.clust, {[item.attr]: value}, {manufacturerCode: null});
             };
         }
         tzLocal.push(tz);

--- a/src/devices/gmmts.ts
+++ b/src/devices/gmmts.ts
@@ -1904,7 +1904,11 @@ function genereateTzLocal() {
         const tz: Tz.Converter = {
             key: [key],
             convertGet: async (entity, key, meta) => {
-                await entity.read(item.clust, [item.attr]);
+                await entity.read(
+                    item.clust,
+                    // @ts-expect-error too dynamic to type
+                    [item.attr],
+                );
             },
         } satisfies Tz.Converter;
         if (item.type === NUM_RW) {
@@ -1912,7 +1916,12 @@ function genereateTzLocal() {
                 if (Number(value) < 0 || Number(value) > 65535) {
                     throw new Error("Value must be between 0 and 65535");
                 }
-                await entity.write(item.clust, {[item.attr]: value}, {manufacturerCode: null});
+                await entity.write(
+                    item.clust,
+                    // @ts-expect-error too dynamic to type
+                    {[item.attr]: value},
+                    {manufacturerCode: null},
+                );
             };
         }
         tzLocal.push(tz);
@@ -1971,7 +1980,11 @@ async function poll(endpoint: Zh.Endpoint, device: ZHModels.Device) {
     for (const item of splited) {
         for (const attr of item.attributes) {
             await endpoint
-                .read(item.cluster, attr)
+                .read(
+                    item.cluster,
+                    // @ts-expect-error too dynamic to type
+                    attr,
+                )
                 .catch((e) => {
                     if (e.message.includes(`Cannot read properties of undefined (reading 'manufacturerID')`)) {
                         // if we remove the device, we stop the polling
@@ -2259,7 +2272,13 @@ export const definitions: DefinitionWithExtend[] = [
             endpoint.configuredReportings.forEach(async (r) => {
                 await endpoint.configureReporting(
                     r.cluster.name,
-                    reporting.payload(r.attribute.name, r.minimumReportInterval, 65535, r.reportableChange),
+                    reporting.payload(
+                        // @ts-expect-error dynamic, expected correct since already applied
+                        r.attribute.name,
+                        r.minimumReportInterval,
+                        65535,
+                        r.reportableChange,
+                    ),
                     {manufacturerCode: null},
                 );
             });
@@ -2274,7 +2293,17 @@ export const definitions: DefinitionWithExtend[] = [
 
                 logger.debug(`Configure ${item.name} ${item.clust} ${item.attr} ${conf.min} ${conf.max} ${conf.change}`, "TICMeter");
                 reportingConfig.push(
-                    endpoint.configureReporting(item.clust, reporting.payload(item.attr, conf.min, conf.max, conf.change), {manufacturerCode: null}),
+                    endpoint.configureReporting(
+                        item.clust,
+                        reporting.payload(
+                            // @ts-expect-error too dynamic to type
+                            item.attr,
+                            conf.min,
+                            conf.max,
+                            conf.change,
+                        ),
+                        {manufacturerCode: null},
+                    ),
                 );
             }
 

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -1095,7 +1094,7 @@ export const definitions: DefinitionWithExtend[] = [
                 ),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
-            interface HeimanRadar extends TCustomCluster {
+            interface HeimanRadar {
                 attributes: {
                     // biome-ignore lint/style/useNamingConvention: TODO
                     enable_indicator: number;
@@ -1112,7 +1111,7 @@ export const definitions: DefinitionWithExtend[] = [
                     sub_region_isolation_table: Buffer;
                 };
                 commands: never;
-                commandResponse: never;
+                commandResponses: never;
             }
 
             const endpoint = device.getEndpoint(1);

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -754,27 +754,45 @@ export const definitions: DefinitionWithExtend[] = [
             const heiman = {
                 configureReporting: {
                     pm25MeasuredValue: async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-                        const payload = reporting.payload("measuredValue", 0, constants.repInterval.HOUR, 1, overrides);
+                        const payload = reporting.payload<"pm25Measurement">("measuredValue", 0, constants.repInterval.HOUR, 1, overrides);
                         await endpoint.configureReporting("pm25Measurement", payload);
                     },
                     formAldehydeMeasuredValue: async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-                        const payload = reporting.payload("measuredValue", 0, constants.repInterval.HOUR, 1, overrides);
+                        const payload = reporting.payload<"msFormaldehyde">("measuredValue", 0, constants.repInterval.HOUR, 1, overrides);
                         await endpoint.configureReporting("msFormaldehyde", payload);
                     },
                     batteryState: async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-                        const payload = reporting.payload("batteryState", 0, constants.repInterval.HOUR, 1, overrides);
+                        const payload = reporting.payload<"heimanSpecificAirQuality">("batteryState", 0, constants.repInterval.HOUR, 1, overrides);
                         await endpoint.configureReporting("heimanSpecificAirQuality", payload);
                     },
                     pm10measuredValue: async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-                        const payload = reporting.payload("pm10measuredValue", 0, constants.repInterval.HOUR, 1, overrides);
+                        const payload = reporting.payload<"heimanSpecificAirQuality">(
+                            "pm10measuredValue",
+                            0,
+                            constants.repInterval.HOUR,
+                            1,
+                            overrides,
+                        );
                         await endpoint.configureReporting("heimanSpecificAirQuality", payload);
                     },
                     tvocMeasuredValue: async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-                        const payload = reporting.payload("tvocMeasuredValue", 0, constants.repInterval.HOUR, 1, overrides);
+                        const payload = reporting.payload<"heimanSpecificAirQuality">(
+                            "tvocMeasuredValue",
+                            0,
+                            constants.repInterval.HOUR,
+                            1,
+                            overrides,
+                        );
                         await endpoint.configureReporting("heimanSpecificAirQuality", payload);
                     },
                     aqiMeasuredValue: async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-                        const payload = reporting.payload("aqiMeasuredValue", 0, constants.repInterval.HOUR, 1, overrides);
+                        const payload = reporting.payload<"heimanSpecificAirQuality">(
+                            "aqiMeasuredValue",
+                            0,
+                            constants.repInterval.HOUR,
+                            1,
+                            overrides,
+                        );
                         await endpoint.configureReporting("heimanSpecificAirQuality", payload);
                     },
                 },
@@ -1077,10 +1095,34 @@ export const definitions: DefinitionWithExtend[] = [
                 ),
         ],
         configure: async (device, coordinatorEndpoint, logger) => {
+            interface HeimanRadar extends TCustomCluster {
+                attributes: {
+                    // biome-ignore lint/style/useNamingConvention: TODO
+                    enable_indicator: number;
+                    sensitivity: number;
+                    // biome-ignore lint/style/useNamingConvention: TODO
+                    enable_sub_region_isolation: number;
+                    // biome-ignore lint/style/useNamingConvention: TODO
+                    installation_method: number;
+                    // biome-ignore lint/style/useNamingConvention: TODO
+                    cell_mounted_table: Buffer;
+                    // biome-ignore lint/style/useNamingConvention: TODO
+                    wall_mounted_table: Buffer;
+                    // biome-ignore lint/style/useNamingConvention: TODO
+                    sub_region_isolation_table: Buffer;
+                };
+                commands: never;
+                commandResponse: never;
+            }
+
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["msOccupancySensing", "RadarSensorHeiman"]);
             await reporting.occupancy(endpoint);
-            await endpoint.read("RadarSensorHeiman", ["cell_mounted_table", "wall_mounted_table", "sub_region_isolation_table"]);
+            await endpoint.read<"RadarSensorHeiman", HeimanRadar>("RadarSensorHeiman", [
+                "cell_mounted_table",
+                "wall_mounted_table",
+                "sub_region_isolation_table",
+            ]);
         },
         endpoint: (device) => ({default: 1}),
     },

--- a/src/devices/imhotepcreation.ts
+++ b/src/devices/imhotepcreation.ts
@@ -181,19 +181,19 @@ export const definitions: DefinitionWithExtend[] = [
                     await reporting.thermostatOccupiedCoolingSetpoint(endpoint);
 
                     const thermostatMinHeatSetpointLimit = async (endpoint: Zh.Endpoint) => {
-                        const p = reporting.payload("minHeatSetpointLimit", 0, constants.repInterval.HOUR, 10);
+                        const p = reporting.payload<"hvacThermostat">("minHeatSetpointLimit", 0, constants.repInterval.HOUR, 10);
                         await endpoint.configureReporting("hvacThermostat", p);
                     };
                     const thermostatMaxHeatSetpointLimit = async (endpoint: Zh.Endpoint) => {
-                        const p = reporting.payload("maxHeatSetpointLimit", 0, constants.repInterval.HOUR, 10);
+                        const p = reporting.payload<"hvacThermostat">("maxHeatSetpointLimit", 0, constants.repInterval.HOUR, 10);
                         await endpoint.configureReporting("hvacThermostat", p);
                     };
                     const thermostatMinCoolSetpointLimit = async (endpoint: Zh.Endpoint) => {
-                        const p = reporting.payload("minCoolSetpointLimit", 0, constants.repInterval.HOUR, 10);
+                        const p = reporting.payload<"hvacThermostat">("minCoolSetpointLimit", 0, constants.repInterval.HOUR, 10);
                         await endpoint.configureReporting("hvacThermostat", p);
                     };
                     const thermostatMaxCoolSetpointLimit = async (endpoint: Zh.Endpoint) => {
-                        const p = reporting.payload("maxCoolSetpointLimit", 0, constants.repInterval.HOUR, 10);
+                        const p = reporting.payload<"hvacThermostat">("maxCoolSetpointLimit", 0, constants.repInterval.HOUR, 10);
                         await endpoint.configureReporting("hvacThermostat", p);
                     };
                     await thermostatMinHeatSetpointLimit(endpoint);

--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -16,7 +16,7 @@ const tzLocal = {
     ts0219_duration: {
         key: ["duration"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write("ssIasWd", {maxDuration: value});
+            await entity.write("ssIasWd", {maxDuration: value as number});
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("ssIasWd", ["maxDuration"]);

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -11,6 +11,154 @@ import * as utils from "../lib/utils";
 const e = exposes.presets;
 const ea = exposes.access;
 
+interface Inovelli {
+    attributes: {
+        dimmingSpeedUpRemote: number;
+        dimmingSpeedUpLocal: number;
+        rampRateOffToOnRemote: number;
+        rampRateOffToOnLocal: number;
+        dimmingSpeedDownRemote: number;
+        dimmingSpeedDownLocal: number;
+        rampRateOnToOffRemote: number;
+        rampRateOnToOffLocal: number;
+        minimumLevel: number;
+        maximumLevel: number;
+        invertSwitch: number;
+        autoTimerOff: number;
+        defaultLevelLocal: number;
+        defaultLevelRemote: number;
+        stateAfterPowerRestored: number;
+        loadLevelIndicatorTimeout: number;
+        activePowerReports: number;
+        periodicPowerAndEnergyReports: number;
+        activeEnergyReports: number;
+        powerType: number;
+        switchType: number;
+        quickStartTime: number;
+        quickStartLevel: number;
+        higherOutputInNonNeutral: number;
+        dimmingMode: number;
+        nonNeutralAuxMediumGear: number;
+        nonNeutralAuxLowGear: number;
+        internalTemperature: number;
+        overheat: number;
+        otaImageType: number;
+        buttonDelay: number;
+        deviceBindNumber: number;
+        smartBulbMode: number;
+        doubleTapUpToParam55: number;
+        doubleTapDownToParam56: number;
+        brightnessLevelForDoubleTapUp: number;
+        brightnessLevelForDoubleTapDown: number;
+        defaultLed1ColorWhenOn: number;
+        defaultLed1ColorWhenOff: number;
+        defaultLed1IntensityWhenOn: number;
+        defaultLed1IntensityWhenOff: number;
+        defaultLed2ColorWhenOn: number;
+        defaultLed2ColorWhenOff: number;
+        defaultLed2IntensityWhenOn: number;
+        defaultLed2IntensityWhenOff: number;
+        defaultLed3ColorWhenOn: number;
+        defaultLed3ColorWhenOff: number;
+        defaultLed3IntensityWhenOn: number;
+        defaultLed3IntensityWhenOff: number;
+        defaultLed4ColorWhenOn: number;
+        defaultLed4ColorWhenOff: number;
+        defaultLed4IntensityWhenOn: number;
+        defaultLed4IntensityWhenOff: number;
+        defaultLed5ColorWhenOn: number;
+        defaultLed5ColorWhenOff: number;
+        defaultLed5IntensityWhenOn: number;
+        defaultLed5IntensityWhenOff: number;
+        defaultLed6ColorWhenOn: number;
+        defaultLed6ColorWhenOff: number;
+        defaultLed6IntensityWhenOn: number;
+        defaultLed6IntensityWhenOff: number;
+        defaultLed7ColorWhenOn: number;
+        defaultLed7ColorWhenOff: number;
+        defaultLed7IntensityWhenOn: number;
+        defaultLed7IntensityWhenOff: number;
+        ledColorWhenOn: number;
+        ledColorWhenOff: number;
+        ledIntensityWhenOn: number;
+        ledIntensityWhenOff: number;
+        ledBarScaling: number;
+        mmwaveControlWiredDevice: number;
+        mmWaveRoomSizePreset: number;
+        singleTapBehavior: number;
+        fanTimerMode: number;
+        auxSwitchUniqueScenes: number;
+        bindingOffToOnSyncLevel: number;
+        breezeMode: number;
+        fanControlMode: number;
+        lowLevelForFanControlMode: number;
+        mediumLevelForFanControlMode: number;
+        highLevelForFanControlMode: number;
+        ledColorForFanControlMode: number;
+        localProtection: number;
+        remoteProtection: number;
+        outputMode: number;
+        onOffLedMode: number;
+        firmwareUpdateInProgressIndicator: number;
+        relayClick: number;
+        doubleTapClearNotifications: number;
+        fanLedLevelType: number;
+    };
+    commands: {
+        ledEffect: {
+            effect: number;
+            color: number;
+            level: number;
+            duration: number;
+        };
+        individualLedEffect: {
+            led: number;
+            effect: number;
+            color: number;
+            level: number;
+            duration: number;
+        };
+        ledEffectComplete: {
+            notificationType: number;
+        };
+    };
+    commandResponses: never;
+}
+
+interface InovelliMmWave {
+    attributes: {
+        mmWaveHoldTime: number;
+        mmWaveDetectSensitivity: number;
+        mmWaveDetectTrigger: number;
+        mmWaveTargetInfoReport: number;
+        mmWaveStayLife: number;
+        mmWaveVersion: number;
+        mmWaveHeightMin: number;
+        mmWaveHeightMax: number;
+        mmWaveWidthMin: number;
+        mmWaveWidthMax: number;
+        mmWaveDepthMin: number;
+        mmWaveDepthMax: number;
+    };
+    commands: {
+        mmWaveControl: {
+            controlID: number;
+        };
+    };
+    commandResponses: {
+        anyoneInReportingArea: {
+            /** boolean */
+            area1: number;
+            /** boolean */
+            area2: number;
+            /** boolean */
+            area3: number;
+            /** boolean */
+            area4: number;
+        };
+    };
+}
+
 const clickLookup: {[key: number]: string} = {
     0: "single",
     1: "release",
@@ -1613,7 +1761,7 @@ const tzLocal = {
     inovelli_led_effect: {
         key: ["led_effect"],
         convertSet: async (entity, key, values, meta) => {
-            await entity.command(
+            await entity.command<typeof INOVELLI_CLUSTER_NAME, "ledEffect", Inovelli>(
                 INOVELLI_CLUSTER_NAME,
                 "ledEffect",
                 {
@@ -1634,19 +1782,16 @@ const tzLocal = {
     inovelli_individual_led_effect: {
         key: ["individual_led_effect"],
         convertSet: async (entity, key, values, meta) => {
-            await entity.command(
+            utils.assertObject(values);
+
+            await entity.command<typeof INOVELLI_CLUSTER_NAME, "individualLedEffect", Inovelli>(
                 INOVELLI_CLUSTER_NAME,
                 "individualLedEffect",
                 {
-                    // @ts-expect-error ignore
                     led: Math.min(Math.max(1, Number.parseInt(values.led)), 7) - 1,
-                    // @ts-expect-error ignore
                     effect: individualLedEffects[values.effect],
-                    // @ts-expect-error ignore
                     color: Math.min(Math.max(0, values.color), 255),
-                    // @ts-expect-error ignore
                     level: Math.min(Math.max(0, values.level), 100),
-                    // @ts-expect-error ignore
                     duration: Math.min(Math.max(0, values.duration), 255),
                 },
                 {disableResponse: true, disableDefaultResponse: true},
@@ -1657,11 +1802,12 @@ const tzLocal = {
     inovelli_mmwave_control_commands: {
         key: ["mmwave_control_commands"],
         convertSet: async (entity, key, values, meta) => {
-            await entity.command(
+            utils.assertObject(values);
+
+            await entity.command<typeof INOVELLI_MMWAVE_CLUSTER_NAME, "mmWaveControl", InovelliMmWave>(
                 INOVELLI_MMWAVE_CLUSTER_NAME,
                 "mmWaveControl",
                 {
-                    // @ts-expect-error ignore
                     controlID: mmWaveControlCommands[values.controlID],
                 },
                 {disableResponse: true, disableDefaultResponse: true},
@@ -1740,7 +1886,7 @@ const tzLocal = {
             const state = meta.message.fan_state != null ? meta.message.fan_state.toString().toLowerCase() : null;
             utils.validateValue(state, ["toggle", "off", "on"]);
 
-            await entity.command("genOnOff", state, {}, utils.getOptions(meta.mapped, entity));
+            await entity.command("genOnOff", state as "toggle" | "off" | "on", {}, utils.getOptions(meta.mapped, entity));
             if (state === "toggle") {
                 const currentState = meta.state[`state${meta.endpoint_name ? `_${meta.endpoint_name}` : ""}`];
                 return currentState ? {state: {fan_state: currentState === "OFF" ? "ON" : "OFF"}} : {};
@@ -1780,7 +1926,7 @@ const tzLocal = {
                 const payload = {ctrlbits: 0, ontime: Math.round(onTime * 10), offwaittime: Math.round(offWaitTime * 10)};
                 await endpoint.command("genOnOff", "onWithTimedOff", payload, utils.getOptions(meta.mapped, entity));
             } else {
-                await endpoint.command("genOnOff", state, {}, utils.getOptions(meta.mapped, endpoint));
+                await endpoint.command("genOnOff", state as "toggle" | "off" | "on", {}, utils.getOptions(meta.mapped, endpoint));
                 if (state === "toggle") {
                     const currentState = meta.state[`state${meta.endpoint_name ? `_${meta.endpoint_name}` : ""}`];
                     return currentState ? {state: {fan_state: currentState === "OFF" ? "ON" : "OFF"}} : {};

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -73,8 +73,8 @@ const mmWaveControlCommands: {[key: string]: number} = {
     reset_mmwave_module: 0,
 };
 
-const INOVELLI_CLUSTER_NAME: string = "manuSpecificInovelli";
-const INOVELLI_MMWAVE_CLUSTER_NAME: string = "manuSpecificInovelliMMWave";
+const INOVELLI_CLUSTER_NAME = "manuSpecificInovelli" as const;
+const INOVELLI_MMWAVE_CLUSTER_NAME = "manuSpecificInovelliMMWave" as const;
 
 const inovelliExtend = {
     addCustomClusterInovelli: () =>
@@ -1540,7 +1540,7 @@ const VZM36_ATTRIBUTES: {[s: string]: Attribute} = {
 };
 
 const tzLocal = {
-    inovelli_parameters: (attributes: {[s: string]: Attribute}, cluster: string) =>
+    inovelli_parameters: (attributes: {[s: string]: Attribute}, cluster: typeof INOVELLI_CLUSTER_NAME | typeof INOVELLI_MMWAVE_CLUSTER_NAME) =>
         ({
             key: Object.keys(attributes).filter((a) => !attributes[a].readOnly),
             convertSet: async (entity, key, value, meta) => {
@@ -1585,7 +1585,8 @@ const tzLocal = {
                     entityToUse = meta.device.getEndpoint(Number(keysplit[1]));
                     keyToUse = keysplit[0];
                 }
-                await entityToUse.read(cluster, [keyToUse], {
+                // XXX: far too dynamic to properly type
+                await entityToUse.read(cluster, [keyToUse] as Parameters<typeof entityToUse.read>[1], {
                     manufacturerCode: INOVELLI,
                 });
             },
@@ -1603,7 +1604,8 @@ const tzLocal = {
                     entityToUse = meta.device.getEndpoint(Number(keysplit[1]));
                     keyToUse = keysplit[0];
                 }
-                await entityToUse.read(cluster, [keyToUse], {
+                // XXX: far too dynamic to properly type
+                await entityToUse.read(cluster, [keyToUse] as Parameters<typeof entityToUse.read>[1], {
                     manufacturerCode: INOVELLI,
                 });
             },
@@ -2160,7 +2162,8 @@ exposesListVZM35.push(e.action(buttonTapSequences));
 const chunkedRead = async (endpoint: Zh.Endpoint, attributes: string[], cluster: string) => {
     const chunkSize = 10;
     for (let i = 0; i < attributes.length; i += chunkSize) {
-        await endpoint.read(cluster, attributes.slice(i, i + chunkSize));
+        // XXX: far too dynamic to properly type
+        await endpoint.read(cluster, attributes.slice(i, i + chunkSize) as Parameters<typeof endpoint.read>[1]);
     }
 };
 

--- a/src/devices/keen_home.ts
+++ b/src/devices/keen_home.ts
@@ -95,7 +95,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            const payload = [{attribute: "modelId", minimumReportInterval: 3600, maximumReportInterval: 14400, reportableChange: 1}];
+            const payload = [{attribute: "modelId" as const, minimumReportInterval: 3600, maximumReportInterval: 14400, reportableChange: 1}];
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBasic"]);
             await endpoint.configureReporting("genBasic", payload);
             device.powerSource = "Mains (single phase)";
@@ -111,7 +111,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            const payload = [{attribute: "modelId", minimumReportInterval: 3600, maximumReportInterval: 14400, reportableChange: 1}];
+            const payload = [{attribute: "modelId" as const, minimumReportInterval: 3600, maximumReportInterval: 14400, reportableChange: 1}];
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBasic"]);
             await endpoint.configureReporting("genBasic", payload);
             device.powerSource = "Mains (single phase)";

--- a/src/devices/kmpcil.ts
+++ b/src/devices/kmpcil.ts
@@ -103,7 +103,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.humidity(endpoint);
             const payloadBattery = [
                 {
-                    attribute: "batteryPercentageRemaining",
+                    attribute: "batteryPercentageRemaining" as const,
                     minimumReportInterval: 1,
                     maximumReportInterval: 120,
                     reportableChange: 1,
@@ -126,7 +126,7 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.write("genBinaryInput", {257: {value: 25, type: 0x23}}, options);
             const payloadBinaryInput = [
                 {
-                    attribute: "presentValue",
+                    attribute: "presentValue" as const,
                     minimumReportInterval: 0,
                     maximumReportInterval: 30,
                     reportableChange: 1,
@@ -136,7 +136,7 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.write("genBinaryOutput", {81: {value: 0x01, type: 0x10}}, options);
             const payloadBinaryOutput = [
                 {
-                    attribute: "presentValue",
+                    attribute: "presentValue" as const,
                     minimumReportInterval: 0,
                     maximumReportInterval: 30,
                     reportableChange: 1,
@@ -174,11 +174,11 @@ export const definitions: DefinitionWithExtend[] = [
             }
 
             await utils.sleep(1000);
-            const p = reporting.payload("batteryVoltage", 0, 10, 1);
+            const p = reporting.payload<"genPowerCfg">("batteryVoltage", 0, 10, 1);
             await endpoint.configureReporting("genPowerCfg", p);
 
             await utils.sleep(1000);
-            const p2 = reporting.payload("presentValue", 0, 300, 1);
+            const p2 = reporting.payload<"genBinaryInput">("presentValue", 0, 300, 1);
             await endpoint.configureReporting("genBinaryInput", p2);
 
             await utils.sleep(1000);

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -158,10 +158,10 @@ export const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBinaryInput", "closuresWindowCovering", "genIdentify"]);
-            let p = reporting.payload("currentPositionLiftPercentage", 1, 120, 1);
+            let p = reporting.payload<"closuresWindowCovering">("currentPositionLiftPercentage", 1, 120, 1);
             await endpoint.configureReporting("closuresWindowCovering", p, legrandOptions);
 
-            p = reporting.payload("currentPositionTiltPercentage", 1, 120, 1);
+            p = reporting.payload<"closuresWindowCovering">("currentPositionTiltPercentage", 1, 120, 1);
             await endpoint.configureReporting("closuresWindowCovering", p, legrandOptions);
         },
     },
@@ -229,10 +229,10 @@ export const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBinaryInput", "closuresWindowCovering", "genIdentify"]);
-            let p = reporting.payload("currentPositionLiftPercentage", 1, 120, 1);
+            let p = reporting.payload<"closuresWindowCovering">("currentPositionLiftPercentage", 1, 120, 1);
             await endpoint.configureReporting("closuresWindowCovering", p, legrandOptions);
 
-            p = reporting.payload("currentPositionTiltPercentage", 1, 120, 1);
+            p = reporting.payload<"closuresWindowCovering">("currentPositionTiltPercentage", 1, 120, 1);
             await endpoint.configureReporting("closuresWindowCovering", p, legrandOptions);
         },
     },
@@ -444,6 +444,7 @@ export const definitions: DefinitionWithExtend[] = [
                     for (const c of endpoint.configuredReportings) {
                         await endpoint.configureReporting(c.cluster.name, [
                             {
+                                // @ts-expect-error dynamic, expected correct since already applied
                                 attribute: c.attribute.name,
                                 minimumReportInterval: c.minimumReportInterval,
                                 maximumReportInterval: c.maximumReportInterval,
@@ -512,6 +513,7 @@ export const definitions: DefinitionWithExtend[] = [
                     for (const c of endpoint.configuredReportings) {
                         await endpoint.configureReporting(c.cluster.name, [
                             {
+                                // @ts-expect-error dynamic, expected correct since already applied
                                 attribute: c.attribute.name,
                                 minimumReportInterval: c.minimumReportInterval,
                                 maximumReportInterval: c.maximumReportInterval,

--- a/src/devices/livolo.ts
+++ b/src/devices/livolo.ts
@@ -1,9 +1,10 @@
+import type {RawClusterAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
-import type {DefinitionWithExtend, Fz, KeyValue, ModernExtend, Zh} from "../lib/types";
+import type {DefinitionWithExtend, Fz, ModernExtend, Zh} from "../lib/types";
 
 const NS = "zhc:livolo";
 
@@ -33,7 +34,7 @@ const mLocal = {
 
 const fzLocal = {
     // biome-ignore lint/suspicious/noExplicitAny: ignore
-    prevent_disconnect: (args: {dp: number; payload: ((data: any) => KeyValue) | KeyValue}): Fz.Converter => {
+    prevent_disconnect: (args: {dp: number; payload: ((data: any) => RawClusterAttributes) | RawClusterAttributes}): Fz.Converter => {
         return {
             // This is needed while pairing in order to let the device know that the interview went right and prevent
             // it from disconnecting from the Zigbee network.

--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1,5 +1,5 @@
 import {Buffer} from "node:buffer";
-
+import type {TPartialClusterAttributes} from "zigbee-herdsman/dist/zspec/zcl/definition/clusters-types";
 import * as fz from "../converters/fromZigbee";
 import {repInterval} from "../lib/constants";
 import * as exposes from "../lib/exposes";
@@ -43,9 +43,10 @@ const tzSeMetering: Tz.Converter = {
             await entity.read("seMetering", [key]);
             return {state: {unitOfMeasure: value}};
         }
-        await entity.write("seMetering", {
-            [key]: value,
-        });
+        const payload: TPartialClusterAttributes<"seMetering"> = {
+            [key as "divisor" | "multiplier" | "unitOfMeasure"]: value,
+        };
+        await entity.write("seMetering", payload);
 
         return {state: {[key]: value}};
     },

--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1838,7 +1838,13 @@ export const definitions: DefinitionWithExtend[] = [
                     unsuscribe.map((e) =>
                         endpoint.configureReporting(
                             e.cluster.name,
-                            reporting.payload(e.attribute.name, e.minimumReportInterval, 65535, e.reportableChange),
+                            reporting.payload(
+                                // @ts-expect-error dynamic, expected correct since already applied
+                                e.attribute.name,
+                                e.minimumReportInterval,
+                                65535,
+                                e.reportableChange,
+                            ),
                             {manufacturerCode: null},
                         ),
                     ),
@@ -1863,9 +1869,19 @@ export const definitions: DefinitionWithExtend[] = [
                     params = {...params, ...e.report};
                 }
                 configReportings.push(
-                    endpoint.configureReporting(e.cluster, reporting.payload(params.att, params.min, params.max, params.change), {
-                        manufacturerCode: null,
-                    }),
+                    endpoint.configureReporting(
+                        e.cluster,
+                        reporting.payload(
+                            // @ts-expect-error dynamic, expected correct since already applied
+                            params.att,
+                            params.min,
+                            params.max,
+                            params.change,
+                        ),
+                        {
+                            manufacturerCode: null,
+                        },
+                    ),
                 );
             }
             (await Promise.allSettled(configReportings))

--- a/src/devices/lytko.ts
+++ b/src/devices/lytko.ts
@@ -80,18 +80,19 @@ const tzLocal = {
             }
         },
         convertSet: async (entity, key, value, meta) => {
-            let payload: KeyValue = {};
             let newValue = value;
             switch (key) {
-                case "sensor_type":
+                case "sensor_type": {
                     newValue = sensorTypes.indexOf(value as string);
-                    payload = {30464: {value: newValue, type: Zcl.DataType.ENUM8}};
+                    const payload = {30464: {value: newValue, type: Zcl.DataType.ENUM8}};
                     await entity.write("hvacThermostat", payload, manufacturerOptions);
                     break;
-                case "target_temp_first":
-                    payload = {30465: {value: newValue, type: Zcl.DataType.BOOLEAN}};
+                }
+                case "target_temp_first": {
+                    const payload = {30465: {value: newValue, type: Zcl.DataType.BOOLEAN}};
                     await entity.write("hvacThermostat", payload, manufacturerOptions);
                     break;
+                }
                 case "min_setpoint_deadband":
                     await entity.write("hvacThermostat", {minSetpointDeadBand: Math.round(toNumber(value) * 10)});
                     break;
@@ -120,17 +121,18 @@ const tzLocal = {
             }
         },
         convertSet: async (entity, key, value, meta) => {
-            let payload: KeyValue = {};
             const newValue = value;
             switch (key) {
-                case "brightness":
-                    payload = {30464: {value: newValue, type: Zcl.DataType.ENUM8}};
+                case "brightness": {
+                    const payload = {30464: {value: newValue, type: Zcl.DataType.ENUM8}};
                     await entity.write("hvacUserInterfaceCfg", payload, manufacturerOptions);
                     break;
-                case "brightness_standby":
-                    payload = {30465: {value: newValue, type: Zcl.DataType.ENUM8}};
+                }
+                case "brightness_standby": {
+                    const payload = {30465: {value: newValue, type: Zcl.DataType.ENUM8}};
                     await entity.write("hvacUserInterfaceCfg", payload, manufacturerOptions);
                     break;
+                }
                 default:
                     break;
             }

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1374,10 +1374,9 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior2: true,
                 switchMode: true,
             }),
-            m.actionEnumLookup({
+            m.actionEnumLookup<"genOnOff", undefined, "tuyaAction">({
                 cluster: "genOnOff",
                 commands: ["commandTuyaAction"],
-                // TODO: using command payload not attribute
                 attribute: "value",
                 actionLookup: {button: 0},
                 buttonLookup: {

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1377,6 +1377,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.actionEnumLookup({
                 cluster: "genOnOff",
                 commands: ["commandTuyaAction"],
+                // TODO: using command payload not attribute
                 attribute: "value",
                 actionLookup: {button: 0},
                 buttonLookup: {

--- a/src/devices/niko.ts
+++ b/src/devices/niko.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -11,7 +10,7 @@ import * as utils from "../lib/utils";
 const e = exposes.presets;
 const ea = exposes.access;
 
-interface NikoConfig extends TCustomCluster {
+interface NikoConfig {
     attributes: {
         switchOperationMode: number;
         outletLedColor: number;
@@ -23,7 +22,7 @@ interface NikoConfig extends TCustomCluster {
     commandResponses: never;
 }
 
-interface NikoState extends TCustomCluster {
+interface NikoState {
     manufacturerCode: Zcl.ManufacturerCode.NIKO_NV;
     attributes: {
         switchActionReporting: number;

--- a/src/devices/niko.ts
+++ b/src/devices/niko.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -10,6 +10,28 @@ import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
+
+interface NikoConfig extends TCustomCluster {
+    attributes: {
+        switchOperationMode: number;
+        outletLedColor: number;
+        outletChildLock: number;
+        outletLedState: number;
+        ledSyncMode: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
+interface NikoState extends TCustomCluster {
+    manufacturerCode: Zcl.ManufacturerCode.NIKO_NV;
+    attributes: {
+        switchActionReporting: number;
+        switchAction: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
 
 const local = {
     modernExtend: {
@@ -169,7 +191,9 @@ const local = {
             },
             convertGet: async (entity, key, meta) => {
                 utils.assertEndpoint(entity);
-                await utils.enforceEndpoint(entity, key, meta).read("manuSpecificNikoConfig", ["switchOperationMode"]);
+                await utils
+                    .enforceEndpoint(entity, key, meta)
+                    .read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["switchOperationMode"]);
             },
         } satisfies Tz.Converter,
         switch_action_reporting: {
@@ -188,18 +212,18 @@ const local = {
                 return {state: {action_reporting: value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificNikoState", ["switchActionReporting"]);
+                await entity.read<"manuSpecificNikoState", NikoState>("manuSpecificNikoState", ["switchActionReporting"]);
             },
         } satisfies Tz.Converter,
         switch_led_enable: {
             key: ["led_enable"],
             convertSet: async (entity, key, value, meta) => {
-                await entity.write("manuSpecificNikoConfig", {outletLedState: value ? 1 : 0});
-                await entity.read("manuSpecificNikoConfig", ["outletLedColor"]);
+                await entity.write<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", {outletLedState: value ? 1 : 0});
+                await entity.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletLedColor"]);
                 return {state: {led_enable: !!value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificNikoConfig", ["outletLedState"]);
+                await entity.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletLedState"]);
             },
         } satisfies Tz.Converter,
         switch_led_state: {
@@ -218,7 +242,7 @@ const local = {
                 return {state: {led_state: value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificNikoConfig", ["outletLedColor"]);
+                await entity.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletLedColor"]);
             },
         } satisfies Tz.Converter,
         switch_led_sync_mode: {
@@ -245,32 +269,34 @@ const local = {
                     // @ts-expect-error ignore
                     result = ledSyncMap[value];
                 }
-                await entity.write("manuSpecificNikoConfig", {ledSyncMode: result});
+                await entity.write<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", {ledSyncMode: result});
                 return {state: {led_sync_mode: value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificNikoConfig", ["ledSyncMode"]);
+                await entity.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["ledSyncMode"]);
             },
         } satisfies Tz.Converter,
         outlet_child_lock: {
             key: ["child_lock"],
             convertSet: async (entity, key, value, meta) => {
                 utils.assertString(value, key);
-                await entity.write("manuSpecificNikoConfig", {outletChildLock: value.toLowerCase() === "lock" ? 0 : 1});
+                await entity.write<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", {
+                    outletChildLock: value.toLowerCase() === "lock" ? 0 : 1,
+                });
                 return {state: {child_lock: value.toLowerCase() === "lock" ? "LOCK" : "UNLOCK"}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificNikoConfig", ["outletChildLock"]);
+                await entity.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletChildLock"]);
             },
         } satisfies Tz.Converter,
         outlet_led_enable: {
             key: ["led_enable"],
             convertSet: async (entity, key, value, meta) => {
-                await entity.write("manuSpecificNikoConfig", {outletLedState: value ? 1 : 0});
+                await entity.write<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", {outletLedState: value ? 1 : 0});
                 return {state: {led_enable: !!value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificNikoConfig", ["outletLedState"]);
+                await entity.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletLedState"]);
             },
         } satisfies Tz.Converter,
     },
@@ -302,8 +328,8 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.currentSummDelivered(endpoint, {min: 60, change: 1});
 
-            await endpoint.read("manuSpecificNikoConfig", ["outletChildLock"]);
-            await endpoint.read("manuSpecificNikoConfig", ["outletLedState"]);
+            await endpoint.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletChildLock"]);
+            await endpoint.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletLedState"]);
         },
         exposes: [
             e.switch(),
@@ -398,11 +424,15 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint);
-            await endpoint.read("manuSpecificNikoConfig", ["switchOperationMode", "outletLedState", "outletLedColor"]);
+            await endpoint.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", [
+                "switchOperationMode",
+                "outletLedState",
+                "outletLedColor",
+            ]);
             // Enable action reporting by default
-            await endpoint.write("manuSpecificNikoState", {switchActionReporting: true});
-            await endpoint.read("manuSpecificNikoState", ["switchActionReporting"]);
-            await endpoint.read("manuSpecificNikoConfig", ["ledSyncMode"]);
+            await endpoint.write<"manuSpecificNikoState", NikoState>("manuSpecificNikoState", {switchActionReporting: 1});
+            await endpoint.read<"manuSpecificNikoState", NikoState>("manuSpecificNikoState", ["switchActionReporting"]);
+            await endpoint.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["ledSyncMode"]);
         },
         exposes: [
             e.switch(),
@@ -440,13 +470,21 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(ep2, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(ep1);
             await reporting.onOff(ep2);
-            await ep1.read("manuSpecificNikoConfig", ["switchOperationMode", "outletLedState", "outletLedColor"]);
-            await ep2.read("manuSpecificNikoConfig", ["switchOperationMode", "outletLedState", "outletLedColor"]);
+            await ep1.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", [
+                "switchOperationMode",
+                "outletLedState",
+                "outletLedColor",
+            ]);
+            await ep2.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", [
+                "switchOperationMode",
+                "outletLedState",
+                "outletLedColor",
+            ]);
             // Enable action reporting by default
-            await ep1.write("manuSpecificNikoState", {switchActionReporting: true});
-            await ep1.read("manuSpecificNikoState", ["switchActionReporting"]);
-            await ep1.read("manuSpecificNikoConfig", ["ledSyncMode"]);
-            await ep2.read("manuSpecificNikoConfig", ["ledSyncMode"]);
+            await ep1.write<"manuSpecificNikoState", NikoState>("manuSpecificNikoState", {switchActionReporting: 1});
+            await ep1.read<"manuSpecificNikoState", NikoState>("manuSpecificNikoState", ["switchActionReporting"]);
+            await ep1.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["ledSyncMode"]);
+            await ep2.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["ledSyncMode"]);
         },
         exposes: [
             e.switch().withEndpoint("l1"),
@@ -493,7 +531,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
             await reporting.onOff(endpoint);
             await reporting.brightness(endpoint);
-            await endpoint.read("manuSpecificNikoConfig", ["outletLedState", "outletLedColor"]);
+            await endpoint.read<"manuSpecificNikoConfig", NikoConfig>("manuSpecificNikoConfig", ["outletLedState", "outletLedColor"]);
         },
     },
     {

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -14,7 +14,7 @@ const e = exposes.presets;
 const ea = exposes.access;
 
 const nodonModernExtend = {
-    calibrationVerticalRunTimeUp: (args?: Partial<m.NumericArgs>) =>
+    calibrationVerticalRunTimeUp: (args?: Partial<m.NumericArgs<"closuresWindowCovering">>) =>
         m.numeric({
             name: "calibration_vertical_run_time_up",
             unit: "10 ms",
@@ -30,7 +30,7 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: 0x128b},
             ...args,
         }),
-    calibrationVerticalRunTimeDowm: (args?: Partial<m.NumericArgs>) =>
+    calibrationVerticalRunTimeDowm: (args?: Partial<m.NumericArgs<"closuresWindowCovering">>) =>
         m.numeric({
             name: "calibration_vertical_run_time_down",
             unit: "10 ms",
@@ -46,7 +46,7 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: 0x128b},
             ...args,
         }),
-    calibrationRotationRunTimeUp: (args?: Partial<m.NumericArgs>) =>
+    calibrationRotationRunTimeUp: (args?: Partial<m.NumericArgs<"closuresWindowCovering">>) =>
         m.numeric({
             name: "calibration_rotation_run_time_up",
             unit: "ms",
@@ -62,7 +62,7 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: 0x128b},
             ...args,
         }),
-    calibrationRotationRunTimeDown: (args?: Partial<m.NumericArgs>) =>
+    calibrationRotationRunTimeDown: (args?: Partial<m.NumericArgs<"closuresWindowCovering">>) =>
         m.numeric({
             name: "calibration_rotation_run_time_down",
             unit: "ms",
@@ -78,7 +78,7 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: 0x128b},
             ...args,
         }),
-    dryContact: (args?: Partial<m.EnumLookupArgs>) =>
+    dryContact: (args?: Partial<m.EnumLookupArgs<"genBinaryInput">>) =>
         m.enumLookup({
             name: "dry_contact",
             lookup: {contact_closed: 0x00, contact_open: 0x01},
@@ -87,7 +87,7 @@ const nodonModernExtend = {
             description: "State of the contact, closed or open.",
             ...args,
         }),
-    impulseMode: (args?: Partial<m.NumericArgs>) => {
+    impulseMode: (args?: Partial<m.NumericArgs<"genOnOff">>) => {
         const resultName = "impulse_mode_configuration";
         const resultUnit = "ms";
         const resultValueMin = 0;
@@ -130,7 +130,7 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchTypeOnOff: (args?: Partial<m.EnumLookupArgs>) => {
+    switchTypeOnOff: (args?: Partial<m.EnumLookupArgs<"genOnOff">>) => {
         const resultName = "switch_type_on_off";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
         const resultDescription = "Select the switch type wire to the device.";
@@ -162,7 +162,7 @@ const nodonModernExtend = {
 
         return result;
     },
-    switchTypeWindowCovering: (args?: Partial<m.EnumLookupArgs>) => {
+    switchTypeWindowCovering: (args?: Partial<m.EnumLookupArgs<"closuresWindowCovering">>) => {
         const resultName = "switch_type_window_covering";
         const resultLookup = {bistable: 0x00, monostable: 0x01, auto_detect: 0x02};
         const resultDescription = "Select the switch type wire to the device.";
@@ -194,7 +194,7 @@ const nodonModernExtend = {
 
         return result;
     },
-    trvMode: (args?: Partial<m.EnumLookupArgs>) =>
+    trvMode: (args?: Partial<m.EnumLookupArgs<"hvacThermostat">>) =>
         m.enumLookup({
             name: "trv_mode",
             lookup: {auto: 0x00, valve_position_mode: 0x01, manual: 0x02},
@@ -208,7 +208,7 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.NXP_SEMICONDUCTORS},
             ...args,
         }),
-    valvePosition: (args?: Partial<m.NumericArgs>) =>
+    valvePosition: (args?: Partial<m.NumericArgs<"hvacThermostat">>) =>
         m.numeric({
             name: "valve_position",
             cluster: "hvacThermostat",

--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -104,7 +103,7 @@ const clusterManuSpecifcOrviboSwitchRewiring = () => {
     });
 };
 
-interface Orvibo2 extends TCustomCluster {
+interface Orvibo2 {
     attributes: {
         powerOnBehavior: number;
     };

--- a/src/devices/orvibo.ts
+++ b/src/devices/orvibo.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -103,6 +103,15 @@ const clusterManuSpecifcOrviboSwitchRewiring = () => {
         commandsResponse: {},
     });
 };
+
+interface Orvibo2 extends TCustomCluster {
+    attributes: {
+        powerOnBehavior: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 const clusterManuSpecificOrviboPowerOnBehavior = () => {
     return m.deviceAddCustomCluster("manuSpecificOrvibo2", {
         ID: 0xff00,
@@ -274,12 +283,12 @@ const orviboSwitchPowerOnBehavior = (): ModernExtend => {
             key: ["power_on_behavior"],
             convertSet: async (entity, key, value, meta) => {
                 if (key === "power_on_behavior") {
-                    await entity.write("manuSpecificOrvibo2", {powerOnBehavior: powerOnLookup2[value as string]});
+                    await entity.write<"manuSpecificOrvibo2", Orvibo2>("manuSpecificOrvibo2", {powerOnBehavior: powerOnLookup2[value as string]});
                 }
             },
             convertGet: async (entity, key, meta) => {
                 if (key === "power_on_behavior") {
-                    await entity.read("manuSpecificOrvibo2", ["powerOnBehavior"]);
+                    await entity.read<"manuSpecificOrvibo2", Orvibo2>("manuSpecificOrvibo2", ["powerOnBehavior"]);
                 }
             },
         },

--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -10,7 +9,7 @@ import type {DefinitionWithExtend, Fz, KeyValue, Tz} from "../lib/types";
 const e = exposes.presets;
 const ea = exposes.access;
 
-interface OwonFallDetection extends TCustomCluster {
+interface OwonFallDetection {
     attributes: {
         status: number;
         // biome-ignore lint/style/useNamingConvention: TODO

--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -9,6 +9,29 @@ import type {DefinitionWithExtend, Fz, KeyValue, Tz} from "../lib/types";
 
 const e = exposes.presets;
 const ea = exposes.access;
+
+interface OwonFallDetection extends TCustomCluster {
+    attributes: {
+        status: number;
+        // biome-ignore lint/style/useNamingConvention: TODO
+        breathing_rate: number;
+        // biome-ignore lint/style/useNamingConvention: TODO
+        location_x: number;
+        // biome-ignore lint/style/useNamingConvention: TODO
+        location_y: number;
+        bedUpperLeftX: number;
+        bedUpperLeftY: number;
+        bedLowerRightX: number;
+        bedLowerRightY: number;
+        doorCenterX: number;
+        doorCenterY: number;
+        leftFallDetectionRange: number;
+        rightFallDetectionRange: number;
+        frontFallDetectionRange: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
 
 const fzLocal = {
     temperature: {
@@ -199,22 +222,25 @@ const tzLocal = {
                 payload[id] = {value: val, type};
             });
 
-            await entity.write("fallDetectionOwon", payload, {manufacturerCode: 0x113c});
+            await entity.write<"fallDetectionOwon", OwonFallDetection>("fallDetectionOwon", payload, {manufacturerCode: 0x113c});
             return {state: {fall_detection_settings: value}};
         },
         convertGet: async (entity, key, meta) => {
-            const attrs = [
-                "bedUpperLeftX",
-                "bedUpperLeftY",
-                "bedLowerRightX",
-                "bedLowerRightY",
-                "doorCenterX",
-                "doorCenterY",
-                "leftFallDetectionRange",
-                "rightFallDetectionRange",
-                "frontFallDetectionRange",
-            ];
-            await entity.read("fallDetectionOwon", attrs, {manufacturerCode: 0x113c});
+            await entity.read<"fallDetectionOwon", OwonFallDetection>(
+                "fallDetectionOwon",
+                [
+                    "bedUpperLeftX",
+                    "bedUpperLeftY",
+                    "bedLowerRightX",
+                    "bedLowerRightY",
+                    "doorCenterX",
+                    "doorCenterY",
+                    "leftFallDetectionRange",
+                    "rightFallDetectionRange",
+                    "frontFallDetectionRange",
+                ],
+                {manufacturerCode: 0x113c},
+            );
         },
     } satisfies Tz.Converter,
 };

--- a/src/devices/perenio.ts
+++ b/src/devices/perenio.ts
@@ -143,8 +143,7 @@ const tzPerenio = {
             };
             await entity.write(
                 "genMultistateValue",
-                // XXX: probably should make sure `value in "switchTypeLookup"`?
-                {presentValue: switchTypeLookup[value as keyof typeof switchTypeLookup]},
+                {presentValue: utils.getFromLookup(value, switchTypeLookup)},
                 utils.getOptions(meta.mapped, entity),
             );
             return {state: {switch_type: value}};

--- a/src/devices/perenio.ts
+++ b/src/devices/perenio.ts
@@ -321,7 +321,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint10, coordinatorEndpoint, ["haDiagnostic"]);
             const payload = [
                 {
-                    attribute: "onOff",
+                    attribute: "onOff" as const,
                     minimumReportInterval: 0,
                     maximumReportInterval: 3600,
                     reportableChange: 0,
@@ -329,13 +329,13 @@ export const definitions: DefinitionWithExtend[] = [
             ];
             const payloadDiagnostic = [
                 {
-                    attribute: "lastMessageLqi",
+                    attribute: "lastMessageLqi" as const,
                     minimumReportInterval: 5,
                     maximumReportInterval: 60,
                     reportableChange: 0,
                 },
                 {
-                    attribute: "lastMessageRssi",
+                    attribute: "lastMessageRssi" as const,
                     minimumReportInterval: 5,
                     maximumReportInterval: 60,
                     reportableChange: 0,
@@ -374,7 +374,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "perenioSpecific"]);
             const payload = [
                 {
-                    attribute: "onOff",
+                    attribute: "onOff" as const,
                     minimumReportInterval: 1,
                     maximumReportInterval: 3600,
                     reportableChange: 0,

--- a/src/devices/perenio.ts
+++ b/src/devices/perenio.ts
@@ -134,14 +134,19 @@ const tzPerenio = {
         key: ["switch_type"],
         convertSet: async (entity, key, value, meta) => {
             utils.assertString(value, key);
-            const switchTypeLookup: KeyValue = {
+            const switchTypeLookup = {
                 momentary_state: 0x0001,
                 maintained_state: 0x0010,
                 maintained_toggle: 0x00cc,
                 momentary_release: 0x00cd,
                 momentary_press: 0x00dc,
             };
-            await entity.write("genMultistateValue", {presentValue: switchTypeLookup[value]}, utils.getOptions(meta.mapped, entity));
+            await entity.write(
+                "genMultistateValue",
+                // XXX: probably should make sure `value in "switchTypeLookup"`?
+                {presentValue: switchTypeLookup[value as keyof typeof switchTypeLookup]},
+                utils.getOptions(meta.mapped, entity),
+            );
             return {state: {switch_type: value}};
         },
         convertGet: async (entity, key, meta) => {

--- a/src/devices/pushok.ts
+++ b/src/devices/pushok.ts
@@ -3,7 +3,7 @@ import * as m from "../lib/modernExtend";
 import type {DefinitionWithExtend, Fz, ModernExtend, Tz} from "../lib/types";
 
 const pushokExtend = {
-    valveStatus: (args?: Partial<m.EnumLookupArgs>) =>
+    valveStatus: (args?: Partial<m.EnumLookupArgs<"genMultistateInput">>) =>
         m.enumLookup({
             name: "status",
             lookup: {OFF: 0, ON: 1, MOVING: 2, STUCK: 3},
@@ -15,7 +15,7 @@ const pushokExtend = {
             reporting: null,
             ...args,
         }),
-    stallTime: (args?: Partial<m.NumericArgs>) =>
+    stallTime: (args?: Partial<m.NumericArgs<"genMultistateValue">>) =>
         m.numeric({
             name: "stall_time",
             cluster: "genMultistateValue",

--- a/src/devices/qa.ts
+++ b/src/devices/qa.ts
@@ -23,6 +23,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.actionEnumLookup({
                 cluster: "genOnOff",
                 commands: ["commandTuyaAction"],
+                // TODO: using command payload not attribute
                 attribute: "value",
                 actionLookup: {button: 0},
                 buttonLookup: {

--- a/src/devices/qa.ts
+++ b/src/devices/qa.ts
@@ -20,10 +20,9 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.modernExtend.tuyaMagicPacket(),
             m.deviceEndpoints({endpoints: {l1: 1}}),
             tuya.modernExtend.tuyaOnOff({endpoints: ["l1"], powerOnBehavior2: true, backlightModeOffOn: true}),
-            m.actionEnumLookup({
+            m.actionEnumLookup<"genOnOff", undefined, "tuyaAction">({
                 cluster: "genOnOff",
                 commands: ["commandTuyaAction"],
-                // TODO: using command payload not attribute
                 attribute: "value",
                 actionLookup: {button: 0},
                 buttonLookup: {
@@ -47,7 +46,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.modernExtend.tuyaMagicPacket(),
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             tuya.modernExtend.tuyaOnOff({endpoints: ["l1", "l2"], powerOnBehavior2: true, backlightModeOffOn: true}),
-            m.actionEnumLookup({
+            m.actionEnumLookup<"genOnOff", undefined, "tuyaAction">({
                 cluster: "genOnOff",
                 commands: ["commandTuyaAction"],
                 attribute: "value",
@@ -73,7 +72,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.modernExtend.tuyaMagicPacket(),
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
             tuya.modernExtend.tuyaOnOff({endpoints: ["l1", "l2", "l3"], powerOnBehavior2: true, backlightModeOffOn: true}),
-            m.actionEnumLookup({
+            m.actionEnumLookup<"genOnOff", undefined, "tuyaAction">({
                 cluster: "genOnOff",
                 commands: ["commandTuyaAction"],
                 attribute: "value",

--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -9,6 +9,31 @@ import type {DefinitionWithExtend} from "../lib/types";
 
 const e = exposes.presets;
 
+interface Salus {
+    attributes: {
+        frostSetpoint: number;
+        minFrostSetpoint: number;
+        maxFrostSetpoint: number;
+        timeDisplayFormat: number;
+        attr4: number;
+        attr5: number;
+        attr6: number;
+        attr7: number;
+        autoCoolingSetpoint: number;
+        autoHeatingSetpoint: number;
+        holdType: number;
+        shortCycleProtection: number;
+        coolingFanDelay: number;
+        ruleCoolingSetpoint: number;
+        ruleHeatingSetpoint: number;
+        attr15: number;
+    };
+    commands: {
+        resetDevice: Record<string, never>;
+    };
+    commandResponses: never;
+}
+
 export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["SPE600"],
@@ -133,7 +158,7 @@ export const definitions: DefinitionWithExtend[] = [
                 },
                 commandsResponse: {},
             }),
-            m.enumLookup<"manuSpecificSalus", true>({
+            m.enumLookup<"manuSpecificSalus", Salus>({
                 name: "preset",
                 lookup: {schedule: 0, temporary_override: 1, permanent_override: 2, standby: 7, eco: 10},
                 cluster: "manuSpecificSalus",

--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -133,7 +133,7 @@ export const definitions: DefinitionWithExtend[] = [
                 },
                 commandsResponse: {},
             }),
-            m.enumLookup({
+            m.enumLookup<"manuSpecificSalus", true>({
                 name: "preset",
                 lookup: {schedule: 0, temporary_override: 1, permanent_override: 2, standby: 7, eco: 10},
                 cluster: "manuSpecificSalus",

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {ClusterOrRawAttributeKeys, PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -199,14 +199,20 @@ const sdevices = {
                     throw new Error(`relay_mode was called with an invalid value (${value})`);
                 }
                 utils.assertEndpoint(entity);
-                await utils
-                    .enforceEndpoint(entity, key, meta)
-                    .write("genOnOff", {sdevicesRelayDecouple: relayDecoupleLookup[value as keyof typeof relayDecoupleLookup]}, manufacturerOptions);
+                await utils.enforceEndpoint(entity, key, meta).write(
+                    "genOnOff",
+                    {
+                        sdevicesRelayDecouple: relayDecoupleLookup[value as keyof typeof relayDecoupleLookup],
+                    } as PartialClusterOrRawWriteAttributes<"genOnOff">,
+                    manufacturerOptions,
+                );
                 return {state: {relay_mode: value.toLowerCase()}};
             },
             convertGet: async (entity, key, meta) => {
                 utils.assertEndpoint(entity);
-                await utils.enforceEndpoint(entity, key, meta).read("genOnOff", ["sdevicesRelayDecouple"], manufacturerOptions);
+                await utils
+                    .enforceEndpoint(entity, key, meta)
+                    .read("genOnOff", ["sdevicesRelayDecouple"] as unknown as ClusterOrRawAttributeKeys<"genOnOff">, manufacturerOptions);
             },
         } satisfies Tz.Converter,
         allow_double_click: {
@@ -803,8 +809,12 @@ export const definitions: DefinitionWithExtend[] = [
             await device.getEndpoint(1).read("genBasic", ["serialNumber"]);
             await device.getEndpoint(1).read("genOnOff", ["onOff", "startUpOnOff"]);
             await device.getEndpoint(2).read("genOnOff", ["onOff", "startUpOnOff"]);
-            await device.getEndpoint(1).read("genOnOff", ["sdevicesRelayDecouple"], manufacturerOptions);
-            await device.getEndpoint(2).read("genOnOff", ["sdevicesRelayDecouple"], manufacturerOptions);
+            await device
+                .getEndpoint(1)
+                .read("genOnOff", ["sdevicesRelayDecouple"] as unknown as ClusterOrRawAttributeKeys<"genOnOff">, manufacturerOptions);
+            await device
+                .getEndpoint(2)
+                .read("genOnOff", ["sdevicesRelayDecouple"] as unknown as ClusterOrRawAttributeKeys<"genOnOff">, manufacturerOptions);
             await device
                 .getEndpoint(1)
                 .read(

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -259,7 +258,7 @@ const sdevicesCustomClusterDefinition = {
     commandsResponse: {},
 };
 
-interface SberDevices extends TCustomCluster {
+interface SberDevices {
     attributes: {
         buttonEnableMultiClick: number;
         childLock: number;
@@ -285,7 +284,7 @@ interface SberDevices extends TCustomCluster {
     commandResponses: never;
 }
 
-interface SberGenOnOff extends TCustomCluster {
+interface SberGenOnOff {
     attributes: {sdevicesRelayDecouple: number};
     commands: never;
     commandResponses: never;

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -182,7 +182,7 @@ const sdevices = {
             key: ["identify"],
             options: tz.identify.options,
             convertSet: async (entity, key, value, meta) => {
-                const identifyTimeout = meta.options.identify_timeout ?? 30;
+                const identifyTimeout = (meta.options.identify_timeout as number) ?? 30;
                 await entity.command("genIdentify", "identify", {identifytime: identifyTimeout}, utils.getOptions(meta.mapped, entity));
             },
         } satisfies Tz.Converter,

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -269,7 +269,7 @@ const sdevicesExtend = {
             commandsResponse: {},
         }),
     onOffRelayDecouple: (args?: Partial<m.EnumLookupArgs<"genOnOff">>) =>
-        m.enumLookup({
+        m.enumLookup<"genOnOff", true>({
             name: "relay_mode",
             description: "Decoupled mode for button",
             cluster: "genOnOff",
@@ -472,7 +472,7 @@ const sdevicesExtend = {
         return {exposes, fromZigbee, toZigbee, isModernExtend: true};
     },
     childLock: () =>
-        m.binary({
+        m.binary<"manuSpecificSDevices", true>({
             name: "child_lock",
             cluster: "manuSpecificSDevices",
             attribute: "childLock",
@@ -492,7 +492,7 @@ const sdevicesExtend = {
             entityCategory: "diagnostic",
         }),
     emergencyShutoffRecovery: () =>
-        m.enumLookup({
+        m.enumLookup<"manuSpecificSDevices", true>({
             name: "emergency_shutoff_recovery",
             cluster: "manuSpecificSDevices",
             attribute: "emergencyShutoffRecovery",
@@ -501,7 +501,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     upperVoltageThreshold: () =>
-        m.numeric({
+        m.numeric<"manuSpecificSDevices", true>({
             name: "upper_voltage_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "upperVoltageThreshold",
@@ -513,7 +513,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     lowerVoltageThreshold: () =>
-        m.numeric({
+        m.numeric<"manuSpecificSDevices", true>({
             name: "lower_voltage_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "lowerVoltageThreshold",
@@ -525,7 +525,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     upperCurrentThreshold: () =>
-        m.numeric({
+        m.numeric<"manuSpecificSDevices", true>({
             name: "upper_current_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "upperCurrentThreshold",
@@ -537,7 +537,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     temperatureThreshold: () =>
-        m.numeric({
+        m.numeric<"manuSpecificSDevices", true>({
             name: "temperature_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "upperTempThreshold",
@@ -618,7 +618,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             sdevicesExtend.sdevicesCustomCluster(),
             sdevicesExtend.genOnOffCluster(),
-            m.binary({
+            m.binary<"manuSpecificSDevices", true>({
                 name: "allow_double_click",
                 cluster: "manuSpecificSDevices",
                 attribute: "buttonEnableMultiClick",

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -193,14 +193,15 @@ const sdevices = {
                 if (typeof value !== "string") {
                     return;
                 }
-                const relayDecoupleLookup: KeyValueAny = {control_relay: 0, decoupled: 1};
-                if (relayDecoupleLookup[value] === undefined) {
+                const relayDecoupleLookup = {control_relay: 0, decoupled: 1};
+                // XXX: probably should make sure `value in "relayDecoupleLookup"`?
+                if (relayDecoupleLookup[value as keyof typeof relayDecoupleLookup] === undefined) {
                     throw new Error(`relay_mode was called with an invalid value (${value})`);
                 }
                 utils.assertEndpoint(entity);
                 await utils
                     .enforceEndpoint(entity, key, meta)
-                    .write("genOnOff", {sdevicesRelayDecouple: relayDecoupleLookup[value]}, manufacturerOptions);
+                    .write("genOnOff", {sdevicesRelayDecouple: relayDecoupleLookup[value as keyof typeof relayDecoupleLookup]}, manufacturerOptions);
                 return {state: {relay_mode: value.toLowerCase()}};
             },
             convertGet: async (entity, key, meta) => {
@@ -267,7 +268,7 @@ const sdevicesExtend = {
             commands: {},
             commandsResponse: {},
         }),
-    onOffRelayDecouple: (args?: Partial<m.EnumLookupArgs>) =>
+    onOffRelayDecouple: (args?: Partial<m.EnumLookupArgs<"genOnOff">>) =>
         m.enumLookup({
             name: "relay_mode",
             description: "Decoupled mode for button",

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -194,15 +194,11 @@ const sdevices = {
                     return;
                 }
                 const relayDecoupleLookup = {control_relay: 0, decoupled: 1};
-                // XXX: probably should make sure `value in "relayDecoupleLookup"`?
-                if (relayDecoupleLookup[value as keyof typeof relayDecoupleLookup] === undefined) {
-                    throw new Error(`relay_mode was called with an invalid value (${value})`);
-                }
                 utils.assertEndpoint(entity);
                 await utils.enforceEndpoint(entity, key, meta).write<"genOnOff", SberGenOnOff>(
                     "genOnOff",
                     {
-                        sdevicesRelayDecouple: relayDecoupleLookup[value as keyof typeof relayDecoupleLookup],
+                        sdevicesRelayDecouple: utils.getFromLookup(value, relayDecoupleLookup),
                     },
                     manufacturerOptions,
                 );

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -306,8 +306,8 @@ const sdevicesExtend = {
             commands: {},
             commandsResponse: {},
         }),
-    onOffRelayDecouple: (args?: Partial<m.EnumLookupArgs<"genOnOff">>) =>
-        m.enumLookup<"genOnOff", true>({
+    onOffRelayDecouple: (args?: Partial<m.EnumLookupArgs<"genOnOff", SberGenOnOff>>) =>
+        m.enumLookup<"genOnOff", SberGenOnOff>({
             name: "relay_mode",
             description: "Decoupled mode for button",
             cluster: "genOnOff",
@@ -510,7 +510,7 @@ const sdevicesExtend = {
         return {exposes, fromZigbee, toZigbee, isModernExtend: true};
     },
     childLock: () =>
-        m.binary<"manuSpecificSDevices", true>({
+        m.binary<"manuSpecificSDevices", SberDevices>({
             name: "child_lock",
             cluster: "manuSpecificSDevices",
             attribute: "childLock",
@@ -530,7 +530,7 @@ const sdevicesExtend = {
             entityCategory: "diagnostic",
         }),
     emergencyShutoffRecovery: () =>
-        m.enumLookup<"manuSpecificSDevices", true>({
+        m.enumLookup<"manuSpecificSDevices", SberDevices>({
             name: "emergency_shutoff_recovery",
             cluster: "manuSpecificSDevices",
             attribute: "emergencyShutoffRecovery",
@@ -539,7 +539,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     upperVoltageThreshold: () =>
-        m.numeric<"manuSpecificSDevices", true>({
+        m.numeric<"manuSpecificSDevices", SberDevices>({
             name: "upper_voltage_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "upperVoltageThreshold",
@@ -551,7 +551,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     lowerVoltageThreshold: () =>
-        m.numeric<"manuSpecificSDevices", true>({
+        m.numeric<"manuSpecificSDevices", SberDevices>({
             name: "lower_voltage_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "lowerVoltageThreshold",
@@ -563,7 +563,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     upperCurrentThreshold: () =>
-        m.numeric<"manuSpecificSDevices", true>({
+        m.numeric<"manuSpecificSDevices", SberDevices>({
             name: "upper_current_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "upperCurrentThreshold",
@@ -575,7 +575,7 @@ const sdevicesExtend = {
             zigbeeCommandOptions: manufacturerOptions,
         }),
     temperatureThreshold: () =>
-        m.numeric<"manuSpecificSDevices", true>({
+        m.numeric<"manuSpecificSDevices", SberDevices>({
             name: "temperature_threshold",
             cluster: "manuSpecificSDevices",
             attribute: "upperTempThreshold",
@@ -656,7 +656,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             sdevicesExtend.sdevicesCustomCluster(),
             sdevicesExtend.genOnOffCluster(),
-            m.binary<"manuSpecificSDevices", true>({
+            m.binary<"manuSpecificSDevices", SberDevices>({
                 name: "allow_double_click",
                 cluster: "manuSpecificSDevices",
                 attribute: "buttonEnableMultiClick",

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -557,22 +557,26 @@ const fzLocal = {
                 // Send Schneider specific ACK to make PowerTag happy
                 // @ts-expect-error ignore
                 const networkParameters = await msg.device.constructor.adapter.getNetworkParameters();
-                const payload = {
-                    options: 0b000,
-                    tempMaster: msg.data.gppNwkAddr,
-                    tempMasterTx: networkParameters.channel - 11,
-                    srcID: msg.data.srcID,
-                    gpdCmd: 0xfe,
-                    gpdPayload: {
-                        commandID: 0xfe,
-                        buffer: Buffer.alloc(1), // I hope it's zero initialised
-                    },
-                };
 
-                await msg.endpoint.commandResponse("greenPower", "response", payload, {
-                    srcEndpoint: 242,
-                    disableDefaultResponse: true,
-                });
+                await msg.endpoint.commandResponse(
+                    "greenPower",
+                    "response",
+                    {
+                        options: 0b000,
+                        tempMaster: msg.data.gppNwkAddr,
+                        tempMasterTx: networkParameters.channel - 11,
+                        srcID: msg.data.srcID,
+                        gpdCmd: 0xfe,
+                        gpdPayload: {
+                            commandID: 0xfe,
+                            buffer: Buffer.alloc(1),
+                        },
+                    },
+                    {
+                        srcEndpoint: 242,
+                        disableDefaultResponse: true,
+                    },
+                );
             }
 
             return ret;

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -13,7 +12,7 @@ import {postfixWithEndpointName} from "../lib/utils";
 const e = exposes.presets;
 const ea = exposes.access;
 
-interface SchneiderOccupancyConfig extends TCustomCluster {
+interface SchneiderOccupancyConfig {
     attributes: {
         ambienceLightThreshold: number;
         occupancyActions: number;

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -131,7 +131,7 @@ const schneiderElectricExtend = {
             commandsResponse: {},
         }),
     visaConfigIndicatorLuminanceLevel: (): ModernExtend => {
-        return m.enumLookup({
+        return m.enumLookup<"visaConfiguration", true>({
             name: "indicator_luminance_level",
             lookup: {
                 "100": 0,
@@ -147,7 +147,7 @@ const schneiderElectricExtend = {
         });
     },
     visaConfigIndicatorColor: (): ModernExtend => {
-        return m.enumLookup({
+        return m.enumLookup<"visaConfiguration", true>({
             name: "indicator_color",
             lookup: {
                 white: 0,
@@ -159,7 +159,7 @@ const schneiderElectricExtend = {
         });
     },
     visaIndicatorMode: ([reverseWithLoad, consistentWithLoad, alwaysOff, alwaysOn]: number[]): ModernExtend => {
-        return m.enumLookup({
+        return m.enumLookup<"visaConfiguration", true>({
             name: "indicator_mode",
             lookup: {
                 reverse_with_load: reverseWithLoad,
@@ -176,7 +176,7 @@ const schneiderElectricExtend = {
         const attribute = `motorTypeChannel${channel || ""}`;
         const description = `Set motor type for channel ${channel || ""}`;
 
-        return m.enumLookup({
+        return m.enumLookup<"visaConfiguration", true>({
             name: `motor_type${channel ? `_${channel}` : ""}`,
             lookup: {
                 ac_motor: 0,
@@ -191,7 +191,7 @@ const schneiderElectricExtend = {
         const attribute = `curtainStatusChannel${channel || ""}`;
         const description = `Set curtain status for channel ${channel}`;
 
-        return m.enumLookup({
+        return m.enumLookup<"visaConfiguration", true>({
             access: "STATE",
             name: `curtain_status${channel ? `_${channel}` : ""}`,
             lookup: {
@@ -353,7 +353,7 @@ const schneiderElectricExtend = {
             return Math.round(10000 * Math.log10(value) + 1);
         };
 
-        const luxThresholdExtend = m.numeric({
+        const luxThresholdExtend = m.numeric<"occupancyConfiguration", true>({
             name: "ambience_light_threshold",
             cluster: "occupancyConfiguration",
             attribute: "ambienceLightThreshold",

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -12,6 +12,17 @@ import {postfixWithEndpointName} from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
+
+interface SchneiderOccupancyConfig extends TCustomCluster {
+    attributes: {
+        ambienceLightThreshold: number;
+        occupancyActions: number;
+        unoccupiedLevelDflt: number;
+        unoccupiedLevel: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
 
 function indicatorMode(endpoint?: string) {
     let description = "Set Indicator Mode.";
@@ -368,7 +379,9 @@ const schneiderElectricExtend = {
         extend.fromZigbee.push(...luxThresholdExtend.fromZigbee);
         extend.toZigbee.push(...luxThresholdExtend.toZigbee);
         extend.exposes.push(...luxThresholdExtend.exposes);
-        extend.configure.push(m.setupConfigureForReading("occupancyConfiguration", ["ambienceLightThreshold"]));
+        extend.configure.push(
+            m.setupConfigureForReading<"occupancyConfiguration", SchneiderOccupancyConfig>("occupancyConfiguration", ["ambienceLightThreshold"]),
+        );
 
         return extend;
     },

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -24,6 +24,24 @@ interface SchneiderOccupancyConfig extends TCustomCluster {
     commandResponses: never;
 }
 
+interface SchneiderVisaConfig {
+    attributes: {
+        indicatorLuminanceLevel: number;
+        indicatorColor: number;
+        indicatorMode: number;
+        motorTypeChannel1: number;
+        motorTypeChannel2: number;
+        curtainStatusChannel1: number;
+        curtainStatusChannel2: number;
+        key1EventNotification: number;
+        key2EventNotification: number;
+        key3EventNotification: number;
+        key4EventNotification: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 function indicatorMode(endpoint?: string) {
     let description = "Set Indicator Mode.";
     if (endpoint) {
@@ -142,7 +160,7 @@ const schneiderElectricExtend = {
             commandsResponse: {},
         }),
     visaConfigIndicatorLuminanceLevel: (): ModernExtend => {
-        return m.enumLookup<"visaConfiguration", true>({
+        return m.enumLookup<"visaConfiguration", SchneiderVisaConfig>({
             name: "indicator_luminance_level",
             lookup: {
                 "100": 0,
@@ -158,7 +176,7 @@ const schneiderElectricExtend = {
         });
     },
     visaConfigIndicatorColor: (): ModernExtend => {
-        return m.enumLookup<"visaConfiguration", true>({
+        return m.enumLookup<"visaConfiguration", SchneiderVisaConfig>({
             name: "indicator_color",
             lookup: {
                 white: 0,
@@ -170,7 +188,7 @@ const schneiderElectricExtend = {
         });
     },
     visaIndicatorMode: ([reverseWithLoad, consistentWithLoad, alwaysOff, alwaysOn]: number[]): ModernExtend => {
-        return m.enumLookup<"visaConfiguration", true>({
+        return m.enumLookup<"visaConfiguration", SchneiderVisaConfig>({
             name: "indicator_mode",
             lookup: {
                 reverse_with_load: reverseWithLoad,
@@ -184,10 +202,11 @@ const schneiderElectricExtend = {
         });
     },
     visaConfigMotorType: (channel?: number): ModernExtend => {
-        const attribute = `motorTypeChannel${channel || ""}`;
+        // TODO: was defaulting `motorTypeChannel` which is not part of the custom cluster
+        const attribute = `motorTypeChannel${channel as 1 | 2}` as const;
         const description = `Set motor type for channel ${channel || ""}`;
 
-        return m.enumLookup<"visaConfiguration", true>({
+        return m.enumLookup<"visaConfiguration", SchneiderVisaConfig>({
             name: `motor_type${channel ? `_${channel}` : ""}`,
             lookup: {
                 ac_motor: 0,
@@ -199,10 +218,11 @@ const schneiderElectricExtend = {
         });
     },
     visaConfigCurtainStatus: (channel?: number): ModernExtend => {
-        const attribute = `curtainStatusChannel${channel || ""}`;
+        // TODO: was defaulting `motorTypeChannel` which is not part of the custom cluster
+        const attribute = `curtainStatusChannel${channel as 1 | 2}` as const;
         const description = `Set curtain status for channel ${channel}`;
 
-        return m.enumLookup<"visaConfiguration", true>({
+        return m.enumLookup<"visaConfiguration", SchneiderVisaConfig>({
             access: "STATE",
             name: `curtain_status${channel ? `_${channel}` : ""}`,
             lookup: {
@@ -364,7 +384,7 @@ const schneiderElectricExtend = {
             return Math.round(10000 * Math.log10(value) + 1);
         };
 
-        const luxThresholdExtend = m.numeric<"occupancyConfiguration", true>({
+        const luxThresholdExtend = m.numeric<"occupancyConfiguration", SchneiderOccupancyConfig>({
             name: "ambience_light_threshold",
             cluster: "occupancyConfiguration",
             attribute: "ambienceLightThreshold",

--- a/src/devices/sengled.ts
+++ b/src/devices/sengled.ts
@@ -4,6 +4,17 @@ import {presets} from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import type {DefinitionWithExtend, Expose, Fz, KeyValueAny, ModernExtend} from "../lib/types";
 
+interface SengledMotionSensor {
+    attributes: {
+        triggerCondition: number;
+        enableAutoOnOff: number;
+        motionStatus: number;
+        offDelay: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 export function sengledLight(args?: m.LightArgs) {
     return m.light({effect: false, powerOnBehavior: false, ...args});
 }
@@ -316,7 +327,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
-            m.enumLookup<"manuSpecificSengledMotionSensor", true>({
+            m.enumLookup<"manuSpecificSengledMotionSensor", SengledMotionSensor>({
                 name: "trigger_condition",
                 lookup: {dark: 0, weak_light: 1},
                 cluster: "manuSpecificSengledMotionSensor",
@@ -325,7 +336,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: 0x1160},
                 access: "STATE_SET",
             }),
-            m.binary<"manuSpecificSengledMotionSensor", true>({
+            m.binary<"manuSpecificSengledMotionSensor", SengledMotionSensor>({
                 name: "enable_auto_on_off",
                 cluster: "manuSpecificSengledMotionSensor",
                 attribute: "enableAutoOnOff",
@@ -335,7 +346,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: 0x1160},
                 access: "STATE_SET",
             }),
-            m.binary<"manuSpecificSengledMotionSensor", true>({
+            m.binary<"manuSpecificSengledMotionSensor", SengledMotionSensor>({
                 name: "motion_status",
                 cluster: "manuSpecificSengledMotionSensor",
                 attribute: "motionStatus",
@@ -346,7 +357,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: 0x1160},
                 access: "STATE_GET",
             }),
-            m.numeric<"manuSpecificSengledMotionSensor", true>({
+            m.numeric<"manuSpecificSengledMotionSensor", SengledMotionSensor>({
                 name: "off_delay",
                 cluster: "manuSpecificSengledMotionSensor",
                 attribute: "offDelay",

--- a/src/devices/sengled.ts
+++ b/src/devices/sengled.ts
@@ -316,7 +316,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
-            m.enumLookup({
+            m.enumLookup<"manuSpecificSengledMotionSensor", true>({
                 name: "trigger_condition",
                 lookup: {dark: 0, weak_light: 1},
                 cluster: "manuSpecificSengledMotionSensor",
@@ -325,7 +325,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: 0x1160},
                 access: "STATE_SET",
             }),
-            m.binary({
+            m.binary<"manuSpecificSengledMotionSensor", true>({
                 name: "enable_auto_on_off",
                 cluster: "manuSpecificSengledMotionSensor",
                 attribute: "enableAutoOnOff",
@@ -335,7 +335,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: 0x1160},
                 access: "STATE_SET",
             }),
-            m.binary({
+            m.binary<"manuSpecificSengledMotionSensor", true>({
                 name: "motion_status",
                 cluster: "manuSpecificSengledMotionSensor",
                 attribute: "motionStatus",
@@ -346,7 +346,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: 0x1160},
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"manuSpecificSengledMotionSensor", true>({
                 name: "off_delay",
                 cluster: "manuSpecificSengledMotionSensor",
                 attribute: "offDelay",

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -82,8 +82,8 @@ const fzLocal = {
         cluster: "seMetering",
         type: ["readResponse"],
         convert: (model, msg, publish, options, meta) => {
-            if (msg.data[0x9001] !== undefined) {
-                const value = msg.data[0x9001];
+            if (msg.data[36865] !== undefined) {
+                const value = msg.data[36865];
                 const lookup = {0: "Auto", 1: "Manual(Forward)", 2: "Manual(Reverse)"};
                 return {ct_direction: utils.getFromLookup(value, lookup)};
             }
@@ -242,11 +242,11 @@ const tzLocal = {
         key: ["ct_direction"],
         convertSet: async (entity, key, value, meta) => {
             const lookup = {Auto: 0, "Manual(Forward)": 1, "Manual(Reverse)": 2};
-            await entity.write("seMetering", {"0x9001": {value: utils.getFromLookup(value, lookup), type: 0x20}});
+            await entity.write("seMetering", {36865: {value: utils.getFromLookup(value, lookup), type: 0x20}});
             return {state: {[key]: value}};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read("seMetering", [0x9001]);
+            await entity.read("seMetering", [36865]);
         },
     } satisfies Tz.Converter,
     force_smoke_alarm: {

--- a/src/devices/shinasystem.ts
+++ b/src/devices/shinasystem.ts
@@ -283,7 +283,7 @@ export const definitions: DefinitionWithExtend[] = [
             const binds = ["genPowerCfg", "genAnalogInput"];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.batteryVoltage(endpoint);
-            const payload = reporting.payload("presentValue", 1, 600, 0);
+            const payload = reporting.payload<"genAnalogInput">("presentValue", 1, 600, 0);
             await endpoint.configureReporting("genAnalogInput", payload);
         },
         exposes: [
@@ -307,7 +307,7 @@ export const definitions: DefinitionWithExtend[] = [
             const binds = ["genPowerCfg", "genAnalogInput"];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.batteryVoltage(endpoint);
-            const payload = reporting.payload("presentValue", 1, 600, 0);
+            const payload = reporting.payload<"genAnalogInput">("presentValue", 1, 600, 0);
             await endpoint.configureReporting("genAnalogInput", payload);
         },
         exposes: [
@@ -814,7 +814,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.occupancy(endpoint, {min: 1, max: 600, change: 1});
             const payload = [
                 {
-                    attribute: "zoneStatus",
+                    attribute: "zoneStatus" as const,
                     minimumReportInterval: 1,
                     maximumReportInterval: 600,
                     reportableChange: 1,
@@ -1119,7 +1119,7 @@ export const definitions: DefinitionWithExtend[] = [
             const binds = ["genPowerCfg", "ssIasZone"];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.batteryVoltage(endpoint, {min: 30, max: 21600, change: 1});
-            const payload = reporting.payload("currentZoneSensitivityLevel", 0, 7200, 1);
+            const payload = reporting.payload<"ssIasZone">("currentZoneSensitivityLevel", 0, 7200, 1);
             await endpoint.configureReporting("ssIasZone", payload);
             await endpoint.read("ssIasZone", ["currentZoneSensitivityLevel"]);
         },

--- a/src/devices/siglis.ts
+++ b/src/devices/siglis.ts
@@ -195,7 +195,7 @@ export const definitions: DefinitionWithExtend[] = [
                 const dimmerEp = device.getEndpoint(7);
 
                 // Bind Control EP (LED)
-                setMetaOption(device, "front_surface_enabled", (await controlEp.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "front_surface_enabled", (await controlEp.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "front_surface_enabled")) {
                     await reporting.bind(controlEp, coordinatorEndpoint, ["genOnOff", "genLevelCtrl", "manuSpecificSiglisZigfred"]);
                     await reporting.onOff(controlEp);
@@ -203,14 +203,14 @@ export const definitions: DefinitionWithExtend[] = [
                 }
 
                 // Bind Relay EP
-                setMetaOption(device, "relay_enabled", (await relayEp.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "relay_enabled", (await relayEp.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "relay_enabled")) {
                     await reporting.bind(relayEp, coordinatorEndpoint, ["genOnOff"]);
                     await reporting.onOff(relayEp);
                 }
 
                 // Bind Dimmer EP
-                setMetaOption(device, "dimmer_enabled", (await dimmerEp.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "dimmer_enabled", (await dimmerEp.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "dimmer_enabled")) {
                     await reporting.bind(dimmerEp, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
                     await reporting.onOff(dimmerEp);
@@ -367,7 +367,7 @@ export const definitions: DefinitionWithExtend[] = [
             if (device != null) {
                 // Bind Control EP (LED)
                 const controlEp = device.getEndpoint(zigfredEndpoint);
-                setMetaOption(device, "front_surface_enabled", (await controlEp.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "front_surface_enabled", (await controlEp.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "front_surface_enabled")) {
                     await reporting.bind(controlEp, coordinatorEndpoint, ["genOnOff", "genLevelCtrl", "manuSpecificSiglisZigfred"]);
                     await reporting.onOff(controlEp);
@@ -376,7 +376,7 @@ export const definitions: DefinitionWithExtend[] = [
 
                 // Bind Dimmer 1 EP
                 const dimmer1Ep = device.getEndpoint(7);
-                setMetaOption(device, "dimmer_1_enabled", (await dimmer1Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "dimmer_1_enabled", (await dimmer1Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "dimmer_1_enabled")) {
                     await reporting.bind(dimmer1Ep, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
                     await reporting.onOff(dimmer1Ep);
@@ -386,7 +386,7 @@ export const definitions: DefinitionWithExtend[] = [
 
                 // Bind Dimmer 2 EP
                 const dimmer2Ep = device.getEndpoint(8);
-                setMetaOption(device, "dimmer_2_enabled", (await dimmer2Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "dimmer_2_enabled", (await dimmer2Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "dimmer_2_enabled")) {
                     await reporting.bind(dimmer2Ep, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
                     await reporting.onOff(dimmer2Ep);
@@ -396,7 +396,7 @@ export const definitions: DefinitionWithExtend[] = [
 
                 // Bind Dimmer 3 EP
                 const dimmer3Ep = device.getEndpoint(9);
-                setMetaOption(device, "dimmer_3_enabled", (await dimmer3Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "dimmer_3_enabled", (await dimmer3Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "dimmer_3_enabled")) {
                     await reporting.bind(dimmer3Ep, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
                     await reporting.onOff(dimmer3Ep);
@@ -406,7 +406,7 @@ export const definitions: DefinitionWithExtend[] = [
 
                 // Bind Dimmer 4 EP
                 const dimmer4Ep = device.getEndpoint(10);
-                setMetaOption(device, "dimmer_4_enabled", (await dimmer4Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "dimmer_4_enabled", (await dimmer4Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "dimmer_4_enabled")) {
                     await reporting.bind(dimmer4Ep, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
                     await reporting.onOff(dimmer4Ep);
@@ -416,7 +416,7 @@ export const definitions: DefinitionWithExtend[] = [
 
                 // Bind Cover 1 EP
                 const cover1Ep = device.getEndpoint(11);
-                setMetaOption(device, "cover_1_enabled", (await cover1Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "cover_1_enabled", (await cover1Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "cover_1_enabled")) {
                     await reporting.bind(cover1Ep, coordinatorEndpoint, ["closuresWindowCovering"]);
                     await reporting.currentPositionLiftPercentage(cover1Ep);
@@ -434,7 +434,7 @@ export const definitions: DefinitionWithExtend[] = [
 
                 // Bind Cover 2 EP
                 const cover2Ep = device.getEndpoint(12);
-                setMetaOption(device, "cover_2_enabled", (await cover2Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled);
+                setMetaOption(device, "cover_2_enabled", (await cover2Ep.read("genBasic", ["deviceEnabled"])).deviceEnabled === 1);
                 if (checkMetaOption(device, "cover_2_enabled")) {
                     await reporting.bind(cover2Ep, coordinatorEndpoint, ["closuresWindowCovering"]);
                     await reporting.currentPositionLiftPercentage(cover2Ep);

--- a/src/devices/simpla_home.ts
+++ b/src/devices/simpla_home.ts
@@ -6,7 +6,7 @@ const measurementIntervalMin = 5;
 const measurementIntervalMax = 4 * 60 * 60;
 
 export const simplaHomeModernExtend = {
-    measurementInterval: (args?: Partial<m.NumericArgs>) => {
+    measurementInterval: (args?: Partial<m.NumericArgs<"genAnalogOutput">>) => {
         const resultName = "measurement_interval";
         const resultUnit = "s";
         const resultDescription = "Defines how often the device performs measurements";

--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -1446,7 +1446,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             const payload = [
                 {
-                    attribute: "actionReport",
+                    attribute: "actionReport" as const,
                     minimumReportInterval: 0,
                     maximumReportInterval: 0,
                     reportableChange: 0,
@@ -1749,7 +1749,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.batteryAlarmState(endpoint);
             await reporting.temperature(endpoint);
 
-            const payload = reporting.payload("presentValue", 10, constants.repInterval.HOUR, 1);
+            const payload = reporting.payload<"genAnalogInput">("presentValue", 10, constants.repInterval.HOUR, 1);
             await endpoint.configureReporting("genAnalogInput", payload);
             await endpoint.read("genAnalogInput", ["presentValue"]);
         },

--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -251,7 +251,7 @@ const tzLocal = {
         key: ["thermostat_occupancy"],
         convertSet: async (entity, key, value, meta) => {
             const sinopeOccupancy = {0: "unoccupied", 1: "occupied"};
-            const SinopeOccupancy = utils.getKey(sinopeOccupancy, value, value, Number);
+            const SinopeOccupancy = utils.getKey(sinopeOccupancy, value, value as number, Number);
             await entity.write("hvacThermostat", {SinopeOccupancy}, manuSinope);
             return {state: {thermostat_occupancy: value}};
         },
@@ -263,7 +263,7 @@ const tzLocal = {
         key: ["backlight_auto_dim"],
         convertSet: async (entity, key, value, meta) => {
             const sinopeBacklightParam = {0: "on_demand", 1: "sensing", 2: "off"};
-            const SinopeBacklight = utils.getKey(sinopeBacklightParam, value, value, Number);
+            const SinopeBacklight = utils.getKey(sinopeBacklightParam, value, value as number, Number);
             await entity.write("hvacThermostat", {SinopeBacklight}, manuSinope);
             return {state: {backlight_auto_dim: value}};
         },
@@ -358,7 +358,7 @@ const tzLocal = {
                 const currentTimeToDisplay = Math.round(thermostatTimeSec - thermostatTimezoneOffsetSec - 946684800);
                 await entity.write("manuSpecificSinope", {currentTimeToDisplay}, manuSinope);
             } else if (value !== "") {
-                await entity.write("manuSpecificSinope", {currentTimeToDisplay: value}, manuSinope);
+                await entity.write("manuSpecificSinope", {currentTimeToDisplay: value as number}, manuSinope);
             }
         },
     } satisfies Tz.Converter,
@@ -461,7 +461,7 @@ const tzLocal = {
         // TH1400ZB and SW2500ZB
         key: ["connected_load"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write("manuSpecificSinope", {connectedLoad: value});
+            await entity.write("manuSpecificSinope", {connectedLoad: value as number});
             return {state: {connected_load: value}};
         },
         convertGet: async (entity, key, meta) => {
@@ -472,7 +472,7 @@ const tzLocal = {
         // TH1400ZB specific
         key: ["aux_connected_load"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write("manuSpecificSinope", {auxConnectedLoad: value});
+            await entity.write("manuSpecificSinope", {auxConnectedLoad: value as number});
             return {state: {aux_connected_load: value}};
         },
         convertGet: async (entity, key, meta) => {
@@ -591,7 +591,7 @@ const tzLocal = {
         // RM3500ZB specific
         key: ["low_water_temp_protection"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write("manuSpecificSinope", {drConfigWaterTempMin: value});
+            await entity.write("manuSpecificSinope", {drConfigWaterTempMin: value as number});
             return {state: {low_water_temp_protection: value}};
         },
         convertGet: async (entity, key, meta) => {

--- a/src/devices/slacky_diy.ts
+++ b/src/devices/slacky_diy.ts
@@ -471,7 +471,9 @@ async function configureCommon(device: Zh.Device, coordinatorEndpoint: Zh.Endpoi
     await reporting.thermostatSystemMode(endpoint1, {min: 0, max: 3600, change: 0});
     await reporting.thermostatTemperatureCalibration(endpoint1, {min: 0, max: 3600, change: 0});
     await reporting.thermostatKeypadLockMode(endpoint1, {min: 0, max: 3600, change: 0});
-    const payload_oper_mode = [{attribute: "programingOperMode", minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];
+    const payload_oper_mode = [
+        {attribute: "programingOperMode" as const, minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},
+    ];
     await endpoint1.configureReporting("hvacThermostat", payload_oper_mode);
     const payload_sensor_used = [
         {attribute: {ID: attrThermSensorUser, type: 0x30}, minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},

--- a/src/devices/slacky_diy.ts
+++ b/src/devices/slacky_diy.ts
@@ -165,7 +165,7 @@ const tzLocal = {
         key: ["brightness", "brightness_day", "brightness_night"],
         options: [exposes.options.transition()],
         convertSet: async (entity, key, value, meta) => {
-            await entity.command("genLevelCtrl", "moveToLevel", {level: value, transtime: 0}, utils.getOptions(meta.mapped, entity));
+            await entity.command("genLevelCtrl", "moveToLevel", {level: value as number, transtime: 0}, utils.getOptions(meta.mapped, entity));
             return {state: {brightness: value}};
         },
         convertGet: async (entity, key, meta) => {

--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -93,13 +93,13 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["msTemperatureMeasurement", "genPowerCfg", "manuSpecificSamsungAccelerometer"]);
             await reporting.temperature(endpoint);
             await reporting.batteryVoltage(endpoint);
-            const payloadA = reporting.payload("acceleration", 10, constants.repInterval.MINUTE, 1);
+            const payloadA = reporting.payload<"manuSpecificSamsungAccelerometer">("acceleration", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadA, options);
-            const payloadX = reporting.payload("x_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadX = reporting.payload<"manuSpecificSamsungAccelerometer">("x_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadX, options);
-            const payloadY = reporting.payload("y_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadY = reporting.payload<"manuSpecificSamsungAccelerometer">("y_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadY, options);
-            const payloadZ = reporting.payload("z_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadZ = reporting.payload<"manuSpecificSamsungAccelerometer">("z_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadZ, options);
             // Has Unknown power source, force it.
             device.powerSource = "Battery";
@@ -281,13 +281,13 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.write("manuSpecificSamsungAccelerometer", {2: {value: 0x0276, type: 0x21}}, options);
             await reporting.temperature(endpoint);
             await reporting.batteryVoltage(endpoint);
-            const payloadA = reporting.payload("acceleration", 10, constants.repInterval.MINUTE, 1);
+            const payloadA = reporting.payload<"manuSpecificSamsungAccelerometer">("acceleration", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadA, options);
-            const payloadX = reporting.payload("x_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadX = reporting.payload<"manuSpecificSamsungAccelerometer">("x_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadX, options);
-            const payloadY = reporting.payload("y_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadY = reporting.payload<"manuSpecificSamsungAccelerometer">("y_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadY, options);
-            const payloadZ = reporting.payload("z_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadZ = reporting.payload<"manuSpecificSamsungAccelerometer">("z_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadZ, options);
             // Has Unknown power source, force it.
             device.powerSource = "Battery";
@@ -319,13 +319,13 @@ export const definitions: DefinitionWithExtend[] = [
             }
             await reporting.temperature(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
-            const payloadA = reporting.payload("acceleration", 10, constants.repInterval.MINUTE, 1);
+            const payloadA = reporting.payload<"manuSpecificSamsungAccelerometer">("acceleration", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadA, options);
-            const payloadX = reporting.payload("x_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadX = reporting.payload<"manuSpecificSamsungAccelerometer">("x_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadX, options);
-            const payloadY = reporting.payload("y_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadY = reporting.payload<"manuSpecificSamsungAccelerometer">("y_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadY, options);
-            const payloadZ = reporting.payload("z_axis", 10, constants.repInterval.MINUTE, 1);
+            const payloadZ = reporting.payload<"manuSpecificSamsungAccelerometer">("z_axis", 10, constants.repInterval.MINUTE, 1);
             await endpoint.configureReporting("manuSpecificSamsungAccelerometer", payloadZ, options);
         },
         exposes: [e.temperature(), e.contact(), e.battery_low(), e.tamper(), e.battery(), e.moving(), e.x_axis(), e.y_axis(), e.z_axis()],
@@ -347,7 +347,7 @@ export const definitions: DefinitionWithExtend[] = [
 
             const payload = [
                 {
-                    attribute: "measuredValue",
+                    attribute: "measuredValue" as const,
                     minimumReportInterval: 10,
                     maximumReportInterval: constants.repInterval.HOUR,
                     reportableChange: 10,

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -109,7 +108,7 @@ type EntityCategoryArgs = {
     entityCategory?: "config" | "diagnostic";
 };
 
-interface SonoffEwelink extends TCustomCluster {
+interface SonoffEwelink {
     attributes: {
         networkLed: number;
         backLight: number;

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -23,6 +23,60 @@ const defaultResponseOptions = {disableDefaultResponse: false};
 const e = exposes.presets;
 const ea = exposes.access;
 
+interface SonoffSnzb02d {
+    attributes: {
+        comfortTemperatureMax: number;
+        comfortTemperatureMin: number;
+        comfortHumidityMin: number;
+        comfortHumidityMax: number;
+        temperatureUnits: number;
+        temperatureCalibration: number;
+        humidityCalibration: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
+interface SonoffSnzb02ld {
+    attributes: {
+        temperatureUnits: number;
+        temperatureCalibration: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
+interface SonoffSnzb02wd {
+    attributes: {
+        temperatureUnits: number;
+        temperatureCalibration: number;
+        humidityCalibration: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+interface SonoffTrvzb {
+    attributes: {
+        childLock: number;
+        tamper: number;
+        illumination: number;
+        openWindow: number;
+        frostProtectionTemperature: number;
+        idleSteps: number;
+        closingSteps: number;
+        valveOpeningLimitVoltage: number;
+        valveClosingLimitVoltage: number;
+        valveMotorRunningVoltage: number;
+        valveOpeningDegree: number;
+        valveClosingDegree: number;
+        tempAccuracy: number;
+        externalTemperatureInput: number;
+        temperatureSensorSelect: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 const fzLocal = {
     router_config: {
         cluster: "genLevelCtrl",
@@ -55,7 +109,7 @@ type EntityCategoryArgs = {
     entityCategory?: "config" | "diagnostic";
 };
 
-interface Ewelink extends TCustomCluster {
+interface SonoffEwelink extends TCustomCluster {
     attributes: {
         networkLed: number;
         backLight: number;
@@ -586,11 +640,11 @@ const sonoffExtend = {
                     value = value.toLowerCase();
                     const lookup = {edge: 0, pulse: 1, "following(off)": 2, "following(on)": 130};
                     const tmpValue = utils.getFromLookup(value, lookup);
-                    await entity.write<typeof clusterName, Ewelink>(clusterName, {[attributeName]: tmpValue}, defaultResponseOptions);
+                    await entity.write<typeof clusterName, SonoffEwelink>(clusterName, {[attributeName]: tmpValue}, defaultResponseOptions);
                     return {state: {[key]: value}};
                 },
                 convertGet: async (entity, key, meta) => {
-                    await entity.read<typeof clusterName, Ewelink>(clusterName, [attributeName], defaultResponseOptions);
+                    await entity.read<typeof clusterName, SonoffEwelink>(clusterName, [attributeName], defaultResponseOptions);
                 },
             },
         ];
@@ -692,11 +746,11 @@ const sonoffExtend = {
                         detachRelayMask &= ~0x04;
                     }
                     // logger.info(`from zigbee detachRelayMask: ${detachRelayMask}`, NS);
-                    await entity.write<typeof clusterName, Ewelink>(clusterName, {[attributeName]: detachRelayMask}, defaultResponseOptions);
+                    await entity.write<typeof clusterName, SonoffEwelink>(clusterName, {[attributeName]: detachRelayMask}, defaultResponseOptions);
                     return {state: {[key]: value}};
                 },
                 convertGet: async (entity, key, meta) => {
-                    await entity.read<typeof clusterName, Ewelink>(clusterName, [attributeName], defaultResponseOptions);
+                    await entity.read<typeof clusterName, SonoffEwelink>(clusterName, [attributeName], defaultResponseOptions);
                 },
             },
         ];
@@ -1267,7 +1321,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.temperature(),
             m.humidity(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
-            m.numeric<"customSonoffSnzb02d", true>({
+            m.numeric<"customSonoffSnzb02d", SonoffSnzb02d>({
                 name: "comfort_temperature_min",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortTemperatureMin",
@@ -1279,7 +1333,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric<"customSonoffSnzb02d", true>({
+            m.numeric<"customSonoffSnzb02d", SonoffSnzb02d>({
                 name: "comfort_temperature_max",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortTemperatureMax",
@@ -1291,7 +1345,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric<"customSonoffSnzb02d", true>({
+            m.numeric<"customSonoffSnzb02d", SonoffSnzb02d>({
                 name: "comfort_humidity_min",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortHumidityMin",
@@ -1303,7 +1357,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "%",
             }),
-            m.numeric<"customSonoffSnzb02d", true>({
+            m.numeric<"customSonoffSnzb02d", SonoffSnzb02d>({
                 name: "comfort_humidity_max",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortHumidityMax",
@@ -1315,7 +1369,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "%",
             }),
-            m.enumLookup<"customSonoffSnzb02d", true>({
+            m.enumLookup<"customSonoffSnzb02d", SonoffSnzb02d>({
                 name: "temperature_units",
                 lookup: {celsius: 0, fahrenheit: 1},
                 cluster: "customSonoffSnzb02d",
@@ -1323,7 +1377,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "The unit of the temperature displayed on the device screen. Note: wake up the device by pressing the button on the back before changing this value.",
             }),
-            m.numeric<"customSonoffSnzb02d", true>({
+            m.numeric<"customSonoffSnzb02d", SonoffSnzb02d>({
                 name: "temperature_calibration",
                 cluster: "customSonoffSnzb02d",
                 attribute: "temperatureCalibration",
@@ -1334,7 +1388,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric<"customSonoffSnzb02d", true>({
+            m.numeric<"customSonoffSnzb02d", SonoffSnzb02d>({
                 name: "humidity_calibration",
                 cluster: "customSonoffSnzb02d",
                 attribute: "humidityCalibration",
@@ -1365,7 +1419,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.battery(),
             m.temperature(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
-            m.enumLookup<"customSonoffSnzb02ld", true>({
+            m.enumLookup<"customSonoffSnzb02ld", SonoffSnzb02ld>({
                 name: "temperature_units",
                 lookup: {celsius: 0, fahrenheit: 1},
                 cluster: "customSonoffSnzb02ld",
@@ -1373,7 +1427,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "The unit of the temperature displayed on the device screen. Note: wake up the device by pressing the button on the back before changing this value.",
             }),
-            m.numeric<"customSonoffSnzb02ld", true>({
+            m.numeric<"customSonoffSnzb02ld", SonoffSnzb02ld>({
                 name: "temperature_calibration",
                 cluster: "customSonoffSnzb02ld",
                 attribute: "temperatureCalibration",
@@ -1406,7 +1460,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.temperature(),
             m.humidity(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
-            m.enumLookup<"customSonoffSnzb02wd", true>({
+            m.enumLookup<"customSonoffSnzb02wd", SonoffSnzb02wd>({
                 name: "temperature_units",
                 lookup: {celsius: 0, fahrenheit: 1},
                 cluster: "customSonoffSnzb02wd",
@@ -1414,7 +1468,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "The unit of the temperature displayed on the device screen. Note: wake up the device by pressing the button on the back before changing this value.",
             }),
-            m.numeric<"customSonoffSnzb02wd", true>({
+            m.numeric<"customSonoffSnzb02wd", SonoffSnzb02wd>({
                 name: "temperature_calibration",
                 cluster: "customSonoffSnzb02wd",
                 attribute: "temperatureCalibration",
@@ -1425,7 +1479,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric<"customSonoffSnzb02wd", true>({
+            m.numeric<"customSonoffSnzb02wd", SonoffSnzb02wd>({
                 name: "humidity_calibration",
                 cluster: "customSonoffSnzb02wd",
                 attribute: "humidityCalibration",
@@ -1752,7 +1806,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
-            m.binary<"customSonoffTrvzb", true>({
+            m.binary<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "child_lock",
                 cluster: "customSonoffTrvzb",
                 attribute: "childLock",
@@ -1761,7 +1815,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOn: ["LOCK", 0x01],
                 valueOff: ["UNLOCK", 0x00],
             }),
-            m.binary<"customSonoffTrvzb", true>({
+            m.binary<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "open_window",
                 cluster: "customSonoffTrvzb",
                 attribute: "openWindow",
@@ -1770,7 +1824,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOn: ["ON", 0x01],
                 valueOff: ["OFF", 0x00],
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "frost_protection_temperature",
                 cluster: "customSonoffTrvzb",
                 attribute: "frostProtectionTemperature",
@@ -1782,7 +1836,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "°C",
                 scale: 100,
             }),
-            m.enumLookup<"customSonoffTrvzb", true>({
+            m.enumLookup<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "temperature_sensor_select",
                 label: "Temperature sensor",
                 lookup: {internal: 0, external: 1, external_2: 2, external_3: 3},
@@ -1791,7 +1845,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "Whether to use the value of the internal temperature sensor or an external temperature sensor for the perceived local temperature. Using an external sensor does not require local temperature calibration.",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "external_temperature_input",
                 label: "External temperature",
                 cluster: "customSonoffTrvzb",
@@ -1806,7 +1860,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 100,
                 precision: 1,
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "idle_steps",
                 cluster: "customSonoffTrvzb",
                 attribute: "idleSteps",
@@ -1814,7 +1868,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Number of steps used for calibration (no-load steps)",
                 access: "STATE_GET",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "closing_steps",
                 cluster: "customSonoffTrvzb",
                 attribute: "closingSteps",
@@ -1822,7 +1876,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Number of steps it takes to close the valve",
                 access: "STATE_GET",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "valve_opening_limit_voltage",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveOpeningLimitVoltage",
@@ -1831,7 +1885,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "mV",
                 access: "STATE_GET",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "valve_closing_limit_voltage",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveClosingLimitVoltage",
@@ -1840,7 +1894,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "mV",
                 access: "STATE_GET",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "valve_motor_running_voltage",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveMotorRunningVoltage",
@@ -1849,7 +1903,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "mV",
                 access: "STATE_GET",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "valve_opening_degree",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveOpeningDegree",
@@ -1865,7 +1919,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 1.0,
                 unit: "%",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "valve_closing_degree",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveClosingDegree",
@@ -1881,7 +1935,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 1.0,
                 unit: "%",
             }),
-            m.numeric<"customSonoffTrvzb", true>({
+            m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "temperature_accuracy",
                 cluster: "customSonoffTrvzb",
                 attribute: "tempAccuracy",
@@ -1927,7 +1981,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             // m.electricityMeter({current: {divisor: 100}, voltage: {divisor: 100}, power: {divisor: 1}, energy: {divisor: 1000}}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.numeric<"customClusterEwelink", true>({
+            m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "current",
                 cluster: "customClusterEwelink",
                 attribute: "acCurrentCurrentValue",
@@ -1936,7 +1990,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric<"customClusterEwelink", true>({
+            m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "voltage",
                 cluster: "customClusterEwelink",
                 attribute: "acCurrentVoltageValue",
@@ -1945,7 +1999,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric<"customClusterEwelink", true>({
+            m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "power",
                 cluster: "customClusterEwelink",
                 attribute: "acCurrentPowerValue",
@@ -1955,7 +2009,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
                 reporting: {min: "10_SECONDS", max: "MAX", change: 0},
             }),
-            m.numeric<"customClusterEwelink", true>({
+            m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "energy_yesterday",
                 cluster: "customClusterEwelink",
                 attribute: "energyYesterday",
@@ -1964,7 +2018,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric<"customClusterEwelink", true>({
+            m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "energy_today",
                 cluster: "customClusterEwelink",
                 attribute: "energyToday",
@@ -1973,7 +2027,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric<"customClusterEwelink", true>({
+            m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "energy_month",
                 cluster: "customClusterEwelink",
                 attribute: "energyMonth",
@@ -1983,7 +2037,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
             sonoffExtend.inchingControlSet(),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "outlet_control_protect",
                 cluster: "customClusterEwelink",
                 attribute: "outlet_control_protect",
@@ -1998,12 +2052,12 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint, {min: 1, max: 1800, change: 0});
-            await endpoint.read<"customClusterEwelink", Ewelink>(
+            await endpoint.read<"customClusterEwelink", SonoffEwelink>(
                 "customClusterEwelink",
                 ["acCurrentCurrentValue", "acCurrentVoltageValue", "acCurrentPowerValue", 0x7003, "outlet_control_protect"],
                 defaultResponseOptions,
             );
-            await endpoint.configureReporting<"customClusterEwelink", Ewelink>("customClusterEwelink", [
+            await endpoint.configureReporting<"customClusterEwelink", SonoffEwelink>("customClusterEwelink", [
                 {attribute: "energyMonth", minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 50},
                 {attribute: "energyYesterday", minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 50},
                 {attribute: "energyToday", minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 50},
@@ -2034,7 +2088,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The water valve is in normal state, water shortage or water leakage",
                 access: "STATE_GET",
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "auto_close_when_water_shortage",
                 cluster: "customClusterEwelink",
                 attribute: "lackWaterCloseValveTimeout",
@@ -2063,7 +2117,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "rf_turbo_mode",
                 cluster: "customClusterEwelink",
                 attribute: "radioPowerWithManuCode",
@@ -2079,7 +2133,7 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint, {min: 1, max: 1800, change: 0});
-            await endpoint.read<"customClusterEwelink", Ewelink>("customClusterEwelink", ["radioPowerWithManuCode"], manufacturerOptions);
+            await endpoint.read<"customClusterEwelink", SonoffEwelink>("customClusterEwelink", ["radioPowerWithManuCode"], manufacturerOptions);
         },
     },
     {
@@ -2092,7 +2146,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"]}),
             m.onOff({configureReporting: false}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2101,7 +2155,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0],
                 valueOn: [true, 1],
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "turbo_mode",
                 cluster: "customClusterEwelink",
                 attribute: "radioPower",
@@ -2110,7 +2164,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0x09],
                 valueOn: [true, 0x14],
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "delayed_power_on_state",
                 cluster: "customClusterEwelink",
                 attribute: "delayedPowerOnState",
@@ -2119,7 +2173,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0],
                 valueOn: [true, 1],
             }),
-            m.numeric<"customClusterEwelink", true>({
+            m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "delayed_power_on_time",
                 cluster: "customClusterEwelink",
                 attribute: "delayedPowerOnTime",
@@ -2131,7 +2185,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "seconds",
                 scale: 2,
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "detach_relay_mode",
                 cluster: "customClusterEwelink",
                 attribute: "detachRelayMode",
@@ -2148,7 +2202,7 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint, {min: 1, max: 1800, change: 0});
-            await endpoint.read<"customClusterEwelink", Ewelink>(
+            await endpoint.read<"customClusterEwelink", SonoffEwelink>(
                 "customClusterEwelink",
                 ["radioPower", 0x0001, 0x0014, 0x0015, 0x0016, 0x0017],
                 defaultResponseOptions,
@@ -2165,7 +2219,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"]}),
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup<"customClusterEwelink", true>({
+            m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2173,7 +2227,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2203,7 +2257,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2"]}),
             m.onOff({endpointNames: ["l1", "l2"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup<"customClusterEwelink", true>({
+            m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2211,7 +2265,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2245,7 +2299,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2", "l3"]}),
             m.onOff({endpointNames: ["l1", "l2", "l3"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup<"customClusterEwelink", true>({
+            m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2253,7 +2307,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2289,7 +2343,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"]}),
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup<"customClusterEwelink", true>({
+            m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2297,7 +2351,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2327,7 +2381,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2"]}),
             m.onOff({endpointNames: ["l1", "l2"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup<"customClusterEwelink", true>({
+            m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2335,7 +2389,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2369,7 +2423,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2", "l3"]}),
             m.onOff({endpointNames: ["l1", "l2", "l3"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup<"customClusterEwelink", true>({
+            m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2377,7 +2431,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary<"customClusterEwelink", true>({
+            m.binary<"customClusterEwelink", SonoffEwelink>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1238,7 +1238,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.temperature(),
             m.humidity(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02d", true>({
                 name: "comfort_temperature_min",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortTemperatureMin",
@@ -1250,7 +1250,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02d", true>({
                 name: "comfort_temperature_max",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortTemperatureMax",
@@ -1262,7 +1262,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02d", true>({
                 name: "comfort_humidity_min",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortHumidityMin",
@@ -1274,7 +1274,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "%",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02d", true>({
                 name: "comfort_humidity_max",
                 cluster: "customSonoffSnzb02d",
                 attribute: "comfortHumidityMax",
@@ -1286,7 +1286,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "%",
             }),
-            m.enumLookup({
+            m.enumLookup<"customSonoffSnzb02d", true>({
                 name: "temperature_units",
                 lookup: {celsius: 0, fahrenheit: 1},
                 cluster: "customSonoffSnzb02d",
@@ -1294,7 +1294,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "The unit of the temperature displayed on the device screen. Note: wake up the device by pressing the button on the back before changing this value.",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02d", true>({
                 name: "temperature_calibration",
                 cluster: "customSonoffSnzb02d",
                 attribute: "temperatureCalibration",
@@ -1305,7 +1305,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02d", true>({
                 name: "humidity_calibration",
                 cluster: "customSonoffSnzb02d",
                 attribute: "humidityCalibration",
@@ -1336,7 +1336,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.battery(),
             m.temperature(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
-            m.enumLookup({
+            m.enumLookup<"customSonoffSnzb02ld", true>({
                 name: "temperature_units",
                 lookup: {celsius: 0, fahrenheit: 1},
                 cluster: "customSonoffSnzb02ld",
@@ -1344,7 +1344,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "The unit of the temperature displayed on the device screen. Note: wake up the device by pressing the button on the back before changing this value.",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02ld", true>({
                 name: "temperature_calibration",
                 cluster: "customSonoffSnzb02ld",
                 attribute: "temperatureCalibration",
@@ -1377,7 +1377,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.temperature(),
             m.humidity(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
-            m.enumLookup({
+            m.enumLookup<"customSonoffSnzb02wd", true>({
                 name: "temperature_units",
                 lookup: {celsius: 0, fahrenheit: 1},
                 cluster: "customSonoffSnzb02wd",
@@ -1385,7 +1385,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "The unit of the temperature displayed on the device screen. Note: wake up the device by pressing the button on the back before changing this value.",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02wd", true>({
                 name: "temperature_calibration",
                 cluster: "customSonoffSnzb02wd",
                 attribute: "temperatureCalibration",
@@ -1396,7 +1396,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02wd", true>({
                 name: "humidity_calibration",
                 cluster: "customSonoffSnzb02wd",
                 attribute: "humidityCalibration",
@@ -1723,7 +1723,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
-            m.binary({
+            m.binary<"customSonoffTrvzb", true>({
                 name: "child_lock",
                 cluster: "customSonoffTrvzb",
                 attribute: "childLock",
@@ -1732,7 +1732,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOn: ["LOCK", 0x01],
                 valueOff: ["UNLOCK", 0x00],
             }),
-            m.binary({
+            m.binary<"customSonoffTrvzb", true>({
                 name: "open_window",
                 cluster: "customSonoffTrvzb",
                 attribute: "openWindow",
@@ -1741,7 +1741,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOn: ["ON", 0x01],
                 valueOff: ["OFF", 0x00],
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "frost_protection_temperature",
                 cluster: "customSonoffTrvzb",
                 attribute: "frostProtectionTemperature",
@@ -1753,7 +1753,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "°C",
                 scale: 100,
             }),
-            m.enumLookup({
+            m.enumLookup<"customSonoffTrvzb", true>({
                 name: "temperature_sensor_select",
                 label: "Temperature sensor",
                 lookup: {internal: 0, external: 1, external_2: 2, external_3: 3},
@@ -1762,7 +1762,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description:
                     "Whether to use the value of the internal temperature sensor or an external temperature sensor for the perceived local temperature. Using an external sensor does not require local temperature calibration.",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "external_temperature_input",
                 label: "External temperature",
                 cluster: "customSonoffTrvzb",
@@ -1777,7 +1777,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 100,
                 precision: 1,
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "idle_steps",
                 cluster: "customSonoffTrvzb",
                 attribute: "idleSteps",
@@ -1785,7 +1785,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Number of steps used for calibration (no-load steps)",
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "closing_steps",
                 cluster: "customSonoffTrvzb",
                 attribute: "closingSteps",
@@ -1793,7 +1793,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Number of steps it takes to close the valve",
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "valve_opening_limit_voltage",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveOpeningLimitVoltage",
@@ -1802,7 +1802,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "mV",
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "valve_closing_limit_voltage",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveClosingLimitVoltage",
@@ -1811,7 +1811,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "mV",
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "valve_motor_running_voltage",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveMotorRunningVoltage",
@@ -1820,7 +1820,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "mV",
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "valve_opening_degree",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveOpeningDegree",
@@ -1836,7 +1836,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 1.0,
                 unit: "%",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "valve_closing_degree",
                 cluster: "customSonoffTrvzb",
                 attribute: "valveClosingDegree",
@@ -1852,7 +1852,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 1.0,
                 unit: "%",
             }),
-            m.numeric({
+            m.numeric<"customSonoffTrvzb", true>({
                 name: "temperature_accuracy",
                 cluster: "customSonoffTrvzb",
                 attribute: "tempAccuracy",
@@ -1898,7 +1898,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             // m.electricityMeter({current: {divisor: 100}, voltage: {divisor: 100}, power: {divisor: 1}, energy: {divisor: 1000}}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.numeric({
+            m.numeric<"customClusterEwelink", true>({
                 name: "current",
                 cluster: "customClusterEwelink",
                 attribute: "acCurrentCurrentValue",
@@ -1907,7 +1907,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customClusterEwelink", true>({
                 name: "voltage",
                 cluster: "customClusterEwelink",
                 attribute: "acCurrentVoltageValue",
@@ -1916,7 +1916,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customClusterEwelink", true>({
                 name: "power",
                 cluster: "customClusterEwelink",
                 attribute: "acCurrentPowerValue",
@@ -1926,7 +1926,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
                 reporting: {min: "10_SECONDS", max: "MAX", change: 0},
             }),
-            m.numeric({
+            m.numeric<"customClusterEwelink", true>({
                 name: "energy_yesterday",
                 cluster: "customClusterEwelink",
                 attribute: "energyYesterday",
@@ -1935,7 +1935,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customClusterEwelink", true>({
                 name: "energy_today",
                 cluster: "customClusterEwelink",
                 attribute: "energyToday",
@@ -1944,7 +1944,7 @@ export const definitions: DefinitionWithExtend[] = [
                 scale: 1000,
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"customClusterEwelink", true>({
                 name: "energy_month",
                 cluster: "customClusterEwelink",
                 attribute: "energyMonth",
@@ -1954,7 +1954,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
             sonoffExtend.inchingControlSet(),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "outlet_control_protect",
                 cluster: "customClusterEwelink",
                 attribute: "outlet_control_protect",
@@ -2005,7 +2005,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The water valve is in normal state, water shortage or water leakage",
                 access: "STATE_GET",
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "auto_close_when_water_shortage",
                 cluster: "customClusterEwelink",
                 attribute: "lackWaterCloseValveTimeout",
@@ -2034,7 +2034,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "rf_turbo_mode",
                 cluster: "customClusterEwelink",
                 attribute: "radioPowerWithManuCode",
@@ -2063,7 +2063,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"]}),
             m.onOff({configureReporting: false}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2072,7 +2072,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0],
                 valueOn: [true, 1],
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "turbo_mode",
                 cluster: "customClusterEwelink",
                 attribute: "radioPower",
@@ -2081,7 +2081,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0x09],
                 valueOn: [true, 0x14],
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "delayed_power_on_state",
                 cluster: "customClusterEwelink",
                 attribute: "delayedPowerOnState",
@@ -2090,7 +2090,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0],
                 valueOn: [true, 1],
             }),
-            m.numeric({
+            m.numeric<"customClusterEwelink", true>({
                 name: "delayed_power_on_time",
                 cluster: "customClusterEwelink",
                 attribute: "delayedPowerOnTime",
@@ -2102,7 +2102,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "seconds",
                 scale: 2,
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "detach_relay_mode",
                 cluster: "customClusterEwelink",
                 attribute: "detachRelayMode",
@@ -2132,7 +2132,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"]}),
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup({
+            m.enumLookup<"customClusterEwelink", true>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2140,7 +2140,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2170,7 +2170,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2"]}),
             m.onOff({endpointNames: ["l1", "l2"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup({
+            m.enumLookup<"customClusterEwelink", true>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2178,7 +2178,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2212,7 +2212,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2", "l3"]}),
             m.onOff({endpointNames: ["l1", "l2", "l3"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup({
+            m.enumLookup<"customClusterEwelink", true>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2220,7 +2220,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2256,7 +2256,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"]}),
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup({
+            m.enumLookup<"customClusterEwelink", true>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2264,7 +2264,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2294,7 +2294,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2"]}),
             m.onOff({endpointNames: ["l1", "l2"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup({
+            m.enumLookup<"customClusterEwelink", true>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2302,7 +2302,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",
@@ -2336,7 +2336,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2", "l3"]}),
             m.onOff({endpointNames: ["l1", "l2", "l3"]}),
             sonoffExtend.addCustomClusterEwelink(),
-            m.enumLookup({
+            m.enumLookup<"customClusterEwelink", true>({
                 name: "device_work_mode",
                 lookup: {"Zigbee end device": 0, "Zigbee router": 1},
                 cluster: "customClusterEwelink",
@@ -2344,7 +2344,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "The device runs as a Zigbee End device or Zigbee router.",
                 access: "STATE_GET",
             }),
-            m.binary({
+            m.binary<"customClusterEwelink", true>({
                 name: "network_indicator",
                 cluster: "customClusterEwelink",
                 attribute: "networkLed",

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -36,6 +36,15 @@ interface SonoffSnzb02d {
     commandResponses: never;
 }
 
+interface SonoffSnzb02p {
+    attributes: {
+        temperatureCalibration: number;
+        humidityCalibration: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 interface SonoffSnzb02ld {
     attributes: {
         temperatureUnits: number;
@@ -1644,7 +1653,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.temperature(),
             m.humidity(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02p", SonoffSnzb02p>({
                 name: "temperature_calibration",
                 cluster: "customSonoffSnzb02p",
                 attribute: "temperatureCalibration",
@@ -1655,7 +1664,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.1,
                 unit: "°C",
             }),
-            m.numeric({
+            m.numeric<"customSonoffSnzb02p", SonoffSnzb02p>({
                 name: "humidity_calibration",
                 cluster: "customSonoffSnzb02p",
                 attribute: "humidityCalibration",

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -578,7 +578,7 @@ export const definitions: DefinitionWithExtend[] = [
             sunricher.extend.thermostatCurrentHeatingSetpoint(),
             m.battery(),
             m.identify(),
-            m.numeric({
+            m.numeric<"hvacThermostat", true>({
                 name: "screen_timeout",
                 cluster: "hvacThermostat",
                 attribute: "screenTimeout",
@@ -589,7 +589,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.numeric({
+            m.numeric<"hvacThermostat", true>({
                 name: "anti_freezing_temp",
                 cluster: "hvacThermostat",
                 attribute: "antiFreezingTemp",
@@ -600,7 +600,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.enumLookup({
+            m.enumLookup<"hvacThermostat", true>({
                 name: "temperature_display_mode",
                 cluster: "hvacThermostat",
                 attribute: "temperatureDisplayMode",
@@ -611,7 +611,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Temperature Display Mode. 1: displays set temp, 2: displays room temp (default)",
                 access: "ALL",
             }),
-            m.numeric({
+            m.numeric<"hvacThermostat", true>({
                 name: "window_open_check",
                 cluster: "hvacThermostat",
                 attribute: "windowOpenCheck",
@@ -622,7 +622,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.numeric({
+            m.numeric<"hvacThermostat", true>({
                 name: "hysteresis",
                 cluster: "hvacThermostat",
                 attribute: "hysteresis",
@@ -635,7 +635,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.binary({
+            m.binary<"hvacThermostat", true>({
                 name: "window_open_flag",
                 cluster: "hvacThermostat",
                 attribute: "windowOpenFlag",
@@ -644,7 +644,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: ["not_opened", 0],
                 access: "STATE_GET",
             }),
-            m.numeric({
+            m.numeric<"hvacThermostat", true>({
                 name: "forced_heating_time",
                 cluster: "hvacThermostat",
                 attribute: "forcedHeatingTime",
@@ -655,7 +655,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.enumLookup({
+            m.enumLookup<"hvacThermostat", true>({
                 name: "error_code",
                 cluster: "hvacThermostat",
                 attribute: "errorCode",
@@ -812,7 +812,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commandsResponse: {},
             }),
             sunricher.extend.indicatorLight(),
-            m.numeric({
+            m.numeric<"sunricherSensor", true>({
                 name: "detection_area",
                 cluster: "sunricherSensor",
                 attribute: "detectionArea",
@@ -824,7 +824,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.numeric({
+            m.numeric<"sunricherSensor", true>({
                 name: "illuminance_threshold",
                 cluster: "sunricherSensor",
                 attribute: "illuminanceThreshold",

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -19,7 +18,7 @@ const ea = exposes.access;
 
 const sunricherManufacturerCode = 0x1224;
 
-export interface SunricherHvacThermostat extends TCustomCluster {
+export interface SunricherHvacThermostat {
     attributes: {
         screenTimeout: number;
         antiFreezingTemp: number;
@@ -30,6 +29,16 @@ export interface SunricherHvacThermostat extends TCustomCluster {
         forcedHeatingTime: number;
         errorCode: number;
         awayOrBoostMode: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
+interface SunricherSensor {
+    attributes: {
+        indicatorLight: number;
+        detectionArea: number;
+        illuminanceThreshold: number;
     };
     commands: never;
     commandResponses: never;
@@ -594,7 +603,7 @@ export const definitions: DefinitionWithExtend[] = [
             sunricher.extend.thermostatCurrentHeatingSetpoint(),
             m.battery(),
             m.identify(),
-            m.numeric<"hvacThermostat", true>({
+            m.numeric<"hvacThermostat", SunricherHvacThermostat>({
                 name: "screen_timeout",
                 cluster: "hvacThermostat",
                 attribute: "screenTimeout",
@@ -605,7 +614,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.numeric<"hvacThermostat", true>({
+            m.numeric<"hvacThermostat", SunricherHvacThermostat>({
                 name: "anti_freezing_temp",
                 cluster: "hvacThermostat",
                 attribute: "antiFreezingTemp",
@@ -616,7 +625,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.enumLookup<"hvacThermostat", true>({
+            m.enumLookup<"hvacThermostat", SunricherHvacThermostat>({
                 name: "temperature_display_mode",
                 cluster: "hvacThermostat",
                 attribute: "temperatureDisplayMode",
@@ -627,7 +636,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Temperature Display Mode. 1: displays set temp, 2: displays room temp (default)",
                 access: "ALL",
             }),
-            m.numeric<"hvacThermostat", true>({
+            m.numeric<"hvacThermostat", SunricherHvacThermostat>({
                 name: "window_open_check",
                 cluster: "hvacThermostat",
                 attribute: "windowOpenCheck",
@@ -638,7 +647,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.numeric<"hvacThermostat", true>({
+            m.numeric<"hvacThermostat", SunricherHvacThermostat>({
                 name: "hysteresis",
                 cluster: "hvacThermostat",
                 attribute: "hysteresis",
@@ -651,7 +660,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.binary<"hvacThermostat", true>({
+            m.binary<"hvacThermostat", SunricherHvacThermostat>({
                 name: "window_open_flag",
                 cluster: "hvacThermostat",
                 attribute: "windowOpenFlag",
@@ -660,7 +669,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: ["not_opened", 0],
                 access: "STATE_GET",
             }),
-            m.numeric<"hvacThermostat", true>({
+            m.numeric<"hvacThermostat", SunricherHvacThermostat>({
                 name: "forced_heating_time",
                 cluster: "hvacThermostat",
                 attribute: "forcedHeatingTime",
@@ -671,7 +680,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.enumLookup<"hvacThermostat", true>({
+            m.enumLookup<"hvacThermostat", SunricherHvacThermostat>({
                 name: "error_code",
                 cluster: "hvacThermostat",
                 attribute: "errorCode",
@@ -828,15 +837,15 @@ export const definitions: DefinitionWithExtend[] = [
                 ID: 0xfc8b,
                 manufacturerCode: 0x120b,
                 attributes: {
-                    indicatorLight: {ID: 0xf001, type: 0x20},
-                    detectionArea: {ID: 0xf002, type: 0x20},
-                    illuminanceThreshold: {ID: 0xf004, type: 0x20},
+                    indicatorLight: {ID: 0xf001, type: Zcl.DataType.UINT8},
+                    detectionArea: {ID: 0xf002, type: Zcl.DataType.UINT8},
+                    illuminanceThreshold: {ID: 0xf004, type: Zcl.DataType.UINT8},
                 },
                 commands: {},
                 commandsResponse: {},
             }),
             sunricher.extend.indicatorLight(),
-            m.numeric<"sunricherSensor", true>({
+            m.numeric<"sunricherSensor", SunricherSensor>({
                 name: "detection_area",
                 cluster: "sunricherSensor",
                 attribute: "detectionArea",
@@ -848,7 +857,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "ALL",
                 entityCategory: "config",
             }),
-            m.numeric<"sunricherSensor", true>({
+            m.numeric<"sunricherSensor", SunricherSensor>({
                 name: "illuminance_threshold",
                 cluster: "sunricherSensor",
                 attribute: "illuminanceThreshold",

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {ClusterOrRawAttributeKeys} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -756,7 +756,7 @@ export const definitions: DefinitionWithExtend[] = [
                             "windowOpenFlag",
                             "forcedHeatingTime",
                             "errorCode",
-                        ]),
+                        ] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">),
                     ];
 
                     await Promise.all(readPromises);

--- a/src/devices/tubeszb.ts
+++ b/src/devices/tubeszb.ts
@@ -13,7 +13,7 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(8);
-            const payload = [{attribute: "zclVersion", minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];
+            const payload = [{attribute: "zclVersion" as const, minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0}];
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBasic"]);
             await endpoint.configureReporting("genBasic", payload);
         },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -455,7 +455,6 @@ const tzLocal = {
             return {state: newState};
         },
         convertGet: async (entity, key, meta) => {
-            // TODO: correct?
             await entity.read("genLevelCtrl", ["currentLevel"]);
             await entity.read("lightingColorCtrl", ["currentHue", "currentSaturation", "tuyaRgbMode", "colorTemperature"]);
         },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -455,7 +455,9 @@ const tzLocal = {
             return {state: newState};
         },
         convertGet: async (entity, key, meta) => {
-            await entity.read("lightingColorCtrl", ["currentHue", "currentSaturation", "currentLevel", "tuyaRgbMode", "colorTemperature"]);
+            // TODO: correct?
+            await entity.read("genLevelCtrl", ["currentLevel"]);
+            await entity.read("lightingColorCtrl", ["currentHue", "currentSaturation", "tuyaRgbMode", "colorTemperature"]);
         },
     } satisfies Tz.Converter,
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
@@ -495,7 +497,7 @@ const tzLocal = {
                 utils.assertString(value, "light");
                 await entity.command("genOnOff", value.toLowerCase() === "on" ? "on" : "off", {}, utils.getOptions(meta.mapped, entity));
             } else if (key === "duration") {
-                await entity.write("ssIasWd", {maxDuration: value}, utils.getOptions(meta.mapped, entity));
+                await entity.write("ssIasWd", {maxDuration: value as number}, utils.getOptions(meta.mapped, entity));
             } else if (key === "volume") {
                 const lookup: KeyValue = {mute: 0, low: 10, medium: 30, high: 50};
                 utils.assertString(value, "volume");
@@ -14274,6 +14276,7 @@ export const definitions: DefinitionWithExtend[] = [
                     actionLookup: {scene_1: 1, scene_2: 2, scene_3: 3, scene_4: 4},
                     cluster: "genOnOff",
                     commands: ["commandTuyaAction"],
+                    // TODO: using command payload not attribute
                     attribute: "data",
                     parse: (msg, attr) => msg.data[attr][1],
                 }),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26,6 +26,12 @@ const fzZosung = zosung.fzZosung;
 const tzZosung = zosung.tzZosung;
 const ez = zosung.presetsZosung;
 
+interface TuyaGenOnOff {
+    attributes: never;
+    commands: {tuyaCountdown: {data: Buffer}};
+    commandResponses: never;
+}
+
 const storeLocal = {
     getPrivatePJ1203A: (device: Zh.Device) => {
         let priv = globalStore.getValue(device, "private_state");
@@ -321,7 +327,7 @@ const tzLocal = {
             utils.assertNumber(value);
             const data = Buffer.alloc(4);
             data.writeUInt32LE(value);
-            await entity.command("genOnOff", "tuyaCountdown", {data});
+            await entity.command<"genOnOff", "tuyaCountdown", TuyaGenOnOff>("genOnOff", "tuyaCountdown", {data});
         },
     } satisfies Tz.Converter,
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
@@ -365,7 +371,7 @@ const tzLocal = {
                 newState.color_mode = colorMode;
 
                 // To switch between white mode and color mode, we have to send a special command:
-                const rgbMode = colorMode === colorModeLookup[ColorMode.HS];
+                const rgbMode = colorMode === colorModeLookup[ColorMode.HS] ? 1 : 0;
                 await entity.command("lightingColorCtrl", "tuyaRgbMode", {
                     enable: rgbMode,
                 });
@@ -377,17 +383,25 @@ const tzLocal = {
 
             if (colorMode === colorModeLookup[ColorMode.ColorTemp]) {
                 if ("brightness" in meta.message) {
-                    const zclData = {level: Number(meta.message.brightness), transtime};
-                    await entity.command("genLevelCtrl", "moveToLevel", zclData, utils.getOptions(meta.mapped, entity));
+                    await entity.command(
+                        "genLevelCtrl",
+                        "moveToLevel",
+                        {level: Number(meta.message.brightness), transtime},
+                        utils.getOptions(meta.mapped, entity),
+                    );
                     newState.brightness = meta.message.brightness;
                 }
 
                 if ("color_temp" in meta.message) {
-                    const zclData = {
-                        colortemp: meta.message.color_temp,
-                        transtime: transtime,
-                    };
-                    await entity.command("lightingColorCtrl", "moveToColorTemp", zclData, utils.getOptions(meta.mapped, entity));
+                    await entity.command(
+                        "lightingColorCtrl",
+                        "moveToColorTemp",
+                        {
+                            colortemp: meta.message.color_temp as number,
+                            transtime: transtime,
+                        },
+                        utils.getOptions(meta.mapped, entity),
+                    );
                     newState.color_temp = meta.message.color_temp;
                 }
             } else if (colorMode === colorModeLookup[ColorMode.HS]) {
@@ -472,9 +486,7 @@ const tzLocal = {
                 (color.isXY() && (color.xy.x === 0.323 || color.xy.y === 0.329));
 
             if (enableWhite) {
-                await entity.command("lightingColorCtrl", "tuyaRgbMode", {
-                    enable: false,
-                });
+                await entity.command("lightingColorCtrl", "tuyaRgbMode", {enable: 0});
                 const newState: KeyValue = {color_mode: "xy"};
                 if (color.isXY()) {
                     newState.color = color.xy;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -14272,11 +14272,10 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.modernExtend.tuyaMagicPacket(),
             m.battery({voltage: true}),
             tuya.modernExtend.combineActions([
-                m.actionEnumLookup({
+                m.actionEnumLookup<"genOnOff", undefined, "tuyaAction">({
                     actionLookup: {scene_1: 1, scene_2: 2, scene_3: 3, scene_4: 4},
                     cluster: "genOnOff",
                     commands: ["commandTuyaAction"],
-                    // TODO: using command payload not attribute
                     attribute: "data",
                     parse: (msg, attr) => msg.data[attr][1],
                 }),

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import {gte as semverGte, valid as semverValid} from "semver";
 import {Zcl} from "zigbee-herdsman";
+import type {ClusterOrRawAttributeKeys, PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -176,7 +177,7 @@ const ubisys = {
                             ubisysTotalSteps: 0xffff,
                             ubisysLiftToTiltTransitionSteps2: 0xffff,
                             ubisysTotalSteps2: 0xffff,
-                        },
+                        } as PartialClusterOrRawWriteAttributes<"closuresWindowCovering">,
                         manufacturerOptions.ubisys,
                     );
                     // enable calibration mode
@@ -274,7 +275,7 @@ const ubisys = {
                             "ubisysAdditionalSteps",
                             "ubisysInactivePowerThreshold",
                             "ubisysStartupSteps",
-                        ],
+                        ] as unknown as ClusterOrRawAttributeKeys<"closuresWindowCovering">,
                         manufacturerOptions.ubisys,
                     ),
                 );
@@ -319,12 +320,20 @@ const ubisys = {
             key: ["minimum_on_level"],
             convertSet: async (entity, key, value, meta) => {
                 if (key === "minimum_on_level") {
-                    await entity.write("genLevelCtrl", {ubisysMinimumOnLevel: value}, manufacturerOptions.ubisys);
+                    await entity.write(
+                        "genLevelCtrl",
+                        {ubisysMinimumOnLevel: value} as PartialClusterOrRawWriteAttributes<"genLevelCtrl">,
+                        manufacturerOptions.ubisys,
+                    );
                 }
                 await ubisys.tz.dimmer_setup_genLevelCtrl.convertGet(entity, key, meta);
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("genLevelCtrl", ["ubisysMinimumOnLevel"], manufacturerOptions.ubisys);
+                await entity.read(
+                    "genLevelCtrl",
+                    ["ubisysMinimumOnLevel"] as unknown as ClusterOrRawAttributeKeys<"genLevelCtrl">,
+                    manufacturerOptions.ubisys,
+                );
             },
         } satisfies Tz.Converter,
         configure_device_setup: {
@@ -367,7 +376,9 @@ const ubisys = {
                     } else {
                         await devMgmtEp.write(
                             "manuSpecificUbisysDeviceSetup",
-                            {[attributeInputConfigurations.name]: {elementType: Zcl.DataType.DATA8, elements: value.input_configurations}},
+                            {
+                                [attributeInputConfigurations.name]: {elementType: Zcl.DataType.DATA8, elements: value.input_configurations},
+                            } as PartialClusterOrRawWriteAttributes<"manuSpecificUbisysDeviceSetup">,
                             manufacturerOptions.ubisysNull,
                         );
                     }
@@ -394,7 +405,9 @@ const ubisys = {
                     } else {
                         await devMgmtEp.write(
                             "manuSpecificUbisysDeviceSetup",
-                            {[attributeInputActions.name]: {elementType: Zcl.DataType.OCTET_STR, elements: value.input_actions}},
+                            {
+                                [attributeInputActions.name]: {elementType: Zcl.DataType.OCTET_STR, elements: value.input_actions},
+                            } as PartialClusterOrRawWriteAttributes<"manuSpecificUbisysDeviceSetup">,
                             manufacturerOptions.ubisysNull,
                         );
                     }
@@ -589,7 +602,9 @@ const ubisys = {
                     } else {
                         await devMgmtEp.write(
                             "manuSpecificUbisysDeviceSetup",
-                            {[attributeInputActions.name]: {elementType: Zcl.DataType.OCTET_STR, elements: resultingInputActions}},
+                            {
+                                [attributeInputActions.name]: {elementType: Zcl.DataType.OCTET_STR, elements: resultingInputActions},
+                            } as PartialClusterOrRawWriteAttributes<"manuSpecificUbisysDeviceSetup">,
                             manufacturerOptions.ubisysNull,
                         );
                     }

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -113,7 +113,6 @@ const ubisys = {
                     do {
                         await sleepSeconds(2);
                         const response = await entity.read("closuresWindowCovering", ["operationalStatus"]);
-                        // @ts-expect-error ignore
                         operationalStatus = response.operationalStatus;
                     } while (operationalStatus !== 0);
                     await sleepSeconds(2);
@@ -135,8 +134,7 @@ const ubisys = {
                         if (converterFunc) {
                             attrValue = converterFunc(attrValue);
                         }
-                        const attributes: KeyValue = {};
-                        attributes[attr] = attrValue;
+                        const attributes = {[attr]: attrValue};
                         await entity.write("closuresWindowCovering", attributes, manufacturerOptions.ubisys);
                         if (delaySecondsAfter) {
                             await sleepSeconds(delaySecondsAfter);
@@ -146,7 +144,6 @@ const ubisys = {
                 const stepsPerSecond = value.steps_per_second || 50;
                 const hasCalibrate = value.calibrate != null;
                 // cancel any running calibration
-                // @ts-expect-error ignore
                 let mode = (await entity.read("closuresWindowCovering", ["windowCoveringMode"])).windowCoveringMode;
                 const modeCalibrationBitMask = 0x02;
                 if (mode & modeCalibrationBitMask) {

--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -12,6 +12,18 @@ import {assertString, getFromLookup, getOptions, toNumber} from "../lib/utils";
 const e = exposes.presets;
 const ea = exposes.access;
 
+interface SprutDevice {
+    attributes: {
+        isConnected: number;
+        // biome-ignore lint/style/useNamingConvention: TODO
+        UartBaudRate: number;
+    };
+    commands: {
+        debug: {data: number};
+    };
+    commandResponses: never;
+}
+
 const sprutCode = 0x6666;
 const manufacturerOptions = {manufacturerCode: sprutCode};
 const switchActionValues = ["OFF", "ON"];
@@ -266,8 +278,8 @@ const sprutModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    sprutIsConnected: (args?: Partial<m.BinaryArgs<"sprutDevice">>) =>
-        m.binary<"sprutDevice", true>({
+    sprutIsConnected: (args?: Partial<m.BinaryArgs<"sprutDevice", SprutDevice>>) =>
+        m.binary<"sprutDevice", SprutDevice>({
             name: "uart_connection",
             cluster: "sprutDevice",
             attribute: "isConnected",
@@ -278,8 +290,8 @@ const sprutModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    sprutUartBaudRate: (args?: Partial<m.EnumLookupArgs<"sprutDevice">>) =>
-        m.enumLookup<"sprutDevice", true>({
+    sprutUartBaudRate: (args?: Partial<m.EnumLookupArgs<"sprutDevice", SprutDevice>>) =>
+        m.enumLookup<"sprutDevice", SprutDevice>({
             name: "uart_baud_rate",
             lookup: {
                 "9600": 9600,

--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import type {TPartialClusterAttributes} from "zigbee-herdsman/dist/zspec/zcl/definition/clusters-types";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -18,7 +18,7 @@ const switchActionValues = ["OFF", "ON"];
 const co2Lookup = {
     co2_autocalibration: "sprutCO2AutoCalibration",
     co2_manual_calibration: "sprutCO2Calibration",
-};
+} as const;
 
 const fzLocal = {
     temperature: {
@@ -224,7 +224,11 @@ const tzLocal = {
             assertString(value, "co2_autocalibration/co2_manual_calibration");
             newValue = switchActionValues.indexOf(value);
             const options = getOptions(meta.mapped, entity, manufacturerOptions);
-            await entity.write("msCO2", {[getFromLookup(key, co2Lookup)]: newValue}, options);
+            const payload: TPartialClusterAttributes<"msCO2"> = {
+                [getFromLookup(key, co2Lookup)]: newValue,
+            };
+
+            await entity.write("msCO2", payload, options);
 
             return {state: {[key]: value}};
         },
@@ -235,9 +239,8 @@ const tzLocal = {
     th_heater: {
         key: ["th_heater"],
         convertSet: async (entity, key, value, meta) => {
-            let newValue = value;
             assertString(value, "th_heater");
-            newValue = switchActionValues.indexOf(value);
+            const newValue = switchActionValues.indexOf(value);
             const options = getOptions(meta.mapped, entity, manufacturerOptions);
             await entity.write("msRelativeHumidity", {sprutHeater: newValue}, options);
 
@@ -250,7 +253,7 @@ const tzLocal = {
 };
 
 const sprutModernExtend = {
-    sprutActivityIndicator: (args?: Partial<m.BinaryArgs>) =>
+    sprutActivityIndicator: (args?: Partial<m.BinaryArgs<"genBinaryOutput">>) =>
         m.binary({
             name: "activity_led",
             cluster: "genBinaryOutput",
@@ -263,7 +266,7 @@ const sprutModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    sprutIsConnected: (args?: Partial<m.BinaryArgs>) =>
+    sprutIsConnected: (args?: Partial<m.BinaryArgs<"sprutDevice">>) =>
         m.binary({
             name: "uart_connection",
             cluster: "sprutDevice",
@@ -275,7 +278,7 @@ const sprutModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    sprutUartBaudRate: (args?: Partial<m.EnumLookupArgs>) =>
+    sprutUartBaudRate: (args?: Partial<m.EnumLookupArgs<"sprutDevice">>) =>
         m.enumLookup({
             name: "uart_baud_rate",
             lookup: {
@@ -292,7 +295,7 @@ const sprutModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    sprutTemperatureOffset: (args?: Partial<m.NumericArgs>) =>
+    sprutTemperatureOffset: (args?: Partial<m.NumericArgs<"msTemperatureMeasurement">>) =>
         m.numeric({
             name: "temperature_offset",
             cluster: "msTemperatureMeasurement",
@@ -307,7 +310,7 @@ const sprutModernExtend = {
             zigbeeCommandOptions: manufacturerOptions,
             ...args,
         }),
-    sprutThHeater: (args?: Partial<m.BinaryArgs>) =>
+    sprutThHeater: (args?: Partial<m.BinaryArgs<"msRelativeHumidity">>) =>
         m.binary({
             name: "th_heater",
             cluster: "msRelativeHumidity",
@@ -320,7 +323,7 @@ const sprutModernExtend = {
             zigbeeCommandOptions: manufacturerOptions,
             ...args,
         }),
-    sprutOccupancyLevel: (args?: Partial<m.NumericArgs>) =>
+    sprutOccupancyLevel: (args?: Partial<m.NumericArgs<"msOccupancySensing">>) =>
         m.numeric({
             name: "occupancy_level",
             cluster: "msOccupancySensing",
@@ -331,7 +334,7 @@ const sprutModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    sprutOccupancyTimeout: (args?: Partial<m.NumericArgs>) =>
+    sprutOccupancyTimeout: (args?: Partial<m.NumericArgs<"msOccupancySensing">>) =>
         m.numeric({
             name: "occupancy_timeout",
             cluster: "msOccupancySensing",
@@ -344,7 +347,7 @@ const sprutModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    sprutOccupancySensitivity: (args?: Partial<m.NumericArgs>) =>
+    sprutOccupancySensitivity: (args?: Partial<m.NumericArgs<"msOccupancySensing">>) =>
         m.numeric({
             name: "occupancy_sensitivity",
             cluster: "msOccupancySensing",
@@ -357,7 +360,7 @@ const sprutModernExtend = {
             zigbeeCommandOptions: manufacturerOptions,
             ...args,
         }),
-    sprutNoise: (args?: Partial<m.NumericArgs>) =>
+    sprutNoise: (args?: Partial<m.NumericArgs<"sprutNoise">>) =>
         m.numeric({
             name: "noise",
             cluster: "sprutNoise",
@@ -370,7 +373,7 @@ const sprutModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    sprutNoiseDetectLevel: (args?: Partial<m.NumericArgs>) =>
+    sprutNoiseDetectLevel: (args?: Partial<m.NumericArgs<"sprutNoise">>) =>
         m.numeric({
             name: "noise_detect_level",
             cluster: "sprutNoise",
@@ -384,7 +387,7 @@ const sprutModernExtend = {
             zigbeeCommandOptions: manufacturerOptions,
             ...args,
         }),
-    sprutNoiseDetected: (args?: Partial<m.BinaryArgs>) =>
+    sprutNoiseDetected: (args?: Partial<m.BinaryArgs<"sprutNoise">>) =>
         m.binary({
             name: "noise_detected",
             cluster: "sprutNoise",
@@ -395,7 +398,7 @@ const sprutModernExtend = {
             access: "STATE_GET",
             ...args,
         }),
-    sprutNoiseTimeout: (args?: Partial<m.NumericArgs>) =>
+    sprutNoiseTimeout: (args?: Partial<m.NumericArgs<"sprutNoise">>) =>
         m.numeric({
             name: "noise_timeout",
             cluster: "sprutNoise",
@@ -408,7 +411,7 @@ const sprutModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    sprutVoc: (args?: Partial<m.NumericArgs>) =>
+    sprutVoc: (args?: Partial<m.NumericArgs<"sprutVoc">>) =>
         m.numeric({
             name: "voc",
             label: "VOC",
@@ -633,6 +636,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Wirenboard",
         description: "Wall-mounted multi sensor",
         extend: [
+            // TODO: looks like this was moved out of ZH but left also in ZH?
             m.deviceAddCustomCluster("sprutDevice", {
                 ID: 26112,
                 manufacturerCode: 26214,

--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -267,7 +267,7 @@ const sprutModernExtend = {
             ...args,
         }),
     sprutIsConnected: (args?: Partial<m.BinaryArgs<"sprutDevice">>) =>
-        m.binary({
+        m.binary<"sprutDevice", true>({
             name: "uart_connection",
             cluster: "sprutDevice",
             attribute: "isConnected",
@@ -279,7 +279,7 @@ const sprutModernExtend = {
             ...args,
         }),
     sprutUartBaudRate: (args?: Partial<m.EnumLookupArgs<"sprutDevice">>) =>
-        m.enumLookup({
+        m.enumLookup<"sprutDevice", true>({
             name: "uart_baud_rate",
             lookup: {
                 "9600": 9600,

--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -608,10 +608,10 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.humidity(endpoint1);
             await reporting.occupancy(endpoint1);
 
-            let payload = reporting.payload("sprutOccupancyLevel", 10, constants.repInterval.MINUTE, 5);
+            let payload = reporting.payload<"msOccupancySensing">("sprutOccupancyLevel", 10, constants.repInterval.MINUTE, 5);
             await endpoint1.configureReporting("msOccupancySensing", payload, manufacturerOptions);
 
-            payload = reporting.payload("noise", 10, constants.repInterval.MINUTE, 5);
+            payload = reporting.payload<"sprutNoise">("noise", 10, constants.repInterval.MINUTE, 5);
             await endpoint1.configureReporting("sprutNoise", payload);
 
             // led_red

--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -648,7 +648,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Wirenboard",
         description: "Wall-mounted multi sensor",
         extend: [
-            // TODO: looks like this was moved out of ZH but left also in ZH?
             m.deviceAddCustomCluster("sprutDevice", {
                 ID: 26112,
                 manufacturerCode: 26214,

--- a/src/devices/xyzroe.ts
+++ b/src/devices/xyzroe.ts
@@ -79,13 +79,12 @@ const tzLocal = {
     zigusb_button_config: {
         key: ["button_mode", "link_to_output", "bind_command"],
         convertGet: async (entity, key, meta) => {
+            // TODO: fix this unknown attr => `switchType`?
             await entity.read("genOnOffSwitchCfg", ["buttonMode", 0x4001, 0x4002]);
         },
         convertSet: async (entity, key, value, meta) => {
-            // biome-ignore lint/suspicious/noImplicitAnyLet: ignored using `--suppress`
-            let payload;
-            // biome-ignore lint/suspicious/noImplicitAnyLet: ignored using `--suppress`
-            let data;
+            let payload: Parameters<typeof entity.write<"genOnOffSwitchCfg">>[1];
+            let data: unknown;
             switch (key) {
                 case "button_mode":
                     data = utils.getFromLookup(value, buttonModesList);

--- a/src/devices/xyzroe.ts
+++ b/src/devices/xyzroe.ts
@@ -79,8 +79,7 @@ const tzLocal = {
     zigusb_button_config: {
         key: ["button_mode", "link_to_output", "bind_command"],
         convertGet: async (entity, key, meta) => {
-            // TODO: fix this unknown attr => `switchType`?
-            await entity.read("genOnOffSwitchCfg", ["buttonMode", 0x4001, 0x4002]);
+            await entity.read("genOnOffSwitchCfg", ["switchType", 0x4001, 0x4002]);
         },
         convertSet: async (entity, key, value, meta) => {
             let payload: Parameters<typeof entity.write<"genOnOffSwitchCfg">>[1];
@@ -88,7 +87,7 @@ const tzLocal = {
             switch (key) {
                 case "button_mode":
                     data = utils.getFromLookup(value, buttonModesList);
-                    payload = {buttonMode: data};
+                    payload = {switchType: data as number};
                     break;
                 case "link_to_output":
                     data = utils.getFromLookup(value, inputLinkList);

--- a/src/devices/yandex.ts
+++ b/src/devices/yandex.ts
@@ -1,6 +1,6 @@
 import type {Models as ZHModels} from "zigbee-herdsman";
-
 import {Zcl} from "zigbee-herdsman";
+import type {ClusterCommandKeys} from "zigbee-herdsman/dist/controller/tstype";
 import {access as ea} from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
@@ -31,7 +31,7 @@ interface Yandex {
 }
 
 interface EnumLookupWithSetCommandArgs extends m.EnumLookupArgs<"manuSpecificYandex", Yandex> {
-    setCommand: string;
+    setCommand: ClusterCommandKeys<"manuSpecificYandex", Yandex>[number];
 }
 
 function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExtend {
@@ -48,7 +48,9 @@ function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExt
                 access & ea.SET
                     ? async (entity, key, value, meta) => {
                           const payloadValue = getFromLookup(value, lookup);
-                          await m.determineEndpoint(entity, meta, cluster).command(cluster, setCommand, {value: payloadValue}, zigbeeCommandOptions);
+                          await m
+                              .determineEndpoint(entity, meta, cluster)
+                              .command<typeof cluster, typeof setCommand, Yandex>(cluster, setCommand, {value: payloadValue}, zigbeeCommandOptions);
                           await m
                               .determineEndpoint(entity, meta, cluster)
                               .read<typeof cluster, Yandex>(cluster, [attributeKey], zigbeeCommandOptions);
@@ -70,7 +72,7 @@ function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExt
 }
 
 interface BinaryWithSetCommandArgs extends m.BinaryArgs<"manuSpecificYandex", Yandex> {
-    setCommand: string;
+    setCommand: ClusterCommandKeys<"manuSpecificYandex", Yandex>[number];
 }
 
 function binaryWithSetCommand(args: BinaryWithSetCommandArgs): ModernExtend {
@@ -87,7 +89,9 @@ function binaryWithSetCommand(args: BinaryWithSetCommandArgs): ModernExtend {
                 access & ea.SET
                     ? async (entity, key, value, meta) => {
                           const payloadValue = value === valueOn[0] ? valueOn[1] : valueOff[1];
-                          await m.determineEndpoint(entity, meta, cluster).command(cluster, setCommand, {value: payloadValue}, zigbeeCommandOptions);
+                          await m
+                              .determineEndpoint(entity, meta, cluster)
+                              .command<typeof cluster, typeof setCommand, Yandex>(cluster, setCommand, {value: payloadValue}, zigbeeCommandOptions);
                           await m
                               .determineEndpoint(entity, meta, cluster)
                               .read<typeof cluster, Yandex>(cluster, [attributeKey], zigbeeCommandOptions);

--- a/src/devices/yandex.ts
+++ b/src/devices/yandex.ts
@@ -11,11 +11,11 @@ import {getFromLookup, isString} from "../lib/utils";
 const NS = "zhc:yandex";
 const manufacturerCode = 0x140a;
 
-interface EnumLookupWithSetCommandArgs extends m.EnumLookupArgs {
+interface EnumLookupWithSetCommandArgs<Cl extends string | number> extends m.EnumLookupArgs<Cl> {
     setCommand: string;
 }
 
-function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExtend {
+function enumLookupWithSetCommand<Cl extends string | number>(args: EnumLookupWithSetCommandArgs<Cl>): ModernExtend {
     const {name, lookup, cluster, attribute, zigbeeCommandOptions, setCommand} = args;
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];
@@ -46,11 +46,11 @@ function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExt
     return {...mExtend, toZigbee};
 }
 
-interface BinaryWithSetCommandArgs extends m.BinaryArgs {
+interface BinaryWithSetCommandArgs<Cl extends string | number> extends m.BinaryArgs<Cl> {
     setCommand: string;
 }
 
-function binaryWithSetCommand(args: BinaryWithSetCommandArgs): ModernExtend {
+function binaryWithSetCommand<Cl extends string | number>(args: BinaryWithSetCommandArgs<Cl>): ModernExtend {
     const {name, valueOn, valueOff, cluster, attribute, zigbeeCommandOptions, setCommand} = args;
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];

--- a/src/devices/yandex.ts
+++ b/src/devices/yandex.ts
@@ -11,16 +11,16 @@ import {getFromLookup, isString} from "../lib/utils";
 const NS = "zhc:yandex";
 const manufacturerCode = 0x140a;
 
-interface EnumLookupWithSetCommandArgs<Cl extends string | number> extends m.EnumLookupArgs<Cl> {
+interface EnumLookupWithSetCommandArgs extends m.EnumLookupArgs<"manuSpecificYandex", true> {
     setCommand: string;
 }
 
-function enumLookupWithSetCommand<Cl extends string | number>(args: EnumLookupWithSetCommandArgs<Cl>): ModernExtend {
+function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExtend {
     const {name, lookup, cluster, attribute, zigbeeCommandOptions, setCommand} = args;
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];
 
-    const mExtend = m.enumLookup(args);
+    const mExtend = m.enumLookup<"manuSpecificYandex", true>(args);
 
     const toZigbee: Tz.Converter[] = [
         {
@@ -46,16 +46,16 @@ function enumLookupWithSetCommand<Cl extends string | number>(args: EnumLookupWi
     return {...mExtend, toZigbee};
 }
 
-interface BinaryWithSetCommandArgs<Cl extends string | number> extends m.BinaryArgs<Cl> {
+interface BinaryWithSetCommandArgs extends m.BinaryArgs<"manuSpecificYandex", true> {
     setCommand: string;
 }
 
-function binaryWithSetCommand<Cl extends string | number>(args: BinaryWithSetCommandArgs<Cl>): ModernExtend {
+function binaryWithSetCommand(args: BinaryWithSetCommandArgs): ModernExtend {
     const {name, valueOn, valueOff, cluster, attribute, zigbeeCommandOptions, setCommand} = args;
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];
 
-    const mExtend = m.binary(args);
+    const mExtend = m.binary<"manuSpecificYandex", true>(args);
 
     const toZigbee: Tz.Converter[] = [
         {

--- a/src/devices/yandex.ts
+++ b/src/devices/yandex.ts
@@ -1,7 +1,7 @@
 import type {Models as ZHModels} from "zigbee-herdsman";
 
 import {Zcl} from "zigbee-herdsman";
-
+import {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import {access as ea} from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
@@ -30,14 +30,18 @@ function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExt
                     ? async (entity, key, value, meta) => {
                           const payloadValue = getFromLookup(value, lookup);
                           await m.determineEndpoint(entity, meta, cluster).command(cluster, setCommand, {value: payloadValue}, zigbeeCommandOptions);
-                          await m.determineEndpoint(entity, meta, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
+                          await m
+                              .determineEndpoint(entity, meta, cluster)
+                              .read<typeof cluster, Yandex>(cluster, [attributeKey], zigbeeCommandOptions);
                           return {state: {[key]: value}};
                       }
                     : undefined,
             convertGet:
                 access & ea.GET
                     ? async (entity, key, meta) => {
-                          await m.determineEndpoint(entity, meta, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
+                          await m
+                              .determineEndpoint(entity, meta, cluster)
+                              .read<typeof cluster, Yandex>(cluster, [attributeKey], zigbeeCommandOptions);
                       }
                     : undefined,
         },
@@ -65,20 +69,44 @@ function binaryWithSetCommand(args: BinaryWithSetCommandArgs): ModernExtend {
                     ? async (entity, key, value, meta) => {
                           const payloadValue = value === valueOn[0] ? valueOn[1] : valueOff[1];
                           await m.determineEndpoint(entity, meta, cluster).command(cluster, setCommand, {value: payloadValue}, zigbeeCommandOptions);
-                          await m.determineEndpoint(entity, meta, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
+                          await m
+                              .determineEndpoint(entity, meta, cluster)
+                              .read<typeof cluster, Yandex>(cluster, [attributeKey], zigbeeCommandOptions);
                           return {state: {[key]: value}};
                       }
                     : undefined,
             convertGet:
                 access & ea.GET
                     ? async (entity, key, meta) => {
-                          await m.determineEndpoint(entity, meta, cluster).read(cluster, [attributeKey], zigbeeCommandOptions);
+                          await m
+                              .determineEndpoint(entity, meta, cluster)
+                              .read<typeof cluster, Yandex>(cluster, [attributeKey], zigbeeCommandOptions);
                       }
                     : undefined,
         },
     ];
 
     return {...mExtend, toZigbee};
+}
+
+interface Yandex extends TCustomCluster {
+    attributes: {
+        switchMode: number;
+        switchType: number;
+        powerType: number;
+        ledIndicator: number;
+        interlock: number;
+        buttonMode: number;
+    };
+    commands: {
+        switchMode: {value: number};
+        switchType: {value: number};
+        powerType: {value: number};
+        ledIndicator: {value: number};
+        interlock: {value: number};
+        buttonMode: {value: number};
+    };
+    commandResponses: never;
 }
 
 function YandexCluster(): ModernExtend {

--- a/src/devices/yandex.ts
+++ b/src/devices/yandex.ts
@@ -1,7 +1,6 @@
 import type {Models as ZHModels} from "zigbee-herdsman";
 
 import {Zcl} from "zigbee-herdsman";
-import {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import {access as ea} from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
@@ -11,7 +10,27 @@ import {getFromLookup, isString} from "../lib/utils";
 const NS = "zhc:yandex";
 const manufacturerCode = 0x140a;
 
-interface EnumLookupWithSetCommandArgs extends m.EnumLookupArgs<"manuSpecificYandex", true> {
+interface Yandex {
+    attributes: {
+        switchMode: number;
+        switchType: number;
+        powerType: number;
+        ledIndicator: number;
+        interlock: number;
+        buttonMode: number;
+    };
+    commands: {
+        switchMode: {value: number};
+        switchType: {value: number};
+        powerType: {value: number};
+        ledIndicator: {value: number};
+        interlock: {value: number};
+        buttonMode: {value: number};
+    };
+    commandResponses: never;
+}
+
+interface EnumLookupWithSetCommandArgs extends m.EnumLookupArgs<"manuSpecificYandex", Yandex> {
     setCommand: string;
 }
 
@@ -20,7 +39,7 @@ function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExt
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];
 
-    const mExtend = m.enumLookup<"manuSpecificYandex", true>(args);
+    const mExtend = m.enumLookup<"manuSpecificYandex", Yandex>(args);
 
     const toZigbee: Tz.Converter[] = [
         {
@@ -50,7 +69,7 @@ function enumLookupWithSetCommand(args: EnumLookupWithSetCommandArgs): ModernExt
     return {...mExtend, toZigbee};
 }
 
-interface BinaryWithSetCommandArgs extends m.BinaryArgs<"manuSpecificYandex", true> {
+interface BinaryWithSetCommandArgs extends m.BinaryArgs<"manuSpecificYandex", Yandex> {
     setCommand: string;
 }
 
@@ -59,7 +78,7 @@ function binaryWithSetCommand(args: BinaryWithSetCommandArgs): ModernExtend {
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];
 
-    const mExtend = m.binary<"manuSpecificYandex", true>(args);
+    const mExtend = m.binary<"manuSpecificYandex", Yandex>(args);
 
     const toZigbee: Tz.Converter[] = [
         {
@@ -87,26 +106,6 @@ function binaryWithSetCommand(args: BinaryWithSetCommandArgs): ModernExtend {
     ];
 
     return {...mExtend, toZigbee};
-}
-
-interface Yandex extends TCustomCluster {
-    attributes: {
-        switchMode: number;
-        switchType: number;
-        powerType: number;
-        ledIndicator: number;
-        interlock: number;
-        buttonMode: number;
-    };
-    commands: {
-        switchMode: {value: number};
-        switchType: {value: number};
-        powerType: {value: number};
-        ledIndicator: {value: number};
-        interlock: {value: number};
-        buttonMode: {value: number};
-    };
-    commandResponses: never;
 }
 
 function YandexCluster(): ModernExtend {

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -1487,7 +1487,7 @@ const YokisDeviceExtend: ModernExtend[] = [
 
 const YokisInputExtend: ModernExtend[] = [
     // InputMode
-    m.enumLookup({
+    m.enumLookup<"manuSpecificYokisInput", true>({
         name: "input_mode",
         lookup: inputModeEnum,
         cluster: "manuSpecificYokisInput",
@@ -1502,7 +1502,7 @@ const YokisInputExtend: ModernExtend[] = [
     }),
 
     // InputMode
-    m.enumLookup({
+    m.enumLookup<"manuSpecificYokisInput", true>({
         name: "contact_mode",
         lookup: {nc: 0x00, no: 0x01},
         cluster: "manuSpecificYokisInput",
@@ -1514,7 +1514,7 @@ const YokisInputExtend: ModernExtend[] = [
     }),
 
     // LastLocalCommandState
-    m.binary({
+    m.binary<"manuSpecificYokisInput", true>({
         name: "last_local_command_state",
         cluster: "manuSpecificYokisInput",
         attribute: "lastLocalCommandState",
@@ -1526,7 +1526,7 @@ const YokisInputExtend: ModernExtend[] = [
     }),
 
     // LastBPConnectState
-    m.binary({
+    m.binary<"manuSpecificYokisInput", true>({
         name: "last_bp_connect_state",
         cluster: "manuSpecificYokisInput",
         attribute: "lastBPConnectState",
@@ -1561,7 +1561,7 @@ const YokisInputExtendWithBacklight: ModernExtend[] = [
 
 const YokisEntryExtend: ModernExtend[] = [
     // eShortPress
-    m.binary({
+    m.binary<"manuSpecificYokisEntryConfigurator", true>({
         name: "enable_short_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eShortPress",
@@ -1572,7 +1572,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // eLongPress
-    m.binary({
+    m.binary<"manuSpecificYokisEntryConfigurator", true>({
         name: "enable_long_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eLongPress",
@@ -1583,7 +1583,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // LongPressDuration
-    m.numeric({
+    m.numeric<"manuSpecificYokisEntryConfigurator", true>({
         name: "long_press_duration",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "longPressDuration",
@@ -1596,7 +1596,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // TimeBetweenPress
-    m.numeric({
+    m.numeric<"manuSpecificYokisEntryConfigurator", true>({
         name: "time_between_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "timeBetweenPress",
@@ -1609,7 +1609,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // eR12MLongPress
-    m.binary({
+    m.binary<"manuSpecificYokisEntryConfigurator", true>({
         name: "enable_R12M_long_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eR12MLongPress",
@@ -1620,7 +1620,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // eLocalConfigLock
-    m.binary({
+    m.binary<"manuSpecificYokisEntryConfigurator", true>({
         name: "enable_local_config_lock",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eLocalConfigLock",
@@ -1632,7 +1632,7 @@ const YokisEntryExtend: ModernExtend[] = [
 ];
 
 const YokisSubSystemExtend: ModernExtend[] = [
-    m.enumLookup({
+    m.enumLookup<"manuSpecificYokisSubSystem", true>({
         name: "power_failure_mode",
         lookup: {last_state: 0x00, off: 0x01, on: 0x02, blink: 0x03},
         cluster: "manuSpecificYokisSubSystem",
@@ -1660,7 +1660,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     // }),
 
     // PrevState
-    m.binary({
+    m.binary<"manuSpecificYokisLightControl", true>({
         name: "prev_state",
         cluster: "manuSpecificYokisLightControl",
         attribute: "prevState",
@@ -1684,7 +1684,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     //     valueOff: ['OFF', 0x00],
     //     entityCategory: 'config',
     // }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "on_timer",
         cluster: "manuSpecificYokisLightControl",
         attribute: "onTimer",
@@ -1697,7 +1697,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // preOnDelay
-    m.binary({
+    m.binary<"manuSpecificYokisLightControl", true>({
         name: "enable_pre_on_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "ePreOnDelay",
@@ -1706,7 +1706,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "pre_on_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "preOnDelay",
@@ -1719,7 +1719,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // preOffDelay
-    m.binary({
+    m.binary<"manuSpecificYokisLightControl", true>({
         name: "enable_pre_off_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "ePreOffDelay",
@@ -1728,7 +1728,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "pre_off_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "preOffDelay",
@@ -1741,7 +1741,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // Pulseduration
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "pulse_duration",
         cluster: "manuSpecificYokisLightControl",
         attribute: "pulseDuration",
@@ -1754,7 +1754,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // TimeType
-    m.enumLookup({
+    m.enumLookup<"manuSpecificYokisLightControl", true>({
         name: "time_type",
         lookup: {seconds: 0x00, minutes: 0x01},
         cluster: "manuSpecificYokisLightControl",
@@ -1766,7 +1766,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // LongOnDuration
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "long_on_duration",
         cluster: "manuSpecificYokisLightControl",
         attribute: "longOnDuration",
@@ -1779,7 +1779,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // OperatingMode
-    m.enumLookup({
+    m.enumLookup<"manuSpecificYokisLightControl", true>({
         name: "operating_mode",
         lookup: {timer: 0x00, staircase: 0x01, pulse: 0x02},
         cluster: "manuSpecificYokisLightControl",
@@ -1792,7 +1792,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // stopAnnounce
-    m.binary({
+    m.binary<"manuSpecificYokisLightControl", true>({
         name: "enable_stop_announce",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eStopAnnounce",
@@ -1801,7 +1801,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "stop_announce_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "stopAnnounceTime",
@@ -1814,7 +1814,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // eDeaf
-    m.binary({
+    m.binary<"manuSpecificYokisLightControl", true>({
         name: "enable_deaf",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eDeaf",
@@ -1823,7 +1823,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "deaf_blink_amount",
         cluster: "manuSpecificYokisLightControl",
         attribute: "deafBlinkAmount",
@@ -1833,7 +1833,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueStep: 1,
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "deaf_blink_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "deafBlinkTime",
@@ -1845,7 +1845,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // Blink
-    m.binary({
+    m.binary<"manuSpecificYokisLightControl", true>({
         name: "enable_blink",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eBlink",
@@ -1854,7 +1854,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "blink_amount",
         cluster: "manuSpecificYokisLightControl",
         attribute: "blinkAmount",
@@ -1864,7 +1864,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueStep: 1,
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "blink_on_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "blinkOnTime",
@@ -1874,7 +1874,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueStep: 1,
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisLightControl", true>({
         name: "blink_off_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "blinkOffTime",
@@ -1886,7 +1886,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // StateAfterBlink
-    m.enumLookup({
+    m.enumLookup<"manuSpecificYokisLightControl", true>({
         name: "state_after_blink",
         lookup: stateAfterBlinkEnum,
         cluster: "manuSpecificYokisLightControl",
@@ -1900,7 +1900,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // eNcCommand
-    m.binary({
+    m.binary<"manuSpecificYokisLightControl", true>({
         name: "enable_nc_command",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eNcCommand",
@@ -1919,7 +1919,7 @@ const yokisLightControlExtend: ModernExtend[] = [
 
 const YokisDimmerExtend: ModernExtend[] = [
     // currentPosition
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "current_position",
         cluster: "manuSpecificYokisDimmer",
         attribute: "currentPosition",
@@ -1929,7 +1929,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // memoryPosition
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "memory_position",
         cluster: "manuSpecificYokisDimmer",
         attribute: "memoryPosition",
@@ -1939,7 +1939,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // RampUp
-    m.binary({
+    m.binary<"manuSpecificYokisDimmer", true>({
         name: "enable_ramp_up",
         cluster: "manuSpecificYokisDimmer",
         attribute: "eRampUp",
@@ -1948,7 +1948,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "ramp_up",
         cluster: "manuSpecificYokisDimmer",
         attribute: "rampUp",
@@ -1960,7 +1960,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // RampDown
-    m.binary({
+    m.binary<"manuSpecificYokisDimmer", true>({
         name: "enable_ramp_down",
         cluster: "manuSpecificYokisDimmer",
         attribute: "eRampDown",
@@ -1969,7 +1969,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "ramp_down",
         cluster: "manuSpecificYokisDimmer",
         attribute: "rampDown",
@@ -1981,7 +1981,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // rampContinuousTime
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "ramp_continuous_time",
         cluster: "manuSpecificYokisDimmer",
         attribute: "rampContinuousTime",
@@ -1993,7 +1993,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepUp
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "step_up",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepUp",
@@ -2005,7 +2005,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // lowDimLimit
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "low_dim_limit",
         cluster: "manuSpecificYokisDimmer",
         attribute: "lowDimLimit",
@@ -2018,7 +2018,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // highDimLimit
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "high_dim_limit",
         cluster: "manuSpecificYokisDimmer",
         attribute: "highDimLimit",
@@ -2031,7 +2031,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightStartingDelay
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "nightlight_starting_delay",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightStartingDelay",
@@ -2043,7 +2043,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightStartingBrightness
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "nightlight_starting_brightness",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightStartingBrightness",
@@ -2055,7 +2055,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightEndingBrightness
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "nightlight_ending_brightness",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightEndingBrightness",
@@ -2068,7 +2068,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightRampTime
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "nightlight_ramp_time",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightRampTime",
@@ -2081,7 +2081,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightOnTime
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "nightlight_on_time",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightOnTime",
@@ -2094,7 +2094,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // favoritePosition1
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "favorite_position_1",
         cluster: "manuSpecificYokisDimmer",
         attribute: "favoritePosition1",
@@ -2106,7 +2106,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // favoritePosition2
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "favorite_position_2",
         cluster: "manuSpecificYokisDimmer",
         attribute: "favoritePosition2",
@@ -2118,7 +2118,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // favoritePosition3
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "favorite_position_3",
         cluster: "manuSpecificYokisDimmer",
         attribute: "favoritePosition3",
@@ -2130,7 +2130,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepControllerMode
-    m.binary({
+    m.binary<"manuSpecificYokisDimmer", true>({
         name: "step_controller_mode",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepControllerMode",
@@ -2142,7 +2142,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // memoryPositionMode
-    m.binary({
+    m.binary<"manuSpecificYokisDimmer", true>({
         name: "memory_position_mode",
         cluster: "manuSpecificYokisDimmer",
         attribute: "memoryPositionMode",
@@ -2153,7 +2153,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepDown
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "step_down",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepDown",
@@ -2165,7 +2165,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepContinuous
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "step_continuous",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepContinuous",
@@ -2177,7 +2177,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepNightLigth
-    m.numeric({
+    m.numeric<"manuSpecificYokisDimmer", true>({
         name: "step_nightlight",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepNightLight",

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -44,7 +44,6 @@ const inputModeEnum: {[s: string]: number} = {
 
 // #region Custom cluster definition
 
-// biome-ignore lint/correctness/noUnusedVariables: for later use
 interface YokisDevice {
     attributes: {
         configurationChanged: number;
@@ -1042,7 +1041,11 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value);
 
-                    await entity.command("manuSpecificYokisDevice", "resetToFactorySettings", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisDevice", "resetToFactorySettings", YokisDevice>(
+                        "manuSpecificYokisDevice",
+                        "resetToFactorySettings",
+                        commandWrapper.payload,
+                    );
                 },
             },
         ];
@@ -1064,7 +1067,11 @@ const yokisCommandsExtend = {
                 key: ["relaunch_ble_advert"],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
-                    await entity.command("manuSpecificYokisDevice", "relaunchBleAdvert", {});
+                    await entity.command<"manuSpecificYokisDevice", "relaunchBleAdvert", YokisDevice>(
+                        "manuSpecificYokisDevice",
+                        "relaunchBleAdvert",
+                        {},
+                    );
                 },
             },
         ];
@@ -1097,7 +1104,11 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value);
 
-                    await entity.command("manuSpecificYokisDevice", "OpenNetwork", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisDevice", "openNetwork", YokisDevice>(
+                        "manuSpecificYokisDevice",
+                        "openNetwork",
+                        commandWrapper.payload,
+                    );
                 },
             },
         ];
@@ -1165,7 +1176,11 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    await entity.command("manuSpecificYokisLightControl", "moveToPosition", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisLightControl", "moveToPosition", YokisLightControl>(
+                        "manuSpecificYokisLightControl",
+                        "moveToPosition",
+                        commandWrapper.payload,
+                    );
                 },
             },
         ];
@@ -1219,7 +1234,11 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    await entity.command("manuSpecificYokisLightControl", "blink", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisLightControl", "blink", YokisLightControl>(
+                        "manuSpecificYokisLightControl",
+                        "blink",
+                        commandWrapper.payload,
+                    );
                 },
             },
         ];
@@ -1309,7 +1328,11 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    await entity.command("manuSpecificYokisLightControl", "deafBlink", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisLightControl", "deafBlink", YokisLightControl>(
+                        "manuSpecificYokisLightControl",
+                        "deafBlink",
+                        commandWrapper.payload,
+                    );
                 },
             },
         ];
@@ -1331,7 +1354,7 @@ const yokisCommandsExtend = {
                 key: ["long_on_command"],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
-                    await entity.command("manuSpecificYokisLightControl", "longOn", {});
+                    await entity.command<"manuSpecificYokisLightControl", "longOn", YokisLightControl>("manuSpecificYokisLightControl", "longOn", {});
                 },
             },
         ];
@@ -1353,7 +1376,7 @@ const yokisCommandsExtend = {
                 key: ["send_press"],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
-                    await entity.command("manuSpecificYokisDevice", "sendPress", {});
+                    await entity.command<"manuSpecificYokisInput", "sendPress", YokisInput>("manuSpecificYokisInput", "sendPress", {});
                 },
             },
         ];
@@ -1375,7 +1398,7 @@ const yokisCommandsExtend = {
                 key: ["send_release"],
                 convertSet: async (entity, key, value, meta) => {
                     yokisExtendChecks.log(key, value);
-                    await entity.command("manuSpecificYokisDevice", "sendRelease", {});
+                    await entity.command<"manuSpecificYokisInput", "sendRelease", YokisInput>("manuSpecificYokisInput", "sendRelease", {});
                 },
             },
         ];
@@ -1400,7 +1423,11 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value);
 
-                    await entity.command("manuSpecificYokisLightControl", "selectInputMode", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisInput", "selectInputMode", YokisInput>(
+                        "manuSpecificYokisInput",
+                        "selectInputMode",
+                        commandWrapper.payload,
+                    );
                 },
             },
         ];
@@ -1442,7 +1469,7 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    await entity.command("manuSpecificYokisDimmer", "dim", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisDimmer", "dim", YokisDimmer>("manuSpecificYokisDimmer", "dim", commandWrapper.payload);
                 },
             },
         ];
@@ -1499,7 +1526,11 @@ const yokisCommandsExtend = {
                 convertSet: async (entity, key, value, meta) => {
                     utils.assertString(value);
                     yokisExtendChecks.log(key, value);
-                    await entity.command("manuSpecificYokisDimmer", value, {});
+                    await entity.command<"manuSpecificYokisDimmer", "dimUp" | "dimDown", YokisDimmer>(
+                        "manuSpecificYokisDimmer",
+                        value as "dimUp" | "dimDown",
+                        {},
+                    );
                 },
             },
         ];
@@ -1522,7 +1553,11 @@ const yokisCommandsExtend = {
                 convertSet: async (entity, key, value, meta) => {
                     utils.assertString(value);
                     yokisExtendChecks.log(key, value);
-                    await entity.command("manuSpecificYokisDimmer", value, {});
+                    await entity.command<"manuSpecificYokisDimmer", "moveToFavorite1" | "moveToFavorite2" | "moveToFavorite3", YokisDimmer>(
+                        "manuSpecificYokisDimmer",
+                        value as "moveToFavorite1" | "moveToFavorite2" | "moveToFavorite3",
+                        {},
+                    );
                 },
             },
         ];
@@ -1545,7 +1580,11 @@ const yokisCommandsExtend = {
                 convertSet: async (entity, key, value, meta) => {
                     utils.assertString(value);
                     yokisExtendChecks.log(key, value);
-                    await entity.command("manuSpecificYokisDimmer", value, {});
+                    await entity.command<"manuSpecificYokisDimmer", "startNightLightModeCurrent", YokisDimmer>(
+                        "manuSpecificYokisDimmer",
+                        value as "startNightLightModeCurrent",
+                        {},
+                    );
                 },
             },
         ];
@@ -1616,7 +1655,11 @@ const yokisCommandsExtend = {
 
                     yokisExtendChecks.log(key, value, commandWrapper.payload);
 
-                    await entity.command("manuSpecificYokisDimmer", "startNightLightMode", commandWrapper.payload);
+                    await entity.command<"manuSpecificYokisDimmer", "startNightLightMode", YokisDimmer>(
+                        "manuSpecificYokisDimmer",
+                        "startNightLightMode",
+                        commandWrapper.payload,
+                    );
                 },
             },
         ];

--- a/src/devices/yokis.ts
+++ b/src/devices/yokis.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-import type {ClusterDefinition} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
+import type {ClusterDefinition, ZclArray} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
@@ -43,6 +43,194 @@ const inputModeEnum: {[s: string]: number} = {
 // #endregion
 
 // #region Custom cluster definition
+
+// biome-ignore lint/correctness/noUnusedVariables: for later use
+interface YokisDevice {
+    attributes: {
+        configurationChanged: number;
+    };
+    commands: {
+        // biome-ignore lint/style/useNamingConvention: TODO
+        resetToFactorySettings: {uc_ResetAction: number};
+        relaunchBleAdvert: Record<string, never>;
+        // biome-ignore lint/style/useNamingConvention: TODO
+        openNetwork: {uc_OpeningTime: number};
+    };
+    commandResponses: never;
+}
+interface YokisInput {
+    attributes: {
+        inputMode: number;
+        contactMode: number;
+        lastLocalCommandState: number;
+        lastBPConnectState: number;
+        backlightIntensity: number;
+    };
+    commands: {
+        sendPress: Record<string, never>;
+        sendRelease: Record<string, never>;
+        // biome-ignore lint/style/useNamingConvention: TODO
+        selectInputMode: {uc_InputMode: number};
+    };
+    commandResponses: never;
+}
+interface YokisEntryConfigurator {
+    attributes: {
+        eShortPress: number;
+        eLongPress: number;
+        longPressDuration: number;
+        timeBetweenPress: number;
+        eR12MLongPress: number;
+        eLocalConfigLock: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+interface YokisLightControl {
+    attributes: {
+        onOff: number;
+        prevState: number;
+        onTimer: number;
+        eOnTimer: number;
+        preOnDelay: number;
+        ePreOnDelay: number;
+        preOffDelay: number;
+        ePreOffDelay: number;
+        pulseDuration: number;
+        timeType: number;
+        longOnDuration: number;
+        operatingMode: number;
+        stopAnnounceTime: number;
+        eStopAnnounce: number;
+        eDeaf: number;
+        eBlink: number;
+        blinkAmount: number;
+        blinkOnTime: number;
+        blinkOffTime: number;
+        deafBlinkAmount: number;
+        deafBlinkTime: number;
+        stateAfterBlink: number;
+        eNcCommand: number;
+    };
+    commands: {
+        moveToPosition: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_BrightnessStart: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_BrightnessEnd: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_PreTimerValue: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            b_PreTimerEnable: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_TimerValue: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            b_TimerEnable: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_TransitionTime: number;
+        };
+        pulse: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            PulseLength: number;
+        };
+        blink: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_BlinkAmount: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_BlinkOnPeriod: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_BlinkOffPeriod: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_StateAfterSequence: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            b_DoPeriodicCycle: number;
+        };
+        deafBlink: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_BlinkAmount: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_BlinkOnTime: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_SequenceAmount: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            tuc_BlinkAmount: ZclArray | unknown[];
+        };
+        longOn: Record<string, never>;
+    };
+    commandResponses: never;
+}
+interface YokisDimmer {
+    attributes: {
+        currentPosition: number;
+        memoryPosition: number;
+        eRampUp: number;
+        rampUp: number;
+        eRampDown: number;
+        rampDown: number;
+        rampContinuousTime: number;
+        stepUp: number;
+        lowDimLimit: number;
+        highDimLimit: number;
+        nightLightStartingDelay: number;
+        nightLightStartingBrightness: number;
+        nightLightEndingBrightness: number;
+        nightLightRampTime: number;
+        nightLightOnTime: number;
+        favoritePosition1: number;
+        favoritePosition2: number;
+        favoritePosition3: number;
+        stepControllerMode: number;
+        memoryPositionMode: number;
+        stepDown: number;
+        stepContinuous: number;
+        stepNightLight: number;
+    };
+    commands: {
+        dimUp: Record<string, never>;
+        dimDown: Record<string, never>;
+        dim: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_RampContinuousDuration: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_StepContinuous: number;
+        };
+        dimStop: Record<string, never>;
+        dimToMin: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_TransitionTime: number;
+        };
+        dimToMax: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_TransitionTime: number;
+        };
+        startNightLightMode: {
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_ChildModeStartingDelay: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_ChildModeBrightnessStart: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_ChildModeBrightnessEnd: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_ChildModeRampDuration: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            ul_ChildModeOnDuration: number;
+            // biome-ignore lint/style/useNamingConvention: TODO
+            uc_ChildStep: number;
+        };
+        startNightLightModeCurrent: Record<string, never>;
+        moveToFavorite1: Record<string, never>;
+        moveToFavorite2: Record<string, never>;
+        moveToFavorite3: Record<string, never>;
+    };
+    commandResponses: never;
+}
+interface YokisSubSystem {
+    attributes: {
+        powerFailureMode: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
 
 const YokisClustersDefinition: {
     [s: string]: ClusterDefinition;
@@ -1487,7 +1675,7 @@ const YokisDeviceExtend: ModernExtend[] = [
 
 const YokisInputExtend: ModernExtend[] = [
     // InputMode
-    m.enumLookup<"manuSpecificYokisInput", true>({
+    m.enumLookup<"manuSpecificYokisInput", YokisInput>({
         name: "input_mode",
         lookup: inputModeEnum,
         cluster: "manuSpecificYokisInput",
@@ -1502,7 +1690,7 @@ const YokisInputExtend: ModernExtend[] = [
     }),
 
     // InputMode
-    m.enumLookup<"manuSpecificYokisInput", true>({
+    m.enumLookup<"manuSpecificYokisInput", YokisInput>({
         name: "contact_mode",
         lookup: {nc: 0x00, no: 0x01},
         cluster: "manuSpecificYokisInput",
@@ -1514,7 +1702,7 @@ const YokisInputExtend: ModernExtend[] = [
     }),
 
     // LastLocalCommandState
-    m.binary<"manuSpecificYokisInput", true>({
+    m.binary<"manuSpecificYokisInput", YokisInput>({
         name: "last_local_command_state",
         cluster: "manuSpecificYokisInput",
         attribute: "lastLocalCommandState",
@@ -1526,7 +1714,7 @@ const YokisInputExtend: ModernExtend[] = [
     }),
 
     // LastBPConnectState
-    m.binary<"manuSpecificYokisInput", true>({
+    m.binary<"manuSpecificYokisInput", YokisInput>({
         name: "last_bp_connect_state",
         cluster: "manuSpecificYokisInput",
         attribute: "lastBPConnectState",
@@ -1561,7 +1749,7 @@ const YokisInputExtendWithBacklight: ModernExtend[] = [
 
 const YokisEntryExtend: ModernExtend[] = [
     // eShortPress
-    m.binary<"manuSpecificYokisEntryConfigurator", true>({
+    m.binary<"manuSpecificYokisEntryConfigurator", YokisEntryConfigurator>({
         name: "enable_short_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eShortPress",
@@ -1572,7 +1760,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // eLongPress
-    m.binary<"manuSpecificYokisEntryConfigurator", true>({
+    m.binary<"manuSpecificYokisEntryConfigurator", YokisEntryConfigurator>({
         name: "enable_long_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eLongPress",
@@ -1583,7 +1771,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // LongPressDuration
-    m.numeric<"manuSpecificYokisEntryConfigurator", true>({
+    m.numeric<"manuSpecificYokisEntryConfigurator", YokisEntryConfigurator>({
         name: "long_press_duration",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "longPressDuration",
@@ -1596,7 +1784,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // TimeBetweenPress
-    m.numeric<"manuSpecificYokisEntryConfigurator", true>({
+    m.numeric<"manuSpecificYokisEntryConfigurator", YokisEntryConfigurator>({
         name: "time_between_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "timeBetweenPress",
@@ -1609,7 +1797,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // eR12MLongPress
-    m.binary<"manuSpecificYokisEntryConfigurator", true>({
+    m.binary<"manuSpecificYokisEntryConfigurator", YokisEntryConfigurator>({
         name: "enable_R12M_long_press",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eR12MLongPress",
@@ -1620,7 +1808,7 @@ const YokisEntryExtend: ModernExtend[] = [
     }),
 
     // eLocalConfigLock
-    m.binary<"manuSpecificYokisEntryConfigurator", true>({
+    m.binary<"manuSpecificYokisEntryConfigurator", YokisEntryConfigurator>({
         name: "enable_local_config_lock",
         cluster: "manuSpecificYokisEntryConfigurator",
         attribute: "eLocalConfigLock",
@@ -1632,7 +1820,7 @@ const YokisEntryExtend: ModernExtend[] = [
 ];
 
 const YokisSubSystemExtend: ModernExtend[] = [
-    m.enumLookup<"manuSpecificYokisSubSystem", true>({
+    m.enumLookup<"manuSpecificYokisSubSystem", YokisSubSystem>({
         name: "power_failure_mode",
         lookup: {last_state: 0x00, off: 0x01, on: 0x02, blink: 0x03},
         cluster: "manuSpecificYokisSubSystem",
@@ -1660,7 +1848,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     // }),
 
     // PrevState
-    m.binary<"manuSpecificYokisLightControl", true>({
+    m.binary<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "prev_state",
         cluster: "manuSpecificYokisLightControl",
         attribute: "prevState",
@@ -1684,7 +1872,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     //     valueOff: ['OFF', 0x00],
     //     entityCategory: 'config',
     // }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "on_timer",
         cluster: "manuSpecificYokisLightControl",
         attribute: "onTimer",
@@ -1697,7 +1885,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // preOnDelay
-    m.binary<"manuSpecificYokisLightControl", true>({
+    m.binary<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "enable_pre_on_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "ePreOnDelay",
@@ -1706,7 +1894,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "pre_on_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "preOnDelay",
@@ -1719,7 +1907,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // preOffDelay
-    m.binary<"manuSpecificYokisLightControl", true>({
+    m.binary<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "enable_pre_off_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "ePreOffDelay",
@@ -1728,7 +1916,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "pre_off_delay",
         cluster: "manuSpecificYokisLightControl",
         attribute: "preOffDelay",
@@ -1741,7 +1929,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // Pulseduration
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "pulse_duration",
         cluster: "manuSpecificYokisLightControl",
         attribute: "pulseDuration",
@@ -1754,7 +1942,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // TimeType
-    m.enumLookup<"manuSpecificYokisLightControl", true>({
+    m.enumLookup<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "time_type",
         lookup: {seconds: 0x00, minutes: 0x01},
         cluster: "manuSpecificYokisLightControl",
@@ -1766,7 +1954,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // LongOnDuration
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "long_on_duration",
         cluster: "manuSpecificYokisLightControl",
         attribute: "longOnDuration",
@@ -1779,7 +1967,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // OperatingMode
-    m.enumLookup<"manuSpecificYokisLightControl", true>({
+    m.enumLookup<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "operating_mode",
         lookup: {timer: 0x00, staircase: 0x01, pulse: 0x02},
         cluster: "manuSpecificYokisLightControl",
@@ -1792,7 +1980,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // stopAnnounce
-    m.binary<"manuSpecificYokisLightControl", true>({
+    m.binary<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "enable_stop_announce",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eStopAnnounce",
@@ -1801,7 +1989,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "stop_announce_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "stopAnnounceTime",
@@ -1814,7 +2002,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // eDeaf
-    m.binary<"manuSpecificYokisLightControl", true>({
+    m.binary<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "enable_deaf",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eDeaf",
@@ -1823,7 +2011,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "deaf_blink_amount",
         cluster: "manuSpecificYokisLightControl",
         attribute: "deafBlinkAmount",
@@ -1833,7 +2021,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueStep: 1,
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "deaf_blink_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "deafBlinkTime",
@@ -1845,7 +2033,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // Blink
-    m.binary<"manuSpecificYokisLightControl", true>({
+    m.binary<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "enable_blink",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eBlink",
@@ -1854,7 +2042,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "blink_amount",
         cluster: "manuSpecificYokisLightControl",
         attribute: "blinkAmount",
@@ -1864,7 +2052,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueStep: 1,
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "blink_on_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "blinkOnTime",
@@ -1874,7 +2062,7 @@ const yokisLightControlExtend: ModernExtend[] = [
         valueStep: 1,
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisLightControl", true>({
+    m.numeric<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "blink_off_time",
         cluster: "manuSpecificYokisLightControl",
         attribute: "blinkOffTime",
@@ -1886,7 +2074,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // StateAfterBlink
-    m.enumLookup<"manuSpecificYokisLightControl", true>({
+    m.enumLookup<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "state_after_blink",
         lookup: stateAfterBlinkEnum,
         cluster: "manuSpecificYokisLightControl",
@@ -1900,7 +2088,7 @@ const yokisLightControlExtend: ModernExtend[] = [
     }),
 
     // eNcCommand
-    m.binary<"manuSpecificYokisLightControl", true>({
+    m.binary<"manuSpecificYokisLightControl", YokisLightControl>({
         name: "enable_nc_command",
         cluster: "manuSpecificYokisLightControl",
         attribute: "eNcCommand",
@@ -1919,7 +2107,7 @@ const yokisLightControlExtend: ModernExtend[] = [
 
 const YokisDimmerExtend: ModernExtend[] = [
     // currentPosition
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "current_position",
         cluster: "manuSpecificYokisDimmer",
         attribute: "currentPosition",
@@ -1929,7 +2117,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // memoryPosition
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "memory_position",
         cluster: "manuSpecificYokisDimmer",
         attribute: "memoryPosition",
@@ -1939,7 +2127,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // RampUp
-    m.binary<"manuSpecificYokisDimmer", true>({
+    m.binary<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "enable_ramp_up",
         cluster: "manuSpecificYokisDimmer",
         attribute: "eRampUp",
@@ -1948,7 +2136,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "ramp_up",
         cluster: "manuSpecificYokisDimmer",
         attribute: "rampUp",
@@ -1960,7 +2148,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // RampDown
-    m.binary<"manuSpecificYokisDimmer", true>({
+    m.binary<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "enable_ramp_down",
         cluster: "manuSpecificYokisDimmer",
         attribute: "eRampDown",
@@ -1969,7 +2157,7 @@ const YokisDimmerExtend: ModernExtend[] = [
         valueOff: ["OFF", 0x00],
         entityCategory: "config",
     }),
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "ramp_down",
         cluster: "manuSpecificYokisDimmer",
         attribute: "rampDown",
@@ -1981,7 +2169,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // rampContinuousTime
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "ramp_continuous_time",
         cluster: "manuSpecificYokisDimmer",
         attribute: "rampContinuousTime",
@@ -1993,7 +2181,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepUp
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "step_up",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepUp",
@@ -2005,7 +2193,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // lowDimLimit
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "low_dim_limit",
         cluster: "manuSpecificYokisDimmer",
         attribute: "lowDimLimit",
@@ -2018,7 +2206,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // highDimLimit
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "high_dim_limit",
         cluster: "manuSpecificYokisDimmer",
         attribute: "highDimLimit",
@@ -2031,7 +2219,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightStartingDelay
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "nightlight_starting_delay",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightStartingDelay",
@@ -2043,7 +2231,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightStartingBrightness
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "nightlight_starting_brightness",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightStartingBrightness",
@@ -2055,7 +2243,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightEndingBrightness
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "nightlight_ending_brightness",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightEndingBrightness",
@@ -2068,7 +2256,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightRampTime
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "nightlight_ramp_time",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightRampTime",
@@ -2081,7 +2269,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // nightLightOnTime
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "nightlight_on_time",
         cluster: "manuSpecificYokisDimmer",
         attribute: "nightLightOnTime",
@@ -2094,7 +2282,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // favoritePosition1
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "favorite_position_1",
         cluster: "manuSpecificYokisDimmer",
         attribute: "favoritePosition1",
@@ -2106,7 +2294,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // favoritePosition2
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "favorite_position_2",
         cluster: "manuSpecificYokisDimmer",
         attribute: "favoritePosition2",
@@ -2118,7 +2306,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // favoritePosition3
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "favorite_position_3",
         cluster: "manuSpecificYokisDimmer",
         attribute: "favoritePosition3",
@@ -2130,7 +2318,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepControllerMode
-    m.binary<"manuSpecificYokisDimmer", true>({
+    m.binary<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "step_controller_mode",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepControllerMode",
@@ -2142,7 +2330,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // memoryPositionMode
-    m.binary<"manuSpecificYokisDimmer", true>({
+    m.binary<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "memory_position_mode",
         cluster: "manuSpecificYokisDimmer",
         attribute: "memoryPositionMode",
@@ -2153,7 +2341,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepDown
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "step_down",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepDown",
@@ -2165,7 +2353,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepContinuous
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "step_continuous",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepContinuous",
@@ -2177,7 +2365,7 @@ const YokisDimmerExtend: ModernExtend[] = [
     }),
 
     // stepNightLigth
-    m.numeric<"manuSpecificYokisDimmer", true>({
+    m.numeric<"manuSpecificYokisDimmer", YokisDimmer>({
         name: "step_nightlight",
         cluster: "manuSpecificYokisDimmer",
         attribute: "stepNightLight",

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -62,8 +62,8 @@ export const develcoModernExtend = {
         ];
         return {configure, isModernExtend: true};
     },
-    voc: (args?: Partial<NumericArgs>) =>
-        numeric({
+    voc: (args?: Partial<NumericArgs<"manuSpecificDevelcoAirQuality", true>>) =>
+        numeric<"manuSpecificDevelcoAirQuality", true>({
             name: "voc",
             cluster: "manuSpecificDevelcoAirQuality",
             attribute: "measuredValue",
@@ -160,16 +160,16 @@ export const develcoModernExtend = {
 
         return {exposes: [expose], fromZigbee, isModernExtend: true};
     },
-    temperature: (args?: Partial<NumericArgs>) =>
+    temperature: (args?: Partial<NumericArgs<"msTemperatureMeasurement">>) =>
         temperature({
             ...args,
         }),
-    deviceTemperature: (args?: Partial<NumericArgs>) =>
+    deviceTemperature: (args?: Partial<NumericArgs<"genDeviceTempCfg">>) =>
         deviceTemperature({
             reporting: {min: "5_MINUTES", max: "1_HOUR", change: 2}, // Device temperature reports with 2 degree change
             ...args,
         }),
-    currentSummation: (args?: Partial<NumericArgs>) =>
+    currentSummation: (args?: Partial<NumericArgs<"seMetering">>) =>
         numeric({
             name: "current_summation",
             cluster: "seMetering",
@@ -180,7 +180,7 @@ export const develcoModernExtend = {
             valueMax: 268435455,
             ...args,
         }),
-    pulseConfiguration: (args?: Partial<NumericArgs>) =>
+    pulseConfiguration: (args?: Partial<NumericArgs<"seMetering">>) =>
         numeric({
             name: "pulse_configuration",
             cluster: "seMetering",

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -1,12 +1,11 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import {presets as e, access as ea} from "./exposes";
 import {deviceAddCustomCluster, deviceTemperature, type NumericArgs, numeric, temperature} from "./modernExtend";
 import type {Configure, Fz, ModernExtend} from "./types";
 
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.DEVELCO};
 
-export interface DevelcoGenBasic extends TCustomCluster {
+export interface DevelcoGenBasic {
     attributes: {
         develcoPrimarySwVersion: Buffer;
         develcoPrimaryHwVersion: Buffer;
@@ -16,7 +15,7 @@ export interface DevelcoGenBasic extends TCustomCluster {
     commandResponses: never;
 }
 
-export interface DevelcoAirQuality extends TCustomCluster {
+export interface DevelcoAirQuality {
     attributes: {
         measuredValue: number;
         minMeasuredValue: number;

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -87,8 +87,8 @@ export const develcoModernExtend = {
         ];
         return {configure, isModernExtend: true};
     },
-    voc: (args?: Partial<NumericArgs<"manuSpecificDevelcoAirQuality", true>>) =>
-        numeric<"manuSpecificDevelcoAirQuality", true>({
+    voc: (args?: Partial<NumericArgs<"manuSpecificDevelcoAirQuality", DevelcoAirQuality>>) =>
+        numeric<"manuSpecificDevelcoAirQuality", DevelcoAirQuality>({
             name: "voc",
             cluster: "manuSpecificDevelcoAirQuality",
             attribute: "measuredValue",

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-import {ClusterOrRawAttributeKeys} from "zigbee-herdsman/dist/controller/tstype";
+import type {ClusterOrRawAttributeKeys} from "zigbee-herdsman/dist/controller/tstype";
 import {presets as e, access as ea} from "./exposes";
 import {deviceAddCustomCluster, deviceTemperature, type NumericArgs, numeric, temperature} from "./modernExtend";
 import type {Configure, Fz, ModernExtend} from "./types";

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -1,5 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
-
+import {ClusterOrRawAttributeKeys} from "zigbee-herdsman/dist/controller/tstype";
 import {presets as e, access as ea} from "./exposes";
 import {deviceAddCustomCluster, deviceTemperature, type NumericArgs, numeric, temperature} from "./modernExtend";
 import type {Configure, Fz, ModernExtend} from "./types";
@@ -41,7 +41,11 @@ export const develcoModernExtend = {
                 for (const ep of device.endpoints) {
                     if (ep.supportsInputCluster("genBasic")) {
                         try {
-                            const data = await ep.read("genBasic", ["develcoPrimarySwVersion", "develcoPrimaryHwVersion"], manufacturerOptions);
+                            const data = (await ep.read(
+                                "genBasic",
+                                ["develcoPrimarySwVersion", "develcoPrimaryHwVersion"] as unknown as ClusterOrRawAttributeKeys<"genBasic">,
+                                manufacturerOptions,
+                            )) as {develcoPrimarySwVersion?: Buffer; develcoPrimaryHwVersion?: Buffer};
 
                             if (data.develcoPrimarySwVersion !== undefined) {
                                 device.softwareBuildID = data.develcoPrimarySwVersion.join(".");

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -1,10 +1,31 @@
 import {Zcl} from "zigbee-herdsman";
-import type {ClusterOrRawAttributeKeys} from "zigbee-herdsman/dist/controller/tstype";
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import {presets as e, access as ea} from "./exposes";
 import {deviceAddCustomCluster, deviceTemperature, type NumericArgs, numeric, temperature} from "./modernExtend";
 import type {Configure, Fz, ModernExtend} from "./types";
 
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.DEVELCO};
+
+export interface DevelcoGenBasic extends TCustomCluster {
+    attributes: {
+        develcoPrimarySwVersion: Buffer;
+        develcoPrimaryHwVersion: Buffer;
+        develcoLedControl: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
+export interface DevelcoAirQuality extends TCustomCluster {
+    attributes: {
+        measuredValue: number;
+        minMeasuredValue: number;
+        maxMeasuredValue: number;
+        resolution: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
 
 export const develcoModernExtend = {
     addCustomClusterManuSpecificDevelcoGenBasic: () =>
@@ -41,11 +62,11 @@ export const develcoModernExtend = {
                 for (const ep of device.endpoints) {
                     if (ep.supportsInputCluster("genBasic")) {
                         try {
-                            const data = (await ep.read(
+                            const data = await ep.read<"genBasic", DevelcoGenBasic>(
                                 "genBasic",
-                                ["develcoPrimarySwVersion", "develcoPrimaryHwVersion"] as unknown as ClusterOrRawAttributeKeys<"genBasic">,
+                                ["develcoPrimarySwVersion", "develcoPrimaryHwVersion"],
                                 manufacturerOptions,
-                            )) as {develcoPrimarySwVersion?: Buffer; develcoPrimaryHwVersion?: Buffer};
+                            );
 
                             if (data.develcoPrimarySwVersion !== undefined) {
                                 device.softwareBuildID = data.develcoPrimarySwVersion.join(".");

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -72,7 +72,7 @@ export const develcoModernExtend = {
                             }
 
                             if (data.develcoPrimaryHwVersion !== undefined) {
-                                device.hardwareVersion = data.develcoPrimaryHwVersion.join(".");
+                                device.hardwareVersion = Number.parseInt(data.develcoPrimaryHwVersion.join(""), 10);
                             }
 
                             device.save();

--- a/src/lib/ewelink.ts
+++ b/src/lib/ewelink.ts
@@ -1,3 +1,4 @@
+import type {SonoffEwelink} from "../devices/sonoff";
 import {access, options, presets} from "./exposes";
 import {battery, setupConfigureForBinding} from "./modernExtend";
 import type {Configure, Expose, Fz, KeyValueAny, ModernExtend, Tz, Zh} from "./types";
@@ -48,7 +49,7 @@ export const ewelinkFromZigbee = {
 };
 
 // ======================= Custom Extend =================================
-function privateMotorClbByPosition(clusterName: string, writeCommand: string): ModernExtend {
+function privateMotorClbByPosition(clusterName: "customClusterEwelink", writeCommand: "protocolData"): ModernExtend {
     const protocol = {
         dooya: {
             supportModel: ["CK-MG22-Z310EE07DOOYA-01(7015)", "MYDY25Z-1", "CK-MG22-JLDJ-01(7015)"],
@@ -215,7 +216,7 @@ function privateMotorClbByPosition(clusterName: string, writeCommand: string): M
                         payloadValue[2] = mapping[value as keyof typeof mapping];
                     }
 
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 } else if (protocol.raex.supportModel.includes(modelID)) {
                     const {deleteMotorClbCommand, updateMotorClbCommand, mapping} = protocol.raex;
                     // Raex Protocol
@@ -234,7 +235,7 @@ function privateMotorClbByPosition(clusterName: string, writeCommand: string): M
                         payloadValue[3] = mapping[value as keyof typeof mapping];
                     }
 
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 } else if (protocol.ak.supportModel.includes(modelID)) {
                     // AK Protocol
                     const {updateMotorClbCommand, mapping} = protocol.ak;
@@ -245,7 +246,7 @@ function privateMotorClbByPosition(clusterName: string, writeCommand: string): M
                     payloadValue[3] = updateMotorClbCommand.dataType;
                     payloadValue.push(...updateMotorClbCommand.dataLength);
                     payloadValue[6] = mapping[value as keyof typeof mapping];
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 }
                 return {state: {[key]: value}};
             },
@@ -255,7 +256,7 @@ function privateMotorClbByPosition(clusterName: string, writeCommand: string): M
     return {exposes, toZigbee, fromZigbee, isModernExtend: true};
 }
 
-function privateMotorMode(clusterName: string, writeCommand: string): ModernExtend {
+function privateMotorMode(clusterName: "customClusterEwelink", writeCommand: "protocolData"): ModernExtend {
     const mode = ["inching", "continuou"];
     const protocol = {
         dooya: {
@@ -369,7 +370,7 @@ function privateMotorMode(clusterName: string, writeCommand: string): ModernExte
                     payloadValue[0] = updateMotorModeCommand.privateCmd;
                     payloadValue[1] = updateMotorModeCommand.subCmd;
                     payloadValue[2] = mapping[value as keyof typeof mapping];
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 } else if (protocol.raex.supportModel.includes(modelID)) {
                     // Raex Protocol
                     const payloadValue = [];
@@ -378,7 +379,7 @@ function privateMotorMode(clusterName: string, writeCommand: string): ModernExte
                     payloadValue[1] = updateMotorModeCommand.dataLength;
                     payloadValue[2] = updateMotorModeCommand.subCmd;
                     payloadValue[3] = mapping[value as keyof typeof mapping];
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 } else if (protocol.ak.supportModel.includes(modelID)) {
                     // AK Protocol
                     const payloadValue = [];
@@ -389,7 +390,7 @@ function privateMotorMode(clusterName: string, writeCommand: string): ModernExte
                     payloadValue[3] = updateMotorModeCommand.dataType;
                     payloadValue.push(...updateMotorModeCommand.dataLength);
                     payloadValue[6] = mapping[value as keyof typeof mapping];
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 }
 
                 return {state: {[key]: value}};
@@ -560,7 +561,7 @@ function privateReportMotorInfo(clusterName: string): ModernExtend {
     return {exposes: [expose], fromZigbee, isModernExtend: true};
 }
 
-function privateMotorSpeed(clusterName: string, writeCommand: string, minSpeed: number, maxSpeed: number): ModernExtend {
+function privateMotorSpeed(clusterName: "customClusterEwelink", writeCommand: "protocolData", minSpeed: number, maxSpeed: number): ModernExtend {
     const protocol = {
         dooya: {
             supportModel: ["CK-MG22-Z310EE07DOOYA-01(7015)", "MYDY25Z-1", "CK-MG22-JLDJ-01(7015)", "Grandekor Smart Curtain Grandekor"],
@@ -631,20 +632,20 @@ function privateMotorSpeed(clusterName: string, writeCommand: string, minSpeed: 
                 const modelID = device.modelID;
 
                 if (protocol.dooya.supportModel.includes(modelID)) {
-                    const payloadValue = [];
+                    const payloadValue: number[] = [];
                     const {updateMotorSpeedCommand} = protocol.dooya;
                     payloadValue[0] = updateMotorSpeedCommand.privateCmd;
                     payloadValue[1] = updateMotorSpeedCommand.subCmd;
-                    payloadValue[2] = value;
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    payloadValue[2] = value as number;
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 } else if (protocol.raex.supportModel.includes(modelID)) {
-                    const payloadValue = [];
+                    const payloadValue: number[] = [];
                     const {updateMotorSpeedCommand} = protocol.raex;
                     payloadValue[0] = updateMotorSpeedCommand.privateCmd;
                     payloadValue[1] = updateMotorSpeedCommand.dataLength;
                     payloadValue[2] = updateMotorSpeedCommand.subCmd;
-                    payloadValue[3] = value;
-                    await entity.command(clusterName, writeCommand, {data: payloadValue});
+                    payloadValue[3] = value as number;
+                    await entity.command<typeof clusterName, typeof writeCommand, SonoffEwelink>(clusterName, writeCommand, {data: payloadValue});
                 }
 
                 return {state: {[key]: value}};
@@ -696,16 +697,16 @@ export const ewelinkModernExtend = {
             isModernExtend: true,
         };
     },
-    ewelinkMotorClbByPosition: (clusterName: string, writeCommand: string): ModernExtend => {
+    ewelinkMotorClbByPosition: (clusterName: "customClusterEwelink", writeCommand: "protocolData"): ModernExtend => {
         return privateMotorClbByPosition(clusterName, writeCommand);
     },
-    ewelinkMotorMode: (clusterName: string, writeCommand: string): ModernExtend => {
+    ewelinkMotorMode: (clusterName: "customClusterEwelink", writeCommand: "protocolData"): ModernExtend => {
         return privateMotorMode(clusterName, writeCommand);
     },
-    ewelinkReportMotorInfo: (clusterName: string): ModernExtend => {
+    ewelinkReportMotorInfo: (clusterName: "customClusterEwelink"): ModernExtend => {
         return privateReportMotorInfo(clusterName);
     },
-    ewelinkMotorSpeed: (clusterName: string, writeCommand: string, min: number, max: number): ModernExtend => {
+    ewelinkMotorSpeed: (clusterName: "customClusterEwelink", writeCommand: "protocolData", min: number, max: number): ModernExtend => {
         return privateMotorSpeed(clusterName, writeCommand, min, max);
     },
 };

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -359,7 +359,7 @@ async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
     const generated: GeneratedExtend[] = [];
     for (const endpoint of endpoints) {
         const description = `binary_input_${endpoint.ID}`;
-        const args: m.BinaryArgs = {
+        const args: m.BinaryArgs<"genBinaryInput"> = {
             name: await getClusterAttributeValue<string>(endpoint, "genBinaryInput", "description", description),
             cluster: "genBinaryInput",
             attribute: "presentValue",
@@ -379,7 +379,7 @@ async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
     const generated: GeneratedExtend[] = [];
     for (const endpoint of endpoints) {
         const description = `binary_output_${endpoint.ID}`;
-        const args: m.BinaryArgs = {
+        const args: m.BinaryArgs<"genBinaryOutput"> = {
             name: await getClusterAttributeValue<string>(endpoint, "genBinaryOutput", "description", description),
             cluster: "genBinaryOutput",
             attribute: "presentValue",

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -283,7 +283,7 @@ async function extenderLock(device: Zh.Device, endpoints: Zh.Endpoint[]): Promis
 
     const endpoint = endpoints[0];
 
-    const pinCodeCount = await getClusterAttributeValue<number>(endpoint, "closuresDoorLock", "numOfPinUsersSupported", 50);
+    const pinCodeCount = await getClusterAttributeValue(endpoint, "closuresDoorLock", "numOfPinUsersSupported", 50);
     return [new ExtendGenerator({extend: m.lock, args: {pinCodeCount}, source: "lock"})];
 }
 
@@ -305,7 +305,7 @@ async function extenderOnOffLight(device: Zh.Device, endpoints: Zh.Endpoint[]): 
         // In case read fails, support all features with 31
         let colorCapabilities = 0;
         if (endpoint.supportsInputCluster("lightingColorCtrl")) {
-            colorCapabilities = await getClusterAttributeValue<number>(endpoint, "lightingColorCtrl", "colorCapabilities", 31);
+            colorCapabilities = await getClusterAttributeValue(endpoint, "lightingColorCtrl", "colorCapabilities", 31);
         }
         const supportsHueSaturation = (colorCapabilities & (1 << 0)) > 0;
         const supportsEnhancedHueSaturation = (colorCapabilities & (1 << 1)) > 0;
@@ -314,8 +314,8 @@ async function extenderOnOffLight(device: Zh.Device, endpoints: Zh.Endpoint[]): 
         const args: m.LightArgs = {};
 
         if (supportsColorTemperature) {
-            const minColorTemp = await getClusterAttributeValue<number>(endpoint, "lightingColorCtrl", "colorTempPhysicalMin", 150);
-            const maxColorTemp = await getClusterAttributeValue<number>(endpoint, "lightingColorCtrl", "colorTempPhysicalMax", 500);
+            const minColorTemp = await getClusterAttributeValue(endpoint, "lightingColorCtrl", "colorTempPhysicalMin", 150);
+            const maxColorTemp = await getClusterAttributeValue(endpoint, "lightingColorCtrl", "colorTempPhysicalMax", 500);
             args.colorTemp = {range: [minColorTemp, maxColorTemp]};
         }
 
@@ -360,7 +360,7 @@ async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
     for (const endpoint of endpoints) {
         const description = `binary_input_${endpoint.ID}`;
         const args: m.BinaryArgs<"genBinaryInput"> = {
-            name: await getClusterAttributeValue<string>(endpoint, "genBinaryInput", "description", description),
+            name: await getClusterAttributeValue(endpoint, "genBinaryInput", "description", description),
             cluster: "genBinaryInput",
             attribute: "presentValue",
             reporting: {attribute: "presentValue", min: "MIN", max: "MAX", change: 1},
@@ -380,7 +380,7 @@ async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
     for (const endpoint of endpoints) {
         const description = `binary_output_${endpoint.ID}`;
         const args: m.BinaryArgs<"genBinaryOutput"> = {
-            name: await getClusterAttributeValue<string>(endpoint, "genBinaryOutput", "description", description),
+            name: await getClusterAttributeValue(endpoint, "genBinaryOutput", "description", description),
             cluster: "genBinaryOutput",
             attribute: "presentValue",
             reporting: {attribute: "presentValue", min: "MIN", max: "MAX", change: 1},

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -1,7 +1,7 @@
 import {gt as semverGt, gte as semverGte, lt as semverLt, valid as semverValid} from "semver";
 
 import {Zcl} from "zigbee-herdsman";
-
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
 import {access, options, presets} from "../lib/exposes";
@@ -45,6 +45,7 @@ const bulbOnEvent: OnEvent.Handler = async (event) => {
             for (const c of endpoint.configuredReportings) {
                 await endpoint.configureReporting(c.cluster.name, [
                     {
+                        // @ts-expect-error dynamic, expected correct since already applied
                         attribute: c.attribute.name,
                         minimumReportInterval: c.minimumReportInterval,
                         maximumReportInterval: c.maximumReportInterval,
@@ -382,56 +383,68 @@ export function ikeaAirPurifier(): ModernExtend {
                         fanMode = (Number(value) / 2.0) * 10 + 5;
                 }
 
-                await entity.write("manuSpecificIkeaAirPurifier", {fanMode: fanMode}, manufacturerOptions);
+                await entity.write<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>(
+                    "manuSpecificIkeaAirPurifier",
+                    {fanMode: fanMode},
+                    manufacturerOptions,
+                );
                 return {state: {fan_mode: value, fan_state: value === "off" ? "OFF" : "ON"}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificIkeaAirPurifier", ["fanMode"]);
+                await entity.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", ["fanMode"]);
             },
         },
         {
             key: ["fan_speed"],
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificIkeaAirPurifier", ["fanSpeed"]);
+                await entity.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", ["fanSpeed"]);
             },
         },
         {
             key: ["pm25", "air_quality"],
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificIkeaAirPurifier", ["particulateMatter25Measurement"]);
+                await entity.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", ["particulateMatter25Measurement"]);
             },
         },
         {
             key: ["replace_filter", "filter_age"],
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificIkeaAirPurifier", ["filterRunTime"]);
+                await entity.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", ["filterRunTime"]);
             },
         },
         {
             key: ["device_age"],
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificIkeaAirPurifier", ["deviceRunTime"]);
+                await entity.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", ["deviceRunTime"]);
             },
         },
         {
             key: ["child_lock"],
             convertSet: async (entity, key, value, meta) => {
                 assertString(value);
-                await entity.write("manuSpecificIkeaAirPurifier", {childLock: value.toLowerCase() === "unlock" ? 0 : 1}, manufacturerOptions);
+                await entity.write<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>(
+                    "manuSpecificIkeaAirPurifier",
+                    {childLock: value.toLowerCase() === "unlock" ? 0 : 1},
+                    manufacturerOptions,
+                );
                 return {state: {child_lock: value.toLowerCase() === "lock" ? "LOCK" : "UNLOCK"}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificIkeaAirPurifier", ["childLock"]);
+                await entity.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", ["childLock"]);
             },
         },
         {
             key: ["led_enable"],
             convertSet: async (entity, key, value, meta) => {
-                await entity.write("manuSpecificIkeaAirPurifier", {controlPanelLight: value ? 0 : 1}, manufacturerOptions);
+                await entity.write<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>(
+                    "manuSpecificIkeaAirPurifier",
+                    {controlPanelLight: value ? 0 : 1},
+                    manufacturerOptions,
+                );
                 return {state: {led_enable: !!value}};
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("manuSpecificIkeaAirPurifier", ["controlPanelLight"]);
+                await entity.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", ["controlPanelLight"]);
             },
         },
     ];
@@ -441,7 +454,7 @@ export function ikeaAirPurifier(): ModernExtend {
             const endpoint = device.getEndpoint(1);
 
             await reporting.bind(endpoint, coordinatorEndpoint, ["manuSpecificIkeaAirPurifier"]);
-            await endpoint.configureReporting(
+            await endpoint.configureReporting<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>(
                 "manuSpecificIkeaAirPurifier",
                 [
                     {
@@ -453,7 +466,7 @@ export function ikeaAirPurifier(): ModernExtend {
                 ],
                 manufacturerOptions,
             );
-            await endpoint.configureReporting(
+            await endpoint.configureReporting<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>(
                 "manuSpecificIkeaAirPurifier",
                 [
                     {
@@ -465,18 +478,22 @@ export function ikeaAirPurifier(): ModernExtend {
                 ],
                 manufacturerOptions,
             );
-            await endpoint.configureReporting(
+            await endpoint.configureReporting<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>(
                 "manuSpecificIkeaAirPurifier",
                 [{attribute: "fanMode", minimumReportInterval: 0, maximumReportInterval: m.TIME_LOOKUP["1_HOUR"], reportableChange: 1}],
                 manufacturerOptions,
             );
-            await endpoint.configureReporting(
+            await endpoint.configureReporting<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>(
                 "manuSpecificIkeaAirPurifier",
                 [{attribute: "fanSpeed", minimumReportInterval: 0, maximumReportInterval: m.TIME_LOOKUP["1_HOUR"], reportableChange: 1}],
                 manufacturerOptions,
             );
 
-            await endpoint.read("manuSpecificIkeaAirPurifier", ["controlPanelLight", "childLock", "filterRunTime"]);
+            await endpoint.read<"manuSpecificIkeaAirPurifier", IkeaAirPurifier>("manuSpecificIkeaAirPurifier", [
+                "controlPanelLight",
+                "childLock",
+                "filterRunTime",
+            ]);
         },
     ];
 
@@ -803,6 +820,22 @@ export function ikeaMediaCommands(): ModernExtend {
     return {exposes, fromZigbee, configure, isModernExtend: true};
 }
 
+export interface IkeaAirPurifier extends TCustomCluster {
+    attributes: {
+        filterRunTime: number;
+        replaceFilter: number;
+        filterLifeTime: number;
+        controlPanelLight: number;
+        particulateMatter25Measurement: number;
+        childLock: number;
+        fanMode: number;
+        fanSpeed: number;
+        deviceRunTime: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 export function addCustomClusterManuSpecificIkeaAirPurifier(): ModernExtend {
     return m.deviceAddCustomCluster("manuSpecificIkeaAirPurifier", {
         ID: 0xfc7d,
@@ -823,6 +856,16 @@ export function addCustomClusterManuSpecificIkeaAirPurifier(): ModernExtend {
     });
 }
 
+export interface IkeaVocIndexMeasurement extends TCustomCluster {
+    attributes: {
+        measuredValue: number;
+        measuredMinValue: number;
+        measuredMaxValue: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 export function addCustomClusterManuSpecificIkeaVocIndexMeasurement(): ModernExtend {
     return m.deviceAddCustomCluster("manuSpecificIkeaVocIndexMeasurement", {
         ID: 0xfc7e,
@@ -835,6 +878,12 @@ export function addCustomClusterManuSpecificIkeaVocIndexMeasurement(): ModernExt
         commands: {},
         commandsResponse: {},
     });
+}
+
+export interface IkeaUnknown extends TCustomCluster {
+    attributes: never;
+    commands: never;
+    commandResponses: never;
 }
 
 // Seems to be present on newer IKEA devices like: VINDSTYRKA, RODRET, and BADRING

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -483,7 +483,7 @@ export function ikeaAirPurifier(): ModernExtend {
     return {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
 }
 
-export function ikeaVoc(args?: Partial<m.NumericArgs>) {
+export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMeasurement">>) {
     return m.numeric({
         name: "voc_index",
         label: "VOC index",

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -1,7 +1,6 @@
 import {gt as semverGt, gte as semverGte, lt as semverLt, valid as semverValid} from "semver";
 
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
 import {access, options, presets} from "../lib/exposes";
@@ -820,7 +819,7 @@ export function ikeaMediaCommands(): ModernExtend {
     return {exposes, fromZigbee, configure, isModernExtend: true};
 }
 
-export interface IkeaAirPurifier extends TCustomCluster {
+export interface IkeaAirPurifier {
     attributes: {
         filterRunTime: number;
         replaceFilter: number;
@@ -856,7 +855,7 @@ export function addCustomClusterManuSpecificIkeaAirPurifier(): ModernExtend {
     });
 }
 
-export interface IkeaVocIndexMeasurement extends TCustomCluster {
+export interface IkeaVocIndexMeasurement {
     attributes: {
         measuredValue: number;
         measuredMinValue: number;
@@ -880,7 +879,7 @@ export function addCustomClusterManuSpecificIkeaVocIndexMeasurement(): ModernExt
     });
 }
 
-export interface IkeaUnknown extends TCustomCluster {
+export interface IkeaUnknown {
     attributes: never;
     commands: never;
     commandResponses: never;

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -500,8 +500,8 @@ export function ikeaAirPurifier(): ModernExtend {
     return {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
 }
 
-export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMeasurement", true>>) {
-    return m.numeric<"manuSpecificIkeaVocIndexMeasurement", true>({
+export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMeasurement", IkeaVocIndexMeasurement>>) {
+    return m.numeric<"manuSpecificIkeaVocIndexMeasurement", IkeaVocIndexMeasurement>({
         name: "voc_index",
         label: "VOC index",
         cluster: "manuSpecificIkeaVocIndexMeasurement",

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -483,8 +483,8 @@ export function ikeaAirPurifier(): ModernExtend {
     return {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
 }
 
-export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMeasurement">>) {
-    return m.numeric({
+export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMeasurement", true>>) {
+    return m.numeric<"manuSpecificIkeaVocIndexMeasurement", true>({
         name: "voc_index",
         label: "VOC index",
         cluster: "manuSpecificIkeaVocIndexMeasurement",

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -137,7 +137,7 @@ async function sendDataPoints(entity: Zh.Endpoint | Zh.Group, dpValues: any, cmd
 
     await entity.command(
         "manuSpecificTuya",
-        cmd || "dataRequest",
+        cmd as "dataRequest",
         {
             seq,
             dpValues,

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -5499,7 +5499,7 @@ const toZigbee2 = {
         convertSet: async (entity, key, value, meta) => {
             const modeId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatSystemMode"), value, null, Number);
             if (modeId !== null) {
-                await sendDataPointEnum(entity, dataPoints.mode, Number.parseInt(modeId as string));
+                await sendDataPointEnum(entity, dataPoints.mode, modeId);
             } else {
                 throw new Error(`TRV system mode ${value} is not recognized.`);
             }
@@ -5510,7 +5510,7 @@ const toZigbee2 = {
         convertSet: async (entity, key, value, meta) => {
             const presetId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset"), value, null, Number);
             if (presetId !== null) {
-                await sendDataPointEnum(entity, dataPoints.mode, Number.parseInt(presetId as string));
+                await sendDataPointEnum(entity, dataPoints.mode, presetId);
             } else {
                 throw new Error(`TRV preset ${value} is not recognized.`);
             }
@@ -5520,20 +5520,13 @@ const toZigbee2 = {
         key: ["away_mode"],
         convertSet: async (entity, key, value, meta) => {
             // HA has special behavior for the away mode
-            // @ts-expect-error ignore
             const awayPresetId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset"), "away", null, Number);
-            const schedulePresetId = utils.getKey(
-                utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset"),
-                "schedule",
-                null,
-                // @ts-expect-error ignore
-                Number,
-            );
+            const schedulePresetId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset"), "schedule", null, Number);
             if (awayPresetId !== null) {
                 if (value === "ON") {
-                    await sendDataPointEnum(entity, dataPoints.mode, Number.parseInt(awayPresetId));
+                    await sendDataPointEnum(entity, dataPoints.mode, awayPresetId);
                 } else if (schedulePresetId != null) {
-                    await sendDataPointEnum(entity, dataPoints.mode, Number.parseInt(schedulePresetId));
+                    await sendDataPointEnum(entity, dataPoints.mode, schedulePresetId);
                 }
                 // In case 'OFF' tuya_thermostat_preset() should be called with another preset
             } else {
@@ -5546,7 +5539,7 @@ const toZigbee2 = {
         convertSet: async (entity, key, value, meta) => {
             const modeId = utils.getKey(fanModes, value, null, Number);
             if (modeId !== null) {
-                await sendDataPointEnum(entity, dataPoints.fanMode, Number.parseInt(modeId as string));
+                await sendDataPointEnum(entity, dataPoints.fanMode, modeId);
             } else {
                 throw new Error(`TRV fan mode ${value} is not recognized.`);
             }
@@ -5557,7 +5550,7 @@ const toZigbee2 = {
         convertSet: async (entity, key, value, meta) => {
             const modeId = utils.getKey(fanModes, value, null, Number);
             if (modeId !== null) {
-                await sendDataPointEnum(entity, dataPoints.bacFanMode, Number.parseInt(modeId as string));
+                await sendDataPointEnum(entity, dataPoints.bacFanMode, modeId);
             } else {
                 throw new Error(`TRV fan mode ${value} is not recognized.`);
             }
@@ -5615,7 +5608,7 @@ const toZigbee2 = {
         convertSet: async (entity, key, value, meta) => {
             const modeId = utils.getKey(thermostatForceMode, value, null, Number);
             if (modeId !== null) {
-                await sendDataPointEnum(entity, dataPoints.forceMode, Number.parseInt(modeId as string));
+                await sendDataPointEnum(entity, dataPoints.forceMode, modeId);
             } else {
                 throw new Error(`TRV force mode ${value} is not recognized.`);
             }
@@ -5626,7 +5619,7 @@ const toZigbee2 = {
         convertSet: async (entity, key, value, meta) => {
             const modeId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatSystemMode"), value, null, Number);
             if (modeId !== null) {
-                await sendDataPointEnum(entity, dataPoints.forceMode, Number.parseInt(modeId as string));
+                await sendDataPointEnum(entity, dataPoints.forceMode, modeId);
             } else {
                 throw new Error(`TRV system mode ${value} is not recognized.`);
             }

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -384,7 +384,7 @@ const tvThermostatPreset: KeyValueAny = {
     3: "holiday",
 };
 // Zemismart ZM_AM02 Roller Shade Converter
-const ZMLookups: KeyValueAny = {
+const ZMLookups = {
     AM02Mode: {
         0: "morning",
         1: "night",
@@ -5497,7 +5497,12 @@ const toZigbee2 = {
     tuya_thermostat_system_mode: {
         key: ["system_mode"],
         convertSet: async (entity, key, value, meta) => {
-            const modeId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatSystemMode"), value, null, Number);
+            const modeId = utils.getKey(
+                utils.getMetaValue(entity, meta.mapped, "tuyaThermostatSystemMode") as Record<number, string>,
+                value,
+                null,
+                Number,
+            );
             if (modeId !== null) {
                 await sendDataPointEnum(entity, dataPoints.mode, modeId);
             } else {
@@ -5508,7 +5513,12 @@ const toZigbee2 = {
     tuya_thermostat_preset: {
         key: ["preset"],
         convertSet: async (entity, key, value, meta) => {
-            const presetId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset"), value, null, Number);
+            const presetId = utils.getKey(
+                utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset") as Record<number, string>,
+                value,
+                null,
+                Number,
+            );
             if (presetId !== null) {
                 await sendDataPointEnum(entity, dataPoints.mode, presetId);
             } else {
@@ -5520,8 +5530,18 @@ const toZigbee2 = {
         key: ["away_mode"],
         convertSet: async (entity, key, value, meta) => {
             // HA has special behavior for the away mode
-            const awayPresetId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset"), "away", null, Number);
-            const schedulePresetId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset"), "schedule", null, Number);
+            const awayPresetId = utils.getKey(
+                utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset") as Record<number, string>,
+                "away",
+                null,
+                Number,
+            );
+            const schedulePresetId = utils.getKey(
+                utils.getMetaValue(entity, meta.mapped, "tuyaThermostatPreset") as Record<number, string>,
+                "schedule",
+                null,
+                Number,
+            );
             if (awayPresetId !== null) {
                 if (value === "ON") {
                     await sendDataPointEnum(entity, dataPoints.mode, awayPresetId);
@@ -5617,7 +5637,12 @@ const toZigbee2 = {
     tuya_thermostat_force_to_mode: {
         key: ["system_mode"],
         convertSet: async (entity, key, value, meta) => {
-            const modeId = utils.getKey(utils.getMetaValue(entity, meta.mapped, "tuyaThermostatSystemMode"), value, null, Number);
+            const modeId = utils.getKey(
+                utils.getMetaValue(entity, meta.mapped, "tuyaThermostatSystemMode") as Record<number, string>,
+                value,
+                null,
+                Number,
+            );
             if (modeId !== null) {
                 await sendDataPointEnum(entity, dataPoints.forceMode, modeId);
             } else {
@@ -6378,10 +6403,10 @@ const toZigbee2 = {
         convertSet: async (entity, key, value: any, meta) => {
             switch (key) {
                 case "o_sensitivity":
-                    await sendDataPointEnum(entity, dataPoints.msOSensitivity, utils.getKey(msLookups.OSensitivity, value));
+                    await sendDataPointEnum(entity, dataPoints.msOSensitivity, utils.getKey(msLookups.OSensitivity, value, undefined, Number));
                     break;
                 case "v_sensitivity":
-                    await sendDataPointEnum(entity, dataPoints.msVSensitivity, utils.getKey(msLookups.VSensitivity, value));
+                    await sendDataPointEnum(entity, dataPoints.msVSensitivity, utils.getKey(msLookups.VSensitivity, value, undefined, Number));
                     break;
                 case "led_status":
                     // @ts-expect-error ignore
@@ -6397,7 +6422,7 @@ const toZigbee2 = {
                     await sendDataPointValue(entity, dataPoints.msLightOffLuminancePrefer, value);
                     break;
                 case "mode":
-                    await sendDataPointEnum(entity, dataPoints.msMode, utils.getKey(msLookups.Mode, value));
+                    await sendDataPointEnum(entity, dataPoints.msMode, utils.getKey(msLookups.Mode, value, undefined, Number));
                     break;
                 default: // Unknown key
                     logger.warning(`toZigbee.tuya_motion_sensor: Unhandled key ${key}`, "zhc:legacy:tz:tuya_motion_sensor");
@@ -6459,7 +6484,7 @@ const toZigbee2 = {
                 case "system_mode":
                     if (value !== "off") {
                         await sendDataPointBool(entity, dataPoints.tvHeatingStop, 0);
-                        await sendDataPointEnum(entity, dataPoints.tvMode, utils.getKey(tvThermostatMode, value));
+                        await sendDataPointEnum(entity, dataPoints.tvMode, utils.getKey(tvThermostatMode, value, undefined, Number));
                     } else {
                         await sendDataPointBool(entity, dataPoints.tvHeatingStop, 1);
                     }
@@ -6525,7 +6550,7 @@ const toZigbee2 = {
                     break;
                 case "preset":
                     await sendDataPointBool(entity, dataPoints.tvHeatingStop, 0);
-                    await sendDataPointEnum(entity, dataPoints.tvMode, utils.getKey(tvThermostatPreset, value));
+                    await sendDataPointEnum(entity, dataPoints.tvMode, utils.getKey(tvThermostatPreset, value, undefined, Number));
                     break;
                 default: // Unknown key
                     logger.warning(`Unhandled key ${key}`, "zhc:legacy:tz:moes_thermostat_tv");
@@ -6714,17 +6739,22 @@ const toZigbee2 = {
             }
             switch (key) {
                 case "mode":
-                    await sendDataPointEnum(entity, dataPoints.AM02Mode, utils.getKey(ZMLookups.AM02Mode, value));
+                    await sendDataPointEnum(entity, dataPoints.AM02Mode, utils.getKey(ZMLookups.AM02Mode, value, undefined, Number));
                     break;
                 case "motor_direction":
-                    await sendDataPointEnum(entity, dataPoints.AM02Direction, utils.getKey(ZMLookups.AM02Direction, value));
+                    await sendDataPointEnum(entity, dataPoints.AM02Direction, utils.getKey(ZMLookups.AM02Direction, value, undefined, Number));
                     break;
                 case "border":
-                    await sendDataPointEnum(entity, dataPoints.AM02Border, utils.getKey(ZMLookups.AM02Border, value));
+                    await sendDataPointEnum(entity, dataPoints.AM02Border, utils.getKey(ZMLookups.AM02Border, value, undefined, Number));
                     break;
-                case "motor_working_mode":
-                    await sendDataPointEnum(entity, dataPoints.AM02MotorWorkingMode, utils.getKey(ZMLookups.AM02MotorWorkingMode, value));
+                case "motor_working_mode": {
+                    await sendDataPointEnum(
+                        entity,
+                        dataPoints.AM02MotorWorkingMode,
+                        utils.getKey(ZMLookups.AM02MotorWorkingMode, value, undefined, Number),
+                    );
                     break;
+                }
             }
         },
     } satisfies Tz.Converter,

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -9,7 +9,7 @@ const NS = "zhc:legrand";
 const e = exposes.presets;
 const ea = exposes.access;
 
-const shutterCalibrationModes: {[k: number]: {description: string; onlyNLLV: boolean; supportsTilt: boolean}} = {
+const shutterCalibrationModes = {
     0: {description: "classic_nllv", onlyNLLV: true, supportsTilt: false},
     1: {description: "specific_nllv", onlyNLLV: true, supportsTilt: false},
     2: {description: "up_down_stop", onlyNLLV: false, supportsTilt: false},
@@ -17,19 +17,19 @@ const shutterCalibrationModes: {[k: number]: {description: string; onlyNLLV: boo
     4: {description: "venetian_bso", onlyNLLV: false, supportsTilt: true},
 };
 
-const ledModes: {[k: number]: string} = {
+const ledModes = {
     1: "led_in_dark",
     2: "led_if_on",
 };
 
-const ledEffects: {[k: number]: string} = {
+const ledEffects = {
     0: "blink 3",
     1: "fixed",
     2: "blink green",
     3: "blink blue",
 };
 
-const ledColors: {[k: number]: string} = {
+const ledColors = {
     0: "default",
     1: "red",
     2: "green",
@@ -82,7 +82,7 @@ export const eLegrand = {
         const calMode = !utils.isDummyDevice(device)
             ? Number(device.getEndpoint(1)?.clusters?.closuresWindowCovering?.attributes?.calibrationMode)
             : 0;
-        const showTilt = calMode ? shutterCalibrationModes[calMode]?.supportsTilt === true : false;
+        const showTilt = calMode ? utils.getFromLookup(calMode, shutterCalibrationModes)?.supportsTilt === true : false;
 
         if (showTilt) {
             c.addFeature(
@@ -165,12 +165,11 @@ export const tzLegrand = {
             const selEffect = identityEffect?.effect ?? ledEffects[0];
             const selColor = identityEffect?.color ?? ledColors[0];
 
-            const effectID = utils.getFromLookupByValue(selEffect, ledEffects, "0");
-            const effectVariant = utils.getFromLookupByValue(selColor, ledColors, "0");
+            const effectID = Number.parseInt(utils.getFromLookupByValue(selEffect, ledEffects, "0"));
+            const effectVariant = Number.parseInt(utils.getFromLookupByValue(selColor, ledColors, "0"));
 
             // Trigger an effect
-            const payload = {effectid: effectID, effectvariant: effectVariant};
-            await entity.command("genIdentify", "triggerEffect", payload, {});
+            await entity.command("genIdentify", "triggerEffect", {effectid: effectID, effectvariant: effectVariant}, {});
             // Trigger the identification
             await entity.command("genIdentify", "identify", {identifytime: 10}, {});
         },

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -133,7 +133,7 @@ export const tzLegrand = {
             convertSet: async (entity, key, value, meta) => {
                 const applicableModes = getApplicableCalibrationModes(isNLLVSwitch);
                 utils.validateValue(value, Object.values(applicableModes));
-                const idx = utils.getKey(applicableModes, value);
+                const idx = Number(utils.getKey(applicableModes, value));
                 await entity.write("closuresWindowCovering", {calibrationMode: idx}, legrandOptions);
             },
             convertGet: async (entity, key, meta) => {

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -1,3 +1,4 @@
+import type {TClusterAttributeKeys} from "zigbee-herdsman/dist/zspec/zcl/definition/clusters-types";
 import {logger} from "./logger";
 import type {Tz, Zh} from "./types";
 import * as utils from "./utils";
@@ -12,7 +13,11 @@ export async function readColorTempMinMax(endpoint: Zh.Endpoint) {
     await endpoint.read("lightingColorCtrl", ["colorTempPhysicalMin", "colorTempPhysicalMax"]);
 }
 
-export function readColorAttributes(entity: Zh.Endpoint | Zh.Group, meta: Tz.Meta, additionalAttributes: string[] = []) {
+export function readColorAttributes(
+    entity: Zh.Endpoint | Zh.Group,
+    meta: Tz.Meta,
+    additionalAttributes: TClusterAttributeKeys<"lightingColorCtrl"> = [],
+) {
     /**
      * Not all bulbs support the same features, we need to take care we read what is supported.
      * `supportsHueAndSaturation` indicates support for currentHue and currentSaturation
@@ -22,7 +27,7 @@ export function readColorAttributes(entity: Zh.Endpoint | Zh.Group, meta: Tz.Met
      *
      * Additionally when we get a "get payload", only request the fields included.
      */
-    const attributes = ["colorMode"];
+    const attributes: TClusterAttributeKeys<"lightingColorCtrl"> = ["colorMode"];
     if (meta?.message) {
         if (!meta.message.color || (utils.isObject(meta.message.color) && meta.message.color.x != null)) {
             attributes.push("currentX");

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -1804,6 +1804,7 @@ export const lumiModernExtend = {
                                         try {
                                             await endpoint.configureReporting(c.cluster.name, [
                                                 {
+                                                    // @ts-expect-error dynamic, expected correct since already applied
                                                     attribute: c.attribute.name,
                                                     minimumReportInterval: c.minimumReportInterval,
                                                     maximumReportInterval: c.maximumReportInterval,

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -1505,7 +1505,7 @@ export const lumiModernExtend = {
         }
         return result;
     },
-    lumiSwitchType: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiSwitchType: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "switch_type",
             lookup: {toggle: 1, momentary: 2, none: 3},
@@ -1516,7 +1516,7 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiMotorSpeed: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiMotorSpeed: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "motor_speed",
             lookup: {low: 0, medium: 1, high: 2},
@@ -1527,7 +1527,7 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiCurtainSpeed: (args?: Partial<modernExtend.NumericArgs>) =>
+    lumiCurtainSpeed: (args?: Partial<modernExtend.NumericArgs<"manuSpecificLumi">>) =>
         modernExtend.numeric({
             name: "curtain_speed",
             cluster: "manuSpecificLumi",
@@ -1541,7 +1541,7 @@ export const lumiModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    lumiCurtainManualOpenClose: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiCurtainManualOpenClose: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "manual_open_close",
             valueOn: ["ON", 1],
@@ -1554,7 +1554,7 @@ export const lumiModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    lumiCurtainAdaptivePullingSpeed: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiCurtainAdaptivePullingSpeed: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "adaptive_pulling_speed",
             valueOn: ["ON", 1],
@@ -1567,7 +1567,7 @@ export const lumiModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    lumiCurtainManualStop: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiCurtainManualStop: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "manual_stop",
             valueOn: ["ON", 1],
@@ -1580,7 +1580,7 @@ export const lumiModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    lumiCurtainReverse: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiCurtainReverse: (args?: Partial<modernExtend.BinaryArgs<"closuresWindowCovering">>) =>
         modernExtend.binary({
             name: "reverse_direction",
             valueOn: [true, 1],
@@ -1592,7 +1592,7 @@ export const lumiModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    lumiCurtainStatus: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiCurtainStatus: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "status",
             lookup: {closing: 0, opening: 1, stopped: 2, blocked: 3},
@@ -1604,7 +1604,7 @@ export const lumiModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    lumiCurtainLastManualOperation: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiCurtainLastManualOperation: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "last_manual_operation",
             lookup: {open: 1, close: 2, stop: 3},
@@ -1616,7 +1616,7 @@ export const lumiModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    lumiCurtainPosition: (args?: Partial<modernExtend.NumericArgs>) =>
+    lumiCurtainPosition: (args?: Partial<modernExtend.NumericArgs<"manuSpecificLumi">>) =>
         modernExtend.numeric({
             name: "curtain_position",
             cluster: "manuSpecificLumi",
@@ -1630,7 +1630,7 @@ export const lumiModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    lumiCurtainTraverseTime: (args?: Partial<modernExtend.NumericArgs>) =>
+    lumiCurtainTraverseTime: (args?: Partial<modernExtend.NumericArgs<"manuSpecificLumi">>) =>
         modernExtend.numeric({
             name: "traverse_time",
             cluster: "manuSpecificLumi",
@@ -1642,7 +1642,7 @@ export const lumiModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    lumiCurtainCalibrationStatus: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiCurtainCalibrationStatus: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "calibration_status",
             lookup: {not_calibrated: 0, half_calibrated: 1, fully_calibrated: 2},
@@ -1654,7 +1654,7 @@ export const lumiModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    lumiCurtainCalibrated: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiCurtainCalibrated: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "calibrated",
             valueOn: [true, 1],
@@ -1667,7 +1667,7 @@ export const lumiModernExtend = {
             entityCategory: "diagnostic",
             ...args,
         }),
-    lumiCurtainIdentifyBeep: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiCurtainIdentifyBeep: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "identify_beep",
             lookup: {short: 0, "1_sec": 1, "2_sec": 2},
@@ -1679,7 +1679,7 @@ export const lumiModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    lumiPowerOnBehavior: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiPowerOnBehavior: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "power_on_behavior",
             lookup: {on: 0, previous: 1, off: 2, inverted: 3},
@@ -1690,7 +1690,7 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiPowerOutageMemory: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiPowerOutageMemory: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "power_outage_memory",
             cluster: "manuSpecificLumi",
@@ -1703,7 +1703,7 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiOperationMode: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiOperationMode: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "operation_mode",
             lookup: {decoupled: 0, control_relay: 1},
@@ -1714,14 +1714,14 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiAction: (args?: Partial<modernExtend.ActionEnumLookupArgs>) =>
+    lumiAction: (args?: Partial<modernExtend.ActionEnumLookupArgs<"genMultistateInput">>) =>
         modernExtend.actionEnumLookup({
             actionLookup: {single: 1},
             cluster: "genMultistateInput",
             attribute: "presentValue",
             ...args,
         }),
-    lumiVoc: (args?: Partial<modernExtend.NumericArgs>) =>
+    lumiVoc: (args?: Partial<modernExtend.NumericArgs<"genAnalogInput">>) =>
         modernExtend.numeric({
             name: "voc",
             cluster: "genAnalogInput",
@@ -1732,7 +1732,7 @@ export const lumiModernExtend = {
             access: "STATE_GET",
             ...args,
         }),
-    lumiAirQuality: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiAirQuality: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "air_quality",
             lookup: {excellent: 1, good: 2, moderate: 3, poor: 4, unhealthy: 5, unknown: 0},
@@ -1743,7 +1743,7 @@ export const lumiModernExtend = {
             access: "STATE_GET",
             ...args,
         }),
-    lumiDisplayUnit: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiDisplayUnit: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "display_unit",
             lookup: {
@@ -1837,7 +1837,7 @@ export const lumiModernExtend = {
         result.ota = true;
         return result;
     },
-    lumiPower: (args?: Partial<modernExtend.NumericArgs>) =>
+    lumiPower: (args?: Partial<modernExtend.NumericArgs<"genAnalogInput">>) =>
         modernExtend.numeric({
             name: "power",
             cluster: "genAnalogInput",
@@ -1864,7 +1864,7 @@ export const lumiModernExtend = {
 
         return {exposes, fromZigbee, isModernExtend: true};
     },
-    lumiOverloadProtection: (args?: Partial<modernExtend.NumericArgs>) =>
+    lumiOverloadProtection: (args?: Partial<modernExtend.NumericArgs<"manuSpecificLumi">>) =>
         modernExtend.numeric({
             name: "overload_protection",
             cluster: "manuSpecificLumi",
@@ -1878,7 +1878,7 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiLedIndicator: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiLedIndicator: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "led_indicator",
             cluster: "manuSpecificLumi",
@@ -1891,7 +1891,7 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiLedDisabledNight: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiLedDisabledNight: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "led_disabled_night",
             cluster: "manuSpecificLumi",
@@ -1905,7 +1905,7 @@ export const lumiModernExtend = {
             reporting: false,
             ...args,
         }),
-    lumiButtonLock: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiButtonLock: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "button_lock",
             cluster: "manuSpecificLumi",
@@ -1918,7 +1918,7 @@ export const lumiModernExtend = {
             zigbeeCommandOptions: {manufacturerCode},
             ...args,
         }),
-    lumiFlipIndicatorLight: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiFlipIndicatorLight: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "flip_indicator_light",
             cluster: "manuSpecificLumi",
@@ -1958,7 +1958,7 @@ export const lumiModernExtend = {
         };
         return {fromZigbee: [converter], isModernExtend: true};
     },
-    lumiClickMode: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiClickMode: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "click_mode",
             lookup: {fast: 1, multi: 2},
@@ -2010,7 +2010,7 @@ export const lumiModernExtend = {
 
         return {fromZigbee, exposes, isModernExtend: true};
     },
-    lumiLockRelay: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiLockRelay: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "lock_relay",
             cluster: "manuSpecificLumi",
@@ -2035,7 +2035,7 @@ export const lumiModernExtend = {
         ];
         return {configure, isModernExtend: true};
     },
-    lumiSwitchMode: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiSwitchMode: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "mode_switch",
             lookup: {quick_mode: 1, anti_flicker_mode: 4},
@@ -2083,7 +2083,7 @@ export const lumiModernExtend = {
 
         return {exposes, fromZigbee, isModernExtend: true};
     },
-    lumiSensitivityAdjustment: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiSensitivityAdjustment: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "sensitivity_adjustment",
             lookup: {high: 1, medium: 2, low: 3},
@@ -2095,7 +2095,7 @@ export const lumiModernExtend = {
             entityCategory: "config",
             ...args,
         }),
-    lumiReportInterval: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    lumiReportInterval: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificLumi">>) =>
         modernExtend.enumLookup({
             name: "report_interval",
             lookup: {"1s": 0x01, "5s": 0x02, "10s": 0x03},
@@ -2338,7 +2338,7 @@ export const lumiModernExtend = {
             ],
         } satisfies ModernExtend;
     },
-    lumiMultiClick: (args?: Partial<modernExtend.BinaryArgs>) =>
+    lumiMultiClick: (args?: Partial<modernExtend.BinaryArgs<"manuSpecificLumi">>) =>
         modernExtend.binary({
             name: "multi_click",
             cluster: "manuSpecificLumi",
@@ -5147,7 +5147,7 @@ export const toZigbee = {
                         getOptions(meta.mapped, entity),
                     );
                 } else {
-                    const payload = {presentValue: value};
+                    const payload = {presentValue: value as number};
                     await entity.write("genAnalogOutput", payload);
                 }
 
@@ -5217,7 +5217,7 @@ export const toZigbee = {
     lumi_curtain_hand_open: {
         key: ["hand_open"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write("manuSpecificLumi", {curtainHandOpen: !value}, manufacturerOptions.lumi);
+            await entity.write("manuSpecificLumi", {curtainHandOpen: value ? 0 : 1}, manufacturerOptions.lumi);
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("manuSpecificLumi", ["curtainHandOpen"], manufacturerOptions.lumi);
@@ -5226,7 +5226,7 @@ export const toZigbee = {
     lumi_curtain_reverse: {
         key: ["reverse_direction"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write("manuSpecificLumi", {curtainReverse: value}, manufacturerOptions.lumi);
+            await entity.write("manuSpecificLumi", {curtainReverse: value ? 1 : 0}, manufacturerOptions.lumi);
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("manuSpecificLumi", ["curtainReverse"], manufacturerOptions.lumi);
@@ -5260,7 +5260,7 @@ export const toZigbee = {
         convertSet: async (entity, key, value, meta) => {
             switch (value) {
                 case "recalibrate":
-                    await entity.write("manuSpecificLumi", {curtainCalibrated: false}, manufacturerOptions.lumi);
+                    await entity.write("manuSpecificLumi", {curtainCalibrated: 0}, manufacturerOptions.lumi);
                     break;
                 case "open":
                     await entity.write("genMultistateOutput", {presentValue: 1}, manufacturerOptions.lumi);
@@ -5278,7 +5278,7 @@ export const toZigbee = {
             // Check if the curtain is already calibrated
             const checkIfCalibrated = async (): Promise<boolean> => {
                 const result = await entity.read("manuSpecificLumi", ["curtainCalibrated"]);
-                return result ? result.curtainCalibrated : false;
+                return result ? !!result.curtainCalibrated : false;
             };
 
             if (await checkIfCalibrated()) {
@@ -5302,12 +5302,12 @@ export const toZigbee = {
                 return await new Promise<void>((resolve) => {
                     const checkState = async () => {
                         const result = await entity.read("manuSpecificLumi", [0x0421]);
-                        const state = result ? result[0x0421] : null;
-                        if (!initialStates.includes(state)) {
+
+                        if (result && !initialStates.includes(result[0x0421] as number)) {
                             const checkDesiredState = async () => {
-                                const result = await entity.read("manuSpecificLumi", [0x0421]);
-                                const state = result ? result[0x0421] : null;
-                                if (desiredStates.includes(state)) {
+                                const result2 = await entity.read("manuSpecificLumi", [0x0421]);
+
+                                if (result2 && desiredStates.includes(result[0x0421] as number)) {
                                     resolve();
                                 } else {
                                     setTimeout(checkDesiredState, 500);

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -5144,7 +5144,7 @@ export const toZigbee = {
                     await entity.command(
                         "closuresWindowCovering",
                         "goToLiftPercentage",
-                        {percentageliftvalue: value},
+                        {percentageliftvalue: value as number},
                         getOptions(meta.mapped, entity),
                     );
                 } else {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -547,7 +547,7 @@ export function identify(args: {isSleepy: boolean} = {isSleepy: false}): ModernE
             key: ["identify"],
             options: [identifyTimeout],
             convertSet: async (entity, key, value, meta) => {
-                const identifyTimeout = meta.options.identify_timeout ?? 3;
+                const identifyTimeout = (meta.options.identify_timeout as number) ?? 3;
                 await entity.command("genIdentify", "identify", {identifytime: identifyTimeout}, getOptions(meta.mapped, entity));
             },
         },

--- a/src/lib/namron.ts
+++ b/src/lib/namron.ts
@@ -84,10 +84,10 @@ export const toZigbee = {
         convertSet: async (entity, key, value, meta) => {
             switch (key) {
                 case "vacation_start_date":
-                    await entity.write("hvacThermostat", {32800: fromDate(String(value))});
+                    await entity.write("hvacThermostat", {32800: {value: fromDate(String(value)), type: Zcl.DataType.UINT32}});
                     break;
                 case "vacation_end_date":
-                    await entity.write("hvacThermostat", {32801: fromDate(String(value))});
+                    await entity.write("hvacThermostat", {32801: {value: fromDate(String(value)), type: Zcl.DataType.UINT32}});
                     break;
             }
         },
@@ -98,15 +98,14 @@ export const toZigbee = {
             switch (key) {
                 case "operating_mode":
                     await entity.write("hvacThermostat", {
-                        37: utils.getFromLookup(value, {manual: 0, program: 1, eco: 5}),
-                        type: Zcl.DataType.BITMAP8,
+                        programingOperMode: utils.getFromLookup(value, {manual: 0, program: 1, eco: 5}),
                     });
                     break;
                 case "holiday_temp_set":
-                    await entity.write("hvacThermostat", {32787: Number(value) * 100, type: Zcl.DataType.INT16});
+                    await entity.write("hvacThermostat", {32787: {value: Number(value) * 100, type: Zcl.DataType.INT16}});
                     break;
                 case "holiday_temp_set_f":
-                    await entity.write("hvacThermostat", {32795: Number(value) * 100, type: Zcl.DataType.INT16});
+                    await entity.write("hvacThermostat", {32795: {value: Number(value) * 100, type: Zcl.DataType.INT16}});
                     break;
             }
         },
@@ -127,7 +126,7 @@ export const toZigbee = {
 };
 
 export const edgeThermostat = {
-    windowOpenDetection: (args?: Partial<modernExtend.BinaryArgs>) =>
+    windowOpenDetection: (args?: Partial<modernExtend.BinaryArgs<"hvacThermostat">>) =>
         modernExtend.binary({
             name: "window_open_check",
             valueOn: ["ON", 1],
@@ -138,7 +137,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    antiFrost: (args?: Partial<modernExtend.BinaryArgs>) =>
+    antiFrost: (args?: Partial<modernExtend.BinaryArgs<"hvacThermostat">>) =>
         modernExtend.binary({
             name: "anti_frost",
             valueOn: ["ON", 1],
@@ -149,7 +148,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    summerWinterSwitch: (args?: Partial<modernExtend.BinaryArgs>) =>
+    summerWinterSwitch: (args?: Partial<modernExtend.BinaryArgs<"hvacThermostat">>) =>
         modernExtend.binary({
             name: "summer_winter_switch",
             valueOn: ["ON", 1],
@@ -160,7 +159,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    vacationMode: (args?: Partial<modernExtend.BinaryArgs>) =>
+    vacationMode: (args?: Partial<modernExtend.BinaryArgs<"hvacThermostat">>) =>
         modernExtend.binary({
             name: "vacation_mode",
             valueOn: ["ON", 1],
@@ -171,7 +170,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    timeSync: (args?: Partial<modernExtend.BinaryArgs>) =>
+    timeSync: (args?: Partial<modernExtend.BinaryArgs<"hvacThermostat">>) =>
         modernExtend.binary({
             name: "time_sync",
             valueOn: ["ON", 1],
@@ -182,7 +181,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    autoTime: (args?: Partial<modernExtend.BinaryArgs>) =>
+    autoTime: (args?: Partial<modernExtend.BinaryArgs<"hvacThermostat">>) =>
         modernExtend.binary({
             name: "auto_time",
             valueOn: ["ON", 1],
@@ -194,7 +193,7 @@ export const edgeThermostat = {
             ...args,
         }),
 
-    displayActiveBacklight: (args?: Partial<modernExtend.NumericArgs>) =>
+    displayActiveBacklight: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "display_active_backlight",
             cluster: "hvacThermostat",
@@ -207,7 +206,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    regulatorPercentage: (args?: Partial<modernExtend.NumericArgs>) =>
+    regulatorPercentage: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "regulator_percentage",
             cluster: "hvacThermostat",
@@ -220,7 +219,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    regulationMode: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    regulationMode: (args?: Partial<modernExtend.EnumLookupArgs<"hvacThermostat">>) =>
         modernExtend.enumLookup({
             name: "regulation_mode",
             cluster: "hvacThermostat",
@@ -230,7 +229,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    displayAutoOff: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    displayAutoOff: (args?: Partial<modernExtend.EnumLookupArgs<"hvacThermostat">>) =>
         modernExtend.enumLookup({
             name: "display_auto_off",
             cluster: "hvacThermostat",
@@ -240,7 +239,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    sensorMode: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    sensorMode: (args?: Partial<modernExtend.EnumLookupArgs<"hvacThermostat">>) =>
         modernExtend.enumLookup({
             name: "sensor_mode",
             cluster: "hvacThermostat",
@@ -250,7 +249,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    boostTime: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    boostTime: (args?: Partial<modernExtend.EnumLookupArgs<"hvacThermostat">>) =>
         modernExtend.enumLookup({
             name: "boost_time_set",
             cluster: "hvacThermostat",
@@ -286,7 +285,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    systemMode: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    systemMode: (args?: Partial<modernExtend.EnumLookupArgs<"hvacThermostat">>) =>
         modernExtend.enumLookup({
             name: "system_mode",
             cluster: "hvacThermostat",
@@ -297,7 +296,7 @@ export const edgeThermostat = {
             ...args,
         }),
 
-    deviceTime: (args?: Partial<modernExtend.NumericArgs>) =>
+    deviceTime: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "time_sync_value",
             cluster: "hvacThermostat",
@@ -308,7 +307,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    absMinHeatSetpointLimitF: (args?: Partial<modernExtend.NumericArgs>) =>
+    absMinHeatSetpointLimitF: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "abs_min_heat_setpoint_limit_f",
             cluster: "hvacThermostat",
@@ -318,7 +317,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    absMaxHeatSetpointLimitF: (args?: Partial<modernExtend.NumericArgs>) =>
+    absMaxHeatSetpointLimitF: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "abs_max_heat_setpoint_limit_f",
             cluster: "hvacThermostat",
@@ -328,7 +327,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    absMinCoolSetpointLimitF: (args?: Partial<modernExtend.NumericArgs>) =>
+    absMinCoolSetpointLimitF: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "abs_min_cool_setpoint_limit_f",
             cluster: "hvacThermostat",
@@ -338,7 +337,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    absMaxCoolSetpointLimitF: (args?: Partial<modernExtend.NumericArgs>) =>
+    absMaxCoolSetpointLimitF: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "abs_max_cool_setpoint_limit_f",
             cluster: "hvacThermostat",
@@ -348,7 +347,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    occupiedCoolingSetpointF: (args?: Partial<modernExtend.NumericArgs>) =>
+    occupiedCoolingSetpointF: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "occupied_cooling_setpoint_f",
             cluster: "hvacThermostat",
@@ -358,7 +357,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    occupiedHeatingSetpointF: (args?: Partial<modernExtend.NumericArgs>) =>
+    occupiedHeatingSetpointF: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "occupied_heating_setpoint_f",
             cluster: "hvacThermostat",
@@ -368,7 +367,7 @@ export const edgeThermostat = {
             access: "ALL",
             ...args,
         }),
-    localTemperatureF: (args?: Partial<modernExtend.NumericArgs>) =>
+    localTemperatureF: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
         modernExtend.numeric({
             name: "local_temperature_f",
             cluster: "hvacThermostat",
@@ -380,7 +379,7 @@ export const edgeThermostat = {
         }),
 
     readOnly: {
-        windowState: (args?: Partial<modernExtend.BinaryArgs>) =>
+        windowState: (args?: Partial<modernExtend.BinaryArgs<"hvacThermostat">>) =>
             modernExtend.binary({
                 name: "window_state",
                 valueOn: ["OPEN", 1],
@@ -391,7 +390,7 @@ export const edgeThermostat = {
                 access: "STATE_GET",
                 ...args,
             }),
-        deviceFault: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+        deviceFault: (args?: Partial<modernExtend.EnumLookupArgs<"hvacThermostat">>) =>
             modernExtend.enumLookup({
                 name: "fault",
                 cluster: "hvacThermostat",
@@ -408,7 +407,7 @@ export const edgeThermostat = {
                 access: "STATE_GET",
                 ...args,
             }),
-        workDays: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+        workDays: (args?: Partial<modernExtend.EnumLookupArgs<"hvacThermostat">>) =>
             modernExtend.enumLookup({
                 name: "work_days",
                 cluster: "hvacThermostat",
@@ -418,7 +417,7 @@ export const edgeThermostat = {
                 access: "STATE_GET",
                 ...args,
             }),
-        boostTimeRemaining: (args?: Partial<modernExtend.NumericArgs>) =>
+        boostTimeRemaining: (args?: Partial<modernExtend.NumericArgs<"hvacThermostat">>) =>
             modernExtend.numeric({
                 name: "boost_time_remaining",
                 cluster: "hvacThermostat",

--- a/src/lib/nodon.ts
+++ b/src/lib/nodon.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as exposes from "./exposes";
 import {logger} from "./logger";
 import {deviceAddCustomCluster} from "./modernExtend";
@@ -13,7 +12,7 @@ const NS = "zhc:nodon";
 const PILOT_WIRE_CLUSTER = "customClusterNodOnPilotWire";
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.NODON};
 
-interface NodonPilotWire extends TCustomCluster {
+interface NodonPilotWire {
     attributes: {
         mode: number;
     };

--- a/src/lib/nodon.ts
+++ b/src/lib/nodon.ts
@@ -75,7 +75,7 @@ const pilotWireConfig = (configureReporting: boolean): ModernExtend => {
                         "comfort_-2": 0x05,
                     });
                     const payload = {mode: mode};
-                    await entity.command(PILOT_WIRE_CLUSTER, "setMode", payload);
+                    await entity.command<typeof PILOT_WIRE_CLUSTER, "setMode", NodonPilotWire>(PILOT_WIRE_CLUSTER, "setMode", payload);
                     return {state: {pilot_wire_mode: value}};
                 },
                 convertGet: async (entity, key, meta) => {

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as reporting from "../lib/reporting";
@@ -58,7 +57,7 @@ export const knownEffects = {
     "1080": "enchant",
 };
 
-interface PhilipsContact extends TCustomCluster {
+interface PhilipsContact {
     attributes: {
         contact: number;
         contactLastChange: number;

--- a/src/lib/reporting.ts
+++ b/src/lib/reporting.ts
@@ -1,7 +1,15 @@
+import type {ConfigureReportingItem} from "zigbee-herdsman/dist/controller/model/endpoint";
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import {repInterval} from "./constants";
 import type {Reporting, Zh} from "./types";
 
-export function payload(attribute: string | number, min: number, max: number, change: number, overrides?: Reporting.Override) {
+export function payload<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
+    attribute: ConfigureReportingItem<Cl, Custom>["attribute"],
+    min: number,
+    max: number,
+    change: number,
+    overrides?: Reporting.Override,
+): ConfigureReportingItem<Cl, Custom>[] {
     const payload = {
         attribute: attribute,
         minimumReportInterval: min,
@@ -35,204 +43,204 @@ export async function readMeteringMultiplierDivisor(endpoint: Zh.Endpoint) {
     await endpoint.read("seMetering", ["multiplier", "divisor"]);
 }
 
-export async function bind(endpoint: Zh.Endpoint, target: Zh.Endpoint, clusters: (number | string)[]) {
+export async function bind(endpoint: Zh.Endpoint, target: Zh.Endpoint, clusters: (number | string)[] | readonly (number | string)[]) {
     for (const cluster of clusters) {
         await endpoint.bind(cluster, target);
     }
 }
 
 export const currentPositionLiftPercentage = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("currentPositionLiftPercentage", 1, repInterval.MAX, 1, overrides);
+    const p = payload<"closuresWindowCovering">("currentPositionLiftPercentage", 1, repInterval.MAX, 1, overrides);
     await endpoint.configureReporting("closuresWindowCovering", p);
 };
 export const currentPositionTiltPercentage = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("currentPositionTiltPercentage", 1, repInterval.MAX, 1, overrides);
+    const p = payload<"closuresWindowCovering">("currentPositionTiltPercentage", 1, repInterval.MAX, 1, overrides);
     await endpoint.configureReporting("closuresWindowCovering", p);
 };
 export const batteryPercentageRemaining = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("batteryPercentageRemaining", repInterval.HOUR, repInterval.MAX, 0, overrides);
+    const p = payload<"genPowerCfg">("batteryPercentageRemaining", repInterval.HOUR, repInterval.MAX, 0, overrides);
     await endpoint.configureReporting("genPowerCfg", p);
     await endpoint.read("genPowerCfg", ["batteryPercentageRemaining"]);
 };
 export const batteryVoltage = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("batteryVoltage", repInterval.HOUR, repInterval.MAX, 0, overrides);
+    const p = payload<"genPowerCfg">("batteryVoltage", repInterval.HOUR, repInterval.MAX, 0, overrides);
     await endpoint.configureReporting("genPowerCfg", p);
     await endpoint.read("genPowerCfg", ["batteryVoltage"]);
 };
 export const batteryAlarmState = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("batteryAlarmState", repInterval.HOUR, repInterval.MAX, 0, overrides);
+    const p = payload<"genPowerCfg">("batteryAlarmState", repInterval.HOUR, repInterval.MAX, 0, overrides);
     await endpoint.configureReporting("genPowerCfg", p);
     await endpoint.read("genPowerCfg", ["batteryAlarmState"]);
 };
 export const onOff = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("onOff", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"genOnOff">("onOff", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("genOnOff", p);
 };
 export const onTime = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("onTime", 0, repInterval.HOUR, 40, overrides);
+    const p = payload<"genOnOff">("onTime", 0, repInterval.HOUR, 40, overrides);
     await endpoint.configureReporting("genOnOff", p);
 };
 export const lockState = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("lockState", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"closuresDoorLock">("lockState", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("closuresDoorLock", p);
 };
 export const doorState = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("doorState", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"closuresDoorLock">("doorState", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("closuresDoorLock", p);
 };
 export const brightness = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("currentLevel", 1, repInterval.HOUR, 1, overrides);
+    const p = payload<"genLevelCtrl">("currentLevel", 1, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("genLevelCtrl", p);
 };
 export const colorTemperature = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("colorTemperature", 0, repInterval.HOUR, 1, overrides);
+    const p = payload<"lightingColorCtrl">("colorTemperature", 0, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("lightingColorCtrl", p);
 };
 export const occupancy = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("occupancy", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"msOccupancySensing">("occupancy", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("msOccupancySensing", p);
 };
 export const temperature = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("measuredValue", 10, repInterval.HOUR, 100, overrides);
+    const p = payload<"msTemperatureMeasurement">("measuredValue", 10, repInterval.HOUR, 100, overrides);
     await endpoint.configureReporting("msTemperatureMeasurement", p);
 };
 export const co2 = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("measuredValue", 10, repInterval.HOUR, 1, overrides);
+    const p = payload<"msCO2">("measuredValue", 10, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("msCO2", p);
 };
 export const deviceTemperature = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("currentTemperature", 300, repInterval.HOUR, 1, overrides);
+    const p = payload<"genDeviceTempCfg">("currentTemperature", 300, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("genDeviceTempCfg", p);
 };
 export const pressure = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("measuredValue", 10, repInterval.HOUR, 5, overrides);
+    const p = payload<"msPressureMeasurement">("measuredValue", 10, repInterval.HOUR, 5, overrides);
     await endpoint.configureReporting("msPressureMeasurement", p);
 };
 export const pressureExtended = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("scaledValue", 10, repInterval.HOUR, 5, overrides);
+    const p = payload<"msPressureMeasurement">("scaledValue", 10, repInterval.HOUR, 5, overrides);
     await endpoint.configureReporting("msPressureMeasurement", p);
 };
 export const illuminance = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("measuredValue", 10, repInterval.HOUR, 5, overrides);
+    const p = payload<"msIlluminanceMeasurement">("measuredValue", 10, repInterval.HOUR, 5, overrides);
     await endpoint.configureReporting("msIlluminanceMeasurement", p);
 };
 export const instantaneousDemand = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("instantaneousDemand", 5, repInterval.HOUR, 1, overrides);
+    const p = payload<"seMetering">("instantaneousDemand", 5, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("seMetering", p);
 };
 export const currentSummDelivered = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("currentSummDelivered", 5, repInterval.HOUR, 257, overrides);
+    const p = payload<"seMetering">("currentSummDelivered", 5, repInterval.HOUR, 257, overrides);
     await endpoint.configureReporting("seMetering", p);
 };
 export const currentSummReceived = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("currentSummReceived", 5, repInterval.HOUR, 257, overrides);
+    const p = payload<"seMetering">("currentSummReceived", 5, repInterval.HOUR, 257, overrides);
     await endpoint.configureReporting("seMetering", p);
 };
 export const thermostatSystemMode = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("systemMode", 10, repInterval.HOUR, null, overrides);
+    const p = payload<"hvacThermostat">("systemMode", 10, repInterval.HOUR, null, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const humidity = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("measuredValue", 10, repInterval.HOUR, 100, overrides);
+    const p = payload<"msRelativeHumidity">("measuredValue", 10, repInterval.HOUR, 100, overrides);
     await endpoint.configureReporting("msRelativeHumidity", p);
 };
 export const thermostatKeypadLockMode = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("keypadLockout", 10, repInterval.HOUR, null, overrides);
+    const p = payload<"hvacUserInterfaceCfg">("keypadLockout", 10, repInterval.HOUR, null, overrides);
     await endpoint.configureReporting("hvacUserInterfaceCfg", p);
 };
 export const thermostatTemperature = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("localTemp", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("localTemp", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatTemperatureCalibration = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("localTemperatureCalibration", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"hvacThermostat">("localTemperatureCalibration", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatOccupiedHeatingSetpoint = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("occupiedHeatingSetpoint", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("occupiedHeatingSetpoint", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatUnoccupiedHeatingSetpoint = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("unoccupiedHeatingSetpoint", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("unoccupiedHeatingSetpoint", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatOccupiedCoolingSetpoint = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("occupiedCoolingSetpoint", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("occupiedCoolingSetpoint", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatUnoccupiedCoolingSetpoint = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("unoccupiedCoolingSetpoint", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("unoccupiedCoolingSetpoint", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatPIHeatingDemand = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("pIHeatingDemand", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("pIHeatingDemand", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatPICoolingDemand = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("pICoolingDemand", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("pICoolingDemand", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatRunningState = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("runningState", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"hvacThermostat">("runningState", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatRunningMode = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("runningMode", 10, repInterval.HOUR, null, overrides);
+    const p = payload<"hvacThermostat">("runningMode", 10, repInterval.HOUR, null, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatOccupancy = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("occupancy", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"hvacThermostat">("occupancy", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatTemperatureSetpointHold = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("tempSetpointHold", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"hvacThermostat">("tempSetpointHold", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatTemperatureSetpointHoldDuration = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("tempSetpointHoldDuration", 0, repInterval.HOUR, 10, overrides);
+    const p = payload<"hvacThermostat">("tempSetpointHoldDuration", 0, repInterval.HOUR, 10, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const thermostatAcLouverPosition = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("acLouverPosition", 0, repInterval.HOUR, null, overrides);
+    const p = payload<"hvacThermostat">("acLouverPosition", 0, repInterval.HOUR, null, overrides);
     await endpoint.configureReporting("hvacThermostat", p);
 };
 export const presentValue = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("presentValue", 10, repInterval.MINUTE, 1, overrides);
+    const p = payload<"genBinaryInput">("presentValue", 10, repInterval.MINUTE, 1, overrides);
     await endpoint.configureReporting("genBinaryInput", p);
 };
 export const activePower = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("activePower", 5, repInterval.HOUR, 1, overrides);
+    const p = payload<"haElectricalMeasurement">("activePower", 5, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("haElectricalMeasurement", p);
 };
 export const reactivePower = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("reactivePower", 5, repInterval.HOUR, 1, overrides);
+    const p = payload<"haElectricalMeasurement">("reactivePower", 5, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("haElectricalMeasurement", p);
 };
 export const apparentPower = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("apparentPower", 5, repInterval.HOUR, 1, overrides);
+    const p = payload<"haElectricalMeasurement">("apparentPower", 5, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("haElectricalMeasurement", p);
 };
 export const rmsCurrent = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("rmsCurrent", 5, repInterval.HOUR, 1, overrides);
+    const p = payload<"haElectricalMeasurement">("rmsCurrent", 5, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("haElectricalMeasurement", p);
 };
 export const rmsVoltage = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("rmsVoltage", 5, repInterval.HOUR, 1, overrides);
+    const p = payload<"haElectricalMeasurement">("rmsVoltage", 5, repInterval.HOUR, 1, overrides);
     await endpoint.configureReporting("haElectricalMeasurement", p);
 };
 export const powerFactor = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("powerFactor", 0, repInterval.MAX, 1, overrides);
+    const p = payload<"haElectricalMeasurement">("powerFactor", 0, repInterval.MAX, 1, overrides);
     await endpoint.configureReporting("haElectricalMeasurement", p);
 };
 export const fanMode = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("fanMode", 0, repInterval.HOUR, 0, overrides);
+    const p = payload<"hvacFanCtrl">("fanMode", 0, repInterval.HOUR, 0, overrides);
     await endpoint.configureReporting("hvacFanCtrl", p);
 };
 export const soil_moisture = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("measuredValue", 10, repInterval.HOUR, 100, overrides);
+    const p = payload<"msSoilMoisture">("measuredValue", 10, repInterval.HOUR, 100, overrides);
     await endpoint.configureReporting("msSoilMoisture", p);
 };
 export const acFrequency = async (endpoint: Zh.Endpoint, overrides?: Reporting.Override) => {
-    const p = payload("acFrequency", 5, repInterval.MINUTES_5, 10, overrides);
+    const p = payload<"haElectricalMeasurement">("acFrequency", 5, repInterval.MINUTES_5, 10, overrides);
     await endpoint.configureReporting("haElectricalMeasurement", p);
 };

--- a/src/lib/sunricher.ts
+++ b/src/lib/sunricher.ts
@@ -21,7 +21,7 @@ const tz = {
     setModel: {
         key: ["model"],
         convertSet: async (entity, key, value, meta) => {
-            await entity.write("genBasic", {modelId: value});
+            await entity.write("genBasic", {modelId: value as string});
             return {state: {model: value}};
         },
     } satisfies Tz.Converter,
@@ -443,8 +443,7 @@ const extend = {
                     const attributeRead = await entity.read(cluster, [attribute]);
                     if (attributeRead === undefined) return;
 
-                    // @ts-expect-error ignore
-                    const currentValue = attributeRead[attribute];
+                    const currentValue = attributeRead[attribute] as number;
                     const newValue = value === "on" ? currentValue | 0x01 : currentValue & ~0x01;
 
                     await entity.write(cluster, {[attribute]: {value: newValue, type: data_type}}, {manufacturerCode});
@@ -802,8 +801,11 @@ const extend = {
                         convertedValue = Number((Math.round(Number((value * 2).toFixed(1))) / 2).toFixed(1)) * 100;
                     }
 
-                    const attribute = awayOrBoostMode === 1 ? "unoccupiedHeatingSetpoint" : "occupiedHeatingSetpoint";
-                    await entity.write("hvacThermostat", {[attribute]: convertedValue});
+                    if (awayOrBoostMode === 1) {
+                        await entity.write("hvacThermostat", {unoccupiedHeatingSetpoint: convertedValue});
+                    } else {
+                        await entity.write("hvacThermostat", {occupiedHeatingSetpoint: convertedValue});
+                    }
                     return {state: {current_heating_setpoint: value}};
                 },
                 convertGet: async (entity, key, meta) => {

--- a/src/lib/sunricher.ts
+++ b/src/lib/sunricher.ts
@@ -1,5 +1,5 @@
 import type {Endpoint, Group} from "zigbee-herdsman/dist/controller/model";
-
+import type {ClusterOrRawAttributeKeys, PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as constants from "./constants";
 import {repInterval} from "./constants";
 import * as exposes from "./exposes";
@@ -688,7 +688,7 @@ const extend = {
                         if (value === "away") {
                             await entity.read("hvacThermostat", ["unoccupiedHeatingSetpoint"]);
                         }
-                        await entity.write("hvacThermostat", {awayOrBoostMode});
+                        await entity.write("hvacThermostat", {awayOrBoostMode} as PartialClusterOrRawWriteAttributes<"hvacThermostat">);
                         return {state: {preset: value, away_or_boost_mode: value}};
                     }
                     globalStore.putValue(entity, "awayOrBoostMode", 0);
@@ -732,7 +732,7 @@ const extend = {
             async (device, coordinatorEndpoint, definition) => {
                 const endpoint = device.getEndpoint(1);
                 await endpoint.read("hvacThermostat", ["systemMode"]);
-                await endpoint.read("hvacThermostat", ["awayOrBoostMode"]);
+                await endpoint.read("hvacThermostat", ["awayOrBoostMode"] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">);
 
                 await reporting.bind(endpoint, coordinatorEndpoint, ["hvacThermostat"]);
                 await reporting.thermostatSystemMode(endpoint);
@@ -747,7 +747,9 @@ const extend = {
         const getAwayOrBoostMode = async (entity: Endpoint | Group) => {
             let result = globalStore.getValue(entity, "awayOrBoostMode");
             if (result === undefined) {
-                const attributeRead = await entity.read("hvacThermostat", ["awayOrBoostMode"]);
+                const attributeRead = await entity.read("hvacThermostat", [
+                    "awayOrBoostMode",
+                ] as unknown as ClusterOrRawAttributeKeys<"hvacThermostat">);
                 // @ts-expect-error ignore
                 result = attributeRead.awayOrBoostMode;
                 globalStore.putValue(entity, "awayOrBoostMode", result);

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1480,10 +1480,13 @@ const tuyaTz = {
         key: ["backlight_mode", "indicator_mode"],
         convertSet: async (entity, key, value, meta) => {
             const lookup = key === "backlight_mode" ? {off: 0, on: 1} : {none: 0, relay: 1, pos: 2};
-            const attribute = key === "backlight_mode" ? "tuyaBacklightSwitch" : "tuyaBacklightMode";
             const result = utils.getFromLookup(value, lookup);
 
-            await entity.write("genOnOff", {[attribute]: result});
+            if (key === "backlight_mode") {
+                await entity.write("genOnOff", {tuyaBacklightSwitch: result});
+            } else {
+                await entity.write("genOnOff", {tuyaBacklightMode: result});
+            }
             return {state: {[key]: value}};
         },
         convertGet: async (entity, key, meta) => {
@@ -2647,7 +2650,7 @@ const tuyaModernExtend = {
 
         return {exposes: [exp], fromZigbee: newFromZigbee, isModernExtend: true};
     },
-    tuyaSwitchMode: (args?: Partial<modernExtend.EnumLookupArgs>) =>
+    tuyaSwitchMode: (args?: Partial<modernExtend.EnumLookupArgs<"manuSpecificTuya3">>) =>
         modernExtend.enumLookup({
             name: "switch_mode",
             lookup: {switch: 0, scene: 1},
@@ -2667,11 +2670,12 @@ const tuyaModernExtend = {
     tuyaMagicPacket(): ModernExtend {
         return {configure: [configureMagicPacket], isModernExtend: true};
     },
-    tuyaOnOffAction(args?: Partial<modernExtend.ActionEnumLookupArgs>): ModernExtend {
+    tuyaOnOffAction(args?: Partial<modernExtend.ActionEnumLookupArgs<"genOnOff">>): ModernExtend {
         return modernExtend.actionEnumLookup({
             actionLookup: {0: "single", 1: "double", 2: "hold"},
             cluster: "genOnOff",
             commands: ["commandTuyaAction"],
+            // TODO: using commands payload not attributes
             attribute: "value",
         });
     },

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -2671,11 +2671,10 @@ const tuyaModernExtend = {
         return {configure: [configureMagicPacket], isModernExtend: true};
     },
     tuyaOnOffAction(args?: Partial<modernExtend.ActionEnumLookupArgs<"genOnOff">>): ModernExtend {
-        return modernExtend.actionEnumLookup({
+        return modernExtend.actionEnumLookup<"genOnOff", undefined, "tuyaAction">({
             actionLookup: {0: "single", 1: "double", 2: "hold"},
             cluster: "genOnOff",
             commands: ["commandTuyaAction"],
-            // TODO: using commands payload not attributes
             attribute: "value",
         });
     },

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -142,8 +142,8 @@ export function dpValueFromString(dp: number, string: string) {
     return {dp, datatype: dataTypes.string, data: Buffer.from(convertStringToHexArray(string))};
 }
 
-function dpValueFromRaw(dp: number, rawBuffer: number[]) {
-    return {dp, datatype: dataTypes.raw, data: Buffer.from(rawBuffer)};
+function dpValueFromRaw(dp: number, rawBuffer: Buffer) {
+    return {dp, datatype: dataTypes.raw, data: rawBuffer};
 }
 
 function dpValueFromBitmap(dp: number, bitmapBuffer: number) {
@@ -162,7 +162,7 @@ export async function sendDataPointEnum(entity: Zh.Group | Zh.Endpoint, dp: numb
     return await sendDataPoints(entity, [dpValueFromEnum(dp, value)], cmd, seq);
 }
 
-export async function sendDataPointRaw(entity: Zh.Group | Zh.Endpoint, dp: number, value: number[], cmd?: string, seq?: number) {
+export async function sendDataPointRaw(entity: Zh.Group | Zh.Endpoint, dp: number, value: Buffer, cmd?: string, seq?: number) {
     return await sendDataPoints(entity, [dpValueFromRaw(dp, value)], cmd, seq);
 }
 
@@ -612,7 +612,7 @@ export const valueConverter = {
                     0,
                     utils.toNumber(threshold, "overload_threshold"),
                 ]);
-                await sendDataPointRaw(entity, 17, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 17, buf, sendCommand, 1);
             } else if (meta.message.overload_threshold) {
                 const state = meta.state.overload_breaker;
                 const buf = Buffer.from([
@@ -621,35 +621,35 @@ export const valueConverter = {
                     0,
                     utils.toNumber(meta.message.overload_threshold, "overload_threshold"),
                 ]);
-                await sendDataPointRaw(entity, 17, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 17, buf, sendCommand, 1);
             } else if (meta.message.leakage_threshold) {
                 const state = meta.state.leakage_breaker;
                 const buf = Buffer.alloc(8);
                 buf.writeUInt8(4, 4);
                 buf.writeUInt8(utils.getFromLookup(state, onOffLookup), 5);
                 buf.writeUInt16BE(utils.toNumber(meta.message.leakage_threshold, "leakage_threshold"), 6);
-                await sendDataPointRaw(entity, 17, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 17, buf, sendCommand, 1);
             } else if (meta.message.leakage_breaker) {
                 const threshold = meta.state.leakage_threshold;
                 const buf = Buffer.alloc(8);
                 buf.writeUInt8(4, 4);
                 buf.writeUInt8(utils.getFromLookup(meta.message.leakage_breaker, onOffLookup), 5);
                 buf.writeUInt16BE(utils.toNumber(threshold, "leakage_threshold"), 6);
-                await sendDataPointRaw(entity, 17, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 17, buf, sendCommand, 1);
             } else if (meta.message.high_temperature_threshold) {
                 const state = meta.state.high_temperature_breaker;
                 const buf = Buffer.alloc(12);
                 buf.writeUInt8(5, 8);
                 buf.writeUInt8(utils.getFromLookup(state, onOffLookup), 9);
                 buf.writeUInt16BE(utils.toNumber(meta.message.high_temperature_threshold, "high_temperature_threshold"), 10);
-                await sendDataPointRaw(entity, 17, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 17, buf, sendCommand, 1);
             } else if (meta.message.high_temperature_breaker) {
                 const threshold = meta.state.high_temperature_threshold;
                 const buf = Buffer.alloc(12);
                 buf.writeUInt8(5, 8);
                 buf.writeUInt8(utils.getFromLookup(meta.message.high_temperature_breaker, onOffLookup), 9);
                 buf.writeUInt16BE(utils.toNumber(threshold, "high_temperature_threshold"), 10);
-                await sendDataPointRaw(entity, 17, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 17, buf, sendCommand, 1);
             }
         },
         from: (v: string) => {
@@ -687,7 +687,7 @@ export const valueConverter = {
                     0,
                     utils.toNumber(meta.message.over_current_threshold, "over_current_threshold"),
                 ]);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             } else if (meta.message.over_current_breaker) {
                 const threshold = meta.state.over_current_threshold;
                 const buf = Buffer.from([
@@ -696,49 +696,49 @@ export const valueConverter = {
                     0,
                     utils.toNumber(threshold, "over_current_threshold"),
                 ]);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             } else if (meta.message.over_voltage_threshold) {
                 const state = meta.state.over_voltage_breaker;
                 const buf = Buffer.alloc(8);
                 buf.writeUInt8(3, 4);
                 buf.writeUInt8(utils.getFromLookup(state, onOffLookup), 5);
                 buf.writeUInt16BE(utils.toNumber(meta.message.over_voltage_threshold, "over_voltage_threshold"), 6);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             } else if (meta.message.over_voltage_breaker) {
                 const threshold = meta.state.over_voltage_threshold;
                 const buf = Buffer.alloc(8);
                 buf.writeUInt8(3, 4);
                 buf.writeUInt8(utils.getFromLookup(meta.message.over_voltage_breaker, onOffLookup), 5);
                 buf.writeUInt16BE(utils.toNumber(threshold, "over_voltage_threshold"), 6);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             } else if (meta.message.under_voltage_threshold) {
                 const state = meta.state.under_voltage_breaker;
                 const buf = Buffer.alloc(12);
                 buf.writeUInt8(4, 8);
                 buf.writeUInt8(utils.getFromLookup(state, onOffLookup), 9);
                 buf.writeUInt16BE(utils.toNumber(meta.message.under_voltage_threshold, "under_voltage_threshold"), 10);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             } else if (meta.message.under_voltage_breaker) {
                 const threshold = meta.state.under_voltage_threshold;
                 const buf = Buffer.alloc(12);
                 buf.writeUInt8(4, 8);
                 buf.writeUInt8(utils.getFromLookup(meta.message.under_voltage_breaker, onOffLookup), 9);
                 buf.writeUInt16BE(utils.toNumber(threshold, "under_voltage_threshold"), 10);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             } else if (meta.message.insufficient_balance_threshold) {
                 const state = meta.state.insufficient_balance_breaker;
                 const buf = Buffer.alloc(16);
                 buf.writeUInt8(8, 12);
                 buf.writeUInt8(utils.getFromLookup(state, onOffLookup), 13);
                 buf.writeUInt16BE(utils.toNumber(meta.message.insufficient_balance_threshold, "insufficient_balance_threshold"), 14);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             } else if (meta.message.insufficient_balance_breaker) {
                 const threshold = meta.state.insufficient_balance_threshold;
                 const buf = Buffer.alloc(16);
                 buf.writeUInt8(8, 12);
                 buf.writeUInt8(utils.getFromLookup(meta.message.insufficient_balance_breaker, onOffLookup), 13);
                 buf.writeUInt16BE(utils.toNumber(threshold, "insufficient_balance_threshold"), 14);
-                await sendDataPointRaw(entity, 18, Array.from(buf), sendCommand, 1);
+                await sendDataPointRaw(entity, 18, buf, sendCommand, 1);
             }
         },
         from: (v: string) => {
@@ -1142,7 +1142,7 @@ export const valueConverter = {
 
             const entity = meta.device.endpoints[0];
             const sendCommand = utils.getMetaValue(entity, meta.mapped, "tuyaSendCommand", undefined, "dataRequest");
-            await sendDataPointRaw(entity, dpId, payload, sendCommand, 1);
+            await sendDataPointRaw(entity, dpId, Buffer.from(payload), sendCommand, 1);
         },
     },
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
@@ -1581,7 +1581,7 @@ const tuyaTz = {
                 } else if (typeof convertedValue === "string") {
                     await sendDataPointStringBuffer(entity, dpId, convertedValue, sendCommand, 1);
                 } else if (Array.isArray(convertedValue)) {
-                    await sendDataPointRaw(entity, dpId, convertedValue, sendCommand, 1);
+                    await sendDataPointRaw(entity, dpId, Buffer.from(convertedValue), sendCommand, 1);
                 } else if (convertedValue instanceof Enum) {
                     await sendDataPointEnum(entity, dpId, convertedValue.valueOf(), sendCommand, 1);
                 } else if (convertedValue instanceof Bitmap) {
@@ -1940,7 +1940,7 @@ export function getHandlersForDP(
                           } else if (type === dataTypes.string) {
                               await sendDataPointStringBuffer(entity, dp, convertedValue as string, sendCommand, seq);
                           } else if (type === dataTypes.raw) {
-                              await sendDataPointRaw(entity, dp, convertedValue as number[], sendCommand, seq);
+                              await sendDataPointRaw(entity, dp, Buffer.from(convertedValue as number[]), sendCommand, seq);
                           } else if (type === dataTypes.enum) {
                               await sendDataPointEnum(entity, dp, convertedValue as number, sendCommand, seq);
                           } else if (type === dataTypes.bitmap) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,6 @@
 import type {Models as ZHModels} from "zigbee-herdsman";
 import type {Header as ZHZclHeader} from "zigbee-herdsman/dist/zspec/zcl";
 import type {FrameControl} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
-
 import type * as exposes from "./exposes";
 
 export interface Logger {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -342,7 +342,7 @@ export namespace Tuya {
     export interface DpValue {
         dp: number;
         datatype: number;
-        data: Buffer | number[];
+        data: Buffer;
     }
     export interface ValueConverterSingle {
         // biome-ignore lint/suspicious/noExplicitAny: value is validated on per-case basis

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -168,7 +168,7 @@ export const ubisysModernExtend = {
             commands: {},
             commandsResponse: {},
         }),
-    localTemperatureOffset: (args?: Partial<NumericArgs>) =>
+    localTemperatureOffset: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
         numeric({
             name: "local_temperature_offset",
             cluster: "hvacThermostat",
@@ -180,7 +180,7 @@ export const ubisysModernExtend = {
             unit: "ºC",
             ...args,
         }),
-    occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs>) =>
+    occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
         numeric({
             name: "occupied_heating_default_setpoint",
             cluster: "hvacThermostat",
@@ -196,7 +196,7 @@ export const ubisysModernExtend = {
             unit: "ºC",
             ...args,
         }),
-    remoteTemperatureDuration: (args?: Partial<NumericArgs>) =>
+    remoteTemperatureDuration: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
         numeric({
             name: "remote_temperature_duration",
             cluster: "hvacThermostat",
@@ -211,10 +211,10 @@ export const ubisysModernExtend = {
             ...args,
         }),
     vacationMode: (): ModernExtend => {
-        const clusterName = "hvacThermostat";
-        const writeableAttributeName = "ubisysVacationMode";
-        const readableAttributeName = "occupancy";
-        const propertyName = "vacation_mode";
+        const clusterName = "hvacThermostat" as const;
+        const writeableAttributeName = "ubisysVacationMode" as const;
+        const readableAttributeName = "occupancy" as const;
+        const propertyName = "vacation_mode" as const;
         const access = ea.ALL;
 
         const expose = e
@@ -262,7 +262,7 @@ export const ubisysModernExtend = {
 
         return {exposes: [expose], fromZigbee, toZigbee, configure, isModernExtend: true};
     },
-    openWindowState: (args?: Partial<BinaryArgs>) =>
+    openWindowState: (args?: Partial<BinaryArgs<"hvacThermostat">>) =>
         binary({
             name: "open_window_state",
             cluster: "hvacThermostat",
@@ -273,7 +273,7 @@ export const ubisysModernExtend = {
             description: "Presents the currently detected window state.",
             ...args,
         }),
-    openWindowDetect: (args?: Partial<BinaryArgs>) =>
+    openWindowDetect: (args?: Partial<BinaryArgs<"hvacThermostat">>) =>
         binary({
             name: "open_window_detect",
             cluster: "hvacThermostat",
@@ -284,7 +284,7 @@ export const ubisysModernExtend = {
             description: "Specifies whether the Open Window Detection is activated or deactivated.",
             ...args,
         }),
-    openWindowTimeout: (args?: Partial<NumericArgs>) =>
+    openWindowTimeout: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
         numeric({
             name: "open_window_timeout",
             cluster: "hvacThermostat",
@@ -299,7 +299,7 @@ export const ubisysModernExtend = {
             unit: "s",
             ...args,
         }),
-    openWindowDetectionPeriod: (args?: Partial<NumericArgs>) =>
+    openWindowDetectionPeriod: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
         numeric({
             name: "open_window_detection_periode",
             cluster: "hvacThermostat",
@@ -313,7 +313,7 @@ export const ubisysModernExtend = {
             unit: "m",
             ...args,
         }),
-    openWindowSensitivity: (args?: Partial<NumericArgs>) =>
+    openWindowSensitivity: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
         numeric({
             name: "open_window_sensitivity",
             cluster: "hvacThermostat",

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -168,8 +168,8 @@ export const ubisysModernExtend = {
             commands: {},
             commandsResponse: {},
         }),
-    localTemperatureOffset: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
-        numeric({
+    localTemperatureOffset: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
+        numeric<"hvacThermostat", true>({
             name: "local_temperature_offset",
             cluster: "hvacThermostat",
             attribute: "ubisysTemperatureOffset",
@@ -180,8 +180,8 @@ export const ubisysModernExtend = {
             unit: "ºC",
             ...args,
         }),
-    occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
-        numeric({
+    occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
+        numeric<"hvacThermostat", true>({
             name: "occupied_heating_default_setpoint",
             cluster: "hvacThermostat",
             attribute: "ubisysDefaultOccupiedHeatingSetpoint",
@@ -196,8 +196,8 @@ export const ubisysModernExtend = {
             unit: "ºC",
             ...args,
         }),
-    remoteTemperatureDuration: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
-        numeric({
+    remoteTemperatureDuration: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
+        numeric<"hvacThermostat", true>({
             name: "remote_temperature_duration",
             cluster: "hvacThermostat",
             attribute: "ubisysRemoteTemperatureValidDuration",
@@ -262,8 +262,8 @@ export const ubisysModernExtend = {
 
         return {exposes: [expose], fromZigbee, toZigbee, configure, isModernExtend: true};
     },
-    openWindowState: (args?: Partial<BinaryArgs<"hvacThermostat">>) =>
-        binary({
+    openWindowState: (args?: Partial<BinaryArgs<"hvacThermostat", true>>) =>
+        binary<"hvacThermostat", true>({
             name: "open_window_state",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowState",
@@ -273,8 +273,8 @@ export const ubisysModernExtend = {
             description: "Presents the currently detected window state.",
             ...args,
         }),
-    openWindowDetect: (args?: Partial<BinaryArgs<"hvacThermostat">>) =>
-        binary({
+    openWindowDetect: (args?: Partial<BinaryArgs<"hvacThermostat", true>>) =>
+        binary<"hvacThermostat", true>({
             name: "open_window_detect",
             cluster: "hvacThermostat",
             attribute: "ubisysDetectOpenWindow",
@@ -284,8 +284,8 @@ export const ubisysModernExtend = {
             description: "Specifies whether the Open Window Detection is activated or deactivated.",
             ...args,
         }),
-    openWindowTimeout: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
-        numeric({
+    openWindowTimeout: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
+        numeric<"hvacThermostat", true>({
             name: "open_window_timeout",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowTimeout",
@@ -299,8 +299,8 @@ export const ubisysModernExtend = {
             unit: "s",
             ...args,
         }),
-    openWindowDetectionPeriod: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
-        numeric({
+    openWindowDetectionPeriod: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
+        numeric<"hvacThermostat", true>({
             name: "open_window_detection_periode",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowDetectionPeriod",
@@ -313,8 +313,8 @@ export const ubisysModernExtend = {
             unit: "m",
             ...args,
         }),
-    openWindowSensitivity: (args?: Partial<NumericArgs<"hvacThermostat">>) =>
-        numeric({
+    openWindowSensitivity: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
+        numeric<"hvacThermostat", true>({
             name: "open_window_sensitivity",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowSensitivity",

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -249,8 +249,8 @@ export const ubisysModernExtend = {
             commands: {},
             commandsResponse: {},
         }),
-    localTemperatureOffset: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
-        numeric<"hvacThermostat", true>({
+    localTemperatureOffset: (args?: Partial<NumericArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        numeric<"hvacThermostat", UbisysHvacThermostat>({
             name: "local_temperature_offset",
             cluster: "hvacThermostat",
             attribute: "ubisysTemperatureOffset",
@@ -261,8 +261,8 @@ export const ubisysModernExtend = {
             unit: "ºC",
             ...args,
         }),
-    occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
-        numeric<"hvacThermostat", true>({
+    occupiedHeatingSetpointDefault: (args?: Partial<NumericArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        numeric<"hvacThermostat", UbisysHvacThermostat>({
             name: "occupied_heating_default_setpoint",
             cluster: "hvacThermostat",
             attribute: "ubisysDefaultOccupiedHeatingSetpoint",
@@ -277,8 +277,8 @@ export const ubisysModernExtend = {
             unit: "ºC",
             ...args,
         }),
-    remoteTemperatureDuration: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
-        numeric<"hvacThermostat", true>({
+    remoteTemperatureDuration: (args?: Partial<NumericArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        numeric<"hvacThermostat", UbisysHvacThermostat>({
             name: "remote_temperature_duration",
             cluster: "hvacThermostat",
             attribute: "ubisysRemoteTemperatureValidDuration",
@@ -340,8 +340,8 @@ export const ubisysModernExtend = {
 
         return {exposes: [expose], fromZigbee, toZigbee, configure, isModernExtend: true};
     },
-    openWindowState: (args?: Partial<BinaryArgs<"hvacThermostat", true>>) =>
-        binary<"hvacThermostat", true>({
+    openWindowState: (args?: Partial<BinaryArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        binary<"hvacThermostat", UbisysHvacThermostat>({
             name: "open_window_state",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowState",
@@ -351,8 +351,8 @@ export const ubisysModernExtend = {
             description: "Presents the currently detected window state.",
             ...args,
         }),
-    openWindowDetect: (args?: Partial<BinaryArgs<"hvacThermostat", true>>) =>
-        binary<"hvacThermostat", true>({
+    openWindowDetect: (args?: Partial<BinaryArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        binary<"hvacThermostat", UbisysHvacThermostat>({
             name: "open_window_detect",
             cluster: "hvacThermostat",
             attribute: "ubisysDetectOpenWindow",
@@ -362,8 +362,8 @@ export const ubisysModernExtend = {
             description: "Specifies whether the Open Window Detection is activated or deactivated.",
             ...args,
         }),
-    openWindowTimeout: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
-        numeric<"hvacThermostat", true>({
+    openWindowTimeout: (args?: Partial<NumericArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        numeric<"hvacThermostat", UbisysHvacThermostat>({
             name: "open_window_timeout",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowTimeout",
@@ -377,8 +377,8 @@ export const ubisysModernExtend = {
             unit: "s",
             ...args,
         }),
-    openWindowDetectionPeriod: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
-        numeric<"hvacThermostat", true>({
+    openWindowDetectionPeriod: (args?: Partial<NumericArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        numeric<"hvacThermostat", UbisysHvacThermostat>({
             name: "open_window_detection_periode",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowDetectionPeriod",
@@ -391,8 +391,8 @@ export const ubisysModernExtend = {
             unit: "m",
             ...args,
         }),
-    openWindowSensitivity: (args?: Partial<NumericArgs<"hvacThermostat", true>>) =>
-        numeric<"hvacThermostat", true>({
+    openWindowSensitivity: (args?: Partial<NumericArgs<"hvacThermostat", UbisysHvacThermostat>>) =>
+        numeric<"hvacThermostat", UbisysHvacThermostat>({
             name: "open_window_sensitivity",
             cluster: "hvacThermostat",
             attribute: "ubisysOpenWindowSensitivity",

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -1,4 +1,5 @@
 import {Zcl} from "zigbee-herdsman";
+import type {PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import {presets as e, access as ea} from "./exposes";
@@ -243,7 +244,7 @@ export const ubisysModernExtend = {
                         //       ZCL DataType used does still need to be 0x0010 (BOOLEAN)
                         await entity.write(
                             clusterName,
-                            {[writeableAttributeName]: value ? 1 : 0},
+                            {[writeableAttributeName]: value ? 1 : 0} as PartialClusterOrRawWriteAttributes<typeof clusterName>,
                             {manufacturerCode: Zcl.ManufacturerCode.UBISYS_TECHNOLOGIES_GMBH},
                         );
                     } else {

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -1,5 +1,4 @@
 import {Zcl} from "zigbee-herdsman";
-import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
 import type {Struct, ZclArray} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
@@ -10,7 +9,7 @@ import type {Configure, Fz, ModernExtend, Tz, Zh} from "./types";
 
 const NS = "zhc:ubisys";
 
-interface UbisysHvacThermostat extends TCustomCluster {
+interface UbisysHvacThermostat {
     attributes: {
         ubisysClassBTemperatureOffset: number;
         ubisysReturnFlowTemperatureWeight: number;
@@ -37,7 +36,7 @@ interface UbisysHvacThermostat extends TCustomCluster {
     commands: never;
     commandResponses: never;
 }
-export interface UbisysGenLevelCtrl extends TCustomCluster {
+export interface UbisysGenLevelCtrl {
     attributes: {
         ubisysMinimumOnLevel: number;
         ubisysValveType: number;
@@ -57,7 +56,7 @@ export interface UbisysGenLevelCtrl extends TCustomCluster {
     commands: never;
     commandResponses: never;
 }
-export interface UbisysClosuresWindowCovering extends TCustomCluster {
+export interface UbisysClosuresWindowCovering {
     attributes: {
         ubisysTurnaroundGuardTime: number;
         ubisysLiftToTiltTransitionSteps: number;
@@ -71,7 +70,7 @@ export interface UbisysClosuresWindowCovering extends TCustomCluster {
     commands: never;
     commandResponses: never;
 }
-export interface UbisysDeviceSetup extends TCustomCluster {
+export interface UbisysDeviceSetup {
     attributes: {
         inputConfigurations: ZclArray | unknown[];
         inputActions: ZclArray | unknown[];
@@ -79,7 +78,7 @@ export interface UbisysDeviceSetup extends TCustomCluster {
     commands: never;
     commandResponses: never;
 }
-export interface UbisysDimmerSetup extends TCustomCluster {
+export interface UbisysDimmerSetup {
     attributes: {
         capabilities: number;
         status: number;

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -1,5 +1,6 @@
 import {Zcl} from "zigbee-herdsman";
-import type {PartialClusterOrRawWriteAttributes} from "zigbee-herdsman/dist/controller/tstype";
+import type {TCustomCluster} from "zigbee-herdsman/dist/controller/tstype";
+import type {Struct, ZclArray} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import {presets as e, access as ea} from "./exposes";
@@ -8,6 +9,85 @@ import {type BinaryArgs, binary, deviceAddCustomCluster, type NumericArgs, numer
 import type {Configure, Fz, ModernExtend, Tz, Zh} from "./types";
 
 const NS = "zhc:ubisys";
+
+interface UbisysHvacThermostat extends TCustomCluster {
+    attributes: {
+        ubisysClassBTemperatureOffset: number;
+        ubisysReturnFlowTemperatureWeight: number;
+        ubisysRawOutdoorTemperature: Struct;
+        ubisysRawLocalTemperatureA: Struct;
+        ubisysRawLocalTemperatureB: Struct;
+        ubisysRawForwardFlowTemperature: Struct;
+        ubisysRawReturnFlowTemperature: Struct;
+        ubisysInstalledExtensions: bigint;
+        ubisysTemperatureOffset: number;
+        ubisysDefaultOccupiedHeatingSetpoint: number;
+        ubisysVacationMode: number;
+        ubisysRemoteTemperature: number;
+        ubisysRemoteTemperatureValidDuration: number;
+        ubisysDetectOpenWindow: number;
+        ubisysOpenWindowState: number;
+        ubisysOpenWindowSensitivity: number;
+        ubisysOpenWindowDetectionPeriod: number;
+        ubisysOpenWindowTimeout: number;
+        ubisysProportionalGain: number;
+        ubisysProportionalShift: number;
+        ubisysIntegralFactor: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+export interface UbisysGenLevelCtrl extends TCustomCluster {
+    attributes: {
+        ubisysMinimumOnLevel: number;
+        ubisysValveType: number;
+        ubisysCyclePeriod: number;
+        ubisysSeason: number;
+        ubisysBackupLevel: number;
+        ubisysAlternateBackupLevel: number;
+        ubisysLowerRange: number;
+        ubisysUpperRange: number;
+        ubisysPumpThresholdOn: number;
+        ubisysPumpThresholdOff: number;
+        ubisysHeatingDemandEnableThreshold: number;
+        ubisysHeatingDemandDisableThreshold: number;
+        ubisysCoolingDemandEnableThreshold: number;
+        ubisysCoolingDemandDisableThreshold: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+export interface UbisysClosuresWindowCovering extends TCustomCluster {
+    attributes: {
+        ubisysTurnaroundGuardTime: number;
+        ubisysLiftToTiltTransitionSteps: number;
+        ubisysTotalSteps: number;
+        ubisysLiftToTiltTransitionSteps2: number;
+        ubisysTotalSteps2: number;
+        ubisysAdditionalSteps: number;
+        ubisysInactivePowerThreshold: number;
+        ubisysStartupSteps: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+export interface UbisysDeviceSetup extends TCustomCluster {
+    attributes: {
+        inputConfigurations: ZclArray | unknown[];
+        inputActions: ZclArray | unknown[];
+    };
+    commands: never;
+    commandResponses: never;
+}
+export interface UbisysDimmerSetup extends TCustomCluster {
+    attributes: {
+        capabilities: number;
+        status: number;
+        mode: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
 
 export const ubisysModernExtend = {
     pollCurrentSummDelivered: (endpointId: number | ((device: Zh.Device) => number)): ModernExtend => {
@@ -239,12 +319,9 @@ export const ubisysModernExtend = {
                 key: [propertyName],
                 convertSet: async (entity, key, value, meta) => {
                     if (typeof value === "boolean") {
-                        // NOTE: DataType is BOOLEAN in zcl definition as per the device technical reference
-                        //       passing a BOOLEAN type 'value' throws INVALID_DATA_TYPE, we need to pass 1 (true) or 0 (false)
-                        //       ZCL DataType used does still need to be 0x0010 (BOOLEAN)
-                        await entity.write(
+                        await entity.write<typeof clusterName, UbisysHvacThermostat>(
                             clusterName,
-                            {[writeableAttributeName]: value ? 1 : 0} as PartialClusterOrRawWriteAttributes<typeof clusterName>,
+                            {[writeableAttributeName]: value ? 1 : 0},
                             {manufacturerCode: Zcl.ManufacturerCode.UBISYS_TECHNOLOGIES_GMBH},
                         );
                     } else {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -206,14 +206,24 @@ export function enforceEndpoint(entity: Zh.Endpoint, key: string, meta: Tz.Meta)
     return entity;
 }
 
-export function getKey<T>(object: {[s: string]: T} | {[s: number]: T}, value: T, fallback?: T, convertTo?: (v: unknown) => T) {
+type RecordStringOrNumber<T> = Record<string, T> | Record<number, T>;
+
+export function getKey<T>(object: RecordStringOrNumber<T>, value: T): string | undefined;
+export function getKey<T, F>(object: RecordStringOrNumber<T>, value: T, fallback: F): string | F;
+export function getKey<T, R>(object: RecordStringOrNumber<T>, value: T, fallback: undefined, convertTo: (v: string | number) => R): R | undefined;
+export function getKey<T, R, F>(object: RecordStringOrNumber<T>, value: T, fallback: F, convertTo: (v: string | number) => R): R | F;
+export function getKey<T, R, F>(
+    object: RecordStringOrNumber<T>,
+    value: T,
+    fallback?: F,
+    convertTo?: (v: string | number) => R,
+): R | F | string | undefined {
     for (const key in object) {
-        // @ts-expect-error ignore
+        // @ts-expect-error too generic
         if (object[key] === value) {
             return convertTo ? convertTo(key) : key;
         }
     }
-
     return fallback;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -492,7 +492,7 @@ export function getObjectProperty(object: KeyValue, key: string, defaultValue: u
     return object && object[key] !== undefined ? object[key] : defaultValue;
 }
 
-export function validateValue(value: unknown, allowed: unknown[]) {
+export function validateValue<T>(value: T, allowed: readonly T[]): asserts value is (typeof allowed)[number] {
     if (!allowed.includes(value)) {
         throw new Error(`'${value}' not allowed, choose between: ${allowed}`);
     }
@@ -652,9 +652,9 @@ export function getFromLookup<V>(value: unknown, lookup: {[s: number | string]: 
 }
 
 export function getFromLookupByValue(value: unknown, lookup: {[s: string]: unknown}, defaultValue: string = undefined): string {
-    for (const entry of Object.entries(lookup)) {
-        if (entry[1] === value) {
-            return entry[0];
+    for (const [key, val] of Object.entries(lookup)) {
+        if (val === value) {
+            return key;
         }
     }
     if (defaultValue === undefined) {

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -1,7 +1,7 @@
-import type {Fz} from "src/lib/types";
 import {describe, expect, it} from "vitest";
 import {findByDevice, type Tz} from "../src/index";
 import * as tuya from "../src/lib/tuya";
+import type {Fz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 describe("lib/tuya", () => {

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -35,7 +35,7 @@ describe("lib/tuya", () => {
                 1,
                 "manuSpecificTuya",
                 "sendData",
-                {seq: 1, dpValues: [{data: [0], datatype: 4, dp: 101}]},
+                {seq: 1, dpValues: [{data: Buffer.from([0]), datatype: 4, dp: 101}]},
                 {disableDefaultResponse: true},
             );
             expect(device.endpoints[0].command).toHaveBeenNthCalledWith(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
-        "module": "commonjs",
+        "module": "NodeNext",
         "esModuleInterop": true,
         "target": "esnext",
         "lib": ["esnext"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
-        "module": "NodeNext",
+        "module": "commonjs",
         "esModuleInterop": true,
         "target": "esnext",
         "lib": ["esnext"],


### PR DESCRIPTION
Requires https://github.com/Koenkk/zigbee-herdsman/pull/1479

TODO:
- [x] support for custom clusters (only custom cluster types required for current code have been added)
- [x] heavy changes in `toZigbee.light_color`, in-depth review needed

and a few more in the code itself

TODO (separate PRs):
- [ ] lib/ewelink -> lots of unnecessary clusterName, writeCommand strings?
- [ ] type `validateValue`? (could remove quite a few `as "x" | "y"` like `as "toggle" | "off" | "on"`
- [ ] `globalStore.getValue` is typed as `any`, should refactor

# Discovered issues

- fix: `toZigbee.danfoss_heat_supply_request` wrong attribute name
- fix: Danfoss Icon2 wrong attribute name
- fix: bacchus using wrong payload format in `timeHHMM`
- fix: ambiguous attr ID hex format in shinasystem `fzLocal.ct_direction` & `tzLocal.ct_direction`
- fix: ambiguous attr value format in legrand `tzLegrand.calibration_mode`
- fix: invalid payload formats in namron `toZigbee.namron_edge_thermostat_vacation_date`
- fix: invalid payload formats in namron `toZigbee.namron_edge_thermostat_holiday_temp`

from commands typing:

- fix: `cover_via_brightness` using invalid value type in command
- fix: `fan_speed` using invalid value type in command
- fix: `twinguardSmokeDetector` `initiateTestMode` command missing payload (was using manuf opts in place, i.e. manuf opts were ignored)
- fix: `twinguardSetup` `pairingCompleted` command missing payload (was using manuf opts in place, i.e. manuf opts were ignored)
- fix: `manuSpecificYokisDevice` `openNetwork` using improper casing in command name
- fix: `manuSpecificYokisInput` `sendPress` using improper custom cluster name
- fix: `manuSpecificYokisInput` `sendRelease` using improper custom cluster name
- fix: `manuSpecificYokisInput` `selectInputMode` using improper custom cluster name