### PR TITLE
Updated wireless endpoint for WS-K02E

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4505,7 +4505,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             lumiZigbeeOTA(),
             lumiPreventReset(),
-            m.deviceEndpoints({endpoints: {top: 1, wireless: 2}}),
+            m.deviceEndpoints({endpoints: {top: 1, wireless: 4}}),
             m.bindCluster({endpointNames: ["top", "wireless"], cluster: "manuSpecificLumi", clusterType: "input"}),
             m.bindCluster({endpointNames: ["top"], cluster: "genOnOff", clusterType: "input"}),
             lumiPower(),


### PR DESCRIPTION
Updating wireless endpoint for WS-K02E from 2 to 4. With wireless set to 2 multiclick is unable to be enabled. Changing to 4 fixes this and displays the proper action such as single_wireless, double_wireless, hold_wireless, and release_wireless.