### PR TITLE
Add vesternet VES-ZB-HLD-017 fingerprint

### DIFF
--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -26,7 +26,10 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [{vendor: "Sunricher", model: "SR-ZG9040A"}],
     },
     {
-        fingerprint: [{modelID: "ON/OFF -M", softwareBuildID: "2.9.2_r54"}],
+        fingerprint: [
+		{modelID: "ON/OFF -M", softwareBuildID: "2.9.2_r54"},
+		{modelID: "ON/OFF -M", softwareBuildID: "2.9.2_r55"},
+	],
         model: "VES-ZB-HLD-017",
         vendor: "Vesternet",
         description: "Zigbee high load switch",


### PR DESCRIPTION
One of the device i purchased came with newer version of build id - `2.9.2_r55`
This is the device I purchased - https://www.amazon.co.uk/dp/B0C1P956JN 

Adding the new  build id to fingerprint. 

Thanks
