### PR TITLE
fix: ROB_200-018-0 - Added _1 postfixed actions

### DIFF
--- a/src/devices/robb.ts
+++ b/src/devices/robb.ts
@@ -284,7 +284,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "ROBB",
         description: "ZigBee knob smart dimmer",
         fromZigbee: [fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move_to_color_temp, fz.battery, fz.command_move_to_color],
-        exposes: [e.battery(), e.action(["on", "off", "brightness_move_to_level", "color_temperature_move", "color_move"])],
+        exposes: [e.battery(), e.action(["on", "off", "brightness_move_to_level", "color_temperature_move", "color_move", "on_1", "off_1", "brightness_move_to_level_1", "color_temperature_move_1", "color_move_1"])],
         toZigbee: [],
         meta: {multiEndpoint: true, battery: {dontDividePercentage: true}},
         whiteLabel: [{vendor: "Sunricher", model: "SR-ZG2835"}],


### PR DESCRIPTION
Added actions with _1 postfix as my ROB_200-018-0 dimmer switches are only exposing those. Please let me know if this should be handled in another way!