### PR TITLE
Inovelli: Fix broken on/off command with recent code cleanup

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -1828,7 +1828,7 @@ const tzLocal = {
                 ...meta,
                 message: {
                     ...meta.message,
-                    transition: !transition.specified ? 6553.5 : Math.round(transition.time / 10),
+                    transition: (!transition.specified ? 0xffff : Math.round(transition.time)) / 10,
                 },
                 converterOptions: {
                     ctrlbits: 0,


### PR DESCRIPTION
@InovelliUSA & @rohankapoorcom pushed some changes recently that are causing on / off to throw an error:

z2m: Publish 'set' 'state' to 'ZB - B - Zone 3 (L)' failed: 'RangeError [ERR_OUT_OF_RANGE]: ZCL command 0xb43a31fffe26e207/1 genLevelCtrl.moveToLevelWithOnOff({"level":null,"transtime":655350}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":false,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (The value of "value" is out of range. It must be >= 0 and <= 65535. Received 655350)'

It seems that the default transition time that Inovelli is supposed to use when an explicit transition time is not specified, is getting multiplied by 10 somewhere. This fix is a workaround until we can find out why that is happening.

@Koenkk curious if you may be familiar with why this is happening. 