### PR TITLE
Update heiman.ts with HS1RGB bulb

### DIFF
--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -926,6 +926,14 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: [153, 370]}})],
     },
     {
+        zigbeeModel: ['ColorLight'],
+        model: 'HS1RGB',
+        vendor: 'Heiman',
+        description: 'HS1RGB bulb E26/E27, RGB+WW 2700K, globe, opal, 400 lm',
+        extend: [light({"colorTemp":{"range":[275,295]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        meta: {applyRedFix: true, turnsOffAtBrightness1: true},
+    },    
+    {
         zigbeeModel: ["CurtainMo-EF-3.0", "CurtainMo-EF"],
         model: "HS2CM-N-DC",
         vendor: "Heiman",


### PR DESCRIPTION
Support for HS1RGB lamp from Heiman.
It has RGB and WW emitters. Redfix needed since red light does not start if requested by Alexa.