### PR TITLE
[Shelly] Add suport for both switch and cover mode for 2PM

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -31,10 +31,46 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.onOff({powerOnBehavior: false}), m.electricityMeter({producedEnergy: true, acFrequency: true})],
     },
     {
-        zigbeeModel: ["2PM"],
-        model: "2PM",
+        fingerprint: [
+            {
+                type: "Router",
+                manufacturerName: "Shelly",
+                modelID: "2PM",
+                endpoints: [
+                    {ID: 1, profileID: 260, deviceID: 514, inputClusters: [0, 3, 4, 5, 258], outputClusters: []},
+                    {ID: 239, profileID: 49153, deviceID: 8193, inputClusters: [64513, 64514], outputClusters: []},
+                    {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
+                ],
+            },
+        ],
+        model: "S4SW-002P16EU-COVER",
         vendor: "Shelly",
-        description: "2PM Gen4",
+        description: "2PM Gen4 (Cover mode)",
         extend: [m.windowCovering({controls: ["lift", "tilt"]})],
+    },
+    {
+        fingerprint: [
+            {
+                type: "Router",
+                manufacturerName: "Shelly",
+                modelID: "2PM",
+                endpoints: [
+                    {ID: 1, profileID: 260, deviceID: 266, inputClusters: [0, 3, 4, 5, 6, 2820, 1794], outputClusters: []},
+                    {ID: 2, profileID: 260, deviceID: 266, inputClusters: [4, 5, 6, 2820, 1794], outputClusters: []},
+                    {ID: 239, profileID: 49153, deviceID: 8193, inputClusters: [64513, 64514], outputClusters: []},
+                    {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
+                ],
+            },
+        ],
+        model: "S4SW-002P16EU-SWITCH",
+        vendor: "Shelly",
+        description: "2PM Gen4 (Switch mode)",
+        extend: [
+            m.onOff({powerOnBehavior: false, endpointNames: ["l1", "l2"]}),
+            m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
+        ],
+        endpoint: (device) => {
+            return {l1: 1, l2: 2};
+        },
     },
 ];


### PR DESCRIPTION
As mentioned by @Koenkk in https://github.com/Koenkk/zigbee2mqtt/issues/28012#issuecomment-3189565384, useed fingerprinting to differenciate between Shelly 2PM modes.

Let me know if there's anything wrong or needs fixing as I'm pretty new to the codebase.

On the documentation, do we need an image per generated device entry? Or can we re-use the 2PM.png?
