### PR TITLE
Create custom modernExtend classes to use with Inovelli devices

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -2451,7 +2451,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.identify(),
             m.temperature(),
             m.humidity(),
-            m.electricityMeter(),
+            m.electricityMeter({energy: {divisor: 1000}}),
         ],
         ota: true,
     },
@@ -2509,6 +2509,7 @@ export const definitions: DefinitionWithExtend[] = [
                 // Current and voltage were removed in version 0.8 of the firmware and expected to be restored in the future
                 current: false,
                 voltage: false,
+                energy: {divisor: 1000},
             }),
             m.illuminance(),
             m.occupancy(),

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -550,7 +550,7 @@ const LED_NOTIFICATION_TYPES: {[key: number]: string} = {
     5: "LED_6",
     6: "LED_7",
     16: "ALL_LEDS",
-    255: "CONFIG_BUTTON_DOUBLE_PRESS",
+    "-1": "CONFIG_BUTTON_DOUBLE_PRESS",
 };
 
 const INOVELLI = 0x122f;
@@ -2389,7 +2389,7 @@ const exposeMMWaveControl = () => {
 
 const exposeLedEffectComplete = () => {
     return e
-        .enum("notificationComplete", ea.STATE_GET, Object.values(LED_NOTIFICATION_TYPES))
+        .enum("notificationComplete", ea.STATE, Object.values(LED_NOTIFICATION_TYPES))
         .withDescription("Indication that a specific notification has completed.")
         .withCategory("diagnostic");
 };

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -2515,7 +2515,11 @@ export const definitions: DefinitionWithExtend[] = [
             inovelliExtend.addCustomClusterInovelli(),
             inovelliExtend.addCustomMMWaveClusterInovelli(),
             m.identify(),
-            m.electricityMeter(),
+            m.electricityMeter({
+                // Current and voltage were removed in version 0.8 of the firmware and expected to be restored in the future
+                current: false,
+                voltage: false,
+            }),
             m.illuminance(),
             m.occupancy(),
         ],

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -2556,7 +2556,7 @@ export const definitions: DefinitionWithExtend[] = [
                 splitValuesByEndpoint: true,
             }),
             inovelliExtend.inovelliLight({splitValuesByEndpoint: true}),
-            inovelliExtend.inovelliLight({splitValuesByEndpoint: true}),
+            inovelliExtend.inovelliFan({endpointId: 2, splitValuesByEndpoint: true}),
             inovelliExtend.addCustomClusterInovelli(),
             m.identify(),
         ],

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -2565,16 +2565,5 @@ export const definitions: DefinitionWithExtend[] = [
             m.identify(),
         ],
         ota: true,
-        // The configure method below is needed to make the device reports on/off state changes
-        // when the device is controlled manually through the button on it.
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
-            await reporting.onOff(endpoint);
-
-            const endpoint2 = device.getEndpoint(2);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
-            await reporting.onOff(endpoint2);
-        },
     },
 ];

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -343,7 +343,7 @@ const inovelliExtend = {
                 },
                 ledEffectComplete: {
                     ID: 0x24,
-                    parameters: [{name: "notificationType", type: Zcl.DataType.UINT8}],
+                    parameters: [{name: "notificationType", type: Zcl.DataType.INT8}],
                 },
             },
             commandsResponse: {},

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -399,6 +399,12 @@ const inovelliExtend = {
         const toZigbee: Tz.Converter[] = [];
         const exposes: Expose[] = [];
 
+        if (supportsLedEffects) {
+            fromZigbee.push(fzLocal.led_effect_complete);
+            toZigbee.push(tzLocal.inovelli_led_effect, tzLocal.inovelli_individual_led_effect);
+            exposes.push(exposeLedEffects(), exposeIndividualLedEffects(), exposeLedEffectComplete());
+        }
+
         for (const attr of attrs) {
             fromZigbee.push(fzLocal.inovelli(attr.attributes, attr.clusterName, splitValuesByEndpoint));
             toZigbee.push(
@@ -406,12 +412,6 @@ const inovelliExtend = {
                 tzLocal.inovelli_parameters_readOnly(attr.attributes, attr.clusterName),
             );
             attributesToExposeList(attr.attributes, exposes);
-        }
-
-        if (supportsLedEffects) {
-            fromZigbee.push(fzLocal.led_effect_complete);
-            toZigbee.push(tzLocal.inovelli_led_effect, tzLocal.inovelli_individual_led_effect);
-            exposes.push(exposeLedEffects(), exposeIndividualLedEffects(), exposeLedEffectComplete());
         }
 
         if (supportsButtonTaps) {
@@ -1981,7 +1981,7 @@ const tzLocal = {
                 ...meta,
                 message: {
                     ...meta.message,
-                    transition: (!transition.specified ? 0xffff : Math.round(transition.time)) / 10,
+                    transition: (!transition.specified ? 0xffff : transition.time) / 10,
                 },
                 converterOptions: {
                     ctrlbits: 0,

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -459,7 +459,7 @@ const inovelliExtend = {
         return {
             fromZigbee,
             toZigbee,
-            exposes: [],
+            exposes,
             configure,
             isModernExtend: true,
         } as ModernExtend;
@@ -500,6 +500,7 @@ const inovelliExtend = {
     inovelliFan: ({endpointId, splitValuesByEndpoint = false}: {endpointId: number; splitValuesByEndpoint?: boolean}) => {
         const fromZigbee: Fz.Converter[] = [fzLocal.fan_mode(endpointId), fzLocal.breeze_mode(endpointId)];
         const toZigbee: Tz.Converter[] = [tzLocal.fan_mode(endpointId), tzLocal.breezeMode(endpointId)];
+        const exposes: Expose[] = [exposeBreezeMode()];
         const bindingList = ["genOnOff"];
 
         if (!splitValuesByEndpoint) {
@@ -524,7 +525,7 @@ const inovelliExtend = {
         return {
             fromZigbee,
             toZigbee,
-            exposes: [],
+            exposes,
             configure,
             isModernExtend: true,
         } as ModernExtend;
@@ -2392,15 +2393,9 @@ const exposesListVZM31: Expose[] = [];
 
 const exposesListVZM32: Expose[] = [exposeMMWaveControl()];
 
-const exposesListVZM35: Expose[] = [
-    e.fan().withState("fan_state").withModes(Object.keys(fanModes)),
-    exposeLedEffects(),
-    exposeIndividualLedEffects(),
-    exposeBreezeMode(),
-    exposeLedEffectComplete(),
-];
+const exposesListVZM35: Expose[] = [e.fan().withState("fan_state").withModes(Object.keys(fanModes))];
 
-const exposesListVZM36: Expose[] = [e.light_brightness(), e.fan().withState("fan_state").withModes(Object.keys(fanModes)), exposeBreezeMode()];
+const exposesListVZM36: Expose[] = [e.fan().withState("fan_state").withModes(Object.keys(fanModes))];
 
 // Populate exposes list from the attributes description
 attributesToExposeList(VZM30_ATTRIBUTES, exposesListVZM30);


### PR DESCRIPTION
I thought it might be helpful to create some `modernExtend`s classes for Inovelli devices since they have a lot of repetitive calls to `fz`/`tz`/`configure` between them and we've run into some issues where things have been added to one device and not others.

This feels like an improvement (for everything except the VZM36). Curious if there's any thoughts on how to clean this up further.

Leaving this in draft format while @InovelliUSA and I finish testing this.