### PR TITLE
Bosch `BMCT-SLZ`: Various enhancements and fixes

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -983,12 +983,14 @@ const boschExtend = {
                         return;
                     }
 
-                    // The BMCT-SLZ asks the coordinator for their ZCL version.
-                    // Without any answer, the device will rejoin the network
-                    // every 10 minutes. This signifies an unnecessary strain
-                    // on the network. Additionally, the LED on the device will
-                    // blink during that operation. To avoid that, we mimic the
-                    // answer from the Bosch Smart Home Controller II.
+                    // During pairing, the BMCT-SLZ asks the coordinator for
+                    // their ZCL version. As Z2M doesn't know the ZCL version of
+                    // the device yet, the request is left unanswered. This
+                    // triggers the device to rejoin the network every 10 minutes,
+                    // which signifies an unnecessary strain on the network.
+                    // Additionally, the LED on the device will blink during that
+                    // operation. To avoid that, we mimic the answer from
+                    // the Bosch Smart Home Controller II.
                     if (msg.data.includes("zclVersion")) {
                         const payload: TPartialClusterAttributes<"genBasic"> = {
                             zclVersion: 1,

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -2149,7 +2149,12 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Light/shutter control unit II",
         extend: [
             m.deviceEndpoints({endpoints: {left: 2, right: 3}}),
-            m.electricityMeter({voltage: false, current: false}),
+            m.electricityMeter({
+                voltage: false,
+                current: false,
+                power: {change: 1},
+                energy: {change: 1},
+            }),
             m.deviceAddCustomCluster("boschSpecific", {
                 ID: 0xfca0,
                 manufacturerCode: Zcl.ManufacturerCode.ROBERT_BOSCH_GMBH,

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -924,6 +924,7 @@ const boschExtend = {
             button_key_change: 0x02,
             rocker_switch: 0x03,
             rocker_switch_key_change: 0x04,
+            none: 0x00,
         };
         const stateSwitchMode = {
             coupled: 0x00,
@@ -2138,6 +2139,7 @@ export const definitions: DefinitionWithExtend[] = [
                 button_key_change: 0x02,
                 rocker_switch: 0x03,
                 rocker_switch_key_change: 0x04,
+                none: 0x00,
             };
             const stateSwitchMode: KeyValue = {
                 coupled: 0x00,

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -936,7 +936,7 @@ const boschExtend = {
             ON: 0x01,
         };
         const fromZigbee: Fz.Converter[] = [
-            fz.on_off,
+            fz.on_off_force_multiendpoint,
             fz.power_on_behavior,
             fz.cover_position_tilt,
             {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -921,7 +921,8 @@ const boschExtend = {
             stopped: 0x00,
             opening: 0x01,
             closing: 0x02,
-            unknown: 0x04,
+            unknownOne: 0x03,
+            unknownTwo: 0x04,
         };
         const stateSwitchType = {
             button: 0x01,
@@ -2092,16 +2093,26 @@ export const definitions: DefinitionWithExtend[] = [
                     calibrationOpeningTime: {ID: 0x0002, type: Zcl.DataType.UINT32},
                     calibrationClosingTime: {ID: 0x0003, type: Zcl.DataType.UINT32},
                     // 0x0005 isn't used at all when using the Bosch SHC as of 30-06-2025.
+                    // As I don't have any shutters, I can't run all calibration steps
+                    // successfully. So, keep any comments regarding these
+                    // attributes with caution.
                     calibrationButtonHoldTime: {ID: 0x0005, type: Zcl.DataType.UINT8},
                     autoOffEnabled: {ID: 0x0006, type: Zcl.DataType.BOOLEAN},
                     autoOffTime: {ID: 0x0007, type: Zcl.DataType.UINT16},
                     childLock: {ID: 0x0008, type: Zcl.DataType.BOOLEAN},
-                    // See comment on calibrationNewMotorStartDelay
+                    // 0x000f is only being set when using the automatic calibration.
+                    // It's being set to 0 then before sending the calibration
+                    // command. Additionally, when changing
+                    // the calibrationOpeningTime or calibrationClosingTime in the
+                    // Bosch app, it's also being set to 0.
+                    // I couldn't find any way to set 0x000f manually in the Bosch app.
                     calibrationMotorStartDelay: {ID: 0x000f, type: Zcl.DataType.UINT8},
                     calibrationMotorReverseDirection: {ID: 0x0032, type: Zcl.DataType.BOOLEAN},
                     motorState: {ID: 0x0013, type: Zcl.DataType.ENUM8},
                     // unknownAttributeOne is always being configured as reporting
                     // attribute on endpoint 1 when using the Bosch SHC.
+                    // Can't tell what this attribute does (always received
+                    // 0x00 as answer on manual lookup).
                     unknownAttributeOne: {ID: 0x0004, type: Zcl.DataType.BITMAP8},
                     // Attribute is being set to 255 when deactivating the automatic
                     // detection of the motor end position by the Bosch SHC. After
@@ -2110,14 +2121,25 @@ export const definitions: DefinitionWithExtend[] = [
                     // change the value.
                     calibrationMotorEndPosition: {ID: 0x0021, type: Zcl.DataType.UINT8},
                     // 0x0033 is used when setting the motor start delay manually
-                    // using the Bosch SHC as of 30-06-2025. Looks like 0x000f is being
-                    // discontinued _OR_ being set automatically during calibration
-                    // as it's always set to 0 when changing the calibrationOpeningTime
-                    // and calibrationClosingTime manually over the Bosch app.
-                    // I couldn't find any way to set 0x000f manually in the Bosch app.
+                    // using the Bosch SHC as of 30-06-2025.
                     // If the user wants to automatically detect the delay during
                     // calibration, it's being set to 0 over the Bosch app.
                     calibrationNewMotorStartDelay: {ID: 0x0033, type: Zcl.DataType.UINT16},
+                    // 0x0010 and 0x0011 is being set simultaneously with the same value
+                    // when changing the delay for the rotation of the slats on venetian
+                    // blinds. Maybe one attribute for each direction?
+                    // It's also being configured as reporting attribute when using
+                    // venetian blinds.
+                    slatRotationDurationOne: {ID: 0x0010, type: Zcl.DataType.UINT32},
+                    slatRotationDurationTwo: {ID: 0x0011, type: Zcl.DataType.UINT32},
+                    // 0x002a is only being used when doing an automatic calibration
+                    // with the Bosch specific startAutomaticMotorCalibration command.
+                    // It's being set to true before starting the calibration process.
+                    // This happens regardless of the shutter type. I didn't capture
+                    // any packages where this attribute is being actively set to false.
+                    // Maybe this activates some "full calibration" flag which is being
+                    // set to false by the device itself afterward?
+                    unknownAttributeTwo: {ID: 0x002a, type: Zcl.DataType.BOOLEAN},
                 },
                 commands: {
                     // Command being sent by the Bosch SHC when starting an

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -919,6 +919,7 @@ const boschExtend = {
             stopped: 0x00,
             opening: 0x01,
             closing: 0x02,
+            unknown: 0x04,
         };
         const stateSwitchType = {
             button: 0x01,
@@ -2110,14 +2111,42 @@ export const definitions: DefinitionWithExtend[] = [
                     switchMode: {ID: 0x0031, type: Zcl.DataType.UINT8},
                     calibrationOpeningTime: {ID: 0x0002, type: Zcl.DataType.UINT32},
                     calibrationClosingTime: {ID: 0x0003, type: Zcl.DataType.UINT32},
+                    // 0x0005 isn't used at all when using the Bosch SHC as of 30-06-2025.
                     calibrationButtonHoldTime: {ID: 0x0005, type: Zcl.DataType.UINT8},
                     autoOffEnabled: {ID: 0x0006, type: Zcl.DataType.BOOLEAN},
                     autoOffTime: {ID: 0x0007, type: Zcl.DataType.UINT16},
                     childLock: {ID: 0x0008, type: Zcl.DataType.BOOLEAN},
+                    // See comment on calibrationNewMotorStartDelay
                     calibrationMotorStartDelay: {ID: 0x000f, type: Zcl.DataType.UINT8},
+                    calibrationMotorReverseDirection: {ID: 0x0032, type: Zcl.DataType.BOOLEAN},
                     motorState: {ID: 0x0013, type: Zcl.DataType.ENUM8},
+                    // unknownAttributeOne is always being configured as reporting
+                    // attribute on endpoint 1 when using the Bosch SHC.
+                    unknownAttributeOne: {ID: 0x0004, type: Zcl.DataType.BITMAP8},
+                    // Attribute is being set to 255 when deactivating the automatic
+                    // detection of the motor end position by the Bosch SHC. After
+                    // activating the automatic end position detection it's being set
+                    // to 0 by the Bosch SHC. Apart from that, there's no way to manually
+                    // change the value.
+                    calibrationMotorEndPosition: {ID: 0x0021, type: Zcl.DataType.UINT8},
+                    // 0x0033 is used when setting the motor start delay manually
+                    // using the Bosch SHC as of 30-06-2025. Looks like 0x000f is being
+                    // discontinued _OR_ being set automatically during calibration
+                    // as it's always set to 0 when changing the calibrationOpeningTime
+                    // and calibrationClosingTime manually over the Bosch app.
+                    // I couldn't find any way to set 0x000f manually in the Bosch app.
+                    // If the user wants to automatically detect the delay during
+                    // calibration, it's being set to 0 over the Bosch app.
+                    calibrationNewMotorStartDelay: {ID: 0x0033, type: Zcl.DataType.UINT16},
                 },
-                commands: {},
+                commands: {
+                    // Command being sent by the Bosch SHC when starting an
+                    // automatic shutter calibration.
+                    startAutomaticMotorCalibration: {ID: 0x00, parameters: []},
+                    // Command being sent by the Bosch SHC when resetting the
+                    // energy meter readings on light control mode.
+                    resetElectricityMeterReadings: {ID: 0x80, parameters: []},
+                },
                 commandsResponse: {},
             }),
             boschExtend.bmct(),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
This pull request includes various enhancements and fixes for the Bosch `BMCT-SLZ` (Light/shutter control unit II).

Here is a list of the changes I made and the reasons behind them:
- **Decouple switch from output**: In the last firmware updates, Bosch included the possibility to decouple the switch from the output. This means that the output state doesn't change when the switch is being used. I offer the same options as the Bosch app does, which means that the `decoupled` and `only_short_press_decoupled` options are not available when using the device for shutter control.
- **Switch state report**: The `BMCT-SLZ` reports any switch changes as a command to the coordinator. Unfortunately, there is no real separation between the inputs as Bosch uses the same command for both. This results in only one action attribute with several states depending on the used switch type, the input and what happened lastly. If there are any suggestions on how I can improve that situation, I'm open for comments!
- **Automatic turn-off in light mode**: When using the `BMCT-SLZ` via the Bosch app, you can automatically turn off each light. This is based on a time schedule for regular changes (which are being stored and executed on the Bosch SHC) as well as two separate attributes on the `BMCT-SLZ` itself for more short-term changes. The latter is being supported by this pull request. To use it, it's necessary to set the desired amount of time to disable the light as well as enable the feature. If the light is already on when enabling the feature, the internal counter starts from that moment. Otherwise, it's counted from the moment the light is turned on.
- **Reset the used energy reading**: Bosch provides a custom command to reset the internal energy meter. This pull request enables the use of that command via Z2M as older firmware versions may have an error which leads to abnormal energy readings (see #9768 for example). By resetting the internal energy meter, at least the abnormal energy reading is gone.
- **Reduce the minimum change value for `seMetering` and `haElectricalMeasurement` to 1**: By default, the `electricityMeter` function uses a minimum change for the `seMetering` and `haElectricalMeasurement` clusters of 5. As lights may use very little energy, this may be a bit high. Therefore, I change the minimum change value to 1 as that fits the use case better, in my opinion (and the Bosch SHC uses it as well).
- **Fix for periodic rejoin requests**: During development on this pull request, I realized the LED is blinking in regular intervals even without any change from my side. I digged into that phenomenon and found out that the `BMCT-SLZ` is under the impression it falls off the network every 10 minutes. The reason is an unanswered `zclVersion` read from the `BMCT-SLZ` to the coordinator. As Z2M uses the reported `zclVersion` from the device, this information isn't available during the interview stage, which explains why the request isn't answered at all. To mitigate that, I created a `customReadResponse` function and mimicked the answer from the Bosch Smart Home Controller II.
- **Fix for unreliable on/off updates in light mode**: The `on_off` state for both light outputs wasn't updated reliably. I fixed that by using the `force_multiendpoint` version of the `on_off` converter.
- **Inclusion of `none` as switch type**: Bosch officially supports the use of the `BMCT-SLZ` without any switch connected to it. This wasn't possible with Z2M up until now as the required value couldn't be set as switch type.
- **Fix for some attributes not being read by default**: I discovered that not all attributes are being read during the `configuration` stage. As it's quite irritating when options are in such an "undefined" state, I included them in the `configure` function. Since I was already there, I also split the configurations into separate functions to make it clear what is being used for which mode (light or shutter). Unfortunately, there is no possibility to trigger a reconfiguration programmatically when setting the `deviceMode`. In that case, we wouldn't have attributes in the state that don't fit into the selected `deviceMode`. This was the initial reason I did the separation in the first place (until I realized that it was not possible) to be honest.
- **Inclusion of newly discovered attributes**: During development, I also used the Bosch app to use the device for shutter control. As I don't have any shutters to connect to the `BMCT-SLZ`, I didn't want to make any real change here. But I tried to document any findings and guesses in the code for someone else to continue as I have to return the devices now.

This (partially) fixes #9129 and #9768.