### PR TITLE
Bosch `BSP-FZ2` (Plug compact II): Support reset of energy meter and lower min value change on electricityMeter reporting

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -2076,7 +2076,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "BSP-FZ2",
         vendor: "Bosch",
         description: "Plug compact EU",
-        extend: [m.onOff(), m.electricityMeter({voltage: false, current: false})],
+        extend: [m.onOff(), m.electricityMeter({voltage: false, current: false}), boschExtend.seMeteringCluster(), boschExtend.resetEnergyReading()],
         ota: true,
         whiteLabel: [
             {vendor: "Bosch", model: "BSP-EZ2", description: "Plug compact FR", fingerprint: [{modelID: "RBSH-SP-ZB-FR"}]},

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -2076,7 +2076,17 @@ export const definitions: DefinitionWithExtend[] = [
         model: "BSP-FZ2",
         vendor: "Bosch",
         description: "Plug compact EU",
-        extend: [m.onOff(), m.electricityMeter({voltage: false, current: false}), boschExtend.seMeteringCluster(), boschExtend.resetEnergyReading()],
+        extend: [
+            m.onOff(),
+            m.electricityMeter({
+                voltage: false,
+                current: false,
+                power: {change: 1},
+                energy: {change: 1},
+            }),
+            boschExtend.seMeteringCluster(),
+            boschExtend.resetEnergyReading(),
+        ],
         ota: true,
         whiteLabel: [
             {vendor: "Bosch", model: "BSP-EZ2", description: "Plug compact FR", fingerprint: [{modelID: "RBSH-SP-ZB-FR"}]},


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
During development of #9852 , I realized that the `BSP-FZ2` uses the same command for resetting the integrated energy meter. Therefore, I support that feature on the `BSP-FZ2`, too. As I already changed the extends, I lowered the minimum value change for the `seMetering` and `haElectricalMeasurement` clusters to match the Bosch default there (as already did for the `BMCT-SLZ`).