### PR TITLE
Create inovelliMMWave modern extend to relocate mmWave commands and support future expansion

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -537,6 +537,15 @@ const inovelliExtend = {
             isModernExtend: true,
         } as ModernExtend;
     },
+    inovelliMMWave: () => {
+        return {
+            fromZigbee: [],
+            toZigbee: [tzLocal.inovelli_mmwave_control_commands, tzLocal.inovelli_mmwave_set_interference_area],
+            exposes: [exposeMMWaveControl()],
+            configure: [],
+            isModernExtend: true,
+        } as ModernExtend;
+    },
 };
 
 const FAN_MODES: {[key: string]: number} = {off: 0, low: 2, smart: 4, medium: 86, high: 170, on: 255};
@@ -1632,7 +1641,7 @@ const VZM32_MMWAVE_ATTRIBUTES: {[s: string]: Attribute} = {
         min: 0,
         max: 600,
         readOnly: false,
-        description: "Defines the detection area in front of the switch)",
+        description: "Defines the detection area in front of the switch",
     },
     mmWaveDepthMax: {
         ID: 106,
@@ -1640,7 +1649,7 @@ const VZM32_MMWAVE_ATTRIBUTES: {[s: string]: Attribute} = {
         min: 0,
         max: 600,
         readOnly: false,
-        description: "Defines the detection area in front of the switch)",
+        description: "Defines the detection area in front of the switch",
     },
 };
 
@@ -2487,7 +2496,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "VZM32-SN",
         vendor: "Inovelli",
         description: "mmWave Zigbee Dimmer",
-        exposes: [exposeMMWaveControl()],
         extend: [
             m.deviceEndpoints({
                 endpoints: {"1": 1, "2": 2, "3": 3},
@@ -2502,6 +2510,7 @@ export const definitions: DefinitionWithExtend[] = [
                 supportsLedEffects: true,
                 supportsButtonTaps: true,
             }),
+            inovelliExtend.inovelliMMWave(),
             inovelliExtend.addCustomClusterInovelli(),
             inovelliExtend.addCustomMMWaveClusterInovelli(),
             m.identify(),
@@ -2514,7 +2523,6 @@ export const definitions: DefinitionWithExtend[] = [
             m.illuminance(),
             m.occupancy(),
         ],
-        toZigbee: [tzLocal.inovelli_mmwave_control_commands],
         ota: true,
     },
     {

--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -540,7 +540,7 @@ const inovelliExtend = {
     inovelliMMWave: () => {
         return {
             fromZigbee: [],
-            toZigbee: [tzLocal.inovelli_mmwave_control_commands, tzLocal.inovelli_mmwave_set_interference_area],
+            toZigbee: [tzLocal.inovelli_mmwave_control_commands],
             exposes: [exposeMMWaveControl()],
             configure: [],
             isModernExtend: true,


### PR DESCRIPTION
We wanted to move the mmWave commands to the bottom of the exposes section. Easiest way to do that was to create another ModernExtend class. This has the benefit of also making it easy to add the additional commands to the mmWave class later on.