### PR TITLE
Remove CMA30651 Unsupported Attributes

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2865,10 +2865,10 @@ export const definitions: DefinitionWithExtend[] = [
         description: "13A Smart Switched Fused Connection Unit",
         extend: [
             tuya.modernExtend.tuyaOnOff({
-                backlightModeOffOn: true,
-                childLock: true,
+                backlightModeOffOn: false,
+                childLock: false,
                 powerOnBehavior: true,
-                onOffCountdown: true,
+                onOffCountdown: false,
             }),
         ],
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->

Remove unsupported attributes from CMA30651. Power on behaviour, backlight and child lock are supported via ClickSmart+ hub and app but apparently not by the generic Tuya description.