### PR TITLE
Restore power_on_behavior for Gledopto GL-S-006P

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -533,7 +533,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Gledopto",
         ota: true,
         description: "Zigbee GU10 LED lamp",
-        extend: [gledoptoLight({colorTemp: {range: [158, 495]}, color: true, turnsOffAtBrightness1: true, powerOnBehavior:true})],
+        extend: [gledoptoLight({colorTemp: {range: [158, 495]}, color: true, turnsOffAtBrightness1: true, powerOnBehavior: true})],
     },
     {
         zigbeeModel: ["GL-S-014P"],


### PR DESCRIPTION
Support for power_on_behavior was disabled in https://github.com/Koenkk/zigbee-herdsman-converters/commit/b0b91c724dea790816d4927b1050faf9256b9124 as a result of https://github.com/Koenkk/zigbee2mqtt/issues/16873 for all the Gledopto devices, but from my tests it works on [GL-S-006P](https://www.zigbee2mqtt.io/devices/GL-S-006P.html) but, only on/off state.
Previously power_on_behavior has been restored for GL-C-006P and GL-LB-001P in https://github.com/Koenkk/zigbee-herdsman-converters/pull/6175