### PR TITLE
Let modernExtend auto-detect endpoints _1,_2 for Shelly 2PM

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -66,11 +66,9 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "2PM Gen4 (Switch mode)",
         extend: [
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             m.onOff({powerOnBehavior: false, endpointNames: ["l1", "l2"]}),
             m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
         ],
-        endpoint: (device) => {
-            return {l1: 1, l2: 2};
-        },
     },
 ];


### PR DESCRIPTION
There was an incorrect mapping for the Shelly 2PM Switch mode endpoints.
After checking the device state it's reporting to `_1` and not `_l1`
Also fixed according to https://shelly-api-docs.shelly.cloud/gen2/Integrations/Zigbee/DeviceFeatures

For each metric theres a `_1`, `_2` and no suffix, unsure what it represents.
Non-suffixed and `_1` seem to be correct according to `ac_frequency` readings.
If this ends up being true we might need to update the mappings.

```json
{
    "ac_frequency": 49.96,
    "ac_frequency_1": 50.01,
    "ac_frequency_2": 5002,
    "current_1": 0.436,
    "current_2": 0.138,
    "energy_1": 1.824558,
    "energy_2": 0.9867159999999999,
    "last_seen": "2025-09-01T22:01:57.652Z",
    "linkquality": 164,
    "power_1": 56,
    "power_2": 31,
    "power_apparent": 0,
    "power_apparent_1": 56,
    "power_apparent_2": 31,
    "power_factor": 0,
    "power_factor_1": 0.01,
    "power_factor_2": 0.01,
    "produced_energy": 0,
    "produced_energy_1": 0,
    "produced_energy_2": 0,
    "state_1": "ON",
    "state_2": "ON",
    "voltage_1": 239.06,
    "voltage_2": 236.01,
    "ac_frequency_l1": null,
    "ac_frequency_l2": null,
    "current_l1": null,
    "current_l2": null,
    "energy_l1": null,
    "energy_l2": null,
    "power_l1": null,
    "power_l2": null,
    "produced_energy_l1": null,
    "produced_energy_l2": null,
    "state_l1": "ON",
    "state_l2": "ON",
    "voltage_l1": null,
    "voltage_l2": null,
    "state": "OFF",
    "current": 0,
    "power": 0,
    "voltage": 236.42000000000002,
    "energy": 1.033073
}
```

Cover mode suffers from the same suffix and non-suffix issue, in this case the correct readings are from `state` and not `state_1`.

```json
{
    "last_seen": "2025-09-01T22:04:30.590Z",
    "linkquality": 204,
    "position": 0,
    "position_1": 100,
    "state": "CLOSE",
    "state_1": "OPEN",
    "tilt_1": 50
}
```