### PR TITLE
Correct Shelly 2PM Gen4 Switch endpoints configuration

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -66,11 +66,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "2PM Gen4 (Switch mode)",
         extend: [
-            m.onOff({powerOnBehavior: false, endpointNames: ["l1", "l2"]}),
-            m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
+            m.identify(),
+            m.deviceEndpoints({endpoints: {"1": 1, "2": 2}}),
+            m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["1", "2"]}),
+            m.onOff({powerOnBehavior: false, endpointNames: ["1", "2"]}),
         ],
-        endpoint: (device) => {
-            return {l1: 1, l2: 2};
-        },
     },
 ];


### PR DESCRIPTION
Correctly configure the endpoints for the Shelly 2PM Gen4 in Switch mode.

With this change, the 2-gangs should be displayed and reflected correctly along with the power metering.

Note that cover mode configuration probably needs updating as well but I do not use the module in that mode so I haven't looked into it.

<img width="1498" height="648" alt="Screenshot 2025-09-02 at 20 57 43" src="https://github.com/user-attachments/assets/f2b3d881-5113-4f0a-aba5-401936c2b5a1" />
