### PR TITLE
fix: Waxman 8840100H: remove support as water leak is not detect properly

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3507,17 +3507,16 @@ export const enocean_ptm216z: Fz.Converter = {
         }
     },
 };
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const _8840100H_water_leak_alarm: Fz.Converter = {
-    cluster: "haApplianceEventsAlerts",
-    type: "commandAlertsNotification",
-    convert: (model, msg, publish, options, meta) => {
-        const alertStatus = msg.data.aalert;
-        return {
-            water_leak: (alertStatus & (1 << 12)) > 0,
-        };
-    },
-};
+// export const _8840100H_water_leak_alarm: Fz.Converter = {
+//     cluster: "haApplianceEventsAlerts",
+//     type: "commandAlertsNotification",
+//     convert: (model, msg, publish, options, meta) => {
+//         const alertStatus = msg.data.aalert;
+//         return {
+//             water_leak: (alertStatus & (1 << 12)) > 0,
+//         };
+//     },
+// };
 export const diyruz_freepad_clicks: Fz.Converter = {
     cluster: "genMultistateInput",
     type: ["readResponse", "attributeReport"],

--- a/src/devices/waxman.ts
+++ b/src/devices/waxman.ts
@@ -7,21 +7,23 @@ import type {DefinitionWithExtend} from "../lib/types";
 const e = exposes.presets;
 
 export const definitions: DefinitionWithExtend[] = [
-    {
-        zigbeeModel: ["leakSMART Water Sensor V2"],
-        model: "8840100H",
-        vendor: "Waxman",
-        description: "leakSMART water sensor v2",
-        fromZigbee: [fz._8840100H_water_leak_alarm, fz.temperature, fz.battery],
-        toZigbee: [],
-        exposes: [e.battery(), e.temperature(), e.water_leak()],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "haApplianceEventsAlerts", "msTemperatureMeasurement"]);
-            await reporting.batteryPercentageRemaining(endpoint);
-            await reporting.temperature(endpoint);
-        },
-    },
+    // Disabled because fz._8840100H_water_leak_alarm is very likely broken
+    // https://github.com/Koenkk/zigbee-herdsman-converters/pull/9867#discussion_r2311954776
+    // {
+    //     zigbeeModel: ["leakSMART Water Sensor V2"],
+    //     model: "8840100H",
+    //     vendor: "Waxman",
+    //     description: "leakSMART water sensor v2",
+    //     fromZigbee: [fz._8840100H_water_leak_alarm, fz.temperature, fz.battery],
+    //     toZigbee: [],
+    //     exposes: [e.battery(), e.temperature(), e.water_leak()],
+    //     configure: async (device, coordinatorEndpoint) => {
+    //         const endpoint = device.getEndpoint(1);
+    //         await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "haApplianceEventsAlerts", "msTemperatureMeasurement"]);
+    //         await reporting.batteryPercentageRemaining(endpoint);
+    //         await reporting.temperature(endpoint);
+    //     },
+    // },
     {
         zigbeeModel: ["House Water Valve - MDL-TBD", "leakSMART Water Valve v2.10"],
         // Should work with all manufacturer model numbers for the 2.0 series:


### PR DESCRIPTION
Remove support for this device as the water leak converter is very likely broken (and it's unclear how to fix it). Having this device as supported can creates a false impression that it can detect water leaks, therefore it's better to remove for now. See https://github.com/Koenkk/zigbee-herdsman-converters/pull/9867#discussion_r2311954776

In case you own this device please comment on this pr.

CC: @Nerivec @presslab-us