### PR TITLE
Add support for Philips Hue Centris ceiling light (929003808401)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4199,4 +4199,11 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
     },
+    {
+        zigbeeModel: ['929003808401_01', '929003808401_02', '929003808401_03'],
+        model: '929003808401',
+        vendor: 'Philips',
+        description: 'Hue White & Color ambience Centris ceiling light (2 spots)',
+        extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+    }
 ];

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4200,10 +4200,10 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ['929003808401_01', '929003808401_02', '929003808401_03'],
-        model: '929003808401',
-        vendor: 'Philips',
-        description: 'Hue White & Color ambience Centris ceiling light (2 spots)',
-        extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
-    }
+        zigbeeModel: ["929003808401_01", "929003808401_02", "929003808401_03"],
+        model: "929003808401",
+        vendor: "Philips",
+        description: "Hue White & Color ambience Centris ceiling light (2 spots)",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+    },
 ];


### PR DESCRIPTION
Link to picture pull request: [Docs PR](https://github.com/Koenkk/zigbee2mqtt.io/pull/4113)

## Device Information
- **Model:** 929003808401
- **Vendor:** Philips
- **Description:** Hue White & Color ambience Centris ceiling light (2 spots)

## Changes
- Added device definition to src/devices/philips.ts
- Supports colour (xy, hs modes with enhanced hue)
- Supports colour temperature (153-500 range)