### PR TITLE
feat: add support for TS020C_TZ3040_wc6kfjtc PIR motion sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -921,16 +921,13 @@ const fzLocal = {
         undefined,
         ["commandDataResponse", "commandDataReport", "commandActiveStatusReport", "commandActiveStatusReportAlt"]
     >,
-    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-    TS020C_illuminance: {
+    ts020cIlluminance: {
         cluster: "manuSpecificTuya_2",
         type: ["attributeReport"],
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValue = {};
-            if (["_TZ3040_wc6kfjtc"].includes(meta.device.manufacturerName)) {
-                if ("57345" in msg.data) {
-                    result.illuminance = msg.data["57345"];
-                }
+            if ("57345" in msg.data) {
+                result.illuminance = msg.data["57345"];
             }
             return result;
         },
@@ -949,20 +946,16 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.gas(), e.tamper()],
     },
     {
-        fingerprint: tuya.fingerprint("TS020C", ["_TZ3040_wc6kfjtc"]),
         zigbeeModel: ["TS020C"],
         model: "TS020C",
         vendor: "Tuya",
         description: "PIR sensor",
-        fromZigbee: [tuya.fz.datapoints, fzLocal.TS020C_illuminance],
-        toZigbee: [tuya.tz.datapoints],
+        fromZigbee: [fzLocal.ts020cIlluminance],
         extend: [tuya.modernExtend.tuyaBase({dp: true, queryOnDeviceAnnounce: true, queryOnConfigure: true})],
         exposes: [
             e.occupancy(),
             e.battery(),
-            e.battery_low(),
-            e.tamper(),
-            e.illuminance().withUnit("lux"),
+            e.illuminance(),
             e
                 .enum("sensitivity", ea.STATE_SET, ["low", "medium", "high"])
                 .withDescription("PIR sensor sensitivity (refresh and update only while active)"),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [here](https://github.com/Koenkk/zigbee2mqtt.io/pull/4117)


This Adds support to generic pir motion sensor with illuminance
had to write a custom converter for the illuminance since datapoint 12 didn't work even tho from tuya iot platform the exposed datapoints were

```json
{"1":"PIR state","4":"Battery level","12":"Illuminance value","101":"PIR sensitivity","102":"Someone hold time","103":"Light sensing collection interval"}
```