### PR TITLE
feat(Bosch): Enable OTA updates for BWA-1, BSIR-EZ and RFPR-ZB-SH-EU

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1550,6 +1550,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.quirkCheckinInterval(0),
         ],
+        ota: true,
     },
     {
         zigbeeModel: ["RBSH-WS-ZB-EU"],
@@ -1598,6 +1599,7 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.read("ssIasZone", ["zoneStatus"]);
             await endpoint.read<"boschSpecific", BoschSpecificBwa1>("boschSpecific", ["alarmOnMotion"], manufacturerOptions);
         },
+        ota: true,
     },
     {
         zigbeeModel: ["RBSH-SD-ZB-EU"],
@@ -2167,6 +2169,7 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.read("genPowerCfg", ["batteryPercentageRemaining"]);
             await endpoint.read("ssIasZone", ["zoneStatus"]);
         },
+        ota: true,
     },
     {
         zigbeeModel: ["RBSH-SWDV-ZB"],


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
Bosch released all OTA files within their Smart Home Controller in recent weeks. Some devices have already got the necessary `ota: true` flag. This pull request adds it to all devices that have an OTA update released, but haven't had the flag yet.