### PR TITLE
Neo NAS-WR01B smart plug - Tuya _TZ3000_gjnozsaz

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6906,7 +6906,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         whiteLabel: [
             {vendor: "LELLKI", model: "TS011F_plug"},
-            {vendor: "Neo", model: "NAS-WR01B"},
             {vendor: "BlitzWolf", model: "BW-SHP15"},
             {vendor: "BlitzWolf", model: "BW-SHP13"},
             {vendor: "MatSee Plus", model: "PJ-ZSW01"},
@@ -7016,7 +7015,6 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "VIKEFON", model: "TS011F"},
             {vendor: "BlitzWolf", model: "BW-SHP15"},
             {vendor: "AVATTO", model: "MIUCOT10Z"},
-            {vendor: "Neo", model: "NAS-WR01B"},
             {vendor: "Neo", model: "PLUG-001SPB2"},
         ],
         ota: true,


### PR DESCRIPTION
Wall plug similiar to other existing plugs based on Tuya stack. Doesn't support activePower reporting as some other models (error details below). 
1/ Added `tuya.whitelabel`
2/ added to `if` condition list to skip `await reporting.activePower(endpoint, {change: 10});`

> Failed to configure '<ieee_address>', attempt 3 (Error: ZCL command <ieee_address>/1 haElectricalMeasurement.configReport([{"attribute":"activePower","minimumReportInterval":5,"maximumReportInterval":3600,"reportableChange":10}], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'INSUFFICIENT_SPACE') at Endpoint.checkStatus (/root/zigbee-herdsman/src/controller/model/endpoint.ts:385:28) at Endpoint.zclCommand (/root/zigbee-herdsman/src/controller/model/endpoint.ts:1055:26) at Endpoint.configureReporting (/root/zigbee-herdsman/src/controller/model/endpoint.ts:768:9) at Object.activePower (/root/zigbee-herdsman-converters/src/lib/reporting.ts:213:5) at configure (/root/zigbee-herdsman-converters/src/devices/tuya.ts:6818:17) at Object.configure (/root/zigbee-herdsman-converters/src/index.ts:366:21) at Configure.configure (/root/zigbee2mqtt/lib/extension/configure.ts:123:13) at EventEmitter.wrappedCallback (/root/zigbee2mqtt/lib/eventBus.ts:252:17))