### PR TITLE
Added: covers mode (SBDV-00199), diagnostics (SBDV-00196,00199,00202)

### DIFF
--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -12,7 +12,8 @@ import * as utils from "../lib/utils";
 const e = exposes.presets;
 const ea = exposes.access;
 
-const NS = "zhc:sdevices";
+const NS = "zhc:sber";
+
 const {tuyaMagicPacket, tuyaOnOffActionLegacy} = tuya.modernExtend;
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.SBERDEVICES_LTD};
 const defaultResponseOptions = {disableDefaultResponse: false};

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -6,7 +6,7 @@ import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, Fz, KeyValue, KeyValueAny, ModernExtend, Tz, Zh} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValue, KeyValueAny, ModernExtend, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
@@ -16,22 +16,6 @@ const NS = "zhc:sdevices";
 const {tuyaMagicPacket, tuyaOnOffActionLegacy} = tuya.modernExtend;
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.SBERDEVICES_LTD};
 const defaultResponseOptions = {disableDefaultResponse: false};
-
-function checkMetaOption(device: Zh.Device, key: string) {
-    if (device != null) {
-        const enabled = device.meta[key];
-        if (enabled === undefined) {
-            return false;
-        }
-        return !!enabled;
-    }
-    return false;
-}
-function setMetaOption(device: Zh.Device, key: string, enabled: boolean) {
-    if (device != null && key != null) {
-        device.meta[key] = enabled;
-    }
-}
 
 const sdevices = {
     fz: {
@@ -1117,7 +1101,7 @@ export const definitions: DefinitionWithExtend[] = [
                         .withDescription("Brightness of LED indicator")
                         .withEndpoint(coversEpName),
                 ];
-                if (checkMetaOption(device, "window_covering_enabled")) {
+                if (device.meta.window_covering_enabled) {
                     return [...coversExposes];
                 }
             }
@@ -1246,18 +1230,18 @@ export const definitions: DefinitionWithExtend[] = [
             if (coveringEp != null) {
                 try {
                     const deviceCoverMode = await device.getEndpoint(3).read("genBasic", ["deviceEnabled"]);
-                    setMetaOption(device, "window_covering_enabled", deviceCoverMode.deviceEnabled !== 0);
+                    device.meta.window_covering_enabled = !!deviceCoverMode.deviceEnabled;
                 } catch (e) {
                     if ((e as Error).message.includes("UNSUPPORTED_ATTRIBUTE")) {
-                        setMetaOption(device, "window_covering_enabled", false);
+                        device.meta.window_covering_enabled = false;
                     } else {
                         throw e;
                     }
                 }
             } else {
-                setMetaOption(device, "window_covering_enabled", false);
+                device.meta.window_covering_enabled = false;
             }
-            if (checkMetaOption(device, "window_covering_enabled")) {
+            if (device.meta.window_covering_enabled) {
                 /* Device is in Window Covering mode */
                 await device.getEndpoint(3).read("genBasic", ["serialNumber"]);
                 await device.getEndpoint(3).read("closuresWindowCovering", ["currentPositionLiftPercentage", "windowCoveringMode"]);

--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -1231,15 +1231,18 @@ export const definitions: DefinitionWithExtend[] = [
                 try {
                     const deviceCoverMode = await device.getEndpoint(3).read("genBasic", ["deviceEnabled"]);
                     device.meta.window_covering_enabled = !!deviceCoverMode.deviceEnabled;
+                    device.save();
                 } catch (e) {
                     if ((e as Error).message.includes("UNSUPPORTED_ATTRIBUTE")) {
                         device.meta.window_covering_enabled = false;
+                        device.save();
                     } else {
                         throw e;
                     }
                 }
             } else {
                 device.meta.window_covering_enabled = false;
+                device.save();
             }
             if (device.meta.window_covering_enabled) {
                 /* Device is in Window Covering mode */


### PR DESCRIPTION
Adding new features for devices from SDevices:

- covers mode (SBDV-00199)
- child lock (SBDV-00196, SBDV-00199)
- diagnostics and serial number (SBDV-00196, SBDV-00199, SBDV-00202)

PR with additional information about switching SBDV-00199 into covers mode: https://github.com/Koenkk/zigbee2mqtt.io/pull/4126