### PR TITLE
Fix detection: _TZ3000_pgq7ormg as TS0001_switch_module_3

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4836,10 +4836,9 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_pgq7ormg"]),
-        model: "TS0001_switch_module_3",
-        vendor: "Tuya",
+        model: "_TZ3000_pgq7ormg",
+        vendor: "iHseno",
         description: "1 gang switch module",
-        whiteLabel: [tuya.whitelabel("iHseno", "_TZ3000_pgq7ormg", "1 gang switch module", ["_TZ3000_pgq7ormg"])],
         extend: [tuya.modernExtend.tuyaOnOff({switchType: true, onOffCountdown: true, indicatorMode: true})],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);


### PR DESCRIPTION
Related to #9952

I created a new converter **TS0001_switch_module_3** that is TS0001_switch_module + indicator LED support.  
And I moved _TZ3000_pgq7ormg 1-gang switch there.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
