### PR TITLE
Add Hue Essentials bulbs A60 and GU10

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4219,7 +4219,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Philips",
         description: "Hue Essential White and Color Ambiance A19",
         extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-        meta: {},
     },
     {
         zigbeeModel: ["LCB003"],
@@ -4227,22 +4226,19 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Philips",
         description: "Hue Essential White and Color Ambiance BR30",
         extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-        meta: {},
     },
     {
         zigbeeModel: ["LCA016"],
         model: "8720169392182",
-        vendor: "Signify Netherlands B.V.",
+        vendor: "Philips",
         description: "Hue Essential White and Color Ambiance A60",
         extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-        meta: {},
     },
     {
         zigbeeModel: ["LCG008"],
         model: "8720169392540",
-        vendor: "Signify Netherlands B.V.",
+        vendor: "Philips",
         description: "Hue Essential White and Color Ambiance GU10",
         extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-        meta: {},
     },
 ];


### PR DESCRIPTION
This PR adds support for two philips lamps.  
Hope I did everything correctly, it's my first time contributing

[Hue Essential A60](https://www.philips-hue.com/en-gb/p/lampe-essential-a60-e27-smarte-lampe-806-lm-8-w/8720169392182)  

[Hue Essential GU10](https://www.philips-hue.com/en-gb/p/bulb-essential-gu10-smart-spotlight-345-lm-47w/8720169392427)

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4142