### PR TITLE
fix: improve Sunricher SR-ZG9041A-2R endpoint naming & remove powerOnBehavior false to use default behavior

### DIFF
--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -181,9 +181,9 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee 2ch smart relay",
         extend: [
             m.identify(),
-            m.commandsScenes({endpointNames: ["1", "2"]}),
-            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}),
-            m.onOff({powerOnBehavior: false, endpointNames: ["1", "2"], configureReporting: true}),
+            m.commandsScenes({endpointNames: ["relay1", "relay2"]}),
+            m.deviceEndpoints({endpoints: {relay1: 1, relay2: 2, "3": 3}}),
+            m.onOff({endpointNames: ["relay1", "relay2"], configureReporting: true}),
             m.electricityMeter({endpointNames: ["3"]}),
         ],
         meta: {multiEndpoint: true},


### PR DESCRIPTION
- Change endpoint names from "1", "2" to "relay1", "relay2" for better identification
- Remove powerOnBehavior: false to use default behavior
- This allows better UI labeling in Zigbee2MQTT for distinguishing between relay channels
