### PR TITLE
Update ecodim.ts to support new eco-dim10 variant

### DIFF
--- a/src/devices/ecodim.ts
+++ b/src/devices/ecodim.ts
@@ -40,7 +40,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["eco-dim07-zigbee", "eco-dim07-Pro-zigbee"],
+        zigbeeModel: ["eco-dim07-zigbee", "eco-dim07-Pro-zigbee", "eco-dim10-zigbee"],
         fingerprint: [
             {type: "Router", manufacturerID: 4714, modelID: "Dimmer-Switch-ZB3.0"},
             {


### PR DESCRIPTION
There's a new variant out there for the same device. 

As reported on tweakers: https://gathering.tweakers.net/forum/list_message/83409780#83409780

```ts
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['eco-dim10-zigbee'],
    model: 'eco-dim10-zigbee',
    vendor: 'EcoDim BV',
    description: 'Automatically generated definition',
    extend: [m.light()],
    meta: {},
};
```

<img width="582" height="800" alt="image" src="https://github.com/user-attachments/assets/3a00d0e5-009f-49c0-a359-7f0987d9cc60" />
https://gathering.tweakers.net/forum/list_message/83409536#83409536