### PR TITLE
fix TS020C, correct cluster name, occ/batt

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -952,7 +952,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: "PIR sensor",
         fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, fzLocal.ts020cIlluminance],
         extend: [tuya.modernExtend.tuyaBase({dp: true, queryOnDeviceAnnounce: true, queryOnConfigure: true})],
-        configure: tuya.configureMagicPacket,
         exposes: [
             e.occupancy(),
             e.battery(),


### PR DESCRIPTION
This is an amendment to PR #9934 (sorry for not thoroughly testing)

Picking the correct cluster for illuminance, and fixing the reporting of occupancy & battery otherwise you get 

```
628:[2025-09-10 13:34:20] debug:        z2m: No converter available for 'TS020C' with cluster 'ssIasZone' and type 'attributeReport' and data '{"61441":1}'
378:[2025-09-10 13:57:03] debug:        z2m: No converter available for 'TS020C' with cluster 'genPowerCfg' and type 'attributeReport' and data '{"batteryPercentageRemaining":200}'
```

discussion: https://github.com/Koenkk/zigbee2mqtt/discussions/28386