### PR TITLE
Namron Simplify Rele 1-2p 16a (BT / Zigbee)

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -1627,8 +1627,8 @@ export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["4512792"],
         model: "4512792",
-        vendor: "Namron AS",
-        description: "Namron Simplify 1-2p Relay (Zigbee / BT)",
+        vendor: "Namron",
+        description: "Simplify 1-2p relay (Zigbee / BT)",
         extend: [
             m.onOff(),
             m.electricityMeter({


### PR DESCRIPTION

<img width="3000" height="4000" alt="4512791" src="https://github.com/user-attachments/assets/f34fabd8-f54e-460d-84b8-85928d33ea87" />
Add support for 
Namron Simplify 1-2p Relay Modell 1402791

The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
