### PR TITLE
Add FZB-1 switch from Nova Digital

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11663,6 +11663,24 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_65ajyxua"]),
+        model: "FZB-1",
+        vendor: "Nova Digital",
+        description: "1-Gang switch with power-on behavior and indicator mode",
+        extend: [
+            tuya.modernExtend.tuyaOnOff({
+                powerOnBehavior2: true,
+                backlightModeOffOn: true,
+                indicatorMode: true,
+                inchingSwitch: true,
+            }),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0003", ["_TZ3000_pv4puuxi", "_TZ3000_avky2mvc", "_TZ3000_785olaiq", "_TZ3000_qxcnwv26"]),
         model: "TS0003_switch_3_gang",
         vendor: "Tuya",


### PR DESCRIPTION
https://www.novadigitalsmart.com.br/produtos/interruptor-tecla-fisica-4x2-fzb-1-2-3---w-b

Generated definition for reference:

```mjs
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['TS0001'],
    model: 'TS0001',
    vendor: '_TZ3000_65ajyxua',
    description: 'Automatically generated definition',
    extend: [m.onOff({"powerOnBehavior":false})],
    meta: {},
};
```

External device for reference:

```mjs
import * as reporting from "zigbee-herdsman-converters/lib/reporting";
import * as tuya from "zigbee-herdsman-converters/lib/tuya";

const definition = {
  fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_65ajyxua"]),
  model: "FZB-1",
  vendor: "Nova Digital",
  description: "1-Gang switch with power-on behavior and indicator mode",
  extend: [
    tuya.modernExtend.tuyaOnOff({
      powerOnBehavior2: true,
      backlightModeOffOn: true,
      indicatorMode: true,
      inchingSwitch: true,
    }),
  ],
  configure: async (device, coordinatorEndpoint) => {
    await tuya.configureMagicPacket(device, coordinatorEndpoint);
    await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, [
      "genOnOff",
    ]);
  },
};

export default definition;
```

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4147

This was previously working with basic switch functionality based on TS0001, but it was lacking backlight control, indicator mode and inching (timer).

With changes in this PR I get the following:

<img width="1247" height="857" alt="image" src="https://github.com/user-attachments/assets/e84ef7cf-c527-441a-8849-3f909e6be212" />
