### PR TITLE
Add support for Philips Hue Datura Small Round Ceiling Lamp

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -13,19 +13,19 @@ const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        zigbeeModel: ['929003736601_01'],
-        model: '929003736601_01',
-        vendor: 'Signify Netherlands B.V.',
-        description: 'Automatically generated definition',
-        extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        zigbeeModel: ["929003736601_01"],
+        model: "929003736601_01",
+        vendor: "Signify Netherlands B.V.",
+        description: "Automatically generated definition",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
-    
+
     {
-        zigbeeModel: ['929003736601_02'],
-        model: '929003736601_02',
-        vendor: 'Signify Netherlands B.V.',
-        description: 'Automatically generated definition',
-        extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        zigbeeModel: ["929003736601_02"],
+        model: "929003736601_02",
+        vendor: "Signify Netherlands B.V.",
+        description: "Automatically generated definition",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["929003810901_01", "929003810901_02", "929003810901_03"],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -13,6 +13,21 @@ const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
+        zigbeeModel: ['929003736601_01'],
+        model: '929003736601_01',
+        vendor: 'Signify Netherlands B.V.',
+        description: 'Automatically generated definition',
+        extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+    },
+    
+    {
+        zigbeeModel: ['929003736601_02'],
+        model: '929003736601_02',
+        vendor: 'Signify Netherlands B.V.',
+        description: 'Automatically generated definition',
+        extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+    },
+    {
         zigbeeModel: ["929003810901_01", "929003810901_02", "929003810901_03"],
         model: "929003810901",
         vendor: "Philips",

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -13,18 +13,10 @@ const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        zigbeeModel: ["929003736601_01"],
-        model: "929003736601_01",
-        vendor: "Signify Netherlands B.V.",
-        description: "Automatically generated definition",
-        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-    },
-
-    {
-        zigbeeModel: ["929003736601_02"],
-        model: "929003736601_02",
-        vendor: "Signify Netherlands B.V.",
-        description: "Automatically generated definition",
+        zigbeeModel: ["929003736601_01", "929003736601_02"],
+        model: "929003736601",
+        vendor: "Philips",
+        description: "Hue Datura LED ceiling panel small round",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {


### PR DESCRIPTION
The  light  fixture presents itself as two seperate entities/lights within one  fixture. Listed both items, unsure of how or if able to combine  them as one

The device is listed  as supported in the database, however  my version(?) pops up as unsupported in the Z2M add-on when joining the device to my network.
