### PR TITLE
adds genAnalogInput/genAnalogOutput

### DIFF
--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -100,6 +100,8 @@ const INPUT_EXTENDERS: Extender[] = [
     ],
     [["genBinaryInput"], extenderBinaryInput],
     [["genBinaryOutput"], extenderBinaryOutput],
+    [["genAnalogInput"], extenderAnalogInput],
+    [["genAnalogOutput"], extenderAnalogOutput],
 ];
 
 const OUTPUT_EXTENDERS: Extender[] = [
@@ -391,6 +393,42 @@ async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
             endpointName: `${endpoint.ID}`,
         };
         generated.push(new ExtendGenerator({extend: m.binary, args, source: "binary"}));
+    }
+    return generated;
+}
+
+async function extenderAnalogInput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
+    const generated: GeneratedExtend[] = [];
+    for (const endpoint of endpoints) {
+        const description = `analog_input_${endpoint.ID}`;
+        const args: m.NumericArgs<"genAnalogInput"> = {
+            name: await getClusterAttributeValue(endpoint, "genAnalogInput", "description", description),
+            cluster: "genAnalogInput",
+            attribute: "presentValue",
+            reporting: {min: "MIN", max: "MAX", change: 1},
+            description: description,
+            access: "STATE_GET",
+            endpointNames: [`${endpoint.ID}`],
+        };
+        generated.push(new ExtendGenerator({extend: m.numeric, args, source: "analog"}));
+    }
+    return generated;
+}
+
+async function extenderAnalogOutput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
+    const generated: GeneratedExtend[] = [];
+    for (const endpoint of endpoints) {
+        const description = `analog_output_${endpoint.ID}`;
+        const args: m.NumericArgs<"genAnalogOutput"> = {
+            name: await getClusterAttributeValue(endpoint, "genAnalogOutput", "description", description),
+            cluster: "genAnalogOutput",
+            attribute: "presentValue",
+            reporting: {min: "MIN", max: "MAX", change: 1},
+            description: description,
+            access: "ALL",
+            endpointNames: [`${endpoint.ID}`],
+        };
+        generated.push(new ExtendGenerator({extend: m.numeric, args, source: "analog"}));
     }
     return generated;
 }


### PR DESCRIPTION
zigbee on esphome can support genBinaryInput https://github.com/esphome/esphome/pull/7340. It adds auto discovery for the cluster. Also related to https://github.com/Koenkk/zigbee2mqtt/issues/27926