### PR TITLE
Add FZB-2 switch from Nova Digital based on TS0002

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4610,6 +4610,7 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "Lonsonho", model: "X702"},
             {vendor: "AVATTO", model: "ZTS02"},
             tuya.whitelabel("PSMART", "T462", "2 Gang switch with backlight, countdown, inching", ["_TZ3000_wnzoyohq"]),
+            tuya.whitelabel("Nova Digital", "FZB-2", "2-Gang switch with backlight, countdown and inching", ["_TZ3000_5ksufhqi"]),
         ],
     },
 


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4151

External Definition for reference: 

```mjs
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['TS0002'],
    model: 'TS0002',
    vendor: '_TZ3000_5ksufhqi',
    description: 'Automatically generated definition',
    extend: [m.deviceEndpoints({"endpoints":{"1":1,"2":2}}), m.onOff({"powerOnBehavior":false,"endpointNames":["1","2"]})],
    meta: {"multiEndpoint":true},
};
```

External device for reference:

```mjs
import * as reporting from "zigbee-herdsman-converters/lib/reporting";
import * as tuya from "zigbee-herdsman-converters/lib/tuya";

const definition = {
  fingerprint: tuya.fingerprint("TS0002", ["_TZ3000_5ksufhqi"]),
  model: "FZB-2",
  vendor: "Nova Digital",
  description: "2-Gang switch with backlight, countdown and inching",
  extend: [
      tuya.modernExtend.tuyaOnOff({
          switchType: true,
          powerOnBehavior2: true,
          backlightModeOffOn: true,
          indicatorMode: true,
          onOffCountdown: true,
          inchingSwitch: true,
          endpoints: ["l1", "l2"],
      }),
      tuya.clusters.addTuyaCommonPrivateCluster(),
  ],
  endpoint: (device) => {
      return {l1: 1, l2: 2};
  },
  meta: {multiEndpoint: true},
  configure: async (device, coordinatorEndpoint) => {
      await tuya.configureMagicPacket(device, coordinatorEndpoint);
      await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
      await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
  },
};

export default definition;
```

I've added as an whitelabel for the existing TS0002 version with all functionality