### PR TITLE
feat(device): Amina S EV Charger - Add charge limit with on/off

### DIFF
--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -159,6 +159,18 @@ const tzLocal = {
             await entity.read<"aminaControlCluster", AminaControlCluster>("aminaControlCluster", ["alarms"], manufacturerOptions);
         },
     } satisfies Tz.Converter,
+    charge_limit_with_on_off: {
+        key: ["charge_limit_with_on_off"],
+        convertSet: async (entity, key, value, meta) => {
+            const level = value as number;
+
+            await entity.command('genLevelCtrl', 'moveToLevelWithOnOff', {level, transtime: 0}, utils.getOptions(meta.mapped, entity));
+        },
+
+        convertGet: async (entity, key, meta) => {
+            await entity.read("genLevelCtrl", ["currentLevel"]);
+        },
+    } satisfies Tz.Converter,
 };
 
 export const definitions: DefinitionWithExtend[] = [
@@ -169,7 +181,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Amina S EV Charger",
         ota: true,
         fromZigbee: [fzLocal.ev_status, fzLocal.alarms],
-        toZigbee: [tzLocal.ev_status, tzLocal.alarms, tzLocal.charge_limit],
+        toZigbee: [tzLocal.ev_status, tzLocal.alarms, tzLocal.charge_limit, tzLocal.charge_limit_with_on_off],
         exposes: [
             e.text("ev_status", ea.STATE_GET).withDescription("Current charging status"),
             e.list("alarms", ea.STATE_GET, e.enum("alarm", ea.STATE_GET, aminaAlarms)).withDescription("List of active alarms"),
@@ -177,6 +189,11 @@ export const definitions: DefinitionWithExtend[] = [
             e.binary("charging", ea.STATE, true, false).withDescription("Power is being delivered to the EV"),
             e.binary("derated", ea.STATE, true, false).withDescription("Charging derated due to high temperature"),
             e.binary("alarm_active", ea.STATE, true, false).withDescription("An active alarm is present"),
+            e.numeric('charge_limit_with_on_off', ea.ALL)
+                .withDescription('Sets the maximum charge amperage and turns charging on/off.')
+                .withUnit('A')
+                .withValueMin(0)
+                .withValueMax(32),
         ],
         extend: [
             m.deviceAddCustomCluster("aminaControlCluster", {


### PR DESCRIPTION
This pull request introduces a new charge_limit_with_on_off endpoint for the Amina EV charger converter.

The existing charge_limit attribute does not support values below 6 A. The new endpoint allows setting the charge limit below 6 A, which will pause charging and also toggle the charger on/off as needed.