### PR TITLE
Add support for Samotech SM309-S-2CH

### DIFF
--- a/src/devices/samotech.ts
+++ b/src/devices/samotech.ts
@@ -44,8 +44,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SM309-S-2CH",
         vendor: "Samotech",
         description: "Zigbee 2 channel in wall dimmer",
-        extend: [m.deviceEndpoints({endpoints: { 1: 1, 2: 2 } }), m.light({endpointNames: ["1", "2"]})],
-        meta: { multiEndpoint: true },
+        extend: [m.deviceEndpoints({endpoints: {1: 1, 2: 2}}), m.light({endpointNames: ["1", "2"]})],
+        meta: {multiEndpoint: true},
     },
     {
         // v1 doesn't support electricity measurements


### PR DESCRIPTION
Hi, this is the first PR to zigbee-herdsman-converters. I've been using below in my own `SM309-S-2CH.js` file in `/homeassistant/zigbee2mqtt/external_converters` folder, so I copied that into `src/devices/samotech.ts` file. Let me know if there is something I should test/confirm/update/anything.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4154

Add support Samotech SM309-S-2CH

https://www.samotech.co.uk/products/zigbee-dimmer-sm309-2ch/
 
Details of device copied from suppliers site and manual -

Supported Zigbee clusters:

ZigBee Clusters the device supports are as follows:
Endpoint 0x01 - Channel 1:
• 0x0000: Basic • 0x0003: Identify • 0x0004: Groups • 0x0005: Scenes • 0x0006: On/off
• 0x0008: Level Control 
Endpoint 0x02 - Channel 2:
• 0x0000: Basic • 0x0003: Identify • 0x0004: Groups • 0x0005: Scenes • 0x0006: On/off
• 0x0008: Level Control 
Endpoint 0x0b - Whole device:
• 0x0000: Basic • 0x0b05: Diagnostics • 0x1000: ZLL Commissioning • 0x0019: OTA

Supports TouchLink and Zigbee Green Power Remote

