### PR TITLE
Bosch `BSEN-M` (Motion detector): Use `iasZoneStatus` to determine if test mode is active or not and harden deferred occupancy turn-off

### DIFF
--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1788,25 +1788,19 @@ export const boschBsenExtend = {
             ON: true,
             OFF: false,
         };
-
-        const enableNormalOperationMode = async (endpoint: Zh.Endpoint | Zh.Group) => {
-            await endpoint.command("ssIasZone", "initNormalOpMode", {});
-        };
-
         const enableTestMode = async (endpoint: Zh.Endpoint | Zh.Group) => {
             await endpoint.command<"ssIasZone", "initCustomTestMode", BoschBsenIasZoneCluster>("ssIasZone", "initCustomTestMode", {
                 data: [0x00, 0x80],
             });
         };
 
+        const disableTestMode = async (endpoint: Zh.Endpoint | Zh.Group) => {
+            await endpoint.command("ssIasZone", "initNormalOpMode", {});
+        };
+
         const exposes: Expose[] = [
             e
-                .binary(
-                    "test_mode",
-                    ea.STATE_SET,
-                    utils.getFromLookupByValue(true, testModeLookup),
-                    utils.getFromLookupByValue(false, testModeLookup),
-                )
+                .binary("test_mode", ea.ALL, utils.getFromLookupByValue(true, testModeLookup), utils.getFromLookupByValue(false, testModeLookup))
                 .withDescription(
                     "Activate the test mode. In this mode, the device blinks on every detected motion without any wait time in between to verify the installation. Please keep in mind that it can take up to 45 seconds for the test mode to be activated.",
                 )
@@ -1816,7 +1810,7 @@ export const boschBsenExtend = {
         const fromZigbee = [
             {
                 cluster: "ssIasZone",
-                type: ["commandStatusChangeNotification", "readResponse"],
+                type: ["commandStatusChangeNotification", "attributeReport", "readResponse"],
                 convert: (model, msg, publish, options, meta) => {
                     const zoneStatus = "zonestatus" in msg.data ? msg.data.zonestatus : msg.data.zoneStatus;
 
@@ -1825,20 +1819,13 @@ export const boschBsenExtend = {
                     }
 
                     const result: KeyValue = {};
-                    const testModeActivationPending = meta.device.meta.awaitTestModeActivation;
-                    const testModeDeactivationPending = meta.device.meta.awaitTestModeDeactivation;
 
-                    if (testModeActivationPending) {
-                        result.test_mode = utils.getFromLookupByValue(true, testModeLookup);
-                        meta.device.meta.awaitTestModeActivation = false;
-                    } else if (testModeDeactivationPending) {
-                        result.test_mode = utils.getFromLookupByValue(false, testModeLookup);
-                        meta.device.meta.awaitTestModeDeactivation = false;
-                    }
+                    const testModeStatus = ((zoneStatus >> 8) & 1) > 0;
+                    result.test_mode = utils.getFromLookupByValue(testModeStatus, testModeLookup);
 
                     return result;
                 },
-            } satisfies Fz.Converter<"ssIasZone", undefined, ["commandStatusChangeNotification", "readResponse"]>,
+            } satisfies Fz.Converter<"ssIasZone", undefined, ["commandStatusChangeNotification", "attributeReport", "readResponse"]>,
         ];
 
         const toZigbee: Tz.Converter[] = [
@@ -1847,28 +1834,20 @@ export const boschBsenExtend = {
                 convertSet: async (entity, key, value, meta) => {
                     if (key === "test_mode") {
                         if (value === utils.getFromLookupByValue(true, testModeLookup)) {
-                            meta.device.meta.awaitTestModeActivation = true;
                             await enableTestMode(entity);
                         } else {
-                            meta.device.meta.awaitTestModeDeactivation = true;
-                            await enableNormalOperationMode(entity);
+                            await disableTestMode(entity);
                         }
-
-                        // The device needs up to 45 seconds until the mode
-                        // change is being done. This is signalised by a
-                        // commandStatusChangeNotification message in the
-                        // ssIasZone cluster. To avoid any confusion, we
-                        // wait for the state change until the device is ready.
-                        return;
                     }
+                },
+                convertGet: async (entity, key, meta) => {
+                    await entity.read("ssIasZone", ["zoneStatus"]);
                 },
             },
         ];
 
         const configure: Configure[] = [
             async (device, coordinatorEndpoint, definition) => {
-                // Workaround for the test mode state to be OFF by default
-                device.meta.awaitTestModeDeactivation = true;
                 const endpoint = device.getEndpoint(1);
                 await endpoint.read("ssIasZone", ["zoneStatus"]);
             },

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1666,9 +1666,9 @@ export const boschBsenExtend = {
                         payload = {occupancy: alarmOneStatus, ...payload};
 
                         const isChangeMessage = msg.type === "commandStatusChangeNotification";
-                        const isNewOccupancyStatusDetected = alarmOneStatus === true;
+                        const newOccupancyStatusDetected = alarmOneStatus === true;
 
-                        if (isChangeMessage && isNewOccupancyStatusDetected) {
+                        if (isChangeMessage && newOccupancyStatusDetected) {
                             // After a detection, the device turns off the motion detection for 3 minutes.
                             // Unfortunately, the alarm is already turned off after 4 seconds for reasons
                             // only known to Bosch. Therefore, we have to manually defer the turn-off by

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1820,8 +1820,8 @@ export const boschBsenExtend = {
 
                     const result: KeyValue = {};
 
-                    const testModeStatus = ((zoneStatus >> 8) & 1) > 0;
-                    result.test_mode = utils.getFromLookupByValue(testModeStatus, testModeLookup);
+                    const testModeEnabled = ((zoneStatus >> 8) & 1) > 0;
+                    result.test_mode = utils.getFromLookupByValue(testModeEnabled, testModeLookup);
 
                     return result;
                 },

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1849,7 +1849,7 @@ export const boschBsenExtend = {
 
                     const result: KeyValue = {};
 
-                    const testModeEnabled = ((zoneStatus >> 8) & 1) > 0;
+                    const testModeEnabled = (zoneStatus & (1 << 8)) > 0;
                     result.test_mode = utils.getFromLookupByValue(testModeEnabled, testModeLookup);
 
                     return result;

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1866,7 +1866,7 @@ export const boschBsenExtend = {
             },
         ];
 
-        const configure: Configure[] = [m.setupConfigureForReading("ssIasZone", ["zoneStatus"])];
+        const configure: Configure[] = [m.setupConfigureForBinding("ssIasZone", "input"), m.setupConfigureForReading("ssIasZone", ["zoneStatus"])];
 
         return {
             exposes,

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1659,9 +1659,9 @@ export const boschBsenExtend = {
                     const tamperStatus = (zoneStatus & (1 << 2)) > 0;
                     payload = {tamper: tamperStatus, ...payload};
 
-                    const isOccupancyLockActive = meta.device.meta.occupancyLockTimeout ? meta.device.meta.occupancyLockTimeout > Date.now() : false;
+                    const occupancyLockActive = meta.device.meta.occupancyLockTimeout ? meta.device.meta.occupancyLockTimeout > Date.now() : false;
 
-                    if (!isOccupancyLockActive) {
+                    if (!occupancyLockActive) {
                         const alarmOneStatus = (zoneStatus & 1) > 0;
                         payload = {occupancy: alarmOneStatus, ...payload};
 

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1684,13 +1684,7 @@ export const boschBsenExtend = {
             } satisfies Fz.Converter<"ssIasZone", undefined, ["commandStatusChangeNotification", "attributeReport", "readResponse"]>,
         ];
 
-        const configure: Configure[] = [
-            async (device, coordinatorEndpoint, definition) => {
-                const endpoint = device.getEndpoint(1);
-                await endpoint.bind("ssIasZone", coordinatorEndpoint);
-                await endpoint.read("ssIasZone", ["zoneStatus"]);
-            },
-        ];
+        const configure: Configure[] = [m.setupConfigureForBinding("ssIasZone", "input"), m.setupConfigureForReading("ssIasZone", ["zoneStatus"])];
 
         const onEvent: OnEvent.Handler[] = [
             async (event) => {
@@ -1769,11 +1763,10 @@ export const boschBsenExtend = {
         ];
 
         const configure: Configure[] = [
+            m.setupConfigureForBinding("ssIasZone", "input"),
+            m.setupConfigureForReading("ssIasZone", ["numZoneSensitivityLevelsSupported", "currentZoneSensitivityLevel"]),
             async (device, coordinatorEndpoint, definition) => {
                 const endpoint = device.getEndpoint(1);
-
-                await endpoint.bind("ssIasZone", coordinatorEndpoint);
-                await endpoint.read("ssIasZone", ["numZoneSensitivityLevelsSupported", "currentZoneSensitivityLevel"]);
 
                 // The write request is made when using the proprietary
                 // Bosch Smart Home Controller II as of 15-09-2025. Looks like
@@ -1793,11 +1786,9 @@ export const boschBsenExtend = {
     },
     changedCheckinInterval: (): ModernExtend => {
         const configure: Configure[] = [
+            m.setupConfigureForReading("genPollCtrl", ["checkinInterval", "longPollInterval", "shortPollInterval"]),
             async (device, coordinatorEndpoint, definition) => {
                 const endpoint = device.getEndpoint(1);
-
-                await endpoint.bind("ssIasZone", coordinatorEndpoint);
-                await endpoint.read("genPollCtrl", ["checkinInterval", "longPollInterval", "shortPollInterval"]);
 
                 // The write request is made when using the proprietary
                 // Bosch Smart Home Controller II as of 15-09-2025.
@@ -1875,12 +1866,7 @@ export const boschBsenExtend = {
             },
         ];
 
-        const configure: Configure[] = [
-            async (device, coordinatorEndpoint, definition) => {
-                const endpoint = device.getEndpoint(1);
-                await endpoint.read("ssIasZone", ["zoneStatus"]);
-            },
-        ];
+        const configure: Configure[] = [m.setupConfigureForReading("ssIasZone", ["zoneStatus"])];
 
         return {
             exposes,


### PR DESCRIPTION
During analysis of the code from the `BSEN-C2`, I learned that Bosch also uses some bits in the `iasZoneStatus` to push device information to the coordinator. For the `BSEN-M`, this includes whether the test mode is active or not. By using that field, the use of the `device.meta` storage is obsolete, which makes the code much easier.

This pull request implements the use of the `iasZoneStatus` bit to determine the test mode status.

Additionally, I harden the deferred occupancy turn-off. In case the server was stopped before the turn-off was executed, the occupancy status stuck at the true value until a new motion was detected. This is fixed with this pull request.