### PR TITLE
fix: Legrand 67772: remove dimmer converters

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -631,12 +631,7 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fz.identify, fz.legrand_binary_input_on_off, fzLegrand.cluster_fc01],
         toZigbee: [tzLegrand.identify, tzLegrand.led_mode],
-        exposes: [
-            e.switch().withEndpoint("left"),
-            e.switch().withEndpoint("right"),
-            eLegrand.ledInDark(),
-            eLegrand.ledIfOn(),
-        ],
+        exposes: [e.switch().withEndpoint("left"), e.switch().withEndpoint("right"), eLegrand.ledInDark(), eLegrand.ledIfOn()],
         extend: [m.deviceEndpoints({endpoints: {left: 2, right: 1}}), m.light({configureReporting: true, endpointNames: ["left", "right"]})],
     },
     {

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -629,34 +629,9 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Legrand",
         description: "Double wired switch with neutral",
         ota: true,
-        fromZigbee: [fz.identify, fz.legrand_binary_input_on_off, fz.lighting_ballast_configuration, fzLegrand.cluster_fc01],
-        toZigbee: [tzLegrand.identify, tz.legrand_device_mode, tzLegrand.led_mode, tz.ballast_config],
+        fromZigbee: [fz.identify, fz.legrand_binary_input_on_off, fzLegrand.cluster_fc01],
+        toZigbee: [tzLegrand.identify, tzLegrand.led_mode],
         exposes: [
-            e
-                .numeric("ballast_minimum_level", ea.ALL)
-                .withValueMin(1)
-                .withValueMax(254)
-                .withDescription("Specifies the minimum brightness value")
-                .withEndpoint("left"),
-            e
-                .numeric("ballast_maximum_level", ea.ALL)
-                .withValueMin(1)
-                .withValueMax(254)
-                .withDescription("Specifies the maximum brightness value")
-                .withEndpoint("left"),
-            e
-                .numeric("ballast_minimum_level", ea.ALL)
-                .withValueMin(1)
-                .withValueMax(254)
-                .withDescription("Specifies the minimum brightness value")
-                .withEndpoint("right"),
-            e
-                .numeric("ballast_maximum_level", ea.ALL)
-                .withValueMin(1)
-                .withValueMax(254)
-                .withDescription("Specifies the maximum brightness value")
-                .withEndpoint("right"),
-            e.binary("device_mode", ea.ALL, "dimmer_on", "dimmer_off").withDescription("Allow the device to change brightness"),
             e.switch().withEndpoint("left"),
             e.switch().withEndpoint("right"),
             eLegrand.ledInDark(),


### PR DESCRIPTION
This device does not support dimming, configuring the device yields warning `Failed to configure (Device 0x... has no input cluster genLevelCtrl)`.

I have this device. See also https://community.jeedom.com/t/legrand-067722-avec-variateur-ou-pas/128581 for another user reporting this issue.

Despite all my efforts, I did not manage to test the change locally.