### PR TITLE
feat: improve support of Tongou TO-Q-SA1

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18962,9 +18962,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TO-Q-SA1",
         vendor: "Tongou",
         description: "Zigbee energy meter (transformer clamp)",
-        whiteLabel: [
-            tuya.whitelabel("Tongou", "TOSA1-01WXJAT2A", "Smart energy meter, two wire", ["_TZE284_4hdbt6rn"]),
-        ],
+        whiteLabel: [tuya.whitelabel("Tongou", "TOSA1-01WXJAT2A", "Smart energy meter, two wire", ["_TZE284_4hdbt6rn"])],
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         exposes: [


### PR DESCRIPTION
Add variation of Tongou TO-Q-SA1 marked as TOSA1-01WXJAT2A witch is the same but have two wire connections

original supported [Tongou TO-Q-SA1](https://www.tongou.com/product/smart-energy-accessory-tosa1-1p/)
my variation [TOSA1-01WXJAT2A](https://www.tongou.com/product/dual-wire-energy-accessory-sa1/)

Do we need add device as new (with new picture) or not?