### PR TITLE
Add new Philips A21 E26 1600 lumen white and color ambience bulb

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4258,9 +4258,8 @@ export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["LCA015"],
         model: "9290038539",
-        vendor: "Signify Netherlands B.V.",
+        vendor: "Philips",
         description: "Hue White and color ambiance A21 - E26 smart bulb - 1600",
         extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-        meta: {},
     },
 ];


### PR DESCRIPTION
This is the bulb: https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-a21-e26-smart-bulb-1600/046677591298

The product claims 50-20000k and the mired range matches. Experimentally this seems correct.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4163
