### PR TITLE
MiBoxer FUT089Z remote: Converter improvements & fixes

### DIFF
--- a/src/devices/miboxer.ts
+++ b/src/devices/miboxer.ts
@@ -46,8 +46,8 @@ function getZoneSuffixFromGroupId(groupId: number | undefined, options: KeyValue
     // Find the zone number for the given group ID
     const zoneNumber = Object.keys(zoneGroupMapping).find((zone) => zoneGroupMapping[Number.parseInt(zone, 10)] === groupId);
 
-    // If no zone number is found for this group or if legacy actions are enabled, add no suffix
-    if (!zoneNumber || options.legacy_actions === true) {
+    // If no zone number is found for this group or if zone actions are disabled, add no suffix
+    if (!zoneNumber || options.zone_actions !== true) {
         return "";
     }
 
@@ -160,16 +160,16 @@ function miboxerFut089zControls() {
         new exposes.Binary("expose_values", exposes.access.SET, true, false).withDescription(
             "Expose additional numeric values for action properties (hue, saturation, level, etc.)",
         ),
-        new exposes.Binary("legacy_actions", exposes.access.SET, true, false).withDescription(
-            "Publish legacy actions without zone IDs (in addition to zone-specific actions)",
+        new exposes.Binary("zone_actions", exposes.access.SET, true, false).withDescription(
+            "Publish zone-specific actions with zone IDs (e.g., on_zone_1, off_zone_2)",
         ),
     ];
 
     // Generate action exposes for all possible zones
-    function zoneActions(legacy: boolean): string[] {
+    function zoneActions(enableZoneActions: boolean): string[] {
         const baseActions = ["on", "off", "brightness_move_to_level", "color_temperature_move", "move_to_hue_and_saturation"];
 
-        if (legacy) {
+        if (!enableZoneActions) {
             return baseActions;
         }
 
@@ -230,7 +230,7 @@ function miboxerFut089zControls() {
                 const dynamicExposes = [];
 
                 // Add action expose with zone-aware actions
-                dynamicExposes.push(e.action(zoneActions(options.legacy_actions === true)));
+                dynamicExposes.push(e.action(zoneActions(options.zone_actions === true)));
 
                 // Add numeric sensors if enabled in options
                 if (options.expose_values === true) {

--- a/src/devices/miboxer.ts
+++ b/src/devices/miboxer.ts
@@ -1,5 +1,6 @@
 import * as fz from "../converters/fromZigbee";
 import * as exposes from "../lib/exposes";
+import * as m from "../lib/modernExtend";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend} from "../lib/types";
 
@@ -33,6 +34,9 @@ export const definitions: DefinitionWithExtend[] = [
             e.battery(),
             e.battery_voltage(),
             e.action(["on", "off", "brightness_move_to_level", "color_temperature_move", "move_to_hue_and_saturation", "tuya_switch_scene"]),
+        ],
+        extend: [
+            m.quirkCheckinInterval(21600), // Device observed to report every 4h, set to 6h (21600s) for safety margin
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/miboxer.ts
+++ b/src/devices/miboxer.ts
@@ -2,9 +2,57 @@ import * as fz from "../converters/fromZigbee";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {Definition, DefinitionWithExtend, Zh} from "../lib/types";
 
 const e = exposes.presets;
+
+// ModernExtend function for FUT089Z remote control (basic functionality)
+function miboxerFut089zControls() {
+    const fromZigbee = [
+        fz.battery,
+        fz.command_on,
+        fz.command_off,
+        fz.command_move_to_level,
+        fz.command_move_to_color_temp,
+        fz.command_move_to_hue_and_saturation,
+        fz.tuya_switch_scene,
+    ];
+
+    const exposesList = [
+        e.battery(),
+        e.battery_voltage(),
+        e.action(["on", "off", "brightness_move_to_level", "color_temperature_move", "move_to_hue_and_saturation", "tuya_switch_scene"]),
+    ];
+
+    return {
+        fromZigbee,
+        exposes: exposesList,
+        isModernExtend: true as true,
+        configure: [
+            async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint, definition: Definition) => {
+                const endpoint = device.getEndpoint(1);
+                if (!endpoint) {
+                    throw new Error("Endpoint 1 not found on device");
+                }
+
+                await tuya.configureMagicPacket(device, coordinatorEndpoint);
+                await endpoint.command("genGroups", "miboxerSetZones", {
+                    zones: [
+                        {zoneNum: 1, groupId: 101},
+                        {zoneNum: 2, groupId: 102},
+                        {zoneNum: 3, groupId: 103},
+                        {zoneNum: 4, groupId: 104},
+                        {zoneNum: 5, groupId: 105},
+                        {zoneNum: 6, groupId: 106},
+                        {zoneNum: 7, groupId: 107},
+                        {zoneNum: 8, groupId: 108},
+                    ],
+                });
+                await endpoint.command("genBasic", "tuyaSetup", {}, {disableDefaultResponse: true});
+            },
+        ],
+    };
+}
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -19,41 +67,10 @@ export const definitions: DefinitionWithExtend[] = [
         model: "FUT089Z",
         vendor: "MiBoxer",
         description: "RGB+CCT Remote",
-        fromZigbee: [
-            fz.battery,
-            fz.command_on,
-            fz.command_off,
-            fz.command_move_to_level,
-            fz.command_move_to_color_temp,
-            fz.command_move_to_hue_and_saturation,
-            fz.tuya_switch_scene,
-        ],
-        toZigbee: [],
         whiteLabel: [tuya.whitelabel("Ledron", "YK-16", "RGB+CCT Remote", ["_TZ3000_zwszqdpy"])],
-        exposes: [
-            e.battery(),
-            e.battery_voltage(),
-            e.action(["on", "off", "brightness_move_to_level", "color_temperature_move", "move_to_hue_and_saturation", "tuya_switch_scene"]),
-        ],
         extend: [
+            miboxerFut089zControls(),
             m.quirkCheckinInterval(21600), // Device observed to report every 4h, set to 6h (21600s) for safety margin
         ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            await endpoint.command("genGroups", "miboxerSetZones", {
-                zones: [
-                    {zoneNum: 1, groupId: 101},
-                    {zoneNum: 2, groupId: 102},
-                    {zoneNum: 3, groupId: 103},
-                    {zoneNum: 4, groupId: 104},
-                    {zoneNum: 5, groupId: 105},
-                    {zoneNum: 6, groupId: 106},
-                    {zoneNum: 7, groupId: 107},
-                    {zoneNum: 8, groupId: 108},
-                ],
-            });
-            await endpoint.command("genBasic", "tuyaSetup", {}, {disableDefaultResponse: true});
-        },
     },
 ];

--- a/src/devices/miboxer.ts
+++ b/src/devices/miboxer.ts
@@ -2,13 +2,51 @@ import * as fz from "../converters/fromZigbee";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as tuya from "../lib/tuya";
-import type {Definition, DefinitionWithExtend, Zh} from "../lib/types";
+import type {Definition, DefinitionExposesFunction, DefinitionWithExtend, Fz, Zh} from "../lib/types";
 
 const e = exposes.presets;
 
+// Create converters that extract action properties to numeric sensors
+const actionPropertyConverters = {
+    hue_saturation: {
+        cluster: "lightingColorCtrl",
+        type: "commandMoveToHueAndSaturation",
+        convert: (model, msg, publish, options, meta) => {
+            if (!options?.expose_values) return undefined;
+            return {
+                hue: msg.data?.hue,
+                saturation: msg.data?.saturation,
+            };
+        },
+    } as Fz.Converter<"lightingColorCtrl", undefined, "commandMoveToHueAndSaturation">,
+
+    color_temp: {
+        cluster: "lightingColorCtrl",
+        type: "commandMoveToColorTemp",
+        convert: (model, msg, publish, options, meta) => {
+            if (!options?.expose_values) return undefined;
+            return {
+                color_temperature: msg.data?.colortemp,
+            };
+        },
+    } as Fz.Converter<"lightingColorCtrl", undefined, "commandMoveToColorTemp">,
+
+    level: {
+        cluster: "genLevelCtrl",
+        type: ["commandMoveToLevel", "commandMoveToLevelWithOnOff"],
+        convert: (model, msg, publish, options, meta) => {
+            if (!options?.expose_values) return undefined;
+            return {
+                level: msg.data?.level,
+            };
+        },
+    } as Fz.Converter<"genLevelCtrl", undefined, ["commandMoveToLevel", "commandMoveToLevelWithOnOff"]>,
+};
+
 // ModernExtend function for FUT089Z remote control (basic functionality)
 function miboxerFut089zControls() {
-    const fromZigbee = [
+    // biome-ignore lint/suspicious/noExplicitAny: Fz.ConverterTypeStringOrArray is not exported
+    const fromZigbee: Fz.Converter<string, undefined, any>[] = [
         fz.battery,
         fz.command_on,
         fz.command_off,
@@ -16,17 +54,65 @@ function miboxerFut089zControls() {
         fz.command_move_to_color_temp,
         fz.command_move_to_hue_and_saturation,
         fz.tuya_switch_scene,
+        // Add converters for numeric sensors (always included, but they check options internally)
+        actionPropertyConverters.hue_saturation,
+        actionPropertyConverters.color_temp,
+        actionPropertyConverters.level,
     ];
 
-    const exposesList = [
-        e.battery(),
-        e.battery_voltage(),
-        e.action(["on", "off", "brightness_move_to_level", "color_temperature_move", "move_to_hue_and_saturation", "tuya_switch_scene"]),
+    // Device exposes (battery info and action)
+    const exposesList = [e.battery(), e.battery_voltage()];
+
+    // Device options for numeric sensors
+    const deviceOptions = [
+        new exposes.Binary("expose_values", exposes.access.SET, true, false).withDescription(
+            "Expose additional numeric values for action properties (hue, saturation, level, etc.)",
+        ),
     ];
 
     return {
         fromZigbee,
-        exposes: exposesList,
+        exposes: [
+            ...exposesList,
+            ((device, options = {}) => {
+                const dynamicExposes = [];
+
+                // Add action expose
+                dynamicExposes.push(
+                    e.action(["on", "off", "brightness_move_to_level", "color_temperature_move", "move_to_hue_and_saturation", "tuya_switch_scene"]),
+                );
+
+                // Add numeric sensors if enabled in options
+                if (options.expose_values === true) {
+                    dynamicExposes.push(
+                        exposes
+                            .numeric("hue", exposes.access.STATE_GET)
+                            .withDescription("Hue value from last action")
+                            .withValueMin(0)
+                            .withValueMax(254),
+                        exposes
+                            .numeric("saturation", exposes.access.STATE_GET)
+                            .withDescription("Saturation value from last action")
+                            .withValueMin(0)
+                            .withValueMax(254),
+                        exposes
+                            .numeric("color_temperature", exposes.access.STATE_GET)
+                            .withDescription("Color temperature value from last action")
+                            .withUnit("mired")
+                            .withValueMin(153)
+                            .withValueMax(500),
+                        exposes
+                            .numeric("level", exposes.access.STATE_GET)
+                            .withDescription("Level value from last action")
+                            .withValueMin(0)
+                            .withValueMax(254),
+                    );
+                }
+
+                return dynamicExposes;
+            }) as DefinitionExposesFunction,
+        ],
+        options: deviceOptions,
         isModernExtend: true as true,
         configure: [
             async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint, definition: Definition) => {


### PR DESCRIPTION
I got one of these remotes recently, and while there has already been a lot of awesome work by others to get it supported in Zigbee2MQTT, it still took me a while to collect all the bits and pieces to get everything running to my satisfaction. Here's what I came up with - I believe that this will ease setting this up also for others, and I hope that you consider at least parts of this worthy to be added - lmk what you think. 

Since this device is available for several year now and probably actively used in many installations, I decided to implement everything as user-configurable additions which should not break existing installations.

### Summary
This PR improves the MiBoxer FUT089Z converter and fixes several open issues and limitations:
- Implement features of the user extension directly in the converter (fixes https://github.com/Koenkk/zigbee2mqtt-user-extensions/issues/7, https://github.com/Koenkk/zigbee2mqtt-user-extensions/issues/14 and https://github.com/Koenkk/zigbee-herdsman-converters/issues/8926)
- Proper numeric exposes for all target values, including hue and saturation (previously not supported in user extension, see  https://www.zigbee2mqtt.io/devices/FUT089Z.html)
- Enable support for multiple FUT089Z remotes on the same network (fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/6274)
- Fix ability to send messages to the device (fixes a quirk mentioned in the documentation https://www.zigbee2mqtt.io/devices/FUT089Z.html)

### Features & fixes in detail

**Implement features from the user extension in the converter**

Previously, the device required installation of a user addon (https://github.com/Koenkk/zigbee2mqtt-user-extensions/tree/main/unstable/miboxer-fut089z) for some functionalities. That user extension is not working with recent Zigbee2MQTT versions (https://github.com/Koenkk/zigbee2mqtt-user-extensions/issues/7 and https://github.com/Koenkk/zigbee2mqtt-user-extensions/issues/14). This PR implements the functionalities of the user addon directly in the converter as user-configurable options, not changing the default behavior. This removes the need to install an additional addon, and basically resolves the issues. It should also resolve https://github.com/Koenkk/zigbee-herdsman-converters/issues/8926, because the features should also work out-of-the-box with other white-label devices.

* Publish zone-specific actions: The FUT089Z has 8 on/off button pairs. All buttons are using the same endpoint ID, unlike other remote controls, which commonly use one endpoint per button pair. Therefore the converter publishes the same actions for each button, e.g. `on`, `off`, etc.. While in principle it is possible to distiguish buttons via group IDs, this is very unusual to do and differs from other similar devices. With the zone-specific actions enabled, the converter appends a suffix to each action (`_zone_1` to `_zone_8`, where "zone" is the term that is used in the user manual of the remote control), thus mimicking the behavior of other devices with different endpoints per button pair more closely. 
* Additionally, the numeric values of the action properties (hue, saturation, level, etc.) can be exposed separately by enabling "expose values". This makes the last values more easily accessible e.g. in Home Assistant for automations. 

**Enable use of multiple FUT089Z devices**
During configuration, each `zone` (on/off button) is assigned to a Zigbee group (101-108). These groups are fixes, so if multiple FUT089Z devices are on the same network, they all control the same groups and devices. 
This PR introduces configuration options (and the corresponding functionality) which let the user define a different group for any button. This fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/6274

**Fix ability to send messages to the device**
As with most battery-powered device, this remote has its Rx turned off most of the time and is only able to receive commands after it sent a command itself (e.g. after a button press). Therefore messages to the device must be queued long enough. This is ensured by the `quirkCheckinInterval(21600)` (i.e. wait for up to 6 hours until the device checks in again - the observed reporting interval of this device is 4 hours). This change is required to reliably modify the device configuration after initial configuration, e.g. to change group IDs. 

### What's still not working
The remote seems to decide internally whether it wants to send a hue/saturation change or a color temperature request. Most of the times (e.g. after pressing one of the on/off buttons), it sends hue/saturation. After the 'W' button is pressed, it sends color temperature. I have not found a way yet to force the remote to a fixed behavior for each zone.

### Next steps
- Update documentation
- ...