### PR TITLE
Improved converter for Mureva EVlink Smart socket outlet

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1658,7 +1658,15 @@ export const definitions: DefinitionWithExtend[] = [
         model: "MUR36014",
         vendor: "Schneider Electric",
         description: "Mureva EVlink Smart socket outlet",
-        extend: [m.onOff({powerOnBehavior: true}), m.electricityMeter()],
+        extend: [
+            m.onOff(),
+            m.electricityMeter({
+                // Unit supports acVoltage and acCurrent, but only acCurrent divisor/multiplier can be read
+                voltage: {multiplier: 1, divisor: 1},
+                // power is provided by 'seMetering' instead of "haElectricalMeasurement"
+                power: {cluster: "metering"},
+            }),
+        ],
     },
     {
         zigbeeModel: ["NHMOTION/SWITCH/1"],


### PR DESCRIPTION
This pull request hopefully solves all issues reported for the MUR36014 (aka Mureva EVlink) in https://github.com/Koenkk/zigbee2mqtt/issues/21457 and https://github.com/Koenkk/zigbee2mqtt/issues/28179 

The problems were caused by the missing attributes `acVoltageMultiplier` and `acVoltageDivisor`  in `haElectricalMeasurement` and by the fact that the power must be obtained from `clusterseMetering` instead of the default cluster `haElectricalMeasurement`.

As a side note, I noticed that converters for other Schneider sockets seem to implement the same behavior using different apis. They may actually all be identical:

https://github.com/Koenkk/zigbee-herdsman-converters/blob/46095f230fe9043de4c2cf43b85643cfdfe07780/src/devices/schneider_electric.ts#L1582
https://github.com/Koenkk/zigbee-herdsman-converters/blob/46095f230fe9043de4c2cf43b85643cfdfe07780/src/devices/schneider_electric.ts#L1607
https://github.com/Koenkk/zigbee-herdsman-converters/blob/46095f230fe9043de4c2cf43b85643cfdfe07780/src/devices/schneider_electric.ts#L1632
