### PR TITLE
Bosch Door/Window Contact II: Overwork devices to match official features

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1695,7 +1695,7 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "genPollCtrl",
                 clusterType: "input",
             }),
-            boschBsenExtend.customDoorWindowContactCluster(),
+            boschBsenExtend.doorWindowContactCluster(),
             boschBsenExtend.breakFunction(),
         ],
         configure: async (device, coordinatorEndpoint) => {
@@ -1711,7 +1711,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Bosch",
         description: "Door/window contact II plus",
         extend: [
-            boschExtend.doorWindowContact(true),
+            boschExtend.doorWindowContact(false),
             m.battery({
                 percentage: true,
                 lowStatus: true,
@@ -1720,7 +1720,8 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "genPollCtrl",
                 clusterType: "input",
             }),
-            boschBsenExtend.customDoorWindowContactCluster(),
+            boschBsenExtend.doorWindowContactCluster(),
+            boschBsenExtend.vibrationDetection(),
             boschBsenExtend.breakFunction(),
         ],
         configure: async (device, coordinatorEndpoint) => {
@@ -1744,7 +1745,7 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "genPollCtrl",
                 clusterType: "input",
             }),
-            boschBsenExtend.customDoorWindowContactCluster(),
+            boschBsenExtend.doorWindowContactCluster(),
             boschBsenExtend.breakFunction(),
         ],
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1683,7 +1683,6 @@ export const definitions: DefinitionWithExtend[] = [
             boschDoorWindowContactExtend.breakFunctionality(),
             boschDoorWindowContactExtend.battery(),
         ],
-        ota: true,
     },
     {
         zigbeeModel: ["RBSH-MMD-ZB-EU"],

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1695,6 +1695,8 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "genPollCtrl",
                 clusterType: "input",
             }),
+            boschBsenExtend.customDoorWindowContactCluster(),
+            boschBsenExtend.breakFunction(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
@@ -1718,6 +1720,8 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "genPollCtrl",
                 clusterType: "input",
             }),
+            boschBsenExtend.customDoorWindowContactCluster(),
+            boschBsenExtend.breakFunction(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
@@ -1740,6 +1744,8 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "genPollCtrl",
                 clusterType: "input",
             }),
+            boschBsenExtend.customDoorWindowContactCluster(),
+            boschBsenExtend.breakFunction(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1681,7 +1681,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["RBSH-SWD-ZB", "RBSH-SWD2-ZB"],
+        zigbeeModel: ["RBSH-SWD-ZB"],
         model: "BSEN-C2",
         vendor: "Bosch",
         description: "Door/window contact II",
@@ -1710,6 +1710,28 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Door/window contact II plus",
         extend: [
             boschExtend.doorWindowContact(true),
+            m.battery({
+                percentage: true,
+                lowStatus: true,
+            }),
+            m.bindCluster({
+                cluster: "genPollCtrl",
+                clusterType: "input",
+            }),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read("genPowerCfg", ["batteryPercentageRemaining"]);
+            await endpoint.read("ssIasZone", ["zoneStatus"]);
+        },
+    },
+    {
+        zigbeeModel: ["RBSH-SWD2-ZB"],
+        model: "BSEN-C2D",
+        vendor: "Bosch",
+        description: "Door/window contact II [+M]",
+        extend: [
+            boschExtend.doorWindowContact(false),
             m.battery({
                 percentage: true,
                 lowStatus: true,

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1643,18 +1643,15 @@ export const boschDoorWindowContactExtend = {
     reportButtonActions: (args?: {doublePressSupported: boolean}): ModernExtend => {
         const {doublePressSupported} = args ?? {doublePressSupported: false};
 
-        const buttonActionsLookup = doublePressSupported
-            ? {
-                  double_press: 0x08,
-                  long_press: 0x02,
-                  single_press: 0x01,
-                  none: 0x00,
-              }
-            : {
-                  long_press: 0x02,
-                  single_press: 0x01,
-                  none: 0x00,
-              };
+        let buttonActionsLookup = {
+            long_press: 0x02,
+            single_press: 0x01,
+            none: 0x00,
+        };
+
+        if (doublePressSupported) {
+            buttonActionsLookup = {...{double_press: 0x08}, ...buttonActionsLookup};
+        }
 
         const exposes: Expose[] = [
             e

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1639,7 +1639,12 @@ export const boschDoorWindowContactExtend = {
             lowStatus: true,
             lowStatusReportingConfig: {min: "MIN", max: "MAX", change: 0},
         }),
-    reportContactState: () => m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1"]}),
+    reportContactState: () =>
+        m.iasZoneAlarm({
+            zoneType: "contact",
+            zoneAttributes: ["alarm_1"],
+            description: "Indicates whether the device detected an open or closed door/window",
+        }),
     reportButtonActions: (args?: {doublePressSupported: boolean}): ModernExtend => {
         const {doublePressSupported} = args ?? {doublePressSupported: false};
 
@@ -1656,7 +1661,7 @@ export const boschDoorWindowContactExtend = {
         const exposes: Expose[] = [
             e
                 .enum("action", ea.STATE, Object.keys(buttonActionsLookup))
-                .withDescription("Triggered action (e.g. a button click)")
+                .withDescription("Indicates button presses on the device")
                 .withCategory("diagnostic"),
         ];
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4173

This pull request overworks the support for the Bosch Door/Window Contacts II (`BSEN-C2`, `BSEN-CV` and `BSEN-C2D`).

Short overview of the changes:
- Implement support to enable/disable the break functionality
- Implement support to set the automatic break timeout from 1 to 15 minutes or disable it completely
- Implement support to see the current break functionality state
- Implement support to enable/disable the vibration sensor on the `BSEN-CV`
- Implement support to set the sensitivity for the vibration sensor on the `BSEN-CV`
- Implement value changes on `BSEN-CV` to match behavior of Bosch SHC II coordinator on interview
- Move `BSEN-C2D` to it's own device as it has a different firmware and needs totally different documentation due to Matter mode as default and no Zigbee QR code on the device
- Implement support for `double_press` action on the `BSEN-C2D` (not available on the `BSEN-C2` and `BSEN-CV`)
- Don't delete `none` as button state to make it easier to use on e.g., Home Assistant