### PR TITLE
Inovelli: reverting change that broke device configuration parsing

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -2216,12 +2216,12 @@ const fzLocal = {
                                 // biome-ignore lint/performance/noAccumulatingSpread: ignored using `--suppress`
                                 ...p,
                                 [key]: Object.keys(attributes[key].values).find(
-                                    (k) => attributes[key].values[k] === msg.data[Number.parseInt(c, 10)],
+                                    (k) => attributes[key].values[k] === msg.data[c],
                                 ),
                             };
                         }
                         // biome-ignore lint/performance/noAccumulatingSpread: ignored using `--suppress`
-                        return {...p, [key]: msg.data[Number.parseInt(c, 10)]};
+                        return {...p, [key]: msg.data[c]};
                     }, {});
                 }
                 return msg.data;


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->

@Nerivec

We noticed that the some changes in this commit: #9867

Caused some problems with the configuration value parsing for our devices. Not sure if the best solution is to change it back or if you think something else is more appropriate. 
