### PR TITLE
Inovelli: fix parsing of custom cluster attribute - fix parsing of 0xFF values of custom cluster

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -2211,7 +2211,6 @@ const fzLocal = {
                 if (msg.type === "readResponse") {
                     return Object.keys(msg.data).reduce((p, c) => {
                         const key = splitValuesByEndpoint ? `${c}_${msg.endpoint.ID}` : c;
-                        const obj = typeof msg.data === "string" ? JSON.parse(msg.data) : msg.data;
                         const raw = (msg.data as Record<string | number, unknown>)[c];
                         if (attributes[key] && attributes[key].displayType === "enum") {
                             return {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
This PR covers two issues. The first is @Nerivec

We noticed that the some changes in this commit: https://github.com/Koenkk/zigbee-herdsman-converters/pull/9867

msg.data[c] changed to msg.data[Number.parseInt(c, 10)]

Caused some problems with the configuration value parsing for our devices.

The second is when the value of the attribute of an UINT8 is 255, it seems to reach the converter as NaN (or null?). There is a workaround in this PR for that issue as well, but I think this issue is new and am curious what might have caused it. 

[2025-09-22 12:08:06] debug:    zh:zstack:znp: <-- AREQ: AF - incomingMsg - {"groupid":0,"clusterid":64561,"srcaddr":27383,"srcendpoint":1,"dstendpoint":1,"wasbroadcast":0,"linkquality":116,"securityuse":0,"timestamp":5253037,"transseqnumber":0,"len":10,"data":{"type":"Buffer","data":[28,47,18,11,1,14,0,0,32,**255**]}}
[2025-09-22 12:08:06] debug:    zh:controller: Received payload: clusterID=64561, address=27383, groupID=0, endpoint=1, destinationEndpoint=1, wasBroadcast=false, linkQuality=116, frame={"header":{"frameControl":{"frameType":0,"manufacturerSpecific":true,"direction":1,"disableDefaultResponse":true,"reservedBits":0},"manufacturerCode":4655,"transactionSequenceNumber":11,"commandIdentifier":1},"payload":[{"attrId":14,"status":0,"dataType":32,**"attrData":null**}],"command":{"ID":1,"name":"readRsp","parameters":[{"name":"attrId","type":33},{"name":"status","type":32},{"name":"dataType","type":32,"conditions":[{"type":"fieldEquals","field":"status","value":0}]},{"name":"attrData","type":1000,"conditions":[{"type":"fieldEquals","field":"status","value":0}]}]}}
[2025-09-22 12:08:06] debug:    zh:zstack:unpi:parser: --- parseNext []
[2025-09-22 12:08:06] debug:    z2m: Received Zigbee message from '0x94deb8fffef4cf5e', type 'readResponse', cluster 'manuSpecificInovelli', data '{**"defaultLevelRemote":null**}' from endpoint 1 with groupID 0