### PR TITLE
MUR36014: Add control for the led indicator

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -77,6 +77,19 @@ function socketIndicatorMode() {
     });
 }
 
+function evlinkIndicatorMode() {
+    return m.enumLookup({
+        name: "indicator_mode",
+        lookup: {
+            default: 1,
+            temporary: 5,
+        },
+        cluster: "manuSpecificSchneiderFanSwitchConfiguration",
+        attribute: "ledIndication",
+        description: "Set indicator mode",
+    });
+}
+
 function fanIndicatorMode() {
     const description = "Set Indicator Mode.";
     return m.enumLookup({
@@ -1658,6 +1671,7 @@ export const definitions: DefinitionWithExtend[] = [
                 // power is provided by 'seMetering' instead of "haElectricalMeasurement"
                 power: {cluster: "metering"},
             }),
+            evlinkIndicatorMode(),
         ],
     },
     {


### PR DESCRIPTION
Add control of the led indicator for the MUR36014 (a.k.a Schneider Electrics Mureva Evlink Socket).

By default, the led is pulsating while charging, green while powered but not charging, and off while not powered. The temporary mode is similar but only during the next 10 seconds after any change of state.
