### PR TITLE
Add Hue Festivia globe outdoor string lights (LCX029, 929004581801)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -13,6 +13,13 @@ const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
+        zigbeeModel: ["LCX029"],
+        model: "929004581801",
+        vendor: "Philips",
+        description: "Hue Festivia globe outdoor string lights",
+        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+    },
+    {
         zigbeeModel: ["LCX030"],
         model: "929004284702",
         vendor: "Philips",


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4183

:smiley: 