### PR TITLE
fix: correctly handle ubisys device setup

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -624,37 +624,6 @@ const ubisys = {
                         );
                     }
                 }
-
-                // re-read effective settings and dump them to the log
-                await ubisys.tz.configure_device_setup.convertGet(entity, key, meta);
-            },
-
-            convertGet: async (entity, key, meta) => {
-                const cluster = Zcl.Utils.getCluster("manuSpecificUbisysDeviceSetup", null, meta.device.customClusters);
-
-                const devMgmtEp = meta.device.getEndpoint(232);
-                await devMgmtEp.zclCommand(
-                    "manuSpecificUbisysDeviceSetup",
-                    "readStructured",
-                    [
-                        {
-                            attrId: cluster.getAttribute("inputConfigurations").ID,
-                            selector: {}, // i.e. "whole"
-                        },
-                    ],
-                    manufacturerOptions.ubisysNull,
-                );
-                await devMgmtEp.zclCommand(
-                    "manuSpecificUbisysDeviceSetup",
-                    "readStructured",
-                    [
-                        {
-                            attrId: cluster.getAttribute("inputActions").ID,
-                            selector: {}, // i.e. "whole"
-                        },
-                    ],
-                    manufacturerOptions.ubisysNull,
-                );
             },
         } satisfies Tz.Converter,
     },


### PR DESCRIPTION
Our implementation was working by accident, this is now corrected and we can write larger payloads. This is done in the format Ubisys expects, however I did remove the old fallback code. It's complicated as, people should really update the firmware if they are running such and old version.

There are so many fw bug fixes missing if they don't, I think it's OK to remove this. There is now a warning logged telling people to upgrade.
