### PR TITLE
Add support for _TZE284_3urschql (GX06)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2585,7 +2585,14 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_aao3yzhs", "_TZE284_nhgdf6qr", "_TZE284_ap9owrsa", "_TZE284_33bwcga2", "_TZE284_wckqztdq", "_TZE284_3urschql"]),
+        fingerprint: tuya.fingerprint("TS0601", [
+            "_TZE284_aao3yzhs",
+            "_TZE284_nhgdf6qr",
+            "_TZE284_ap9owrsa",
+            "_TZE284_33bwcga2",
+            "_TZE284_wckqztdq",
+            "_TZE284_3urschql",
+        ]),
         model: "TS0601_soil_3",
         vendor: "Tuya",
         description: "Soil sensor",
@@ -2604,7 +2611,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
         whiteLabel: [
             tuya.whitelabel("GIEX", "GX04", "Soil Moisture Sensor", ["_TZE284_nhgdf6qr"]),
-            tuya.whitelabel("GIEX", "GX06", "Soil Moisture Sensor", ["_TZE284_3urschql"])
+            tuya.whitelabel("GIEX", "GX06", "Soil Moisture Sensor", ["_TZE284_3urschql"]),
         ],
     },
     {


### PR DESCRIPTION
This PR adds support for a new device:

- Model: GX06
- Manufacturer: _TZE284_3urschql
- Description: Same functionality as existing device, only the physical appearance is different.

No additional converters were required, it reuses the same logic as the existing model.

Thanks
