### PR TITLE
Add support for power and energy metering on Namron 4512760 dimmer

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -143,7 +143,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Namron",
         description: "Zigbee dimmer 400W",
         ota: true,
-        extend: [m.light({configureReporting: true})],
+        extend: [m.light({configureReporting: true}), m.electricityMeter({voltage: false, current: false})],
     },
     {
         zigbeeModel: ["4512708"],


### PR DESCRIPTION
Hi,

Thanks for an excellent piece of software.

The Namron 451<area>2760 'Zigbee dimmer 400W' (which is a rebadge of the Sunricher SR-ZG9040A) supports metering, but this isn't currently exposed through Z2M.  I have quite a few of these dimmers and the metering was working ok in Homey, so when I switched to HA I missed that and wanted to get it working.  This was pretty straightforward as you can see from the diff, but there are a couple of caveats:

- The metering is on the output from the chopper so if you are expecting to see line voltage then you get 'strange' voltage readings.  I chose to disable voltage and current reporting because of this, but it does work.
- Pushing this change without reconfiguring the affected devices will badly screw up the energy statistics as the divisors for all the electrical attributes won't be picked up.  Or at least that was the case for me using an external converter.  I don't know how you normally deal with this kind of problem?
