### PR TITLE
fix(detect): Detect _TZ3000_kfu8zapd as Moes XH-SY-04Z

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3939,7 +3939,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Tuya", "TS0044_1", "Zigbee 4 button remote - 12 scene", ["_TZ3000_dziaict4", "_TZ3000_mh9px7cq", "_TZ3000_j61x9rxn"]),
             tuya.whitelabel("Tuya", "TM-YKQ004", "Zigbee 4 button remote - 12 scene", ["_TZ3000_u3nv1jwk"]),
             tuya.whitelabel("HOBEIAN", "ZG-101ZS", "Star Ring 4 Gang Scene Switch", ["_TZ3000_bgtzm4ny"]),
-            tuya.whitelabel("Moes", "XH-SY-04Z", "4 button portable remote control", ["_TZ3000_zgyzgdua"]),
+            tuya.whitelabel("Moes", "XH-SY-04Z", "4 button portable remote control", ["_TZ3000_kfu8zapd"]),
             tuya.whitelabel("LoraTap", "SS6400ZB", "4 button portable remote control", ["_TZ3000_ee8nrt2l"]),
         ],
         fromZigbee: [tuya.fz.on_off_action, fz.battery],


### PR DESCRIPTION
Changed to correct model identifier

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
