### PR TITLE
Update awox.ts, add support for ERCU_WS_Zm

### DIFF
--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -293,4 +293,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.battery(), m.occupancy(), m.commandsOnOff(), m.commandsLevelCtrl()],
         whiteLabel: [{vendor: "EGLO", model: "99106"}],
     },
+    {
+        zigbeeModel: ['ERCU_WS_Zm'],
+        model: 'ERCU_WS_Zm',
+        vendor: 'AwoX',
+        description: 'Connect-Z magnetic wall mountable light RCU',
+        extend: [m.deviceEndpoints({"endpoints":{"1":1,"3":3}}), m.commandsOnOff(), m.commandsLevelCtrl(), m.commandsColorCtrl()],
+        meta: {"multiEndpoint":true},
+        whitelabel: [{vendor: "EGLO", model: "900116"}],
+    },
 ];

--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -294,12 +294,12 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [{vendor: "EGLO", model: "99106"}],
     },
     {
-        zigbeeModel: ['ERCU_WS_Zm'],
-        model: 'ERCU_WS_Zm',
-        vendor: 'AwoX',
-        description: 'Connect-Z magnetic wall mountable light RCU',
-        extend: [m.deviceEndpoints({"endpoints":{"1":1,"3":3}}), m.commandsOnOff(), m.commandsLevelCtrl(), m.commandsColorCtrl()],
-        meta: {"multiEndpoint":true},
+        zigbeeModel: ["ERCU_WS_Zm"],
+        model: "ERCU_WS_Zm",
+        vendor: "AwoX",
+        description: "Connect-Z magnetic wall mountable light RCU",
+        extend: [m.deviceEndpoints({endpoints: {"1": 1, "3": 3}}), m.commandsOnOff(), m.commandsLevelCtrl(), m.commandsColorCtrl()],
+        meta: {multiEndpoint: true},
         whitelabel: [{vendor: "EGLO", model: "900116"}],
     },
 ];

--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -300,6 +300,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Connect-Z magnetic wall mountable light RCU",
         extend: [m.deviceEndpoints({endpoints: {"1": 1, "3": 3}}), m.commandsOnOff(), m.commandsLevelCtrl(), m.commandsColorCtrl()],
         meta: {multiEndpoint: true},
-        whitelabel: [{vendor: "EGLO", model: "900116"}],
+        whiteLabel: [{vendor: "EGLO", model: "900116"}],
     },
 ];


### PR DESCRIPTION
EGLO / AwoX Connect-Z series RCU with wall mountable magnetic holder. Binding device clusters with this device doesn't produce any effect. Devices need to be in zigbee group with hard-coded ID 32776 to be manageable by this device. It uses one CR2032 battery. Next to the battery is one small plastic button for pairing which needs to be pressed once shortly. Firmware update is possible via bluetooth on Android device with help of vendor subdivision (AwoX) application.
<img width="512" height="512" alt="ERCU_WS_Zm" src="https://github.com/user-attachments/assets/587fbdd1-70b7-4eec-86a9-6f07a5c6d8a1" />
