### PR TITLE
add noTamperModel TYZB01_ttvdudvx

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2413,6 +2413,7 @@ export const definitions: DefinitionWithExtend[] = [
                 "_TZ3000_k4ej3ww2", // Aubess IH-K665
                 "_TZ3000_kstbkt6a", // Aubess IH-K665
                 "_TZ3000_upgcbody", // Zigbee water leak sensor
+                "_TYZB01_ttvdudvx", // Zigbee water leak sensor
             ];
             if (!device || !noTamperModels.includes(device.manufacturerName)) {
                 exps.push(e.tamper());


### PR DESCRIPTION
For the Tuya device with manufacturer name _TYZB01_ttvdudvx and model ID TS0207, the device does not have a tamper sensor. Therefore, an exception handling was necessary, and the model has been added accordingly.
