### PR TITLE
Add extra support for Scneider Electric S520619

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -2211,6 +2211,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withLocalTemperature()
                 .withSystemMode(["off", "heat", "cool"])
                 .withPiHeatingDemand(),
+                .withPiCoolingDemand(),
             e.temperature(),
             e.occupancy(),
         ],
@@ -2220,6 +2221,7 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint4 = device.getEndpoint(4);
             await reporting.bind(endpoint1, coordinatorEndpoint, ["hvacThermostat"]);
             await reporting.thermostatPIHeatingDemand(endpoint1);
+            await reporting.thermostatPICoolingDemand(endpoint1);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint1);
             await reporting.thermostatOccupiedCoolingSetpoint(endpoint1);
             await reporting.temperature(endpoint2);

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -2197,6 +2197,7 @@ export const definitions: DefinitionWithExtend[] = [
             tz.schneider_pilot_mode,
             tz.schneider_thermostat_keypad_lockout,
             tz.thermostat_temperature_display_mode,
+            tz.thermostat_running_state,
         ],
         exposes: [
             e.binary("keypad_lockout", ea.STATE_SET, "lock1", "unlock").withDescription("Enables/disables physical input on the device"),
@@ -2210,6 +2211,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withSetpoint("occupied_cooling_setpoint", 4, 30, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(["off", "heat", "cool"])
+                .withRunningState(["idle", "heat", "cool"])
                 .withPiHeatingDemand(),
                 .withPiCoolingDemand(),
             e.temperature(),

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -2212,7 +2212,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withLocalTemperature()
                 .withSystemMode(["off", "heat", "cool"])
                 .withRunningState(["idle", "heat", "cool"])
-                .withPiHeatingDemand(),
+                .withPiHeatingDemand()
                 .withPiCoolingDemand(),
             e.temperature(),
             e.occupancy(),

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -706,6 +706,18 @@ export class Climate extends Base {
         return this;
     }
 
+    withPiCoolingDemand(access = a.STATE) {
+        this.addFeature(
+            new Numeric("pi_cooling_demand", access)
+                .withLabel("PI cooling demand")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withUnit("%")
+                .withDescription("Position of the valve (= demanded cooling) where 0% is fully closed and 100% is fully open"),
+        );
+        return this;
+    }
+
     withControlSequenceOfOperation(modes: string[], access = a.STATE) {
         const allowed = [
             "cooling_only",


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
The Scneider Electric WWiser Odace Smart thermostat (with model S520619) supports cooling, which is not fully implemented in the converters.

The state as reported by Z2M:
```
{
    "keypad_lockout": "unlock",
    "last_seen": "2025-09-30T22:21:52+02:00",
    "linkquality": 80,
    "local_temperature": 18.16,
    "occupancy": true,
    "occupied_cooling_setpoint": 20,
    "occupied_heating_setpoint": 15,
    "pi_cooling_demand": 0,
    "pi_heating_demand": 0,
    "running_state": "idle",
    "schneider_pilot_mode": "contactor",
    "system_mode": "heat",
    "temperature_display_mode": "celsius",
    "temperature": null
}
```

As seen, `pi_cooling_demand` and `running_state` are reported. This code adds the functionality for reporting this info to the Z2M frontend.
Unfortunately, testing this fix wasn't possible since my `external_converters/converter.mjs` was ignored (maybe this is related to https://github.com/Koenkk/zigbee2mqtt/issues/28775).

Please let me know if I need to test this (and how I could test this).