### PR TITLE
Renamed the attribute 'sensor' for Aqara W500 to match lumiExternalSensor

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4930,8 +4930,8 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.humidity(),
             m.enumLookup({
-                name: "sensor_source",
-                lookup: {internal: 0, ntc: 2},
+                name: "sensor",
+                lookup: {internal: 0, external: 1, ntc: 2},
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0280, type: Zcl.DataType.UINT8},
                 description: "Temperature sensor source",


### PR DESCRIPTION
These changes ensure the attribute name doesn't change after the release.
I'll add support for using an external sensor in the future.