### PR TITLE
add manufacture TZ3000_tas0zemd for 2gang switch fingerprint

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4547,6 +4547,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_ruldv5dt",
             "_TZ3000_fbjdkph9",
             "_TZ3000_zbfya6h0",
+            "_TZ3000_tas0zemd",
         ]),
         model: "TS0002_basic",
         vendor: "Tuya",


### PR DESCRIPTION
The TZ3000_tas0zemd model supports only the on-off switch, but it provides extended backlight mode and other non-functional features, so we added it to the white model.