### PR TITLE
FIX: MINI-ZBRBS Wrong OPEN/CLOSE State

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2512,7 +2512,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee smart roller shutter switch",
         extend: [
             sonoffExtend.addCustomClusterEwelink(),
-            m.windowCovering({controls: ["lift"], coverInverted: true}),
+            m.windowCovering({controls: ["lift"], coverInverted: false}),
             m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "motor_travel_calibration_status",
                 lookup: {Uncalibrated: 0, Calibrated: 1},


### PR DESCRIPTION
Corrects the wrong OPEN/CLOSE state of the device, tested.

Issue: https://github.com/Koenkk/zigbee2mqtt/issues/28792

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.  

**Instructions:**
1. Create a fork by clicking [here](https://github.com/Koenkk/zigbee2mqtt.io/fork)
2. Go to the `public/images/devices` directory, *Add file* -> *Upload files*
  - Name the picture file exactly as the `model` of the device (e.g., `MODEL.png`)
3. Upload the files and press *Commit changes*
4. Press *Contribute* -> *Open pull request* -> update title/description -> *Create pull request*

**Make sure that:**
- The filename is `MODEL.png`
- The size is 512x512
- The background is transparent (use e.g. [Adobe remove background](https://new.express.adobe.com/tools/remove-background))

The line below can be removed if you are NOT adding support for a new device.
-->
