### PR TITLE
Bosch devices: Fix unset attributes in `expose` functions due to cluster rename

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1585,6 +1585,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             boschGeneralExtend.customSeMeteringCluster(),
             boschSmartPlugExtend.smartPlugCluster(),
+            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
             boschSmartPlugExtend.onOff(),
             boschGeneralExtend.autoOff(),
             boschSmartPlugExtend.electricityMeter(),
@@ -1620,6 +1621,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Door/window contact II",
         extend: [
             boschDoorWindowContactExtend.doorWindowContactCluster(),
+            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschDoorWindowContactCluster"),
             boschDoorWindowContactExtend.reportContactState(),
             boschDoorWindowContactExtend.reportButtonActions(),
             boschDoorWindowContactExtend.breakFunctionality(),
@@ -1634,6 +1636,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Door/window contact II plus",
         extend: [
             boschDoorWindowContactExtend.doorWindowContactCluster(),
+            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschDoorWindowContactCluster"),
             boschDoorWindowContactExtend.reportContactState(),
             boschDoorWindowContactExtend.reportButtonActions(),
             boschDoorWindowContactExtend.vibrationDetection(),
@@ -1648,6 +1651,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Door/window contact II [+M]",
         extend: [
             boschDoorWindowContactExtend.doorWindowContactCluster(),
+            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschDoorWindowContactCluster"),
             boschDoorWindowContactExtend.reportContactState(),
             boschDoorWindowContactExtend.reportButtonActions({doublePressSupported: true}),
             boschDoorWindowContactExtend.breakFunctionality(),
@@ -1675,6 +1679,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
+            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
             m.light({
                 configureReporting: true,
                 levelConfig: {features: ["on_level", "current_level_startup"]},
@@ -1718,6 +1723,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
+            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
             boschBmctExtend.rzDeviceModes({
                 deviceModesLookup: boschBmctRzSettings.deviceModes,
             }),
@@ -1821,6 +1827,7 @@ export const definitions: DefinitionWithExtend[] = [
                 },
                 commandsResponse: {},
             }),
+            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
             boschGeneralExtend.handleZclVersionReadRequest(),
             boschBmctExtend.slzExtends(),
             boschGeneralExtend.customSeMeteringCluster(),

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -1585,7 +1585,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             boschGeneralExtend.customSeMeteringCluster(),
             boschSmartPlugExtend.smartPlugCluster(),
-            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
+            boschGeneralExtend.handleRenamedCustomCluster("boschSpecific", "boschEnergyDevice"),
             boschSmartPlugExtend.onOff(),
             boschGeneralExtend.autoOff(),
             boschSmartPlugExtend.electricityMeter(),
@@ -1621,7 +1621,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Door/window contact II",
         extend: [
             boschDoorWindowContactExtend.doorWindowContactCluster(),
-            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschDoorWindowContactCluster"),
+            boschGeneralExtend.handleRenamedCustomCluster("boschSpecific", "boschDoorWindowContactCluster"),
             boschDoorWindowContactExtend.reportContactState(),
             boschDoorWindowContactExtend.reportButtonActions(),
             boschDoorWindowContactExtend.breakFunctionality(),
@@ -1636,7 +1636,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Door/window contact II plus",
         extend: [
             boschDoorWindowContactExtend.doorWindowContactCluster(),
-            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschDoorWindowContactCluster"),
+            boschGeneralExtend.handleRenamedCustomCluster("boschSpecific", "boschDoorWindowContactCluster"),
             boschDoorWindowContactExtend.reportContactState(),
             boschDoorWindowContactExtend.reportButtonActions(),
             boschDoorWindowContactExtend.vibrationDetection(),
@@ -1651,7 +1651,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Door/window contact II [+M]",
         extend: [
             boschDoorWindowContactExtend.doorWindowContactCluster(),
-            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschDoorWindowContactCluster"),
+            boschGeneralExtend.handleRenamedCustomCluster("boschSpecific", "boschDoorWindowContactCluster"),
             boschDoorWindowContactExtend.reportContactState(),
             boschDoorWindowContactExtend.reportButtonActions({doublePressSupported: true}),
             boschDoorWindowContactExtend.breakFunctionality(),
@@ -1679,7 +1679,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
-            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
+            boschGeneralExtend.handleRenamedCustomCluster("boschSpecific", "boschEnergyDevice"),
             m.light({
                 configureReporting: true,
                 levelConfig: {features: ["on_level", "current_level_startup"]},
@@ -1723,7 +1723,7 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
-            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
+            boschGeneralExtend.handleRenamedCustomCluster("boschSpecific", "boschEnergyDevice"),
             boschBmctExtend.rzDeviceModes({
                 deviceModesLookup: boschBmctRzSettings.deviceModes,
             }),
@@ -1827,7 +1827,7 @@ export const definitions: DefinitionWithExtend[] = [
                 },
                 commandsResponse: {},
             }),
-            boschGeneralExtend.handleRenamedCluster("boschSpecific", "boschEnergyDevice"),
+            boschGeneralExtend.handleRenamedCustomCluster("boschSpecific", "boschEnergyDevice"),
             boschGeneralExtend.handleZclVersionReadRequest(),
             boschBmctExtend.slzExtends(),
             boschGeneralExtend.customSeMeteringCluster(),

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -70,25 +70,16 @@ export const boschGeneralExtend = {
                         logger.debug(`Attempt to read all attributes for cluster ${newClusterName} from endpoint ${endpoint.ID}`, NS);
 
                         for (const attributeToRead in newClusterDefinition.attributes) {
-                            const attributeValueExistsInDatabase =
-                                endpoint.getClusterAttributeValue(newClusterName, newClusterDefinition.attributes[attributeToRead].ID) === undefined;
-                            if (attributeValueExistsInDatabase) {
-                                logger.debug(
-                                    `Attempt to read undefined attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID}`,
-                                    NS,
-                                );
+                            logger.debug(
+                                `Attempt to read attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID}`,
+                                NS,
+                            );
 
-                                try {
-                                    await endpoint.read(newClusterDefinition.ID, [newClusterDefinition.attributes[attributeToRead].ID]);
-                                } catch (exception) {
-                                    logger.debug(
-                                        `Error during read attempt for attribute ${attributeToRead}. Probably unsupported attribute on this device or endpoint. Skipping... ${exception}`,
-                                        NS,
-                                    );
-                                }
-                            } else {
+                            try {
+                                await endpoint.read(newClusterDefinition.ID, [newClusterDefinition.attributes[attributeToRead].ID]);
+                            } catch (exception) {
                                 logger.debug(
-                                    `Value for attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID} already in database. Skipping...`,
+                                    `Error during read attempt for attribute ${attributeToRead}. Probably unsupported attribute on this device or endpoint. Skipping... ${exception}`,
                                     NS,
                                 );
                             }

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -70,12 +70,18 @@ export const boschGeneralExtend = {
                         logger.debug(`Attempt to read all attributes for cluster ${newClusterName} from endpoint ${endpoint.ID}`, NS);
 
                         for (const attributeToRead in newClusterDefinition.attributes) {
-                            logger.debug(`Attempt to read attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID}`, NS);
+                            logger.debug(
+                                `Attempt to read attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID}`,
+                                NS,
+                            );
 
                             try {
                                 await endpoint.read(newClusterDefinition.ID, [newClusterDefinition.attributes[attributeToRead].ID]);
                             } catch (exception) {
-                                logger.debug(`Error during read attempt for attribute ${attributeToRead}. Probably unsupported attribute on this device or endpoint. Skipping... ${exception}`, NS);
+                                logger.debug(
+                                    `Error during read attempt for attribute ${attributeToRead}. Probably unsupported attribute on this device or endpoint. Skipping... ${exception}`,
+                                    NS,
+                                );
                             }
                         }
                     }

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -45,7 +45,7 @@ export const boschGeneralExtend = {
      * https://github.com/Koenkk/zigbee2mqtt/issues/28806. To prevent that
      * we have to make sure that all attributes of the renamed cluster are
      * available when using "getEndpoint().getClusterAttributeValue()". */
-    handleRenamedCluster: (oldClusterName: string, newClusterName: string): ModernExtend => {
+    handleRenamedCustomCluster: (oldClusterName: string, newClusterName: string): ModernExtend => {
         const onEvent: OnEvent.Handler[] = [
             async (event) => {
                 if (event.type !== "start") {

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -54,7 +54,7 @@ export const boschGeneralExtend = {
 
                 const device = event.data.device;
                 logger.debug(
-                    `Try to apply cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr}, current meta state: ${JSON.stringify(device.meta)}`,
+                    `Try to apply cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr}. Current meta state: ${JSON.stringify(device.meta)}`,
                     NS,
                 );
 
@@ -70,7 +70,7 @@ export const boschGeneralExtend = {
                             logger.debug(`Try to read ${attributeToRead} in ${newClusterName}`, NS);
                             await endpoint.read(clusterDefinition.ID, [clusterDefinition.attributes[attributeToRead].ID]);
                         } catch (exception) {
-                            logger.debug(`Error during read attempt on attribute ${attributeToRead}, skipping... ${exception}`, NS);
+                            logger.debug(`Error during read attempt on attribute ${attributeToRead}. Skipping... ${exception}`, NS);
                         }
                     }
 
@@ -85,7 +85,7 @@ export const boschGeneralExtend = {
                     );
                 } else {
                     logger.debug(
-                        `Cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr} already applied, skipping...`,
+                        `Cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr} already applied. Skipping...`,
                         NS,
                     );
                 }

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -44,8 +44,7 @@ export const boschGeneralExtend = {
      * originally used. This can lead to issues like those described in
      * https://github.com/Koenkk/zigbee2mqtt/issues/28806 . To prevent that
      * we have to make sure that all attributes of the renamed cluster are
-     * available when using "getClusterAttributeValue()" in the
-     * "exposes" function. */
+     * available when using "getEndpoint().getClusterAttributeValue()". */
     handleRenamedCluster: (oldClusterName: string, newClusterName: string): ModernExtend => {
         const onEvent: OnEvent.Handler[] = [
             async (event) => {

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -70,16 +70,25 @@ export const boschGeneralExtend = {
                         logger.debug(`Attempt to read all attributes for cluster ${newClusterName} from endpoint ${endpoint.ID}`, NS);
 
                         for (const attributeToRead in newClusterDefinition.attributes) {
-                            logger.debug(
-                                `Attempt to read attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID}`,
-                                NS,
-                            );
-
-                            try {
-                                await endpoint.read(newClusterDefinition.ID, [newClusterDefinition.attributes[attributeToRead].ID]);
-                            } catch (exception) {
+                            const attributeValueExistsInDatabase =
+                                endpoint.getClusterAttributeValue(newClusterName, newClusterDefinition.attributes[attributeToRead].ID) === undefined;
+                            if (attributeValueExistsInDatabase) {
                                 logger.debug(
-                                    `Error during read attempt for attribute ${attributeToRead}. Probably unsupported attribute on this device or endpoint. Skipping... ${exception}`,
+                                    `Attempt to read undefined attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID}`,
+                                    NS,
+                                );
+
+                                try {
+                                    await endpoint.read(newClusterDefinition.ID, [newClusterDefinition.attributes[attributeToRead].ID]);
+                                } catch (exception) {
+                                    logger.debug(
+                                        `Error during read attempt for attribute ${attributeToRead}. Probably unsupported attribute on this device or endpoint. Skipping... ${exception}`,
+                                        NS,
+                                    );
+                                }
+                            } else {
+                                logger.debug(
+                                    `Value for attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID} already in database. Skipping...`,
                                     NS,
                                 );
                             }

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -53,14 +53,13 @@ export const boschGeneralExtend = {
                 }
 
                 const device = event.data.device;
-                logger.debug(
-                    `Try to apply cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr}. Current meta state: ${JSON.stringify(device.meta)}`,
-                    NS,
-                );
 
                 const renameAlreadyApplied = device.meta.renamedClusters?.includes(oldClusterName);
                 if (!renameAlreadyApplied) {
-                    logger.debug("The cluster rename isn't applied yet. Read all available attributes once", NS);
+                    logger.debug(
+                        `Try to apply cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr}. Current meta state: ${JSON.stringify(device.meta)}`,
+                        NS,
+                    );
 
                     const newClusterDefinition = device.customClusters[newClusterName];
                     const endpointsWithNewCluster = device.endpoints.filter((endpoint) => endpoint.clusters[newClusterName] !== undefined);
@@ -103,11 +102,6 @@ export const boschGeneralExtend = {
                         device.meta.renamedClusters === undefined ? [oldClusterName] : [...device.meta.renamedClusters, oldClusterName];
                     logger.debug(
                         `Cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr} successfully applied. New meta state: ${JSON.stringify(device.meta)}`,
-                        NS,
-                    );
-                } else {
-                    logger.debug(
-                        `Cluster rename from ${oldClusterName} to ${newClusterName} for device ${device.ieeeAddr} already applied. Skipping...`,
                         NS,
                     );
                 }

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -71,8 +71,9 @@ export const boschGeneralExtend = {
 
                         for (const attributeToRead in newClusterDefinition.attributes) {
                             const attributeValueExistsInDatabase =
-                                endpoint.getClusterAttributeValue(newClusterName, newClusterDefinition.attributes[attributeToRead].ID) === undefined;
-                            if (attributeValueExistsInDatabase) {
+                                endpoint.getClusterAttributeValue(newClusterName, newClusterDefinition.attributes[attributeToRead].ID) !== undefined;
+
+                            if (!attributeValueExistsInDatabase) {
                                 logger.debug(
                                     `Attempt to read undefined attribute ${attributeToRead} in cluster ${newClusterName} from endpoint ${endpoint.ID}`,
                                     NS,

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -100,7 +100,7 @@ export const boschGeneralExtend = {
     handleZclVersionReadRequest: (): ModernExtend => {
         const onEvent: OnEvent.Handler[] = [
             (event) => {
-                if (event.type !== "start") {
+                if (event.type !== "deviceAnnounce") {
                     return;
                 }
 


### PR DESCRIPTION
Due to the rename of the custom cluster from `boschSpecific` to `boschEnergyDevice`, the devices in the BMCT line of Bosch didn't work correctly anymore. The reason is the use of cached cluster attributes from those custom clusters via `device.getEndpoint().getClusterAttributeValue()` in some `exposes` functions, which lead to important functions not being exposed.

My proposal for this issue would be this pull request, which reads all attributes in the renamed cluster once and calls `deviceExposesChanged()` to ensure all exposed functions are based on actual values in the renamed custom cluster. That way, I don't have to consider the cluster rename throughout the whole code base in the future.

This fix should only be necessary for the BMCT line of devices (all others don't use the `getClusterAttributeValue()` function), but as this issue will possibly lead to a hotfix release, I tend to be more conservative and apply it for the Bosch door/window contacts and the smart plug compact as well ([although there is a successful upgrade for a door/window contact being reported](github.com/Koenkk/zigbee-herdsman-converters/issues/8610)). The new BSP-FD isn't affected, as it used the new cluster name from the beginning.

I'm really sorry for this stupid error and the inconvenience it might bring!

This fixes https://github.com/Koenkk/zigbee2mqtt/issues/28806.