### PR TITLE
PJ-1203A: Revert change of the sign from positive to negative for produced energy value.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -257,9 +257,8 @@ const convLocal = {
             from: (v: number, meta: Fz.Meta, options: KeyValue) => {
                 const invertedEnergyFlowKey = `invert_energy_flow_${channel}`;
                 const result_key = options[invertedEnergyFlowKey] ? `energy_produced_${channel}` : `energy_${channel}`;
-                const energy_sign = options[invertedEnergyFlowKey] ? -1 : 1;
                 const result = {} as KeyValueAny;
-                result[result_key] = (v / 100) * energy_sign;
+                result[result_key] = v / 100;
 
                 return result;
             },
@@ -271,9 +270,8 @@ const convLocal = {
             from: (v: number, meta: Fz.Meta, options: KeyValue) => {
                 const invertedEnergyFlowKey = `invert_energy_flow_${channel}`;
                 const result_key = options[invertedEnergyFlowKey] ? `energy_${channel}` : `energy_produced_${channel}`;
-                const energy_sign = options[invertedEnergyFlowKey] ? 1 : -1;
                 const result = {} as KeyValueAny;
-                result[result_key] = (v / 100) * energy_sign;
+                result[result_key] = v / 100;
 
                 return result;
             },


### PR DESCRIPTION
Fix for the issues with Home Assistant energy statistics, reported in [9889](https://github.com/Koenkk/zigbee-herdsman-converters/pull/9889#issuecomment-3362539447)