### PR TITLE
fix(detect): Detect HT-THERMZ3W-1 as SR-ZG9092A

### DIFF
--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -1831,7 +1831,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["ZG9092", "HK-LN-HEATER-A", "ROB_200-040-0"],
+        zigbeeModel: ["ZG9092", "HK-LN-HEATER-A", "ROB_200-040-0", "HT-THERMZ3W-1"],
         model: "SR-ZG9092A",
         vendor: "Sunricher",
         description: "Touch thermostat",


### PR DESCRIPTION
This PR is an attempt to fix Koenkk/zigbee2mqtt#28661

I tested my device by manually changing record in `database.db` replacing modelId with `ZG9092` instead of `HT-THERMZ3W-1`, and that way i can normally use my device.