### PR TITLE
added LGT009 and LGT010 for Hue Play wall washer

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4229,7 +4229,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
-        zigbeeModel: ["LGT012", "046677590161", "046677590130"],
+        zigbeeModel: ["LGT009", "LGT010", "LGT012", "046677590161", "046677590130"],
         model: "046677590161",
         vendor: "Philips",
         description: "Hue Play wall washer",


### PR DESCRIPTION
Added support for two more Philips Hue Play wall washer models, namely LGT009 and LGT010.