### PR TITLE
Update Mec driver recognition

### DIFF
--- a/src/devices/ls.ts
+++ b/src/devices/ls.ts
@@ -31,9 +31,24 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["Mec Driver module"],
-        model: "7061427",
+        model: "756200026",
         vendor: "LS Deutschland GmbH",
-        description: "Mec Driver power supply platform",
+        description: "Mec Driver module 1-channel Zigbee (12V)",
+        whiteLabel: [{model: "756200027", vendor: "LS Deutschland GmbH", description: "Mec Driver module 1-channel Zigbee (24V)"}],
         extend: [m.light({colorTemp: {range: [153, 500]}})],
+    },
+    {
+        fingerprint: [
+            {modelID: "Mec Driver module", softwareBuildID: "3.12.25-026"},
+            {modelID: "Mec Driver module", softwareBuildID: "4.09.03-027"},
+        ],
+        model: "756200030",
+        vendor: "LS Deutschland GmbH",
+        description: "Mec Driver module 4-channel Zigbee (12V)",
+        whiteLabel: [{model: "756200031", vendor: "LS Deutschland GmbH", description: "Mec Driver module 4-channel Zigbee (24V)"}],
+        extend: [
+            m.deviceEndpoints({endpoints: {11: 11, 12: 12, 13: 13, 14: 14}}),
+            m.light({endpointNames: ["11", "12", "13", "14"], colorTemp: {range: [153, 500]}}),
+        ],
     },
 ];

--- a/src/devices/ls.ts
+++ b/src/devices/ls.ts
@@ -31,10 +31,10 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["Mec Driver module"],
-        model: "756200026",
+        model: "756200027",
         vendor: "LS Deutschland GmbH",
         description: "Mec Driver module 1-channel Zigbee (12V)",
-        whiteLabel: [{model: "756200027", vendor: "LS Deutschland GmbH", description: "Mec Driver module 1-channel Zigbee (24V)"}],
+        whiteLabel: [{model: "756200028", vendor: "LS Deutschland GmbH", description: "Mec Driver module 1-channel Zigbee (24V)"}],
         extend: [m.light({colorTemp: {range: [153, 500]}})],
     },
     {


### PR DESCRIPTION
Add 4-channels driver

As I do not have access to the modules, I use the softwareID to make a difference between the 1-channel and the 4-channel as it seems they share the same modelID... Maybe not the best option.

I also slightly modified the 1-channel description

From discussion
https://github.com/Koenkk/zigbee2mqtt/discussions/28840

and issue
https://github.com/Koenkk/zigbee2mqtt/issues/28852

https://www.ls-light.com/hubfs/LS_MEC_LITE_EN.pdf (page 22)
https://www.ls-light.com/hubfs/LS_DE_General-Catalog-en-2.pdf (page 192)

CC: @PantheraIgnis, @benzfreak