### PR TITLE
Fix Livolo TI0001-pir prevent disconnect payload

### DIFF
--- a/src/devices/livolo.ts
+++ b/src/devices/livolo.ts
@@ -187,7 +187,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.livolo_pir_state,
             fzLocal.prevent_disconnect({
                 dp: 0x01,
-                payload: {8194: {value: [0, 0, 0, 0, 0, 0, 0], type: 0x0e}},
+                payload: {8194: {value: 0n, type: 0x0e}},
             }),
         ],
         extend: [mLocal.poll()],


### PR DESCRIPTION
Getting the following error in my logs when trying to re-pair the Livolo TI0001-pir motion detector:

```
Cannot mix BigInt and other types, use explicit conversions
```

In https://github.com/Koenkk/zigbee-herdsman-converters/pull/9116 this was already fixed for the Livolo TI0001 switches, but the pir motion detector was forgotten.