### PR TITLE
Fix Livolo TI0001-illuminance reported unit

### DIFF
--- a/src/devices/livolo.ts
+++ b/src/devices/livolo.ts
@@ -216,7 +216,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Livolo",
         exposes: [
             e.noise_detected(),
-            e.illuminance().withUnit("%").withValueMin(0).withValueMax(100),
+            e.illuminance(),
             e.enum("noise_level", ea.STATE, ["silent", "normal", "lively", "noisy"]).withDescription("Detected noise level"),
         ],
         fromZigbee: [


### PR DESCRIPTION
Since a while, Home Assistant would give the following error with the Livolo TI0001-illuminance device:
```
ERROR (MainThread) [homeassistant.components.mqtt.entity] Error 'The unit of measurement `%` is not valid together with device class `illuminance`' when processing MQTT discovery message topic
```

This fixes that by removing the % unit from the illuminance sensor. The reported values are ofcourse still between 0 and 100% but I think that's where the "Illuminance calibration" value in the "Device Settings (specific)" can come in handy. That should allow you to convert the percentage value to a meaningful lux level. 