### PR TITLE
Change regulatorPercentage from MQTT for Namron Edge Thermostat

### DIFF
--- a/src/lib/namron.ts
+++ b/src/lib/namron.ts
@@ -210,7 +210,7 @@ export const edgeThermostat = {
         modernExtend.numeric({
             name: "regulator_percentage",
             cluster: "hvacThermostat",
-            attribute: {ID: 0x801d, type: Zcl.DataType.UINT8},
+            attribute: {ID: 0x801d, type: Zcl.DataType.INT16},
             description: "Regulator percentage",
             unit: "%",
             valueMax: 100,


### PR DESCRIPTION
Fixes the issue where the regulator_percentage attribute cannot be set via MQTT because it has the wrong data type.

I found the manual after I fiddled around with /set payload to guess what datatype it might be, where it actually says INT16S.
[4512783-84-Zigbee-User-Guide.pdf](https://github.com/user-attachments/files/22742831/4512783-84-Zigbee-User-Guide.pdf)
