### PR TITLE
Fix & improvements to FP300, FP1e addon

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4989,6 +4989,7 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.read("manuSpecificLumi", [0x019a], {manufacturerCode: manufacturerCode}); // Read detection range
         },
         extend: [
+            lumi.lumiModernExtend.lumiPreventLeave(),
             lumi.lumiModernExtend.lumiBattery({
                 voltageToPercentage: {min: 2850, max: 3000},
                 voltageAttribute: 0x0017, // Attribute: 23

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1808,9 +1808,9 @@ export const definitions: DefinitionWithExtend[] = [
             lumi.lumiModernExtend.fp1eSpatialLearning(),
             lumi.lumiModernExtend.fp1eRestartDevice(),
             m.identify(),
-            
+
             lumi.lumiModernExtend.fp1eAIInterference(),
-            lumi.lumiModernExtend.fp1eAdaptiveSensitivity()
+            lumi.lumiModernExtend.fp1eAdaptiveSensitivity(),
         ],
     },
     {
@@ -5009,7 +5009,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Presence detection sensor type",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            
+
             lumi.lumiModernExtend.fp1eAIInterference(),
             lumi.lumiModernExtend.fp1eAdaptiveSensitivity(),
 

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5007,6 +5007,28 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode},
             }),
 
+            m.binary({
+                name: "ai_interference_source_selfidentification",
+                valueOn: ["ON", 1],
+                valueOff: ["OFF", 0],
+                cluster: "manuSpecificLumi",
+                attribute: {ID: 0x015e, type: 0x20}, // Attribute: 350
+                description: "AI interference source self-identification switch (identifies interference sources such as fans and air conditioners)",
+                access: "ALL",
+                zigbeeCommandOptions: {manufacturerCode},
+            }),
+
+            m.binary({
+                name: "ai_sensitivity_adaptive",
+                valueOn: ["ON", 1],
+                valueOff: ["OFF", 0],
+                cluster: "manuSpecificLumi",
+                attribute: {ID: 0x015d, type: 0x20}, // Attribute: 349
+                description: "AI adaptive sensitivity",
+                access: "ALL",
+                zigbeeCommandOptions: {manufacturerCode},
+            }),
+
             m.numeric({
                 name: "absence_delay_timer",
                 valueMin: 10,

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1808,6 +1808,9 @@ export const definitions: DefinitionWithExtend[] = [
             lumi.lumiModernExtend.fp1eSpatialLearning(),
             lumi.lumiModernExtend.fp1eRestartDevice(),
             m.identify(),
+            
+            lumi.lumiModernExtend.fp1eAIInterference(),
+            lumi.lumiModernExtend.fp1eAdaptiveSensitivity()
         ],
     },
     {
@@ -5006,28 +5009,9 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Presence detection sensor type",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-
-            m.binary({
-                name: "ai_interference_source_selfidentification",
-                valueOn: ["ON", 1],
-                valueOff: ["OFF", 0],
-                cluster: "manuSpecificLumi",
-                attribute: {ID: 0x015e, type: 0x20}, // Attribute: 350
-                description: "AI interference source self-identification switch (identifies interference sources such as fans and air conditioners)",
-                access: "ALL",
-                zigbeeCommandOptions: {manufacturerCode},
-            }),
-
-            m.binary({
-                name: "ai_sensitivity_adaptive",
-                valueOn: ["ON", 1],
-                valueOff: ["OFF", 0],
-                cluster: "manuSpecificLumi",
-                attribute: {ID: 0x015d, type: 0x20}, // Attribute: 349
-                description: "AI adaptive sensitivity",
-                access: "ALL",
-                zigbeeCommandOptions: {manufacturerCode},
-            }),
+            
+            lumi.lumiModernExtend.fp1eAIInterference(),
+            lumi.lumiModernExtend.fp1eAdaptiveSensitivity(),
 
             m.numeric({
                 name: "absence_delay_timer",

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2556,7 +2556,7 @@ export const lumiModernExtend = {
             description: "Adaptive sensitivity switch function.",
             access: "ALL",
             zigbeeCommandOptions: {manufacturerCode},
-        };
+        });
     },
     fp1ePresence: () => {
         const attribute = {ID: 0x0142, type: 0x20};

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2532,6 +2532,32 @@ export const lumiModernExtend = {
             ],
         } satisfies ModernExtend;
     },
+    fp1eAIInterference: () => {
+        const attribute = {ID: 0x015e, type: 0x20}; // Attribute: 350
+        return m.binary({
+            name: "ai_interference_source_selfidentification",
+            valueOn: ["ON", 1],
+            valueOff: ["OFF", 0],
+            cluster: "manuSpecificLumi",
+            attribute: attribute,
+            description: "AI interference source self-identification switch, when enabled can identify fans, air conditioners and other interference sources",
+            access: "ALL",
+            zigbeeCommandOptions: {manufacturerCode},
+        });
+    },
+    fp1eAdaptiveSensitivity: () => {
+        const attribute = {ID: 0x015d, type: 0x20}; // Attribute: 349
+        return m.binary({
+            name: "ai_sensitivity_adaptive",
+            valueOn: ["ON", 1],
+            valueOff: ["OFF", 0],
+            cluster: "manuSpecificLumi",
+            attribute: attribute,
+            description: "Adaptive sensitivity switch function.",
+            access: "ALL",
+            zigbeeCommandOptions: {manufacturerCode},
+        };
+    },
     fp1ePresence: () => {
         const attribute = {ID: 0x0142, type: 0x20};
         return modernExtend.binary({

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2540,7 +2540,8 @@ export const lumiModernExtend = {
             valueOff: ["OFF", 0],
             cluster: "manuSpecificLumi",
             attribute: attribute,
-            description: "AI interference source self-identification switch, when enabled can identify fans, air conditioners and other interference sources",
+            description:
+                "AI interference source self-identification switch, when enabled can identify fans, air conditioners and other interference sources",
             access: "ALL",
             zigbeeCommandOptions: {manufacturerCode},
         });

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -345,6 +345,8 @@ export const numericAttributes2Payload = async (
                     // https://github.com/Koenkk/zigbee2mqtt/issues/12279
                 } else if (["RTCGQ15LM"].includes(model.model)) {
                     payload.occupancy = value;
+                } else if (["PS-S04D"].includes(model.model)) {
+                    payload.presence = value === 1;
                 } else if (["WSDCGQ01LM", "WSDCGQ11LM", "WSDCGQ12LM", "VOCKQJK11LM"].includes(model.model)) {
                     // https://github.com/Koenkk/zigbee2mqtt/issues/798
                     // Sometimes the sensor publishes non-realistic vales, filter these
@@ -427,7 +429,7 @@ export const numericAttributes2Payload = async (
                     assertNumber(value);
                     const battery = value / 2;
                     payload.battery = precisionRound(battery, 2);
-                } else if (["RTCZCGQ11LM", "PS-S04D"].includes(model.model)) {
+                } else if (["RTCZCGQ11LM"].includes(model.model)) {
                     payload.presence = getFromLookup(value, {0: false, 1: true, 255: null});
                 } else if (["ZNXDD01LM"].includes(model.model)) {
                     payload.brightness = value;


### PR DESCRIPTION
- Fixed FP300 fromZigbee presence detection (meant to use attribute 100 but mistakenly used 101)
- Added lumi prevent leave to FP300
- Added two remaining functions (adaptive sensitivity, AI environment learning) to FP300 and FP1e (attributes 349, 350)

Recreating due to stuck MR ( #10250 )