### PR TITLE
CK-BL702-AL-01_1: Enable "hs" color mode for the light definition.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2142,7 +2142,7 @@ export const definitions: DefinitionWithExtend[] = [
                 effect: true,
                 powerOnBehavior: true,
                 moveToLevelWithOnOffDisable: true,
-                color: {modes: ["xy"], enhancedHue: false},
+                color: {modes: ["hs", "xy"], enhancedHue: false},
             }),
         ],
         exposes: [tuya.exposes.doNotDisturb()],


### PR DESCRIPTION
Enable "hs" color mode for the light definition - [28500](https://github.com/Koenkk/zigbee2mqtt/issues/28500).