### PR TITLE
feat: add TS0601 window sensor (_TZE284_6teua268) with 3-state opening

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1858,6 +1858,39 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        // Tuya/Senoro window sensor variant with 3-state opening on DP101.
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6teua268"]),
+        model: "TS0601_window_TZE284_6teua268",
+        vendor: "Tuya/Senoro",
+        description: "Window sensor with 3-state opening (DP101), optional alarm, battery",
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "2000"})],
+        exposes: [
+            // DP101 → enum; device reports 0=open, 1=closed, 2=tilted (note swapped 0/1).
+            e.enum("opening_state", ea.STATE, ["open", "closed", "tilted"])
+                .withDescription("Opening state (Tuya DP101)"),
+            // Some firmware variants expose an alarm bit (commonly DP16).
+            e.binary("alarm", ea.STATE, true, false)
+                .withDescription("Alarm (Tuya DP16; some FW variants may differ)"),
+            e.battery(),
+        ],
+        meta: {
+            // Datapoints from logs:
+            //  - 101: 0=open, 1=closed, 2=tilted
+            //  - 16 : alarm (boolean) — optional by firmware
+            //  - 102: battery percentage (0..100)
+            tuyaDatapoints: [
+                [101, "opening_state", tuya.valueConverterBasic.lookup({open: 0, closed: 1, tilted: 2})],
+                // Alarm: some FW-Versions uses 10/13/16 (1=true, 0=false)
+                [10,  "alarm", tuya.valueConverter.trueFalse1_0],
+                [13,  "alarm", tuya.valueConverter.trueFalse1_0],
+                [16,  "alarm", tuya.valueConverter.trueFalse1_0],
+                // Battery: primary DP102; DP2 as fallback for other batches
+                [102, "battery", tuya.valueConverter.raw],
+                [2,   "battery", tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
         zigbeeModel: ["ZG-301Z"],
         fingerprint: [
             ...tuya.fingerprint("TS0001", [


### PR DESCRIPTION
Adds support for the Tuya/Senoro TS0601 window sensor (fingerprint `_TZE284_6teua268`).

### Summary
- Implements a converter block in `src/devices/tuya.ts` using modern Tuya EF00 handling.
- Exposes:
  - `opening_state` (enum: `open` / `closed` / `tilted`)
  - `alarm` (binary; optional, depends on FW)
  - `battery` (%)

### Datapoint mapping (from device logs)
- **DP101 → opening_state:** `0=open`, `1=closed`, `2=tilted`
- **DP102 → battery** (percentage, primary)
- **DP2   → battery** (fallback for other batches)
- **DP10 / DP13 / DP16 → alarm** (boolean; `1=true`, `0=false`, optional by firmware)

### Test evidence (short excerpts)
... raw_ef00 ... dp=101 datatype=4 data=[0] → open
... raw_ef00 ... dp=101 datatype=4 data=[1] → closed
... raw_ef00 ... dp=101 datatype=4 data=[2] → tilted
... raw_ef00 ... dp=102 datatype=2 data=[0,0,0,0] → battery report

### Environment
- Zigbee2MQTT: 2.6.2
- Home Assistant: MQTT discovery enabled
- Coordinator/adapter: standard Z2M setup

### Notes
- Multiple FW variants exist; `alarm` may appear on one of DP10/13/16 only.
- Keeping DP2 for battery to remain compatible with other TS0601 batches.

Closes #10246

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4255