### PR TITLE
Add support for the Zemismart KES-606US-L4 switch

### DIFF
--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -823,9 +823,9 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0004", ["_TZ3000_nsa76jai"]),
-        model: 'KES-606US-L4',
-        vendor: 'Zemismart',
-        description: 'Smart light switch - 4 gang (US)',
+        model: "KES-606US-L4",
+        vendor: "Zemismart",
+        description: "Smart light switch - 4 gang (US)",
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3, l4: 4}}),
             tuya.modernExtend.tuyaOnOff({


### PR DESCRIPTION
This adds support for the Zemismart 4 gang light switch:
- Fingerprint: TS0004, _TZ3000_nsa76jai

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4258

Fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/10267
