### PR TITLE
Restore behavior of using MoveToLevel when state is null

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1303,7 +1303,7 @@ export const light_onoff_brightness: Tz.Converter = {
         } else {
             await entity.command(
                 "genLevelCtrl",
-                "moveToLevelWithOnOff",
+                state === null ? "moveToLevel" : "moveToLevelWithOnOff",
                 {level: Number(brightness), transtime: transition.time},
                 utils.getOptions(meta.mapped, entity),
             );


### PR DESCRIPTION
The intended behavior is to allow the user to request MoveToLevel instead of MoveToLevelWithOnOff if they pass `"state": null` in the MQTT message. This was broken by https://github.com/Koenkk/zigbee-herdsman-converters/pull/9998, which only allowed MoveToLevel if the converter sets `moveToLevelWithOnOffDisable`.