### PR TITLE
Feature: Wi-Fi Configuration via Zigbee for Shelly Gen4 Devices

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1,5 +1,180 @@
+import {Zcl, ZSpec} from "zigbee-herdsman";
+import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {Configure, DefinitionWithExtend, Expose, Fz, KeyValue, ModernExtend, Tz} from "../lib/types";
+import {assertObject, determineEndpoint} from "../lib/utils";
+
+const e = exposes.presets;
+const ea = exposes.access;
+
+const SHELLY_ENDPOINT_ID = 239;
+const SHELLY_OPTIONS = {profileId: ZSpec.CUSTOM_SHELLY_PROFILE_ID};
+
+const shellyModernExtend = {
+    shellyCustomClusters(): ModernExtend[] {
+        return [
+            m.deviceAddCustomCluster("shellyRPCCluster", {
+                ID: 0xfc01,
+                manufacturerCode: Zcl.ManufacturerCode.SHELLY,
+                attributes: {
+                    data: {ID: 0x0000, type: Zcl.DataType.CHAR_STR},
+                    txCtl: {ID: 0x0001, type: Zcl.DataType.UINT32},
+                    rxCtl: {ID: 0x0002, type: Zcl.DataType.UINT32},
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+            m.deviceAddCustomCluster("shellyWiFiSetupCluster", {
+                ID: 0xfc02,
+                manufacturerCode: Zcl.ManufacturerCode.SHELLY,
+                attributes: {
+                    status: {ID: 0x0000, type: Zcl.DataType.CHAR_STR},
+                    ip: {ID: 0x0001, type: Zcl.DataType.CHAR_STR},
+                    actionCode: {ID: 0x0002, type: Zcl.DataType.UINT8},
+                    dhcp: {ID: 0x0003, type: Zcl.DataType.BOOLEAN},
+                    enabled: {ID: 0x0004, type: Zcl.DataType.BOOLEAN},
+                    ssid: {ID: 0x0005, type: Zcl.DataType.CHAR_STR},
+                    password: {ID: 0x0006, type: Zcl.DataType.CHAR_STR},
+                    staticIp: {ID: 0x0007, type: Zcl.DataType.CHAR_STR},
+                    netMask: {ID: 0x0008, type: Zcl.DataType.CHAR_STR},
+                    gateway: {ID: 0x0009, type: Zcl.DataType.CHAR_STR},
+                    nameServer: {ID: 0x000a, type: Zcl.DataType.CHAR_STR},
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+        ];
+    },
+    shellyWiFiSetup(): ModernExtend {
+        // biome-ignore lint/suspicious/noExplicitAny: generic
+        const refresh = async (endpoint: any) => {
+            await endpoint.write("shellyWiFiSetupCluster", {actionCode: 0}, SHELLY_OPTIONS);
+            await endpoint.read("shellyWiFiSetupCluster", ["status", "ip", "enabled", "dhcp", "ssid"], SHELLY_OPTIONS);
+            await endpoint.read("shellyWiFiSetupCluster", ["staticIp", "netMask", "gateway", "nameServer"], SHELLY_OPTIONS);
+        };
+
+        const exposes: Expose[] = [
+            e.text("wifi_status", ea.STATE_GET).withLabel("Wi-Fi status").withDescription("Current connection status").withCategory("diagnostic"),
+            e
+                .text("ip_address", ea.STATE_GET)
+                .withLabel("IP address")
+                .withDescription("IP address currently assigned to the device")
+                .withCategory("diagnostic"),
+            e
+                .binary("dhcp_enabled", ea.STATE_GET, true, false)
+                .withLabel("DHCP enabled")
+                .withDescription("Indicates whether DHCP is used to automatically assign network settings")
+                .withCategory("diagnostic"),
+            e
+                .composite("wifi_config", "wifi_config", ea.ALL)
+                .withFeature(
+                    e.binary("enabled", ea.STATE_SET, true, false).withLabel("Wi-Fi enabled").withDescription("Enable/disable Wi-Fi connectivity"),
+                )
+                .withFeature(e.text("ssid", ea.STATE_SET).withLabel("Network").withDescription("Name (SSID) of the Wi-Fi network to connect to"))
+                .withFeature(e.text("password", ea.SET).withLabel("Password").withDescription("Password for the selected Wi-Fi network"))
+                .withFeature(
+                    e
+                        .text("static_ip", ea.STATE_SET)
+                        .withLabel("IPv4 address")
+                        .withDescription("Manually assigned IP address (used when DHCP is disabled)"),
+                )
+                .withFeature(
+                    e.text("net_mask", ea.STATE_SET).withLabel("Network mask").withDescription("Subnet mask for the static IP configuration"),
+                )
+                .withFeature(
+                    e.text("gateway", ea.STATE_SET).withLabel("Gateway").withDescription("Default gateway address for static IP configuration"),
+                )
+                .withFeature(e.text("name_server", ea.STATE_SET).withLabel("DNS").withDescription("Name server address for static IP configuration"))
+                .withLabel("Wi-Fi Configuration")
+                .withCategory("config"),
+        ];
+
+        // biome-ignore lint/suspicious/noExplicitAny: generic
+        const fromZigbee: Fz.Converter<any, any, any>[] = [
+            {
+                cluster: "shellyWiFiSetupCluster",
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg, publish, options, meta) => {
+                    const wifi_config: KeyValue = {};
+                    const state: KeyValue = {wifi_config};
+
+                    // Diagnostic data
+                    if (msg.data.status !== undefined) state.wifi_status = msg.data.status;
+                    if (msg.data.ip !== undefined) state.ip_address = msg.data.ip;
+                    if (msg.data.dhcp !== undefined) state.dhcp_enabled = msg.data.dhcp === 1;
+
+                    // Wi-Fi config
+                    if (msg.data.enabled !== undefined) wifi_config.enabled = msg.data.enabled === 1;
+                    if (msg.data.ssid !== undefined) wifi_config.ssid = msg.data.ssid;
+                    if (msg.data.staticIp !== undefined) wifi_config.static_ip = msg.data.staticIp;
+                    if (msg.data.netMask !== undefined) wifi_config.net_mask = msg.data.netMask;
+                    if (msg.data.gateway !== undefined) wifi_config.gateway = msg.data.gateway;
+                    if (msg.data.nameServer !== undefined) wifi_config.name_server = msg.data.nameServer;
+
+                    // Cleanup empty keys
+                    for (const key in wifi_config) {
+                        if (wifi_config[key] === "") {
+                            wifi_config[key] = undefined;
+                        }
+                    }
+
+                    return state;
+                },
+            },
+        ];
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ["wifi_status", "ip_address", "dhcp_enabled"],
+                convertGet: async (entity, key, meta) => {
+                    const ep = determineEndpoint(entity, meta, "shellyWiFiSetupCluster");
+                    await refresh(ep);
+                },
+            },
+            {
+                key: ["wifi_config"],
+                convertGet: async (entity, key, meta) => {
+                    const ep = determineEndpoint(entity, meta, "shellyWiFiSetupCluster");
+                    await refresh(ep);
+                },
+                convertSet: async (entity, key, value, meta) => {
+                    assertObject<KeyValue>(value);
+                    const ep = determineEndpoint(entity, meta, "shellyWiFiSetupCluster");
+
+                    // Write first batch
+                    const attr1 = {
+                        enabled: value.enabled === true,
+                        ssid: value.ssid || "",
+                        password: value.password || "",
+                    };
+                    await ep.write("shellyWiFiSetupCluster", attr1, SHELLY_OPTIONS);
+
+                    // Write second batch batch
+                    const attr2 = {
+                        staticIp: value.static_ip || "",
+                        netMask: value.net_mask || "",
+                        gateway: value.gateway || "",
+                        nameServer: value.name_server || "",
+                    };
+                    await ep.write("shellyWiFiSetupCluster", attr2, SHELLY_OPTIONS);
+
+                    // Apply config
+                    const attr3 = {actionCode: 1};
+                    await ep.write("shellyWiFiSetupCluster", attr3, SHELLY_OPTIONS);
+                },
+            },
+        ];
+
+        const configure: Configure[] = [
+            async (device, coordinatorEndpoint, definition) => {
+                const ep = device.getEndpoint(SHELLY_ENDPOINT_ID);
+                await refresh(ep);
+            },
+        ];
+
+        return {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
+    },
+};
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -7,28 +182,38 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S4SW-001X8EU",
         vendor: "Shelly",
         description: "1 Mini Gen 4",
-        extend: [m.onOff({powerOnBehavior: false})],
+        extend: [m.onOff({powerOnBehavior: false}), ...shellyModernExtend.shellyCustomClusters(), shellyModernExtend.shellyWiFiSetup()],
     },
     {
         fingerprint: [{modelID: "1", manufacturerName: "Shelly"}],
         model: "S4SW-001X16EU",
         vendor: "Shelly",
         description: "1 Gen 4",
-        extend: [m.onOff({powerOnBehavior: false})],
+        extend: [m.onOff({powerOnBehavior: false}), ...shellyModernExtend.shellyCustomClusters(), shellyModernExtend.shellyWiFiSetup()],
     },
     {
         zigbeeModel: ["Mini1PM", "1PM Mini"],
         model: "S4SW-001P8EU",
         vendor: "Shelly",
         description: "1PM Mini Gen 4",
-        extend: [m.onOff({powerOnBehavior: false}), m.electricityMeter({producedEnergy: true, acFrequency: true})],
+        extend: [
+            m.onOff({powerOnBehavior: false}),
+            m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyWiFiSetup(),
+        ],
     },
     {
         zigbeeModel: ["1PM"],
         model: "S4SW-001P16EU",
         vendor: "Shelly",
         description: "1PM Gen 4",
-        extend: [m.onOff({powerOnBehavior: false}), m.electricityMeter({producedEnergy: true, acFrequency: true})],
+        extend: [
+            m.onOff({powerOnBehavior: false}),
+            m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyWiFiSetup(),
+        ],
     },
     {
         fingerprint: [
@@ -46,7 +231,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S4SW-002P16EU-COVER",
         vendor: "Shelly",
         description: "2PM Gen4 (Cover mode)",
-        extend: [m.windowCovering({controls: ["lift", "tilt"]})],
+        extend: [m.windowCovering({controls: ["lift", "tilt"]}), ...shellyModernExtend.shellyCustomClusters(), shellyModernExtend.shellyWiFiSetup()],
     },
     {
         fingerprint: [
@@ -69,6 +254,8 @@ export const definitions: DefinitionWithExtend[] = [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             m.onOff({powerOnBehavior: false, endpointNames: ["l1", "l2"]}),
             m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyWiFiSetup(),
         ],
     },
     {
@@ -80,6 +267,8 @@ export const definitions: DefinitionWithExtend[] = [
             m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}),
             m.onOff({powerOnBehavior: false, endpointNames: ["1", "2", "3", "4"]}),
             m.electricityMeter({endpointNames: ["1", "2", "3", "4"]}),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyWiFiSetup(),
         ],
     },
     {
@@ -87,6 +276,11 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S4SN-0071A",
         vendor: "Shelly",
         description: "Flood Gen 4",
-        extend: [m.battery(), m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low"]})],
+        extend: [
+            m.battery(),
+            m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low"]}),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyWiFiSetup(),
+        ],
     },
 ];


### PR DESCRIPTION
This PR introduces support for configuring Wi-Fi settings directly over Zigbee for all Shelly Gen4 devices. It leverages the `shellyWiFiSetupCluster`, enabling remote network setup through Zigbee2MQTT.

Supported Wi-Fi Parameters:
- Enable/disable Wi-Fi
- SSID and password
- Static IP configuration (IP, netmask, gateway, DNS)

Full Zigbee cluster specification: https://shelly-api-docs.shelly.cloud/gen2/Integrations/Zigbee/WiFiSetupCluster/

This is a mix between https://github.com/Koenkk/zigbee-herdsman-converters/pull/9468 and https://github.com/Koenkk/zigbee-herdsman-converters/pull/9927.

I believe diagnostic data should be exposed as standalone state entries (exposes) to enable seamless integration with Home Assistant automations (for example, triggering actions when Wi-Fi is enabled or disabled on a Shelly device). In contrast, Wi-Fi setup parameters are currently exposed as a single composite entry.

<img width="1395" height="1551" alt="image" src="https://github.com/user-attachments/assets/c440848e-5887-4c1e-b1c0-67e7d45cc424" />

<img width="780" height="379" alt="image" src="https://github.com/user-attachments/assets/b8e4e4aa-de54-474c-be11-1c6f6482f6fd" />

---

View from Home Assistant:

<img width="346" height="632" alt="image" src="https://github.com/user-attachments/assets/979fc3e3-430a-4905-b777-f302c450d1ff" />

---

### How it works

**Refresh Action (/get or UI "refresh" icon)**
When the user triggers a refresh for any Wi-Fi attribute, the converter performs the following steps:
1. Resets attributes by writing `0` to the `Action (0x02)` attribute, syncing all values with the current device configuration.
1. Reads all Wi-Fi attributes via two Zigbee **attribute read** operations, updating the internal state and UI accordingly.

**Apply Action (/set wifi_config or UI "Apply" button)**
When the user applies a new configuration, the converter executes:
1. Writes all editable Wi-Fi attributes to the Zigbee cluster via two Zigbee **attribute write** operations
1. Applies the configuration by writing `1` to the `Action (0x02)` attribute, committing the current Zigbee attribute values to the device.

**Note**: The Wi-Fi password must be provided each time the "Apply" action is used, as it is not stored in the device state.

---

I tested this code on a **Mini 1 Gen4** device with firmware **1.7.1**, using both DHCP and static configurations, as an [external converter](https://gist.github.com/dan-danache/54200d51103fe3f0145179d0a59cce24) in my production environment. For this pull request, I made minimal adjustments to ensure compatibility, primarily updating import paths and TypeScript types where necessary.

Have fun!