### PR TITLE
Add 929003479901 (Koenkk/zigbee2mqtt#14841)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2139,6 +2139,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: true})],
     },
     {
+        zigbeeModel: ["929003479901"],
+        model: "929003479901",
+        vendor: "Philips",
+        description: "Hue Gradient Signe floor lamp (oak)",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: true})],
+    },
+    {
         zigbeeModel: ["LCT020"],
         model: "4080148P7",
         vendor: "Philips",


### PR DESCRIPTION
Add support for Hue Gradient Signe floor lamp (Oak) - variant of existing models as discussed in Koenkk/zigbee2mqtt#14841
