### PR TITLE
fix(namron): correct lookup values for window open check

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -39,7 +39,7 @@ const fzLocal = {
             }
             if (data[0x1009] !== undefined) {
                 // WindowOpenCheck
-                const lookup = {0: "enable", 1: "disable"};
+                const lookup = {0: "disable", 1: "enable"};
                 result.window_open_check = utils.getFromLookup(data[0x1009], lookup);
             }
             if (data[0x100a] !== undefined) {
@@ -81,7 +81,7 @@ const tzLocal = {
                 const payload = {4100: {value: utils.getFromLookup(value, lookup), type: Zcl.DataType.ENUM8}};
                 await entity.write("hvacThermostat", payload, sunricherManufacturer);
             } else if (key === "window_open_check") {
-                const lookup = {enable: 0, disable: 1};
+                const lookup = {disable: 0, enable: 1};
                 const payload = {4105: {value: utils.getFromLookup(value, lookup), type: Zcl.DataType.ENUM8}};
                 await entity.write("hvacThermostat", payload, sunricherManufacturer);
             } else if (key === "hysterersis") {


### PR DESCRIPTION
The window open check is the wrong way around.
According to the manual the symbol is only visible on the display when the check is enabled this happens when you click on "disable" in the UI and not enable that makes sense.
So I have swapped it around so it is correct.
I don't even use the function but I think the integration should be correct anyway in the case anyone else uses it.

I even made a mini-external converter to test the change on my live site
```javascript
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';
import {Zcl} from "zigbee-herdsman";
import * as exposes from "zigbee-herdsman-converters/lib/exposes";
import * as utils from "zigbee-herdsman-converters/lib/utils";

const ea = exposes.access;
const e = exposes.presets;

const sunricherManufacturer = {manufacturerCode: Zcl.ManufacturerCode.SHENZHEN_SUNRICHER_TECHNOLOGY_LTD};

const fzLocal = {
    namron_panelheater: {
        cluster: "hvacThermostat",
        type: ["attributeReport", "readResponse"],
        convert: (model, msg, publish, options, meta) => {
            const result = {};
            const data = msg.data;
            if (data[0x1000] !== undefined) {
                // OperateDisplayBrightnesss
                result.display_brightnesss = data[0x1000];
            }
            if (data[0x1001] !== undefined) {
                // DisplayAutoOffActivation
                const lookup = {0: "deactivated", 1: "activated"};
                result.display_auto_off = utils.getFromLookup(data[0x1001], lookup);
            }
            if (data[0x1004] !== undefined) {
                // PowerUpStatus
                const lookup = {0: "manual", 1: "last_state"};
                result.power_up_status = utils.getFromLookup(data[0x1004], lookup);
            }
            if (data[0x1009] !== undefined) {
                // WindowOpenCheck
                const lookup = {0: "disable", 1: "enable"};
                result.window_open_check = utils.getFromLookup(data[0x1009], lookup);
            }
            if (data[0x100a] !== undefined) {
                // Hysterersis
                result.hysterersis = utils.precisionRound(data[0x100a], 2) / 10;
            }
            return result;
        },
    },
};

const tzLocal = {
    namron_panelheater: {
        key: ["display_brightnesss", "display_auto_off", "power_up_status", "window_open_check", "hysterersis"],
        convertSet: async (entity, key, value, meta) => {
            if (key === "display_brightnesss") {
                const payload = {4096: {value: value, type: Zcl.DataType.ENUM8}};
                await entity.write("hvacThermostat", payload, sunricherManufacturer);
            } else if (key === "display_auto_off") {
                const lookup = {deactivated: 0, activated: 1};
                const payload = {4097: {value: utils.getFromLookup(value, lookup), type: Zcl.DataType.ENUM8}};
                await entity.write("hvacThermostat", payload, sunricherManufacturer);
            } else if (key === "power_up_status") {
                const lookup = {manual: 0, last_state: 1};
                const payload = {4100: {value: utils.getFromLookup(value, lookup), type: Zcl.DataType.ENUM8}};
                await entity.write("hvacThermostat", payload, sunricherManufacturer);
            } else if (key === "window_open_check") {
                const lookup = {disable: 0, enable: 1};
                const payload = {4105: {value: utils.getFromLookup(value, lookup), type: Zcl.DataType.ENUM8}};
                await entity.write("hvacThermostat", payload, sunricherManufacturer);
            } else if (key === "hysterersis") {
                const payload = {4106: {value: utils.toNumber(value, "hysterersis") * 10, type: 0x20}};
                await entity.write("hvacThermostat", payload, sunricherManufacturer);
            }
        },
        convertGet: async (entity, key, meta) => {
            switch (key) {
                case "display_brightnesss":
                    await entity.read("hvacThermostat", [0x1000], sunricherManufacturer);
                    break;
                case "display_auto_off":
                    await entity.read("hvacThermostat", [0x1001], sunricherManufacturer);
                    break;
                case "power_up_status":
                    await entity.read("hvacThermostat", [0x1004], sunricherManufacturer);
                    break;
                case "window_open_check":
                    await entity.read("hvacThermostat", [0x1009], sunricherManufacturer);
                    break;
                case "hysterersis":
                    await entity.read("hvacThermostat", [0x100a], sunricherManufacturer);
                    break;

                default: // Unknown key
                    throw new Error(`Unhandled key toZigbee.namron_panelheater.convertGet ${key}`);
            }
        },
    },
};


export default {
    zigbeeModel: ['5401395'],
    model: '5401395',
    vendor: 'NAMRON AS',
    description: 'Automatically generated definition',
    extend: [m.electricityMeter()],
    meta: {},
    fromZigbee: [fzLocal.namron_panelheater],
    toZigbee: [
        tzLocal.namron_panelheater,
    ],
    exposes: [
        e.enum("window_open_check", ea.ALL, ["enable", "disable"]).withDescription("Turn on/off window check mode"),
    ],
};
```