### PR TITLE
fix: Paul Neuhaus NLG-TW light state reporting by enabling configureReporting

### DIFF
--- a/src/devices/paul_neuhaus.ts
+++ b/src/devices/paul_neuhaus.ts
@@ -58,7 +58,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "NLG-TW light",
         vendor: "Paul Neuhaus",
         description: "Various tunable white lights (e.g. 8195-55)",
-        extend: [m.light({colorTemp: {range: [153, 370]}})],
+        extend: [m.light({colorTemp: {range: [153, 370]}, configureReporting: true})],
     },
     {
         zigbeeModel: ["NLG-RGBW light "], // the space as the end is intentional, as this is what the device sends


### PR DESCRIPTION
Enable configureReporting for Paul Neuhaus NLG-TW lights. Without this, the light does not report any state changes when controlled by bound remotes.


| Before | After |
|--------|--------|
| Delayed and inconsistent state update | Instant and stable state update |
| <img width="2004" height="585" alt="image" src="https://github.com/user-attachments/assets/78dd40f8-47f9-4d47-89a3-4e10566daeae" /> | <img width="2046" height="706" alt="image" src="https://github.com/user-attachments/assets/5101314a-0c04-4b75-b6f6-2fce58ef1ffb" /> | 