### PR TITLE
Update Tuya backlightModeOffOn and indicatorMode to config entities

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -322,7 +322,8 @@ const tuyaExposes = {
     backlightModeLowMediumHigh: () => e.enum("backlight_mode", ea.ALL, ["low", "medium", "high"]).withDescription("Intensity of the backlight"),
     backlightModeOffNormalInverted: () => e.enum("backlight_mode", ea.ALL, ["off", "normal", "inverted"]).withDescription("Mode of the backlight"),
     backlightModeOffOn: () => e.binary("backlight_mode", ea.ALL, "ON", "OFF").withDescription("Mode of the backlight").withCategory("config"),
-    indicatorMode: () => e.enum("indicator_mode", ea.ALL, ["off", "off/on", "on/off", "on"]).withDescription("LED indicator mode").withCategory("config"),
+    indicatorMode: () =>
+        e.enum("indicator_mode", ea.ALL, ["off", "off/on", "on/off", "on"]).withDescription("LED indicator mode").withCategory("config"),
     indicatorModeNoneRelayPos: () => e.enum("indicator_mode", ea.ALL, ["none", "relay", "pos"]).withDescription("Mode of the indicator light"),
     powerOutageMemory: () => e.enum("power_outage_memory", ea.ALL, ["on", "off", "restore"]).withDescription("Recover state after power outage"),
     batteryState: () => e.enum("battery_state", ea.STATE, ["low", "medium", "high"]).withDescription("State of the battery"),


### PR DESCRIPTION
Currently those entities are threaded as 'control' (normal) entities, but should be handled as 'config' entities to separate them in the device control page.

For more context, see https://github.com/Koenkk/zigbee2mqtt/issues/29074

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/29074