### PR TITLE
Bosch BSEN-CV (Door/window contact II plus): Fix vibration detection sensitivity overwrite on each configuration

### DIFF
--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -2092,11 +2092,11 @@ export const boschDoorWindowContactExtend = {
             async (device, coordinatorEndpoint, definition) => {
                 const endpoint = device.getEndpoint(1);
 
+                // The write request is made when using the proprietary
+                // Bosch Smart Home Controller II as of 19-09-2025. Looks like
+                // the default value was too high, and they didn't want to
+                // push a firmware update. We mimic it here to avoid complaints.
                 if (device.meta.newDefaultSensitivityApplied === undefined) {
-                    // The write request is made when using the proprietary
-                    // Bosch Smart Home Controller II as of 19-09-2025. Looks like
-                    // the default value was too high, and they didn't want to
-                    // push a firmware update. We mimic it here to avoid complaints.
                     await endpoint.write<"boschDoorWindowContactCluster", BoschDoorWindowContactCluster>("boschDoorWindowContactCluster", {
                         vibrationDetectionSensitivity: vibrationDetectionSensitivityLookup.medium,
                     });


### PR DESCRIPTION
Bosch changes the default vibration sensitivity level on the BSEN-CV from the firmware default `very_high` to `medium` during first connection with the Bosch Smart Home Contoller. This is being done in Z2M since the change in #10055 as well. Unfortunately, I forgot to make sure that the vibration sensitivity isn't being overwritten each time the device is being configured.

This pull request changes that by adding a `device.meta` value when the changed default value was applied.