### PR TITLE
Tuya water meter support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1271,7 +1271,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_ajlu4cud", "_TZE284_ajlu4cud"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_ajlu4cud"]),
         model: "TS0601_water_meter",
         vendor: "Tuya",
         description: "Ultrasonic water meter",


### PR DESCRIPTION
Currently only Tuya 214C is detected, this properly detects Tuya water meter (without valve), model 213E.
I.e: https://www.zemismart.com/products/213e

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4280

Notes:
Getting the device into pairing mode takes multiple short and long presses of the button, instructions can be found here:
https://imgbox.com/bt1URkeo