### PR TITLE
(Develco MOSZB-140) - Adjust reporting parameters for temperature and illuminance

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -642,8 +642,8 @@ export const definitions: DefinitionWithExtend[] = [
             develcoModernExtend.readGenBasicPrimaryVersions(),
             // Prevent excessive reports
             // https://github.com/Koenkk/zigbee-herdsman-converters/pull/10081
-            develcoModernExtend.temperature({reporting: {min: 10, max: 3600, change: 100}}),
-            m.illuminance({reporting: {min: 10, max: 3600, change: 100}}),
+            develcoModernExtend.temperature({reporting: {min: 60, max: 3600, change: 100}}),
+            m.illuminance({reporting: {min: 300, max: 3600, change: 100}}),
             m.battery({
                 voltageToPercentage: {min: 2500, max: 3000},
                 percentage: true,


### PR DESCRIPTION
Updated reporting parameters for temperature and illuminance.
The values ​​have been better adjusted so that they do not report excessively.
