### PR TITLE
Add new dateCode for COZB0001

### DIFF
--- a/src/devices/eurotronic.ts
+++ b/src/devices/eurotronic.ts
@@ -103,6 +103,7 @@ export const definitions: DefinitionWithExtend[] = [
             {modelID: "SPZB0001", manufacturerName: "Eurotronic", dateCode: "20240821"},
             {modelID: "SPZB0001", manufacturerName: "Eurotronic", dateCode: "20241105"},
             {modelID: "SPZB0001", manufacturerName: "Eurotronic", dateCode: "20240315"},
+            {modelID: "SPZB0001", manufacturerName: "Eurotronic", dateCode: "20231019"},
         ],
         model: "COZB0001",
         vendor: "Eurotronic",


### PR DESCRIPTION
Add another dateCode for a physical COZB0001 identifying as SPZB0001. See issue-comment https://github.com/Koenkk/zigbee2mqtt/issues/28649#issuecomment-3412799443.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

