### PR TITLE
Schneider Electric EKO07259: update temperature range for thermostat

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1807,7 +1807,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("The temperature format displayed on the thermostat screen"),
             e
                 .climate()
-                .withSetpoint("occupied_heating_setpoint", 4, 30, 0.5)
+                .withSetpoint("occupied_heating_setpoint", 0, 40, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(["off", "heat"])
                 .withRunningState(["idle", "heat"])


### PR DESCRIPTION
Changed the temperature range according to the datasheet. 0-40°C is the maximum range. 4-30°C that it originally was is the range where the temp sensor is the most accurate.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
