### PR TITLE
Fix wrong energy value reported by Sinopé TH1123ZB-G2

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -805,7 +805,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TH1123ZB-G2",
         vendor: "Sinopé",
         description: "Zigbee line volt thermostat",
-        extend: [m.electricityMeter()],
+        extend: [m.electricityMeter({energy: {divisor: 1000, multiplier: 1}})],
         fromZigbee: [fzLocal.thermostat, fzLocal.sinope, fz.hvac_user_interface, fz.ignore_temperature_report],
         toZigbee: [
             tz.thermostat_local_temperature,


### PR DESCRIPTION
The Sinopé TH1123ZB-G2 is reporting its energy in Wh, and not in KWh, leaading to the wrong energy value being reported.

For example here's the state of a relatively new thermostat:
```
{
    "current": 0,
    "energy": 135296.01,
    "linkquality": 200,
    "local_temperature": 19.29,
    "occupied_heating_setpoint": 17.5,
    "pi_heating_demand": 0,
    "power": 0,
    "running_state": "idle",
    "second_display_mode": "outdoor temp",
    "system_mode": "off",
    "thermostat_outdoor_temperature": 2,
    "unoccupied_heating_setpoint": 15,
    "backlight_auto_dim": null,
    "enable_outdoor_temperature": null,
    "keypad_lockout": null,
    "main_cycle_output": null,
    "outdoor_temperature_timeout": null,
    "temperature_display_mode": null,
    "thermostat_occupancy": null,
    "time_format": null,
    "voltage": null
}
```

As you can see, I've not consumed 10% of a nuclear reactor output on one heater.

I've also opened an issue on the main repository of z2m here: https://github.com/Koenkk/zigbee2mqtt/issues/26740

I've not been able to test it locally, I'd appreciate any help or guidance as to make sure this fix works properly, I've run all tests and fixes on codespace, everything is green.