### PR TITLE
Add LTA019

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -137,7 +137,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["LTA019"],
-        model: "LTA019",
+        model: "929003853901",
         vendor: "Philips",
         description: "Hue white ambiance and color E26",
         extend: [philips.m.light({colorTemp: {range: [50, 1000]}})],


### PR DESCRIPTION
Add device definition for Philips Hue white ambiance and color E26 (LTA019).

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4298
