### PR TITLE
Add Philips Hue Datura LED large

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -41,11 +41,11 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
-        zigbeeModel: ["929003736501_01","929003736501_02"],
+        zigbeeModel: ["929003736501_01", "929003736501_02"],
         model: "929003736501",
         vendor: "Philips",
         description: "Hue Datura LED ceiling panel large round",
-        extend: [philips.m.light({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["929003810901_01", "929003810901_02", "929003810901_03"],


### PR DESCRIPTION
Add support for Philips Hue Datura LED large ( model 929003736501 which shows up as two zigbee lights 929003736501_01 and 929003736501_02)

Picture already exists: https://github.com/Koenkk/zigbee2mqtt.io/blob/master/public/images/devices/929003736501.png

Fixes #10412 