### PR TITLE
add support for Salus FC600NH

### DIFF
--- a/src/devices/salus_controls.ts
+++ b/src/devices/salus_controls.ts
@@ -125,9 +125,10 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["FC600", "FC600NH"],
-        model: "FC600/FC600NH",
+        model: "FC600",
         vendor: "Salus Controls",
         description: "Fan coil thermostat",
+        whiteLabel: [{vendor: "Salus Controls", model: "FC600NH", description: "Fan coil thermostat", fingerprint: [{modelID: "FC600NH"}]}],
         extend: [
             m.deviceAddCustomCluster("manuSpecificSalus", {
                 ID: 0xfc04,


### PR DESCRIPTION
Salus FC600NH seems to be a new version of FC600. It's sold as FC600 in Montenegro where I got it. Tested alongside an older FC600, everything that is supported by zigbee2mqtt so far works fine.