### PR TITLE
Update Tuya device whitelabel Girier JR-ZPM01 (_TZ3000_ww6drja5) remove IndicatorMode

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7357,6 +7357,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Nous", "A6Z", "Outdoor smart socket", ["_TZ3000_266azbg3"]),
             tuya.whitelabel("Nedis", "ZBPO130FWT", "Outdoor smart plug (with power monitoring)", ["_TZ3000_3ias4w4o"]),
             tuya.whitelabel("Nous", "A9Z", "Smart Zigbee Socket", ["_TZ3210_ddigca5n"]),
+            tuya.whitelabel("Girier", "JR-ZPM01", "Smart Plug", ["_TZ3000_ww6drja5"]),
             tuya.whitelabel("Nous", "A7Z", "Smart Zigbee Socket", ["_TZ3210_rwmitwj4"]),
             tuya.whitelabel("Zbeacon", "TS011F_plug_1_1", "Smart plug (with power monitoring)", ["Zbeacon"]),
             tuya.whitelabel("NEO", "NAS-WR01B", "Smart plug (with electrical measurements)", ["_TZ3000_gjnozsaz"]),
@@ -7367,7 +7368,7 @@ export const definitions: DefinitionWithExtend[] = [
                 electricalMeasurements: true,
                 electricalMeasurementsFzConverter: fzLocal.TS011F_electrical_measurement,
                 powerOutageMemory: true,
-                indicatorMode: true,
+                indicatorMode: (manufacturerName) => manufacturerName === "_TZ3000_ww6drja5",
                 childLock: true,
                 onOffCountdown: true,
             }),
@@ -7382,7 +7383,7 @@ export const definitions: DefinitionWithExtend[] = [
                 await reporting.rmsCurrent(endpoint, {change: 50});
             }
 
-            if (!["_TZ3000_0zfrhq4i", "_TZ3000_okaz9tjs", "_TZ3000_typdpbpg", "Zbeacon"].includes(device.manufacturerName)) {
+            if (!["_TZ3000_0zfrhq4i", "_TZ3000_okaz9tjs", "_TZ3000_typdpbpg", "_TZ3000_ww6drja5", "Zbeacon"].includes(device.manufacturerName)) {
                 // Gives INVALID_DATA_TYPE error for _TZ3000_0zfrhq4i (as well as a few others in issue 20028)
                 // https://github.com/Koenkk/zigbee2mqtt/discussions/19680#discussioncomment-7667035
                 // Don't do this for `_TZ3000_gjnozsaz` (was previously in the list, but removed after:
@@ -7402,22 +7403,6 @@ export const definitions: DefinitionWithExtend[] = [
             utils.attachOutputCluster(device, "genOta");
             device.save();
         },
-    },
-    {
-        fingerprint: [{modelID: "TS011F", manufacturerName: "_TZ3000_ww6drja5"}],
-        model: "JR-ZPM01",
-        vendor: "Girier",
-        description: "Smart plug (with power monitoring, indicator not controllable)", // indicator LED not controllable via Zigbee, attribute exists but no hardware effect
-        extend: [
-            tuya.modernExtend.tuyaOnOff({
-                electricalMeasurements: true,
-                electricalMeasurementsFzConverter: fzLocal.TS011F_electrical_measurement,
-                powerOutageMemory: true,
-                indicatorMode: false, // disabled, no hardware effect
-                childLock: true,
-                onOffCountdown: true,
-            }),
-        ],
     },
     {
         fingerprint: tuya.fingerprint("TS011F", [

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -2586,7 +2586,7 @@ const tuyaModernExtend = {
             switchType?: boolean;
             switchTypeCurtain?: boolean;
             backlightModeLowMediumHigh?: boolean;
-            indicatorMode?: boolean;
+            indicatorMode?: boolean | ((manufacturerName: string) => boolean);
             indicatorModeNoneRelayPos?: boolean;
             backlightModeOffNormalInverted?: boolean;
             backlightModeOffOn?: boolean;
@@ -2599,6 +2599,7 @@ const tuyaModernExtend = {
             inchingSwitch?: boolean;
         } = {},
     ): ModernExtend => {
+        const {indicatorMode = false} = args;
         const exposes: (Expose | DefinitionExposesFunction)[] = args.endpoints
             ? args.endpoints.map((ee) => e.switch().withEndpoint(ee))
             : [e.switch()];
@@ -2660,9 +2661,13 @@ const tuyaModernExtend = {
             exposes.push(tuyaExposes.backlightModeOffNormalInverted());
             toZigbee.push(tuyaTz.backlight_indicator_mode_1);
         }
-        if (args.indicatorMode) {
+        if (indicatorMode) {
             fromZigbee.push(tuyaFz.indicator_mode);
-            exposes.push(tuyaExposes.indicatorMode());
+            if (typeof indicatorMode === "function") {
+                exposes.push((d) => (indicatorMode(d.manufacturerName) ? [tuyaExposes.indicatorMode()] : []));
+            } else {
+                exposes.push(tuyaExposes.indicatorMode());
+            }
             toZigbee.push(tuyaTz.backlight_indicator_mode_1);
         }
         if (args.indicatorModeNoneRelayPos) {


### PR DESCRIPTION
Removed Girier JR-ZPM01 smart plug (_TZ3000_ww6drja5) entry from whitelabel list and added new entry for Girier smart plug with power monitoring.

From my experience with the device, and from these two issues, wouldn't it be better to remove IndicatorMode for this device?
https://github.com/Koenkk/zigbee2mqtt/issues/28190
https://github.com/Koenkk/zigbee2mqtt/issues/28384
I think this device doesn't have controllable indicator that can be controlled via zigbee. Maybe hardwired or something like that.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

This is my first time PR on this repo so please give me your input