### PR TITLE
Adjust temperature delta min and step values

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -42,8 +42,8 @@ export const definitions: DefinitionWithExtend[] = [
                 .numeric("temperature_delta", ea.STATE_SET)
                 .withUnit("°C")
                 .withValueMax(10)
-                .withValueMin(0.5)
-                .withValueStep(0.5)
+                .withValueMin(0.1)
+                .withValueStep(0.1)
                 .withPreset("default", 1, "Default value")
                 .withDescription("The delta between local_temperature and current_heating_setpoint to trigger Heat"),
             e.enum("working_day", ea.STATE_SET, ["mon_fri", "mon_sat", "mon_sun"]).withDescription("Workday setting"),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
1. .withValueMin(0.1) - Changed from 0.5 to 0.1
2. .withValueStep(0.1) - Changed from 0.5 to 0.1

This now allows the temperature delta to be set from 0.1°C to 10°C in 0.1°C increments, giving you much finer control over when the heating should trigger based on the difference between the current temperature and the setpoint.
