### PR TITLE
Add new fingerprint to TS0601 Human Presence Sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5543,7 +5543,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_debczeci", "_TZE284_1lvln0x6"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_debczeci", "_TZE284_1lvln0x6", "_TZE204_debczeci"]),
         model: "iHsenso_TS0601_human_presence",
         vendor: "iHseno",
         description: "Human presence sensor",


### PR DESCRIPTION
I just received two TS0601 Human Presence sensors. One of them was recognized automatically `_TZE284_debczeci`, while `_TZE204_debczeci` was not.
