### PR TITLE
Update the Model ID from "MIR-IL100-ZB" to "MIR-IL100"

### DIFF
--- a/src/devices/multir.ts
+++ b/src/devices/multir.ts
@@ -36,8 +36,8 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["MIR-IL100-ZB"],
-        model: "MIR-IL100-ZB",
+        zigbeeModel: ["MIR-IL100"],
+        model: "MIR-IL100",
         vendor: "MultIR",
         description: "PIR sensor",
         extend: [


### PR DESCRIPTION
Sorry for the confusion in the previous commit: [f7ad615515a67b08874d4bf1c75700fd399c1130](https://github.com/Koenkk/zigbee-herdsman-converters/commit/f7ad615515a67b08874d4bf1c75700fd399c1130). 

In that commit, the Model ID was mixed up. The actual test sample should use "MIR-IL100-ZB", and the correct formal ID "MIR-IL100" has now been updated in this PR.
