### PR TITLE
Aqara: better temperature sensor for SRTS-A01

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3623,6 +3623,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.battery_voltage(),
             e.battery(),
             e.power_outage_count(),
+            e.device_temperature(),
             e.local_temperature().withAccess(ea.STATE),
             e.schedule(),
             e


### PR DESCRIPTION
Aqara SRTS-A01 currently exposes `device_temperature` which I suspect is the microcontroller's internal temperature (usually a few degrees higher than the air temp, and only has 1° precision, whereas this one has 0.1°)

The device also has `local_temperature` which seems to be the air temperature, and already is the measured temperature for the climate entity. this means that `local_temperature` is not exposed as a sensor. This fixes it.

Potentially, we could keep both, but I'm not familiar enough with the dev of this project to make it clear which is which (if you keep both, you have 2 sensors exposed, and it's difficult to know which is which because they both are named temperature.)

Also, since local_temperature is only access.STATE, you have to wait until it is reported to get a value, so it might be unavailable on startup?


Open for suggestions