### PR TITLE
Candeo C210: Add disableDefaultResponse to resolve command timeouts

### DIFF
--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -276,6 +276,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Candeo",
         description: "Zigbee dimming smart plug",
         extend: [m.light({configureReporting: true, levelConfig: {features: ["current_level_startup"]}, powerOnBehavior: true})],
+        meta: {disableDefaultResponse: true},
     },
     {
         fingerprint: [{modelID: "C204", manufacturerName: "Candeo"}],


### PR DESCRIPTION
## Problem

  The Candeo C210 dimming plug does not send ZCL default response acknowledgments after receiving
   commands (on/off, brightness). This causes Zigbee2MQTT to wait for the full 10-second timeout
  on every command before processing the next one, resulting in:

  - 10-second delays between consecutive commands
  - `Error: ZCL command ... timed out after 10000ms` errors in logs
  - Commands queue sequentially instead of executing rapidly

  The device **does** execute commands correctly and reports state changes via attribute
  reporting, but never sends command responses.

  ## Solution

  Add `meta: {disableDefaultResponse: true}` to the C210 device definition. This tells
  Zigbee2MQTT to not wait for command acknowledgments from this device, allowing commands to
  execute immediately.

  ## Testing

  Tested on C210 hardware (firmware 0.0.0, date code 20241204):
  - ✅ Rapid on/off commands execute instantly without timeouts
  - ✅ Brightness adjustments work without delays
  - ✅ Device continues to report state changes normally
  - ✅ No timeout errors in logs