### PR TITLE
LiXee ZLinky: fix polling interval + improve option descriptions

### DIFF
--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1806,7 +1806,8 @@ export const definitions: DefinitionWithExtend[] = [
                 .numeric("measurement_poll_chunk", ea.SET)
                 .withValueMin(1)
                 .withDescription(
-                    "During the poll, request multiple exposes to the Zlinky at once for reducing Zigbee network overload. Too much request at once could exceed device limit. Requires Z2M restart. Default: 4",
+                    "Number of attributes requested from the ZLinky in each poll to reduce Zigbee network load. " +
+                        "Requesting too many at once may exceed the device's limit and cause read errors. Requires Z2M restart. Default: 4.",
                 ),
             e
                 .text("tic_command_whitelist", ea.SET)


### PR DESCRIPTION
* fix: LiXee ZLinky: make polling interval configurable again
  e30ace459d702 broke the polling interval configuration. Since then, it
was always set to 600 seconds.


* fix: LiXee ZLinky: describe actual default polling interval
  The default description ("This device does not support reporting
  electric measurements so it is polled instead. The default poll interval
  is 60 seconds, set to -1 to disable.") mentioned a default of 60 seconds
  but it is actually 600.
  It was also misleading: not all attributes are polled, several of them
  have reporting configured and are automatically updated.


* fix: LiXee ZLinky: improve description of measurement_poll_chunk
