### PR TITLE
Add support for SONOFF Dongle-M Router in ZHC

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1640,7 +1640,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["Dongle-M_ZBRouter"],
         model: "ZBDongle-M",
         vendor: "SONOFF",
-        description: "Sonoff Dongle Max MG24 (EFR32MG24) with router firmware",
+        description: "Dongle Max MG24 (EFR32MG24) with router firmware",
         fromZigbee: [fz.linkquality_from_basic],
         toZigbee: [],
         extend: [m.forcePowerSource({powerSource: "Mains (single phase)"})],


### PR DESCRIPTION
This PR adds support for the SONOFF Dongle-M Router in ZHC.