### PR TITLE
Extend zigbeetlc.js by ZY-ZTH02-z

### DIFF
--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -287,7 +287,7 @@ export const definitions: DefinitionWithExtend[] = [
         - Humidity (+calibration)
     */
     {
-        zigbeeModel: ["TS0201-z", "TS0201-bz", "TH03Z-z", "TH03Z-bz", "ZTH01-z", "ZTH01-bz", "ZTH02-z", "ZTH02-bz"],
+        zigbeeModel: ["TS0201-z", "TS0201-bz", "TH03Z-z", "TH03Z-bz", "ZTH01-z", "ZTH01-bz", "ZTH02-z", "ZTH02-bz", "ZY-ZTH02-z"],
         // TS0201 with ZigbeeTLc firmware
         model: "TS0201-z",
         vendor: "Tuya",


### PR DESCRIPTION
Picture can remain the same.
However, new device definitions were added by pvvx and my device is now reported as "ZY-ZTH02-z".
(TS0201 _TZ3000_v1w2k9dd)

Should be fully compatible, though.

I Tried testing this with a local external_converters js, but even though no error appears in the logs, nothing happens.
