### PR TITLE
fix: use node:zlib for crc calc

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "packageManager": "pnpm@10.18.3",
+    "engines": {
+        "node": ">=20.15.0"
+    },
     "files": [
         "dist",
         "CHANGELOG.md"
@@ -40,7 +43,6 @@
     },
     "homepage": "https://github.com/Koenkk/zigbee-herdsman-converters",
     "dependencies": {
-        "buffer-crc32": "^1.0.0",
         "iconv-lite": "^0.7.0",
         "semver": "^7.7.3",
         "zigbee-herdsman": "^6.3.2"
@@ -54,7 +56,6 @@
     },
     "devDependencies": {
         "@biomejs/biome": "^2.2.6",
-        "@types/buffer-crc32": "^0.2.4",
         "@types/node": "^24.8.1",
         "@types/semver": "^7.7.1",
         "@vitest/coverage-v8": "3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      buffer-crc32:
-        specifier: ^1.0.0
-        version: 1.0.0
       iconv-lite:
         specifier: ^0.7.0
         version: 0.7.0
@@ -24,9 +21,6 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.6
         version: 2.2.6
-      '@types/buffer-crc32':
-        specifier: ^0.2.4
-        version: 0.2.4
       '@types/node':
         specifier: ^24.8.1
         version: 24.8.1
@@ -455,9 +449,6 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
-  '@types/buffer-crc32@0.2.4':
-    resolution: {integrity: sha512-GSrhSZOK1/wazf2CjDp3CVJQKWzSc5Ugq3NyZ/RQqg1MWtmA9mAT6i6LzGKhzcRxDOl8aLB+AzvObDSlrMpvLw==}
-
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -545,10 +536,6 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  buffer-crc32@1.0.0:
-    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
-    engines: {node: '>=8.0.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1335,10 +1322,6 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.15
 
-  '@types/buffer-crc32@0.2.4':
-    dependencies:
-      '@types/node': 24.8.1
-
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1446,8 +1429,6 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
-
-  buffer-crc32@1.0.0: {}
 
   cac@6.7.14: {}
 

--- a/src/lib/ota.ts
+++ b/src/lib/ota.ts
@@ -2,11 +2,8 @@ import assert from "node:assert";
 import crypto from "node:crypto";
 import {readFileSync} from "node:fs";
 import path from "node:path";
-
-import crc32 from "buffer-crc32";
-
+import {crc32} from "node:zlib";
 import {Zcl} from "zigbee-herdsman";
-
 import {logger} from "./logger";
 import type {Ota, Zh} from "./types";
 
@@ -327,7 +324,7 @@ function validateSilabsEbl(data: Buffer): void {
             assert(data.readUInt8(position2) === EBL_PADDING, "Image padding contains invalid bytes");
         }
 
-        const calculatedCrc32 = crc32.unsigned(data.subarray(0, position));
+        const calculatedCrc32 = crc32(data.subarray(0, position));
 
         assert(calculatedCrc32 === VALID_SILABS_CRC, "Image CRC-32 is invalid");
 
@@ -345,11 +342,8 @@ function validateSilabsGbl(data: Buffer): void {
     assert(gblEndTagIndex > 16, "Not a valid GBL image"); // after HEADER, just because...
 
     const gblEnd = gblEndTagIndex + 12; // tag + length + crc32 (4*3)
-    // TODO: nodejs >= v20.15.0, remove dep buffer-crc32
-    //       import {crc32} from 'zlib';
-    //       const calculatedCrc32 = crc32(data.subarray(0, gblEnd));
     // ignore possible padding
-    const calculatedCrc32 = crc32.unsigned(data.subarray(0, gblEnd));
+    const calculatedCrc32 = crc32(data.subarray(0, gblEnd));
 
     assert(calculatedCrc32 === VALID_SILABS_CRC, "Image CRC-32 is invalid");
 }


### PR DESCRIPTION
https://nodejs.org/api/zlib.html#zlibcrc32data-value

Should set 20.15.0 as min for Z2M too, some earlier Node versions are already causing problems (import, type errors...), we should at least output the warning in case some users are still using them.