### PR TITLE
fix: Remove duplicate `meta.multiEndpoint` from generated definition

### DIFF
--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -234,10 +234,6 @@ export async function generateDefinition(device: Zh.Device): Promise<{externalDe
         generated: true,
     };
 
-    if (multiEndpoint) {
-        definition.meta = {multiEndpoint};
-    }
-
     const externalDefinitionSource = generateSource(definition, generatedExtend);
     return {externalDefinitionSource, definition};
 }

--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -190,7 +190,6 @@ export default {
     vendor: '',
     description: 'Automatically generated definition',
     extend: [m.deviceEndpoints({"endpoints":{"1":1,"2":2}}), m.temperature({"endpointNames":["1","2"]}), m.onOff({"powerOnBehavior":false})],
-    meta: {"multiEndpoint":true},
 };
             `,
         });


### PR DESCRIPTION
Already part of `m.deviceEndpoints`