### PR TITLE
fix: LiXee ZLinky: handle empty TIC command list

### DIFF
--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1746,7 +1746,7 @@ function getCurrentConfig(device: Zh.Device, options: KeyValue) {
     }
 
     // Filter exposed attributes with user whitelist
-    if (options?.tic_command_whitelist != null) {
+    if (options?.tic_command_whitelist) {
         // @ts-expect-error ignore
         const tic_commands_str = options.tic_command_whitelist.toUpperCase();
         if (tic_commands_str !== "ALL") {
@@ -1811,7 +1811,7 @@ export const definitions: DefinitionWithExtend[] = [
                 ),
             e
                 .text("tic_command_whitelist", ea.SET)
-                .withDescription("List of TIC commands to be exposed (separated by comma). Reconfigure device after change. Default: all"),
+                .withDescription("Comma-separated list of TIC commands to expose. Requires Z2M restart. Default: all"),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
   If the user defines a value for tic_command_whitelist and then clears
    it, it remains in the configuration as an empty string.
    An empty string should be the same as no value at all. Before this
    change, when the string was empty, no attributes were polled.
    
   Let's also suggest a Z2M restart in the description, it's the easiest way to
    restart the poll.
