### PR TITLE
Add support for Philips LWA033 9290038561 Hue White A60 E27 1100 lumen

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -756,10 +756,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light()],
     },
     {
-        zigbeeModel: ['LWA033'],
-        model: '9290038561',
-        vendor: 'Philips',
-        description: 'Hue White A60 E27 1100 lumen',
+        zigbeeModel: ["LWA033"],
+        model: "9290038561",
+        vendor: "Philips",
+        description: "Hue White A60 E27 1100 lumen",
         extend: [philips.m.light()],
     },
     {


### PR DESCRIPTION
This is one of those fancy new Matter bulbs, works just fine as a Zigbee device.

Fixes: #10531

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4333
