### PR TITLE
Add support for Philips Hue Centris 3-spot (929003808601)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2277,6 +2277,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
+        zigbeeModel: ["929003808601_01", "929003808601_02", "929003808601_03", "929003808601_04"],
+        model: "929003808601",
+        vendor: "Philips",
+        description: "Hue White & Color ambience Centris ceiling light (3 spots)",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+    },
+    {
         zigbeeModel: ["929003808701_01", "929003808701_02", "929003808701_03", "929003808701_04"],
         model: "929003808701",
         vendor: "Philips",


### PR DESCRIPTION
- Model: 929003808601
- Vendor: Philips
- Description: Hue White & Color Ambiance Centris ceiling light (3 spots + panel)
- Features: Color temperature 153-500 mired, full RGB with xy/hs modes, enhanced hue
- Zigbee models: 929003808601_01 through _04 (4 endpoints)
- Tested with Zigbee2MQTT 2.6.2 using external converter

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4339
