### PR TITLE
Fix Moes Smart Knob ZG-101ZD (_TZ3000_gwkzibhs)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10186,7 +10186,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         whiteLabel: [
             tuya.whitelabel("Tuya", "ZG-101Z_D_1", "Smart knob", ["_TZ3000_402vrq2i"]),
-            tuya.whitelabel("HOBEIAN", "ZG-101ZD", "Smart knob", ["_TZ3000_gwkzibhs"]),
+            tuya.whitelabel("Moes", "ZG-101ZD", "Smart knob", ["_TZ3000_gwkzibhs"]),
         ],
         toZigbee: [tz.tuya_operation_mode],
         exposes: [
@@ -10237,13 +10237,6 @@ export const definitions: DefinitionWithExtend[] = [
                 modelID: "TS004F",
                 manufacturerName: "_TZ3000_abrsvsou",
                 applicationVersion: 145,
-                priority: 1,
-            },
-            // https://github.com/Koenkk/zigbee2mqtt/issues/28149
-            {
-                modelID: "TS004F",
-                manufacturerName: "_TZ3000_gwkzibhs",
-                applicationVersion: 147,
                 priority: 1,
             },
         ],


### PR DESCRIPTION
In pull request version #9727, created based on issue https://github.com/Koenkk/zigbee2mqtt/issues/28149, the definition for _TZ3000_gwkzibhs version 147 was changed, which led to the removal of most of the actions. The author of issue states in the comments https://github.com/Koenkk/zigbee2mqtt/issues/28149#issuecomment-3150327886 and https://github.com/Koenkk/zigbee-herdsman-converters/pull/9727#issuecomment-3152431000 that he is aware of the removed actions, but that he does not need them :-(

This pull request reverts pull request #9727, changes the manufacturer and model to Moes ZG-101ZD (according to my smart knob purchased at https://www.aliexpress.com/item/1005008777398199.html) and updates the device picture.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4355

Fixies: https://github.com/Koenkk/zigbee2mqtt/issues/28149
Fixies: https://github.com/Koenkk/zigbee2mqtt/issues/28461
Fixies: https://github.com/Koenkk/zigbee2mqtt/issues/28626