### PR TITLE
Add Somfy Sonesse2 40 Zigbee Roller support

### DIFF
--- a/src/devices/somfy.ts
+++ b/src/devices/somfy.ts
@@ -44,6 +44,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.windowCovering({controls: ["lift"]})],
     },
     {
+        zigbeeModel: ["Sonesse2 40 Zigbee Roller"],
+        model: "1245920",
+        vendor: "SOMFY",
+        description: "Sonesse2 40 Zigbee roller shades",
+        extend: [m.windowCovering({controls: ["lift"]})],
+    },
+    {
         zigbeeModel: ["Ysia 5 HP Zigbee"],
         model: "1871154",
         vendor: "SOMFY",


### PR DESCRIPTION
This adds support for the new zigbee roller / integration using all the same standard extends, which is working correctly.

Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/29271

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4358
