### PR TITLE
Add new fingerprint for TS0001 device

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12118,7 +12118,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_bmqxalil", "_TZ3000_w1tcofu8", "_TZ3000_ma3mhpx2"]),
+        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_bmqxalil", "_TZ3000_w1tcofu8", "_TZ3000_ma3mhpx2", "_TZ3000_wijoqjk1"]),
         model: "TS0001_switch_1_gang",
         vendor: "Tuya",
         description: "1-Gang switch with backlight",


### PR DESCRIPTION
Recognize `_TZ3000_wijoqjk1` as [TS0001_switch_1_gang](https://www.zigbee2mqtt.io/devices/TS0001_switch_1_gang.html).

Before this change, my [BSEED 1-gang switch](https://www.bseed.com/products/bseed-zigbee-1-2-3gang-1-2-3way-switch-wall-smart-light-switch-for-staircase) was recognized as a standard [TS0001](https://www.zigbee2mqtt.io/devices/TS0001.html) which made `backlight_mode` inavailable. Now the switch is tested as working properly with backlight mode setting.

I can also confirm that [BSEED 2-gang switch](https://www.bseed.com/products/bseed-zigbee-1-2-3gang-1-2-3way-switch-wall-smart-light-switch-for-staircase?variant=42163562184859) is already supported as [TS0002, 2-Gang switch with backlight, countdown and inching](https://www.zigbee2mqtt.io/devices/TS0002.html) - working properly with backlight mode switch out of the box.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://www.zigbee2mqtt.io/devices/TS0001_switch_1_gang.html - the correct picture is already present