### PR TITLE
feat(tuya): enhance window sensor capabilities with new states and al…

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1999,7 +1999,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Window sensor with 3-state opening (DP101), optional alarm, battery",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
-            e.enum("opening_state", ea.STATE, ["open", "closed", "tilted"]).withDescription("Opening state (Tuya DP101)"),
+            e.enum("opening_state", ea.STATE, ["open", "closed", "tilted"]).withDescription("Opening state"),
             e.binary("alarm_state", ea.STATE_SET, true, false).withDescription("Alarm was triggered."),
             e.binary("setup_mode", ea.STATE_SET, true, false).withDescription("Set mode status"),
             e.binary("alarm_siren", ea.STATE_SET, true, false).withDescription("Activate the siren when the alarm is triggered."),


### PR DESCRIPTION
This PR provides official manufacturer support for the Tuya window sensor (TS0601_sensor_window), extending the initial community implementation with complete feature support based on official device specifications.

Changes Made
**Core Sensor Features:**

- Full 3-state opening detection (open/closed/tilted) via DP101
- Alarm state monitoring (DP16)
- Setup mode status (DP107)

**Alarm System:**

- Alarm siren control (DP103)
- Configurable siren duration: 5-180 seconds (DP109)
- Alarm state reporting

**Vibration Detection:**

- Vibration value reporting (DP102)
- Adjustable sensitivity limit: 0-100 (DP106)
- Vibration-triggered siren (DP108)
- Configurable vibration siren duration: 5-180 seconds (DP110)

**Additional Features:**

- Close signal notification toggle (DP104)
- Transmission power control: 11-19 (DP105) - higher values increase range but consume more battery
- Magnetic sensor status (DP111)
- Battery reporting via DP2 (fallback) and DP102 for vibration

**Technical Details**

All data points are mapped according to official device specifications using Tuya value converters with appropriate constraints. The implementation maintains backward compatibility while exposing the complete feature set.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

