### PR TITLE
Add reverse water consumption, fix flow_rate and update report period

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1296,72 +1296,99 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         meta: {
             tuyaDatapoints: [
-            [1, 'water_consumed', tuya.valueConverter.divideBy1000],
-            [2, 'month_consumption', {
-                from: (value, meta) => {
-                    const buffer = Buffer.from(value);
-                    if (buffer.length >= 8) {
-                        try {
-                            const uintValue = buffer.slice(-4).readUInt32BE(0);
-                            return uintValue / 1000;
-                        } catch (_error) {
+                [1, "water_consumed", tuya.valueConverter.divideBy1000],
+                [
+                    2,
+                    "month_consumption",
+                    {
+                        from: (value, meta) => {
+                            const buffer = Buffer.from(value);
+                            if (buffer.length >= 8) {
+                                try {
+                                    const uintValue = buffer.slice(-4).readUInt32BE(0);
+                                    return uintValue / 1000;
+                                } catch (_error) {
+                                    return null;
+                                }
+                            }
                             return null;
-                        }
-                    }
-                    return null;
-                },
-            }],
-            [3, 'daily_consumption', {
-                from: (value, meta) => {
-                    const buffer = Buffer.from(value);
-                    if (buffer.length >= 8) {
-                        try {
-                            const uintValue = buffer.slice(-4).readUInt32BE(0);
-                            return uintValue / 1000;
-                        } catch (_error) {
+                        },
+                    },
+                ],
+                [
+                    3,
+                    "daily_consumption",
+                    {
+                        from: (value, meta) => {
+                            const buffer = Buffer.from(value);
+                            if (buffer.length >= 8) {
+                                try {
+                                    const uintValue = buffer.slice(-4).readUInt32BE(0);
+                                    return uintValue / 1000;
+                                } catch (_error) {
+                                    return null;
+                                }
+                            }
                             return null;
-                        }
-                    }
-                    return null;
-                },
-            }],
-            [21, 'flow_rate', {
-                from: (value, meta) => {
-                    const buffer = Buffer.from(value);
-                    if (buffer.length >= 4) {
-                        try {
-                            const uintValue = buffer.slice(-4).readUInt32BE(0);
-                            return uintValue / 1000;
-                        } catch (_error) {
+                        },
+                    },
+                ],
+                [
+                    21,
+                    "flow_rate",
+                    {
+                        from: (value, meta) => {
+                            const buffer = Buffer.from(value);
+                            if (buffer.length >= 4) {
+                                try {
+                                    const uintValue = buffer.slice(-4).readUInt32BE(0);
+                                    return uintValue / 1000;
+                                } catch (_error) {
+                                    return null;
+                                }
+                            }
                             return null;
-                        }
-                    }
-                    return null;
-                },
-            }],
-            [4, 'report_period', tuya.valueConverterBasic.lookup({
-                '1h': 0, '2h': 1, '3h': 2, '4h': 3, '6h': 4, '8h': 5, '12h': 6, '24h': 7,
-            })],
-            [5, 'fault', tuya.valueConverterBasic.lookup({empty_pipe: 6144, no_fault: 0})],
-            [16, 'meter_id', tuya.valueConverter.raw],
-            [18, 'reverse_water_consumed', {
-                from: (value, meta) => {
-                    const buffer = Buffer.from(value);
-                    if (buffer.length >= 4) {
-                        try {
-                            const uintValue = buffer.readUInt32BE(0);
-                            return uintValue / 1000;
-                        } catch (_error) {
+                        },
+                    },
+                ],
+                [
+                    4,
+                    "report_period",
+                    tuya.valueConverterBasic.lookup({
+                        "1h": 0,
+                        "2h": 1,
+                        "3h": 2,
+                        "4h": 3,
+                        "6h": 4,
+                        "8h": 5,
+                        "12h": 6,
+                        "24h": 7,
+                    }),
+                ],
+                [5, "fault", tuya.valueConverterBasic.lookup({empty_pipe: 6144, no_fault: 0})],
+                [16, "meter_id", tuya.valueConverter.raw],
+                [
+                    18,
+                    "reverse_water_consumed",
+                    {
+                        from: (value, meta) => {
+                            const buffer = Buffer.from(value);
+                            if (buffer.length >= 4) {
+                                try {
+                                    const uintValue = buffer.readUInt32BE(0);
+                                    return uintValue / 1000;
+                                } catch (_error) {
+                                    return null;
+                                }
+                            }
                             return null;
-                        }
-                    }
-                    return null;
-                },
-            }],
-            [22, 'temperature', tuya.valueConverter.divideBy100],
-            [26, 'voltage', tuya.valueConverter.divideBy100],
-        ],
-    },
+                        },
+                    },
+                ],
+                [22, "temperature", tuya.valueConverter.divideBy100],
+                [26, "voltage", tuya.valueConverter.divideBy100],
+            ],
+        },
         options: [
             exposes.options.precision("water_consumed"),
             exposes.options.calibration("water_consumed"),


### PR DESCRIPTION
In this new version i fixed flow_rate, add some new sensor for daily, month consumption and water revers consumption.

The only problem with Flow rate is because reporting is every hour not instant like he say in documentation, so if water is open at every hour at 10 minutes , you will se that sensor give you data

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: 
<img width="317" height="968" alt="image" src="https://github.com/user-attachments/assets/4ac36c44-6a6d-420b-b4c2-0f85e2e1435e" />

