### PR TITLE
Add support for Hue Milliskin White Ambiance Spot 5042148P9

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4344,10 +4344,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
-        zigbeeModel: ['5042148P9'],
-        model: '5042148P9',
-        vendor: 'Philips',
-        description: 'Hue White ambiance Milliskin (square)',
-        extend: [philips.m.light({"colorTemp":{"range":[153,454]}})],
+        zigbeeModel: ["5042148P9"],
+        model: "5042148P9",
+        vendor: "Philips",
+        description: "Hue White ambiance Milliskin (square)",
+        extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: (https://github.com/Koenkk/zigbee2mqtt.io/pull/4364)
