### PR TITLE
add current_heatin_ setpoint in eurotronic.ts

### DIFF
--- a/src/devices/eurotronic.ts
+++ b/src/devices/eurotronic.ts
@@ -218,7 +218,8 @@ export const definitions: DefinitionWithExtend[] = [
             e.child_lock(),
             e
                 .climate()
-                .withSetpoint("occupied_heating_setpoint", 8, 28, 0.5)
+                .withSetpoint("current_heating_setpoint", 5, 30, 0.5)
+                .withSetpoint("occupied_heating_setpoint", 5, 30, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(["off", "auto", "heat"])
                 .withRunningState(["idle", "heat"])


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Makes sure changing setpoint on Eurotronic ZSPB0001 TRV via device controls is reflected correctly in Home Assistant.
fixes https://github.com/Koenkk/zigbee2mqtt/issues/29372

