### PR TITLE
Add Climax power plug device configuration

### DIFF
--- a/src/devices/climax.ts
+++ b/src/devices/climax.ts
@@ -73,7 +73,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "PSM-29ZBS",
         vendor: "Climax",
         description: "Power plug",
-        fromZigbee: [fz.on_off, fz.metering],
         extend: [m.onOff({powerOnBehavior: false}), m.electricityMeter({current: false, voltage: false})],
     },
     {


### PR DESCRIPTION
Added model "PSMP5_00.00.03.12TC"
This is branded as PSM-29ZBS by Climax. Same as PSM-29ZBSR except PSM-29ZBS is an end device whereas PSM-29ZBSR is a router.
Link to picture pull request: [image for PSM-29ZBS](https://github.com/Koenkk/zigbee2mqtt.io/pull/4376)
