### PR TITLE
Rename PIR settings to sensitivity and delay_time (iHsenso_TS0601_human_presence)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5704,15 +5704,15 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             e.presence().withDescription("Human presence detected"),
             e.battery().withDescription("Battery percentage"),
-            e.enum("pir_sensitivity", ea.STATE_SET, ["low", "middle", "high"]).withDescription("PIR sensor sensitivity"),
-            e.enum("pir_time", ea.STATE_SET, ["15s", "30s", "60s"]).withDescription("PIR delay time in seconds"),
+            e.enum("sensitivity", ea.STATE_SET, ["low", "middle", "high"]).withDescription("Sensor sensitivity"),
+            e.enum("delay_time", ea.STATE_SET, ["15s", "30s", "60s"]).withDescription("Delay time in seconds"),
         ],
         meta: {
             tuyaDatapoints: [
                 [1, "presence", tuya.valueConverter.trueFalse0],
                 [4, "battery", tuya.valueConverter.raw],
-                [9, "pir_sensitivity", tuya.valueConverterBasic.lookup({low: 0, middle: 1, high: 2})],
-                [10, "pir_time", tuya.valueConverterBasic.lookup({"15s": 0, "30s": 1, "60s": 2})],
+                [9, "sensitivity", tuya.valueConverterBasic.lookup({low: 0, middle: 1, high: 2})],
+                [10, "delay_time", tuya.valueConverterBasic.lookup({"15s": 0, "30s": 1, "60s": 2})],
             ],
         },
     },


### PR DESCRIPTION
Remove the misleading “PIR” label from settings of iHsenso_TS0601_human_presence.
Since this device actually uses a SKYRELAY RC2412 mmWave sensor (see images below), even if its performance isn't good, it's still not a PIR sensor, but rather a mmWave sensor.
Field names are now neutral (sensitivity, delay_time) while keeping datapoint IDs unchanged.

<details>
  <summary>internal img</summary>

![Gambar WhatsApp 2025-11-02 pukul 12 55 42_da53d985](https://github.com/user-attachments/assets/a8ecbef2-8eb7-4eb3-aacb-e1a2946abb00)
![Gambar WhatsApp 2025-11-02 pukul 12 55 42_877bc620](https://github.com/user-attachments/assets/33c27db6-2786-4879-901c-cc22cc94fe12)
</details>

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

