### PR TITLE
Add support for Tuya TS0004 fan/light controller (_TZ3000_ncb6mkx8)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -769,16 +769,7 @@ const tzLocal = {
             const lookup = {red_when_on: 0, pink_when_on: 1, red_on_blue_off: 2, pink_on_blue_off: 3};
             const modeValue = utils.getFromLookup(value, lookup);
             await entity.write("genOnOff", {tuyaBacklightMode: modeValue});
-            return {
-                state: {
-                    backlight_mode: utils.getFromLookup(modeValue, {
-                        0: "red_when_on",
-                        1: "pink_when_on",
-                        2: "red_on_blue_off",
-                        3: "pink_on_blue_off",
-                    }),
-                },
-            };
+            return {state: {backlight_mode: utils.getFromLookup(modeValue, lookup)}};
         },
     } satisfies Tz.Converter,
 };


### PR DESCRIPTION
## Device Information
- **Model**: TS0004_fan_light_switch
- **Vendor**: Tuya
- **Manufacturer ID**: _TZ3000_ncb6mkx8
- **Description**: Fan and light controller with 3 speeds
- **Product Link**: https://smarthomesmatter.com.au/products/zigbee-fan-light-switch

## Changes Made
- Added custom backlight mode converters (`fzLocal.TS0004_backlight_mode` and `tzLocal.TS0004_backlight_mode`)
- Supports 4 backlight color modes: red_when_on, pink_when_on, red_on_blue_off, pink_on_blue_off
- Configured custom endpoints for fan control:
  - `lights`: Endpoint 1 (independent light control)
  - `low`: Endpoint 3 (fan low speed)
  - `medium`: Endpoint 4 (fan medium speed)
  - `high`: Endpoint 2 (fan high speed)

## Testing
Device has been tested with external converter and all features work correctly:
- ✅ Light switch control
- ✅ Fan speed control (3 speeds)
- ✅ Backlight mode configuration (4 color modes)
- ✅ Multi-endpoint support
- ✅ Device rejoining and reconfiguration

## Notes
This device uses a unique backlight system with 4 color modes accessed via the `tuyaBacklightMode` attribute on the genOnOff cluster, requiring custom converters rather than the standard `backlightModeOffOn` or `backlightModeLowMediumHigh` implementations.