### PR TITLE
Add support of Philips Hue Flex Strip Light 5m

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -13,11 +13,11 @@ const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        zigbeeModel: ['929004610602'],
-        model: '929004610602',
-        vendor: 'Philips',
-        description: 'Hue White and Color Flux Strip Light 5m',
-        extend: [philips.m.light({"colorTemp":{"range":[50,1000]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        zigbeeModel: ["929004610602"],
+        model: "929004610602",
+        vendor: "Philips",
+        description: "Hue White and Color Flux Strip Light 5m",
+        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["LCX028"],


### PR DESCRIPTION
Added Hue White and Color Flux Strip Light 5m

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: public/images/devices/Hue-929004610602.png
