### PR TITLE
Add Sunricher SR-ZG2868EK7-DIM remote support

### DIFF
--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -1385,13 +1385,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.battery(),
             m.commandsOnOff({commands: ["on", "off"]}),
             m.commandsLevelCtrl({
-                commands: [
-                    "brightness_step_up",
-                    "brightness_step_down",
-                    "brightness_move_up",
-                    "brightness_move_down",
-                    "brightness_stop",
-                ],
+                commands: ["brightness_step_up", "brightness_step_down", "brightness_move_up", "brightness_move_down", "brightness_stop"],
             }),
             m.commandsScenes({commands: ["recall", "store"]}),
         ],


### PR DESCRIPTION
Added support for Sunricher ZigBee handheld dimming remote (SR-ZG2868EK7-DIM) from issue

https://github.com/Koenkk/zigbee2mqtt/issues/29342

**Picture**

Done in

https://github.com/Koenkk/zigbee2mqtt.io/pull/4383
