### PR TITLE
Add Iluminize 5110.80. Feat: add reporting to 5112.80

### DIFF
--- a/src/devices/iluminize.ts
+++ b/src/devices/iluminize.ts
@@ -291,13 +291,6 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["5112.80"],
-        model: "5112.80",
-        vendor: "Iluminize",
-        description: "Zigbee 3.0 LED-controller 1x 8A",
-        extend: [m.light()],
-    },
-    {
         zigbeeModel: ["ZGRC-TEUR-001"],
         model: "511.544",
         vendor: "Iluminize",


### PR DESCRIPTION
From discussion

https://github.com/Koenkk/zigbee2mqtt/discussions/29441

I added this device as a whitelabel as it shares the same functionalities according to the manufacturer documentation

https://cdn.iluminize.com/web/image/58568?unique=ab521bf2938987e44066afc0e7bfa7c447a81081

**Images**:

https://github.com/Koenkk/zigbee2mqtt.io/pull/4390