### PR TITLE
Fix: use correct max values for Aqara W100 temp_period and humi_period

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4747,7 +4747,7 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "sec",
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x016a, type: Zcl.DataType.UINT32},
-                description: "Temperature reporting period",
+                description: "Humidity reporting period",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.numeric({


### PR DESCRIPTION
This PR fixes the wrong boundaries defined or temp_period and humi_period for the Aqara W100 temperature and humidity sensors. The boundaries are taken from this article: https://homekitnews.com/2025/05/15/aqara-climate-monitor-w100-review/

I also tested the values via external converter:
Here are humidity measurements for different `humi_period` settings in Home Assistant:
<img width="1492" height="373" alt="image" src="https://github.com/user-attachments/assets/beec5f08-5e90-4523-aba8-85497b7edfff" />

Here are temperature measurements for different `temp_period` settings:
<img width="1303" height="743" alt="image" src="https://github.com/user-attachments/assets/04373d34-378a-4294-9d35-d1c6270f74c0" />

