### PR TITLE
Add: new modelID for NSPpanel

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -1174,7 +1174,7 @@ const sonoffExtend = {
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        zigbeeModel: ["NSPanelP-Router"],
+        zigbeeModel: ["NSPanelP-Router", "Cuber ZLI Router"],
         model: "NSPanelP-Router",
         vendor: "SONOFF",
         description: "Router",


### PR DESCRIPTION
It should solve issues:

https://github.com/Koenkk/zigbee2mqtt/issues/29502
https://github.com/Koenkk/zigbee2mqtt/issues/29239
https://github.com/Koenkk/zigbee2mqtt/issues/28848

The modeelID and manufacturer used seem to be generic. I am not sure if it is a good idea to add it in the Sonoff.ts file. Maybe, we should create a new definition and add the nspanel with this new modelID as a whitelabel.

Any hints from the dev would be appreciated
