### PR TITLE
Add support for BB 262 E27 bulb in innr.ts

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -237,6 +237,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({turnsOffAtBrightness1: true})],
     },
     {
+        zigbeeModel: ["BB 262"],
+        model: "BB 262",
+        vendor: "Innr",
+        description: "E27 bulb",
+        extend: [m.light({turnsOffAtBrightness1: true})],
+    },
+    {
         zigbeeModel: ["RB 265"],
         model: "RB 265",
         vendor: "Innr",


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [https://github.com/Koenkk/zigbee2mqtt.io/pull/4403](url)
