### PR TITLE
feat: manage exit/entry delay for IAS ACE devices

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -292,8 +292,21 @@ export const arm_mode: Tz.Converter = {
             panelStatus = mode !== 0 && mode !== 4 ? 0x80 : 0x00;
         }
 
+        let secondsRemain = 0;
+        let delayUntil = 0;
+        if ((mode === 4 || mode === 5) && value.delay != null) {
+            utils.assertNumber(value.delay, "delay");
+            if (!utils.isInRange(0, constants.iasMaxSecondsRemain, value.delay)) {
+                throw new Error(`Invalid delay value: ${value.delay} (expected ${0} to ${constants.iasMaxSecondsRemain})`);
+            }
+
+            secondsRemain = Math.round(value.delay);
+            delayUntil = performance.now() + value.delay * 1000;
+        }
+
         globalStore.putValue(entity, "panelStatus", panelStatus);
-        const payload = {panelstatus: panelStatus, secondsremain: 0, audiblenotif: 0, alarmstatus: 0};
+        globalStore.putValue(entity, "delayUntil", delayUntil);
+        const payload = {panelstatus: panelStatus, secondsremain: secondsRemain, audiblenotif: 0, alarmstatus: 0};
         await entity.commandResponse("ssIasAce", "panelStatusChanged", payload);
     },
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -288,6 +288,8 @@ export const armNotification = {
     6: "already_disarmed",
 };
 
+export const iasMaxSecondsRemain = 255;
+
 // ID's from ZCL mapped to ha names where appropriate
 // https://github.com/home-assistant/core/pull/47720
 export const ColorMode = {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -737,9 +737,11 @@ export function iasGetPanelStatusResponse(): ModernExtend {
         type: ["commandGetPanelStatus"],
         convert: (model, msg, publish, options, meta) => {
             if (globalStore.hasValue(msg.endpoint, "panelStatus")) {
+                const delayUntil = globalStore.getValue(msg.endpoint, "delayUntil", 0);
+                const secondsRemain = delayUntil > 0 ? Math.round(Math.max(0, delayUntil - performance.now()) / 1000) : 0;
                 const payload = {
                     panelstatus: globalStore.getValue(msg.endpoint, "panelStatus"),
-                    secondsremain: 0x00,
+                    secondsremain: Math.min(secondsRemain, constants.iasMaxSecondsRemain),
                     audiblenotif: 0x00,
                     alarmstatus: 0x00,
                 };


### PR DESCRIPTION
# What?
This PR adds support for exit and entry delay handling for IAS ACE devices.

# Why?
With my Develco KEYZB-110, I noticed the LED stayed solid during the `exit_delay` and `entry_delay` modes instead of blinking as specified in Develco documentation. Examining the logs showed that in these modes the device floods the server with `commandGetPanelStatus`.

By modifying the `secondsremain` field of the response to a positive value, it appears the KEYZB-110 only sends a `commandGetPanelStatus` after the number of seconds indicated. When this value is 0, the device sends a `commandGetPanelStatus` immediately without waiting.

# How?
I added the ability to specify a `delay` field in the `arm_mode` payload, which is only considered for the `exit_delay` and `entry_delay` modes. This field is optional and does not change behavior when not specified, which corresponds to a `secondsremain` value of 0.

The target timestamp of the expiration, based on a monotonic clock, is stored in the global store so the updated `secondsremain` value can be sent in subsequent `getPanelStatusRsp`.

# Test?
Tested only with Develco KEYZB-110.