### PR TITLE
Update konke.ts

### DIFF
--- a/src/devices/konke.ts
+++ b/src/devices/konke.ts
@@ -126,7 +126,7 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.occupancy(), e.battery_voltage(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
-        zigbeeModel: ["3AFE21100402102A", "3AFE22010402102A"],
+        zigbeeModel: ["3AFE21100402102A", "3AFE22010402102A", "3AFE12010402102A"],
         model: "KK-WA-J01W",
         vendor: "Konke",
         description: "Water detector",


### PR DESCRIPTION
Add the new version of the “KK-WA-J01W” water sensor model. 
The '3AFE12010402102A' type 'KK-WA-J01W' water sensor is a custom model for the China Telecom Smart Home platform.

Link to picture pull request: TODO
