### PR TITLE
Add support for Philips Hue Downlight LTD022 zigbee model

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -549,7 +549,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
-        zigbeeModel: ["LTD021"],
+        zigbeeModel: ["LTD021", "LTD022"],
         model: "9290035842",
         vendor: "Philips",
         description: "Garnea downlight",


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
In addition to the philips hue zigbee model LTD021, there is also a variant LTD022 thats reported in zigbee but is the exact same device
