### PR TITLE
feat(TS0601): add high-precision AC frequency (DP135)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11965,7 +11965,7 @@ export const definitions: DefinitionWithExtend[] = [
                 tuya.exposes.powerFactorWithPhase("c"),
             ];
 
-            if ((device as any).applicationVersion >= 132) {
+            if (device.applicationVersion >= 132) {
                 baseExposes.push(e.numeric("ac_frequency_high_precision", ea.STATE).withUnit("Hz").withValueMin(0).withValueMax(100));
             }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -250,6 +250,7 @@ export interface ModernExtend {
 export type DummyDevice = {
     manufacturerName?: string;
     isDummyDevice: true;
+    applicationVersion?: number;
 };
 
 export type DefinitionExposesFunction = (device: Zh.Device | DummyDevice, options: KeyValue) => Expose[];


### PR DESCRIPTION
This PR adds support for high-precision AC frequency (DP135) on TS0601 3-phase clamp power meters.

- Exposes `ac_frequency_high_precision` in Hz for devices with `applicationVersion >= 132`.
- Updates `tuyaDatapoints` and `exposes` accordingly.
- Maintains backward compatibility for older devices without DP135.