### PR TITLE
fix: move weekly schedule to config section for Sonoff TRVZB

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -332,6 +332,7 @@ const sonoffExtend = {
     weeklySchedule: (): ModernExtend => {
         const exposes = e
             .composite("schedule", "weekly_schedule", ea.STATE_SET)
+            .withCategory("config")
             .withDescription(
                 'The preset heating schedule to use when the system mode is set to "auto" (indicated with ⏲ on the TRV). ' +
                     "Up to 6 transitions can be defined per day, where a transition is expressed in the format 'HH:mm/temperature', each " +


### PR DESCRIPTION
I've noticed that the weekly schedule for the Sonoff TRVZB is not marked as type `config` for the `entityCategory`.

This results in extra entities displaying in dashboards when they shouldn't since they aren't control entities. Moving them to the configuration section is where they should be rather than as every day controls.

Note I've amended the modern extend `weeklySchedule` which is currently only referenced by the Sonoff TRV but this should make sense as the default for any future variants.