### PR TITLE
Add LTA016 Philips Hue white ambiance A67/E27 1600lm

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -143,6 +143,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [222, 454]}})],
     },
     {
+        zigbeeModel: ["LTA016"],
+        model: "9290038550H",
+        vendor: "Philips",
+        description: "Hue white ambiance A67 1600lm with Bluetooth E27",
+        extend: [philips.m.light({colorTemp: {range: [50, 1000]}})],
+    },
+    {
         zigbeeModel: ["LTA018"],
         model: "9290038552",
         vendor: "Philips",


### PR DESCRIPTION
This is apparently a new bulb (https://www.philips-hue.com/de-at/p/hue-white-ambiance-a67-smarte-lampe-e27-1600/8720169364288), but probably similar to already defined ones. I didn't find a perfect match though, so I am submitting it as a new device.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4418