### PR TITLE
Add new Zigbee model for LED Controller

### DIFF
--- a/src/devices/lightsolutions.ts
+++ b/src/devices/lightsolutions.ts
@@ -38,10 +38,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light()],
     },
     {
-        zigbeeModel: ['91-943'],
-        model: '91-943',
-        vendor: 'Light Solutions',
-        description: 'LED Controller 12/24v',
-        extend: [philips.m.light({"colorTemp":{"range":[153,370]},"color":{"modes":["xy","hs"]}})],
+        zigbeeModel: ["91-943"],
+        model: "91-943",
+        vendor: "Light Solutions",
+        description: "LED Controller 12/24v",
+        extend: [philips.m.light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"]}})],
     },
 ];


### PR DESCRIPTION
https://ledpaerer.dk/philips-hue-kompatibel-rgbcw-controller-12-24v.html

the predecessor to the 91-943-pro, have a few devices with 1.1.0 20200521 but also 2 with 3.1.0 20210302, both physically identical

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
