### PR TITLE
Add Thaleos TWC-R01 thermostat support #2

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20255,42 +20255,40 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Smart thermostat for electric heater with pilot wire",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
-    		e.pilot_wire_mode(["comfort", "eco", "antifrost", "off", "comfort_1", "comfort_2"]), // Not using climate here because setpoint is not supported
-    		e.local_temperature(),
-    		e
-    			.numeric("local_temperature_calibration", ea.STATE_SET)
-    			.withUnit("°C")
-    			.withValueMin(-8)
-    			.withValueMax(8)
-    			.withValueStep(0.5)
-    			.withDescription("Set temperature calibration"),
-    		e.binary("eco_mode", ea.STATE_SET, "ON", "OFF").withDescription("Enables/disables the weekly program."),
-    		e.open_window(),
-    		e.open_window_temperature(),
-    		e.power(),
-    		e.voltage(),
-    		e.current(),
-    		e.energy(),
-    		e.numeric("energy_today", ea.STATE).withUnit("kWh").withDescription("Energy consumed today"),
-    		e.numeric("energy_yesterday", ea.STATE).withUnit("kWh").withDescription("Energy consumed yesterday"),
-    		e
-    			.binary("device_mode_type", ea.STATE_SET, "ON", "OFF")
-    			.withDescription("Set pilot wire mode to 6 (includes comfort 1 & 2).")
+            e.pilot_wire_mode(["comfort", "eco", "antifrost", "off", "comfort_1", "comfort_2"]), // Not using climate here because setpoint is not supported
+            e.local_temperature(),
+            e
+                .numeric("local_temperature_calibration", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(-8)
+                .withValueMax(8)
+                .withValueStep(0.5)
+                .withDescription("Set temperature calibration"),
+            e.binary("eco_mode", ea.STATE_SET, "ON", "OFF").withDescription("Enables/disables the weekly program."),
+            e.open_window(),
+            e.open_window_temperature(),
+            e.power(),
+            e.voltage(),
+            e.current(),
+            e.energy(),
+            e.numeric("energy_today", ea.STATE).withUnit("kWh").withDescription("Energy consumed today"),
+            e.numeric("energy_yesterday", ea.STATE).withUnit("kWh").withDescription("Energy consumed yesterday"),
+            e.binary("device_mode_type", ea.STATE_SET, "ON", "OFF").withDescription("Set pilot wire mode to 6 (includes comfort 1 & 2)."),
         ],
         meta: {
             tuyaDatapoints: [
-    			[
-    				2,
-    				"pilot_wire_mode",
-    				tuya.valueConverterBasic.lookup({
-    					comfort: tuya.enum(0),
-    					eco: tuya.enum(1),
-    					antifrost: tuya.enum(2),
-    					off: tuya.enum(3),
-    					comfort_1: tuya.enum(4),
-    					comfort_2: tuya.enum(5),
-    				}),
-    			],
+                [
+                    2,
+                    "pilot_wire_mode",
+                    tuya.valueConverterBasic.lookup({
+                        comfort: tuya.enum(0),
+                        eco: tuya.enum(1),
+                        antifrost: tuya.enum(2),
+                        off: tuya.enum(3),
+                        comfort_1: tuya.enum(4),
+                        comfort_2: tuya.enum(5),
+                    }),
+                ],
                 [11, "power", tuya.valueConverter.raw],
                 [16, "local_temperature", tuya.valueConverter.divideBy10],
                 [19, "local_temperature_calibration", tuya.valueConverter.localTempCalibration2],
@@ -20309,7 +20307,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [111, "open_window_temperature", tuya.valueConverter.raw],
                 [112, "window_time", tuya.valueConverter.raw],
                 [113, "window_timeout", tuya.valueConverter.raw],
-			    [114, "device_mode_type", tuya.valueConverter.onOff],
+                [114, "device_mode_type", tuya.valueConverter.onOff],
                 [115, "voltage", tuya.valueConverter.divideBy10],
                 [116, "current", tuya.valueConverter.divideBy1000],
                 [117, "energy", tuya.valueConverter.raw],


### PR DESCRIPTION
Hi,
As discussed here https://github.com/Koenkk/zigbee-herdsman-converters/pull/10516, I reverted the use of climate expose and used numeric/pilot_wire_mode instead.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4330