### PR TITLE
Add TWCLBulb50AU support for Aurora Lighting

### DIFF
--- a/src/devices/aurora_lighting.ts
+++ b/src/devices/aurora_lighting.ts
@@ -304,10 +304,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.identify(), m.light({powerOnBehavior: false})],
     },
     {
-    zigbeeModel: ["AU-A1CE14ZCX6"],
-    model: "AU-A1CE14ZCX6",
-    vendor: "Aurora Lighting",
-    description: "AOne smart tuneable candle lamp bulb",
-    extend: [m.light({"colorTemp":{"range":[200,454]}})],
+        zigbeeModel: ["AU-A1CE14ZCX6"],
+        model: "AU-A1CE14ZCX6",
+        vendor: "Aurora Lighting",
+        description: "AOne smart tuneable candle lamp bulb",
+        extend: [m.light({colorTemp: {range: [200, 454]}})],
     },
 ];


### PR DESCRIPTION
Added support for TWCLBulb50AU smart bulb with tunable color temperature.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [https://github.com/Koenkk/zigbee2mqtt.io/pull/4425](https://github.com/Koenkk/zigbee2mqtt.io/pull/4425)
