### PR TITLE
Update vendor name for Zigbee smart plug

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -178,7 +178,7 @@ export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["4512789"],
         model: "4512789",
-        vendor: "Namron AS",
+        vendor: "Namron",
         description: "Zigbee smart plug 16A IP44",
         extend: [m.deviceTemperature({scale: 100}), m.onOff(), m.electricityMeter()],
     },


### PR DESCRIPTION
Consolidating vendor name "Namron AS" -> "Namron", see also https://github.com/Koenkk/zigbee2mqtt.io/pull/4420

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
