### PR TITLE
Add DIMMER mode support for DOMRAEM DOM-Z-105P

### DIFF
--- a/src/devices/domraem.ts
+++ b/src/devices/domraem.ts
@@ -3,9 +3,10 @@ import type {DefinitionWithExtend} from "../lib/types";
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        fingerprint: [{modelID: "RGB", manufacturerName: "DOMRAEM"},
-                     {modelID: 'DIMMER', manufacturerName: "DOMRAEM"},
-                     ],
+        fingerprint: [
+            {modelID: "RGB", manufacturerName: "DOMRAEM"},
+            {modelID: "DIMMER", manufacturerName: "DOMRAEM"},
+        ],
         model: "DOM-Z-105P",
         vendor: "DOMRAEM",
         description: "LED controller",


### PR DESCRIPTION
## Changes
- Added DIMMER mode fingerprint to existing DOM-Z-105P device definition

## Testing
- Device: DOMRAEM DOM-Z-105P (Dimmer mode)
- Tested features:
  - ✅ On/Off control
  - ✅ Brightness control
  - ✅ Effects (blink, breathe, okay)
  - ✅ Power-on behavior

## Notes
- Device supports multiple modes (RGB/RGBW/RGBCW/CCD/DIMMER)
- Only dimmer mode tested with appropriate hardware
- RGB mode was already supported in the existing definition