### PR TITLE
Removed redundant SA-3 entry and added support for Ekaza Mercurio

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5167,7 +5167,7 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0003", ["_TZ3000_dyzkbcip"]),
         model: "Mercurio-3",
         vendor: "Ekaza",
-        description: "Smart 3-channel switch with countdown + indicator mode + power outage memory",
+        description: "Smart 3-channel switch",
         configure: tuya.configureMagicPacket,
         extend: [
             tuya.modernExtend.tuyaBase(),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Removed redundant SA-3 entry and added support for Ekaza Mercurio

Link to picture pull request: TODO
