### PR TITLE
Configure level reporting for Candeo C202.1

### DIFF
--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -268,7 +268,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.light({
                 configureReporting: true,
                 levelReportingConfig: {min: 1, max: 3600, change: 1},
-                powerOnBehavior: false
+                powerOnBehavior: false,
             }),
         ],
     },


### PR DESCRIPTION
Specify `levelReportingConfig` for Candeo C202.1 device. This matches the configuration from other Candeo devices. e.g. C201/C202/C203/C204
