### PR TITLE
Identify C-ZB-LC20v2-RGBCCT as GL-C-008P

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -650,7 +650,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({color: {modes: ["xy", "hs"], enhancedHue: true}}), m.identify(), gledoptoConfigureReadModelID()],
     },
     {
-        zigbeeModel: ["GL-C-008P"],
+        zigbeeModel: ["GL-C-008P", "C-ZB-LC20v2-RGBCCT"],
         model: "GL-C-008P",
         vendor: "Gledopto",
         ota: true,


### PR DESCRIPTION
After an OTA firmware update two of my Gledopto GL-C-008P now identify as C-ZB-LC20v2-RGBCCT