### PR TITLE
Add battery level to RC 210 and RC 250

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -25,6 +25,7 @@ export const definitions: DefinitionWithExtend[] = [
                 "color_temperature_move",
             ]),
         ],
+        extend: [m.battery()],
         configure: async (device, coordinatorEndpoint) => {
             const ep = device.getEndpoint(1);
             await reporting.bind(ep, coordinatorEndpoint, ["genBasic", "genOnOff", "genLevelCtrl", "lightingColorCtrl"]);
@@ -38,6 +39,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fz.command_step, fz.command_on, fz.command_off, fz.command_move_to_level, fz.command_move_to_color_temp],
         toZigbee: [],
         exposes: [e.action(["on", "off", "brightness_step_up", "brightness_step_down", "brightness_move_to_level", "color_temperature_move"])],
+        extend: [m.battery()],
         configure: async (device, coordinatorEndpoint) => {
             const ep = device.getEndpoint(1);
             await reporting.bind(ep, coordinatorEndpoint, ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"]);


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Both of these devices are capable of reporting their battery status, so this PR adds the battery percentage to their converters.

Tested locally through the external converters feature in zigbee2mqtt.
