### PR TITLE
Add 929004608001 (Hue OmniGlow lightstrip 3m)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3290,10 +3290,17 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: true})],
     },
     {
+        zigbeeModel: ["929004608001"],
+        model: "929004608001",
+        vendor: "Philips",
+        description: "Hue OmniGlow lightstrip 3m",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ["sparkle", "opal", "glisten"]}})],
+    },
+    {
         zigbeeModel: ["929004608004"],
         model: "929004608004",
         vendor: "Philips",
-        description: "Hue Omniglow lightstrip",
+        description: "Hue OmniGlow lightstrip",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ["sparkle", "opal", "glisten"]}})],
     },
     {


### PR DESCRIPTION
Add 3m version of OmniGlow lightstrip based on https://github.com/Koenkk/zigbee-herdsman-converters/pull/10690

(also renamed existing entry to OmniGlow based on the capitalization on the Hue website)

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4428
