### PR TITLE
Add hue e17 gradient

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3517,7 +3517,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "9290022975",
         vendor: "Philips",
         description: "Hue White Ambiance E17 40W 470 lumen",
-        extend: [philips.m.light({colorTemp: {range: [153,454]}})],
+        extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ["1746630P7"],


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4439

This seems to be a Japan-market product. Tried to follow instructions as well as I could.