### PR TITLE
[CK-BL702-AL-01] Add power on behavior with hybrid (existing) code

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2346,24 +2346,18 @@ export const definitions: DefinitionWithExtend[] = [
         model: "CK-BL702-AL-01",
         vendor: "Tuya",
         description: "Zigbee LED bulb",
-
-        // Add standard Zigbee power on behavior converters
         toZigbee: [tz.power_on_behavior],
         fromZigbee: [fz.power_on_behavior],
-
         extend: [
             tuya.modernExtend.tuyaLight({
                 colorTemp: {range: [142, 500]},
                 color: true,
             }),
         ],
-        // Add power on behavior expose
         exposes: [e.power_on_behavior(["off", "on", "toggle", "previous"])],
-
         meta: {
             moveToLevelWithOnOffDisable: true,
         },
-
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read("genOnOff", ["startUpOnOff"]);


### PR DESCRIPTION
### Changes
Add standard Zigbee power-on behavior support to CK-BL702-AL-01

### Background
This device supports standard Zigbee `genOnOff.startUpOnOff` attribute for power-on behavior (at least on my device with `CK-BL702-AL-01(7009_Z102LG03-1)` model), but it is not accessible through Tuya datapoints.
The feature is not exposed in the Tuya app, but the firmware implements it via standard Zigbee clusters.

**This is confirmed by:**
- ZHA exposes power-on behavior with 4 options
- Z2M's "Generate external definition" tool detects standard Zigbee light clusters
- Manual testing confirms all 4 power-on behavior options work correctly

<details>
  <summary># ZHA screenshot #</summary>
  
  <img width="464" height="545" alt="Cuplikan layar 2025-11-12 120830" src="https://github.com/user-attachments/assets/37b0636e-77cc-432c-bd95-5e3c6fe45996" />

</details>



### Implementation
This PR uses a **hybrid** approach:
- Keeps existing `tuya.modernExtend.tuyaLight` code for light control (proven reliable with Tuya protocol)
- Adds manual standard Zigbee converters specifically for power-on behavior
- Does not modify existing functionality to **avoid breaking changes** for current users (older device/other firmware)

**Alternative considered:**  
The device fully supports standard Zigbee and could use `m.light()` similar to CK-BL702-AL-01_1 (at least on my device), but the hybrid approach was chosen for backward compatibility.

Generated external definition:
```
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['CK-BL702-AL-01(7009_Z102LG03-1)'],
    model: 'CK-BL702-AL-01(7009_Z102LG03-1)',
    vendor: 'eWeLink',
    description: 'Automatically generated definition',
    extend: [m.light({"colorTemp":{"range":[142,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
};
```
*This confirms the device fully supports standard Zigbee light clusters.*

### Testing
**Zigbee Model:** CK-BL702-AL-01(7009_Z102LG03-1)
- ✅ Power-on behavior: all 4 options (off, on, toggle, previous) work correctly
- ✅ Settings persist after power cycle
- ✅ Light control: brightness, color temp, RGB color all functional
- ✅ No errors or warnings in debug log

### ⚠️ Additional Notes
- Related to https://github.com/Koenkk/zigbee2mqtt/issues/23000
- The existing "do not disturb" feature does not work with this device (Tuya DP not supported)
- ZHA does not expose "do not disturb" either

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

