### PR TITLE
Update DOMRAEM device definitions and fingerprints

### DIFF
--- a/src/devices/domraem.ts
+++ b/src/devices/domraem.ts
@@ -4,30 +4,30 @@ import type {DefinitionWithExtend} from "../lib/types";
 export const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: [{modelID: "RGB", manufacturerName: "DOMRAEM"}],
-        model: "DOM-Z-105P",
+        model: "DOM-Z-105P_RGB",
         vendor: "DOMRAEM",
-        description: "LED controller",
+        description: "LED controller 5 in 1",
         extend: [m.light({color: {modes: ["hs"], enhancedHue: false}})],
     },
     {
         fingerprint: [{modelID: "RGBWC", manufacturerName: "DOMRAEM"}],
-        model: "DOM-Z-105P",
+        model: "DOM-Z-105P_RGBW",
         vendor: "DOMRAEM",
-        description: "LED controller 5 in 1 (RGBW)",
+        description: "LED controller 5 in 1",
         extend: [m.light({colorTemp: {range: [158, 495]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         fingerprint: [{modelID: "WW/CW", manufacturerName: "DOMRAEM"}],
-        model: "DOM-Z-105P",
+        model: "DOM-Z-105P_WW/CW",
         vendor: "DOMRAEM",
-        description: "LED controller 5 in 1 (WW/CW)",
+        description: "LED controller 5 in 1",
         extend: [m.light({colorTemp: {range: [158, 500]}})],
     },
     {
         fingerprint: [{modelID: "DIMMER", manufacturerName: "DOMRAEM"}],
-        model: "DOM-Z-105P",
+        model: "DOM-Z-105P_DIMMER",
         vendor: "DOMRAEM",
-        description: "LED controller 5 in 1 (DIMMER)",
+        description: "LED controller 5 in 1",
         extend: [m.light()],
     },
 ];


### PR DESCRIPTION
Refactor DOMRAEM device definitions to include additional models and update fingerprint structure.

It should resolve:
https://github.com/Koenkk/zigbee2mqtt/issues/29699
https://github.com/Koenkk/zigbee2mqtt/issues/29645
https://github.com/Koenkk/zigbee2mqtt/issues/29631
https://github.com/Koenkk/zigbee2mqtt/issues/29236
https://github.com/Koenkk/zigbee2mqtt/issues/29138

@powerrffs Would you mind share the database.db entry when your device is set in `DIMMER` only ?

According to this issue, the device changes its definition when a different mode is selected. As I do not own one, it would be nice if someone could test and report what is the exact behavior of this led controller.

https://github.com/Koenkk/zigbee2mqtt/issues/29383

An external converter is also attached to this PR for testing purpose.

```javascript
import * as m from "zigbee-herdsman-converters/lib/modernExtend";

export default [
    {
        fingerprint: [{modelID: "RGB", manufacturerName: "DOMRAEM"}],
        model: "DOM-Z-105P",
        vendor: "DOMRAEM",
        description: "LED controller 5 in 1 (RGB)",
        extend: [m.light({color: {modes: ["hs"], enhancedHue: false}})],
    },
    {
        fingerprint: [{modelID: "RGBWC", manufacturerName: "DOMRAEM"}],
        model: "DOM-Z-105P",
        vendor: "DOMRAEM",
        description: "LED controller 5 in 1 (RGBW)",
        extend: [m.light({colorTemp: {range: [158, 495]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
    },
    {
        fingerprint: [{modelID: "WW/CW", manufacturerName: "DOMRAEM"}],
        model: "DOM-Z-105P",
        vendor: "DOMRAEM",
        description: "LED controller 5 in 1 (WW/CW)",
        extend: [m.light({colorTemp: {range: [158, 500]}})],
    },
    {
        fingerprint: [{modelID: "DIMMER", manufacturerName: "DOMRAEM"}],
        model: "DOM-Z-105P",
        vendor: "DOMRAEM",
        description: "LED controller 5 in 1 (DIMMER)",
        extend: [m.light()],
    },
];
```

If there is a more elegant way to solve this, I would be happy to know and to correct the code I submitted.
