### PR TITLE
Add ENGO E40 Zigbee thermostat support

### DIFF
--- a/src/devices/engo.ts
+++ b/src/devices/engo.ts
@@ -418,9 +418,8 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         whiteLabel: [tuya.whitelabel("ENGO", "E40", "Zigbee Smart Thermostat", ["_TZE204_lnxdk2ch"])],
-        onEvent: async (...args: any[]) => {
-            const device = args[2];
-            if (device?.manufacturerName?.startsWith('_TZE204')) {
+        onEvent: async (_type: unknown, _data: unknown, device: any) => {
+            if (device.manufacturerName?.startsWith('_TZE204')) {
                 device.meta.supported = true;
             }
         },


### PR DESCRIPTION
Added support for the ENGO E40 Zigbee smart thermostat with various features including state control, climate settings, and scheduling.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4454
