### PR TITLE
Adds support for ACW02 HVAC Thermostat - a custom DIY Zigbee device based on ESP32-C6.

### DIFF
--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -154,7 +154,6 @@ const fzLocal = {
             }
         },
     } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
-
     acw02_error_status: {
         cluster: "genOnOff",
         type: ["attributeReport", "readResponse"],
@@ -164,7 +163,6 @@ const fzLocal = {
             }
         },
     } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
-
     acw02_error_text: {
         cluster: "genBasic",
         type: ["attributeReport", "readResponse"],
@@ -184,7 +182,6 @@ const fzLocal = {
             }
         },
     } satisfies Fz.Converter<"genBasic", undefined, ["attributeReport", "readResponse"]>,
-
     acw02_thermostat: {
         cluster: "hvacThermostat",
         type: ["attributeReport", "readResponse"],
@@ -1161,14 +1158,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ACW02-ZB",
         vendor: "Custom devices (DiY)",
         description: "ACW02 HVAC Thermostat Controller via Zigbee (Router)",
-
-        meta: {
-            multiEndpoint: true,
-        },
-
+        meta: {multiEndpoint: true},
         fromZigbee: [fzLocal.acw02_thermostat, fzLocal.acw02_clean_status, fzLocal.acw02_error_status, fz.on_off, fzLocal.acw02_error_text],
         toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_system_mode, tz.on_off],
-
         exposes: [
             e
                 .climate()
@@ -1186,7 +1178,6 @@ export const definitions: DefinitionWithExtend[] = [
             exposes.binary("filter_clean_status", ea.STATE_GET, "ON", "OFF").withDescription("Filter cleaning reminder (read-only)"),
             e.switch().withEndpoint("mute").withDescription("Mute beep sounds"),
         ],
-
         endpoint: (device) => {
             return {
                 default: 1,
@@ -1200,7 +1191,6 @@ export const definitions: DefinitionWithExtend[] = [
                 error_sensor: 9,
             };
         },
-
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint1 = device.getEndpoint(1);
             const endpoint2 = device.getEndpoint(2);
@@ -1235,7 +1225,6 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint1.read("genBasic", ["locationDesc"]);
             await endpoint1.read("hvacFanCtrl", ["fanMode"]);
         },
-
         extend: [
             m.enumLookup({
                 name: "fan_mode",


### PR DESCRIPTION
## Description
Adds support for ACW02 HVAC Thermostat - a custom DIY Zigbee device based on ESP32-C6.

## Device Details
- **Model:** ACW02-ZB
- **Vendor:** Custom devices (DiY)
- **Zigbee Model ID:** acw02-z
- **Manufacturer Name:** Custom devices (DiY)
- **Device Type:** Router
- **Chip:** ESP32-C6 with ESP-Zigbee SDK 5.5.1

## Hardware Information

- **Hardware Repository:** https://github.com/Fabiancrg/acw02_zb
- **MCU:** ESP32-C6 (XIAO ESP32-C6 board)
- **UART:** Connected to Airton AC unit via custom protocol (in replacement of ACW02 WiFi module)

## Features
- **Climate Control:**
  - Temperature setpoint: 16-31°C (single setpoint for both heating/cooling)
  - Local temperature reading
  - System modes: off, auto, cool, heat, dry, fan_only
  - Running state: idle, heat, cool, fan_only

- **Fan Control:**
  - Custom fan speeds: quiet, low, low-med, medium, med-high, high, auto
  - Maps to ACW02 protocol values (SILENT, P20, P40, P60, P80, P100, AUTO)

- **Switches (9 endpoints total):**
  - Eco mode (endpoint 2)
  - Swing mode (endpoint 3)
  - Display control (endpoint 4)
  - Night/sleep mode (endpoint 5)
  - Air purifier/ionizer (endpoint 6)
  - Mute beep sounds (endpoint 8)

- **Read-only Sensors:**
  - Filter cleaning status (endpoint 7)
  - Error status indicator (endpoint 9)
  - Error text messages (via locationDesc attribute)

- **Additional:**
  - OTA firmware updates supported
  - Optimized reporting (most attributes auto-report via REPORTING flag)
  - Minimal polling for unreportable attributes (runningMode, fanMode, error_text)

## Testing
- Tested with Zigbee2MQTT version: 2.6.3
- Coordinator: Sonoff ZB Dongle-P 
- All features verified working


## Device Information for Users

Once merged, users can find the device in Zigbee2MQTT as:

**Supported Devices → Custom devices (DiY) → ACW02-ZB**

### Device Pairing
1. Power on the device
2. It will automatically enter pairing mode (factory new)
3. Permit joining in Zigbee2MQTT
4. Device should appear with all endpoints

### Configuration Options
- `acw02_poll_interval`: Polling interval for unreportable attributes (default: 60s, set to -1 to disable)
