### PR TITLE
fix: Fixed inability to add PEHPL0X as an energy consumption device to Home Assistant

### DIFF
--- a/src/devices/perenio.ts
+++ b/src/devices/perenio.ts
@@ -411,7 +411,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("default_on_off_state", ea.ALL, defaultOnOffStateValues),
             e.numeric("rms_voltage", ea.STATE).withUnit("V").withDescription("RMS voltage"),
             e.numeric("active_power", ea.STATE).withUnit("W").withDescription("Active power"),
-            e.numeric("consumed_energy", ea.STATE).withUnit("W*h").withDescription("Consumed energy"),
+            e.numeric("consumed_energy", ea.STATE).withUnit("Wh").withDescription("Consumed energy"),
             e
                 .binary("alarm_voltage_min", ea.ALL, true, false)
                 .withDescription("Indicates if the alarm is triggered on the voltage drop below the limit, allows to reset alarms"),


### PR DESCRIPTION
PEHPL0X's `consumed_energy` entity wouldn't show up in Home Assistant's energy configuration. Turns out that Home Assistant expects the unit to be `Wh` and not `W*h`.