### PR TITLE
Add SPP01G device configuration and reporting

### DIFF
--- a/src/devices/mercator.ts
+++ b/src/devices/mercator.ts
@@ -88,7 +88,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [tuya.modernExtend.tuyaLight({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-    fingerprint: tuya.fingerprint("TS011F", ["_TZ3210_q7oryllx"]),
+        fingerprint: tuya.fingerprint("TS011F", ["_TZ3210_q7oryllx"]),
         model: "SPP01G",
         vendor: "Mercator Ikuü",
         description: "Single power point",
@@ -97,17 +97,17 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint1 = device.getEndpoint(1);
             await reporting.bind(endpoint1, coordinatorEndpoint, ["genBasic", "genOnOff", "haElectricalMeasurement", "seMetering"]);
             await reporting.onOff(endpoint1);
-            await reporting.rmsVoltage(endpoint1, { change: 5 });
-            await reporting.rmsCurrent(endpoint1, { change: 50 });
-            await reporting.activePower(endpoint1, { change: 1 });
+            await reporting.rmsVoltage(endpoint1, {change: 5});
+            await reporting.rmsCurrent(endpoint1, {change: 50});
+            await reporting.activePower(endpoint1, {change: 1});
             await reporting.currentSummDelivered(endpoint1);
             //await reporting.onOff(endpoint1);
-            endpoint1.saveClusterAttributeKeyValue("haElectricalMeasurement", { acCurrentDivisor: 1000, acCurrentMultiplier: 1 });
-            endpoint1.saveClusterAttributeKeyValue("seMetering", { divisor: 100, multiplier: 1 });
+            endpoint1.saveClusterAttributeKeyValue("haElectricalMeasurement", {acCurrentDivisor: 1000, acCurrentMultiplier: 1});
+            endpoint1.saveClusterAttributeKeyValue("seMetering", {divisor: 100, multiplier: 1});
             device.save();
         },
-        extend: [tuya.modernExtend.tuyaOnOff({ powerOutageMemory: true, electricalMeasurements: true, onOffCountdown: true, childLock: true})],
-},
+        extend: [tuya.modernExtend.tuyaOnOff({powerOutageMemory: true, electricalMeasurements: true, onOffCountdown: true, childLock: true})],
+    },
     {
         fingerprint: tuya.fingerprint("TS011F", ["_TZ3210_raqjcxo5"]),
         model: "SPP02G",


### PR DESCRIPTION
Added configuration and reporting for SPP01G power point device.

Switch does support inching, but 
```
extend: [tuya.modernExtend.tuyaOnOff({inchingSwitch: true}) 
```
doesn't work.  gives error:
```
z2m: Publish 'set' 'inching_control_set' to '0x842e14fffe13d05f' failed: 'Error: Cluster with name 'manuSpecificTuya4' does not exist'
```
device only has manuSpecificTuya cluster

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4467

DP's.  101 is inching.  
```
{"1":"Switch 1","9":"countdown1","17":"Increase electricity","18":"Current current","19":"Current power","20":"Current voltage","26":"Fault","27":"relay status","29":"child lock","101":"点动"}
```
