### PR TITLE
Fix: Sonoff TRVZB - prevent out of range local temperature calibration offset

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2055,7 +2055,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .climate()
                 .withSetpoint("occupied_heating_setpoint", 4, 35, 0.5)
                 .withLocalTemperature()
-                .withLocalTemperatureCalibration(-12.8, 12.7, 0.2)
+                .withLocalTemperatureCalibration(-12.7, 12.7, 0.2)
                 .withSystemMode(["off", "auto", "heat"], ea.ALL, "Mode of the thermostat")
                 .withRunningState(["idle", "heat"], ea.STATE_GET),
             e.battery(),


### PR DESCRIPTION
Sonoff TRVZB do not accept local temperature calibration offset when it is set to either min or max value and will then silently reset the offset to undefinied.

So far, this didn't pose an issue for max values due to the offset step of 0.2, since 12.7 isn't a multiple of 0.2 and 12.6 is still valid. However, -12.8 is a multiple of 0.2, so Zigbee2Mqtt will actually try to set it which then might lead to undesired behaviour.

And that undesired behaviour currently in fact means Better Thermostat spinning in an endless loop due to python `ValueError` during float conversion of value `Unknown` that eventually leads to HomeAssistant stalling entirely with 100% CPU usage... and then of course quite some overheated rooms :-/

