### PR TITLE
Correct vendor name and add new device definition

### DIFF
--- a/src/devices/nous.ts
+++ b/src/devices/nous.ts
@@ -268,14 +268,5 @@ export const definitions: DefinitionWithExtend[] = [
             m.onOff({endpointNames: ["l1", "l2", "l3"], powerOnBehavior: false}),
             m.electricityMeter(),
         ],
-        exposes: [
-            e.switch().withEndpoint("l1"),
-            e.switch().withEndpoint("l2"),
-            e.switch().withEndpoint("l3"),
-            e.power(),
-            e.current(),
-            e.voltage(),
-            e.energy(),
-        ],
     },
 ];


### PR DESCRIPTION
Updated vendor name from 'Nous' to 'Nous' for consistency and added a new device definition for 'A11Z' smart power strip.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
const m = require('zigbee-herdsman-converters/lib/modernExtend');

const definition = {
    fingerprint: [{ modelID: 'TS011F', manufacturerName: '_TZ3210_6cmeijtd' }],
    model: 'A11Z',
    vendor: 'Nous',
    description: 'Smart power strip 3 gang',
    extend: [
        m.deviceEndpoints({ endpoints: { l1: 1, l2: 2, l3: 3 } }),
        m.onOff({ endpointNames: ['l1', 'l2', 'l3'], powerOnBehavior: false }),
        m.electricityMeter(),
    ],
};

module.exports = definition;
