### PR TITLE
Add new whitelabel entry for Nous A10Z socket

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7687,6 +7687,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Zbeacon", "TS011F_plug_1_1", "Smart plug (with power monitoring)", ["Zbeacon"]),
             tuya.whitelabel("NEO", "NAS-WR01B", "Smart plug (with electrical measurements)", ["_TZ3000_gjnozsaz"]),
             tuya.whitelabel("GreenSun", "HSC-ZW-EU", "Outdoor Smart Plug (with power monitoring)", ["_TZ3000_cicwjqth"]),
+            tuya.whitelabel("Nous", "A10Z", "Smart Zigbee Socket", ["_TZ3210_jlf1nepw"]),
         ],
         ota: true,
         extend: [


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
