### PR TITLE
Fix LIDL HG06106 bulbs

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4401,13 +4401,34 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
         whiteLabel: [
-            tuya.whitelabel("Lidl", "HG06106B", "Livarno Lux E14 candle RGB", ["_TZ3000_odygigth"]),
-            tuya.whitelabel("Lidl", "HG06106A", "Livarno Lux GU10 spot RGB", ["_TZ3000_kdpxju99"]),
-            tuya.whitelabel("Lidl", "HG06106C", "Livarno Lux E27 bulb RGB", ["_TZ3000_dbou1ap4"]),
             tuya.whitelabel("Lidl", "14148906L", "Livarno Lux mood light RGB+CCT", ["_TZ3000_9cpuaca6"]),
             tuya.whitelabel("Lidl", "14149505L/14149506L_1", "Livarno Lux light bar RGB+CCT (black/white)", ["_TZ3000_gek6snaj"]),
             tuya.whitelabel("Mycket", "MS-SP-LE27WRGB", "E27 RGBW bulb", ["_TZ3000_evag0pvn"]),
             tuya.whitelabel("Lidl", "HG06104A", "Livarno Home RGB+CCT LED light strip 2m", ["_TZ3000_riwp3k79", "_TZ3000_riwp3k79"]),
+        ],
+        configure: (device, coordinatorEndpoint) => {
+            device.getEndpoint(1).saveClusterAttributeKeyValue("lightingColorCtrl", {
+                colorCapabilities: 29,
+            });
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0505A", ["_TZ3000_kdpxju99", "_TZ3000_odygigth", "_TZ3000_dbou1ap4"]),
+        model: "TS0505A_1",
+        vendor: "Tuya",
+        description: "RGB+CCT light",
+        extend: [
+            tuya.modernExtend.tuyaLight({
+                colorTemp: {range: [150, 500]},
+                color: true,
+                doNotDisturb: false,
+                colorPowerOnBehavior: false,
+            }),
+        ],
+        whiteLabel: [
+            tuya.whitelabel("Lidl", "HG06106A", "Livarno Lux GU10 spot RGB", ["_TZ3000_kdpxju99"]),
+            tuya.whitelabel("Lidl", "HG06106B", "Livarno Lux E14 candle RGB", ["_TZ3000_odygigth"]),
+            tuya.whitelabel("Lidl", "HG06106C", "Livarno Lux E27 bulb RGB", ["_TZ3000_dbou1ap4"]),
         ],
         configure: (device, coordinatorEndpoint) => {
             device.getEndpoint(1).saveClusterAttributeKeyValue("lightingColorCtrl", {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
I removed `doNotDisturb` and `colorPowerOnBehavior` from the Tuya TS0505A converter.
- The settings don't do anything on my TS0505A (`_TZ3000_kdpxju99`) → remove
- I confirm they are working on my TS0505B (`_TZ3210_cieijuw1`) → keep