### PR TITLE
fix(ignore): Hue reset make extended pan ID optional

### DIFF
--- a/src/converters/actions.ts
+++ b/src/converters/actions.ts
@@ -91,7 +91,7 @@ export const ACTIONS: Record<string, (controller: Controller, args: Record<strin
 
         return await controller.sendRaw(rawPayload);
     },
-    hue_factory_reset: async (controller, args): Promise<undefined> => {
+    philips_hue_factory_reset: async (controller, args): Promise<undefined> => {
         let extendedPanId = args.extended_pan_id;
         if (!extendedPanId) {
             extendedPanId = (await controller.getNetworkParameters()).extendedPanID;


### PR DESCRIPTION
Default to the extended pan ID of the current network, this avoids having people to look it up and potentially make mistakes in it. I expect that in 99% of the cases they want to join current network.

CC: @Mstrodl
