### PR TITLE
feat(add): Moes ZM4LT2

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1697,6 +1697,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Moes",
         description: "2-gang switch module with buzzer",
         extend: [
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             tuya.modernExtend.tuyaOnOff({
                 switchType: true,
                 indicatorMode: true,
@@ -1705,10 +1706,6 @@ export const definitions: DefinitionWithExtend[] = [
                 endpoints: ["l1", "l2"],
             }),
         ],
-        endpoint: (device) => {
-            return {l1: 1, l2: 2};
-        },
-        meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4480
Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/28191
Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/29787

- `powerOnBehavior2` was reported uneffective.
- I saw `moesStartUpOnOff` in the database entry
- I don't have the device to test further

@ThatMishakov I think you have this device (in case you want to test this)