### PR TITLE
fix: del invalid custom cluster

### DIFF
--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -675,7 +675,6 @@ export const definitions: DefinitionWithExtend[] = [
                 },
                 commandsResponse: {},
             }),
-            m.forcePowerSource({powerSource: "Mains (single phase)"}),
             m.deviceEndpoints({
                 endpoints: {default: 1, l1: 2, l2: 3, l3: 4, indicator: 5},
                 multiEndpointSkip: ["occupancy"],


### PR DESCRIPTION
An issue has arisen (commit: 50ea9ba) where when extending a standard cluster with custom attributes, the standard genBasic attributes become unavailable from the zigbee2mqtt web interface.
The mechanism for expanding a standard cluster via a converter file turned out to be unclear.
Expansion is only possible through cluster.ts?