### PR TITLE
Add new Philips lighting device support

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4584,12 +4584,12 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
-    zigbeeModel: ['Xi InterAct'],
-    model: 'RC132V LED36S/840 W30L120 IA1 NOC',
-    vendor: 'Philips Lighting',
-    description: 'Signify rectangle panel light',
-    extend: [m.deviceEndpoints({"endpoints":{"2":2,"64":64,"80":80}}), m.light({"colorTemp":{"range":[150,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}}), m.light()],
-    };
+        zigbeeModel: ["Xi InterAct"],
+        model: "912401483126",
+        vendor: "Philips",
+        description: "Signify rectangle panel light",
+        extend: [m.light({colorTemp: {range: [150, 500]}})],
+    },
     {
         zigbeeModel: ["RDM005"],
         model: "RDM005",


### PR DESCRIPTION
Support for Signify CoreLine panel
Model: RC132V LED36S/840 W30L120 IA1 NOC

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
