### PR TITLE
update 3r dual_plug

### DIFF
--- a/src/devices/third_reality.ts
+++ b/src/devices/third_reality.ts
@@ -363,7 +363,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.battery(),
             m.windowCovering({controls: ["lift"]}),
-            m.commandsWindowCovering({commands: ["open", "close", "stop"], endpointNames: ["3"]}),
+            m.commandsWindowCovering({commands: ["open", "close", "stop"]}),
             m.deviceAddCustomCluster("3rSmartBlindGen2SpecialCluster", {
                 ID: 0xfff1,
                 manufacturerCode: 0x1233,


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
There are two types of dual plugs, one with left and right sockets, and the other with top and bottom sockets, with EP1 located below
