### PR TITLE
add hej door, motion sensor, move 2 gang switch

### DIFF
--- a/src/devices/hej.ts
+++ b/src/devices/hej.ts
@@ -1,5 +1,9 @@
+import * as fz from "../converters/fromZigbee";
+import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import type {DefinitionWithExtend} from "../lib/types";
+
+const e = exposes.presets;
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -66,5 +70,23 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior: false,
             }),
         ],
+    },
+    {
+        fingerprint: [{modelID: "RH3001", manufacturerName: "TUYATEC-ktge2vqt"}],
+        model: "KKZ-DO021",
+        vendor: "Hej",
+        description: "Door contact sensor",
+        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
+        toZigbee: [],
+        exposes: [e.contact(), e.battery()],
+    },
+    {
+        fingerprint: [{modelID: "RH3040", manufacturerName: "TUYATEC-smmlguju"}],
+        model: "KKZ-MO021",
+        vendor: "Hej",
+        description: "PIR sensor",
+        fromZigbee: [fz.battery, fz.ias_occupancy_alarm_1],
+        toZigbee: [],
+        exposes: [e.battery(), e.occupancy()],
     },
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5210,7 +5210,6 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_ruldv5dt",
             "_TZ3000_fbjdkph9",
             "_TZ3000_zbfya6h0",
-            "_TZ3000_tas0zemd",
         ]),
         model: "TS0002_basic",
         vendor: "Tuya",
@@ -5323,11 +5322,12 @@ export const definitions: DefinitionWithExtend[] = [
     },
 
     {
-        fingerprint: tuya.fingerprint("TS0002", ["_TZ3000_h1ipgkwn"]),
+        fingerprint: tuya.fingerprint("TS0002", ["_TZ3000_h1ipgkwn", "_TZ3000_tas0zemd"]),
         model: "_TZ3000_h1ipgkwn",
         description: "2 channel USB switch",
         vendor: "Tuya",
         extend: [m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}), m.onOff({powerOnBehavior: true, endpointNames: ["l1", "l2"]})],
+        whiteLabel: [tuya.whitelabel("Hej", "BDS03G2", "2 gang switch", ["_TZ3000_tas0zemd"])],
     },
 
     ////////////////////////


### PR DESCRIPTION
Added hej door sensor and motion sensor devices.
Moved the 2-gang switch (_TZ3000_tas0zemd) definition to a different location due to unsupported features.
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4487
Thank you.