### PR TITLE
Add support for Philips Hue White 1600lm A67 E27 (LWA034)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4650,7 +4650,6 @@ export const definitions: DefinitionWithExtend[] = [
                 ),
         ],
     },
-
     {
         zigbeeModel: ["LWA034"],
         model: "929003856201",


### PR DESCRIPTION
This PR adds support for the Philips Hue White 1600lm A67 E27, model number 929003856201, Zigbee model LWA034. The device exposes on/off and brightness controls only (White, non-Ambiance model). It uses the standard Philips preset light_onoff_brightness() and works as expected.
