### PR TITLE
Add fingerprint for Paulmann Zigbee device 500.46

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -167,7 +167,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: undefined}})],
     },
     {
-        fingerprint : [{"modelID": "CCT", "manufacturerName": "Paulmann Licht GmbH", "dateCode": "20190515"}],
+        fingerprint: [{modelID: "CCT", manufacturerName: "Paulmann Licht GmbH", dateCode: "20190515"}],
         zigbeeModel: ["500.46"],
         model: "500.46",
         vendor: "Paulmann",


### PR DESCRIPTION
added fingerprint for a 500.46 falsely identifing as CCT

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
