### PR TITLE
Add Moes ZM-104-M-16AM switch module support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4991,6 +4991,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_jsfzkftc",
             "_TZ3000_0ghwhypc",
             "_TZ3000_1adss9de",
+            "_TZ3000_x8mbwtsz",
         ]),
         model: "TS0001_power",
         description: "Switch with power monitoring",
@@ -5042,6 +5043,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Colorock", "CR-MNZ1", "1 gang switch 30A with power monitoring", ["_TZ3000_tgddllx4"]),
             tuya.whitelabel("Nous", "L6Z", "Switch with power monitoring", ["_TZ3000_qaabwu5c", "_TZ3000_1adss9de"]),
             tuya.whitelabel("Tuya", "XSH01A", "1 gang switch", ["_TZ3000_x3ewpzyr"]),
+            tuya.whitelabel("Moes", "ZM-104-M-16AM", "1 gang switch with power monitoring", ["_TZ3000_x8mbwtsz"]),
         ],
         extend: [
             tuya.modernExtend.electricityMeasurementPoll({


### PR DESCRIPTION
Added support for Moes ZM-104-M-16AM switch module with electricity measurement.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4492
