### PR TITLE
Try to bind battery endpoint for all TS0205 variants

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1144,7 +1144,7 @@ export const definitions: DefinitionWithExtend[] = [
             // https://github.com/Koenkk/zigbee2mqtt/issues/19910#issuecomment-2634971788
             try {
                 const endpoint = device.getEndpoint(1);
-                await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+                await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
                 await reporting.batteryPercentageRemaining(endpoint);
                 //await reporting.batteryVoltage(endpoint);
             } catch {


### PR DESCRIPTION
Try to bind battery endpoint for all devices variants and adding `_TZ3210_4c6b5m1e` as an other whitelabel device.

- Should fix https://github.com/Koenkk/zigbee2mqtt/issues/29837
- Merge https://github.com/Koenkk/zigbee2mqtt/issues/19910#issuecomment-1840343690 as this seems to work for all devices.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
