### PR TITLE
fix: Sinopé TH1124ZB: fix energy value

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -705,7 +705,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TH1124ZB",
         vendor: "Sinopé",
         description: "Zigbee line volt thermostat",
-        extend: [m.electricityMeter()],
+        extend: [m.electricityMeter({energy: {divisor: 1000, multiplier: 1}})],
         fromZigbee: [fzLocal.thermostat, fzLocal.sinope, fz.hvac_user_interface, fz.ignore_temperature_report],
         toZigbee: [
             tz.thermostat_local_temperature,


### PR DESCRIPTION
I have a Sinopé TH1124ZB that began reporting energy in kWh instead of Wh after upgrading from 1.3.6 -> 2.6.1.  Fix is copied from the TH1123ZB-G2 fix at https://github.com/Koenkk/zigbee-herdsman-converters/pull/10389