### PR TITLE
Add HS2SA-EF-3.0 device definition

### DIFF
--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -467,12 +467,12 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.battery(), m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1", "battery_low"]})],
     },
     {
-       zigbeeModel: ['HS2SA-EF-3.0'],
-       model: 'HS2SA-EF-3.0',
-       vendor: 'HEIMAN',
-       description: 'Automatically generated definition',
-       extend: [m.battery(), m.iasZoneAlarm({"zoneType":"generic","zoneAttributes":["alarm_1","alarm_2","tamper","battery_low"]}), m.iasWarning()],
-       meta: {}, 
+        zigbeeModel: ["HS2SA-EF-3.0"],
+        model: "HS2SA-EF-3.0",
+        vendor: "HEIMAN",
+        description: "Automatically generated definition",
+        extend: [m.battery(), m.iasZoneAlarm({zoneType: "generic", zoneAttributes: ["alarm_1", "alarm_2", "tamper", "battery_low"]}), m.iasWarning()],
+        meta: {},
     },
     {
         zigbeeModel: ["D1-EF2-3.0"],


### PR DESCRIPTION
Added Auto generated device information for Heiman Smoke detector HS2SA-EF-3.0

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
