### PR TITLE
fix(ignore): Allow users to enter serial written on device

### DIFF
--- a/src/converters/actions.ts
+++ b/src/converters/actions.ts
@@ -96,7 +96,7 @@ export const ACTIONS: Record<string, (controller: Controller, args: Record<strin
         if (!extendedPanId) {
             extendedPanId = (await controller.getNetworkParameters()).extendedPanID;
         }
-        assert(typeof extendedPanId === "string" && /^0x[a-f0-9]{16}$/.test(extendedPanId));
+        assert(typeof extendedPanId === "string" && /^0x[a-f0-9]{16}$/i.test(extendedPanId));
         assert(
             Array.isArray(args.serial_numbers) &&
                 args.serial_numbers.length > 0 &&


### PR DESCRIPTION
This PR automatically converters the hex string to a number. This allows users to send exactly what is written on the Hue device itself and prevents them from having to do this translation themselves.

(CC: @Mstrodl)