### PR TITLE
feat: LiXee ZLinky: use reportable attribute for pricing period (LTARF)

### DIFF
--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1775,6 +1775,7 @@ function getCurrentConfig(device: Zh.Device, options: KeyValue) {
     );
 
     if (device.applicationVersion > 15) {
+        // @ts-expect-error ignore
         myExpose = myExpose.map((e) => {
             // For recent firmwares, use the reportable tariffPeriod attribute
             // instead of the old polled currentPrice and


### PR DESCRIPTION
Use a reportable attribute (`tariff_period`) for the pricing period:
* for meters in legacy ("historique") mode, use it for PTEC instead of
  the polled attribute (`activeRegisterTierDelivered`).
* for meters in standard mode, use it for LTARF instead of the polled
  attribute (`currentPrice`).

This requires the ZLinky to be on firmware v16 or newer, otherwise the
new attribute (`0x0010`) will not be present
(https://github.com/fairecasoimeme/Zlinky_TIC/commit/04acc113da9a).

### ⚠️  The device needs to be reconfigured to enable reporting for the new attribute.

See also https://github.com/fairecasoimeme/Zlinky_TIC/issues/318 and
https://github.com/fairecasoimeme/Zlinky_TIC/issues/348#issuecomment-3113289205.

Thanks a lot to @KipK for his help.
