### PR TITLE
Fix TS0004 backlight_mode converter - getFromLookup is not bidirectional

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -784,7 +784,7 @@ const tzLocal = {
             const lookup = {red_when_on: 0, pink_when_on: 1, red_on_blue_off: 2, pink_on_blue_off: 3};
             const modeValue = utils.getFromLookup(value, lookup);
             await entity.write("genOnOff", {tuyaBacklightMode: modeValue});
-            return {state: {backlight_mode: utils.getFromLookup(modeValue, lookup)}};
+            return {state: {backlight_mode: value}};
         },
     } satisfies Tz.Converter,
 };


### PR DESCRIPTION
## Problem

The simplification in commit 5e03de453 broke `backlight_mode` for the TS0004 fan/light controller (`_TZ3000_ncb6mkx8`).

Error when setting backlight_mode:
```
Value: '3' not found in: [red_when_on, pink_when_on, red_on_blue_off, pink_on_blue_off]
```

## Root Cause

`utils.getFromLookup` is **not bidirectional**. Looking at [`src/lib/utils.ts:641-670`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/lib/utils.ts#L641-L670), it only does forward lookups (key → value).

When passing `modeValue` (a number like `3`) to look up in `{red_when_on: 0, pink_when_on: 1, red_on_blue_off: 2, pink_on_blue_off: 3}`, it fails because `3` is not a key - it's a value.

## Fix

Return `value` directly in the state since `getFromLookup` already validated it. This matches the pattern used by other converters like `TS0726_switch_mode` (line 400).