### PR TITLE
fix: update vendor name for Senoro window sensor in Tuya definitions

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2340,11 +2340,10 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        // Tuya/Senoro window sensor variant with 3-state opening on DP101.
+        // Senoro window sensor variant with 3-state opening on DP101.
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6teua268"]),
-        model: "TZE284_6teua268",
-        vendor: "Tuya",
-        whiteLabel: [{vendor: "Senoro", model: "Senoro.Win v2"}],
+        model: "Senoro.Win v2",
+        vendor: "Senoro",
         description: "Window sensor with 3-state opening (DP101), optional alarm, battery",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [


### PR DESCRIPTION
### Fix vendor name for Senoro window sensor
Updates the vendor name from "Tuya" to "Senoro" for the window/door sensor in the Tuya device definitions file.

**Changes:**

Changed vendor field from "Tuya" to "Senoro" for device model _TZE284_6teua268
Cleaned up formatting in the device definition
This ensures the device is correctly attributed to its actual manufacturer, Senoro, rather than being listed under the generic Tuya vendor.


