### PR TITLE
fix: move temporary mode to config section for Sonoff TRVZB

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2147,6 +2147,7 @@ export const definitions: DefinitionWithExtend[] = [
                 lookup: {boost: 0, timer: 1},
                 cluster: "customSonoffTrvzb",
                 attribute: "temporaryMode",
+                entityCategory: "config",
                 description:
                     "Boost mode: Activates maximum TRV temperature for a user-defined duration, enabling rapid heating. " +
                     "Timer Mode: Allows customization of temperature and duration for precise heating control." +


### PR DESCRIPTION
The new temporary mode for the Sonoff TRVZB is not marked as type `config` for the `entityCategory`.

This results in extra entities displaying in dashboards when they shouldn't since they aren't control entities. Moving them to the configuration section is where they should be rather than as every day controls.
