### PR TITLE
Fix detect "_TZ3000_yupc0pb7" as "TH09Z". Update tuya.ts

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -858,7 +858,7 @@ const fzLocal = {
     TS0201_humidity: {
         ...fz.humidity,
         convert: (model, msg, publish, options, meta) => {
-            if (["_TZ3210_ncw88jfq", "_TZ3000_ywagc4rj", "_TZ3000_isw9u95y"].includes(meta.device.manufacturerName)) {
+            if (["_TZ3210_ncw88jfq", "_TZ3000_ywagc4rj", "_TZ3000_isw9u95y", "_TZ3000_yupc0pb7"].includes(meta.device.manufacturerName)) {
                 msg.data.measuredValue *= 10;
             }
             return fz.humidity.convert(model, msg, publish, options, meta);
@@ -4395,7 +4395,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Danfoss", "014G2480", "Temperature and humidity sensor", ["_TZ3000_mxzo5rhf"]),
             tuya.whitelabel("Tuya", "HS09", "Hanging temperature humidity sensor", ["_TZ3000_1twfmkcc"]),
             tuya.whitelabel("Nedis", "ZBSC10WT", "Temperature and humidity sensor", ["_TZ3000_fie1dpkm"]),
-            tuya.whitelabel("Tuya", "TH09Z", "Temperature and humidity sensor", ["_TZ3000_isw9u95y"]),
+            tuya.whitelabel("Tuya", "TH09Z", "Temperature and humidity sensor", ["_TZ3000_isw9u95y", "_TZ3000_yupc0pb7"]),
         ],
     },
     {


### PR DESCRIPTION
This fix issue: https://github.com/Koenkk/zigbee2mqtt/issues/29972

[03/12/2025, 12:51:25] zh:controller: Succesfully interviewed '0xa4c138daccb4e9ae'
[03/12/2025, 12:51:25] z2m: Successfully interviewed '0xa4c138daccb4e9ae', device has successfully been paired
[03/12/2025, 12:51:25] z2m: Device '0xa4c138daccb4e9ae' is supported, identified as: Tuya Temperature & humidity sensor with display (TS0201)

But it is only a Tuya Temperature & humidity sensor without display known as TH09z.

Link to picture pull request: No need, because picture is provided. Just problem with detection device