### PR TITLE
Tuya PJ1203A single zero removal option

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -229,7 +229,7 @@ const convLocal = {
                     const singleZeroRemoveKey = "single_zero_remove";
                     const singleZeroRemove = options[singleZeroRemoveKey] != null ? options[singleZeroRemoveKey] : false;
                     if (singleZeroRemove && !priv[`zero_power_${channel}`]) {
-                        logger.info("[PJ1203A] power is zero, flushing one time",NS);
+                        logger.info("[PJ1203A] power is zero, flushing one time", NS);
                         priv.flushNull(result, channel, options);
                     } else {
                         priv.flushZero(result, channel, options);
@@ -253,7 +253,7 @@ const convLocal = {
                     const singleZeroRemoveKey = "single_zero_remove";
                     const singleZeroRemove = options[singleZeroRemoveKey] != null ? options[singleZeroRemoveKey] : false;
                     if (singleZeroRemove && !priv[`zero_current_${channel}`]) {
-                        logger.info("[PJ1203A] current is zero, flushing one time",NS);
+                        logger.info("[PJ1203A] current is zero, flushing one time", NS);
                         priv.flushNull(result, channel, options);
                     } else {
                         priv.flushZero(result, channel, options);


### PR DESCRIPTION
Added functionality to handle single zero values for power and current readings, allowing for optional removal of these readings based on a new option.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

