### PR TITLE
Enable set position for GTZ10

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18196,11 +18196,11 @@ export const definitions: DefinitionWithExtend[] = [
                 .withValueMax(90),
             e.binary("switch_type", ea.STATE_SET, "ON", "OFF").withDescription("Enables/disables valve switch"),
             e
-                .numeric("position", ea.STATE)
+                .numeric("position", ea.STATE_SET)
                 .withUnit("%")
                 .withValueMin(0)
                 .withValueMax(100)
-                .withDescription("Position"), // set actually not working
+                .withDescription("Position. To set the value you need to turn on valve switch"),
             e.enum("screen_orientation", ea.STATE_SET, ["up", "right", "down", "left"]).withDescription("Screen orientation"),
         ],
         meta: {


### PR DESCRIPTION
Setting valve_opening (position) worked through tuya developer portal if I turned on the valve_switch (switch_type) toggle. I investigated and tested that with local external converter and that also worked. 
They either patched that in some newer firmware or someone initially was trying to set position without enabling the switch type.