### PR TITLE
fix(lumi): suppress unknown key 65522 debug message

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -919,6 +919,10 @@ export const numericAttributes2Payload = async (
                 // @ts-expect-error ignore
                 payload.power_outage_count = value[4].elmVal - 1;
                 break;
+            case "65522":
+                // Aqara devices (bulbs, relays, etc.) send telemetry data in this attribute.
+                // Contains runtime statistics and device metadata but meaning is not fully decoded.
+                break;
             case "mode":
                 assertNumber(value);
                 payload.operation_mode = ["command", "event"][value];


### PR DESCRIPTION
Aqara devices (bulbs, relays, ceiling lights, etc.) send telemetry data in manuSpecificLumi attribute 65522. The data contains runtime statistics and device metadata but the meaning is not fully decoded.

Add a case to ignore this attribute and prevent noisy debug logs.
