### PR TITLE
Update colorTemp range for Philips White Ambiance E27 bulbs to match the capabilities

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -289,7 +289,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "9290038549H",
         vendor: "Philips",
         description: "Hue white ambiance",
-        extend: [philips.m.light({colorTemp: {range: [222, 454]}})],
+        extend: [philips.m.light({colorTemp: {range: [50, 1000]}})],
     },
     {
         zigbeeModel: ["LTA016"],


### PR DESCRIPTION
Hi,

thank you for your work.

I believe the Philips [9290038549H](https://www.zigbee2mqtt.io/devices/9290038549H.html#philips-9290038549h) may be misconfigured in the current philips.ts device definition, as the device is listed with a range of [222, 454] but it reports a range of [50, 1000] in my zigbee2mqtt instance.
I've also tested this change locally and indeed it now shows the expected much broader color temp range in contrast to the previous generations.
Thanks and please let me know if  you need anything else.