### PR TITLE
Update candeo.ts

### DIFF
--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -45,6 +45,14 @@ const rd1pKnobActionsMap: {[key: string]: string} = {
     commandStop: "stopped_rotating",
 };
 
+interface CandeoOnOff {
+    attributes: never;
+    commands: {
+        release: never;
+    };
+    commandResponses: never;
+}
+
 const luxScale: m.ScaleFunction = (value: number, type: "from" | "to") => {
     let result = value;
     if (type === "from") {
@@ -202,7 +210,7 @@ const fzLocal = {
             utils.addActionGroup(payload, msg, model);
             return payload;
         },
-    } satisfies Fz.Converter<"genOnOff", undefined, ["commandOn", "commandOff", "commandToggle", "commandRelease"]>,
+    } satisfies Fz.Converter<"genOnOff", CandeoOnOff, ["commandOn", "commandOff", "commandToggle", "commandRelease"]>,
 };
 
 const tzLocal = {


### PR DESCRIPTION
Fixes missing "release" event (generated from custom genOnOff Cluster value 0x03) caused by "raw" type data no longer being passed to converter function rd1p_knob_press.

Extended genOnOff cluster using deviceAddCustomCluster to add the 0x03 value and updated type on the rd1p_knob_press function to match.

Thanks for the assist @Koenkk 

Closes https://github.com/Koenkk/zigbee-herdsman-converters/issues/10940
