### PR TITLE
fix: Bosch BTH-R*: Tweak attribute reporting config

### DIFF
--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -3242,7 +3242,7 @@ export const boschThermostatExtend = {
             reporting: false,
             entityCategory: "config",
         }),
-    humidity: () => m.humidity({reporting: true}),
+    humidity: () => m.humidity({reporting: {min: "1_MINUTE", max: "1_HOUR", change: 100}}),
     operatingMode: (args?: {enableReporting: boolean}) =>
         m.enumLookup<"hvacThermostat", BoschThermostatCluster>({
             name: "operating_mode",


### PR DESCRIPTION
This PR adjusts the attribute reporting configuration for Bosch thermostats so that they at least report every hour and at most every minute if the temperature changes by 0.1 degrees.

These parameters might be tuned further, based on user feedback.

Should fix https://github.com/Koenkk/zigbee2mqtt/issues/30048