### PR TITLE
Add Zemismart ZMS-208US-3 device support

### DIFF
--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -830,7 +830,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [107, "name_l3", valueConverterLocal.name],
             ],
         },
-    }
+    },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_mpg22jc1"]),
         model: "ZN-USC1U-HT",


### PR DESCRIPTION
Added support for Zemismart ZMS-208US-3 smart screen switch with multiple endpoints and countdown features.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4527
