### PR TITLE
Add support for Legrand Wireless Color Ambiance Switch.

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3688,7 +3688,15 @@ export const legrand_scenes: Fz.Converter<"genScenes", undefined, "commandRecall
     cluster: "genScenes",
     type: "commandRecall",
     convert: (model, msg, publish, options, meta) => {
-        const lookup: KeyValueAny = {65527: "enter", 65526: "leave", 65524: "sleep", 65525: "wakeup", 65518: "ambiance_I", 65519: "ambiance_II", 65520: "ambiance_III"};
+        const lookup: KeyValueAny = {
+            65527: "enter",
+            65526: "leave",
+            65524: "sleep",
+            65525: "wakeup",
+            65518: "ambiance_I",
+            65519: "ambiance_II",
+            65520: "ambiance_III",
+        };
         return {action: lookup[msg.data.groupid] ? lookup[msg.data.groupid] : "default"};
     },
 };

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -727,7 +727,7 @@ export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: [" Wireless Color Dimmer\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"],
         model: "067767",
-        vendor: ' Legrand',
+        vendor: " Legrand",
         description: "Wireless Color Ambiance Switch 067767/68/69 - 077710L",
         ota: true,
         meta: {battery: {voltageToPercentage: {min: 2500, max: 3000}}},


### PR DESCRIPTION
Sends actions "ambiance_I", "ambiance_II", "ambiance_III", "toggle", "off" and brightess up /stop / down. Link to product documentation : https://assets.legrand.com/pim/NP-FT-GT/F03826EN-00.pdf

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4529

