### PR TITLE
feature(add): Sinope thermostats (TH1123ZB(-G2)/TH1124ZB(-G2)) expose ecoMode

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -242,6 +242,9 @@ const fzLocal = {
             if (msg.data.drConfigWaterTempMin !== undefined) {
                 result.low_water_temp_protection = msg.data.drConfigWaterTempMin;
             }
+            if (msg.data.ecoMode !== undefined) {
+                result.eco_mode = msg.data.ecoMode;
+            }
             return result;
         },
     } satisfies Fz.Converter<"manuSpecificSinope", undefined, ["attributeReport", "readResponse"]>,
@@ -598,6 +601,16 @@ const tzLocal = {
             await entity.read("manuSpecificSinope", ["drConfigWaterTempMin"]);
         },
     } satisfies Tz.Converter,
+    eco_mode: {
+        key: ["eco_mode"],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write("manuSpecificSinope", {ecoMode: value as number});
+            return {state: {eco_mode: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read("manuSpecificSinope", ["ecoMode"]);
+        },
+    } satisfies Tz.Converter,
 };
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -623,6 +636,7 @@ export const definitions: DefinitionWithExtend[] = [
             tzLocal.outdoor_temperature_timeout,
             tzLocal.thermostat_occupancy,
             tzLocal.main_cycle_output,
+            tzLocal.eco_mode,
         ],
         exposes: [
             e
@@ -666,6 +680,12 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "sensing"]).withDescription("Control backlight dimming behavior"),
             e.enum("keypad_lockout", ea.ALL, ["unlock", "lock1"]).withDescription("Enables or disables the device’s buttons"),
             e.enum("main_cycle_output", ea.ALL, ["15_sec", "15_min"]).withDescription("The length of the control cycle: 15_sec=normal 15_min=fan"),
+            e
+                .numeric("eco_mode", ea.ALL)
+                .withUnit("°C")
+                .withValueMin(-128)
+                .withValueMax(100)
+                .withDescription("Adjust temperature setpoint to fulfill demand response"),
         ],
 
         configure: async (device, coordinatorEndpoint) => {
@@ -723,6 +743,7 @@ export const definitions: DefinitionWithExtend[] = [
             tzLocal.outdoor_temperature_timeout,
             tzLocal.thermostat_occupancy,
             tzLocal.main_cycle_output,
+            tzLocal.eco_mode,
         ],
         exposes: [
             e
@@ -766,6 +787,12 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "sensing"]).withDescription("Control backlight dimming behavior"),
             e.enum("keypad_lockout", ea.ALL, ["unlock", "lock1"]).withDescription("Enables or disables the device’s buttons"),
             e.enum("main_cycle_output", ea.ALL, ["15_sec", "15_min"]).withDescription("The length of the control cycle: 15_sec=normal 15_min=fan"),
+            e
+                .numeric("eco_mode", ea.ALL)
+                .withUnit("°C")
+                .withValueMin(-128)
+                .withValueMax(100)
+                .withDescription("Adjust temperature setpoint to fulfill demand response"),
         ],
 
         configure: async (device, coordinatorEndpoint) => {
@@ -823,6 +850,7 @@ export const definitions: DefinitionWithExtend[] = [
             tzLocal.outdoor_temperature_timeout,
             tzLocal.thermostat_occupancy,
             tzLocal.main_cycle_output,
+            tzLocal.eco_mode,
         ],
         exposes: [
             e
@@ -866,6 +894,12 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "sensing", "off"]).withDescription("Control backlight dimming behavior"),
             e.enum("keypad_lockout", ea.ALL, ["unlock", "lock1"]).withDescription("Enables or disables the device’s buttons"),
             e.enum("main_cycle_output", ea.ALL, ["15_sec", "15_min"]).withDescription("The length of the control cycle: 15_sec=normal 15_min=fan"),
+            e
+                .numeric("eco_mode", ea.ALL)
+                .withUnit("°C")
+                .withValueMin(-128)
+                .withValueMax(100)
+                .withDescription("Adjust temperature setpoint to fulfill demand response"),
         ],
 
         configure: async (device, coordinatorEndpoint) => {
@@ -934,6 +968,7 @@ export const definitions: DefinitionWithExtend[] = [
             tzLocal.outdoor_temperature_timeout,
             tzLocal.thermostat_occupancy,
             tzLocal.main_cycle_output,
+            tzLocal.eco_mode,
         ],
         exposes: [
             e
@@ -977,6 +1012,12 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "sensing", "off"]).withDescription("Control backlight dimming behavior"),
             e.enum("keypad_lockout", ea.ALL, ["unlock", "lock1"]).withDescription("Enables or disables the device’s buttons"),
             e.enum("main_cycle_output", ea.ALL, ["15_sec", "15_min"]).withDescription("The length of the control cycle: 15_sec=normal 15_min=fan"),
+            e
+                .numeric("eco_mode", ea.ALL)
+                .withUnit("°C")
+                .withValueMin(-128)
+                .withValueMax(100)
+                .withDescription("Adjust temperature setpoint to fulfill demand response"),
         ],
 
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Here is my first tentative to exposing ecoMode for Sinope thermostats TH1123ZB(-G2)/TH1124ZB(-G2).

My thermostats are all -G2, a mix of 23s and 24s. My tests are done on a TH1123ZB-G2.

This gives me the following error:
`z2m sinope No converter available for 'set' 'eco_mode' (-128)`

Even comparing to other properties from the same sinope.ts, I don't see what the difference is.

I've tried adding `, manuSinope` as a third parameter to `entity.read` and `entity.write` calls. but it didn't change much, except that setting the ecoMode stopped working completely.

I've tried adding `logger.debug(JSON.stringify(***), NS)` for `entity`, `value`, `msg` and pretty much every other bit of data I had available, but that only ended up with `undefined variable entity` error message (without a line number).

Even trying to set the ecoMode using the DevTools or a `mqtt.publish` action stopped working (it did before).

Whatever I write I see this appear:
`[10/12/2025, 08:56:13] zhc:tz: Wrote '{"ecoMode":null}' to 'manuSpecificSinope'`

And follow up reads always show:
`[10/12/2025, 08:56:42] zhc:tz: Read result of 'manuSpecificSinope': {"ecoMode":0}`

On the thermostat, the eco indicator is always flashing after any write, even -128, until I discard it by using the physical controls on the thermostat.

Additionally (unsure if related, feel free to ignore if not), since I've added these, (all) my thermostats fail to reconfigure upon restarting Z2M, because of `INSUFICIENT_SPACE`  with this error:
`[10/12/2025, 08:57:55] z2m: Failed to configure 'thermostat', attempt 4 (Error: ZCL command 0xf4b3b1fffeba6093/1 haElectricalMeasurement.configReport([{"minimumReportInterval":10,"maximumReportInterval":65000,"reportableChange":5,"attribute":"activePower"},{"minimumReportInterval":10,"maximumReportInterval":65000,"reportableChange":50,"attribute":"rmsCurrent"},{"minimumReportInterval":10,"maximumReportInterval":65000,"reportableChange":50,"attribute":"rmsVoltage"}], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'INSUFFICIENT_SPACE')`

But in the reporting tab for the device, I only see values for `hvacThermostat` cluser (`localTemp`, `plHeatingDemand`, `occupiedHeatingSetpoint`, `systemMode`, `unoccupiedHeatingSetpoint`), which are the defaults.

The reconfigure error eventually subsides and the thermostats seem to work fine despite that afterwards. There seem to be a bit of congestion and they are slow to respond to commands or refresh their states while the errors are pilling up in the logs. But that's not unexpected.

Both the ecoMode management and reconfigure issues remained even after removing the external converter, factory reset of the thermostat, or uninstall (with permanent remove add-on data) and reinstall of the Z2M addon.

I'd appreciate any help or suggestions.