### PR TITLE
fix(develco): add SIRZB-111 to warning info reverse list

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -572,7 +572,7 @@ export const warning: Tz.Converter = {
         let info;
         // https://github.com/Koenkk/zigbee2mqtt/issues/8310 some devices require the info to be reversed.
         if (Array.isArray(meta.mapped)) throw new Error("Not supported for groups");
-        if (["SIRZB-110", "SRAC-23B-ZBSR", "AV2010/29A", "AV2010/24A"].includes(meta.mapped.model)) {
+        if (["SIRZB-110", "SIRZB-111", "SRAC-23B-ZBSR", "AV2010/29A", "AV2010/24A"].includes(meta.mapped.model)) {
             info = utils.getFromLookup(values.mode, mode) + ((values.strobe ? 1 : 0) << 4) + (utils.getFromLookup(values.level, level) << 6);
         } else {
             info = (utils.getFromLookup(values.mode, mode) << 4) + ((values.strobe ? 1 : 0) << 2) + utils.getFromLookup(values.level, level);


### PR DESCRIPTION
## What
Add SIRZB-111 to the list of devices that require reversed warning info bits in the `warning_simple` toZigbee converter.

## Why
The SIRZB-111 requires the same bit order as SIRZB-110 for the `startwarninginfo` parameter. Without this fix, the alarm OFF command sends `startwarninginfo: 192` instead of `0`, which fails to stop the siren.

## Testing
Tested on a frient SIRZB-111 siren:
- Before fix: `{"alarm": "OFF"}` sent `startwarninginfo: 192` → siren did NOT stop
- After fix: `{"alarm": "OFF"}` sends `startwarninginfo: 0` → siren stops correctly

## Related Issues
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/28847