### PR TITLE
Add support for CCTFR6710 heating thermostat

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -2329,4 +2329,42 @@ export const definitions: DefinitionWithExtend[] = [
             schneiderElectricExtend.visaConfigCurtainStatus(1),
         ],
     },
+    {
+        fingerprint: [{modelID: "CCTFR6710", manufacturerName: "Schneider Electric"}],
+        model: "CCTFR6710",
+        vendor: "Schneider Electric",
+        description: "Heating thermostat",
+        fromZigbee: [fz.thermostat, fz.metering, fz.schneider_pilot_mode],
+        toZigbee: [
+            tz.schneider_temperature_measured_value,
+            tz.thermostat_system_mode,
+            tz.thermostat_running_state,
+            tz.thermostat_local_temperature,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_control_sequence_of_operation,
+            tz.schneider_pilot_mode,
+            tz.schneider_temperature_measured_value,
+        ],
+        exposes: [
+            e.power(),
+            e.energy(),
+            e.enum("schneider_pilot_mode", ea.ALL, ["pilot"]).withDescription("Controls piloting mode"),
+            e
+                .climate()
+                .withSetpoint("occupied_heating_setpoint", 4, 30, 0.5)
+                .withLocalTemperature()
+                .withSystemMode(["off", "auto", "heat"])
+                .withPiHeatingDemand(),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint1 = device.getEndpoint(1);
+            const endpoint2 = device.getEndpoint(2);
+            await reporting.bind(endpoint1, coordinatorEndpoint, ["hvacThermostat"]);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint1);
+            await reporting.thermostatPIHeatingDemand(endpoint1);
+            await reporting.bind(endpoint2, coordinatorEndpoint, ["seMetering"]);
+            await reporting.instantaneousDemand(endpoint2, {min: 0, max: 60, change: 1});
+            await reporting.currentSummDelivered(endpoint2, {min: 0, max: 60, change: 1});
+        },
+    },
 ];


### PR DESCRIPTION
same funciton as CCTFR6700 without contactor mode , i'll add a picture of it soon

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
