### PR TITLE
Fix setting set point of Eurotronic SPZB0001

### DIFF
--- a/src/devices/eurotronic.ts
+++ b/src/devices/eurotronic.ts
@@ -39,8 +39,8 @@ export const definitions: DefinitionWithExtend[] = [
             e.child_lock(),
             e
                 .climate()
-                .withSetpoint("current_heating_setpoint", 5, 30, 0.5)
                 .withSetpoint("occupied_heating_setpoint", 5, 30, 0.5)
+                .withSetpoint("current_heating_setpoint", 5, 30, 0.5)
                 .withLocalTemperature()
                 .withSystemMode(["off", "auto", "heat"])
                 .withRunningState(["idle", "heat"])


### PR DESCRIPTION
Reverts 310130d08fa16d08b880f59a1952096b6bfe16c7 as it turned out to break things Koenkk/zigbee2mqtt#30005

I am aware that there has been #10641 in which @FrankBakkerNl did exactly the opposite. As it turned out that seems to break things for many people. We need to figure out what the correct solution is and understand why one way works for some and the other for others.

In my setup this change fixes things for me. Both directions work. Setting set point from within z2m/HA is followed by the device and setting the set point at the device is followed by z2m/HA. Firmware version of my devices is `App: f.f build 255Stack: f.f build 255`.
