### PR TITLE
Refactor Tuya device fingerprint and whiteLabel entries

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2087,13 +2087,13 @@ export const definitions: DefinitionWithExtend[] = [
                     .withValueStep(1)
                     .withDescription("Sensitivity of humidity"),
             ];
-            
+
             if (device && device.manufacturerName === "_TZE284_cwyqwqbf") {
                 exps.push(tuya.exposes.batteryState());
             } else {
                 exps.push(e.battery());
             }
-            
+
             return exps;
         },
         meta: {


### PR DESCRIPTION
moved _TZE284_cwyqwqbf to separate entry containing battery state instead of battery percentage.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->