### PR TITLE
Add support for Shelly SBHT-203C device

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -741,7 +741,7 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: [{modelID: "BLU H&T ZB", manufacturerName: "Shelly"}],
         model: "SBHT-203C",
         vendor: "Shelly",
-        description: "Humidity & Temperature",
+        description: "Humidity & temperature sensor",
         extend: [m.battery(), m.temperature(), m.humidity()],
     },
 ];


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4555

The device presents itself as `BLU H&T ZB`:

```
zigbeeModel: ['BLU H&T ZB'],
model: 'BLU H&T ZB',
```

So I hope I entered the detail in the correct field :-)