### PR TITLE
Namron Panel Heater PRO 4512777 and 4512776

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -236,7 +236,7 @@ const namronPanelHeaterProExtend = (): ModernExtend => {
             return result;
         },
     };
- const fz.NamronMetering: Fz.Converter<"seMetering", undefined, ["attributeReport", "readResponse"]> = {
+ const Fz.NamronMetering: Fz.Converter<"seMetering", undefined, ["attributeReport", "readResponse"]> = {
         cluster: "seMetering",
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {


### PR DESCRIPTION
This PR adds full support for the Namron Zigbee Panel Heater PRO models:

- 4512776 (white)
- 4512777 (black)

The device joins with Zigbee model `Panel Heater` and exposes advanced
manufacturer-specific thermostat functionality.

### Supported features
- Standard Zigbee thermostat (local temperature, heating setpoint, system mode)
- Power and energy metering
- PID controller parameters (Kp / Ki / Kd)
- Selectable control method (PID / hysteresis)
- Adjustable hysteresis
- Adaptive preheat function (AS)
- Window open detection (enable/disable + window open status)
- Frost protection mode (7°C) with restore of previous mode and setpoint
- Display auto-off control
- Display brightness (read-only, firmware does not allow writes via Zigbee)

### Notes
- Display brightness (attribute 0x1000) is readable but not writable.
  All tested write attempts return INVALID_VALUE / INVALID_DATA_TYPE,
  so it is exposed as read-only. (Still working on this...)
- Display auto-off (attribute 0x1001) is fully writable and exposed as a switch.
- Manufacturer-specific attributes are implemented using the
  Sunricher/Namron manufacturer code.

### Testing
Tested with:
- Zigbee2MQTT
- Home Assistant
- Real hardware (Namron Panel Heater PRO)

All exposed features have been verified to work as expected.
----
Pictures: 
https://github.com/Koenkk/zigbee2mqtt.io/pull/4564
