### PR TITLE
Update philips.ts

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3751,7 +3751,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ["929002966501"],
+        zigbeeModel: ["929002966501", "929002966502"],
         model: "929002966501",
         vendor: "Philips",
         description: "Hue White and Color Ambiance Surimu rectangle panel",


### PR DESCRIPTION
Philips 929002966501 seems to be the same as Philips 929002966502 (new version?)

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
