### PR TITLE
Add support for A-OK AM25 Blind motor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3971,52 +3971,6 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.battery(), m.windowCovering({controls: ["lift"]})],
         whiteLabel: [tuya.whitelabel("Yookee", "D10110_1", "Smart blind", ["_TZE200_9caxna4s"])],
     },
-        fingerprint: tuya.fingerprint("TS0301", [
-        "_TZE210_m6lwazh9",
-    ]),
-    model: 'TS0301_a_ok',
-    vendor: 'Tuya',
-    description: 'A-OK AM25 Blind motor',
-    options: [exposes.options.invert_cover()],
-    extend: [
-        tuya.modernExtend.tuyaBase({
-            dp: true,
-            // Enable this line in case the device has a clock, if time is incorrect with
-            // `1970`, try with `2000`.
-            // timeStart: "1970",
-        }),
-    ],
-    exposes: [
-        e.battery(),
-        e.cover_position().setAccess("position", ea.STATE_SET),
-        e.enum("reverse_direction", ea.STATE_SET, ["forward", "back"]).withDescription("Reverse the motor direction"),
-    ],
-    meta: {
-        // All datapoints go in here
-        tuyaDatapoints: [
-            [
-                1,
-                "state",
-                tuya.valueConverterBasic.lookup({
-                    OPEN: tuya.enum(0),
-                    STOP: tuya.enum(1),
-                    CLOSE: tuya.enum(2),
-                }),
-            ],
-            [2, "position", tuya.valueConverter.coverPosition],
-            [3, "position", tuya.valueConverter.coverPosition],
-            [
-                5,
-                "reverse_direction",
-                tuya.valueConverterBasic.lookup({
-                    forward: tuya.enum(0),
-                    back: tuya.enum(1),
-                }),
-            ],
-            [12, "motor_fault", tuya.valueConverter.trueFalse1],
-            [13, "battery", tuya.valueConverter.raw],
-        ],
-    },
     {
         fingerprint: tuya.fingerprint("TS0601", [
             "_TZE200_aqnazj70",
@@ -6638,6 +6592,7 @@ Ensure all 12 segments are defined and separated by spaces.`,
             "_TZE200_ba69l9ol",
             "_TZE200_68nvbi09",
             "_TZE200_vexa5o82",
+            "_TZE210_m6lwazh9",
         ]),
         model: "TS0601_cover_3",
         vendor: "Tuya",


### PR DESCRIPTION
My first attempt at adding to Zigbee2MQTT so hopefully ok.
There were two other AM25 devices previously however it appears the battery has changed to a new ID 13.   When I made this I found the default behaviour open and closed was reversed and couldn't work out how to flip that so ended up adding in the option via     options: [exposes.options.invert_cover()].

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
