### PR TITLE
refactor: update weekly schedule handling for Sonoff TRVZB to use individual day properties

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -345,23 +345,16 @@ const sonoffExtend = {
         };
     },
     weeklySchedule: (): ModernExtend => {
-        const exposes = e
-            .composite("schedule", "weekly_schedule", ea.STATE_SET)
-            .withCategory("config")
-            .withDescription(
-                'The preset heating schedule to use when the system mode is set to "auto" (indicated with ⏲ on the TRV). ' +
-                    "Up to 6 transitions can be defined per day, where a transition is expressed in the format 'HH:mm/temperature', each " +
-                    "separated by a space. The first transition for each day must start at 00:00 and the valid temperature range is 4-35°C " +
-                    "(in 0.5°C steps). The temperature will be set at the time of the first transition until the time of the next transition, " +
-                    "e.g. '04:00/20 10:00/25' will result in the temperature being set to 20°C at 04:00 until 10:00, when it will change to 25°C.",
-            )
-            .withFeature(e.text("sunday", ea.STATE_SET))
-            .withFeature(e.text("monday", ea.STATE_SET))
-            .withFeature(e.text("tuesday", ea.STATE_SET))
-            .withFeature(e.text("wednesday", ea.STATE_SET))
-            .withFeature(e.text("thursday", ea.STATE_SET))
-            .withFeature(e.text("friday", ea.STATE_SET))
-            .withFeature(e.text("saturday", ea.STATE_SET));
+        const scheduleDescription =
+            'The preset heating schedule to use when the system mode is set to "auto" (indicated with ⏲ on the TRV). ' +
+            "Up to 6 transitions can be defined per day, where a transition is expressed in the format 'HH:mm/temperature', each " +
+            "separated by a space. The first transition for each day must start at 00:00 and the valid temperature range is 4-35°C " +
+            "(in 0.5°C steps). The temperature will be set at the time of the first transition until the time of the next transition, " +
+            "e.g. '04:00/20 10:00/25' will result in the temperature being set to 20°C at 04:00 until 10:00, when it will change to 25°C.";
+
+        const days = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"] as const;
+
+        const exposes = days.map((day) => e.text(`weekly_schedule_${day}`, ea.STATE_SET).withCategory("config").withDescription(scheduleDescription));
 
         const fromZigbee = [
             {
@@ -387,10 +380,7 @@ const sonoffExtend = {
                         .join(" ");
 
                     return {
-                        weekly_schedule: {
-                            ...(meta.state.weekly_schedule as Record<string, string>[]),
-                            [day]: transitions,
-                        },
+                        [`weekly_schedule_${day}`]: transitions,
                     };
                 },
             } satisfies Fz.Converter<"hvacThermostat", undefined, ["commandGetWeeklyScheduleRsp"]>,
@@ -398,75 +388,75 @@ const sonoffExtend = {
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ["weekly_schedule"],
+                key: days.map((day) => `weekly_schedule_${day}`),
                 convertSet: async (entity, key, value, meta) => {
                     // Transition format: HH:mm/temperature
                     const transitionRegex = /^(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])\/(\d+(\.5)?)$/;
 
-                    utils.assertObject(value, key);
+                    utils.assertString(value, key);
 
-                    for (const dayOfWeekName of Object.keys(value)) {
-                        const dayKey = utils.getKey(constants.thermostatDayOfWeek, dayOfWeekName.toLowerCase(), null);
+                    // Extract day name from key (e.g., "weekly_schedule_monday" -> "monday")
+                    const dayOfWeekName = key.replace("weekly_schedule_", "");
+                    const dayKey = utils.getKey(constants.thermostatDayOfWeek, dayOfWeekName, null);
 
-                        if (dayKey === null) {
-                            throw new Error(`Invalid schedule: invalid day name, found: ${dayOfWeekName}`);
-                        }
-
-                        const dayOfWeekBit = Number(dayKey);
-
-                        const rawTransitions = value[dayOfWeekName].split(" ").sort();
-
-                        if (rawTransitions.length > 6) {
-                            throw new Error("Invalid schedule: days must have no more than 6 transitions");
-                        }
-
-                        const transitions = [];
-
-                        for (const transition of rawTransitions) {
-                            const matches = transition.match(transitionRegex);
-
-                            if (!matches) {
-                                throw new Error(
-                                    `Invalid schedule: transitions must be in format HH:mm/temperature (e.g. 12:00/15.5), found: ${transition}`,
-                                );
-                            }
-
-                            const hour = Number.parseInt(matches[1], 10);
-                            const mins = Number.parseInt(matches[2], 10);
-                            const temp = Number.parseFloat(matches[3]);
-
-                            if (temp < 4 || temp > 35) {
-                                throw new Error(`Invalid schedule: temperature value must be between 4-35 (inclusive), found: ${temp}`);
-                            }
-
-                            transitions.push({
-                                transitionTime: hour * 60 + mins,
-                                heatSetpoint: Math.round(temp * 100),
-                            });
-                        }
-
-                        if (transitions[0].transitionTime !== 0) {
-                            throw new Error("Invalid schedule: the first transition of each day should start at 00:00");
-                        }
-
-                        await entity.command(
-                            "hvacThermostat",
-                            "setWeeklySchedule",
-                            {
-                                dayofweek: 1 << Number(dayOfWeekBit),
-                                numoftrans: rawTransitions.length,
-                                mode: 1 << 0, // heat
-                                transitions,
-                            },
-                            utils.getOptions(meta.mapped, entity),
-                        );
+                    if (dayKey === null) {
+                        throw new Error(`Invalid schedule: invalid day name, found: ${dayOfWeekName}`);
                     }
+
+                    const dayOfWeekBit = Number(dayKey);
+
+                    const rawTransitions = value.split(" ").sort();
+
+                    if (rawTransitions.length > 6) {
+                        throw new Error("Invalid schedule: days must have no more than 6 transitions");
+                    }
+
+                    const transitions = [];
+
+                    for (const transition of rawTransitions) {
+                        const matches = transition.match(transitionRegex);
+
+                        if (!matches) {
+                            throw new Error(
+                                `Invalid schedule: transitions must be in format HH:mm/temperature (e.g. 12:00/15.5), found: ${transition}`,
+                            );
+                        }
+
+                        const hour = Number.parseInt(matches[1], 10);
+                        const mins = Number.parseInt(matches[2], 10);
+                        const temp = Number.parseFloat(matches[3]);
+
+                        if (temp < 4 || temp > 35) {
+                            throw new Error(`Invalid schedule: temperature value must be between 4-35 (inclusive), found: ${temp}`);
+                        }
+
+                        transitions.push({
+                            transitionTime: hour * 60 + mins,
+                            heatSetpoint: Math.round(temp * 100),
+                        });
+                    }
+
+                    if (transitions[0].transitionTime !== 0) {
+                        throw new Error("Invalid schedule: the first transition of each day should start at 00:00");
+                    }
+
+                    await entity.command(
+                        "hvacThermostat",
+                        "setWeeklySchedule",
+                        {
+                            dayofweek: 1 << Number(dayOfWeekBit),
+                            numoftrans: rawTransitions.length,
+                            mode: 1 << 0, // heat
+                            transitions,
+                        },
+                        utils.getOptions(meta.mapped, entity),
+                    );
                 },
             },
         ];
 
         return {
-            exposes: [exposes],
+            exposes,
             fromZigbee,
             toZigbee,
             isModernExtend: true,

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -2,20 +2,24 @@ import type {Mock} from "vitest";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import type {Models as ZHModels} from "zigbee-herdsman";
 import {findByDevice} from "../src/index";
-import type {Definition, Fz, KeyValueAny, Tz} from "../src/lib/types";
+import type {Definition, Fz, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 interface State {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-    readonly weekly_schedule: {
-        readonly sunday: string;
-        readonly monday: string;
-        readonly tuesday: string;
-        readonly wednesday: string;
-        readonly thursday: string;
-        readonly friday: string;
-        readonly saturday: string;
-    };
+    readonly weekly_schedule_sunday?: string;
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    readonly weekly_schedule_monday?: string;
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    readonly weekly_schedule_tuesday?: string;
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    readonly weekly_schedule_wednesday?: string;
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    readonly weekly_schedule_thursday?: string;
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    readonly weekly_schedule_friday?: string;
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    readonly weekly_schedule_saturday?: string;
 }
 
 describe("Sonoff TRVZB", () => {
@@ -79,14 +83,15 @@ describe("Sonoff TRVZB", () => {
 
                     const state = fzConverter.convert(trv, msg, null, null, meta) as State;
 
-                    expect(state.weekly_schedule).toEqual({
-                        [day]: "00:00/5 01:30/10",
+                    expect(state).toEqual({
+                        [`weekly_schedule_${day}`]: "00:00/5 01:30/10",
                     });
                 });
             });
 
             describe("when multiple commandGetWeeklyScheduleRsp messages are received for different days", () => {
-                let state: State;
+                let state1: State;
+                let state2: State;
 
                 beforeEach(() => {
                     const msg1: Fz.Message = {
@@ -135,14 +140,16 @@ describe("Sonoff TRVZB", () => {
                         linkquality: 0,
                     };
 
-                    meta.state = fzConverter.convert(trv, msg1, null, null, meta) as KeyValueAny;
-                    state = fzConverter.convert(trv, msg2, null, null, meta) as State;
+                    state1 = fzConverter.convert(trv, msg1, null, null, meta) as State;
+                    state2 = fzConverter.convert(trv, msg2, null, null, meta) as State;
                 });
 
-                it("should merge the schedules into state", () => {
-                    expect(state.weekly_schedule).toEqual({
-                        sunday: "00:00/5 01:30/10",
-                        monday: "01:00/5.5 03:00/12.5",
+                it("should return individual day schedules", () => {
+                    expect(state1).toEqual({
+                        weekly_schedule_sunday: "00:00/5 01:30/10",
+                    });
+                    expect(state2).toEqual({
+                        weekly_schedule_monday: "01:00/5.5 03:00/12.5",
                     });
                 });
             });
@@ -168,7 +175,7 @@ describe("Sonoff TRVZB", () => {
             ];
 
             beforeEach(() => {
-                tzConverter = trv.toZigbee.find((c) => c.key.includes("weekly_schedule"));
+                tzConverter = trv.toZigbee.find((c) => c.key.includes("weekly_schedule_monday"));
 
                 meta = {
                     state: {},
@@ -188,81 +195,31 @@ describe("Sonoff TRVZB", () => {
             });
 
             it.each(invalidTransitions)("should throw error if transition format is invalid ($description)", async ({transition, description}) => {
-                await expect(
-                    tzConverter.convertSet(
-                        endpoint,
-                        "weekly_schedule",
-                        {
-                            monday: transition,
-                        },
-                        meta,
-                    ),
-                ).rejects.toEqual(
+                await expect(tzConverter.convertSet(endpoint, "weekly_schedule_monday", transition, meta)).rejects.toEqual(
                     new Error(`Invalid schedule: transitions must be in format HH:mm/temperature (e.g. 12:00/15.5), found: ${transition}`),
                 );
             });
 
             it("should throw error if first transition does not start at 00:00", async () => {
-                await expect(
-                    tzConverter.convertSet(
-                        endpoint,
-                        "weekly_schedule",
-                        {
-                            monday: "00:01/5",
-                        },
-                        meta,
-                    ),
-                ).rejects.toEqual(new Error("Invalid schedule: the first transition of each day should start at 00:00"));
+                await expect(tzConverter.convertSet(endpoint, "weekly_schedule_monday", "00:01/5", meta)).rejects.toEqual(
+                    new Error("Invalid schedule: the first transition of each day should start at 00:00"),
+                );
             });
 
             it("should throw error if day has more than 6 transitions", async () => {
                 await expect(
-                    tzConverter.convertSet(
-                        endpoint,
-                        "weekly_schedule",
-                        {
-                            monday: "00:00/1 00:00/1 00:00/1 00:00/1 00:00/1 00:00/1 00:00/1",
-                        },
-                        meta,
-                    ),
+                    tzConverter.convertSet(endpoint, "weekly_schedule_monday", "00:00/1 00:00/1 00:00/1 00:00/1 00:00/1 00:00/1 00:00/1", meta),
                 ).rejects.toEqual(new Error("Invalid schedule: days must have no more than 6 transitions"));
             });
 
             it.each([3, 36])("should throw error if temperature value is outside of valid range ($temperature) ", async (temperature) => {
-                await expect(
-                    tzConverter.convertSet(
-                        endpoint,
-                        "weekly_schedule",
-                        {
-                            monday: `00:00/${temperature}`,
-                        },
-                        meta,
-                    ),
-                ).rejects.toEqual(new Error(`Invalid schedule: temperature value must be between 4-35 (inclusive), found: ${temperature}`));
-            });
-
-            it("should throw error if day name is invalid", async () => {
-                await expect(
-                    tzConverter.convertSet(
-                        endpoint,
-                        "weekly_schedule",
-                        {
-                            notaday: "00:00/5",
-                        },
-                        meta,
-                    ),
-                ).rejects.toEqual(new Error("Invalid schedule: invalid day name, found: notaday"));
+                await expect(tzConverter.convertSet(endpoint, "weekly_schedule_monday", `00:00/${temperature}`, meta)).rejects.toEqual(
+                    new Error(`Invalid schedule: temperature value must be between 4-35 (inclusive), found: ${temperature}`),
+                );
             });
 
             it("should send setWeeklySchedule command if transitions are valid", async () => {
-                await tzConverter.convertSet(
-                    endpoint,
-                    "weekly_schedule",
-                    {
-                        sunday: "00:00/5 06:30/10.5 12:00/15 18:30/20 20:45/15.5 23:00/4",
-                    },
-                    meta,
-                );
+                await tzConverter.convertSet(endpoint, "weekly_schedule_sunday", "00:00/5 06:30/10.5 12:00/15 18:30/20 20:45/15.5 23:00/4", meta);
 
                 expect(commandFn).toHaveBeenCalledWith(
                     "hvacThermostat",
@@ -303,14 +260,7 @@ describe("Sonoff TRVZB", () => {
             });
 
             it("should send setWeeklySchedule command with transitions in ascending time order", async () => {
-                await tzConverter.convertSet(
-                    endpoint,
-                    "weekly_schedule",
-                    {
-                        sunday: "00:00/5 12:00/15 06:30/10.5",
-                    },
-                    meta,
-                );
+                await tzConverter.convertSet(endpoint, "weekly_schedule_sunday", "00:00/5 12:00/15 06:30/10.5", meta);
 
                 expect(commandFn).toHaveBeenCalledWith(
                     "hvacThermostat",
@@ -339,16 +289,9 @@ describe("Sonoff TRVZB", () => {
             });
 
             it("should send a setWeeklySchedule command for each day", async () => {
-                await tzConverter.convertSet(
-                    endpoint,
-                    "weekly_schedule",
-                    {
-                        sunday: "00:00/5",
-                        monday: "00:00/10",
-                        tuesday: "00:00/15",
-                    },
-                    meta,
-                );
+                await tzConverter.convertSet(endpoint, "weekly_schedule_sunday", "00:00/5", meta);
+                await tzConverter.convertSet(endpoint, "weekly_schedule_monday", "00:00/10", meta);
+                await tzConverter.convertSet(endpoint, "weekly_schedule_tuesday", "00:00/15", meta);
 
                 expect(commandFn).toHaveBeenCalledTimes(3);
 


### PR DESCRIPTION
Update weekly schedule handling for Sonoff TRVZB to use individual day properties

From:
``` 
"weekly_schedule": {
        "friday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
        "monday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
        "saturday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
        "sunday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
        "thursday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
        "tuesday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
        "wednesday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17"
},
```

To:
```
"weekly_schedule_monday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
"weekly_schedule_tuesday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
"weekly_schedule_wednesday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
"weekly_schedule_thursday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
"weekly_schedule_friday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
"weekly_schedule_saturday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
"weekly_schedule_sunday": "00:00/16 06:30/19 19:00/20 21:30/17 21:30/17 21:30/17",
```
