### PR TITLE
Inovelli - Adding toggle option for parameter 130 (firmware 3.0+)

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -828,7 +828,7 @@ const COMMON_ATTRIBUTES: {[s: string]: Attribute} = {
         ID: 130,
         dataType: Zcl.DataType.UINT8,
         displayType: "enum",
-        values: {Disabled: 0, "Multi Tap": 1, Cycle: 2},
+        values: {Disabled: 0, "Multi Tap": 1, Cycle: 2, Toggle: 3},
         description: "Which mode to use when binding EP3 (config button) to another device (like a fan module).",
     },
     lowLevelForFanControlMode: {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Simple update to add an option for the Inovelli VZM31-SN firmware 3.0+