### PR TITLE
Add generic SPI ZB Controller

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -1241,10 +1241,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.onOff()],
     },
     {
-        fingerprint: [
-            {modelID: "TS0601", manufacturerName: "_TZE284_gt5al3bl"},
-            {modelID: "TS0601", manufacturerName: "_TZE204_8fffc3kb"},
-        ],
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_8fffc3kb", "_TZE284_gt5al3bl"]),
         model: "GL-SPI-206P",
         vendor: "Gledopto",
         description: "SPI pixel controller RGBCCT/RGBW/RGB",


### PR DESCRIPTION
Add generic ZB SPI RGBW Controller (https://de.aliexpress.com/item/1005007388990504.html), seems to be fully compatible with the GL-SPI-206.

<img width="533" height="213" alt="image" src="https://github.com/user-attachments/assets/bb49a1c0-e7fc-46fe-a569-dab113d03d19" />
