### PR TITLE
Update Philips device descriptions and models

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4369,7 +4369,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Philips",
         description: "Hue Devote Ceiling Hanging Light White Ambiance",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
-        whiteLabel: [{model: "929003055701", fingerprint: [{modelID: "929003055701"}]}],
     },
     {
         zigbeeModel: ["929004297401", "929004297402", "929004297501"],


### PR DESCRIPTION
Add new Hue Devote models, and also updated existing mapping that was linked to the wrong version.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: You can use the 929003823501, as they look the same.