### PR TITLE
Add support for Müller Licht tint Flores Gen2 garden light (MDGARD401)

### DIFF
--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -303,7 +303,6 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: [{manufacturerName: "MLI", modelID: "Garden light"}],
-        zigbeeModel: ["Garden light"],
         model: "MDGARD401",
         vendor: "Müller Licht",
         description: "tint Flores Gen2 garden light",


### PR DESCRIPTION
This PR adds support for the Müller Licht tint Flores Gen2 garden light.

- Manufacturer: MLI
- Zigbee model: Garden light
- Model/Firmware: MDGARD401

Tested with Zigbee2MQTT:
- on/off
- brightness
- color (xy/hs)
- color temperature

Note:
Effects and power-on behavior are disabled to avoid "unknown" states in Home Assistant.

![tint_Flores_Gen2](https://github.com/user-attachments/assets/9fb00d91-3d23-4db7-8cd9-999e47e17482)