### PR TITLE
Add labels for energy consumption metrics for Sonoff Zigbee smart plug

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2374,6 +2374,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "energy_yesterday",
+                label: "Energy yesterday",
                 cluster: "customClusterEwelink",
                 attribute: "energyYesterday",
                 description: "Electricity consumption for the yesterday",
@@ -2383,6 +2384,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "energy_today",
+                label: "Energy today",
                 cluster: "customClusterEwelink",
                 attribute: "energyToday",
                 description: "Electricity consumption for the day",
@@ -2392,6 +2394,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.numeric<"customClusterEwelink", SonoffEwelink>({
                 name: "energy_month",
+                label: "Energy month",
                 cluster: "customClusterEwelink",
                 attribute: "energyMonth",
                 description: "Electricity consumption for the month",


### PR DESCRIPTION
This pull request makes small improvements to the Sonoff device definitions by adding user-friendly labels to energy-related attributes. These labels help clarify the meaning of each energy metric in the user interface. 

Energy sensors showed up like this in Home Assistant, and it is not easily discernible what each metric means.

<img width="366" height="578" alt="Screenshot 2025-12-23 at 14 10 15" src="https://github.com/user-attachments/assets/97a14295-e5d0-42a6-a05e-94226d45ca31" />

---

- Device definition enhancements:
  * Added the `label` property to the `energy_yesterday`, `energy_today`, and `energy_month` numeric attributes in `src/devices/sonoff.ts` to provide clearer names for these metrics. 
  


