### PR TITLE
Breaking change: Remove bogus `humidity` value from Third Reality 3RSM0147Z.

### DIFF
--- a/src/devices/third_reality.ts
+++ b/src/devices/third_reality.ts
@@ -505,7 +505,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Smart Soil Moisture Sensor",
         extend: [
             m.temperature(),
-            m.humidity(),
             m.soilMoisture(),
             m.battery(),
             m.deviceAddCustomCluster("3rSoilSpecialCluster", {


### PR DESCRIPTION
Note that this is a breaking change! See below.

This sensor does not measure humidity. It only measures temperature and soil moisture.

It appears that there was some confusion when this device was manufactured, and the original firmware used to report only temperature and humidity -- except that the humidity reported was actually soil moisture. Recent firmware versions now report a dedicated soil moisture field (this was added in commit e9f05f749c). However, for backwards-compatibility, they still report the bogus "humidity" value that is incorrect. This patch removes reporting the humidity value.

Why remove it? I bought one of these and immediately thought it was broken, because it reported a mostly-correct temperature, a humidity value that was obviously completely wrong when compared to the rest of my humidity sensors, and then showed "null" for soil moisture (the entire reason I bought the device!). However, after an OTA firmware update, the soil moisture field was no longer null -- and now exactly matches the completely-wrong "humidity" field I saw before. At this point I finally realized that the device actually works, but that the Z2M converter (and original firmware) are both incorrect due to a firmware bug.

This is a breaking change because anyone who depends on the `humidity` field will need to revise their automations, dashboards, etc. However, the good news is that this might fix many broken automations.