### PR TITLE
Update innr.ts - add RB 256 C support

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -884,10 +884,10 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["RB 256 C"],
         model: "RB 256 C",
         vendor: "Innr",
-        description: 'E14 mini bulb RGBW 510lm',
+        description: "E14 mini bulb RGBW 510lm",
         extend: [
             m.light({
-                colorTemp: {range: [153,556]},
+                colorTemp: {range: [153, 556]},
                 color: {modes: ["xy", "hs"], enhancedHue: true},
             }),
         ],


### PR DESCRIPTION
E14 color mini bulb. Similar to RB 255 C, but enhancedHue is true.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: use the same picture as for already supported RB 255 C.
