### PR TITLE
Add support for OWON AC221 IR controller

### DIFF
--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -559,7 +559,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["AC221"],
         model: "AC221",
         vendor: "OWON",
-        description: "AC Controller / IR Blaster (AC221)",
+        description: "AC controller / IR blaster",
         extend: [m.deviceAddCustomCluster("manuSpecificOwonAc", OwonClustersDefinition.manuSpecificOwonAc)],
         fromZigbee: [fz.fan, fz.thermostat, fzLocal.owonAcOneKeyPairingResponse, fzLocal.owonAcReadPairingCodeResponse],
         toZigbee: [


### PR DESCRIPTION
### Summary
This PR adds support for the OWON AC221, an IR (infrared) controller device.

The AC221 is an IR-only device and does not provide real state feedback from
controlled appliances, therefore optimistic control is used.

### Changes
- Add a new device definition for the OWON AC221 IR controller
- Define the OWON private cluster with proper TypeScript typing
- Implement one-key pairing as a SET-only action
- Parse and expose one-key pairing result data from the device
- Avoid unknown (`?`) UI states in zigbee2mqtt

### Motivation
Previously, the AC221 was not supported and one-key pairing resulted in an
unknown state in the UI. Since IR devices are inherently one-way, treating
pairing as an action instead of a readable state better matches the device
behavior and improves user experience.

### Compatibility
- No breaking changes
- Existing devices and configurations are unaffected

### Tested with
- OWON AC221
- zigbee2mqtt (latest)
