### PR TITLE
Ikea E2204/E2206

### DIFF
--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -1046,7 +1046,7 @@ export const ikeaModernExtend = {
                     !isDummyDevice(device) &&
                     device.softwareBuildID &&
                     semverValid(device.softwareBuildID) &&
-                    semverGte(device.softwareBuildID, "2.4.25")
+                    semverGte(device.softwareBuildID, "2.4.4")
                 ) {
                     return [binary(resultName, access.ALL, "LOCK", "UNLOCK").withDescription(resultDescription).withCategory("config")];
                 }


### PR DESCRIPTION
Following request in PR #10793, `Child lock` is now enabled for software build 2.4.4 or higher. This was tested only with the E2204. I could not test this on E2206.

I have reached my typescript knowledge for the `led enable` option. If someone is able to help here and as suggested in the comment below, it would be great.

https://github.com/Koenkk/zigbee-herdsman-converters/pull/10793#issuecomment-3676229932


CC: @andrei-lazarov 