### PR TITLE
Add manufacturer name for ENGO `EONE-230W`

### DIFF
--- a/src/devices/engo.ts
+++ b/src/devices/engo.ts
@@ -547,7 +547,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_ca3i8m8p","_TZE200_awnadkan"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_ca3i8m8p", "_TZE200_awnadkan"]),
         model: "EONE-230W",
         vendor: "ENGO",
         description: "Zigbee smart thermostat",


### PR DESCRIPTION
I have nine `ENGO EONE-230W` devices, one of which I ordered later has a supported manufacturer name, the rest have different ones. I use exsternal_covnerters to support them in my local setup, but the best would be to just add manufacturer name for the existing supported configuration files.

Thanks