### PR TITLE
fix: remove  ignore_tuya_set_time for _TZE200_2ekuz3dz TuYa X5H-GB-B

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10277,7 +10277,7 @@ Ensure all 12 segments are defined and separated by spaces.`,
         model: "X5H-GB-B",
         vendor: "Tuya",
         description: "Wall-mount thermostat",
-        fromZigbee: [fz.ignore_tuya_set_time, legacy.fromZigbee.x5h_thermostat],
+        fromZigbee: [legacy.fromZigbee.x5h_thermostat],
         toZigbee: [legacy.toZigbee.x5h_thermostat],
         whiteLabel: [
             {vendor: "Beok", model: "TGR85-ZB"},


### PR DESCRIPTION
I added some time ago this flag for this thermostat in [#6850](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6850).
Thermostat's time is set now from time to time to very strange values like 25:34.
Better without time update