### PR TITLE
Add support for TS0601_DDS238-1-Z1 (_TZE204_byzdayie)  energy meter

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22891,31 +22891,19 @@ Ensure all 12 segments are defined and separated by spaces.`,
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_byzdayie"]),
-        model: "TS0601_DDS238-1-Z1",
-        vendor: "Tuya",
-        description: "Zigbee DIN energy meter",
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
-        configure: tuya.configureMagicPacket,
-        exposes: [
-            tuya.exposes.switch(),
-            e.current().withAccess(ea.STATE).withUnit("A").withDescription("Current"),
-            e.power().withAccess(ea.STATE).withUnit("W").withDescription("Power"),
-            e.voltage().withAccess(ea.STATE).withUnit("V").withDescription("Voltage"),
-            e.produced_energy().withUnit("kwh").withDescription("Produced energy"),
-        ],
+        model: "DDS238-1-Z1",
+        vendor: "TOMZN",
+        description: "Single phase DIN-rail energy meter with switch function",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [tuya.exposes.switch(), e.current(), e.power(), e.voltage(), e.energy()],
         meta: {
             tuyaDatapoints: [
-                [1, "state", tuya.valueConverter.onOff], // DP 1: Switch
-                [17, "total_energy", tuya.valueConverter.divideBy1000], // DP 17 Add Electricity
-                [18, "current", tuya.valueConverter.divideBy1000], // DP 10: Current in mA -> A
-                [19, "power", tuya.valueConverter.divideBy10], // DP 19: Power in dW -> W
-                [20, "voltage", tuya.valueConverter.divideBy10], // DP 20: Voltage in dV -> V
+                [1, "state", tuya.valueConverter.onOff],
+                [17, "energy", tuya.valueConverter.divideBy1000],
+                [18, "current", tuya.valueConverter.divideBy1000],
+                [19, "power", tuya.valueConverter.divideBy10],
+                [20, "voltage", tuya.valueConverter.divideBy10],
             ],
         },
-        whiteLabel: [
-            {vendor: "Tuya", model: "DDS238-1-Z1"},
-            tuya.whitelabel("TOMZN", "DDS238-1-Z1", "Single phase DIN-rail energy meter with switch function", ["_TZE204_byzdayie"]),
-        ],
     },
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/ced2git/zigbee2mqtt.io/blob/master/public/images/devices/DDS238-1-Z1.png

Request to add support for DDS228-1-Z1 from TOMZN. 

Definition and found in https://github.com/Koenkk/zigbee2mqtt/issues/25414 but never integrated . 
