### PR TITLE
SZLMR10: fading_time max value from 60 to 300

### DIFF
--- a/src/devices/lincukoo.ts
+++ b/src/devices/lincukoo.ts
@@ -130,7 +130,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withUnit("m")
                 .withDescription("Maximum range"),
             e.numeric("radar_sensitivity", ea.STATE_SET).withValueMin(0).withValueMax(9).withValueStep(1).withDescription("Sensitivity of the radar"),
-            e.numeric("fading_time", ea.STATE_SET).withValueMin(30).withValueMax(60).withValueStep(1).withDescription("Fading time").withUnit("s"),
+            e.numeric("fading_time", ea.STATE_SET).withValueMin(30).withValueMax(300).withValueStep(1).withDescription("Fading time").withUnit("s"),
             e.binary("radar_switch", ea.STATE_SET, "ON", "OFF").withDescription("Radar switch"),
             e.binary("indicator", ea.STATE_SET, "ON", "OFF").withDescription("LED indicator"),
             e.enum("work_mode", ea.STATE_SET, ["pir_mode", "radar_mode", "combine_mode"]).withDescription("work mode of device"),


### PR DESCRIPTION
Increase fading_time max value from 60 to 300 seconds.
Based on the Tuya app, fading time settings range from 5 to 300 seconds, but from device testing the shortest time is 30 seconds.
So the min value remains 30 seconds.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

