### PR TITLE
Modernextend implementation of Schneider Electric thermostat

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1902,7 +1902,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC},
             }),
             m.enumLookup({
-                name: "LocalTemperatureSourceSelect",
+                name: "local_temperature_source_select",
                 cluster: "hvacThermostat",
                 attribute: {ID: 0xe212, type: Zcl.DataType.UINT8},
                 description: "On devices with more than one temperature input, this selects which should be used for LocalTemperature.",
@@ -1911,7 +1911,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC},
             }),
             m.enumLookup({
-                name: "Temperature_Sensor_Type",
+                name: "temperature_sensor_type",
                 cluster: "msTemperatureMeasurement",
                 attribute: {ID: 0xe021, type: Zcl.DataType.ENUM8},
                 description: "This is used to specify the type of temperature sensor connected to this input",


### PR DESCRIPTION
Added extended features for Schneider Electric thermostat including setpoints, occupancy, electricity meter, and display settings.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

