### PR TITLE
Add support for CentraLite 3455-L

### DIFF
--- a/src/devices/centralite.ts
+++ b/src/devices/centralite.ts
@@ -210,26 +210,26 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light()],
     },
     {
-        zigbeeModel: ['3455-L'],
-        model: '3455-L',
-        vendor: 'Centralite',
-        description: 'Iris Care Pendant (Panic Button)',
+        zigbeeModel: ["3455-L"],
+        model: "3455-L",
+        vendor: "Centralite",
+        description: "Iris Care Pendant (Panic Button)",
         extend: [
             m.identify(),
             m.battery(),
             m.iasZoneAlarm({
-                zoneType: 'generic',
-                zoneAttributes: ['alarm_1', 'alarm_2', 'tamper', 'battery_low'],
+                zoneType: "generic",
+                zoneAttributes: ["alarm_1", "alarm_2", "tamper", "battery_low"],
             }),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'ssIasZone']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "ssIasZone"]);
             await reporting.batteryVoltage(endpoint);
-            await endpoint.write('ssIasZone', {iasCieAddr: coordinatorEndpoint.deviceIeeeAddress});
-            await endpoint.command('ssIasZone', 'enrollRsp', {enrollrspcode: 0, zoneid: 23});
+            await endpoint.write("ssIasZone", {iasCieAddr: coordinatorEndpoint.deviceIeeeAddress});
+            await endpoint.command("ssIasZone", "enrollRsp", {enrollrspcode: 0, zoneid: 23});
         },
-        meta: {battery: {voltageToPercentage: '3V_2100'}},
+        meta: {battery: {voltageToPercentage: "3V_2100"}},
     },
     {
         fingerprint: [


### PR DESCRIPTION
 Adds support for the CentraLite 3455-L Iris Care Pendant (Panic Button).
   
   Tested working with:
   - Battery reporting
   - Panic button activation (IAS zone alarms)

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [TODO](https://github.com/Koenkk/zigbee2mqtt.io/pull/4635)
