### PR TITLE
Add Tuya presence sensor _TZE200_juzago6i

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12573,6 +12573,40 @@ Ensure all 12 segments are defined and separated by spaces.`,
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_juzago6i"]),
+        model: "TS0601-PIR-Sensor",
+        vendor: "Tuya",
+        description: "PIR 24GHz human presence sensor",
+        extend: [m.battery(), tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [
+            e.presence(),
+            e.illuminance(),
+            e.numeric("detection_distance", ea.STATE_SET).withValueMin(1).withValueMax(6).withUnit("m").withDescription("Maximum detection distance"),
+            e
+                .numeric("fading_time", ea.STATE_SET)
+                .withValueMin(10)
+                .withValueMax(180)
+                .withValueStep(10)
+                .withUnit("s")
+                .withDescription("Presence keep time"),
+            e.enum("last_time", ea.STATE, ["pir", "none"]).withDescription("Last trigger type"),
+            e.numeric("static_detection_sensitivity", ea.STATE_SET).withValueMin(1).withValueMax(10).withDescription("Static detection sensitivity"),
+            e.numeric("motion_detection_sensitivity", ea.STATE_SET).withValueMin(1).withValueMax(10).withDescription("Motion detection sensitivity"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "presence", tuya.valueConverter.trueFalse0],
+                [4, "battery", tuya.valueConverter.raw],
+                [12, "illuminance", tuya.valueConverter.raw],
+                [101, "detection_distance", tuya.valueConverter.raw],
+                [103, "fading_time", tuya.valueConverter.raw],
+                [104, "last_time", tuya.valueConverterBasic.lookup({pir: 0, none: 1})],
+                [105, "static_detection_sensitivity", tuya.valueConverter.raw],
+                [106, "motion_detection_sensitivity", tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS110E", ["_TZ3210_zxbtub8r"]),
         model: "TS110E_1gang_1",
         vendor: "Tuya",


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

Add Tuya battery powered PIR 24GHz human presence sensor `_TZE200_juzago6i`.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4638
