### PR TITLE
Whitelabel for Philips Hue 929003597602

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2089,7 +2089,12 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Philips",
         description: "Hue black ambiance Aurelle square panel light",
         whiteLabel: [
-        {model: "929003597602", vendor: "Philips", description: "Hue black ambiance Aurelle square panel light 60x60", fingerprint: [{modelID: "929003597602"}]}
+            {
+                model: "929003597602",
+                vendor: "Philips",
+                description: "Hue black ambiance Aurelle square panel light 60x60",
+                fingerprint: [{modelID: "929003597602"}],
+            },
         ],
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },


### PR DESCRIPTION
Added Whitelabel for Philips Hue 929003597602
