### PR TITLE
EKO07259 Fix configuration for energy reporting

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1850,7 +1850,7 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "metering",
                 voltage: false,
                 current: false,
-                energy: {divisor: 1000, multiplier: 1}, 
+                energy: {divisor: 1000, multiplier: 1},
                 configureReporting: true,
             }),
             m.numeric({
@@ -1947,13 +1947,13 @@ export const definitions: DefinitionWithExtend[] = [
                 reporting: {min: 0, max: 3600, change: 0},
             }),
         ],
-            fromZigbee: [fz.metering],
-            configure: async (device, coordinatorEndpoint) => {
-                const endpoint5 = device.getEndpoint(5);
-                await reporting.bind(endpoint5, coordinatorEndpoint, ["seMetering"]);
-                await reporting.currentSummDelivered(endpoint5, {min: 0, max: 60, change: 1});
-                await reporting.instantaneousDemand(endpoint5, {min: 0, max: 60, change: 1});
-                await reporting.readMeteringMultiplierDivisor(endpoint5);
+        fromZigbee: [fz.metering],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint5 = device.getEndpoint(5);
+            await reporting.bind(endpoint5, coordinatorEndpoint, ["seMetering"]);
+            await reporting.currentSummDelivered(endpoint5, {min: 0, max: 60, change: 1});
+            await reporting.instantaneousDemand(endpoint5, {min: 0, max: 60, change: 1});
+            await reporting.readMeteringMultiplierDivisor(endpoint5);
         },
     },
     {


### PR DESCRIPTION
The meter reporting is on endpoint 5, I struggled with energy values 1000 times too high. Introduced a configure section for ep5 and that seems to have solved the issue.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

