### PR TITLE
fix(third-reality): force 3RWS18BZ to battery power source

### DIFF
--- a/src/devices/third_reality.ts
+++ b/src/devices/third_reality.ts
@@ -176,6 +176,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zoneAttributes: ["alarm_1", "battery_low"],
             }),
             m.battery(),
+            m.forcePowerSource({powerSource: "Battery"}),
             m.binary<"3rWaterSensorcluster", ThirdWaterSensor>({
                 name: "water_leak_buzzer",
                 valueOn: ["ON", 1],


### PR DESCRIPTION
A few weeks ago, I configured 2 ThirdReality `3RWS18BZ` (Water Sensor) which got configured correctly as `Battery` devices. A couple of days ago, I bought 2 new ones and when I configured them, the new ones were showing as `Mains (single phase)` instead of `Battery`.

This PR forces ThirdReality `3RWS18BZ` (Water Sensor)  to have a `Battery` power source.

<img width="1008" height="320" alt="image" src="https://github.com/user-attachments/assets/e5f2f853-aa4f-485d-ae0d-e2918a469f59" />

<img width="926" height="308" alt="image" src="https://github.com/user-attachments/assets/467f02e4-0eb2-469d-9d60-6d9ad09539f3" />
