### PR TITLE
feat: Bosch BTH-RM*: Enable `auto` mode via `operating_mode` for HA

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -744,6 +744,31 @@ export const definitions: DefinitionWithExtend[] = [
         model: "BTH-RM",
         vendor: "Bosch",
         description: "Room thermostat II",
+        meta: {
+            overrideHaDiscoveryPayload: (payload) => {
+                if (payload.mode_command_topic?.endsWith("/system_mode")) {
+                    payload.mode_command_topic = payload.mode_command_topic.substring(0, payload.mode_command_topic.lastIndexOf("/system_mode"));
+                    payload.mode_command_template =
+                        "{% set values = " +
+                        `{ 'auto':'schedule','heat':'manual','cool':'manual','off':'pause'} %}` +
+                        `{% if value == "heat" or value == "cool" %}` +
+                        `{"operating_mode": "manual", "system_mode": "{{ value }}"}` +
+                        "{% else %}" +
+                        `{"operating_mode": "{{ values[value] if value in values.keys() else 'pause' }}"}` +
+                        "{% endif %}";
+                    payload.mode_state_template =
+                        "{% set values = " +
+                        `{'schedule':'auto','manual':'heat','pause':'off'} %}` +
+                        "{% set value = value_json.operating_mode %}" +
+                        `{% if value == "manual" %}` +
+                        "{{ value_json.system_mode }}" +
+                        "{% else %}" +
+                        `{{ values[value] if value in values.keys() else 'off' }}` +
+                        "{% endif %}";
+                    payload.modes = ["off", "heat", "cool", "auto"];
+                }
+            },
+        },
         extend: [
             boschGeneralExtend.handleZclVersionReadRequest(),
             boschThermostatExtend.customThermostatCluster(),


### PR DESCRIPTION
It's currently not super convenient to use schedules with these thermostats because setting `system_mode` to `0x01` a.k.a. **Auto** isn't supported _for some reason_...
To work around this, we'll have to override the HA discovery payload and use `operating_mode` instead.

This is mostly a proof of concept, so any feedback is highly appreciated. 😊