### PR TITLE
Update tuya.ts TS0001_repeater to include _TZ3000_trdx8uxs

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3369,7 +3369,9 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Repeater",
         fromZigbee: [fz.linkquality_from_basic],
         toZigbee: [],
-        whiteLabel: [tuya.whitelabel("Tuya", "TS0001_repeater", "Zigbee signal repeater", ["_TZ3000_n0lphcok", "_TZ3000_wn65ixz9", "_TZ3000_trdx8uxs"])],
+        whiteLabel: [
+            tuya.whitelabel("Tuya", "TS0001_repeater", "Zigbee signal repeater", ["_TZ3000_n0lphcok", "_TZ3000_wn65ixz9", "_TZ3000_trdx8uxs"]),
+        ],
         exposes: [],
     },
     {


### PR DESCRIPTION
https://www.aliexpress.com/item/1005007352880907.html (Order date: Dec 17, 2025)

Unsure if this is needed in both places?

```
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['TS0001'],
    model: 'TS0001',
    vendor: '_TZ3000_trdx8uxs',
    description: 'Automatically generated definition',
    extend: [m.onOff({"powerOnBehavior":false}), m.electricityMeter()],
};
```
<img width="1377" height="840" alt="image" src="https://github.com/user-attachments/assets/069deaba-efa9-4a97-9904-abe3aa6f965b" />
