### PR TITLE
add paulman LED Filament Bulb tuneable white

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -384,7 +384,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [{vendor: "Paulmann", model: "984.43", fingerprint: [{modelID: "98443"}]}],
     },
     {
-        zigbeeModel: ["CCT light", "CCT_light", "CCT light "],
+        zigbeeModel: ["CCT light bulb", "CCT_light_bulb"],
         model: "50394",
         vendor: "Paulmann",
         description: "LED Filament Bulb tuneable white",


### PR DESCRIPTION
Add paulman LED Filament Bulb tuneable white. Fixes https://github.com/Koenkk/zigbee2mqtt/issues/29472
Link to picture pull request: https://www.dropbox.com/scl/fi/tqf0i88vqjkqh9vcww6oj/Paulmann-50394-LED-E27-7W.png?rlkey=po5is2sao92a1zy90n7legmml&dl=0
Bulb reached already EOL status in result there is no product page at paulmann.com anymore. Best link with data and image that i found was at idealo.de.
https://www.idealo.de/preisvergleich/OffersOfProduct/202095996_-led-zigbee-filament-birnenform-tunable-white-e27-7w-2200-6500k-806lm-dimmbar-klar-50394-paulmann.html#datasheet

Note: this is my first PR for z2m, Not sure if is fine...... Maybe something is missing. Please review.
