### PR TITLE
Tuya: expose backlight color/brightness for TS0601_dimmer_3

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3861,6 +3861,14 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.exposes.lightType().withEndpoint("l3"),
             e.power_on_behavior().withAccess(ea.STATE_SET),
             tuya.exposes.backlightModeOffNormalInverted().withAccess(ea.STATE_SET),
+            e.enum("backlight_color", ea.ALL, Object.keys(tuya.BacklightColorEnum)).withDescription("Backlight color"),
+            e
+                .numeric("backlight_brightness", ea.ALL)
+                .withValueMin(0)
+                .withValueMax(100)
+                .withUnit("%")
+                .withValueStep(1)
+                .withDescription("Backlight brightness"),
         ],
         meta: {
             multiEndpoint: true,
@@ -3885,6 +3893,8 @@ export const definitions: DefinitionWithExtend[] = [
                 [19, "max_brightness_l3", tuya.valueConverter.scale0_254to0_1000],
                 [20, "countdown_l3", tuya.valueConverter.countdown],
                 [21, "backlight_mode", tuya.valueConverter.backlightModeOffNormalInverted],
+                [101, "backlight_color", tuya.valueConverterBasic.lookup(tuya.BacklightColorEnum)],
+                [103, "backlight_brightness", tuya.valueConverter.raw],
             ],
         },
         endpoint: (device) => {

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -436,6 +436,17 @@ export class Enum extends Base {}
 const enumConstructor = (value: number) => new Enum(value);
 export {enumConstructor as enum};
 
+export const BacklightColorEnum = {
+    red: enumConstructor(0),
+    blue: enumConstructor(1),
+    green: enumConstructor(2),
+    white: enumConstructor(3),
+    yellow: enumConstructor(4),
+    magenta: enumConstructor(5),
+    cyan: enumConstructor(6),
+    warm_white: enumConstructor(7),
+} as const;
+
 export class Bitmap extends Base {}
 
 type LookupMap = {[s: string]: number | boolean | Enum | string};


### PR DESCRIPTION
Summary
- Add backlight color + brightness exposes for TS0601_dimmer_3.
- Map DP 101 (backlight_color) and DP 103 (backlight_brightness).
- Add shared BacklightColorEnum in tuya lib.

Above changes allow to lower the brightness and set custom backlight color - very useful as default blue/white backlight is very bright at night - not comfortable in bedrooms.

Testing
- pnpm test

Device verification
- Tested via external converter on 3 gang dimmer: TS0601 _TZE204_znvwzxkq (Zemismart ZN2S‑RS3E‑DH).

Notes
- pnpm run check fails locally on Windows due to Biome schema mismatch/CRLF; ran `pnpm dlx @biomejs/biome@2.3.8` on changed files only.

device page:
https://www.zigbee2mqtt.io/devices/ZN2S-RS3E-DH.html

