### PR TITLE
Add Meian GA01 gas sensor support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2693,13 +2693,13 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             e.gas(),
             tuya.exposes.selfTestResult(),
-            e.binary('preheat', ea.STATE, true, false).withDescription('Indicates sensor preheat is active'),
+            e.binary("preheat", ea.STATE, true, false).withDescription("Indicates sensor preheat is active"),
         ],
         meta: {
             tuyaDatapoints: [
-                [1, 'gas', tuya.valueConverter.trueFalse0],
-                [9, 'self_test_result', tuya.valueConverter.selfTestResult],
-                [16, 'preheat', tuya.valueConverter.raw],
+                [1, "gas", tuya.valueConverter.trueFalse0],
+                [9, "self_test_result", tuya.valueConverter.selfTestResult],
+                [16, "preheat", tuya.valueConverter.raw],
             ],
         },
     },


### PR DESCRIPTION
Added support for Meian GA01 gas sensor with relevant metadata and exposes.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4668
