### PR TITLE
Add: Hue Perifo cylinder pendant (White/Black)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4277,16 +4277,16 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ["929003117201", "929003115901"],
+        zigbeeModel: ["929003117101", "929003117201"],
         model: "929003117201",
         vendor: "Philips",
         description: "Hue Perifo ceiling light, 3 pendant (White)",
         whiteLabel: [
             {
-                model: "929003115901",
+                model: "929003117101",
                 vendor: "Philips",
                 description: "Hue Perifo ceiling light, 3 pendant (Black)",
-                fingerprint: [{modelID: "929003115901"}],
+                fingerprint: [{modelID: "929003117101"}],
             },
         ],
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],


### PR DESCRIPTION
Updated zigbeeModel and description for various Philips Perifo devices. Added whiteLabel entries for better identification.

Following

https://github.com/Koenkk/zigbee2mqtt/issues/30477

ModelID of Perifo 3 pendants (Black) has been updated according to

https://www.philips-hue.com/en-gb/p/hue-white-and-colour-ambiance-perifo-straight-ceiling-base-kit-3-pendants/8719514407725

and ModelId  929003115901 is Perifo cylinder pendant

https://www.philips-hue.com/en-gb/p/hue-white-and-colour-ambiance-perifo-cylinder-pendant/8719514407480

Link to picture pull request: Done in

https://github.com/Koenkk/zigbee2mqtt.io/pull/4671
