### PR TITLE
Update ikea.ts

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -721,10 +721,11 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["INSPELNING Smart plug"],
-        model: "E2206",
+        model: "E22xx",
         vendor: "IKEA",
         description: "INSPELNING smart plug",
         whiteLabel: [
+            {model: "E2206", vendor: "IKEA", description: "INSPELNING smart plug (EU)"},
             {model: "E2220", vendor: "IKEA", description: "INSPELNING smart plug (US)"},
             {model: "E2223", vendor: "IKEA", description: "INSPELNING smart plug (UK)"},
             {model: "E2224", vendor: "IKEA", description: "INSPELNING smart plug (CH)"},


### PR DESCRIPTION
The actuel converter show an EU smart plug E2206 for the CH smart plug E2224 ! (wrong picture)

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
