### PR TITLE
fix: Bosch Twinguard: Rework air quality feature

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -224,13 +224,7 @@ const boschExtend = {
         };
         const exposes: Expose[] = [
             e.binary("smoke", ea.STATE, true, false).withDescription("Indicates whether the device detected smoke"),
-            e
-                .numeric("temperature", ea.STATE)
-                .withValueMin(0)
-                .withValueMax(65)
-                .withValueStep(0.1)
-                .withUnit("°C")
-                .withDescription("Temperature"),
+            e.numeric("temperature", ea.STATE).withValueMin(0).withValueMax(65).withValueStep(0.1).withUnit("°C").withDescription("Temperature"),
             e.numeric("humidity", ea.STATE).withValueMin(0).withValueMax(100).withValueStep(0.1).withUnit("%").withDescription("Relative humidity"),
             e
                 .numeric("co2", ea.STATE)


### PR DESCRIPTION
This PR contains breaking changes, but for good reason.

After extensive research, it [became clear](https://community.bosch-sensortec.com/mems-sensors-forum-jrmujtaw/post/bme680-min-and-max-values-of-co2e-and-b-voc-u8vzMo8UtKyV63K) that a [simple conversion](https://community.bosch-sensortec.com/mems-sensors-forum-jrmujtaw/post/bme680---how-do-i-convert-the-iaq-value-to-ug-m3-WAJhoehBZ4DEJBU) from ppm to µg/m³ is not really possible for [this type](https://community.bosch-sensortec.com/mems-sensors-forum-jrmujtaw/post/explanation-on-static-iaq-breath-voc-and-co2-equivalent-oe2xLhefJakKSLE) (Bosch Sensortec BME680) of [TVOC sensor](https://community.bosch-sensortec.com/mems-sensors-forum-jrmujtaw/post/explanation-on-static-iaq-breath-voc-and-co2-equivalent-oe2xLhefJakKSLE).

Checking the Twinguard [help article](https://www.bosch-smarthome.com/uk/en/support/help/product-help/twinguard-help/), you'll also see the following:

> The Twinguard can detect values between 500 ppm and 5500 ppm. Please note that there is an error tolerance of approximately +/- 15% at these limit values.

So we can _somewhat_ safely assume that a linear conversion from raw AQI (0–500) to ppm (500–5500) is done by the SHC. However, we would need longer-term data from a SHC-paired Twinguard to verify.

After about four years, we pretty much ended up exactly where @safakaltun left off. 🙈
If anyone can come up with an accurate formula to estimate µg/m³ from ppm, _please_ let me know!

### Breaking changes

- Remove `voc` from expose
- Adjust CO2-equivalent formula

