### PR TITLE
BOT-R9V-ZB preset mode moved to climate object

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -23004,7 +23004,7 @@ Ensure all 12 segments are defined and separated by spaces.`,
                 .withLocalTemperatureCalibration(-9.9, 9.9, 0.1, ea.STATE_SET)
                 .withSystemMode(["off", "heat"], ea.STATE_SET)
                 .withRunningState(["idle", "heat"], ea.STATE)
-                .withPreset(["auto", "manual", "eco"], ea.STATE_SET),
+                .withPreset(["auto", "manual", "eco"]),
             e.child_lock(),
             e.battery(),
             e.enum("valve_state", ea.STATE, ["open", "close"]).withDescription("Valve state (open/close)"),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
