### PR TITLE
Update tuya.ts TS0001_repeater to include _TZ3000_gdsvhfao

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3391,7 +3391,12 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fz.linkquality_from_basic],
         toZigbee: [],
         whiteLabel: [
-            tuya.whitelabel("Tuya", "TS0001_repeater", "Zigbee signal repeater", ["_TZ3000_n0lphcok", "_TZ3000_wn65ixz9", "_TZ3000_trdx8uxs", "_TZ3000_gdsvhfao"]),
+            tuya.whitelabel("Tuya", "TS0001_repeater", "Zigbee signal repeater", [
+                "_TZ3000_n0lphcok",
+                "_TZ3000_wn65ixz9",
+                "_TZ3000_trdx8uxs",
+                "_TZ3000_gdsvhfao",
+            ]),
         ],
         exposes: [],
     },


### PR DESCRIPTION
https://www.aliexpress.us/item/3256807258124349.html

```
import * as m from 'zigbee-herdsman-converters/lib/modernExtend';

export default {
    zigbeeModel: ['TS0001'],
    model: 'TS0001',
    vendor: '_TZ3000_gdsvhfao',
    description: 'Automatically generated definition',
    extend: [m.onOff({"powerOnBehavior":false})],
};

```

Tuya repeater(_TZ3000_gdsvhfao) identified incorrectly as a TS0001 1 gang switch.

This appears to be a newer model of the TS0207_repeater. It now has a pairing button. Would this be considered a new device?

![S55b7cf81bcd943d587c44414e0eecd8a3 jpg_220x220q75](https://github.com/user-attachments/assets/307b8ec3-5be8-43fd-a77b-a8dae9dba418)
 

