### PR TITLE
Fix datatype in Niko switchAction attribute

### DIFF
--- a/src/devices/niko.ts
+++ b/src/devices/niko.ts
@@ -59,7 +59,7 @@ const local = {
                 manufacturerCode: Zcl.ManufacturerCode.NIKO_NV,
                 attributes: {
                     switchActionReporting: {ID: 0x0001, type: Zcl.DataType.BITMAP8, write: true},
-                    switchAction: {ID: 0x0002, type: Zcl.DataType.UINT8, write: true, max: 0xff},
+                    switchAction: {ID: 0x0002, type: Zcl.DataType.BITMAP32, write: true, max: 0xffff},
                 },
                 commands: {},
                 commandsResponse: {},


### PR DESCRIPTION
Set switchAction data type of the Niko 552-721X2 to 27 (0x1b), which is BITMAP32.
Set limit to 0xffff, corresponding to 2 bytes. Possibly more are used, but at least not recognized by the converter. If the limit is reached again, we review this.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
