### PR TITLE
Add support for unknown device 0x54ef44100146289d

### DIFF
--- a/src/devices/unknown_0x54ef.ts
+++ b/src/devices/unknown_0x54ef.ts
@@ -1,9 +1,1 @@
-export default [
-    {
-        zigbeeModel: [""],
-        model: "",
-        vendor: "",
-        description: "Automatically generated definition",
-        extend: [],
-    },
-];
+export default [];


### PR DESCRIPTION
Add automatically generated device definition for IEEE address 0x54ef44100146289d. The device is currently unsupported, and this file provides a baseline definition for further development.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
