### PR TITLE
Add SMOK_YDLV10N smoke sensor support

### DIFF
--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -995,6 +995,7 @@ export const definitions: DefinitionWithExtend[] = [
             "c3442b4ac59b4ba1a83119d938f283ab",
             "SmokeSensor-EF-3.0",
             "SMOK_HV14",
+            "SMOK_YDLV10N",
         ],
         model: "HS1SA",
         vendor: "Heiman",
@@ -1006,7 +1007,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
             await reporting.batteryPercentageRemaining(endpoint);
         },
-        whiteLabel: [{model: "HS1SA-E", description: "Smoke detector", fingerprint: [{modelID: "SmokeSensor-EF-3.0"}]}],
+        whiteLabel: [{model: "HS1SA-E", description: "Smoke detector", fingerprint: [{modelID: "SmokeSensor-EF-3.0"}, {modelID: "SMOK_YDLV10N"}]}],
         exposes: [e.smoke(), e.battery_low(), e.battery(), e.test()],
     },
     {
@@ -2085,12 +2086,5 @@ export const definitions: DefinitionWithExtend[] = [
                 .withFeature(e.enum("mode", ea.SET, ["stop", "burglar", "fire", "emergency"]).withDescription("Mode of the warning(sound effect)")),
         ],
         ota: true,
-    },
-    {
-        zigbeeModel: ["SMOK_YDLV10N"],
-        model: "SMOK_YDLV10N",
-        vendor: "HEIMAN",
-        description: "Smoke sensor",
-        extend: [m.battery(), m.iasZoneAlarm({zoneType: "smoke", zoneAttributes: ["alarm_1", "alarm_2", "tamper", "battery_low"]})],
     },
 ];


### PR DESCRIPTION
Added zigbee smoke sensor from vendor HEIMAN model <img width="512" height="512" alt="HEIMAN-SMOK_YDLV10N" src="https://github.com/user-attachments/assets/e454aa10-0095-46e3-88a1-2bee5f46f7b0" />

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/user-attachments/assets/e454aa10-0095-46e3-88a1-2bee5f46f7b0