### PR TITLE
Add Sunricher SR-ZG9001T2-SW device support

### DIFF
--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -2487,6 +2487,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SR-ZG9101SAC-HP2",
         vendor: "Sunricher",
         description: "Zigbee 2 channel AC phase-cut dimmer",
-        extend: [m.deviceEndpoints({endpoints: {l1: 1, l2: 2}, configureReporting: true}), m.light({endpointNames: ["l1", "l2"]})],
+        extend: [m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}), m.light({endpointNames: ["l1", "l2"], configureReporting: true})],
     },
 ];


### PR DESCRIPTION
Added support for Sunricher Zigbee 2 channel AC phase-cut dimmer SR-ZG9001T2-SW.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4679
