### PR TITLE
IKEA plugs - update LED and Child Lock (part 3)

### DIFF
--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -1085,7 +1085,12 @@ export const ikeaModernExtend = {
                 ) {
                     return [binary(resultName, access.ALL, "TRUE", "FALSE").withDescription(resultDescription).withCategory("config")];
                 }
-                return [];
+                return [
+                    binary(resultName, access.ALL, "TRUE", "FALSE")
+                        .withDescription(resultDescription)
+                        .withCategory("config")
+                        .withLabel("Led disable"),
+                ];
             },
         ];
 


### PR DESCRIPTION
**Changes for IKEA plugs TRETAKT and INSPELNING:**
- Child lock is now enabled for all versions
- Led control is now exposed for all versions, 
but it's called 'Led disable' under v2.4.25 to reflect the old fw behavior

> I think it's the nicest to extend `binary` with a function e.g. shouldExpose(device), based on that we can make it conditional and keep the m.binary construction.

@Koenkk I didn't have much success with your suggestion either 😅 
Different label seems like the least code duplication.

CC:
- Part 1: https://github.com/Koenkk/zigbee-herdsman-converters/pull/10793
- Part 2: https://github.com/Koenkk/zigbee-herdsman-converters/pull/11110
- @chris-1243 

