### PR TITLE
fix(detect): Detect `_TZ3000_iv4eq7eh` as AVATTO ZWSM16-3-Zigbee

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5940,7 +5940,14 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0003", ["_TZ3000_4o16jdca", "_TZ3000_odzoiovu", "_TZ3000_hbic3ka3", "_TZ3000_lvhy15ix", "_TZ3000_mhhxxjrs"]),
+        fingerprint: tuya.fingerprint("TS0003", [
+            "_TZ3000_4o16jdca",
+            "_TZ3000_odzoiovu",
+            "_TZ3000_hbic3ka3",
+            "_TZ3000_lvhy15ix",
+            "_TZ3000_mhhxxjrs",
+            "_TZ3000_iv4eq7eh",
+        ]),
         model: "TS0003_switch_module_2",
         vendor: "Tuya",
         description: "3 gang switch module",
@@ -5963,7 +5970,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ["genOnOff"]);
         },
         whiteLabel: [
-            tuya.whitelabel("AVATTO", "ZWSM16-3-Zigbee", "3 gang switch module", ["_TZ3000_hbic3ka3"]),
+            tuya.whitelabel("AVATTO", "ZWSM16-3-Zigbee", "3 gang switch module", ["_TZ3000_hbic3ka3", "_TZ3000_iv4eq7eh"]),
             tuya.whitelabel("iHseno", "_TZ3000_mhhxxjrs", "3 gang switch module", ["_TZ3000_mhhxxjrs"]),
         ],
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

New AVATTO 3-gang variant from Discord.