### PR TITLE
Update philips.ts to support LTC009

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3850,7 +3850,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ["LTF001"],
+        zigbeeModel: ["LTF001", "LTC009"],
         model: "6109231C5",
         vendor: "Philips",
         description: "Hue white ambiance Apogee square",


### PR DESCRIPTION
I use this lamp. The LTC009 model is a copy of the LTF001 and is intended for the Chinese market, as I bought it on Taobao. Functionality verified.

https://e.tb.cn/h.7RGG9GKW0726Bsf?tk=VWcmU1AWL0C

<img width="774" height="764" alt="tb_image_share_1767843457009 jpg" src="https://github.com/user-attachments/assets/c85023e5-3a58-4a7e-a8b8-feb1b97b1d5b" />
