### PR TITLE
Revert "fix: Sinope TH1123ZB-G2 and TH1124ZB-G2: swap sensing and off values for backlight dimming modes Koenkk/zigbee2mqtt#29828"

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -55,7 +55,7 @@ const fzLocal = {
                 result.backlight_auto_dim = utils.getFromLookup(msg.data["1026"], lookup);
             }
             if (msg.data.SinopeBacklight !== undefined) {
-                const lookup = {0: "on_demand", 1: "off", 2: "sensing"};
+                const lookup = {0: "on_demand", 1: "sensing", 2: "off"};
                 result.backlight_auto_dim = utils.getFromLookup(msg.data.SinopeBacklight, lookup);
             }
             if (msg.data["1028"] !== undefined) {
@@ -265,7 +265,7 @@ const tzLocal = {
     backlight_autodim: {
         key: ["backlight_auto_dim"],
         convertSet: async (entity, key, value, meta) => {
-            const sinopeBacklightParam = {0: "on_demand", 1: "off", 2: "sensing"};
+            const sinopeBacklightParam = {0: "on_demand", 1: "sensing", 2: "off"};
             const SinopeBacklight = utils.getKey(sinopeBacklightParam, value, value as number, Number);
             await entity.write("hvacThermostat", {SinopeBacklight}, manuSinope);
             return {state: {backlight_auto_dim: value}};


### PR DESCRIPTION
As per feedback on https://github.com/Koenkk/zigbee2mqtt/issues/29828, I am reverting the changes since it breaks other devices and will try to provide a better fix later on.

Sorry.