### PR TITLE
fix(utils): handle case-insensitive enum values in getFromLookupByValue

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -673,6 +673,14 @@ export function getFromLookupByValue(value: unknown, lookup: {[s: string]: unkno
             return key;
         }
     }
+    if (isString(value)) {
+        const valueLower = value.toLowerCase();
+        for (const key of Object.keys(lookup)) {
+            if (key.toLowerCase() === valueLower) {
+                return key;
+            }
+        }
+    }
     if (defaultValue === undefined) {
         throw new Error(`Expected one of: ${Object.values(lookup).join(", ")}, got: '${value}'`);
     }


### PR DESCRIPTION
## Problem

Some Sonoff TH sensors (SNZB-02D, SNZB-02LD, SNZB-02WD, SNZB-02DR2) with newer firmware (v8960+) send `temperature_units` as `"Celsius"` or `"Fahrenheit"` (capitalized) instead of `"celsius"` or `"fahrenheit"` (lowercase).

This causes Home Assistant to reject the value with an error like:

`Invalid option for select.office_th_sensor_temperature_units: 'Celsius' (valid options: ['celsius', 'fahrenheit'])`


## Solution

Added a case-insensitive key matching fallback in `getFromLookupByValue()`. When the device sends a string value that doesn't match any lookup value exactly, the function now checks if the string matches any lookup key case-insensitively and returns the correctly-cased key.

- Device sends `"Celsius"` → returns `"celsius"` ✅
- Device sends `"Fahrenheit"` → returns `"fahrenheit"` ✅

## Affected Devices

- Sonoff SNZB-02D
- Sonoff SNZB-02LD  
- Sonoff SNZB-02WD
- Sonoff SNZB-02DR2

## Testing

The fix is backward compatible - existing numeric value handling remains unchanged.
