### PR TITLE
fix(shelly): override haElectricalMeasurement powerFactor datatype to INT16

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -13,6 +13,9 @@ const SHELLY_OPTIONS = {profileId: ZSpec.CUSTOM_SHELLY_PROFILE_ID};
 
 const NS = "zhc:shelly";
 
+const HA_ELECTRICAL_MEASUREMENT_CLUSTER_ID = 0x0b04;
+const HA_ELECTRICAL_MEASUREMENT_POWER_FACTOR_ATTR_ID = 0x0510;
+
 interface ShellyRPC {
     attributes: {
         data: string;
@@ -24,6 +27,18 @@ interface ShellyRPC {
 }
 
 const shellyModernExtend = {
+    shellyPowerFactorInt16Fix(): ModernExtend {
+        // Shelly Gen4 devices report haElectricalMeasurement.powerFactor (0x0510) as INT16 (0x29)
+        // while zigbee-herdsman defines it as INT8 (0x28). This breaks configureReporting (INVALID_DATA_TYPE).
+        return m.deviceAddCustomCluster("haElectricalMeasurement", {
+            ID: HA_ELECTRICAL_MEASUREMENT_CLUSTER_ID,
+            attributes: {
+                powerFactor: {ID: HA_ELECTRICAL_MEASUREMENT_POWER_FACTOR_ATTR_ID, type: Zcl.DataType.INT16},
+            },
+            commands: {},
+            commandsResponse: {},
+        });
+    },
     shellyCustomClusters(): ModernExtend[] {
         return [
             m.deviceAddCustomCluster("shellyRPCCluster", {
@@ -514,6 +529,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
@@ -526,6 +542,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
@@ -537,6 +554,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "EM Mini Gen4",
         extend: [
             m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
@@ -580,6 +598,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             m.onOff({powerOnBehavior: false, endpointNames: ["l1", "l2"]}),
             m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
@@ -592,6 +611,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter(),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
@@ -605,6 +625,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}),
             m.onOff({powerOnBehavior: false, endpointNames: ["1", "2", "3", "4"]}),
             m.electricityMeter({endpointNames: ["1", "2", "3", "4"]}),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["PowerstripUI"]),
             shellyModernExtend.shellyWiFiSetup(),
@@ -733,6 +754,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.light({configureReporting: true}),
             m.electricityMeter(),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],


### PR DESCRIPTION
### Summary

Fix `configureReporting` for `haElectricalMeasurement.powerFactor` on Shelly Gen4 power measuring devices by overriding the attribute datatype from **INT8** to **INT16** in the Shelly converter.

This is a Shelly-specific workaround: Shelly reports `powerFactor` (attr `0x0510`) with ZCL datatype `0x29` (**INT16**), while zigbee-herdsman defines it as `0x28` (**INT8**), which results in `INVALID_DATA_TYPE` when configuring reporting.

Closes/Refs: https://github.com/Koenkk/zigbee2mqtt/issues/30430
---

### What was happening

When calling `zigbee2mqtt/bridge/request/device/reporting/configure` for:

- cluster: `haElectricalMeasurement`
- attribute: `powerFactor`

Z2M fails with:

`Status 'INVALID_DATA_TYPE'`

Observed incoming attribute reports from Shelly show:

- `attrId`: `0x0510` (1296)
- `dataType`: `0x29` (INT16)

---

### What this PR changes

- Adds a small helper extend in `shelly.ts` that overrides:
  - cluster: `haElectricalMeasurement` (`0x0b04`)
  - attribute: `powerFactor` (`0x0510`)
  - datatype: `INT16`

- Applies this extend to **all Shelly device definitions that include `m.electricityMeter(...)`** (i.e., Shelly power measuring devices in this file).

---

### Testing

Verified using an external converter first, then applied the same override in `shelly.ts`:

- Shelly 2PM Gen4 (Switch mode): configuring reporting for `powerFactor` succeeds.
- Shelly Power Strip 4 Gen4: configuring reporting for `powerFactor` succeeds.

---

### Notes

This change is intentionally scoped to Shelly converters (not a global zigbee-herdsman cluster definition change), because the mismatch is device-specific.
