### PR TITLE
enable OTA support for Aqara W600 (WT-A03E)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5070,6 +5070,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.identify(),
+            lumiZigbeeOTA(),
         ],
     },
     {


### PR DESCRIPTION
- enables OTA support for Aqara W600 ([WT-A03E](https://www.zigbee2mqtt.io/devices/WT-A03E.html)) Radiator thermostat.
- an OTA image is now available: https://github.com/Koenkk/zigbee-OTA/pull/1009

I'm not sure if `ota: true` is needed as well or instead. Please let me know.
