### PR TITLE
fix(zigbee2mqtt#30567): ubisysRemoteTemepratureValidDuration is UNIT16

### DIFF
--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -196,11 +196,10 @@ export const ubisysModernExtend = {
                 },
                 ubisysRemoteTemperatureValidDuration: {
                     ID: 0x0014,
-                    type: Zcl.DataType.UINT8,
+                    type: Zcl.DataType.UINT16,
                     manufacturerCode: Zcl.ManufacturerCode.UBISYS_TECHNOLOGIES_GMBH,
-
                     write: true,
-                    max: 0xff,
+                    max: 0x15180,
                 },
                 ubisysDetectOpenWindow: {
                     ID: 0x0015,


### PR DESCRIPTION
should fix https://github.com/koenkk/zigbee2mqtt/issues/30567

I didn't test this as I am not home but according to the [docs](https://www.ubisys.de/downloads/ubisys-h1-technical-reference.pdf) this should be unint16.

![](https://private-user-images.githubusercontent.com/379665/533825073-c05feffd-d0ca-4406-8dfc-706d87851003.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Njc5NTI5MjUsIm5iZiI6MTc2Nzk1MjYyNSwicGF0aCI6Ii8zNzk2NjUvNTMzODI1MDczLWMwNWZlZmZkLWQwY2EtNDQwNi04ZGZjLTcwNmQ4Nzg1MTAwMy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMTA5JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDEwOVQwOTU3MDVaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0wOWEwZWQ1MjM0ZDQ4NjQwNWFhZGQ1ODcxOTZiZjc0NTk0NGI4ZTQ1NTQzNjI3YzQ1M2UzOTUzMDExOGJhY2I0JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.w3FajrdnG2xmKWXdQW474yt_TQsvFq57ZrJ_QJus5c8)
