### PR TITLE
Overlooked the external inputs to the NIko 552-721xx devices. Extending the permitted range of the switchAction attribute.

### DIFF
--- a/src/devices/niko.ts
+++ b/src/devices/niko.ts
@@ -59,7 +59,7 @@ const local = {
                 manufacturerCode: Zcl.ManufacturerCode.NIKO_NV,
                 attributes: {
                     switchActionReporting: {ID: 0x0001, type: Zcl.DataType.BITMAP8, write: true},
-                    switchAction: {ID: 0x0002, type: Zcl.DataType.BITMAP32, write: true, max: 0xffff},
+                    switchAction: {ID: 0x0002, type: Zcl.DataType.BITMAP32, write: true, max: 0x7ffff},
                 },
                 commands: {},
                 commandsResponse: {},


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
