### PR TITLE
add model ZG2855-RGB to sunricher.ts

### DIFF
--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -2490,7 +2490,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}), m.light({endpointNames: ["l1", "l2"], configureReporting: true})],
     },
     {
-        zigbeeModel: ['ZG2855-RGB'],
+        zigbeeModel: ["ZG2855-RGB"],
         model: "ZG2855-RGB",
         vendor: "Sunricher",
         description: "DIM RGB 3 in 1 Zigbee remote",


### PR DESCRIPTION
add support for ZG2855-RGB from Sunricher. 
vendor link : https://www.sunricher.com/dim-cct-rgb-3-in-1-zigbee-push-button-remote-sr-zg2855-5c.html

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4701
