### PR TITLE
Fix Philips Hue interPAN reset assertions

### DIFF
--- a/src/converters/actions.ts
+++ b/src/converters/actions.ts
@@ -109,8 +109,6 @@ export const ACTIONS: Record<string, (controller: Controller, args: Record<strin
             clusterKey: "manuSpecificPhilipsPairing",
             interPan: true,
             zcl: {
-                frameType: Zcl.FrameType.SPECIFIC,
-                direction: Zcl.Direction.CLIENT_TO_SERVER,
                 disableDefaultResponse: true,
                 manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V,
                 tsn: 0,


### PR DESCRIPTION
## Summary
- Stop setting `zcl.frameType` and `zcl.direction` for the Philips Hue interPAN reset action.

## Why
- zigbee-herdsman 8.x asserts that interPAN ZCL frames must not include explicit frameType/direction; the action currently set both and triggered AssertionError on send.

## Testing
- pnpm test
