### PR TITLE
Add TS0301 Dual Rail Shade

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4379,35 +4379,27 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TS0301_dual_rail",
         vendor: "Tuya",
         description: "Top-down bottom-up dual motor shade",
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
+        extend: [tuya.modernExtend.tuyaBase({dp: true}), m.deviceEndpoints({endpoints: {bottom: 1, top: 1}})],
         exposes: [
             e.cover_position().withEndpoint("bottom").withDescription("Bottom rail"),
             e.cover_position().withEndpoint("top").withDescription("Top rail"),
             e.battery(),
         ],
         meta: {
-            multiEndpoint: true,
             tuyaDatapoints: [
                 // Bottom rail - DP109 is control, DP101 is set position, DP102 is current position
                 [109, "state_bottom", tuya.valueConverterBasic.lookup({OPEN: tuya.enum(0), CLOSE: tuya.enum(1), STOP: tuya.enum(2)})],
                 [101, "position_bottom", tuya.valueConverter.coverPositionInverted],
                 [102, "position_bottom", tuya.valueConverter.coverPositionInverted],
-
                 // Top rail - DP1 is control, DP2 is set position, DP3 is current position
                 // Note: State commands are reversed for Home Assistant compatibility with top-down operation
                 [1, "state_top", tuya.valueConverterBasic.lookup({OPEN: tuya.enum(1), CLOSE: tuya.enum(0), STOP: tuya.enum(2)})],
                 [2, "position_top", tuya.valueConverter.coverPosition],
                 [3, "position_top", tuya.valueConverter.coverPosition],
-
                 // Battery
                 [13, "battery", tuya.valueConverter.raw],
             ],
         },
-        endpoint: (device) => {
-            return {bottom: 1, top: 1};
-        },
-        configure: tuya.configureMagicPacket,
     },
     {
         fingerprint: tuya.fingerprint("TS0601", [


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/mkventure/zigbee2mqtt.io/commit/5a83c8d1253ba664f82d0b54a77e57b6de021fcd

Added [yoolax dual rail top down bottom up shade](https://www.yoolax.com/products/motorized-top-down-bottom-up-roman-shades-lf?variant=43938411085964&option-value=%257B%2522Remote%2522%253A%252216-Channel%2520Remote%2520%255BZ561%255D%2522%252C%2522Extended%2520Motor%2520Service%2522%253A%25223-Year%2520Limited%2520Warranty%2522%252C%2522ymq_product_quantity%2522%253A1%257D)

Fully Tuya Data Points, for the record:

{"1":"Control",
"2":"Curtain Position Setting",
"3":"Current Curtain Position",
"10":"Total Time",
"11":"Situation Set",
"13":"Battery Percentage",
"16":"Border",
"101":"Curtain Position Setting2",
"102":"Current Curtain Position2",
"109":"Control 2"}