### PR TITLE
Fix bugs in generateDefinitions()

### DIFF
--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -418,6 +418,291 @@ async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
     return generated;
 }
 
+function getUnitfromApplicationType(applicationType: number): string | undefined {
+    // Map of applicationType to unit strings. Only take type ( Bits 16 to 23 ) into account.
+    const type = (applicationType >> 16) & 0xff;
+    const applicationTypeMap: {[key: number]: string} = {
+        0: "°C", // Temp_Degrees_C
+        1: "%", // Relative_Humidity_Percent
+        2: "Pa", // Pressure_Pascal
+        3: "L/s", // Flow_Liters_Per_Sec
+        4: "%", // Percentage
+        5: "ppm", // Parts_Per_Million
+        6: "rpm", // Rotational_Speed_RPM
+        7: "A", // Current_Amps
+        8: "Hz", // Frequency_Hz
+        9: "W", // Power_Watts
+        10: "kW", // Power_Kilo_Watts
+        11: "kWh", // Energy_Kilo_Watt_Hours
+        12: undefined, // Count
+        13: "kJ/kg", // Enthalpy_KJoules_Per_Kg
+        14: "s", // Time_Seconds
+    };
+
+    return applicationTypeMap[type];
+}
+
+function getUnitfromBACnetUnit(bacnetUnit: number): string | undefined {
+    const bacnetUnitMap: {[key: number]: string | undefined} = {
+        0: "m²",
+        1: "ft²",
+        2: "mA",
+        3: "A",
+        4: "Ω",
+        5: "V",
+        6: "kV",
+        7: "MV",
+        8: "VA",
+        9: "kVA",
+        10: "MVA",
+        11: "var",
+        12: "kvar",
+        13: "Mvar",
+        14: "°phase",
+        15: "pf",
+        16: "J",
+        17: "kJ",
+        18: "Wh",
+        19: "kWh",
+        20: "Btu",
+        21: "therm",
+        22: "ton·h",
+        23: "J/kg",
+        24: "Btu/lb",
+        25: "cycles/h",
+        26: "cycles/min",
+        27: "Hz",
+        28: "g/kg",
+        29: "%",
+        30: "mm",
+        31: "m",
+        32: "in",
+        33: "ft",
+        34: "W/ft²",
+        35: "W/m²",
+        36: "lm",
+        37: "lx",
+        38: "fc",
+        39: "kg",
+        40: "lb",
+        41: "tons",
+        42: "kg/s",
+        43: "kg/min",
+        44: "kg/h",
+        45: "lb/min",
+        46: "lb/h",
+        47: "W",
+        48: "kW",
+        49: "MW",
+        50: "Btu/h",
+        51: "hp",
+        52: "ton",
+        53: "Pa",
+        54: "kPa",
+        55: "bar",
+        56: "psi",
+        57: "cm H₂O",
+        58: "in H₂O",
+        59: "mmHg",
+        60: "cm Hg",
+        61: "in Hg",
+        62: "°C",
+        63: "K",
+        64: "°F",
+        65: "°C·d",
+        66: "°F·d",
+        67: "years",
+        68: "months",
+        69: "weeks",
+        70: "days",
+        71: "hours",
+        72: "minutes",
+        73: "seconds",
+        74: "m/s",
+        75: "km/h",
+        76: "ft/s",
+        77: "ft/min",
+        78: "mph",
+        79: "ft³",
+        80: "m³",
+        81: "imp gal",
+        82: "L",
+        83: "gal",
+        84: "ft³/min",
+        85: "m³/s",
+        86: "imp gal/min",
+        87: "L/s",
+        88: "L/min",
+        89: "gal/min",
+        90: "°",
+        91: "°C/h",
+        92: "°C/min",
+        93: "°F/h",
+        94: "°F/min",
+        95: undefined,
+        96: "ppm",
+        97: "ppb",
+        98: "%",
+        99: "%/s",
+        100: "1/min",
+        101: "1/s",
+        102: "psi/°F",
+        103: "rad",
+        104: "rpm",
+        105: "currency",
+        106: "currency",
+        107: "currency",
+        108: "currency",
+        109: "currency",
+        110: "currency",
+        111: "currency",
+        112: "currency",
+        113: "currency",
+        114: "currency",
+        115: "in²",
+        116: "cm²",
+        117: "Btu/lb",
+        118: "cm",
+        119: "lb/s",
+        120: "Δ°F",
+        121: "ΔK",
+        122: "kΩ",
+        123: "MΩ",
+        124: "mV",
+        125: "kJ/kg",
+        126: "MJ",
+        127: "J/K",
+        128: "J/(kg·K)",
+        129: "kHz",
+        130: "MHz",
+        131: "1/h",
+        132: "mW",
+        133: "hPa",
+        134: "mbar",
+        135: "m³/h",
+        136: "L/h",
+        137: "kWh/m²",
+        138: "kWh/ft²",
+        139: "MJ/m²",
+        140: "MJ/ft²",
+        141: "W/(m²·K)",
+        142: "ft³/s",
+        143: "% obscuration/ft",
+        144: "% obscuration/m",
+        145: "mΩ",
+        146: "MWh",
+        147: "kBtu",
+        148: "MBtu",
+        149: "kJ/kg_dry",
+        150: "MJ/kg_dry",
+        151: "kJ/K",
+        152: "MJ/K",
+        153: "N",
+        154: "g/s",
+        155: "g/min",
+        156: "tons/h",
+        157: "kBtu/h",
+        158: "1/100 s",
+        159: "ms",
+        160: "N·m",
+        161: "mm/s",
+        162: "mm/min",
+        163: "m/min",
+        164: "m/h",
+        165: "m³/min",
+        166: "m/s²",
+        167: "A/m",
+        168: "A/m²",
+        169: "A·m²",
+        170: "F",
+        171: "H",
+        172: "Ω·m",
+        174: "S/m",
+        175: "T",
+        176: "V/K",
+        177: "V/m",
+        178: "Wb",
+        179: "cd",
+        180: "cd/m²",
+        181: "K/h",
+        182: "K/min",
+        183: "J·s",
+        184: "rad/s",
+        185: "m²/N",
+        186: "kg/m³",
+        187: "N·s",
+        188: "N/m",
+        189: "W/(m·K)",
+        190: "µS/cm",
+        191: "ft³/h",
+        192: "gal/h",
+        193: "km",
+        194: "µm",
+        195: "g",
+        196: "mg",
+        197: "mL",
+        198: "mL/s",
+        199: "dB",
+        200: "dBm",
+        201: "dBV",
+        202: "mS/cm",
+        203: "var·h",
+        204: "kvar·h",
+        205: "Mvar·h",
+        206: "mm H₂O",
+        207: "‰",
+        208: "g/g",
+        209: "kg/kg",
+        210: "g/kg",
+        211: "mg/g",
+        212: "mg/kg",
+        213: "g/mL",
+        214: "g/L",
+        215: "mg/L",
+        216: "µg/L",
+        217: "g/m³",
+        218: "mg/m³",
+        219: "µg/m³",
+        220: "ng/m³",
+        221: "g/cm³",
+        222: "Bq",
+        223: "kBq",
+        224: "MBq",
+        225: "Gy",
+        226: "mGy",
+        227: "µGy",
+        228: "Sv",
+        229: "mSv",
+        230: "µSv",
+        231: "µSv/h",
+        232: "dBA",
+        233: "NTU",
+        234: "pH",
+        235: "g/m²",
+        236: "min/K",
+        237: "Ω·m²/m",
+        238: "A·s",
+        239: "VA·h",
+        240: "kVA·h",
+        241: "MVA·h",
+        242: "var·h",
+        243: "kvar·h",
+        244: "Mvar·h",
+        245: "V²·h",
+        246: "A²·h",
+        247: "J/h",
+        248: "ft³/d",
+        249: "m³/d",
+        250: "Wh/m³",
+        251: "J/m³",
+        252: "mol%",
+        253: "Pa·s",
+        254: "MMSCFM",
+    };
+
+    return bacnetUnitMap[bacnetUnit];
+}
+
 async function extenderAnalogInput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
     let endpointNames: string[] | undefined;
@@ -431,6 +716,17 @@ async function extenderAnalogInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
             label = name;
         }
         const description = `Analog Input ${name} on endpoint ${endpoint.ID}`;
+        const applicationType = await getClusterAttributeValue(endpoint, "genAnalogInput", "applicationType", undefined);
+        let unit: string | undefined;
+        if (applicationType !== undefined) {
+            unit = getUnitfromApplicationType(applicationType);
+        }
+        if (unit === undefined) {
+            const bacnet_unit = await getClusterAttributeValue(endpoint, "genAnalogInput", "engineeringUnits", undefined);
+            if (bacnet_unit !== undefined) {
+                unit = getUnitfromBACnetUnit(bacnet_unit);
+            }
+        }
         const args: m.NumericArgs<"genAnalogInput"> = {
             name: name.replace(/\s+/g, "_").toLowerCase(),
             label: label,
@@ -443,6 +739,7 @@ async function extenderAnalogInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
             description: description,
             access: "STATE_GET",
             endpointNames: endpointNames,
+            unit: unit,
         };
         generated.push(new ExtendGenerator({extend: m.numeric, args, source: "numeric"}));
     }
@@ -462,6 +759,17 @@ async function extenderAnalogOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
             label = name;
         }
         const description = `Analog Output ${name} on endpoint ${endpoint.ID}`;
+        const applicationType = await getClusterAttributeValue(endpoint, "genAnalogOutput", "applicationType", undefined);
+        let unit: string | undefined;
+        if (applicationType !== undefined) {
+            unit = getUnitfromApplicationType(applicationType);
+        }
+        if (unit === undefined) {
+            const bacnet_unit = await getClusterAttributeValue(endpoint, "genAnalogOutput", "engineeringUnits", undefined);
+            if (bacnet_unit !== undefined) {
+                unit = getUnitfromBACnetUnit(bacnet_unit);
+            }
+        }
         const args: m.NumericArgs<"genAnalogOutput"> = {
             name: name.replace(/\s+/g, "_").toLowerCase(),
             label: label,
@@ -474,6 +782,7 @@ async function extenderAnalogOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
             description: description,
             access: "ALL",
             endpointNames: endpointNames,
+            unit: unit,
         };
         generated.push(new ExtendGenerator({extend: m.numeric, args, source: "numeric"}));
     }


### PR DESCRIPTION
This PR fixes multiple bugs in generateDefinition.ts:

- set endpointNames correctly for light/onoff endpoints: fix https://github.com/Koenkk/zigbee2mqtt/issues/27925
- add endpointName(s) in binary/analog input/outputs only if we have more than 1 endpoint: fix https://github.com/Koenkk/zigbee2mqtt/issues/29888
- Fix name/label/description in binary/analog input/output: Currently devices with names that contain a space would not show up in HA

Probably the same endpoint fix could be applied to `extenderLock` and `extenderElectricityMeter` as well, but I don't have devices to test.