### PR TITLE
fix: mapping of colors

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -744,11 +744,12 @@ export const color_colortemp: Fz.Converter<"lightingColorCtrl", undefined, ["att
         // Use postfixWithEndpointName with an empty value to get just the postfix that
         // needs to be added to the result key.
         const epPostfix = postfixWithEndpointName("", msg, model, meta);
+        const gamut = libColor.getDeviceGamut(model);
 
         // handle color property sync
         // NOTE: this should the last thing we do, as we need to have processed all attributes,
         //       we use assign here so we do not lose other attributes.
-        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, epPostfix));
+        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, epPostfix, gamut));
     },
 };
 export const meter_identification: Fz.Converter<"seMeterIdentification", undefined, ["readResponse"]> = {
@@ -2130,7 +2131,9 @@ export const tuya_led_controller: Fz.Converter<"lightingColorCtrl", undefined, [
         // Use postfixWithEndpointName with an empty value to get just the postfix that
         // can be added to the result keys.
         const epPostfix = postfixWithEndpointName("", msg, model, meta);
-        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, epPostfix));
+        const gamut = libColor.getDeviceGamut(model);
+
+        return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, epPostfix, gamut));
     },
 };
 export const tuya_doorbell_button: Fz.Converter<"ssIasZone", undefined, "commandStatusChangeNotification"> = {

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -92,8 +92,8 @@ export const light_color: Tz.Converter = {
 
             newState.color_mode = constants.colorModeLookup[1];
             newState.color = xy.toObject();
-            const colorx = utils.mapNumberRange(xy.x, 0, 1, 0, 65535);
-            const colory = utils.mapNumberRange(xy.y, 0, 1, 0, 65535);
+            const colorx = Math.min(utils.mapNumberRange(xy.x, 0, 1, 0, 0xffff), 0xfeff);
+            const colory = Math.min(utils.mapNumberRange(xy.y, 0, 1, 0, 0xffff), 0xfeff);
 
             await entity.command(
                 "lightingColorCtrl",
@@ -111,16 +111,16 @@ export const light_color: Tz.Converter = {
                 await entity.command(
                     "genLevelCtrl",
                     "moveToLevelWithOnOff",
-                    {level: utils.mapNumberRange(hsvCorrected.value, 0, 100, 0, 254), transtime, optionsMask: 0, optionsOverride: 0},
+                    {level: utils.mapNumberRange(hsvCorrected.value, 0, 100, 0, 0xfe), transtime, optionsMask: 0, optionsOverride: 0},
                     utils.getOptions(meta.mapped, entity),
                 );
             }
 
             if (hsv.hue !== null && hsv.saturation !== null) {
-                const saturation = utils.mapNumberRange(hsvCorrected.saturation, 0, 100, 0, 254);
+                const saturation = utils.mapNumberRange(hsvCorrected.saturation, 0, 100, 0, 0xfe);
 
                 if (supportsEnhancedHue) {
-                    const enhancehue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 65535);
+                    const enhancehue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 0xffff);
                     await entity.command(
                         "lightingColorCtrl",
                         "enhancedMoveToHueAndSaturation",
@@ -128,7 +128,7 @@ export const light_color: Tz.Converter = {
                         utils.getOptions(meta.mapped, entity),
                     );
                 } else {
-                    const hue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 254);
+                    const hue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 0xfe);
                     await entity.command(
                         "lightingColorCtrl",
                         "moveToHueAndSaturation",
@@ -140,7 +140,7 @@ export const light_color: Tz.Converter = {
                 const direction = ((value as KeyValue).direction as number) || 0;
 
                 if (supportsEnhancedHue) {
-                    const enhancehue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 65535);
+                    const enhancehue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 0xffff);
                     await entity.command(
                         "lightingColorCtrl",
                         "enhancedMoveToHue",
@@ -148,7 +148,7 @@ export const light_color: Tz.Converter = {
                         utils.getOptions(meta.mapped, entity),
                     );
                 } else {
-                    const hue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 254);
+                    const hue = utils.mapNumberRange(hsvCorrected.hue, 0, 360, 0, 0xfe);
                     await entity.command(
                         "lightingColorCtrl",
                         "moveToHue",
@@ -157,7 +157,7 @@ export const light_color: Tz.Converter = {
                     );
                 }
             } else if (hsv.saturation !== null) {
-                const saturation = utils.mapNumberRange(hsvCorrected.saturation, 0, 100, 0, 254);
+                const saturation = utils.mapNumberRange(hsvCorrected.saturation, 0, 100, 0, 0xfe);
 
                 await entity.command(
                     "lightingColorCtrl",
@@ -1435,7 +1435,7 @@ export const light_colortemp_startup: Tz.Converter = {
     key: ["color_temp_startup"],
     convertSet: async (entity, key, value, meta) => {
         const [colorTempMin, colorTempMax] = light.findColorTempRange(entity);
-        const preset = {warmest: colorTempMax, warm: 454, neutral: 370, cool: 250, coolest: colorTempMin, previous: 65535};
+        const preset = {warmest: colorTempMax, warm: 454, neutral: 370, cool: 250, coolest: colorTempMin, previous: 0xffff};
 
         if (utils.isString(value) && value in preset) {
             value = utils.getFromLookup(value, preset);

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -78,8 +78,9 @@ export const light_color: Tz.Converter = {
         }
 
         if (newColor.isRGB() || newColor.isXY()) {
+            const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
             // Convert RGB to XY color mode because Zigbee doesn't support RGB (only x/y and hue/saturation)
-            const xy = newColor.isRGB() ? newColor.rgb.gammaCorrected().toXY().rounded(4) : newColor.xy;
+            const xy = newColor.isRGB() ? newColor.rgb.toXY(gamut).rounded(4) : newColor.xy;
 
             // Some bulbs e.g. RB 185 C don't turn to red (they don't respond at all) when x: 0.701 and y: 0.299
             // is send. These values are e.g. send by Home Assistant when clicking red in the color wheel.
@@ -105,7 +106,7 @@ export const light_color: Tz.Converter = {
             const hsv = newColor.hsv;
             const hsvCorrected = hsv.colorCorrected(meta);
             newState.color_mode = constants.colorModeLookup[0];
-            newState.color = hsv.toObject(false);
+            newState.color = hsv.toObject(true);
 
             if (hsv.value !== null && utils.isObject(value)) {
                 await entity.command(
@@ -170,7 +171,9 @@ export const light_color: Tz.Converter = {
             throw new Error("Invalid color");
         }
 
-        return {state: libColor.syncColorState(newState, meta.state, entity, meta.options)};
+        const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
+        return {state: libColor.syncColorState(newState, meta.state, entity, meta.options, undefined, gamut)};
     },
     convertGet: async (entity, key, meta) => {
         await entity.read("lightingColorCtrl", light.readColorAttributes(entity, meta));
@@ -206,8 +209,18 @@ export const light_colortemp: Tz.Converter = {
             {colortemp: value as number, transtime: utils.getTransition(entity, key, meta).time, optionsMask: 0, optionsOverride: 0},
             utils.getOptions(meta.mapped, entity),
         );
+
+        const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
         return {
-            state: libColor.syncColorState({color_mode: constants.colorModeLookup[2], color_temp: value}, meta.state, entity, meta.options),
+            state: libColor.syncColorState(
+                {color_mode: constants.colorModeLookup[2], color_temp: value},
+                meta.state,
+                entity,
+                meta.options,
+                undefined,
+                gamut,
+            ),
         };
     },
     convertGet: async (entity, key, meta) => {
@@ -1155,8 +1168,18 @@ export const light_color_and_colortemp_via_color: Tz.Converter = {
                 },
                 utils.getOptions(meta.mapped, entity),
             );
+
+            const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
             return {
-                state: libColor.syncColorState({color_mode: constants.colorModeLookup[2], color_temp: value}, meta.state, entity, meta.options),
+                state: libColor.syncColorState(
+                    {color_mode: constants.colorModeLookup[2], color_temp: value},
+                    meta.state,
+                    entity,
+                    meta.options,
+                    undefined,
+                    gamut,
+                ),
             };
         }
     },
@@ -3158,8 +3181,9 @@ export const tuya_led_control: Tz.Converter = {
                 color_mode: constants.colorModeLookup[2],
                 color_temp: meta.message.color_temp,
             };
+            const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
 
-            return {state: libColor.syncColorState(newState, meta.state, entity, meta.options)};
+            return {state: libColor.syncColorState(newState, meta.state, entity, meta.options, undefined, gamut)};
         }
 
         if (key === "color_temp") {
@@ -3185,8 +3209,9 @@ export const tuya_led_control: Tz.Converter = {
                 color_mode: constants.colorModeLookup[2],
                 color_temp: value,
             };
+            const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
 
-            return {state: libColor.syncColorState(newState, meta.state, entity, meta.options)};
+            return {state: libColor.syncColorState(newState, meta.state, entity, meta.options, undefined, gamut)};
         }
 
         const zclData = {
@@ -3254,8 +3279,9 @@ export const tuya_led_control: Tz.Converter = {
             },
             color_mode: constants.colorModeLookup[0],
         };
+        const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
 
-        return {state: libColor.syncColorState(newState, meta.state, entity, meta.options)};
+        return {state: libColor.syncColorState(newState, meta.state, entity, meta.options, undefined, gamut)};
     },
     convertGet: async (entity, key, meta) => {
         await entity.read("lightingColorCtrl", ["currentHue", "currentSaturation", "tuyaBrightness", "tuyaRgbMode", "colorTemperature"]);
@@ -4039,7 +4065,9 @@ export const scene_recall: Tz.Converter = {
                         recalledState = addColorMode(recalledState);
                     }
 
-                    Object.assign(recalledState, libColor.syncColorState(recalledState, meta.state, entity, meta.options));
+                    const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
+                    Object.assign(recalledState, libColor.syncColorState(recalledState, meta.state, entity, meta.options, undefined, gamut));
                     membersState[member.getDevice().ieeeAddr] = recalledState;
                 } else {
                     logger.warning(`Unknown scene was recalled for ${member.getDevice().ieeeAddr}, can't restore state.`, NS);
@@ -4056,7 +4084,9 @@ export const scene_recall: Tz.Converter = {
                 recalledState = addColorMode(recalledState);
             }
 
-            Object.assign(recalledState, libColor.syncColorState(recalledState, meta.state, entity, meta.options));
+            const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
+            Object.assign(recalledState, libColor.syncColorState(recalledState, meta.state, entity, meta.options, undefined, gamut));
             logger.info("Successfully recalled scene", NS);
             return {state: recalledState};
         }
@@ -4154,9 +4184,10 @@ export const scene_add: Tz.Converter = {
                             extField: [0, 0, hScaled, sScaled, 0, 0, 0, 0],
                         });
                     } else {
+                        const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
                         // The extensionFieldSet is always EnhancedCurrentHue according to ZCL
                         // When the bulb or all bulbs in a group do not support enhanchedHue,
-                        const colorXY = hsvCorrected.toXY();
+                        const colorXY = hsvCorrected.toXY(gamut);
                         const xScaled = utils.mapNumberRange(colorXY.x, 0, 1, 0, 65535);
                         const yScaled = utils.mapNumberRange(colorXY.y, 0, 1, 0, 65535);
                         extensionfieldsets.push({
@@ -4166,7 +4197,7 @@ export const scene_add: Tz.Converter = {
                         });
                     }
                     state.color_mode = constants.colorModeLookup[0];
-                    state.color = newColor.hsv.toObject(false, false);
+                    state.color = newColor.hsv.toObject(false);
                 }
             }
         }

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -628,8 +628,10 @@ const tzLocal = {
                         // We convert the former into the latter.
                         const c = libColor.Color.fromConverterArg(meta.message.color);
                         if (c.isRGB()) {
+                            const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
                             // https://github.com/Koenkk/zigbee2mqtt/issues/13421#issuecomment-1426044963
-                            c.hsv = c.rgb.gammaCorrected().toXY().toHSV();
+                            c.hsv = c.rgb.toXY(gamut).toHSV(gamut);
                         }
                         const color = c.hsv;
 
@@ -659,9 +661,11 @@ const tzLocal = {
                 }
             }
 
+            const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
             // If we're in white mode, calculate a matching display color for the set color temperature. This also kind
             // of works in the other direction.
-            Object.assign(newState, libColor.syncColorState(newState, meta.state, entity, meta.options));
+            Object.assign(newState, libColor.syncColorState(newState, meta.state, entity, meta.options, undefined, gamut));
 
             return {state: newState};
         },
@@ -688,10 +692,15 @@ const tzLocal = {
                 if (color.isXY()) {
                     newState.color = color.xy;
                 } else {
-                    newState.color = color.rgb.gammaCorrected().toXY().rounded(4);
+                    const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
+                    newState.color = color.rgb.toXY(gamut).rounded(4);
                 }
+
+                const gamut = libColor.getDeviceGamut(Array.isArray(meta.mapped) ? meta.mapped[0] : meta.mapped);
+
                 return {
-                    state: libColor.syncColorState(newState, meta.state, entity, meta.options) as KeyValue,
+                    state: libColor.syncColorState(newState, meta.state, entity, meta.options, undefined, gamut),
                 };
             }
             return await tz.light_color.convertSet(entity, key, value, meta);

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -70,8 +70,7 @@ export class ColorRGB {
      * @returns new ColoRGB object
      */
     static fromHex(hex: string): ColorRGB {
-        hex = hex.replace("#", "");
-        const bigint = Number.parseInt(hex, 16);
+        const bigint = Number.parseInt(hex.replace("#", ""), 16);
         return new ColorRGB(((bigint >> 16) & 255) / 255, ((bigint >> 8) & 255) / 255, (bigint & 255) / 255);
     }
 
@@ -136,6 +135,7 @@ export class ColorRGB {
 
     /**
      * Convert to CIE
+     * TODO: refactor, this is the Philips Hue formula, not the CIE 1931 gamut
      * @returns color in CIE space
      */
     toXY(): ColorXY {
@@ -243,6 +243,7 @@ export class ColorXY {
 
     /**
      * Converts CIE color space to RGB color space
+     * TODO: refactor, this is the Philips Hue formula, not the CIE 1931 gamut
      * From: https://github.com/usolved/cie-rgb-converter/blob/master/cie_rgb_converter.js
      */
     toRGB(): ColorRGB {
@@ -326,7 +327,7 @@ export class ColorHSV {
      */
     constructor(hue: number, saturation: number = null, value: number = null) {
         /** hue component (0..360) */
-        this.hue = hue === null ? null : hue % 360;
+        this.hue = hue === null ? null : hue === 360 ? hue : hue % 360;
         /** saturation component (0..100) */
         this.saturation = saturation;
         /** value component (0..100) */

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -78,8 +78,11 @@ export function findColorTempRange(entity: Zh.Endpoint | Zh.Group) {
         colorTempMax = entity.getClusterAttributeValue("lightingColorCtrl", "colorTempPhysicalMax") as number;
     }
     if (colorTempMin == null || colorTempMax == null) {
-        const entityId = utils.isGroup(entity) ? entity.groupID : entity.deviceIeeeAddress;
-        logger.debug(`Missing colorTempPhysicalMin and/or colorTempPhysicalMax for ${utils.isGroup(entity) ? "group" : "endpoint"} ${entityId}!`, NS);
+        logger.debug(
+            () =>
+                `Missing colorTempPhysicalMin and/or colorTempPhysicalMax for ${utils.isGroup(entity) ? `group ${entity.groupID}` : `endpoint ${entity.ID} of ${entity.deviceIeeeAddress}`}!`,
+            NS,
+        );
     }
     return [colorTempMin, colorTempMax];
 }

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -54,10 +54,9 @@ export function readColorAttributes(
 }
 
 export function findColorTempRange(entity: Zh.Endpoint | Zh.Group) {
-    // biome-ignore lint/suspicious/noImplicitAnyLet: ignored using `--suppress`
-    let colorTempMin;
-    // biome-ignore lint/suspicious/noImplicitAnyLet: ignored using `--suppress`
-    let colorTempMax;
+    let colorTempMin: number | undefined | null;
+    let colorTempMax: number | undefined | null;
+
     if (utils.isGroup(entity)) {
         const minCandidates = entity.members
             .map((m) => m.getClusterAttributeValue("lightingColorCtrl", "colorTempPhysicalMin"))
@@ -84,7 +83,9 @@ export function findColorTempRange(entity: Zh.Endpoint | Zh.Group) {
             NS,
         );
     }
-    return [colorTempMin, colorTempMax];
+
+    // default to Zigbee spec min/max range
+    return [colorTempMin ?? 0x0000, colorTempMax ?? 0xfeff] as const;
 }
 
 export function clampColorTemp(colorTemp: number, colorTempMin: number, colorTempMax: number) {

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -3,7 +3,6 @@ import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as reporting from "../lib/reporting";
 import * as libColor from "./color";
-import {ColorRGB, ColorXY} from "./color";
 import * as exposes from "./exposes";
 import {logger} from "./logger";
 import * as modernExtend from "./modernExtend";
@@ -16,26 +15,6 @@ const NS = "zhc:philips";
 const ea = exposes.access;
 const e = exposes.presets;
 const eNumeric = exposes.Numeric;
-
-const encodeRGBToScaledGradient = (hex: string) => {
-    const xy = ColorRGB.fromHex(hex).toXY();
-    const x = (xy.x * 4095) / 0.7347;
-    const y = (xy.y * 4095) / 0.8413;
-    const xx = Math.round(x).toString(16).padStart(3, "0");
-    const yy = Math.round(y).toString(16).padStart(3, "0");
-
-    return [xx[1], xx[2], yy[2], xx[0], yy[0], yy[1]].join("");
-};
-
-const decodeScaledGradientToRGB = (p: string) => {
-    const x = p[3] + p[0] + p[1];
-    const y = p[4] + p[5] + p[2];
-
-    const xx = Number(((Number.parseInt(x, 16) * 0.7347) / 4095).toFixed(4));
-    const yy = Number(((Number.parseInt(y, 16) * 0.8413) / 4095).toFixed(4));
-
-    return new ColorXY(xx, yy).toRGB().toHEX();
-};
 
 const COLOR_MODE_GRADIENT = "4b01";
 const COLOR_MODE_COLOR_XY = "0b00";
@@ -363,9 +342,7 @@ const philipsTz = {
         return {
             key: ["gradient"],
             convertSet: async (entity, key, value, meta) => {
-                // @ts-expect-error ignore
-                const scene = encodeGradientColors(value, opts);
-                const payload = {data: Buffer.from(scene, "hex")};
+                const payload = {data: encodeGradientColors(value as string[], opts)};
                 await entity.command("manuSpecificPhilips2", "multiColor", payload);
             },
             convertGet: async (entity, key, meta) => {
@@ -652,8 +629,7 @@ const philipsFz = {
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
             if (msg.data.state !== undefined) {
-                const input = msg.data.state.toString("hex");
-                const decoded = decodeGradientColors(input, {reverse: true});
+                const decoded = decodeGradientColors(msg.data.state, {reverse: true});
                 if (decoded.color_mode === "gradient") {
                     return {gradient: decoded.colors};
                 }
@@ -736,8 +712,13 @@ const philipsFz = {
 
 export {philipsFz as fz};
 
+const GAMUT = libColor.SUPPORTED_GAMUTS.wide;
+const MAX_X = GAMUT.red[0];
+const MAX_Y = GAMUT.green[1];
+
+// https://github.com/chrivers/bifrost/blob/master/doc/hue-zigbee-format.md#property-gradient_colors-color-encoding
 // decoder for manuSpecificPhilips2.state
-export function decodeGradientColors(input: string, opts: KeyValue) {
+export function decodeGradientColors(input: Buffer, opts: KeyValue) {
     // Gradient mode (4b01)
     // Example: 4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800
     // 4b01 - mode? (4) (0b00 single color?, 4b01 gradient?)
@@ -779,45 +760,50 @@ export function decodeGradientColors(input: string, opts: KeyValue) {
     // 0300 - mode (4)
     //     01 - on/off (2)
     //       b2 - brightness (2)
+    let bufOffset = 0;
 
     // Device color mode
-    const mode = input.slice(0, 4);
-    input = input.slice(4);
+    const mode = input.toString("hex", bufOffset, 2);
+    bufOffset += 2;
 
-    // On/off (2 bytes)
-    const on = Number.parseInt(input.slice(0, 2), 16) === 1;
-    input = input.slice(2);
+    // On/off (1 byte)
+    const on = input.readUInt8(bufOffset) === 1;
+    bufOffset += 1;
 
-    // Brightness (2 bytes)
-    const brightness = Number.parseInt(input.slice(0, 2), 16);
-    input = input.slice(2);
+    // Brightness (1 byte)
+    const brightness = input.readUInt8(bufOffset);
+    bufOffset += 1;
 
     // Gradient mode
     if (mode === COLOR_MODE_GRADIENT) {
-        // Unknown (8 bytes)
-        input = input.slice(8);
+        // Unknown (4 bytes)
+        // Length (1 bytes)
+        bufOffset += 5;
+        // Number of colors (1 bytes)
+        const nColors = input.readUInt8(bufOffset) >> 4;
+        // Unknown (3 bytes)
+        bufOffset += 4;
+        const colors: string[] = [];
 
-        // Length (2 bytes)
-        input = input.slice(2);
+        for (let i = 0; i < nColors; i++) {
+            const b0 = input.readUInt8(bufOffset);
+            const b1 = input.readUInt8(bufOffset + 1);
+            const b2 = input.readUInt8(bufOffset + 2);
+            const rawX = b0 | ((b1 & 0x0f) << 8);
+            const rawY = (b2 << 4) | (b1 >> 4);
+            bufOffset += 3;
+            const x = Math.round(((rawX * MAX_X) / 0xfff) * 10000.0) / 10000;
+            const y = Math.round(((rawY * MAX_Y) / 0xfff) * 10000.0) / 10000;
 
-        // Number of colors (2 bytes)
-        const nColors = Number.parseInt(input.slice(0, 2), 16) >> 4;
-        input = input.slice(2);
+            colors.push(new libColor.ColorXY(x, y).toRGB(GAMUT).toHex());
+        }
 
-        // Unknown (6 bytes)
-        input = input.slice(6);
-
-        // Colors (6 * nColors bytes)
-        const colorsPayload = input.slice(0, 6 * nColors);
-        input = input.slice(6 * nColors);
-        const colors = colorsPayload.match(/.{6}/g).map(decodeScaledGradientToRGB);
-
-        // Segments (2 bytes)
-        const segments = Number.parseInt(input.slice(0, 2), 16) >> 3;
-        input = input.slice(2);
-
-        // Offset (2 bytes)
-        const offset = Number.parseInt(input.slice(0, 2), 16) >> 3;
+        // Segments (1 bytes)
+        const segments = input.readUInt8(bufOffset) >> 3;
+        bufOffset += 1;
+        // Offset (1 bytes)
+        const offset = input.readUInt8(bufOffset) >> 3;
+        bufOffset += 1;
 
         if (opts?.reverse) {
             colors.reverse();
@@ -834,17 +820,17 @@ export function decodeGradientColors(input: string, opts: KeyValue) {
     }
     if (mode === COLOR_MODE_COLOR_XY || mode === COLOR_MODE_EFFECT) {
         // XY Color mode
-        const xLow = Number.parseInt(input.slice(0, 2), 16);
-        input = input.slice(2);
-        const xHigh = Number.parseInt(input.slice(0, 2), 16) << 8;
-        input = input.slice(2);
-        const yHigh = Number.parseInt(input.slice(0, 2), 16);
-        input = input.slice(2);
-        const yLow = Number.parseInt(input.slice(0, 2), 16) << 8;
-        input = input.slice(2);
+        const xLow = input.readUInt8(bufOffset);
+        bufOffset += 1;
+        const xHigh = input.readUInt8(bufOffset) << 8;
+        bufOffset += 1;
+        const yHigh = input.readUInt8(bufOffset);
+        bufOffset += 1;
+        const yLow = input.readUInt8(bufOffset) << 8;
+        bufOffset += 1;
 
-        const x = Math.round(((xHigh | xLow) / 65535) * 10000) / 10000;
-        const y = Math.round(((yHigh | yLow) / 65535) * 10000) / 10000;
+        const x = Math.round(((xHigh | xLow) / 0xffff) * 10000) / 10000;
+        const y = Math.round(((yHigh | yLow) / 0xffff) * 10000) / 10000;
 
         if (mode === COLOR_MODE_COLOR_XY) {
             return {
@@ -857,9 +843,11 @@ export function decodeGradientColors(input: string, opts: KeyValue) {
         }
 
         // Effect mode
-        const effect = input.slice(0, 4);
+        const effect = input.toString("hex", bufOffset, bufOffset + 2);
+        bufOffset += 2;
         // @ts-expect-error ignore
         const name = knownEffects[effect] || `unknown_${effect}`;
+
         return {
             color_mode: "xy",
             x,
@@ -871,10 +859,10 @@ export function decodeGradientColors(input: string, opts: KeyValue) {
     }
     if (mode === COLOR_MODE_COLOR_TEMP) {
         // Color temperature mode
-        const low = Number.parseInt(input.slice(0, 2), 16);
-        input = input.slice(2);
-        const high = Number.parseInt(input.slice(0, 2), 16) << 8;
-        input = input.slice(2);
+        const low = input.readUInt8(bufOffset);
+        bufOffset += 1;
+        const high = input.readUInt8(bufOffset) << 8;
+        bufOffset += 1;
 
         const temp = high | low;
 
@@ -905,19 +893,8 @@ export function encodeGradientColors(value: string[], opts: KeyValueAny) {
         throw new Error("Expected at least 1 color, got 0");
     }
 
-    // For devices where it makes more sense to specify the colors in reverse
-    // For example Hue Signe, where the last color is the top color.
-    if (opts.reverse) {
-        value.reverse();
-    }
-
-    // The number of colors and segments can technically differ. Here they are always the same, but we could
-    // support it by extending the API.
-    // If number of colors is less than the number of segments, the colors will repeat.
-    // It seems like the maximum number of colors is 9, and the maximum number of segments is 31.
-    const nColors = (value.length << 4).toString(16).padStart(2, "0");
-
     let segments = value.length;
+
     if (opts.segments) {
         segments = opts.segments;
     }
@@ -925,24 +902,50 @@ export function encodeGradientColors(value: string[], opts: KeyValueAny) {
     if (segments < 1 || segments > 31) {
         throw new Error(`Expected segments to be between 1 and 31 (inclusive), got ${segments}`);
     }
-    const segmentsPayload = (segments << 3).toString(16).padStart(2, "0");
-
-    // Encode the colors
-    const colorsPayload = value.map(encodeRGBToScaledGradient).join("");
 
     // Offset of the first color. 0 means the first segment uses the first color. (min 0, max 31)
     let offset = 0;
+
     if (opts.offset) {
         offset = opts.offset;
     }
-    const offsetPayload = (offset << 3).toString(16).padStart(2, "0");
 
+    // For devices where it makes more sense to specify the colors in reverse
+    // For example Hue Signe, where the last color is the top color.
+    if (opts.reverse) {
+        value.reverse();
+    }
+
+    let bufOffset = 0;
+    const buf = Buffer.alloc(4 + 2 + 3 * (value.length + 1) + 2, 0x00);
+    bufOffset = buf.writeUInt32BE(0x50010400, bufOffset);
     // Payload length
-    const length = (1 + 3 * (value.length + 1)).toString(16).padStart(2, "0");
+    bufOffset = buf.writeUInt8(1 + 3 * (value.length + 1), bufOffset);
+    // The number of colors and segments can technically differ. Here they are always the same, but we could
+    // support it by extending the API.
+    // If number of colors is less than the number of segments, the colors will repeat.
+    // It seems like the maximum number of colors is 9, and the maximum number of segments is 31.
+    bufOffset = buf.writeUInt8(value.length << 4, bufOffset);
+    // 3 zero bytes
+    bufOffset += 3;
 
-    // 5001 - mode? set gradient?
-    // 0400 - unknown
-    const scene = `50010400${length}${nColors}000000${colorsPayload}${segmentsPayload}${offsetPayload}`;
+    // Encode the colors
+    for (let i = 0; i < value.length; i++) {
+        const xy = libColor.ColorRGB.fromHex(value[i]).toXY(GAMUT);
+        const rawX = Math.round(((xy.x * 0xfff) / MAX_X) * 10000.0) / 10000;
+        const rawY = Math.round(((xy.y * 0xfff) / MAX_Y) * 10000.0) / 10000;
 
-    return scene;
+        const b0 = rawX & 0xff;
+        const b1 = ((rawX >> 8) & 0x0f) | ((rawY & 0x0f) << 4);
+        const b2 = (rawY >> 4) & 0xff;
+
+        bufOffset = buf.writeUInt8(b0, bufOffset);
+        bufOffset = buf.writeUInt8(b1, bufOffset);
+        bufOffset = buf.writeUInt8(b2, bufOffset);
+    }
+
+    bufOffset = buf.writeUInt8(segments << 3, bufOffset);
+    bufOffset = buf.writeUInt8(offset << 3, bufOffset);
+
+    return buf;
 }

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -1,5 +1,9 @@
-import {describe, expect, test} from "vitest";
+import {beforeEach, describe, expect, it, test} from "vitest";
+import {light_color} from "../src/converters/toZigbee";
+import {findByDevice, type Tz} from "../src/index";
 import {Color, ColorHSV, ColorRGB, ColorXY} from "../src/lib/color";
+import {getOptions} from "../src/lib/utils";
+import {type MockEndpointArgs, mockDevice} from "./utils";
 
 describe("lib/color", () => {
     describe("ColorRGB", () => {
@@ -183,6 +187,136 @@ describe("lib/color", () => {
 
         test.each([[{}], [{v: 100}], [{unknown_property: 42}]])(".fromConverterArg() invalid - %j", (value) => {
             expect(() => Color.fromConverterArg(value)).toThrow();
+        });
+    });
+
+    describe("tz.light_color", () => {
+        const defaultMeta = async (device: Tz.Meta["device"], message: Tz.Meta["message"], state: Tz.Meta["state"]): Promise<Tz.Meta> => {
+            const definition = await findByDevice(device);
+
+            return {
+                endpoint_name: "default",
+                options: {transition: undefined, hue_correction: undefined},
+                message: {...message},
+                device,
+                state,
+                membersState: undefined,
+                mapped: definition,
+                publish: () => {},
+            };
+        };
+        const DEFAULT_LIGHT_ENDPOINT: MockEndpointArgs = {
+            ID: 1,
+            profileID: 0x104,
+            deviceID: 0x65,
+            inputClusters: ["genBasic", "genIdentify", "genGroups", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl", "touchlink"],
+            outputClusters: ["genOta"],
+            attributes: {lightingColorCtrl: {colorTempPhysicalMin: 100, colorTempPhysicalMax: 500}},
+        };
+        const MAX_X = 0.7347;
+        const MAX_Y = 0.7174;
+        const MIN_X = 0.1666;
+        const MIN_Y = 0.0089;
+
+        beforeEach(() => {});
+
+        it.each([
+            ["white", {x: 1 / 3, y: 1 / 3}, {x: 1 / 3, y: 1 / 3}, {colorx: 21845, colory: 21845}],
+            ["red", {x: 0.7347, y: 0.2653}, {x: 0.7347, y: 0.2653}, {colorx: 48149, colory: 17386}],
+            ["green", {x: 0.2738, y: 0.7174}, {x: 0.2738, y: 0.7174}, {colorx: 17943, colory: 47015}],
+            ["blue", {x: 0.1666, y: 0.0089}, {x: 0.1666, y: 0.0089}, {colorx: 10918, colory: 583}],
+            ["max x/y", {x: MAX_X, y: MAX_Y}, {x: MAX_X, y: MAX_Y}, {colorx: 48149, colory: 47015}],
+            ["min x/y", {x: MIN_X, y: MIN_Y}, {x: MIN_X, y: MIN_Y}, {colorx: 10918, colory: 583}],
+            ["max x / min y", {x: MAX_X, y: MIN_Y}, {x: MAX_X, y: MIN_Y}, {colorx: 48149, colory: 583}],
+            ["min x / max y", {x: MIN_X, y: MAX_Y}, {x: MIN_X, y: MAX_Y}, {colorx: 10918, colory: 47015}],
+            ["random", {x: 0.234, y: 0.543}, {x: 0.234, y: 0.543}, {colorx: 15335, colory: 35586}],
+            ["random 2", {x: 0.7, y: 0.298}, {x: 0.7, y: 0.298}, {colorx: 45875, colory: 19529}],
+        ])("processes XY payload for %s", async (_name, inColor, outColor, outCmdColor) => {
+            const device = mockDevice(
+                {
+                    modelID: "TS0505A",
+                    endpoints: [{...DEFAULT_LIGHT_ENDPOINT}],
+                },
+                "Router",
+            );
+            const endpoint = device.getEndpoint(1);
+            const message = {color: inColor};
+            const meta = await defaultMeta(device, message, {});
+
+            await expect(light_color.convertSet(endpoint, "color", message.color, meta)).resolves.toStrictEqual({
+                state: {color_mode: "xy", color: outColor},
+            });
+            expect(endpoint.command).toHaveBeenCalledWith(
+                "lightingColorCtrl",
+                "moveToColor",
+                {transtime: 0, optionsMask: 0, optionsOverride: 0, ...outCmdColor},
+                getOptions(meta.mapped, endpoint),
+            );
+        });
+
+        it.each([
+            ["white", {r: 255, g: 255, b: 255}, {x: 1 / 3, y: 1 / 3}, {colorx: 21066, colory: 21477}],
+            ["red", {r: 255, g: 0, b: 0}, {x: 0.7347, y: 0.2653}, {colorx: 45734, colory: 19538}],
+            ["green", {r: 0, g: 255, b: 0}, {x: 0.2738, y: 0.7174}, {colorx: 11254, colory: 48750}],
+            ["blue", {r: 0, g: 0, b: 255}, {x: 0.1666, y: 0.0089}, {colorx: 8845, colory: 2605}],
+            ["random", {r: 60, g: 138, b: 164}, {x: 0.267, y: 0.3165}, {colorx: 15184, colory: 20334}],
+        ])("processes RGB payload for %s", async (_name, inColor, outColor, outCmdColor) => {
+            const device = mockDevice(
+                {
+                    modelID: "TS0505A",
+                    endpoints: [{...DEFAULT_LIGHT_ENDPOINT}],
+                },
+                "Router",
+            );
+            const endpoint = device.getEndpoint(1);
+            const message = {color: inColor};
+            const meta = await defaultMeta(device, message, {});
+            const stateColor = (await light_color.convertSet(endpoint, "color", message.color, meta)) as {
+                // biome-ignore lint/style/useNamingConvention: API
+                state: {color_mode: string; color: {x: number; y: number}};
+            };
+
+            expect(stateColor).toStrictEqual({
+                state: {color_mode: "xy", color: {x: expect.any(Number), y: expect.any(Number)}},
+            });
+            expect(stateColor.state.color.x).toBeCloseTo(outColor.x, 3);
+            expect(stateColor.state.color.y).toBeCloseTo(outColor.y, 3);
+            expect(endpoint.command).toHaveBeenCalledWith(
+                "lightingColorCtrl",
+                "moveToColor",
+                {transtime: 0, optionsMask: 0, optionsOverride: 0, ...outCmdColor},
+                getOptions(meta.mapped, endpoint),
+            );
+        });
+
+        it.each([
+            ["white", {hue: 0.0, saturation: 0.0}, {hue: 0.0, saturation: 0.0}, {hue: 0, saturation: 0}],
+            ["white", {hue: 360.0, saturation: 100.0}, {hue: 360.0, saturation: 100.0}, {hue: 254, saturation: 254}],
+            ["red", {hue: 0.0, saturation: 100.0}, {hue: 0.0, saturation: 100.0}, {hue: 0, saturation: 254}],
+            ["green", {hue: 120.0, saturation: 100.0}, {hue: 120.0, saturation: 100.0}, {hue: 85, saturation: 254}],
+            ["blue", {hue: 240.0, saturation: 100.0}, {hue: 240.0, saturation: 100.0}, {hue: 169, saturation: 254}],
+            ["random", {hue: 234.0, saturation: 54.3}, {hue: 234.0, saturation: 54.3}, {hue: 165, saturation: 138}],
+        ])("processes HS payload for %s", async (_name, inColor, outColor, outCmdColor) => {
+            const device = mockDevice(
+                {
+                    modelID: "TS0505A",
+                    endpoints: [{...DEFAULT_LIGHT_ENDPOINT}],
+                },
+                "Router",
+            );
+            const endpoint = device.getEndpoint(1);
+            const message = {color: inColor};
+            const meta = await defaultMeta(device, message, {});
+
+            await expect(light_color.convertSet(endpoint, "color", message.color, meta)).resolves.toStrictEqual({
+                state: {color_mode: "hs", color: outColor},
+            });
+            expect(endpoint.command).toHaveBeenCalledWith(
+                "lightingColorCtrl",
+                "moveToHueAndSaturation",
+                {transtime: 0, optionsMask: 0, optionsOverride: 0, ...outCmdColor},
+                getOptions(meta.mapped, endpoint),
+            );
         });
     });
 });

--- a/test/philips.test.ts
+++ b/test/philips.test.ts
@@ -1,101 +1,113 @@
-import {describe, expect, test} from "vitest";
+import {describe, expect, it} from "vitest";
 import {decodeGradientColors, encodeGradientColors} from "../src/lib/philips";
 
 describe("lib/philips", () => {
     describe("decodeGradientColors", () => {
-        test.each([
-            ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", true, ["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"]],
-            ["4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", false, ["#ff77f8", "#7951ff", "#2538ff", "#1137ff", "#0c32ff"]],
-            ["4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800", true, ["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"]],
-            ["4b010127a0526f5410400000000727640e9f5d0727640e9f5d2000", true, ["#ff0500", "#ffffff", "#ff0500", "#ffffff"]],
-        ])("colors(%s) should be %s", (input, optsReverse, expected) => {
+        it.each([
+            [
+                Buffer.from("4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", "hex"),
+                true,
+                ["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"],
+            ],
+            [
+                Buffer.from("4b0101b2875a25411350000000b3474def153e2ad42e98232c7483292800", "hex"),
+                false,
+                ["#ff77f8", "#7951ff", "#2538ff", "#1137ff", "#0c32ff"],
+            ],
+            [
+                Buffer.from("4b010164fb74346b1350000000f3297fda7d55da7d55f3297fda7d552800", "hex"),
+                true,
+                ["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"],
+            ],
+            [Buffer.from("4b010127a0526f5410400000000727640e9f5d0727640e9f5d2000", "hex"), true, ["#ff0500", "#ffffff", "#ff0500", "#ffffff"]],
+        ])("gradients", (input, optsReverse, expected) => {
             const ret = decodeGradientColors(input, {reverse: optsReverse});
             expect(ret.colors).toStrictEqual(expected);
         });
 
         // XY Color
-        test.each([
-            ["0b00015c05b1ec4e", [0.6915, 0.3083]], // Red (#ff0500)
-            ["0b00015c842b32b3", [0.17, 0.7]], // Green (#00ff0e)
-            ["0b00011d37272c0c", [0.1532, 0.0475]], // Blue (#0a00ff)
-        ])("xy(%s) should be %s", (input, expected) => {
+        it.each([
+            [Buffer.from("0b00015c05b1ec4e", "hex"), [0.6915, 0.3083]], // Red (#ff0500)
+            [Buffer.from("0b00015c842b32b3", "hex"), [0.17, 0.7]], // Green (#00ff0e)
+            [Buffer.from("0b00011d37272c0c", "hex"), [0.1532, 0.0475]], // Blue (#0a00ff)
+        ])("xy", (input, expected) => {
             const ret = decodeGradientColors(input, {});
             expect([ret.x, ret.y]).toStrictEqual(expected);
         });
 
-        test.each([
-            ["4b010110ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 16],
-            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 100],
-            ["0f0001044d01ab6f7067", 4],
-            ["0f00011a4d01ab6f7067", 26],
-            ["0f0000b2ff004c628461", 178],
-            ["0b00015c842b32b3", 92],
-            ["0b00011d842b32b3", 29],
-            ["ab000153df7e446a0180", 83],
-            ["030001b2", 178],
-            ["03000164", 100],
-            ["030001fe", 254],
-        ])("brightness(%s) should be %s", (input, expected) => {
+        it.each([
+            [Buffer.from("4b010110ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "hex"), 16],
+            [Buffer.from("4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "hex"), 100],
+            [Buffer.from("0f0001044d01ab6f7067", "hex"), 4],
+            [Buffer.from("0f00011a4d01ab6f7067", "hex"), 26],
+            [Buffer.from("0f0000b2ff004c628461", "hex"), 178],
+            [Buffer.from("0b00015c842b32b3", "hex"), 92],
+            [Buffer.from("0b00011d842b32b3", "hex"), 29],
+            [Buffer.from("ab000153df7e446a0180", "hex"), 83],
+            [Buffer.from("030001b2", "hex"), 178],
+            [Buffer.from("03000164", "hex"), 100],
+            [Buffer.from("030001fe", "hex"), 254],
+        ])("brightness", (input, expected) => {
             const ret = decodeGradientColors(input, {});
             expect(ret.brightness).toBe(expected);
         });
 
-        test.each([
-            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", true],
-            ["4b010026ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", false],
-            ["0f0000044d01ab6f7067", false],
-            ["0f0001044d01ab6f7067", true],
-            ["0b00015c842b32b3", true],
-            ["0b00001d842b32b3", false],
-            ["ab000153df7e446a0180", true],
-            ["ab000053df7e446a0180", false],
-            ["03000164", true],
-            ["0300004f", false],
-        ])("power(%s) should be %s", (input, expected) => {
+        it.each([
+            [Buffer.from("4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "hex"), true],
+            [Buffer.from("4b010026ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "hex"), false],
+            [Buffer.from("0f0000044d01ab6f7067", "hex"), false],
+            [Buffer.from("0f0001044d01ab6f7067", "hex"), true],
+            [Buffer.from("0b00015c842b32b3", "hex"), true],
+            [Buffer.from("0b00001d842b32b3", "hex"), false],
+            [Buffer.from("ab000153df7e446a0180", "hex"), true],
+            [Buffer.from("ab000053df7e446a0180", "hex"), false],
+            [Buffer.from("03000164", "hex"), true],
+            [Buffer.from("0300004f", "hex"), false],
+        ])("power", (input, expected) => {
             const ret = decodeGradientColors(input, {});
             expect(ret.on).toBe(expected);
         });
 
-        test.each([
-            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", 0],
-            ["4b01012701b1ea4e13500000000e9f5d0727640e9f5d0727640e9f5d2810", 2],
-        ])("offset(%s) should be %s", (input, expected) => {
+        it.each([
+            [Buffer.from("4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "hex"), 0],
+            [Buffer.from("4b01012701b1ea4e13500000000e9f5d0727640e9f5d0727640e9f5d2810", "hex"), 2],
+        ])("offset", (input, expected) => {
             const ret = decodeGradientColors(input, {});
             expect(ret.offset).toBe(expected);
         });
 
-        test.each([
-            ["0f00011dfa0094611b61", 250],
-            ["0f00011d7201ab751969", 370],
-            ["0f00015cf401d486ce69", 500],
-        ])("colorTemperature(%s) should be %s", (input, expected) => {
+        it.each([
+            [Buffer.from("0f00011dfa0094611b61", "hex"), 250],
+            [Buffer.from("0f00011d7201ab751969", "hex"), 370],
+            [Buffer.from("0f00015cf401d486ce69", "hex"), 500],
+        ])("colorTemperature", (input, expected) => {
             const ret = decodeGradientColors(input, {});
             expect(ret.color_temp).toBe(expected);
         });
 
-        test.each([
-            ["0f00011dfa0094611b61", "color_temp"],
-            ["0b00015c842b32b3", "xy"],
-            ["4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "gradient"],
-            ["ab000153df7e446a0180", "xy"],
-        ])("color_mode(%s) should be %s", (input, expected) => {
+        it.each([
+            [Buffer.from("0f00011dfa0094611b61", "hex"), "color_temp"],
+            [Buffer.from("0b00015c842b32b3", "hex"), "xy"],
+            [Buffer.from("4b010164ee2df18f1350000000e8b3aac7589f2dba903f4a7720ba602800", "hex"), "gradient"],
+            [Buffer.from("ab000153df7e446a0180", "hex"), "xy"],
+        ])("color_mode", (input, expected) => {
             const ret = decodeGradientColors(input, {});
             expect(ret.color_mode).toBe(expected);
         });
 
-        test.each([
-            ["ab000153df7e446a0180", "candle"],
-            ["ab0001febd9238660280", "fireplace"],
-            ["ab0001febe92ab650380", "colorloop"],
-            ["ab0001febe92ab659999", "unknown_9999"],
-        ])("effect(%s) should be %s", (input, expected) => {
+        it.each([
+            [Buffer.from("ab000153df7e446a0180", "hex"), "candle"],
+            [Buffer.from("ab0001febd9238660280", "hex"), "fireplace"],
+            [Buffer.from("ab0001febe92ab650380", "hex"), "colorloop"],
+            [Buffer.from("ab0001febe92ab659999", "hex"), "unknown_9999"],
+        ])("effect", (input, expected) => {
             const ret = decodeGradientColors(input, {});
             expect(ret.name).toBe(expected);
         });
     });
 
     describe("encodeGradientColors", () => {
-        test.each([
+        it.each([
             [["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"], {reverse: true}, "500104001350000000b2474df0353e29e42e98332c7043292800"],
             [["#0c32ff", "#1137ff", "#2538ff", "#7951ff", "#ff77f8"], {reverse: false}, "50010400135000000070432998332c29e42ef0353eb2474d2800"],
             [["#ff0517", "#ffa52c", "#ff0517", "#ff0517", "#ffa52c"], {reverse: true}, "500104001350000000f3297fd56d55d56d55f3297fd56d552800"],
@@ -106,9 +118,9 @@ describe("lib/philips", () => {
             ],
             [["#ffffff"], {reverse: true}, "5001040007100000000727640800"],
             [["#ffffff"], {reverse: false}, "5001040007100000000727640800"],
-        ])("colors(%s) opts(%s) should be %s", (colors, opts, expected) => {
+        ])("gradients", (colors, opts, expected) => {
             const ret = encodeGradientColors(colors, opts);
-            expect(ret).toStrictEqual(expected);
+            expect(ret).toStrictEqual(Buffer.from(expected, "hex"));
         });
     });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,7 +7,7 @@ import {findByDevice} from "../src/index";
 import type {Definition, DefinitionMeta, Fz, Zh} from "../src/lib/types";
 import * as utils from "../src/lib/utils";
 
-interface MockEndpointArgs {
+export interface MockEndpointArgs {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     ID?: number;
     profileID?: number;
@@ -67,6 +67,7 @@ function mockEndpoint(args: MockEndpointArgs, device: Zh.Device | undefined): Zh
         ID: args.ID ?? 1,
         profileID: args.profileID ?? 1,
         deviceID: args.deviceID ?? 1,
+        deviceIeeeAddress: "0x12345678",
         // @ts-expect-error ignore
         constructor: {name: "Endpoint"},
         bind: vi.fn(),


### PR DESCRIPTION
- fix XY conversion, use CIE 1931 per spec
- add gamut support (with extra support for Philips Hue, and Philips LivingColors)

Philips gradients are not agreeing with previous tests. I don't have any, so, can't confirm what values are right.
@chrivers can you provide any insights?

Cf https://github.com/Nerivec/zigbee2mqtt-windfront/blob/main/src/components/editors/index.ts