### PR TITLE
Update tuya.ts

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11723,7 +11723,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_qasjif9e", "_TZE204_ztqnh5cg", "_TZE204_iadro9bf", "_TZE284_iadro9bf"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_qasjif9e", "_TZE200_qasjif9e", "_TZE204_ztqnh5cg", "_TZE204_iadro9bf", "_TZE284_iadro9bf"]),
         model: "ZY-M100-S_2",
         vendor: "Tuya",
         description: "Mini human breathe sensor",


### PR DESCRIPTION
add _TZE200_qasjif9e support due to https://github.com/Andrik45719/ZY-M100: 

> ignore TZE200/TZE204 mismatch is Tuya Zigbee module version only "abracadabra" make sense

 *currently works with the config being changed

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
