### PR TITLE
Fix "gas" not seteable

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2231,7 +2231,7 @@ function genericMeter(args: MeterArgs = {}) {
     } else if (args.cluster === "metering" && args.type === "gas") {
         if (args.power !== false)
             exposes.push(e.numeric("volume_flow_rate", ea.STATE_GET).withUnit("m³/h").withDescription("Instantaneous gas flow in m³/h"));
-        if (args.energy !== false) exposes.push(e.numeric("gas", ea.ALL).withUnit("m³").withDescription("Total gas consumption in m³"));
+        if (args.energy !== false) exposes.push(e.numeric("gas", ea.STATE_GET).withUnit("m³").withDescription("Total gas consumption in m³"));
         fromZigbee = [args.fzMetering ?? fz.gas_metering];
         toZigbee = [
             {


### PR DESCRIPTION
Fixes #11219 losing functionality but at this time it is the simplest approach.

Note, the problem with the "gas" value represented as "number" rather than a "sensor" is that the number max value is set to 100 (default value) and HA ignores any value higher than that so the gas counter is useless as it is now.