### PR TITLE
New Device Support Novato ZİS-01P

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -23431,10 +23431,8 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_vceqncho"]),
         model: "ZIS-01P",
         vendor: "Novato",
-        description: "Dual-tech presence sensor (PIR + Radar)",
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
-        configure: tuya.configureMagicPacket,
+        description: "Dual-tech presence sensor (PIR + radar)",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             e.occupancy(),
             e


### PR DESCRIPTION
Novato ZİS-01P

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

<img width="512" height="512" alt="ZİS-01P" src="https://github.com/user-attachments/assets/b64dcc03-b846-4895-a0e7-0dded4004484" />

## Device
- **Model:** ZIS-01P
- **Vendor:** Novato
- **Description:** Dual-tech presence sensor with PIR and Radar

## Link
https://novato.com.tr/urun/zigbee-insan-varligi-sensoru/

## Tested features
- ✅ Occupancy detection
- ✅ Presence distance (1-3m)
- ✅ Presence sensitivity (1-3)
- ✅ PIR sensitivity (1-3)
- ✅ Radar switch ON/OFF
- ✅ LED switch ON/OFF
- ✅ Delay time (10-600s)
- ✅ Illuminance (lux)
- ✅ Radar threshold (5-50)
- ⏳ Battery percentage

## Zigbee2MQTT version
2.7.2
