### PR TITLE
Update ledvance.ts - LED Tube T8 EM Connected P 1500mm 24W 840

### DIFF
--- a/src/devices/ledvance.ts
+++ b/src/devices/ledvance.ts
@@ -364,7 +364,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["TUBE_T8_CON_1500_24W_840ZBV"],
-        model: "TUBE_T8_CON_1500_24W_840ZBV",
+        model: "4058075824010",
         vendor: "LEDVANCE",
         description: "LED Tube T8 EM Connected P 1500mm 24W 840",
         extend: [m.light(), m.electricityMeter()],


### PR DESCRIPTION
Hi, just adding the 1500mm version of the LED Zigbee LED Tube. Not sure about the "extend:" line, that's what the generate external definition created.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: (https://github.com/Koenkk/zigbee2mqtt.io/pull/4711)
