### PR TITLE
Update sinope.ts

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -676,7 +676,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .enum("temperature_display_mode", ea.ALL, ["celsius", "fahrenheit"])
                 .withDescription("The temperature format displayed on the thermostat screen"),
             e.enum("time_format", ea.ALL, ["24h", "12h"]).withDescription("The time format featured on the thermostat display"),
-            e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "sensing"]).withDescription("Control backlight dimming behavior"),
+            e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "off"]).withDescription("Control backlight dimming behavior"),
             e.enum("keypad_lockout", ea.ALL, ["unlock", "lock1"]).withDescription("Enables or disables the device’s buttons"),
             e.enum("main_cycle_output", ea.ALL, ["15_sec", "15_min"]).withDescription("The length of the control cycle: 15_sec=normal 15_min=fan"),
             e


### PR DESCRIPTION
Device TH1123ZG does not support "sensing" but "off" mode for backlight_auto_dim. Setting "on_demand" stay correct. 

z2m: Publish 'set' 'backlight_auto_dim' to 'T2_s_bain' failed: 'Error: ZCL command 0x500b914000010a3f/1 hvacThermostat.write({"SinopeBacklight":2}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"manufacturerCode":4508,"writeUndiv":false}) failed (Status 'INVALID_VALUE')'

<img width="496" height="123" alt="capture_TH1123ZB" src="https://github.com/user-attachments/assets/30480475-59af-436c-8468-3db9e1a9192b" />



Link to picture pull request: TODO
