### PR TITLE
fix: RB-SRAIN01: fix illuminance_raw mV unit for HA compatibility

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3477,7 +3477,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [tuya.fz.datapoints],
         extend: [m.iasZoneAlarm({zoneType: "rain", zoneAttributes: ["alarm_1"]}), m.battery({percentageReporting: true})],
         exposes: [
-            e.illuminance_raw().withUnit("mV"),
+            e.numeric("illuminance_raw", ea.STATE).withUnit("mV").withDescription("Raw illuminance voltage"),
             e.numeric("illuminance_average_20min", ea.STATE).withUnit("mV").withDescription("Illuminance average for the last 20 minutes"),
             e.numeric("illuminance_maximum_today", ea.STATE).withUnit("mV").withDescription("Illuminance maximum for the last 24 hours"),
             e.binary("cleaning_reminder", ea.STATE, true, false).withDescription("Cleaning reminder"),


### PR DESCRIPTION
illuminance_raw now correctly reports with unit mV in Home Assistant. 

Previously, it had no unit and caused display inconsistencies. Other sensors remain unchanged.
