### PR TITLE
Update philips.ts to add Hue OmniGlow lightstrip 5m 929004608101

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3517,7 +3517,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "929004608101",
         vendor: "Philips",
         description: "Hue OmniGlow lightstrip 5m",
-        extend: [philips.m.light({"colorTemp":{"range":[50,1000]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["929003099301", "929003099302"],


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: (https://github.com/Koenkk/zigbee2mqtt.io/pull/4725)
