### PR TITLE
Fixed error with BOX ERC2201-Z: Device has no endpoint 'l1' (or 'l2')

### DIFF
--- a/src/devices/box.ts
+++ b/src/devices/box.ts
@@ -184,7 +184,7 @@ export const definitions: DefinitionWithExtend[] = [
                 type: tuya.dataTypes.bool,
                 valueOn: ["ON", true],
                 valueOff: ["OFF", false],
-                expose: e.switch().withEndpoint("l1"),
+                description: "On/off state of the switch",
             }),
             tuya.modernExtend.dpBinary({
                 name: "state_l2",
@@ -192,7 +192,7 @@ export const definitions: DefinitionWithExtend[] = [
                 type: tuya.dataTypes.bool,
                 valueOn: ["ON", true],
                 valueOff: ["OFF", false],
-                expose: e.switch().withEndpoint("l2"),
+                description: "On/off state of the switch",
             }),
             tuya.modernExtend.dpEnumLookup({
                 name: "record_rf",


### PR DESCRIPTION
When a relay "BOX ERC2201-Z" is used from Home Assistant, Z2M notifies about errors:
`Device has no endpoint 'l1'`
or
`Device has no endpoint 'l2'`
