### PR TITLE
Add ikea lights scene support

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -17,6 +17,7 @@ import {
     ikeaLight,
     ikeaMediaCommands,
     ikeaModernExtend,
+    ikeaScenes,
     ikeaVoc,
     styrbarCommandOn,
     tradfriCommandsLevelCtrl,
@@ -62,14 +63,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2109G6",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, color/white spectrum, globe, opal, 800/806/810 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: {modes: ["xy", "hs"]}}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: {modes: ["xy", "hs"]}}), ikeaScenes(), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E27 WS clear 950lm", "TRADFRI bulb E26 WS clear 950lm", "TRADFRI bulb E27 WS\uFFFDclear 950lm"],
         model: "LED1546G12",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, white spectrum, globe, clear, 950 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true}), ikeaScenes(), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI bulb E27 opal 1000lm", "TRADFRI bulb E27 W opal 1000lm"],
@@ -186,7 +187,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1924G9",
         vendor: "IKEA",
         description: "TRADFRI bulb E26/E27, color/white spectrum, globe, opal, 800/806/810 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true, turnsOffAtBrightness1: true}), m.identify()],
+        extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
+            ikeaLight({colorTemp: true, color: true, turnsOffAtBrightness1: true}),
+            ikeaScenes(),
+            m.identify(),
+        ],
     },
     {
         zigbeeModel: ["TRADFRI bulb E27 WS opal 1000lm", "TRADFRI bulb E26 WS opal 1000lm"],
@@ -320,7 +326,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED1925G6",
         vendor: "IKEA",
         description: "TRADFRI bulb E12/E14/E17, color/white spectrum, globe, opal, 440/450/470 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true, turnsOffAtBrightness1: true}), m.identify()],
+        extend: [
+            addCustomClusterManuSpecificIkeaUnknown(),
+            ikeaLight({colorTemp: true, color: true, turnsOffAtBrightness1: true}),
+            ikeaScenes(),
+            m.identify(),
+        ],
     },
     {
         zigbeeModel: ["TRADFRIbulbE14WWclear250lm", "TRADFRIbulbE12WWclear250lm", "TRADFRIbulbE17WWclear250lm"],
@@ -348,7 +359,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "LED2111G6",
         vendor: "IKEA",
         description: "TRADFRI bulb E12/E14/E17, color/white spectrum, globe, opal, 800/806/810 lm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: {modes: ["xy", "hs"]}}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: {modes: ["xy", "hs"]}}), ikeaScenes(), m.identify()],
     },
     // #endregion E12/E14/E17
     // #region GU10
@@ -473,14 +484,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "L2205",
         vendor: "IKEA",
         description: "JETSTROM wall light panel, color/white spectrum, 30x30 cm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true}), ikeaScenes(), m.identify()],
     },
     {
         zigbeeModel: ["JETSTROM 3030 ceiling"],
         model: "L2206",
         vendor: "IKEA",
         description: "JETSTROM ceiling light panel, color/white spectrum, 30x30 cm",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true}), ikeaScenes(), m.identify()],
     },
     {
         zigbeeModel: ["JORMLIEN door WS 40x80"],
@@ -633,7 +644,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "L2112",
         vendor: "IKEA",
         description: "ORMANAS LED strip",
-        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true}), m.identify()],
+        extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight({colorTemp: true, color: true}), ikeaScenes(), m.identify()],
     },
     {
         zigbeeModel: ["TRADFRI transformer 10W", "TRADFRI Driver 10W"],


### PR DESCRIPTION
This PR extends support for scenes with Ikea light devices. It adds a few new sections to the Exposes tab:
<img width="441" height="420" alt="Screenshot 2026-01-15 224943" src="https://github.com/user-attachments/assets/8185d30c-feaa-4d6d-9786-76dc5795b20b" />

The goal was to mimic more of the functionality that Ikea Home provides when pairing a TRADFRI light with a STYRBAR controller. The default behavior from IKEA allows the left and right buttons to change scenes.

---

This was originally created as an external convertor that seems to work well enough from my testing (for a month or so now). I figured it would be a neat experiment to try and rebuild the convertor into the upstream for all Ikea owners benefit.