### PR TITLE
Support all 5 modes of DOMRAEM DOM-Z-105P

### DIFF
--- a/src/devices/domraem.ts
+++ b/src/devices/domraem.ts
@@ -14,7 +14,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DOM-Z-105P_RGBW",
         vendor: "DOMRAEM",
         description: "LED controller 5 in 1",
-        extend: [m.light({colorTemp: {range: undefined}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+        extend: [m.light({colorTemp: {range: [158, 495]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         fingerprint: [{modelID: "RGBWC", manufacturerName: "DOMRAEM"}],


### PR DESCRIPTION
Add support for "RGBW" (not "RGBWC" -> RGBCCT) mode to DOMRAEM DOM-Z-105P. Tested on two devices.
