### PR TITLE
fix: add adaptation_run_status lost_in_progress

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -201,7 +201,7 @@ export const definitions: DefinitionWithExtend[] = [
                 e.numeric("load_estimate", ea.STATE_GET).withDescription("Load estimate on this radiator").withValueMin(-8000).withValueMax(3600),
                 e.binary("preheat_status", ea.STATE_GET, true, false).withDescription("Specific for pre-heat running in Zigbee Weekly Schedule mode"),
                 e
-                    .enum("adaptation_run_status", ea.STATE_GET, ["none", "in_progress", "found", "lost"])
+                    .enum("adaptation_run_status", ea.STATE_GET, ["none", "in_progress", "found", "lost", "lost_in_progress"])
                     .withDescription(
                         "Status of adaptation run: None (before first run), In Progress, Valve Characteristic Found, Valve Characteristic Lost",
                     ),

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -126,6 +126,7 @@ export const danfossAdaptionRunStatus: KeyValueNumberString = {
     1: "in_progress",
     2: "found",
     4: "lost",
+    5: "lost_in_progress",
 };
 
 export const danfossAdaptionRunControl: KeyValueNumberString = {


### PR DESCRIPTION
The Danfoss Ally seems to report the adaption run status 5 if a new run was triggered after the characteristics have been lost:

```
[17.1.2026, 14:19:07] zhc:tz: Read result of 'hvacThermostat': {"danfossAdaptionRunStatus":5}
```
I've added `lost_in_progress` as a new possible value. It seems like the field is a bit mask, see slide 10 [here](https://assets.danfoss.com/documents/latest/367874/AU417130778872en-000102.pdf).