### PR TITLE
Fix Lutron Z3-1BRL (Aurora) actions

### DIFF
--- a/src/devices/lutron.ts
+++ b/src/devices/lutron.ts
@@ -28,7 +28,7 @@ const fzLocal = {
             addActionGroup(payload, msg, model);
             return payload;
         },
-    } satisfies Fz.Converter,
+    } satisfies Fz.Converter<"genLevelCtrl", undefined, ["commandMoveToLevel", "commandMoveToLevelWithOnOff"]>,
 };
 
 export const definitions: DefinitionWithExtend[] = [


### PR DESCRIPTION
Switch now sends `on_press | off_press | rotate`:

```
{"action":"rotate","battery":100,"brightness":205,"linkquality":91,"update": ...}
{"action":"off_press","action_group":8093,"battery":100,"brightness":197,"linkquality":91,"update": ...}
{"action":"on_press","action_group":8093,"battery":100,"brightness":197,"linkquality":91,"update": ...}
```

We could drop `brightness` from the press payload if that's more consistent with other devices.

Separately, we can distinguish off/on based on what the switch reports, but...should we? Or should we combine them into a stateless `press`? Eg, if a light changes state because of an outside service call, it becomes out of sync with this switch. This can easily be handled at the automation level, but perhaps it should be handled here.

Related: https://github.com/Koenkk/zigbee2mqtt/issues/28450, https://github.com/Koenkk/zigbee2mqtt/issues/25538, https://github.com/Koenkk/zigbee2mqtt/issues/12291