### PR TITLE
Rename STYRBAR to E2001/E2002/E2313

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -893,7 +893,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["Remote Control N2"],
-        model: "E2001/E2002",
+        model: "E2001/E2002/E2313",
         vendor: "IKEA",
         description: "STYRBAR remote control",
         extend: [


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
- Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4735

Tiny change to include the E2313. 

We can differentiate between them with `productCode` from `genBasic`.
Left a comment here:
- https://github.com/Koenkk/zigbee-herdsman/pull/1282#issuecomment-3764503782