### PR TITLE
Update Nous Zigbee sensor E12

### DIFF
--- a/src/devices/nous.ts
+++ b/src/devices/nous.ts
@@ -17,30 +17,25 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee carbon monoxide (CO) sensor",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
-           e.enum('co_state', ea.STATE, Object.values(CO_STATES))
-            .withDescription('CO alarm state (normal or alarm)'),
-        e.numeric('co_value', ea.STATE).withUnit('ppm').withDescription('Current CO concentration'),
-        e.binary('self_checking', ea.ALL, 'ON', 'OFF')
-            .withDescription('Triggers self-checking process'),
-        e.enum('checking_result', ea.STATE, Object.values(CHECK_RESULTS))
-            .withDescription('Result of self-checking'),
-        e.enum('preheat', ea.STATE, Object.values(PREHEAT_STATE))
-            .withDescription('Sensor preheating status'),
-        e.enum('fault', ea.STATE, Object.values(FAULT_STATE))
-            .withDescription('Sensor fault indicator'),
-        e.numeric('lifecycle', ea.STATE).withUnit('days').withDescription('Sensor service life or usage counter'),
-        e.battery(),
+            e.enum("co_state", ea.STATE, Object.values(CO_STATES)).withDescription("CO alarm state (normal or alarm)"),
+            e.numeric("co_value", ea.STATE).withUnit("ppm").withDescription("Current CO concentration"),
+            e.binary("self_checking", ea.ALL, "ON", "OFF").withDescription("Triggers self-checking process"),
+            e.enum("checking_result", ea.STATE, Object.values(CHECK_RESULTS)).withDescription("Result of self-checking"),
+            e.enum("preheat", ea.STATE, Object.values(PREHEAT_STATE)).withDescription("Sensor preheating status"),
+            e.enum("fault", ea.STATE, Object.values(FAULT_STATE)).withDescription("Sensor fault indicator"),
+            e.numeric("lifecycle", ea.STATE).withUnit("days").withDescription("Sensor service life or usage counter"),
+            e.battery(),
         ],
         meta: {
             tuyaDatapoints: [
-            [DP_CO_STATE,     'co_state',        valueConverterLookup(CO_STATES)],
-            [DP_CO_VALUE,     'co_value',        tuya.valueConverter.raw],
-            [DP_SELF_CHECKING, 'self_checking',  trueFalseRobust],
-            [DP_CHECK_RESULT, 'checking_result', valueConverterLookup(CHECK_RESULTS)],
-            [DP_PREHEAT,      'preheat',         valueConverterLookup(PREHEAT_STATE)],
-            [DP_FAULT,        'fault',           valueConverterLookup(FAULT_STATE)],
-            [DP_LIFECYCLE,    'lifecycle',       tuya.valueConverter.raw],
-            [DP_BATTERY_STATE,'battery',         tuya.valueConverter.raw],
+                [DP_CO_STATE, "co_state", valueConverterLookup(CO_STATES)],
+                [DP_CO_VALUE, "co_value", tuya.valueConverter.raw],
+                [DP_SELF_CHECKING, "self_checking", trueFalseRobust],
+                [DP_CHECK_RESULT, "checking_result", valueConverterLookup(CHECK_RESULTS)],
+                [DP_PREHEAT, "preheat", valueConverterLookup(PREHEAT_STATE)],
+                [DP_FAULT, "fault", valueConverterLookup(FAULT_STATE)],
+                [DP_LIFECYCLE, "lifecycle", tuya.valueConverter.raw],
+                [DP_BATTERY_STATE, "battery", tuya.valueConverter.raw],
             ],
         },
     },


### PR DESCRIPTION
Hi, could you please tell me why after the update some devices stopped working correctly, namely… what could be the reason? I had to rewrite the converter.
Here is the corrected converter.

const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const tz = require('zigbee-herdsman-converters/converters/toZigbee');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const tuya = require('zigbee-herdsman-converters/lib/tuya');
const e = exposes.presets;
const ea = exposes.access;

const DP_CO_STATE = 1;
const DP_CO_VALUE = 2;
const DP_SELF_CHECKING = 8;
const DP_CHECK_RESULT = 9;
const DP_PREHEAT = 10;
const DP_FAULT = 11;
const DP_LIFECYCLE = 12;
const DP_BATTERY_STATE = 14;

const CO_STATES = {0: 'normal', 1: 'alarm'};
const CHECK_RESULTS = {0: 'ok', 1: 'error'};
const PREHEAT_STATE = {0: 'off', 1: 'on'};
const FAULT_STATE = {0: 'normal', 1: 'fault'};

const valueConverterLookup = (lookupTable) => ({
    from: (v) => lookupTable[v] ?? v,
    to: (v) => {
        const entry = Object.entries(lookupTable).find(([, name]) => name === v);
        return entry ? Number(entry[0]) : v;
    },
});


const trueFalseRobust = {
    from: (v) => !!v,  
    to: (v) => (v ? 1 : 0),
};

const definition = {
    fingerprint: tuya.fingerprint('TS0601', ['_TZE284_sonkaxrd']),

    model: 'E12',
    vendor: 'Nous',
    description: 'Zigbee carbon monoxide (CO) sensor',

    fromZigbee: [tuya.fz.datapoints],
    toZigbee: [tuya.tz.datapoints],

    configure: tuya.configureMagicPacket,

    exposes: [
        e.enum('co_state', ea.STATE, Object.values(CO_STATES))
            .withDescription('CO alarm state (normal or alarm)'),
        e.numeric('co_value', ea.STATE).withUnit('ppm').withDescription('Current CO concentration'),
        e.binary('self_checking', ea.ALL, 'ON', 'OFF')
            .withDescription('Triggers self-checking process'),
        e.enum('checking_result', ea.STATE, Object.values(CHECK_RESULTS))
            .withDescription('Result of self-checking'),
        e.enum('preheat', ea.STATE, Object.values(PREHEAT_STATE))
            .withDescription('Sensor preheating status'),
        e.enum('fault', ea.STATE, Object.values(FAULT_STATE))
            .withDescription('Sensor fault indicator'),
        e.numeric('lifecycle', ea.STATE).withUnit('days').withDescription('Sensor service life or usage counter'),
        e.battery(),
    ],

    meta: {
        tuyaDatapoints: [
            [DP_CO_STATE,     'co_state',        valueConverterLookup(CO_STATES)],
            [DP_CO_VALUE,     'co_value',        tuya.valueConverter.raw],
            [DP_SELF_CHECKING, 'self_checking',  trueFalseRobust],
            [DP_CHECK_RESULT, 'checking_result', valueConverterLookup(CHECK_RESULTS)],
            [DP_PREHEAT,      'preheat',         valueConverterLookup(PREHEAT_STATE)],
            [DP_FAULT,        'fault',           valueConverterLookup(FAULT_STATE)],
            [DP_LIFECYCLE,    'lifecycle',       tuya.valueConverter.raw],
            [DP_BATTERY_STATE,'battery',         tuya.valueConverter.raw],
        ],
    },
};

module.exports = definition;