### PR TITLE
Enhance Nous smart power strip with new features

### DIFF
--- a/src/devices/nous.ts
+++ b/src/devices/nous.ts
@@ -265,7 +265,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Smart power strip 3 gang with power monitoring",
         meta: {
             multiEndpoint: true,
-            multiEndpointSkip: ['energy', 'current', 'voltage', 'power'],
+            multiEndpointSkip: ["energy", "current", "voltage", "power"],
         },
         extend: [
             tuya.modernExtend.tuyaOnOff({
@@ -274,7 +274,7 @@ export const definitions: DefinitionWithExtend[] = [
                 onOffCountdown: true,
                 indicatorMode: true,
                 childLock: true,
-                endpoints: ['l1', 'l2', 'l3'],
+                endpoints: ["l1", "l2", "l3"],
             }),
             tuya.modernExtend.electricityMeasurementPoll({
                 metering: (device) => [100, 160, 192].includes(device.applicationVersion) || ["1.0.5"].includes(device.softwareBuildID),


### PR DESCRIPTION

Hi, could you please tell me why after the update some devices stopped working correctly, namely… what could be the reason? I had to rewrite the converter.
Here is the corrected converter.

const tuya = require('zigbee-herdsman-converters/lib/tuya');
const utils = require('zigbee-herdsman-converters/lib/utils');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const e = exposes.presets;
const ea = exposes.access;

module.exports = [
    {
        fingerprint: tuya.fingerprint('TS011F', ['_TZ3210_6cmeijtd']),

        model: 'A11Z',
        vendor: 'Nous',
        description: 'Smart power strip 3 gang with energy monitoring & countdown',

        endpoint: (device) => {
            return { l1: 1, l2: 2, l3: 3 };
        },

        meta: {
            multiEndpoint: true,
            multiEndpointSkip: ['energy', 'current', 'voltage', 'power'],
        },

        extend: [
            tuya.modernExtend.tuyaOnOff({
                electricalMeasurements: true,
                powerOutageMemory: true,
                onOffCountdown: true,
                indicatorMode: true,
                childLock: true,
                endpoints: ['l1', 'l2', 'l3'],
            }),
            tuya.modernExtend.electricityMeasurementPoll({
                metering: (device) => [100, 160, 192].includes(device.applicationVersion) || ["1.0.5"].includes(device.softwareBuildID),
            }),
        ],

        configure: async (device, coordinatorEndpoint) => {
            await tuya.configureMagicPacket(device, coordinatorEndpoint);
            const endpoint = device.getEndpoint(1);
            

            endpoint.saveClusterAttributeKeyValue('haElectricalMeasurement', {
                acCurrentDivisor: 1000,
                acCurrentMultiplier: 1,
                acVoltageDivisor: 10,
                acVoltageMultiplier: 1,
                acPowerDivisor: 10,
                acPowerMultiplier: 1,
            });
            endpoint.saveClusterAttributeKeyValue('seMetering', {
                divisor: 100,
                multiplier: 1,
            });
            
            utils.attachOutputCluster(device, 'genOta');
            device.save();
        },
    },
];