### PR TITLE
Add: Lightstrip Ultra Bright and Gradient effects to Lightstrip Flux

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4834,29 +4834,35 @@ export const definitions: DefinitionWithExtend[] = [
             {
                 model: "929004610502",
                 vendor: "Philips",
-                description: "Hue White and Color  Lightstrip Flux (4m)",
+                description: "Hue White and Color Lightstrip Flux (4m)",
                 fingerprint: [{modelID: "929004610502"}],
             },
             {
                 model: "929004610602",
                 vendor: "Philips",
-                description: "Hue White and Color  Lightstrip Flux (5m)",
+                description: "Hue White and Color Lightstrip Flux (5m)",
                 fingerprint: [{modelID: "929004610602"}],
             },
             {
                 model: "929004610702",
                 vendor: "Philips",
-                description: "Hue White and Color  Lightstrip Flux (6m)",
+                description: "Hue White and Color Lightstrip Flux (6m)",
                 fingerprint: [{modelID: "929004610702"}],
             },
             {
                 model: "929004610802",
                 vendor: "Philips",
-                description: "Hue White and Color  Lightstrip Flux (10m)",
+                description: "Hue White and Color Lightstrip Flux (10m)",
                 fingerprint: [{modelID: "929004610802"}],
             },
         ],
-        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+        extend: [
+            philips.m.light({
+                colorTemp: {range: [50, 1000]},
+                color: {modes: ["xy", "hs"], enhancedHue: true},
+                gradient: {extraEffects: ["sparkle", "opal", "glisten", "prism", "underwater", "cosmos", "sunbeam", "enchant"]},
+            }),
+        ],
     },
     {
         zigbeeModel: ["929004276602", "929004276702", "929004276802"],


### PR DESCRIPTION
From issue
 - https://github.com/Koenkk/zigbee2mqtt/issues/30691

Also update color range of the Lightstrip Flux and add Gradient effects

```
{"id":3,"type":"Router","ieeeAddr":"0x001788010fca2459","nwkAddr":30719,"manufId":4107,"manufName":"Signify Netherlands B.V.","powerSource":"Mains (single phase)","modelId":"929004610602","epList":[11,242],"endpoints":{"11":{"profId":260,"epId":11,"devId":269,"inClusterList":[0,3,4,5,6,8,4096,64515,768,64513,64516],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"modelId":"929004610602","manufacturerName":"Signify Netherlands B.V.","powerSource":1,"zclVersion":8,"appVersion":2,"stackVersion":1,"hwVersion":1,"dateCode":"20251117","swBuildId":"1.129.5"}},"lightingColorCtrl":{"attributes":{"colorCapabilities":31,"colorTempPhysicalMin":50,"colorTempPhysicalMax":1000,"currentHue":162,"colorMode":0}},"genOnOff":{"attributes":{"onOff":0}},"genLevelCtrl":{"attributes":{"currentLevel":254}}},"binds":[],"configuredReportings":[],"meta":{"onLevelSupported":false}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":2,"stackVersion":1,"hwVersion":1,"dateCode":"20251117","swBuildId":"1.129.5","zclVersion":8,"interviewCompleted":true,"interviewState":"SUCCESSFUL","meta":{"configured":332242049},"lastSeen":1768850848433}
```

Link to picture pull request: DONE IN
 - https://github.com/Koenkk/zigbee2mqtt.io/pull/4744
