### PR TITLE
feat(schneider): Add custom converter for NHPB/DIMMER/1 strict ZCL compliance

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1218,6 +1218,7 @@ export const light_onoff_brightness: Tz.Converter = {
         const transition = utils.getTransition(entity, "brightness", meta);
         const turnsOffAtBrightness1 = utils.getMetaValue(entity, meta.mapped, "turnsOffAtBrightness1", "allEqual", false);
         const moveToLevelWithOnOffDisable = utils.getMetaValue(entity, meta.mapped, "moveToLevelWithOnOffDisable", "allEqual", false);
+        const omitOptionalLevelParams = utils.getMetaValue(entity, meta.mapped, "omitOptionalLevelParams", "allEqual", false);
         let state = message.state !== undefined ? (typeof message.state === "string" ? message.state.toLowerCase() : null) : undefined;
         let brightness: number;
 
@@ -1350,27 +1351,47 @@ export const light_onoff_brightness: Tz.Converter = {
 
             if (typeof meta.state.state === "string" && meta.state.state.toLowerCase() !== targetState) {
                 if (targetState === "on") {
-                    await entity.command(
-                        "genLevelCtrl",
-                        "moveToLevel",
-                        {level: Number(brightness), transtime: transition.time, optionsMask: 0, optionsOverride: 0},
-                        utils.getOptions(meta.mapped, entity),
-                    );
+                    const payload = {level: Number(brightness), transtime: transition.time} as {
+                        level: number;
+                        transtime: number;
+                        optionsMask?: number;
+                        optionsOverride?: number;
+                    };
+                    if (!omitOptionalLevelParams) {
+                        payload.optionsMask = 0;
+                        payload.optionsOverride = 0;
+                    }
+                    await entity.command("genLevelCtrl", "moveToLevel", payload, utils.getOptions(meta.mapped, entity));
                 }
                 await on_off.convertSet(entity, "state", state, meta);
             } else {
-                await entity.command(
-                    "genLevelCtrl",
-                    "moveToLevel",
-                    {level: Number(brightness), transtime: transition.time, optionsMask: 0, optionsOverride: 0},
-                    utils.getOptions(meta.mapped, entity),
-                );
+                const payload = {level: Number(brightness), transtime: transition.time} as {
+                    level: number;
+                    transtime: number;
+                    optionsMask?: number;
+                    optionsOverride?: number;
+                };
+                if (!omitOptionalLevelParams) {
+                    payload.optionsMask = 0;
+                    payload.optionsOverride = 0;
+                }
+                await entity.command("genLevelCtrl", "moveToLevel", payload, utils.getOptions(meta.mapped, entity));
             }
         } else {
+            const payload = {level: Number(brightness), transtime: transition.time} as {
+                level: number;
+                transtime: number;
+                optionsMask?: number;
+                optionsOverride?: number;
+            };
+            if (!omitOptionalLevelParams) {
+                payload.optionsMask = 0;
+                payload.optionsOverride = 0;
+            }
             await entity.command(
                 "genLevelCtrl",
                 state === null ? "moveToLevel" : "moveToLevelWithOnOff",
-                {level: Number(brightness), transtime: transition.time, optionsMask: 0, optionsOverride: 0},
+                payload,
                 utils.getOptions(meta.mapped, entity),
             );
         }

--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -495,49 +495,6 @@ const schneiderElectricExtend = {
 };
 
 const tzLocal = {
-    /**
-     * Custom level control converter for Schneider Electric devices with strict ZCL compliance.
-     * These devices reject commands containing optional parameters (optionsMask, optionsOverride)
-     * that are not explicitly supported, even with value 0.
-     * This converter sends only the mandatory level and transtime parameters.
-     */
-    schneider_strict_level_control: {
-        key: ["brightness", "brightness_percent", "level"],
-        options: [exposes.options.transition()],
-        convertSet: async (entity, key, value, meta) => {
-            // Determine target level based on input key
-            let level: number;
-            if (key === "level") {
-                level = Number(value);
-            } else if (key === "brightness_percent") {
-                level = utils.toNumber(value, "brightness_percent");
-                level = Math.round((level * 254) / 100);
-            } else {
-                // key === "brightness"
-                level = utils.toNumber(value, "brightness");
-            }
-
-            // Clamp level to valid range [0, 254] per ZCL spec
-            level = Math.min(254, Math.max(0, level));
-
-            // Calculate transition time
-            const transitionTime = utils.getTransition(entity, key, meta).time;
-
-            // Send command with only mandatory parameters for strict ZCL compliance
-            // Do NOT include optionsMask or optionsOverride - Schneider devices reject them
-            const payload = {
-                level: level,
-                transtime: transitionTime,
-            };
-
-            await entity.command("genLevelCtrl", "moveToLevelWithOnOff", payload, utils.getOptions(meta.mapped, entity));
-
-            return {state: {brightness: level}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read("genLevelCtrl", ["currentLevel"]);
-        },
-    } satisfies Tz.Converter,
     lift_duration: {
         key: ["lift_duration"],
         convertSet: async (entity, key, value, meta) => {
@@ -991,11 +948,20 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["NHPB/DIMMER/1"],
         model: "WDE002386",
         vendor: "Schneider Electric",
-        description: "Push button dimmer with strict ZCL compliance",
-        fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.power_on_behavior],
-        toZigbee: [tz.on_off, tzLocal.schneider_strict_level_control, tz.level_config, tz.power_on_behavior, tz.ignore_transition],
-        exposes: [e.light_brightness().withLevelConfig(["on_level", "current_level_startup"]), e.power_on_behavior(["off", "on", "previous"])],
-        extend: [m.lightingBallast(), m.identify(), schneiderElectricExtend.dimmingMode(), indicatorMode()],
+        description: "Push button dimmer",
+        extend: [
+            m.light({
+                effect: false,
+                powerOnBehavior: true,
+                configureReporting: true,
+                levelConfig: {features: ["on_level", "current_level_startup"]},
+            }),
+            m.lightingBallast(),
+            m.identify(),
+            schneiderElectricExtend.dimmingMode(),
+            indicatorMode(),
+        ],
+        meta: {omitOptionalLevelParams: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(3);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "genLevelCtrl", "lightingBallastCfg"]);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -181,6 +181,12 @@ export interface DefinitionMeta {
      */
     turnsOffAtBrightness1?: boolean;
     moveToLevelWithOnOffDisable?: boolean | ((entity: Zh.Endpoint) => boolean);
+    /**
+     * Omit optional optionsMask/optionsOverride parameters for devices with strict ZCL v1 compliance
+     *
+     * @defaultValue false
+     */
+    omitOptionalLevelParams?: boolean;
     tuyaThermostatPreset?: {[s: number]: string};
     /** Tuya specific thermostat options */
     tuyaThermostatSystemMode?: {[s: number]: string};


### PR DESCRIPTION
Schneider Electric NHPB/DIMMER/1 (WDE002386) implements strict ZCL v1 without optional optionsMask/optionsOverride parameters. Add custom converter schneider_strict_level_control that sends only mandatory parameters (level, transtime) to ensure device compatibility.

Requires zigbee-herdsman PR for MINIMUM_REMAINING_BUFFER_BYTES support.

**Update Jan 21st 2026**

Following review feedback from @Koenkk, this PR implements a **meta option approach** to avoid code duplication:

### Changes
- Added `omitOptionalLevelParams?: boolean` to `DefinitionMeta` in `src/lib/types.ts`
- Modified `light_onoff_brightness` converter in `src/converters/toZigbee.ts` to conditionally omit `optionsMask` and `optionsOverride` parameters
- Applied `meta: {omitOptionalLevelParams: true}` to the Schneider Electric NHPB/DIMMER/1 device definition

### Implementation
Follows the same pattern as `turnsOffAtBrightness1`, making it reusable for any device with strict ZCL v1 compliance requirements.

### Testing
Tested successfully with Schneider Electric WDE002386 (NHPB/DIMMER/1) - all brightness commands work correctly with both dimmers.



