### PR TITLE
Add Develco WISZB-134 Window/Door sensor support

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -562,17 +562,13 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["WISZB-134"],
         model: "WISZB-134",
         vendor: "Develco",
-        description: "Window/Door sensor",
-        fromZigbee: [fz.ias_contact_alarm_1],
-        toZigbee: [],
-        exposes: [e.contact(), e.battery_low(), e.tamper()],
+        description: "Window/door sensor",
         ota: true,
-        endpoint: (device) => {
-            return {default: 35};
-        },
+        endpoint: () => ({default: 35}),
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
+            m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1", "battery_low", "tamper"]}),
             m.battery({
                 voltageToPercentage: "3V_2100",
                 percentage: true,


### PR DESCRIPTION
Added support for WISZB-134 Window/Door sensor with custom cluster and battery reporting. Tested locally, OTA worked.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4752
