### PR TITLE
Add support for Momax SL12S mmWave sensor

### DIFF
--- a/src/devices/linptech.ts
+++ b/src/devices/linptech.ts
@@ -81,9 +81,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ES1ZZ(TY)",
         vendor: "Linptech",
         description: "mmWave Presence sensor",
-        whiteLabel: [
-            tuya.whitelabel("Momax", "SL12S", "mmWave Presence sensor", ["_TZ3218_ewrxirng"]),
-        ],
+        whiteLabel: [tuya.whitelabel("Momax", "SL12S", "mmWave Presence sensor", ["_TZ3218_ewrxirng"])],
         fromZigbee: [fz.ias_occupancy_alarm_1, fzLocal.TS0225, fzLocal.TS0225_illuminance],
         toZigbee: [tzLocal.TS0225],
         extend: [tuya.modernExtend.tuyaBase({dp: true})],


### PR DESCRIPTION
Extended the TS0225 device definition to include the '_TZ3218_ewrxirng' fingerprint and added a white label entry for the Momax SL12S mmWave Presence sensor.

Related https://github.com/Koenkk/zigbee-herdsman-converters/pull/10784
Fix https://github.com/Koenkk/zigbee2mqtt/issues/29676

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4756
