### PR TITLE
Inovelli - Adding Energy Reset Command for VZM30-SN, VZM31-SN, and VZM32-SN

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -2364,9 +2364,9 @@ export const definitions: DefinitionWithExtend[] = [
             tz.level_config,
             tzLocal.inovelli_led_effect,
             tzLocal.inovelli_individual_led_effect,
-            tzLocal.inovelli_energy_reset,
             tzLocal.inovelli_parameters(VZM30_ATTRIBUTES, INOVELLI_CLUSTER_NAME),
             tzLocal.inovelli_parameters_readOnly(VZM30_ATTRIBUTES, INOVELLI_CLUSTER_NAME),
+            tzLocal.inovelli_energy_reset
         ],
         fromZigbee: [
             fz.on_off,
@@ -2419,9 +2419,9 @@ export const definitions: DefinitionWithExtend[] = [
             tz.level_config,
             tzLocal.inovelli_led_effect,
             tzLocal.inovelli_individual_led_effect,
-            tzLocal.inovelli_energy_reset,
             tzLocal.inovelli_parameters(VZM31_ATTRIBUTES, INOVELLI_CLUSTER_NAME),
             tzLocal.inovelli_parameters_readOnly(VZM31_ATTRIBUTES, INOVELLI_CLUSTER_NAME),
+            tzLocal.inovelli_energy_reset
         ],
         fromZigbee: [
             fz.on_off,


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

