### PR TITLE
Inovelli - Adding Energy Reset Command for VZM30-SN, VZM31-SN, and VZM32-SN

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -111,7 +111,7 @@ interface Inovelli {
             level: number;
             duration: number;
         };
-        energyReset: {};
+        energyReset: Record<string, never>;
         individualLedEffect: {
             led: number;
             effect: number;
@@ -2455,10 +2455,7 @@ const exposeLedEffectComplete = () => {
 };
 
 const exposeEnergyReset = () => {
-    return e
-        .enum("energy_reset", ea.SET, ["reset"])
-        .withDescription("Reset energy meter")
-        .withCategory("config");
+    return e.enum("energy_reset", ea.SET, ["reset"]).withDescription("Reset energy meter").withCategory("config");
 };
 
 const BUTTON_TAP_SEQUENCES = [


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Inovelli - Adding Energy Reset Command for VZM30-SN, VZM31-SN, and VZM32-SN