### PR TITLE
Improve: Philips Omniglow Lighstrip definition

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3506,13 +3506,6 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: true})],
     },
     {
-        zigbeeModel: ["929004608001"],
-        model: "929004608001",
-        vendor: "Philips",
-        description: "Hue OmniGlow lightstrip 3m",
-        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ["sparkle", "opal", "glisten"]}})],
-    },
-    {
         zigbeeModel: ["929004608004"],
         model: "929004608004",
         vendor: "Philips",
@@ -3520,17 +3513,14 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ["sparkle", "opal", "glisten"]}})],
     },
     {
-        zigbeeModel: ["929004608101"],
-        model: "929004608101",
+        zigbeeModel: ["929004608001", "929004608101", "929004608201"],
+        model: "929004608001",
         vendor: "Philips",
-        description: "Hue OmniGlow lightstrip 5m",
-        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-    },
-    {
-        zigbeeModel: ["929004608201"],
-        model: "929004608201",
-        vendor: "Philips",
-        description: "Hue OmniGlow lightstrip 10m",
+        description: "Hue OmniGlow lightstrip (3m)",
+        whiteLabel: [
+            {model: "929004608101", vendor: "Philips", description: "Hue OmniGlow lightstrip (5m)", fingerprint: [{modelID: "929004608101"}]},
+            {model: "929004608201", vendor: "Philips", description: "Hue OmniGlow lightstrip (10m)", fingerprint: [{modelID: "929004608201"}]},
+        ],
         extend: [
             philips.m.light({
                 colorTemp: {range: [50, 1000]},


### PR DESCRIPTION
Updated the 3m and 5m version to use the 10m definition which is more complete. Also updated descriptions and move all versions as whitelabel to reduce code.
