### PR TITLE
Added Neon Outdoor Lightstrips

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3521,13 +3521,6 @@ export const definitions: DefinitionWithExtend[] = [
             {model: "929004608101", vendor: "Philips", description: "Hue OmniGlow lightstrip (5m)", fingerprint: [{modelID: "929004608101"}]},
             {model: "929004608201", vendor: "Philips", description: "Hue OmniGlow lightstrip (10m)", fingerprint: [{modelID: "929004608201"}]},
         ],
-        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
-    },
-    {
-        zigbeeModel: ["929004608201"],
-        model: "929004608201",
-        vendor: "Philips",
-        description: "Hue OmniGlow lightstrip 10m",
         extend: [
             philips.m.light({
                 colorTemp: {range: [50, 1000]},


### PR DESCRIPTION
Added Philips Neon Outdoor Lightstrips in 3 configs 3m, 5m, 10m

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/blob/fb3873b1f0287d10852ba7798a297d2107c32df6/public/images/devices/PH-NEON-LS2.png
