### PR TITLE
feat: IM6001-WLP01 expose voltage

### DIFF
--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -405,7 +405,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.temperature(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
         },
-        exposes: [e.temperature(), e.water_leak(), e.battery_low(), e.tamper(), e.battery()],
+        exposes: [e.temperature(), e.water_leak(), e.battery_low(), e.tamper(), e.battery(), e.voltage()],
     },
     {
         zigbeeModel: ["moisturev4"],


### PR DESCRIPTION
## Summary
- Expose voltage for the SmartThings IM6001-WLP01 water leak sensor (2018 model)
- The voltage is already captured by the `fz.battery` converter, this change makes it visible in the exposed properties

## Test plan
- [ ] Verify voltage appears in device state for IM6001-WLP01

🤖 Generated with [Claude Code](https://claude.com/claude-code)