### PR TITLE
Add Shelly BLU TRV

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -798,9 +798,9 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["BLU TRV"],
-        model: "BLU TRV",
+        model: "SBTR-001AEU",
         vendor: "Shelly",
-        description: "BLU TRV - Thermostatic Radiator Valve",
+        description: "Thermostatic radiator valve",
         fromZigbee: [
             fz.thermostat,
             {
@@ -814,7 +814,7 @@ export const definitions: DefinitionWithExtend[] = [
                     }
                     return result;
                 },
-            },
+            } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
         ],
         toZigbee: [
             {


### PR DESCRIPTION
In firmware v1.3.2 Shelly added proper support for Zigbee for their BLU TRV thermostatic valve. The valve now operates hybrid Bluetooth and Zigbee mode - the BLU GW is not required but adds more settings that are not available via Zigbee right now. (Zigbee mode pairing is activated triple pressing the button on the inside of the valve)

[Link to the Zigbee documentation (at the end of the page)](https://shelly-api-docs.shelly.cloud/docs-ble/Devices/BLU_ZB/trv). 

Automatic endpoint detection found only the battery, nothing else was detected.
I have tested all of this in a form of external converter and all of the main functionality seem to be working correctly. (Both automatic and manual mode)
There are endpoints for Occupancy and Remote sensing, but these seem to be read-only and (maybe) expect data from another Shelly BLU sensor via Bluetooth? That is just my guess, I have not figured out how to provide the data via Zigbee, everyone is welcome to contribute if you figure this out. I have chose not to implement it because the functionality is unknown for now.

I would be happy If anyone else who has there valves tests this and reports their findings. 

Link to picture pull request: [Koenkk/zigbee2mqtt.io/pull/4763](https://github.com/Koenkk/zigbee2mqtt.io/pull/4763)