### PR TITLE
chore: enforce snake case for expose & option `name` & `property`

### DIFF
--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -14,6 +14,26 @@ describe("Check definitions", () => {
         return typeof definition.exposes === "function" ? definition.exposes({isDummyDevice: true}, {}) : definition.exposes;
     }
 
+    function iterateExposes(exposes: Expose[], fn: (expose: Expose) => void): number {
+        let count = 0;
+
+        for (const expose of exposes) {
+            count++;
+
+            fn(expose);
+
+            if (expose.features) {
+                iterateExposes(expose.features, fn);
+            }
+
+            if ("item_type" in expose && expose.item_type.features) {
+                iterateExposes(expose.item_type.features, fn);
+            }
+        }
+
+        return count;
+    }
+
     beforeAll(() => {
         for (const def of baseDefinitions) {
             definitions.push(prepareDefinition(def));
@@ -130,6 +150,172 @@ describe("Check definitions", () => {
                     }
                 }
             }
+        }
+    });
+
+    it("respect snake case naming conventions for exposes and options", () => {
+        const SNAKE_CASE_RE = /^[a-z0-9]+(?:_[a-z0-9]+)*$/;
+        /** @deprecated 3.0 (change will break cache) */
+        const IGNORE_CASE_LIST = [
+            "BTicino|K4003C/L4003C/N4003C/NT4003C",
+            "BTicino|4411C/L4411C/N4411C/NT4411C",
+            "BTicino|F20T60A",
+            "BTicino|L4531C",
+            "EFEKTA|EFEKTA_T1_NTC10K",
+            "EFEKTA|EFEKTA_T1_POW_NTC10K",
+            "EFEKTA|EFEKTA_PS_POW_PRO",
+            "Efektalab|Netuya_CO2_Smart_Box",
+            "EFEKTA|EFEKTA_eAir_Monitor",
+            "Inovelli|VZM30-SN",
+            "Inovelli|VZM31-SN",
+            "Inovelli|VZM32-SN",
+            "Inovelli|VZM35-SN",
+            "Inovelli|VZM36",
+            "Legrand|412173",
+            "Legrand|412171",
+            "Legrand|412170",
+            "Legrand|067776",
+            "Legrand|067776_inverted",
+            "Legrand|067776A",
+            "Legrand|067771",
+            "Legrand|199182",
+            "Legrand|067775/741811",
+            "Legrand|064888",
+            "Legrand|412175",
+            "Legrand|412015",
+            "Legrand|067772",
+            "Legrand|WNRR15/WNRR20",
+            "Legrand|WNAL50/WNRL50",
+            "Legrand|067766",
+            "Legrand|067797",
+            "Legrand|281506",
+            "LiXee|ZLinky_TIC",
+            "LiXee|ZiPulses",
+            "LYTKO|L101Ze-DBN",
+            "LYTKO|L101Ze-SBN",
+            "Aqara|TH-S04D",
+            "Schneider Electric|MEG5779",
+            "Slacky-DIY|THERM_SLACKY_DIY_R01",
+            "Slacky-DIY|THERM_SLACKY_DIY_R01",
+            "Slacky-DIY|THERM_SLACKY_DIY_R02",
+            "Slacky-DIY|THERM_SLACKY_DIY_R02",
+            "Slacky-DIY|THERM_SLACKY_DIY_R03",
+            "Slacky-DIY|THERM_SLACKY_DIY_R03",
+            "Slacky-DIY|THERM_SLACKY_DIY_R04",
+            "Slacky-DIY|THERM_SLACKY_DIY_R04",
+            "Slacky-DIY|THERM_SLACKY_DIY_R05",
+            "Slacky-DIY|THERM_SLACKY_DIY_R05",
+            "Slacky-DIY|THERM_SLACKY_DIY_R06",
+            "Slacky-DIY|THERM_SLACKY_DIY_R06",
+            "Slacky-DIY|THERM_SLACKY_DIY_R07",
+            "Slacky-DIY|THERM_SLACKY_DIY_R07",
+            "Slacky-DIY|THERM_SLACKY_DIY_R08",
+            "Slacky-DIY|THERM_SLACKY_DIY_R08",
+            "Slacky-DIY|THERM_SLACKY_DIY_R09",
+            "Slacky-DIY|THERM_SLACKY_DIY_R09",
+            "Slacky-DIY|THERM_SLACKY_DIY_R0A",
+            "Slacky-DIY|THERM_SLACKY_DIY_R0A",
+            "Slacky-DIY|THERM_SLACKY_DIY_R0B",
+            "Slacky-DIY|THERM_SLACKY_DIY_R0B",
+            "Slacky-DIY|THERM_SLACKY_DIY_R0C",
+            "Slacky-DIY|THERM_SLACKY_DIY_R0C",
+            "Tuya|SPM02",
+            "Ubisys|H1",
+            "Ubisys|H1",
+            "Viessmann|ZK03840",
+            "Viessmann|ZK03840",
+            "YOKIS|MTR500E-UP",
+            "YOKIS|MTR1300E-UP",
+            "YOKIS|MTR2000E-UP",
+            "YOKIS|MTV300E-UP",
+            "YOKIS|MVR500E-UP",
+            "YOKIS|TLC1-UP",
+            "YOKIS|TLM1-UP",
+            "YOKIS|TLM2-UP",
+            "YOKIS|TLM4-UP",
+            "YOKIS|GALET4-UP",
+        ];
+        const ignoredList = new Set<string>();
+        const badList = new Set<string>();
+        let exposesCount = 0;
+        let optionsCount = 0;
+
+        for (const definition of definitions) {
+            const ignored = IGNORE_CASE_LIST.includes(`${definition.vendor}|${definition.model}`);
+
+            if (definition.exposes) {
+                const exposes = definitionExposes(definition);
+
+                exposesCount += iterateExposes(exposes, (expose) => {
+                    if (expose.name) {
+                        if (!SNAKE_CASE_RE.test(expose.name)) {
+                            if (ignored) {
+                                ignoredList.add(`${definition.vendor}|${definition.model}|expose.name=${expose.name}`);
+                            } else {
+                                badList.add(`${definition.vendor}|${definition.model}|expose.name=${expose.name}`);
+                            }
+                        }
+                    }
+
+                    if (expose.property) {
+                        if (!SNAKE_CASE_RE.test(expose.property)) {
+                            if (ignored) {
+                                ignoredList.add(`${definition.vendor}|${definition.model}|expose.name=${expose.property}`);
+                            } else {
+                                badList.add(`${definition.vendor}|${definition.model}|expose.name=${expose.property}`);
+                            }
+                        }
+                    }
+                });
+            }
+
+            if (definition.options) {
+                optionsCount += iterateExposes(definition.options, (option) => {
+                    if (option.name) {
+                        if (!SNAKE_CASE_RE.test(option.name)) {
+                            if (ignored) {
+                                ignoredList.add(`${definition.vendor}|${definition.model}|option.name=${option.name}`);
+                            } else {
+                                badList.add(`${definition.vendor}|${definition.model}|option.name=${option.name}`);
+                            }
+                        }
+                    }
+
+                    if (option.property) {
+                        if (!SNAKE_CASE_RE.test(option.property)) {
+                            if (ignored) {
+                                ignoredList.add(`${definition.vendor}|${definition.model}|option.name=${option.property}`);
+                            } else {
+                                badList.add(`${definition.vendor}|${definition.model}|option.name=${option.property}`);
+                            }
+                        }
+                    }
+                });
+            }
+        }
+
+        if (badList.size > 0) {
+            let lines = "Definitions not using snake case for expose/option:\n";
+
+            for (const entry of badList) {
+                lines += `${entry}\n`;
+            }
+
+            lines += `TOTAL: ${badList.size} out of ${exposesCount + optionsCount} (e=${exposesCount}, o=${optionsCount})`;
+
+            throw new Error(lines);
+        }
+
+        if (ignoredList.size > 0) {
+            let lines = "Definitions currently ignored (3.0 breaking change) not using snake case for expose/option:\n";
+
+            for (const entry of ignoredList) {
+                lines += `${entry}\n`;
+            }
+
+            lines += `TOTAL: ${ignoredList.size} out of ${exposesCount + optionsCount} (e=${exposesCount}, o=${optionsCount})`;
+
+            console.log(lines);
         }
     });
 });


### PR DESCRIPTION
Due to it being a breaking change, we cannot mass-rename until 3.0, but we can prevent more additions with a test.
Note: some are due to `withWeeklySchedule` issues in `lib/exposes` (`featureTransitionTime`, `featureTransitionHeatSetPoint`, `featureTransitionCoolSetPoint`). I figured we can deprecate it, and add a fixed version for future use?

```
Definitions currently ignored (3.0 breaking change) not using snake case for expose/option:
BTicino|K4003C/L4003C/N4003C/NT4003C|option.name=Identity effect
BTicino|4411C/L4411C/N4411C/NT4411C|option.name=Identity effect
BTicino|F20T60A|option.name=Identity effect
BTicino|L4531C|option.name=Identity effect
EFEKTA|EFEKTA_T1_NTC10K|expose.name=ntc status
EFEKTA|EFEKTA_T1_POW_NTC10K|expose.name=ntc status
EFEKTA|EFEKTA_PS_POW_PRO|expose.name=Bar
Efektalab|Netuya_CO2_Smart_Box|expose.name=alarm volume
Efektalab|Netuya_CO2_Smart_Box|expose.name=alarm level
Efektalab|Netuya_CO2_Smart_Box|expose.name=calibration mode
EFEKTA|EFEKTA_eAir_Monitor|expose.name=оperating_mode
Inovelli|VZM30-SN|expose.name=notificationComplete
Inovelli|VZM30-SN|expose.name=dimmingSpeedUpRemote
Inovelli|VZM30-SN|expose.name=dimmingSpeedUpLocal
Inovelli|VZM30-SN|expose.name=rampRateOffToOnRemote
Inovelli|VZM30-SN|expose.name=rampRateOffToOnLocal
Inovelli|VZM30-SN|expose.name=dimmingSpeedDownRemote
Inovelli|VZM30-SN|expose.name=dimmingSpeedDownLocal
Inovelli|VZM30-SN|expose.name=rampRateOnToOffRemote
Inovelli|VZM30-SN|expose.name=rampRateOnToOffLocal
Inovelli|VZM30-SN|expose.name=invertSwitch
Inovelli|VZM30-SN|expose.name=autoTimerOff
Inovelli|VZM30-SN|expose.name=defaultLevelLocal
Inovelli|VZM30-SN|expose.name=defaultLevelRemote
Inovelli|VZM30-SN|expose.name=stateAfterPowerRestored
Inovelli|VZM30-SN|expose.name=loadLevelIndicatorTimeout
Inovelli|VZM30-SN|expose.name=switchType
Inovelli|VZM30-SN|expose.name=internalTemperature
Inovelli|VZM30-SN|expose.name=buttonDelay
Inovelli|VZM30-SN|expose.name=deviceBindNumber
Inovelli|VZM30-SN|expose.name=smartBulbMode
Inovelli|VZM30-SN|expose.name=doubleTapUpToParam55
Inovelli|VZM30-SN|expose.name=doubleTapDownToParam56
Inovelli|VZM30-SN|expose.name=brightnessLevelForDoubleTapUp
Inovelli|VZM30-SN|expose.name=brightnessLevelForDoubleTapDown
Inovelli|VZM30-SN|expose.name=ledColorWhenOn
Inovelli|VZM30-SN|expose.name=ledColorWhenOff
Inovelli|VZM30-SN|expose.name=ledIntensityWhenOn
Inovelli|VZM30-SN|expose.name=ledIntensityWhenOff
Inovelli|VZM30-SN|expose.name=singleTapBehavior
Inovelli|VZM30-SN|expose.name=fanControlMode
Inovelli|VZM30-SN|expose.name=lowLevelForFanControlMode
Inovelli|VZM30-SN|expose.name=mediumLevelForFanControlMode
Inovelli|VZM30-SN|expose.name=highLevelForFanControlMode
Inovelli|VZM30-SN|expose.name=ledColorForFanControlMode
Inovelli|VZM30-SN|expose.name=auxSwitchUniqueScenes
Inovelli|VZM30-SN|expose.name=bindingOffToOnSyncLevel
Inovelli|VZM30-SN|expose.name=localProtection
Inovelli|VZM30-SN|expose.name=remoteProtection
Inovelli|VZM30-SN|expose.name=onOffLedMode
Inovelli|VZM30-SN|expose.name=firmwareUpdateInProgressIndicator
Inovelli|VZM30-SN|expose.name=defaultLed1ColorWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed1ColorWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed1IntensityWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed1IntensityWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed2ColorWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed2ColorWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed2IntensityWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed2IntensityWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed3ColorWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed3ColorWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed3IntensityWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed3IntensityWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed4ColorWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed4ColorWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed4IntensityWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed4IntensityWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed5ColorWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed5ColorWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed5IntensityWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed5IntensityWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed6ColorWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed6ColorWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed6IntensityWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed6IntensityWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed7ColorWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed7ColorWhenOff
Inovelli|VZM30-SN|expose.name=defaultLed7IntensityWhenOn
Inovelli|VZM30-SN|expose.name=defaultLed7IntensityWhenOff
Inovelli|VZM30-SN|expose.name=fanTimerMode
Inovelli|VZM30-SN|expose.name=doubleTapClearNotifications
Inovelli|VZM30-SN|expose.name=fanLedLevelType
Inovelli|VZM30-SN|expose.name=ledBarScaling
Inovelli|VZM30-SN|expose.name=activePowerReports
Inovelli|VZM30-SN|expose.name=periodicPowerAndEnergyReports
Inovelli|VZM30-SN|expose.name=activeEnergyReports
Inovelli|VZM30-SN|expose.name=outputMode
Inovelli|VZM31-SN|expose.name=notificationComplete
Inovelli|VZM31-SN|expose.name=dimmingSpeedUpRemote
Inovelli|VZM31-SN|expose.name=dimmingSpeedUpLocal
Inovelli|VZM31-SN|expose.name=rampRateOffToOnRemote
Inovelli|VZM31-SN|expose.name=rampRateOffToOnLocal
Inovelli|VZM31-SN|expose.name=dimmingSpeedDownRemote
Inovelli|VZM31-SN|expose.name=dimmingSpeedDownLocal
Inovelli|VZM31-SN|expose.name=rampRateOnToOffRemote
Inovelli|VZM31-SN|expose.name=rampRateOnToOffLocal
Inovelli|VZM31-SN|expose.name=invertSwitch
Inovelli|VZM31-SN|expose.name=autoTimerOff
Inovelli|VZM31-SN|expose.name=defaultLevelLocal
Inovelli|VZM31-SN|expose.name=defaultLevelRemote
Inovelli|VZM31-SN|expose.name=stateAfterPowerRestored
Inovelli|VZM31-SN|expose.name=loadLevelIndicatorTimeout
Inovelli|VZM31-SN|expose.name=switchType
Inovelli|VZM31-SN|expose.name=internalTemperature
Inovelli|VZM31-SN|expose.name=buttonDelay
Inovelli|VZM31-SN|expose.name=deviceBindNumber
Inovelli|VZM31-SN|expose.name=smartBulbMode
Inovelli|VZM31-SN|expose.name=doubleTapUpToParam55
Inovelli|VZM31-SN|expose.name=doubleTapDownToParam56
Inovelli|VZM31-SN|expose.name=brightnessLevelForDoubleTapUp
Inovelli|VZM31-SN|expose.name=brightnessLevelForDoubleTapDown
Inovelli|VZM31-SN|expose.name=ledColorWhenOn
Inovelli|VZM31-SN|expose.name=ledColorWhenOff
Inovelli|VZM31-SN|expose.name=ledIntensityWhenOn
Inovelli|VZM31-SN|expose.name=ledIntensityWhenOff
Inovelli|VZM31-SN|expose.name=singleTapBehavior
Inovelli|VZM31-SN|expose.name=fanControlMode
Inovelli|VZM31-SN|expose.name=lowLevelForFanControlMode
Inovelli|VZM31-SN|expose.name=mediumLevelForFanControlMode
Inovelli|VZM31-SN|expose.name=highLevelForFanControlMode
Inovelli|VZM31-SN|expose.name=ledColorForFanControlMode
Inovelli|VZM31-SN|expose.name=auxSwitchUniqueScenes
Inovelli|VZM31-SN|expose.name=bindingOffToOnSyncLevel
Inovelli|VZM31-SN|expose.name=localProtection
Inovelli|VZM31-SN|expose.name=remoteProtection
Inovelli|VZM31-SN|expose.name=onOffLedMode
Inovelli|VZM31-SN|expose.name=firmwareUpdateInProgressIndicator
Inovelli|VZM31-SN|expose.name=defaultLed1ColorWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed1ColorWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed1IntensityWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed1IntensityWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed2ColorWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed2ColorWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed2IntensityWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed2IntensityWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed3ColorWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed3ColorWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed3IntensityWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed3IntensityWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed4ColorWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed4ColorWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed4IntensityWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed4IntensityWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed5ColorWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed5ColorWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed5IntensityWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed5IntensityWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed6ColorWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed6ColorWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed6IntensityWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed6IntensityWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed7ColorWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed7ColorWhenOff
Inovelli|VZM31-SN|expose.name=defaultLed7IntensityWhenOn
Inovelli|VZM31-SN|expose.name=defaultLed7IntensityWhenOff
Inovelli|VZM31-SN|expose.name=doubleTapClearNotifications
Inovelli|VZM31-SN|expose.name=fanLedLevelType
Inovelli|VZM31-SN|expose.name=minimumLevel
Inovelli|VZM31-SN|expose.name=maximumLevel
Inovelli|VZM31-SN|expose.name=powerType
Inovelli|VZM31-SN|expose.name=outputMode
Inovelli|VZM31-SN|expose.name=ledBarScaling
Inovelli|VZM31-SN|expose.name=activePowerReports
Inovelli|VZM31-SN|expose.name=periodicPowerAndEnergyReports
Inovelli|VZM31-SN|expose.name=activeEnergyReports
Inovelli|VZM31-SN|expose.name=quickStartTime
Inovelli|VZM31-SN|expose.name=quickStartLevel
Inovelli|VZM31-SN|expose.name=higherOutputInNonNeutral
Inovelli|VZM31-SN|expose.name=dimmingMode
Inovelli|VZM31-SN|expose.name=relayClick
Inovelli|VZM32-SN|expose.name=notificationComplete
Inovelli|VZM32-SN|expose.name=dimmingSpeedUpRemote
Inovelli|VZM32-SN|expose.name=dimmingSpeedUpLocal
Inovelli|VZM32-SN|expose.name=rampRateOffToOnRemote
Inovelli|VZM32-SN|expose.name=rampRateOffToOnLocal
Inovelli|VZM32-SN|expose.name=dimmingSpeedDownRemote
Inovelli|VZM32-SN|expose.name=dimmingSpeedDownLocal
Inovelli|VZM32-SN|expose.name=rampRateOnToOffRemote
Inovelli|VZM32-SN|expose.name=rampRateOnToOffLocal
Inovelli|VZM32-SN|expose.name=invertSwitch
Inovelli|VZM32-SN|expose.name=autoTimerOff
Inovelli|VZM32-SN|expose.name=defaultLevelLocal
Inovelli|VZM32-SN|expose.name=defaultLevelRemote
Inovelli|VZM32-SN|expose.name=stateAfterPowerRestored
Inovelli|VZM32-SN|expose.name=loadLevelIndicatorTimeout
Inovelli|VZM32-SN|expose.name=switchType
Inovelli|VZM32-SN|expose.name=internalTemperature
Inovelli|VZM32-SN|expose.name=buttonDelay
Inovelli|VZM32-SN|expose.name=deviceBindNumber
Inovelli|VZM32-SN|expose.name=smartBulbMode
Inovelli|VZM32-SN|expose.name=doubleTapUpToParam55
Inovelli|VZM32-SN|expose.name=doubleTapDownToParam56
Inovelli|VZM32-SN|expose.name=brightnessLevelForDoubleTapUp
Inovelli|VZM32-SN|expose.name=brightnessLevelForDoubleTapDown
Inovelli|VZM32-SN|expose.name=ledColorWhenOn
Inovelli|VZM32-SN|expose.name=ledColorWhenOff
Inovelli|VZM32-SN|expose.name=ledIntensityWhenOn
Inovelli|VZM32-SN|expose.name=ledIntensityWhenOff
Inovelli|VZM32-SN|expose.name=singleTapBehavior
Inovelli|VZM32-SN|expose.name=fanControlMode
Inovelli|VZM32-SN|expose.name=lowLevelForFanControlMode
Inovelli|VZM32-SN|expose.name=mediumLevelForFanControlMode
Inovelli|VZM32-SN|expose.name=highLevelForFanControlMode
Inovelli|VZM32-SN|expose.name=ledColorForFanControlMode
Inovelli|VZM32-SN|expose.name=auxSwitchUniqueScenes
Inovelli|VZM32-SN|expose.name=bindingOffToOnSyncLevel
Inovelli|VZM32-SN|expose.name=localProtection
Inovelli|VZM32-SN|expose.name=remoteProtection
Inovelli|VZM32-SN|expose.name=onOffLedMode
Inovelli|VZM32-SN|expose.name=firmwareUpdateInProgressIndicator
Inovelli|VZM32-SN|expose.name=defaultLed1ColorWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed1ColorWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed1IntensityWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed1IntensityWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed2ColorWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed2ColorWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed2IntensityWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed2IntensityWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed3ColorWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed3ColorWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed3IntensityWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed3IntensityWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed4ColorWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed4ColorWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed4IntensityWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed4IntensityWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed5ColorWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed5ColorWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed5IntensityWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed5IntensityWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed6ColorWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed6ColorWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed6IntensityWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed6IntensityWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed7ColorWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed7ColorWhenOff
Inovelli|VZM32-SN|expose.name=defaultLed7IntensityWhenOn
Inovelli|VZM32-SN|expose.name=defaultLed7IntensityWhenOff
Inovelli|VZM32-SN|expose.name=fanTimerMode
Inovelli|VZM32-SN|expose.name=doubleTapClearNotifications
Inovelli|VZM32-SN|expose.name=fanLedLevelType
Inovelli|VZM32-SN|expose.name=minimumLevel
Inovelli|VZM32-SN|expose.name=maximumLevel
Inovelli|VZM32-SN|expose.name=powerType
Inovelli|VZM32-SN|expose.name=outputMode
Inovelli|VZM32-SN|expose.name=ledBarScaling
Inovelli|VZM32-SN|expose.name=activePowerReports
Inovelli|VZM32-SN|expose.name=periodicPowerAndEnergyReports
Inovelli|VZM32-SN|expose.name=activeEnergyReports
Inovelli|VZM32-SN|expose.name=quickStartTime
Inovelli|VZM32-SN|expose.name=quickStartLevel
Inovelli|VZM32-SN|expose.name=higherOutputInNonNeutral
Inovelli|VZM32-SN|expose.name=dimmingMode
Inovelli|VZM32-SN|expose.name=otaImageType
Inovelli|VZM32-SN|expose.name=mmwaveControlWiredDevice
Inovelli|VZM32-SN|expose.name=mmWaveRoomSizePreset
Inovelli|VZM32-SN|expose.name=mmWaveHoldTime
Inovelli|VZM32-SN|expose.name=mmWaveDetectSensitivity
Inovelli|VZM32-SN|expose.name=mmWaveDetectTrigger
Inovelli|VZM32-SN|expose.name=mmWaveTargetInfoReport
Inovelli|VZM32-SN|expose.name=mmWaveStayLife
Inovelli|VZM32-SN|expose.name=mmWaveVersion
Inovelli|VZM32-SN|expose.name=mmWaveHeightMin
Inovelli|VZM32-SN|expose.name=mmWaveHeightMax
Inovelli|VZM32-SN|expose.name=mmWaveWidthMin
Inovelli|VZM32-SN|expose.name=mmWaveWidthMax
Inovelli|VZM32-SN|expose.name=mmWaveDepthMin
Inovelli|VZM32-SN|expose.name=mmWaveDepthMax
Inovelli|VZM32-SN|expose.name=controlID
Inovelli|VZM35-SN|expose.name=breeze mode
Inovelli|VZM35-SN|expose.name=breezeMode
Inovelli|VZM35-SN|expose.name=notificationComplete
Inovelli|VZM35-SN|expose.name=dimmingSpeedUpRemote
Inovelli|VZM35-SN|expose.name=dimmingSpeedUpLocal
Inovelli|VZM35-SN|expose.name=rampRateOffToOnRemote
Inovelli|VZM35-SN|expose.name=rampRateOffToOnLocal
Inovelli|VZM35-SN|expose.name=dimmingSpeedDownRemote
Inovelli|VZM35-SN|expose.name=dimmingSpeedDownLocal
Inovelli|VZM35-SN|expose.name=rampRateOnToOffRemote
Inovelli|VZM35-SN|expose.name=rampRateOnToOffLocal
Inovelli|VZM35-SN|expose.name=invertSwitch
Inovelli|VZM35-SN|expose.name=autoTimerOff
Inovelli|VZM35-SN|expose.name=defaultLevelLocal
Inovelli|VZM35-SN|expose.name=defaultLevelRemote
Inovelli|VZM35-SN|expose.name=stateAfterPowerRestored
Inovelli|VZM35-SN|expose.name=loadLevelIndicatorTimeout
Inovelli|VZM35-SN|expose.name=switchType
Inovelli|VZM35-SN|expose.name=internalTemperature
Inovelli|VZM35-SN|expose.name=buttonDelay
Inovelli|VZM35-SN|expose.name=deviceBindNumber
Inovelli|VZM35-SN|expose.name=smartBulbMode
Inovelli|VZM35-SN|expose.name=doubleTapUpToParam55
Inovelli|VZM35-SN|expose.name=doubleTapDownToParam56
Inovelli|VZM35-SN|expose.name=brightnessLevelForDoubleTapUp
Inovelli|VZM35-SN|expose.name=brightnessLevelForDoubleTapDown
Inovelli|VZM35-SN|expose.name=ledColorWhenOn
Inovelli|VZM35-SN|expose.name=ledColorWhenOff
Inovelli|VZM35-SN|expose.name=ledIntensityWhenOn
Inovelli|VZM35-SN|expose.name=ledIntensityWhenOff
Inovelli|VZM35-SN|expose.name=singleTapBehavior
Inovelli|VZM35-SN|expose.name=fanControlMode
Inovelli|VZM35-SN|expose.name=lowLevelForFanControlMode
Inovelli|VZM35-SN|expose.name=mediumLevelForFanControlMode
Inovelli|VZM35-SN|expose.name=highLevelForFanControlMode
Inovelli|VZM35-SN|expose.name=ledColorForFanControlMode
Inovelli|VZM35-SN|expose.name=auxSwitchUniqueScenes
Inovelli|VZM35-SN|expose.name=bindingOffToOnSyncLevel
Inovelli|VZM35-SN|expose.name=localProtection
Inovelli|VZM35-SN|expose.name=remoteProtection
Inovelli|VZM35-SN|expose.name=onOffLedMode
Inovelli|VZM35-SN|expose.name=firmwareUpdateInProgressIndicator
Inovelli|VZM35-SN|expose.name=defaultLed1ColorWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed1ColorWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed1IntensityWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed1IntensityWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed2ColorWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed2ColorWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed2IntensityWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed2IntensityWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed3ColorWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed3ColorWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed3IntensityWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed3IntensityWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed4ColorWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed4ColorWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed4IntensityWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed4IntensityWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed5ColorWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed5ColorWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed5IntensityWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed5IntensityWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed6ColorWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed6ColorWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed6IntensityWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed6IntensityWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed7ColorWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed7ColorWhenOff
Inovelli|VZM35-SN|expose.name=defaultLed7IntensityWhenOn
Inovelli|VZM35-SN|expose.name=defaultLed7IntensityWhenOff
Inovelli|VZM35-SN|expose.name=fanTimerMode
Inovelli|VZM35-SN|expose.name=doubleTapClearNotifications
Inovelli|VZM35-SN|expose.name=fanLedLevelType
Inovelli|VZM35-SN|expose.name=minimumLevel
Inovelli|VZM35-SN|expose.name=maximumLevel
Inovelli|VZM35-SN|expose.name=powerType
Inovelli|VZM35-SN|expose.name=outputMode
Inovelli|VZM35-SN|expose.name=quickStartTime
Inovelli|VZM35-SN|expose.name=nonNeutralAuxMediumGear
Inovelli|VZM35-SN|expose.name=nonNeutralAuxLowGear
Inovelli|VZM36|expose.name=breeze mode
Inovelli|VZM36|expose.name=breezeMode
Inovelli|VZM36|expose.name=dimmingSpeedUpRemote_1
Inovelli|VZM36|expose.name=rampRateOffToOnRemote_1
Inovelli|VZM36|expose.name=dimmingSpeedDownRemote_1
Inovelli|VZM36|expose.name=rampRateOnToOffRemote_1
Inovelli|VZM36|expose.name=minimumLevel_1
Inovelli|VZM36|expose.name=maximumLevel_1
Inovelli|VZM36|expose.name=autoTimerOff_1
Inovelli|VZM36|expose.name=defaultLevelRemote_1
Inovelli|VZM36|expose.name=stateAfterPowerRestored_1
Inovelli|VZM36|expose.name=quickStartTime_1
Inovelli|VZM36|expose.name=quickStartLevel_1
Inovelli|VZM36|expose.name=higherOutputInNonNeutral_1
Inovelli|VZM36|expose.name=dimmingMode_1
Inovelli|VZM36|expose.name=smartBulbMode_1
Inovelli|VZM36|expose.name=ledColorWhenOn_1
Inovelli|VZM36|expose.name=ledIntensityWhenOn_1
Inovelli|VZM36|expose.name=outputMode_1
Inovelli|VZM36|expose.name=dimmingSpeedUpRemote_2
Inovelli|VZM36|expose.name=rampRateOffToOnRemote_2
Inovelli|VZM36|expose.name=dimmingSpeedDownRemote_2
Inovelli|VZM36|expose.name=rampRateOnToOffRemote_2
Inovelli|VZM36|expose.name=minimumLevel_2
Inovelli|VZM36|expose.name=maximumLevel_2
Inovelli|VZM36|expose.name=autoTimerOff_2
Inovelli|VZM36|expose.name=defaultLevelRemote_2
Inovelli|VZM36|expose.name=stateAfterPowerRestored_2
Inovelli|VZM36|expose.name=quickStartTime_2
Inovelli|VZM36|expose.name=smartBulbMode_2
Inovelli|VZM36|expose.name=outputMode_2
Legrand|412173|option.name=Identity effect
Legrand|412171|option.name=Identity effect
Legrand|412170|option.name=Identity effect
Legrand|067776|option.name=Identity effect
Legrand|067776_inverted|option.name=Identity effect
Legrand|067776A|option.name=Identity effect
Legrand|067771|option.name=Identity effect
Legrand|199182|option.name=Identity effect
Legrand|067775/741811|option.name=Identity effect
Legrand|064888|option.name=Identity effect
Legrand|412175|option.name=Identity effect
Legrand|412015|option.name=Identity effect
Legrand|067772|option.name=Identity effect
Legrand|WNRR15/WNRR20|option.name=Identity effect
Legrand|WNAL50/WNRL50|option.name=Identity effect
Legrand|067766|option.name=Identity effect
Legrand|067797|option.name=Identity effect
Legrand|281506|option.name=Identity effect
LiXee|ZLinky_TIC|expose.name=EAST
LiXee|ZLinky_TIC|expose.name=EAIT
LiXee|ZLinky_TIC|expose.name=EASF01
LiXee|ZLinky_TIC|expose.name=EASF02
LiXee|ZLinky_TIC|expose.name=EASF03
LiXee|ZLinky_TIC|expose.name=EASF04
LiXee|ZLinky_TIC|expose.name=EASF05
LiXee|ZLinky_TIC|expose.name=EASF06
LiXee|ZLinky_TIC|expose.name=EASF07
LiXee|ZLinky_TIC|expose.name=EASF08
LiXee|ZLinky_TIC|expose.name=EASF09
LiXee|ZLinky_TIC|expose.name=EASF10
LiXee|ZLinky_TIC|expose.name=ADSC
LiXee|ZLinky_TIC|expose.name=PRM
LiXee|ZLinky_TIC|expose.name=PREF
LiXee|ZLinky_TIC|expose.name=PCOUP
LiXee|ZLinky_TIC|expose.name=VTIC
LiXee|ZLinky_TIC|expose.name=CCASN
LiXee|ZLinky_TIC|expose.name=CCASN-1
LiXee|ZLinky_TIC|expose.name=UMOY1
LiXee|ZLinky_TIC|expose.name=ERQ1
LiXee|ZLinky_TIC|expose.name=ERQ2
LiXee|ZLinky_TIC|expose.name=ERQ3
LiXee|ZLinky_TIC|expose.name=ERQ4
LiXee|ZLinky_TIC|expose.name=IRMS1
LiXee|ZLinky_TIC|expose.name=URMS1
LiXee|ZLinky_TIC|expose.name=EASD01
LiXee|ZLinky_TIC|expose.name=EASD02
LiXee|ZLinky_TIC|expose.name=EASD03
LiXee|ZLinky_TIC|expose.name=EASD04
LiXee|ZLinky_TIC|expose.name=DATE
LiXee|ZLinky_TIC|expose.name=NTARF
LiXee|ZLinky_TIC|expose.name=LTARF
LiXee|ZLinky_TIC|expose.name=NGTF
LiXee|ZLinky_TIC|expose.name=NJOURF
LiXee|ZLinky_TIC|expose.name=NJOURF+1
LiXee|ZLinky_TIC|expose.name=PJOURF+1
LiXee|ZLinky_TIC|expose.name=PPOINTE1
LiXee|ZLinky_TIC|expose.name=CCAIN
LiXee|ZLinky_TIC|expose.name=CCAIN-1
LiXee|ZLinky_TIC|expose.name=SINSTI
LiXee|ZLinky_TIC|expose.name=SMAXIN
LiXee|ZLinky_TIC|expose.name=SMAXIN-1
LiXee|ZLinky_TIC|expose.name=MSG1
LiXee|ZLinky_TIC|expose.name=MSG2
LiXee|ZLinky_TIC|expose.name=RELAIS
LiXee|ZLinky_TIC|expose.name=DPM1
LiXee|ZLinky_TIC|expose.name=DPM2
LiXee|ZLinky_TIC|expose.name=DPM3
LiXee|ZLinky_TIC|expose.name=STGE
LiXee|ZLinky_TIC|expose.name=FPM1
LiXee|ZLinky_TIC|expose.name=FPM2
LiXee|ZLinky_TIC|expose.name=FPM3
LiXee|ZLinky_TIC|expose.name=SMAXSN
LiXee|ZLinky_TIC|expose.name=SINSTS
LiXee|ZLinky_TIC|expose.name=SMAXSN-1
LiXee|ZLinky_TIC|expose.name=SMAXSN2
LiXee|ZLinky_TIC|expose.name=SMAXSN3
LiXee|ZLinky_TIC|expose.name=SINSTS2
LiXee|ZLinky_TIC|expose.name=SINSTS3
LiXee|ZLinky_TIC|expose.name=UMOY3
LiXee|ZLinky_TIC|expose.name=UMOY2
LiXee|ZLinky_TIC|expose.name=IRMS2
LiXee|ZLinky_TIC|expose.name=IRMS3
LiXee|ZLinky_TIC|expose.name=URMS2
LiXee|ZLinky_TIC|expose.name=URMS3
LiXee|ZLinky_TIC|expose.name=SMAXSN2-1
LiXee|ZLinky_TIC|expose.name=SMAXSN3-1
LiXee|ZLinky_TIC|expose.name=PTEC
LiXee|ZLinky_TIC|expose.name=MOTDETAT
LiXee|ZLinky_TIC|expose.name=HHPHC
LiXee|ZLinky_TIC|expose.name=PEJP
LiXee|ZLinky_TIC|expose.name=DEMAIN
LiXee|ZLinky_TIC|expose.name=IMAX
LiXee|ZLinky_TIC|expose.name=ADPS
LiXee|ZLinky_TIC|expose.name=IMAX2
LiXee|ZLinky_TIC|expose.name=IMAX3
LiXee|ZLinky_TIC|expose.name=PPOT
LiXee|ZLinky_TIC|expose.name=ADIR1
LiXee|ZLinky_TIC|expose.name=ADIR2
LiXee|ZLinky_TIC|expose.name=ADIR3
LiXee|ZLinky_TIC|option.name=kWh_precision
LiXee|ZiPulses|expose.name=unitOfMeasure
LYTKO|L101Ze-SBN|expose.name=brigness_Active
LYTKO|L101Ze-SBN|expose.name=brigness_Standby
LYTKO|L101Ze-DBN|expose.name=brigness_Active
LYTKO|L101Ze-DBN|expose.name=brigness_Standby
Aqara|TH-S04D|expose.name=PMTSD_from_W100_Data
Schneider Electric|MEG5779|expose.name=keypadLockout
Slacky-DIY|THERM_SLACKY_DIY_R01|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R01|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R02|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R02|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R03|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R03|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R04|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R04|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R05|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R05|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R06|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R06|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R07|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R07|expose.name=coolSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R08|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R08|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R09|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R09|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R0A|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R0A|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R0B|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R0B|expose.name=heatSetpoint
Slacky-DIY|THERM_SLACKY_DIY_R0C|expose.name=transitionTime
Slacky-DIY|THERM_SLACKY_DIY_R0C|expose.name=heatSetpoint
Tuya|SPM02|expose.name=voltage_X
Tuya|SPM02|expose.name=voltage_Y
Tuya|SPM02|expose.name=voltage_Z
Tuya|SPM02|expose.name=power_X
Tuya|SPM02|expose.name=power_Y
Tuya|SPM02|expose.name=power_Z
Tuya|SPM02|expose.name=current_X
Tuya|SPM02|expose.name=current_Y
Tuya|SPM02|expose.name=current_Z
Ubisys|H1|expose.name=transitionTime
Ubisys|H1|expose.name=heatSetpoint
Viessmann|ZK03840|expose.name=transitionTime
Viessmann|ZK03840|expose.name=heatSetpoint
YOKIS|MTR500E-UP|expose.name=uc_BlinkAmountItem
YOKIS|MTR500E-UP|expose.name=enable_R12M_long_press
YOKIS|MTR1300E-UP|expose.name=uc_BlinkAmountItem
YOKIS|MTR1300E-UP|expose.name=enable_R12M_long_press
YOKIS|MTR2000E-UP|expose.name=uc_BlinkAmountItem
YOKIS|MTR2000E-UP|expose.name=enable_R12M_long_press
YOKIS|MTV300E-UP|expose.name=uc_BlinkAmountItem
YOKIS|MTV300E-UP|expose.name=dimmer_Up_down_command
YOKIS|MTV300E-UP|expose.name=enable_R12M_long_press
YOKIS|MVR500E-UP|expose.name=enable_R12M_long_press
YOKIS|TLC1-UP|expose.name=samplingPeriod
YOKIS|TLC1-UP|expose.name=samplingNumber
YOKIS|TLC1-UP|expose.name=deltaTemp
YOKIS|TLC1-UP|expose.name=minimalSendingPeriod
YOKIS|TLC1-UP|expose.name=maximalSendingPeriod
YOKIS|TLM1-UP|expose.name=samplingPeriod
YOKIS|TLM1-UP|expose.name=samplingNumber
YOKIS|TLM1-UP|expose.name=deltaTemp
YOKIS|TLM1-UP|expose.name=minimalSendingPeriod
YOKIS|TLM1-UP|expose.name=maximalSendingPeriod
YOKIS|TLM2-UP|expose.name=samplingPeriod
YOKIS|TLM2-UP|expose.name=samplingNumber
YOKIS|TLM2-UP|expose.name=deltaTemp
YOKIS|TLM2-UP|expose.name=minimalSendingPeriod
YOKIS|TLM2-UP|expose.name=maximalSendingPeriod
YOKIS|TLM4-UP|expose.name=samplingPeriod
YOKIS|TLM4-UP|expose.name=samplingNumber
YOKIS|TLM4-UP|expose.name=deltaTemp
YOKIS|TLM4-UP|expose.name=minimalSendingPeriod
YOKIS|TLM4-UP|expose.name=maximalSendingPeriod
YOKIS|GALET4-UP|expose.name=samplingPeriod
YOKIS|GALET4-UP|expose.name=samplingNumber
YOKIS|GALET4-UP|expose.name=deltaTemp
YOKIS|GALET4-UP|expose.name=minimalSendingPeriod
YOKIS|GALET4-UP|expose.name=maximalSendingPeriod
TOTAL: 559 out of 32763 (e=21969, o=10794)
```