### PR TITLE
Add another device id to ENGO ECB62-ZB converter

### DIFF
--- a/src/devices/engo.ts
+++ b/src/devices/engo.ts
@@ -8,7 +8,7 @@ const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_oahqgdig"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_oahqgdig", "_TZE200_zaabefnt"]),
         model: "ECB62-ZB",
         vendor: "ENGO",
         description: "Control box for underfloor heating system",


### PR DESCRIPTION
I have one ENGO ECB62-ZB in my hands and it works like charm but just has a different ID so I add this to an existing converter