### PR TITLE
fix: ZBMicro: entity category 'config' for 'RF turbo mode'

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2591,6 +2591,7 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Enable/disable Radio power turbo mode",
                 valueOff: [false, 0x09],
                 valueOn: [true, 0x14],
+                entityCategory: "config",
             }),
             sonoffExtend.inchingControlSet(),
         ],


### PR DESCRIPTION
The "RF turbo mode" expose should be in the `config` entity category (not the implied default `control`).
