### PR TITLE
feat: Futurehome TS0601 expose energy consumption

### DIFF
--- a/src/devices/futurehome.ts
+++ b/src/devices/futurehome.ts
@@ -10,15 +10,14 @@ const localValueConverters = {
     energyMonotonic: {
         from: (value: number, meta: Fz.Meta) => {
             const scaled = tuya.valueConverter.divideBy100.from(value);
-            const lastValue = meta.device.meta.energy;
-
-            if (typeof lastValue === "number" && scaled < lastValue && scaled !== 0) {
+            const lastValue = meta.device.meta.energy ?? 0;
+            if (scaled < lastValue && scaled !== 0) {
                 // Erraneous reading that is less than previous readings (and not a reset to 0), ignore it.
-                return {};
+                return lastValue;
             }
 
             meta.device.meta.energy = scaled;
-            return {energy: scaled};
+            return scaled;
         },
     },
 };
@@ -95,7 +94,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [106, "window_detection", tuya.valueConverter.onOff],
                 [107, "max_temperature_protection", tuya.valueConverter.raw],
                 // Reported as a monotonically increasing counter while heating, using unit 0.01 kWh.
-                [123, "", localValueConverters.energyMonotonic],
+                [123, "energy", localValueConverters.energyMonotonic],
             ],
         },
     },


### PR DESCRIPTION
Expose energy consumption metric, ignoring outdated values which seem to happen often at least in a busier network.

Fixes feature request https://github.com/Koenkk/zigbee2mqtt/issues/23139
