### PR TITLE
enhance ENGO EONE 230W with presets and floor temp limits

### DIFF
--- a/src/devices/engo.ts
+++ b/src/devices/engo.ts
@@ -739,7 +739,7 @@ export const definitions: DefinitionWithExtend[] = [
                     tuya.valueConverterBasic.lookup({
                         off: tuya.enum(0),
                         on: tuya.enum(1),
-                        anti_stop: tuya.enum(2)
+                        anti_stop: tuya.enum(2),
                     }),
                 ],
             ],


### PR DESCRIPTION
I also got a piece of ENGO EONE 230W from local representative. The firmware is 2.1 (latest at the moment)
Previous convertor lacked datapoint for temperature calibraion, used wrong valve protection convertor and didn't implemet floor temparature limits at all

Also, presets were a bit off with no datapoint and extra modes