### PR TITLE
fix(detect): Support North American Ikea Jetström

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -455,7 +455,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [addCustomClusterManuSpecificIkeaUnknown(), ikeaLight(), m.identify()],
     },
     {
-        zigbeeModel: ["JETSTROM 40100"],
+        zigbeeModel: ["JETSTROM 40100", "JETSTROM 40100 NA"],
         model: "L2208",
         vendor: "IKEA",
         description: "JETSTROM ceiling light panel, white spectrum, 100x40 cm",


### PR DESCRIPTION
I recently installed an [Ikea Jetström 100x40cm](https://www.zigbee2mqtt.io/devices/L2208.html).

It identifies as "JETSTROM 40100 NA (unsupported)" in the current version of Zigbee2MQTT, but otherwise works fine.