### PR TITLE
Fix MOES cover switch position

### DIFF
--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -3100,6 +3100,7 @@ const fromZigbee = {
             let fixedValue = null;
             switch (dp) {
                 case dataPoints.coverPosition: {
+                    // https://github.com/Koenkk/zigbee-herdsman-converters/pull/11408
                     if (value >= 100 && value <= 127) {
                         fixedValue = 100;
                     } else if (value > 127 || value < 0) {


### PR DESCRIPTION
Sometimes MOES curtain switches return an incorrect position (this always happens with mine). The value falls outside the range of 0–100 in either direction and can be either greater than 100 or less than 0. This causes problems with detecting the open/closed state, as well as with settings in Home Assistant.