### PR TITLE
Add Shelly remotes: BLU Button Tough 1 ZB, BLU RC Button 4 ZB, BLU Wall Switch 4 ZB

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -4,6 +4,7 @@ import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
 import type {Configure, DefinitionWithExtend, Expose, Fz, KeyValue, ModernExtend, Tz, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
 import {assertObject, determineEndpoint, sleep} from "../lib/utils";
 
 const e = exposes.presets;
@@ -518,6 +519,45 @@ const shellyModernExtend = {
     },
 };
 
+const fzLocal = {
+    one_button_events: {
+        cluster: "genOnOff",
+        type: ["commandToggle"],
+        convert: (model, msg, publish, options, meta) => {
+            const event = utils.getFromLookup(msg.endpoint.ID, {1: "single", 2: "double", 3: "triple"});
+            return {action: event};
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["commandToggle"]>,
+
+    four_buttons_single_events: {
+        cluster: "genOnOff",
+        type: ["commandOn", "commandOff"],
+        convert: (model, msg, publish, options, meta) => {
+            const event = utils.getFromLookup(`${msg.endpoint.ID}_${msg.type}`, {
+                "1_commandOn": "1_single",
+                "1_commandOff": "2_single",
+                "2_commandOn": "3_single",
+                "2_commandOff": "4_single",
+            });
+            return {action: event};
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["commandOn", "commandOff"]>,
+
+    four_buttons_hold_events: {
+        cluster: "genLevelCtrl",
+        type: ["commandStep"],
+        convert: (model, msg, publish, options, meta) => {
+            const event = utils.getFromLookup(`${msg.endpoint.ID}_${msg.data.stepmode}`, {
+                "1_0": "1_hold",
+                "1_1": "2_hold",
+                "2_0": "3_hold",
+                "2_1": "4_hold",
+            });
+            return {action: event};
+        },
+    } satisfies Fz.Converter<"genLevelCtrl", undefined, ["commandStep"]>,
+};
+
 export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["Mini1", "1 Mini"],
@@ -808,26 +848,18 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SBBT-102C",
         vendor: "Shelly",
         description: "BLU Button Tough 1 ZB",
-        extend: [
-            m.battery(),
-            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}),
-            m.commandsOnOff({endpointNames: ["1", "2", "3"]}),
-            m.commandsLevelCtrl(),
-            m.identify(),
-        ],
+        fromZigbee: [fzLocal.one_button_events],
+        exposes: [e.action(["single", "double", "triple"])],
+        extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}), m.identify()],
     },
     {
         fingerprint: [{modelID: "BLU RC Button 4 ZB", manufacturerName: "Shelly"}],
         model: "SBBT-104CUS",
         vendor: "Shelly",
         description: "BLU RC Button 4 ZB",
-        extend: [
-            m.battery(),
-            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}),
-            m.commandsOnOff({endpointNames: ["1", "2", "3", "4"]}),
-            m.commandsLevelCtrl({endpointNames: ["1", "2", "3", "4"]}),
-            m.identify(),
-        ],
+        fromZigbee: [fzLocal.four_buttons_single_events, fzLocal.four_buttons_hold_events],
+        exposes: [e.action(["1_single", "2_single", "3_single", "4_single", "1_hold", "2_hold", "3_hold", "4_hold"])],
+        extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}), m.identify()],
     },
     {
         zigbeeModel: ["BLU Wall Switch 4 ZB"],
@@ -835,13 +867,9 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "BLU Wall Switch 4 ZB",
         whiteLabel: [{vendor: "Shelly", model: "SBBT-104CEU", description: "BLU Wall Switch 4 ZB DK"}],
-        extend: [
-            m.battery(),
-            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}),
-            m.commandsOnOff({endpointNames: ["1", "2", "3", "4"]}),
-            m.commandsLevelCtrl({endpointNames: ["1", "2", "3", "4"]}),
-            m.identify(),
-        ],
+        fromZigbee: [fzLocal.four_buttons_single_events, fzLocal.four_buttons_hold_events],
+        exposes: [e.action(["1_single", "2_single", "3_single", "4_single", "1_hold", "2_hold", "3_hold", "4_hold"])],
+        extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}), m.identify()],
     },
     {
         zigbeeModel: ["BLU TRV"],


### PR DESCRIPTION
Just the external definitions from these issues.
~~_2 and 3 could have more commands from double/triple clicks._~~

1. Fixes https://github.com/Koenkk/zigbee2mqtt/issues/30764
2. Fixes https://github.com/Koenkk/zigbee2mqtt/issues/30640
3. Fixes https://github.com/Koenkk/zigbee2mqtt/issues/30680
- pictures: https://github.com/Koenkk/zigbee2mqtt.io/pull/4786