### PR TITLE
fix: Bosch Twinguard 8750001213: Rename expose `co2` to `eco2`

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -234,7 +234,7 @@ const boschExtend = {
                 .withLabel("eCO₂")
                 .withUnit("ppm")
                 .withDescription("TVOC-derived CO₂-equivalent"),
-            e.numeric("iaq", ea.STATE).withValueMin(0).withValueMax(500).withValueStep(1).withLabel("IAQ").withDescription("Index for Air Quality"),
+            e.numeric("aqi", ea.STATE).withValueMin(0).withValueMax(500).withValueStep(1).withLabel("IAQ").withDescription("Index for Air Quality"),
             e.illuminance(),
             e
                 .numeric("battery", ea.STATE)


### PR DESCRIPTION
This is a follow-up to a discussion started at https://github.com/Koenkk/zigbee-herdsman-converters/pull/11204#issuecomment-3716976392.

To avoid further confusion about capabilities, renaming `co2` to `eco2` seems to be an appropriate step. This should prevent ecosystems from misrepresenting sensor readings.

