### PR TITLE
Add Zemismart ZMR4 (no dimmer) to whiteLabels

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5134,7 +5134,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("HOBEIAN", "ZG-101ZS", "Star Ring 4 Gang Scene Switch", ["_TZ3000_bgtzm4ny"]),
             tuya.whitelabel("Moes", "XH-SY-04Z", "4 button portable remote control", ["_TZ3000_kfu8zapd"]),
             tuya.whitelabel("LoraTap", "SS6400ZB", "4 button portable remote control", ["_TZ3000_ee8nrt2l"]),
-            tuya.whitelabel("Zemismart", "ZMR4", "4 button portable remote control (without dimmer)", ["_TZ3000_xwuveizv"]),
+            tuya.whitelabel("Zemismart", "ZMR4_1", "4 button portable remote control (without dimmer)", ["_TZ3000_xwuveizv"]),
         ],
         fromZigbee: [tuya.fz.on_off_action, fz.battery],
         exposes: [


### PR DESCRIPTION
This adds the Zemismart ZMR4 (without dimmer) to the whitelabel configuration of Tuya TS0044. This is different that the model with dimmer functionality, but looks identical (image can be reused).

Link to picture pull request: [image already exists](https://github.com/LucasHagen/zigbee2mqtt.io/blob/master/public/images/devices/ZMR4.png)
