### PR TITLE
fix: correctly test 'exposes' values

### DIFF
--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -165,7 +165,7 @@ export default {
             endpoints: {"1": 1, "2": 2},
             fromZigbee: [expect.objectContaining({cluster: "msTemperatureMeasurement"}), fz.on_off],
             toZigbee: ["temperature", "state", "on_time", "off_wait_time"],
-            exposes: ["switch(state)", "temperature", "temperature"],
+            exposes: ["switch(state)", "temperature_1", "temperature_2"],
             bind: {1: ["msTemperatureMeasurement", "genOnOff"], 2: ["msTemperatureMeasurement"]},
             read: {
                 1: [

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -316,9 +316,9 @@ describe("ModernExtend", () => {
             ],
             exposes: [
                 "action",
-                "effect",
-                "effect",
-                "effect",
+                "effect_l1",
+                "effect_l2",
+                "effect_s1",
                 "light_l1(state,brightness)",
                 "light_l2(state,brightness)",
                 "light_s1(state,brightness)",

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -139,7 +139,7 @@ export async function assertDefinition(args: AssertDefinitionArgs) {
 
     utils.assertArray(definition.exposes);
     const expectedExposes = definition.exposes
-        ?.map((e) => e.name ?? `${e.type}${e.endpoint ? `_${e.endpoint}` : ""}(${e.features?.map((f) => f.name).join(",")})`)
+        ?.map((e) => e.property ?? `${e.type}${e.endpoint ? `_${e.endpoint}` : ""}(${e.features?.map((f) => f.name).join(",")})`)
         .sort();
     logIfNotEqual(expectedExposes, args.exposes);
     expect(expectedExposes).toEqual(args.exposes);


### PR DESCRIPTION
For devices with more than one endpoint
'exposes' values can have endpoints attached,
but they were not correctly tested, skipping the endpoint part.

P.S: would be nice for generated definitions to write tests for endpoint ID > 1. As in this case it will test if endpoint name are correctly applied while generating definition, and for first endpoint values should still be correct either way.

Related to https://github.com/Koenkk/zigbee-herdsman-converters/pull/11422 (merging one will require updating another before merge)

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

