### PR TITLE
[_TZE204_w2vunxzm] Enhance Tuya device details and features

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15105,7 +15105,8 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             e.pressure(),
             e.temperature(),
-            e.numeric("display_brightness", ea.STATE_SET)
+            e
+                .numeric("display_brightness", ea.STATE_SET)
                 .withValueMin(0)
                 .withValueMax(8)
                 .withValueStep(1)


### PR DESCRIPTION
`_TZE204_w2vunxzm` Air pressure sensor

Updated device description, and added display brightness exposure based on settings in the Tuya app.
Interestingly, if I set the brightness level to 0, the display turns off, so I also added that to the definition.

Fix issue https://github.com/Koenkk/zigbee2mqtt/issues/30596#issuecomment-3737618766
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4792
