### PR TITLE
AU-A1ZBSCRGBCX enable HS color

### DIFF
--- a/src/devices/aurora_lighting.ts
+++ b/src/devices/aurora_lighting.ts
@@ -106,7 +106,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "AU-A1ZBSCRGBCX",
         vendor: "Aurora Lighting",
         description: "RGBW LED strip controller",
-        extend: [m.light({colorTemp: {range: [166, 400]}, color: true})],
+        extend: [m.light({colorTemp: {range: [166, 400]}, color: {modes: ["hs"]}})],
     },
     {
         zigbeeModel: ["TWGU10Bulb50AU"],


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
XY color doesn't work for this device:
- https://github.com/Koenkk/zigbee2mqtt/discussions/30827

Trying HS color