### PR TITLE
Add support for Aqara H2 EU shutter switch (DS-K02D/DS-K02E)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5430,9 +5430,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Aqara H2 EU shutter switch",
         fromZigbee: [fz.cover_position_tilt, fzLocal.aqara_h2_shutter_multistate_input],
         toZigbee: [],
-        exposes: [
-            e.action(["button_top_right_single", "button_bottom_right_single"]).withDescription("Single press actions from right buttons"),
-        ],
+        exposes: [e.action(["button_top_right_single", "button_bottom_right_single"]).withDescription("Single press actions from right buttons")],
         extend: [m.windowCovering({controls: ["lift"]})],
         meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -6,7 +6,7 @@ import {logger} from "../lib/logger";
 import * as lumi from "../lib/lumi";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, Fz} from "../lib/types";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -81,7 +81,7 @@ const fzLocal = {
             }
             return null;
         },
-    } satisfies Fz.Converter,
+    } satisfies Fz.Converter<"genMultistateInput", undefined, ["attributeReport", "readResponse"]>,
 };
 
 export const definitions: DefinitionWithExtend[] = [

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -6,7 +6,7 @@ import {logger} from "../lib/logger";
 import * as lumi from "../lib/lumi";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz} from "../lib/types";
+import type {DefinitionWithExtend} from "../lib/types";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -63,26 +63,6 @@ const {
 
 const NS = "zhc:lumi";
 const {manufacturerCode} = lumi;
-
-const fzLocal = {
-    aqara_h2_shutter_multistate_input: {
-        cluster: "genMultistateInput",
-        type: ["attributeReport", "readResponse"],
-        convert: (model, msg, publish, options, meta) => {
-            const endpoint = msg.endpoint.ID;
-            const value = msg.data.presentValue;
-            const buttonMap: {[key: number]: string} = {
-                3: "button_top_right",
-                4: "button_bottom_right",
-            };
-            if (buttonMap[endpoint] !== undefined && value === 1) {
-                const action = `${buttonMap[endpoint]}_single`;
-                return {action};
-            }
-            return null;
-        },
-    } satisfies Fz.Converter<"genMultistateInput", undefined, ["attributeReport", "readResponse"]>,
-};
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -5428,9 +5408,20 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DS-K02D/DS-K02E",
         vendor: "Aqara",
         description: "Aqara H2 EU shutter switch",
-        fromZigbee: [fz.cover_position_tilt, fzLocal.aqara_h2_shutter_multistate_input],
+        fromZigbee: [fz.cover_position_tilt, lumi.fromZigbee.lumi_action_multistate],
         toZigbee: [],
-        exposes: [e.action(["button_top_right_single", "button_bottom_right_single"]).withDescription("Single press actions from right buttons")],
+        exposes: [
+            e.action([
+                "single_top_right",
+                "single_bottom_right",
+                "double_top_right",
+                "double_bottom_right",
+                "hold_top_right",
+                "hold_bottom_right",
+                "release_top_right",
+                "release_bottom_right",
+            ]),
+        ],
         extend: [m.windowCovering({controls: ["lift"]})],
         meta: {coverInverted: true},
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -67,7 +67,7 @@ const {manufacturerCode} = lumi;
 const fzLocal = {
     aqara_h2_shutter_multistate_input: {
         cluster: "genMultistateInput",
-        type: ["attributeReport", "readResponse"] as const,
+        type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
             const endpoint = msg.endpoint.ID;
             const value = msg.data.presentValue;
@@ -81,7 +81,7 @@ const fzLocal = {
             }
             return null;
         },
-    },
+    } satisfies Fz.Converter,
 };
 
 export const definitions: DefinitionWithExtend[] = [

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -3878,6 +3878,9 @@ export const fromZigbee = {
             if (["WS-USC02", "WS-USC04"].includes(model.model)) {
                 buttonLookup = {41: "top", 42: "bottom", 51: "both"};
             }
+            if (["DS-K02D", "DS-K02E"].includes(model.model)) {
+                buttonLookup = {3: "top_right", 4: "bottom_right"};
+            }
 
             const action = actionLookup[msg.data.presentValue];
 


### PR DESCRIPTION
## Description
This PR adds support for the Aqara H2 EU shutter switch (models DS-K02D/DS-K02E, zigbeeModel: `lumi.switch.aeu003`).

## Device capabilities
- Window covering control (lift)
- Two additional buttons on the right side (top and bottom) that report single press actions
- Endpoints 3 and 4 are used for button press reporting via genMultistateInput cluster

## Changes
- Added local fromZigbee converter for button press handling via genMultistateInput cluster
- Added device definition with proper configuration for endpoints 3 and 4
- Added action exposes for button presses
- Window covering is inverted (meta: coverInverted)

## Notes
This converter is based on the user's working custom converter for this device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)