### PR TITLE
Add another Philips Hue white PAR38 outdoor model

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2271,6 +2271,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light()],
     },
     {
+        zigbeeModel: ["LWS003"],
+        model: "9290031509",
+        vendor: "Philips",
+        description: "Hue white PAR38 outdoor",
+        extend: [philips.m.light()],
+    },
+    {
         zigbeeModel: ["LLC010"],
         model: "7199960PH",
         vendor: "Philips",


### PR DESCRIPTION
As far as I can tell, this is the same as this one this other model, the picture is the same too: https://www.zigbee2mqtt.io/devices/9290018189.html. Let me know if you need anything else. Thanks!
