### PR TITLE
Fix SNZB-06P occupancy_timeout description (fixes #11434)

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2274,7 +2274,7 @@ export const definitions: DefinitionWithExtend[] = [
                 name: "occupancy_timeout",
                 cluster: 0x0406,
                 attribute: {ID: 0x0020, type: 0x21},
-                description: "Unoccupied to occupied delay",
+                description: "Occupied to unoccupied delay",
                 valueMin: 15,
                 valueMax: 65535,
             }),


### PR DESCRIPTION
Fixes incorrect label for `occupancy_timeout` on SNZB-06P.

Fixes #11434 