### PR TITLE
Refactor WS90 weather station calculations and converters

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -62,20 +62,20 @@ function getWS90Meta(device: Zh.Device): WS90Meta {
 /**
  * Calculate dew point using Magnus formula
  */
-function calculateDewPoint(T: number | undefined, RH: number | undefined): number | null {
-    if (T === undefined || RH === undefined || RH <= 0) return null;
+function calculateDewPoint(T: number | undefined, Rh: number | undefined): number | null {
+    if (T === undefined || Rh === undefined || Rh <= 0) return null;
     const a = 17.27;
     const b = 237.7;
-    const alpha = (a * T) / (b + T) + Math.log(RH / 100);
-    return Math.round((b * alpha) / (a - alpha) * 10) / 10;
+    const alpha = (a * T) / (b + T) + Math.log(Rh / 100);
+    return Math.round(((b * alpha) / (a - alpha)) * 10) / 10;
 }
 
 /**
  * Calculate humidex (Canadian heat index)
  */
-function calculateHumidex(T: number | undefined, RH: number | undefined): number | null {
-    if (T === undefined || RH === undefined) return null;
-    const dewPoint = calculateDewPoint(T, RH);
+function calculateHumidex(T: number | undefined, Rh: number | undefined): number | null {
+    if (T === undefined || Rh === undefined) return null;
+    const dewPoint = calculateDewPoint(T, Rh);
     if (dewPoint === null) return null;
     const ee = 6.11 * Math.exp(5417.753 * (1 / 273.15 - 1 / (273.15 + dewPoint)));
     return Math.round((T + 0.5555 * (ee - 10)) * 10) / 10;
@@ -88,7 +88,7 @@ function calculateWindChill(T: number | undefined, windMs: number | undefined): 
     if (T === undefined || windMs === undefined) return null;
     const windKmh = windMs * 3.6;
     if (T > 10 || windKmh < 4.8) return Math.round(T * 10) / 10;
-    const wc = 13.12 + 0.6215 * T - 11.37 * Math.pow(windKmh, 0.16) + 0.3965 * T * Math.pow(windKmh, 0.16);
+    const wc = 13.12 + 0.6215 * T - 11.37 * windKmh ** 0.16 + 0.3965 * T * windKmh ** 0.16;
     return Math.round(wc * 10) / 10;
 }
 
@@ -97,14 +97,14 @@ function calculateWindChill(T: number | undefined, windMs: number | undefined): 
  */
 function calculateHeatStress(
     T: number | undefined,
-    RH: number | undefined,
+    Rh: number | undefined,
     lux: number | undefined,
     windMs: number | undefined,
     precipitation: number | undefined,
 ): number | null {
     if (T === undefined) return null;
     const solar = (lux || 0) / 100;
-    const base = T + solar / 100 + (RH || 0) / 10;
+    const base = T + solar / 100 + (Rh || 0) / 10;
     const cooled = base - (windMs || 0) / 2;
     const adjusted = cooled - ((precipitation || 0) > 0 ? 3 : 0);
     const scaled = (adjusted - 18) / (42 - 18);
@@ -115,14 +115,10 @@ function calculateHeatStress(
 /**
  * Calculate apparent temperature (wind chill when cold, humidex when warm)
  */
-function calculateApparentTemperature(
-    T: number | undefined,
-    RH: number | undefined,
-    windMs: number | undefined,
-): number | null {
+function calculateApparentTemperature(T: number | undefined, Rh: number | undefined, windMs: number | undefined): number | null {
     if (T === undefined) return null;
     const windChill = calculateWindChill(T, windMs);
-    const humidex = calculateHumidex(T, RH);
+    const humidex = calculateHumidex(T, Rh);
     if (windChill !== null && windChill < T) return windChill;
     if (humidex !== null && humidex > T) return humidex;
     return Math.round(T * 10) / 10;
@@ -220,20 +216,17 @@ function calculateWeatherCondition(state: {[key: string]: number | boolean | und
 
     if ((illuminance as number) > 40000) {
         return isWindy ? "windy" : "sunny";
-    } else if ((illuminance as number) > 10000) {
-        return isWindy ? "windy-variant" : "partlycloudy";
-    } else {
-        return "cloudy";
     }
+    if ((illuminance as number) > 10000) {
+        return isWindy ? "windy-variant" : "partlycloudy";
+    }
+    return "cloudy";
 }
 
 /**
  * Update calculated values whenever we get new sensor data (uses device.meta for persistence)
  */
-function updateWS90CalculatedValues(
-    device: Zh.Device,
-    payload: {[key: string]: number | boolean},
-): {[key: string]: number | string | null} {
+function updateWS90CalculatedValues(device: Zh.Device, payload: {[key: string]: number | boolean}): {[key: string]: number | string | null} {
     const meta = getWS90Meta(device);
     if (!meta.state) meta.state = {};
     Object.assign(meta.state, payload);
@@ -820,7 +813,7 @@ const shellyModernExtend = {
                 convert: (model, msg, publish, options, meta) => {
                     if (msg.data.measuredValue !== undefined) {
                         const measuredValue = msg.data.measuredValue;
-                        const illuminance = measuredValue > 0 ? Math.round(Math.pow(10, (measuredValue - 1) / 10000)) : 0;
+                        const illuminance = measuredValue > 0 ? Math.round(10 ** ((measuredValue - 1) / 10000)) : 0;
                         const calculated = updateWS90CalculatedValues(msg.device, {illuminance});
                         return {illuminance, ...calculated};
                     }
@@ -915,7 +908,6 @@ const fzLocal = {
         },
     } satisfies Fz.Converter<"genLevelCtrl", undefined, ["commandStep"]>,
 };
-
 
 // =============================================================================
 // Device Definitions


### PR DESCRIPTION
## Summary

This PR enhances the Shelly WS90 Weather Station with calculated weather values derived from the sensor data. All calculations run locally on the coordinator without requiring external services.

## New Features

### Calculated Sensors
- **dew_point** - Magnus formula calculation from temperature and humidity
- **wind_chill** - Effective temperature when cold and windy (Environment Canada formula)
- **humidex** - Canadian humidity index for hot conditions
- **apparent_temperature** - Combined "feels like" temperature using wind chill or humidex as appropriate
- **heat_stress** - Percentage-based heat stress indicator (0-100%)
- **rain_rate** - Precipitation intensity in mm/hour calculated from consecutive readings
- **pressure_trend** - Barometric pressure change rate in hPa/hour
- **weather_condition** - HA-compatible weather condition string derived from all sensors

### Weather Condition Logic
Determines condition based on:
- Illuminance for day/night and cloud cover detection
- Rain status + rain rate for precipitation (requires both to avoid stale cache issues)
- Temperature for snow detection (<1°C)
- Wind speed for windy conditions (>10 m/s)
- Pressure + pressure trend for hail/storm detection

Supported conditions: `sunny`, `clear-night`, `partlycloudy`, `cloudy`, `rainy`, `pouring`, `snowy`, `hail`, `windy`, `windy-variant`

## Technical Implementation

- Device state cache per IEEE address for cross-sensor calculations
- Pressure history buffer for trend calculation
- Rain rate calculation from consecutive precipitation readings with timestamps
- Custom `fromZigbee` converters that trigger calculated value updates on every sensor reading
- Proper handling of undefined values throughout all calculations

## Home Assistant Customization

The calculated sensors work out of the box, but for optimal Home Assistant integration (proper icons, device classes, and units), add this to your Zigbee2MQTT `configuration.yaml` under your device:

```yaml
devices:
  '0xYOUR_DEVICE_IEEE':
    friendly_name: Weather Station
    homeassistant:
      dew_point:
        device_class: temperature
        state_class: measurement
        icon: mdi:water-thermometer
      wind_chill:
        device_class: temperature
        state_class: measurement
        icon: mdi:snowflake-thermometer
      humidex:
        device_class: temperature
        state_class: measurement
        icon: mdi:sun-thermometer
      heat_stress:
        state_class: measurement
        unit_of_measurement: '%'
        icon: mdi:heat-wave
      apparent_temperature:
        device_class: temperature
        state_class: measurement
        icon: mdi:thermometer-lines
      rain_rate:
        device_class: precipitation_intensity
        state_class: measurement
        icon: mdi:weather-pouring
      pressure_trend:
        state_class: measurement
        unit_of_measurement: hPa/h
        icon: mdi:trending-up
      weather_condition:
        icon: mdi:weather-partly-cloudy
```

A future PR to zigbee2mqtt will add native `meta.homeassistant` support for these sensors.

## Breaking Changes

None - this is additive functionality. Existing sensors continue to work as before.

## Testing

Tested on production Shelly WS90 device with:
- All weather conditions verified (sunny, cloudy, rainy, snowy transitions)
- Pressure trend calculation verified over multiple hours
- Rain rate calculation verified during precipitation events