### PR TITLE
Tidying up messy PRs of Excellux devices

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -23775,9 +23775,7 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("Excellux", ["DHT0001", "DHTA001"]),
         model: "DHT0001",
         vendor: "Excellux",
-        whiteLabel: [
-            {vendor: "Excellux", model: "DHTA001", fingerprint: tuya.fingerprint("Excellux", ["DHTA001"])},
-        ],
+        whiteLabel: [{vendor: "Excellux", model: "DHTA001", fingerprint: tuya.fingerprint("Excellux", ["DHTA001"])}],
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         description: "Temperature and humidity sensor",
         exposes: [


### PR DESCRIPTION
Tidying up messy PRs.
I only tidied up the appearance/cosmetics related stuff, like naming, etc, without changing the converter logic inside.

Original commit: ------------------------------------------- This commit:

Device name | Fingerprint | PNG name | → | Selected name |
|:--------------|:------------|:------------|:---|:-----------------|
NTCHT-01     | NTCHT01  | NTCHT01    |     | ZG-105NTH   |
                     |                  | ZG-105NTH |     |                       |
PIRIV-01       | PIRIV01     | PIRIV01        |    | ZG-104PLV     |
                     |                  | ZG-104PLV   |     |                       |
Contact-01   | CAT0001   | ZG-102MV   |     | ZG-102MV     |
VABRATE-01 | VABRATE   | ZG-103V      |    | ZG-103V         |
Scene-Switc | DSS0010    | DSS0010      |    | ZG-101K         |
                    |                    | ZG-101K      |    |                        |
FEDHT-01    | DHT0001    | DHT0001     |    |  DHT0001       |
                    | DHTA001    | DHTA001     |    | DHTA001 (whitelabel) |

Other:
- Fixed unit `S` → `s` (seconds)
- Fixed typo `illumiance` → `illuminance`
- Fixed name `presence_state` → `presence`
- Capitalized descriptions consistently
- Replaced manual battery definition with `e.battery()`
- Removed `.withUnit("times")` from `vibration_sensitivity`

Related:
- ZHC
https://github.com/Koenkk/zigbee-herdsman-converters/pull/11297
https://github.com/Koenkk/zigbee-herdsman-converters/pull/11290

- z2m.io
https://github.com/Koenkk/zigbee2mqtt.io/pull/4723
https://github.com/Koenkk/zigbee2mqtt.io/pull/4726
https://github.com/Koenkk/zigbee2mqtt.io/pull/4771

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
<br>

Link to picture pull request:
**NB:** For PNG images, it will follow because it has been committed by the original contributor,  just need to clean up unused images after the next update.
