### PR TITLE
Update ikea.ts - LED2411G3, added alternative zigbeeModel

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -673,7 +673,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         // https://github.com/Koenkk/zigbee2mqtt/issues/30211#issuecomment-3697858054
-        zigbeeModel: ["KAJPLATS E27 WS G60 clear 470lm"],
+        zigbeeModel: ["KAJPLATS E27 WS G60 clear 470lm", "KAJPLATS E27 470lm smart WS"],
         model: "LED2411G3",
         vendor: "IKEA",
         description: "KAJPLATS E27 bulb, white spectrum, globe, clear, 470 lm",


### PR DESCRIPTION
For me LED2411G3 showed as Unsupported after pairing (15 times off/on + touchlink scan). Dev console shows zigbeeModel "KAJPLATS E27 470lm smart WS".

Zigbee2MQTT version: 2.8.0