### PR TITLE
Fix battery division on Vesternet VES-ZB-REM-013

### DIFF
--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -4,9 +4,7 @@ import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend, Fz, KeyValueAny} from "../lib/types";
-import {
-    precisionRound,
-} from "../lib/utils";
+import {precisionRound} from "../lib/utils";
 
 const e = exposes.presets;
 const fzLocal = {
@@ -15,10 +13,7 @@ const fzLocal = {
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
             const payload: KeyValueAny = {};
-            if (
-                msg.data.batteryPercentageRemaining !== undefined &&
-                msg.data.batteryPercentageRemaining < 255
-            ) {
+            if (msg.data.batteryPercentageRemaining !== undefined && msg.data.batteryPercentageRemaining < 255) {
                 // 2.5.3_r20 fw doesn't comply with Zigbee spec and reports battery as 0-100.
                 // Newer firmware has already this issue fixed and reports battery as 0-200.
                 const dontDividePercentage = meta.device.softwareBuildID === "2.5.3_r20";
@@ -31,7 +26,6 @@ const fzLocal = {
         },
     } satisfies Fz.Converter<"genPowerCfg", undefined, ["attributeReport", "readResponse"]>,
 };
-
 
 export const definitions: DefinitionWithExtend[] = [
     {


### PR DESCRIPTION
My device reports that its battery is 200%.
<img width="1250" height="700" alt="Screenshot 2026-02-03 at 18 42 53" src="https://github.com/user-attachments/assets/a9405811-9cd6-4d74-be89-682694f8b6a7" />
I have no way to test it on other FW versions, but I hope it will work similarly.

@martyn-vesternet Do you have any information about the difference between FW versions?

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
