### PR TITLE
Update tuya.ts for TS0601 _TZE284_noixx2uz

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -442,7 +442,7 @@ const bindSlotTS0601SmartSceneKnob = async (entity: Zh.Endpoint | Zh.Group, slot
     await tuya.sendDataPointRaw(entity as Zh.Endpoint, 102, payload, "dataRequest", 0x10 + (slot - 1));
 };
 
-const trv603ScheduleConverter = (dayNumber: number): tuya.valueConverter => {
+const trv603ScheduleConverter = (dayNumber: number) => {
     return {
         from: (value: unknown) => {
             const buf = Buffer.isBuffer(value)


### PR DESCRIPTION
Added support for TRV603 (TS0601 [ _TZE284_noixx2uz]). Includes full schedule support and temperature validation, which was missing in previous attempts/requests, plus functional child lock (inverted in this device, see other comment), plus custom code for decoding/encoding daily schedule. Also, for local temperature, the device can give up to a maximum of -9, at -10 it will give E1, but I translated correctly the value for a reason: we want it to function better than the original.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
<img width="95" height="162" alt="image" src="https://github.com/user-attachments/assets/242853a0-349e-4117-961e-c4d50f7b9f3a" />

Large image with white bg (transparency R:255 G:255 B:255):
<img width="383" height="656" alt="image" src="https://github.com/user-attachments/assets/b9ec2b64-b3bb-4126-a259-732c71942158" />


