### PR TITLE
Inovelli - fixing data type for internalTemperature

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -371,7 +371,7 @@ const inovelliExtend = {
                 dimmingMode: {ID: 0x001a, type: Zcl.DataType.UINT8, write: true, max: 0xff},
                 nonNeutralAuxMediumGear: {ID: 0x001e, type: Zcl.DataType.UINT8, write: true, max: 0xff},
                 nonNeutralAuxLowGear: {ID: 0x001f, type: Zcl.DataType.UINT8, write: true, max: 0xff},
-                internalTemperature: {ID: 0x0020, type: Zcl.DataType.UINT8, write: true, max: 0xff},
+                internalTemperature: {ID: 0x0020, type: Zcl.DataType.INT8, write: true, max: 0xff},
                 overheat: {ID: 0x0021, type: Zcl.DataType.BOOLEAN, write: true},
                 otaImageType: {ID: 0x0022, type: Zcl.DataType.UINT8, write: true, max: 0xff},
                 buttonDelay: {ID: 0x0032, type: Zcl.DataType.UINT8, write: true, max: 0xff},
@@ -1038,7 +1038,7 @@ const COMMON_ATTRIBUTES: {[s: string]: Attribute} = {
     },
     internalTemperature: {
         ID: 32,
-        dataType: Zcl.DataType.UINT8,
+        dataType: Zcl.DataType.INT8,
         min: 0,
         max: 127,
         readOnly: true,


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Fixing data type so you can configure the reporting for this attribute. 
