### PR TITLE
fix: Sinope TH1123ZB-G2 and TH1124ZB-G2: swap sensing and off values for backlight dimming modes Koenkk/zigbee2mqtt#29828

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -269,7 +269,7 @@ const tzLocal = {
     backlight_autodim: {
         key: ["backlight_auto_dim"],
         convertSet: async (entity, key, value, meta) => {
-            const sinopeBacklightParam = utils.getMetaValue(entity, meta.mapped, "alternateBacklightAutoDim", "allEqual", false)
+            const sinopeBacklightParam = utils.getMetaValue(entity, meta.mapped, "sinopeAlternateBacklightAutoDim", "allEqual", false)
                 ? {0: "on_demand", 1: "off", 2: "sensing"}
                 : {0: "on_demand", 1: "sensing", 2: "off"};
             const SinopeBacklight = utils.getKey(sinopeBacklightParam, value, value as number, Number);


### PR DESCRIPTION
Sorry, but when reviewing the code for the last PR (Koenkk/zigbee-herdsman-converters#11454), I noticed the name of the property for the meta check in the tzLocal converter hasn't been adjusted.

I suppose there is some missing type check...

I checked with the Z2M Edge addon/app, and indeed, it doesn't work.

Anyway, here is the fix for that. Again, sorry for the back-and-forth.

(Hopefully, final fix for Koenkk/zigbee2mqtt#29828)