### PR TITLE
Remove battery state and change battery datapoints

### DIFF
--- a/src/devices/avatto.ts
+++ b/src/devices/avatto.ts
@@ -12,9 +12,9 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_s139roas"]),
         model: "ZWSH16",
         vendor: "AVATTO",
-        description: "Smart Temperature and Humidity Detector",
+        description: "Smart temperature and humidity detector",
         extend: [tuya.modernExtend.tuyaBase({dp: true, mcuVersionRequestOnConfigure: true})],
-        exposes: [e.battery(), e.temperature(), e.humidity(), tuya.exposes.temperatureUnit(), tuya.exposes.batteryState()],
+        exposes: [e.battery(), e.temperature(), e.humidity(), tuya.exposes.temperatureUnit()],
         meta: {
             tuyaDatapoints: [
                 [1, "temperature", tuya.valueConverter.divideBy10],


### PR DESCRIPTION
Removed battery state and change battery datapoints from Tuya metadata.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
