### PR TITLE
fix: generated definition inputs/outputs issues

### DIFF
--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -378,19 +378,28 @@ async function extenderElectricityMeter(device: Zh.Device, endpoints: Zh.Endpoin
 async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
     let endpointName: string | undefined;
+
     for (const endpoint of endpoints) {
         if (!onlyFirstDeviceEnpoint(device, endpoints)) {
             endpointName = endpoint.ID.toString();
         }
-        const name = await getClusterAttributeValue(endpoint, "genBinaryInput", "description", `binary_input_${endpoint.ID}`);
+
+        const name = await getClusterAttributeValue(
+            endpoint,
+            "genBinaryInput",
+            "description",
+            endpointName ? "binary_input" : `binary_input_${endpoint.ID}`,
+        );
         let label: string | undefined;
-        if (name !== `binary_input_${endpoint.ID}`) {
+
+        if (name !== "binary_input" && name !== `binary_input_${endpoint.ID}`) {
             label = name;
         }
+
         const description = `Binary Input ${name} on endpoint ${endpoint.ID}`;
         const args: m.BinaryArgs<"genBinaryInput"> = {
             name: name.replace(/\s+/g, "_").toLowerCase(),
-            label: label,
+            label,
             cluster: "genBinaryInput",
             attribute: "presentValue",
             reporting: {min: "MIN", max: "MAX", change: 1},
@@ -398,29 +407,39 @@ async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
             valueOff: ["OFF", 0],
             description: description,
             access: "STATE_GET",
-            endpointName: endpointName,
+            endpointName,
         };
         generated.push(new ExtendGenerator({extend: m.binary, args, source: "binary"}));
     }
+
     return generated;
 }
 
 async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
     let endpointName: string | undefined;
+
     for (const endpoint of endpoints) {
         if (!onlyFirstDeviceEnpoint(device, endpoints)) {
             endpointName = endpoint.ID.toString();
         }
-        const name = await getClusterAttributeValue(endpoint, "genBinaryOutput", "description", `binary_output_${endpoint.ID}`);
+
+        const name = await getClusterAttributeValue(
+            endpoint,
+            "genBinaryOutput",
+            "description",
+            endpointName ? "binary_output" : `binary_output_${endpoint.ID}`,
+        );
         let label: string | undefined;
-        if (name !== `binary_output_${endpoint.ID}`) {
+
+        if (name !== "binary_output" && name !== `binary_output_${endpoint.ID}`) {
             label = name;
         }
+
         const description = `Binary Output ${name} on endpoint ${endpoint.ID}`;
         const args: m.BinaryArgs<"genBinaryOutput"> = {
             name: name.replace(/\s+/g, "_").toLowerCase(),
-            label: label,
+            label,
             cluster: "genBinaryOutput",
             attribute: "presentValue",
             reporting: {min: "MIN", max: "MAX", change: 1},
@@ -428,10 +447,11 @@ async function extenderBinaryOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
             valueOff: ["OFF", 0],
             description: description,
             access: "ALL",
-            endpointName: endpointName,
+            endpointName,
         };
         generated.push(new ExtendGenerator({extend: m.binary, args, source: "binary"}));
     }
+
     return generated;
 }
 
@@ -723,30 +743,42 @@ function getUnitfromBACnetUnit(bacnetUnit: number): string | undefined {
 async function extenderAnalogInput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
     let endpointNames: string[] | undefined;
+
     for (const endpoint of endpoints) {
         if (!onlyFirstDeviceEnpoint(device, endpoints)) {
             endpointNames = [endpoint.ID.toString()];
         }
-        const name = await getClusterAttributeValue(endpoint, "genAnalogInput", "description", `analog_input_${endpoint.ID}`);
+
+        const name = await getClusterAttributeValue(
+            endpoint,
+            "genAnalogInput",
+            "description",
+            endpointNames ? "analog_input" : `analog_input_${endpoint.ID}`,
+        );
         let label: string | undefined;
-        if (name !== `analog_input_${endpoint.ID}`) {
+
+        if (name !== "analog_input" && name !== `analog_input_${endpoint.ID}`) {
             label = name;
         }
+
         const description = `Analog Input ${name} on endpoint ${endpoint.ID}`;
         const applicationType = await getClusterAttributeValue(endpoint, "genAnalogInput", "applicationType", undefined);
         let unit: string | undefined;
+
         if (applicationType !== undefined) {
             unit = getUnitfromApplicationType(applicationType);
         }
+
         if (unit === undefined) {
             const bacnet_unit = await getClusterAttributeValue(endpoint, "genAnalogInput", "engineeringUnits", undefined);
             if (bacnet_unit !== undefined) {
                 unit = getUnitfromBACnetUnit(bacnet_unit);
             }
         }
+
         const args: m.NumericArgs<"genAnalogInput"> = {
             name: name.replace(/\s+/g, "_").toLowerCase(),
-            label: label,
+            label,
             valueMin: await getClusterAttributeValue(endpoint, "genAnalogInput", "minPresentValue", undefined),
             valueMax: await getClusterAttributeValue(endpoint, "genAnalogInput", "maxPresentValue", undefined),
             valueStep: await getClusterAttributeValue(endpoint, "genAnalogInput", "resolution", undefined),
@@ -755,41 +787,54 @@ async function extenderAnalogInput(device: Zh.Device, endpoints: Zh.Endpoint[]):
             reporting: {min: "MIN", max: "MAX", change: 1},
             description: description,
             access: "STATE_GET",
-            endpointNames: endpointNames,
-            unit: unit,
+            endpointNames,
+            unit,
         };
         generated.push(new ExtendGenerator({extend: m.numeric, args, source: "numeric"}));
     }
+
     return generated;
 }
 
 async function extenderAnalogOutput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
     let endpointNames: string[] | undefined;
+
     for (const endpoint of endpoints) {
         if (!onlyFirstDeviceEnpoint(device, endpoints)) {
             endpointNames = [endpoint.ID.toString()];
         }
-        const name = await getClusterAttributeValue(endpoint, "genAnalogOutput", "description", `analog_output_${endpoint.ID}`);
+
+        const name = await getClusterAttributeValue(
+            endpoint,
+            "genAnalogOutput",
+            "description",
+            endpointNames ? "analog_output" : `analog_output_${endpoint.ID}`,
+        );
         let label: string | undefined;
-        if (name !== `analog_output_${endpoint.ID}`) {
+
+        if (name !== "analog_output" && name !== `analog_output_${endpoint.ID}`) {
             label = name;
         }
+
         const description = `Analog Output ${name} on endpoint ${endpoint.ID}`;
         const applicationType = await getClusterAttributeValue(endpoint, "genAnalogOutput", "applicationType", undefined);
         let unit: string | undefined;
+
         if (applicationType !== undefined) {
             unit = getUnitfromApplicationType(applicationType);
         }
+
         if (unit === undefined) {
             const bacnet_unit = await getClusterAttributeValue(endpoint, "genAnalogOutput", "engineeringUnits", undefined);
             if (bacnet_unit !== undefined) {
                 unit = getUnitfromBACnetUnit(bacnet_unit);
             }
         }
+
         const args: m.NumericArgs<"genAnalogOutput"> = {
             name: name.replace(/\s+/g, "_").toLowerCase(),
-            label: label,
+            label,
             valueMin: await getClusterAttributeValue(endpoint, "genAnalogOutput", "minPresentValue", undefined),
             valueMax: await getClusterAttributeValue(endpoint, "genAnalogOutput", "maxPresentValue", undefined),
             valueStep: await getClusterAttributeValue(endpoint, "genAnalogOutput", "resolution", undefined),
@@ -798,10 +843,11 @@ async function extenderAnalogOutput(device: Zh.Device, endpoints: Zh.Endpoint[])
             reporting: {min: "MIN", max: "MAX", change: 1},
             description: description,
             access: "ALL",
-            endpointNames: endpointNames,
-            unit: unit,
+            endpointNames,
+            unit,
         };
         generated.push(new ExtendGenerator({extend: m.numeric, args, source: "numeric"}));
     }
+
     return generated;
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -107,11 +107,12 @@ const DefaultTz = [
 export type AssertDefinitionArgs = {
     device: Zh.Device;
     meta: DefinitionMeta | undefined;
-    fromZigbee: Fz.Converter[];
+    // biome-ignore lint/suspicious/noExplicitAny: generic
+    fromZigbee: Fz.Converter<any, any, any>[];
     toZigbee: string[];
     exposes: string[];
     bind: {[s: number]: string[]};
-    read: {[s: number]: [string, string[]][]};
+    read: {[s: number]: ([string, string[]] | [string, string[], Record<string, unknown> | undefined])[]};
     configureReporting: {[s: number]: [string, ReturnType<typeof reportingItem>[]][]};
     endpoints?: {[s: string]: number};
     findByDeviceFn?: (device: Device) => Promise<Definition>;
@@ -155,7 +156,13 @@ export async function assertDefinition(args: AssertDefinitionArgs) {
         expect(endpoint.read).toHaveBeenCalledTimes(args.read[endpoint.ID]?.length ?? 0);
         if (args.read[endpoint.ID]) {
             args.read[endpoint.ID].forEach((read, idx) => {
-                expect(endpoint.read).toHaveBeenNthCalledWith(idx + 1, read[0], read[1]);
+                const options = read[2];
+
+                if (options) {
+                    expect(endpoint.read).toHaveBeenNthCalledWith(idx + 1, read[0], read[1], options);
+                } else {
+                    expect(endpoint.read).toHaveBeenNthCalledWith(idx + 1, read[0], read[1]);
+                }
             });
         }
 


### PR DESCRIPTION
- fix name having duplicate endpoint ID appended
- add tests for better coverage of various inputs/outputs generated definitions

@Koenkk do we have a problem with `toZigbee` having multiple instances of the same logic under the same `key`? (On Z2M side it's a `find`, so first entry wins?)