### PR TITLE
fix(WS90): Persist pressure_trend between updates and reduce interval to 30min

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -62,20 +62,20 @@ function getWS90Meta(device: Zh.Device): WS90Meta {
 /**
  * Calculate dew point using Magnus formula
  */
-function calculateDewPoint(T: number | undefined, RH: number | undefined): number | null {
-    if (T === undefined || RH === undefined || RH <= 0) return null;
+function calculateDewPoint(T: number | undefined, Rh: number | undefined): number | null {
+    if (T === undefined || Rh === undefined || Rh <= 0) return null;
     const a = 17.27;
     const b = 237.7;
-    const alpha = (a * T) / (b + T) + Math.log(RH / 100);
-    return Math.round((b * alpha) / (a - alpha) * 10) / 10;
+    const alpha = (a * T) / (b + T) + Math.log(Rh / 100);
+    return Math.round(((b * alpha) / (a - alpha)) * 10) / 10;
 }
 
 /**
  * Calculate humidex (Canadian heat index)
  */
-function calculateHumidex(T: number | undefined, RH: number | undefined): number | null {
-    if (T === undefined || RH === undefined) return null;
-    const dewPoint = calculateDewPoint(T, RH);
+function calculateHumidex(T: number | undefined, Rh: number | undefined): number | null {
+    if (T === undefined || Rh === undefined) return null;
+    const dewPoint = calculateDewPoint(T, Rh);
     if (dewPoint === null) return null;
     const ee = 6.11 * Math.exp(5417.753 * (1 / 273.15 - 1 / (273.15 + dewPoint)));
     return Math.round((T + 0.5555 * (ee - 10)) * 10) / 10;
@@ -88,7 +88,7 @@ function calculateWindChill(T: number | undefined, windMs: number | undefined): 
     if (T === undefined || windMs === undefined) return null;
     const windKmh = windMs * 3.6;
     if (T > 10 || windKmh < 4.8) return Math.round(T * 10) / 10;
-    const wc = 13.12 + 0.6215 * T - 11.37 * Math.pow(windKmh, 0.16) + 0.3965 * T * Math.pow(windKmh, 0.16);
+    const wc = 13.12 + 0.6215 * T - 11.37 * windKmh ** 0.16 + 0.3965 * T * windKmh ** 0.16;
     return Math.round(wc * 10) / 10;
 }
 
@@ -97,14 +97,14 @@ function calculateWindChill(T: number | undefined, windMs: number | undefined): 
  */
 function calculateHeatStress(
     T: number | undefined,
-    RH: number | undefined,
+    Rh: number | undefined,
     lux: number | undefined,
     windMs: number | undefined,
     precipitation: number | undefined,
 ): number | null {
     if (T === undefined) return null;
     const solar = (lux || 0) / 100;
-    const base = T + solar / 100 + (RH || 0) / 10;
+    const base = T + solar / 100 + (Rh || 0) / 10;
     const cooled = base - (windMs || 0) / 2;
     const adjusted = cooled - ((precipitation || 0) > 0 ? 3 : 0);
     const scaled = (adjusted - 18) / (42 - 18);
@@ -115,14 +115,10 @@ function calculateHeatStress(
 /**
  * Calculate apparent temperature (wind chill when cold, humidex when warm)
  */
-function calculateApparentTemperature(
-    T: number | undefined,
-    RH: number | undefined,
-    windMs: number | undefined,
-): number | null {
+function calculateApparentTemperature(T: number | undefined, Rh: number | undefined, windMs: number | undefined): number | null {
     if (T === undefined) return null;
     const windChill = calculateWindChill(T, windMs);
-    const humidex = calculateHumidex(T, RH);
+    const humidex = calculateHumidex(T, Rh);
     if (windChill !== null && windChill < T) return windChill;
     if (humidex !== null && humidex > T) return humidex;
     return Math.round(T * 10) / 10;
@@ -220,20 +216,17 @@ function calculateWeatherCondition(state: {[key: string]: number | boolean | und
 
     if ((illuminance as number) > 40000) {
         return isWindy ? "windy" : "sunny";
-    } else if ((illuminance as number) > 10000) {
-        return isWindy ? "windy-variant" : "partlycloudy";
-    } else {
-        return "cloudy";
     }
+    if ((illuminance as number) > 10000) {
+        return isWindy ? "windy-variant" : "partlycloudy";
+    }
+    return "cloudy";
 }
 
 /**
  * Update calculated values whenever we get new sensor data (uses device.meta for persistence)
  */
-function updateWS90CalculatedValues(
-    device: Zh.Device,
-    payload: {[key: string]: number | boolean},
-): {[key: string]: number | string | null} {
+function updateWS90CalculatedValues(device: Zh.Device, payload: {[key: string]: number | boolean}): {[key: string]: number | string | null} {
     const meta = getWS90Meta(device);
     if (!meta.state) meta.state = {};
     Object.assign(meta.state, payload);
@@ -273,7 +266,7 @@ function updateWS90CalculatedValues(
         if (trend !== null) {
             result.pressure_trend = trend;
             state.pressure_trend = trend;
-        } else if (typeof state.pressure_trend === 'number') {
+        } else if (typeof state.pressure_trend === "number") {
             result.pressure_trend = state.pressure_trend;
         }
     }
@@ -791,7 +784,7 @@ const shellyModernExtend = {
                     if (msg.data.measuredValue !== undefined) {
                         const temperature = msg.data.measuredValue / 100;
                         const calculated = updateWS90CalculatedValues(msg.device, {temperature});
-                        return calculated;  // Only calculated values; m.temperature() handles base temperature
+                        return calculated; // Only calculated values; m.temperature() handles base temperature
                     }
                 },
             },
@@ -802,7 +795,7 @@ const shellyModernExtend = {
                     if (msg.data.measuredValue !== undefined) {
                         const humidity = msg.data.measuredValue / 100;
                         const calculated = updateWS90CalculatedValues(msg.device, {humidity});
-                        return calculated;  // Only calculated values; m.humidity() handles base humidity
+                        return calculated; // Only calculated values; m.humidity() handles base humidity
                     }
                 },
             },
@@ -813,7 +806,7 @@ const shellyModernExtend = {
                     if (msg.data.measuredValue !== undefined) {
                         const pressure = msg.data.measuredValue / 10;
                         const calculated = updateWS90CalculatedValues(msg.device, {pressure});
-                        return calculated;  // Only calculated values; m.pressure() handles base pressure
+                        return calculated; // Only calculated values; m.pressure() handles base pressure
                     }
                 },
             },
@@ -823,9 +816,9 @@ const shellyModernExtend = {
                 convert: (model, msg, publish, options, meta) => {
                     if (msg.data.measuredValue !== undefined) {
                         const measuredValue = msg.data.measuredValue;
-                        const illuminance = measuredValue > 0 ? Math.round(Math.pow(10, (measuredValue - 1) / 10000)) : 0;
+                        const illuminance = measuredValue > 0 ? Math.round(10 ** ((measuredValue - 1) / 10000)) : 0;
                         const calculated = updateWS90CalculatedValues(msg.device, {illuminance});
-                        return calculated;  // Only calculated values; m.illuminance() handles base illuminance
+                        return calculated; // Only calculated values; m.illuminance() handles base illuminance
                     }
                 },
             },
@@ -837,7 +830,7 @@ const shellyModernExtend = {
                     if (data.uv_index !== undefined) {
                         const uv_index = (data.uv_index as number) / 10;
                         const calculated = updateWS90CalculatedValues(msg.device, {uv_index});
-                        return calculated;  // Only return calculated values, m.numeric() handles uv_index
+                        return calculated; // Only return calculated values, m.numeric() handles uv_index
                     }
                 },
             },
@@ -851,7 +844,7 @@ const shellyModernExtend = {
                     if (data.wind_direction !== undefined) payload.wind_direction = (data.wind_direction as number) / 10;
                     if (data.gust_speed !== undefined) payload.gust_speed = (data.gust_speed as number) / 10;
                     const calculated = updateWS90CalculatedValues(msg.device, payload);
-                    return calculated;  // Only calculated values; m.numeric() handles base wind values
+                    return calculated; // Only calculated values; m.numeric() handles base wind values
                 },
             },
             {
@@ -878,7 +871,7 @@ const shellyModernExtend = {
                     calculated.rain_rate = rain_rate;
 
                     msg.device.save();
-                    return calculated;  // Only calculated values; m.binary()/m.numeric() handle base rain values
+                    return calculated; // Only calculated values; m.binary()/m.numeric() handle base rain values
                 },
             },
         ];
@@ -929,7 +922,6 @@ const fzLocal = {
         },
     } satisfies Fz.Converter<"genLevelCtrl", undefined, ["commandStep"]>,
 };
-
 
 // =============================================================================
 // Device Definitions


### PR DESCRIPTION
## Summary
- Fixed pressure_trend showing gaps/spikes instead of continuous values by persisting the last calculated trend between updates
- Reduced pressure_trend update interval from 1 hour to 30 minutes for more responsive weather forecasting

## What was broken
After the previous timing bug fix, pressure_trend would calculate correctly every hour but return `null` for all sensor reports in between. This caused the sensor to show sporadic spikes on graphs instead of a stable continuous reading, making it unsuitable for weather forecasting.

## Fix
- When the 30-minute interval hasn't passed, return the previously calculated trend value from `device.meta.ws90.state.pressure_trend` instead of `null`
- Changed interval from 3600000ms (1 hour) to 1800000ms (30 minutes) for better responsiveness while maintaining meteorological accuracy

## Result
Pressure trend now shows stable, continuous values that update every 30 minutes, properly supporting weather condition forecasting and forecast generation.