### PR TITLE
Add Moes ZM-105B-M fingerprint _TZE200_bxoo2swd for existing TS0601_dimmer_4

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4193,7 +4193,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_bxoo2swd", "_TZE200_tsxpl0d0"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_bxoo2swd", "_TZE204_bxoo2swd", "_TZE200_tsxpl0d0"]),
         model: "TS0601_dimmer_4",
         vendor: "Tuya",
         description: "2 gang smart dimmer module",
@@ -4253,7 +4253,7 @@ export const definitions: DefinitionWithExtend[] = [
             return {l1: 1, l2: 1};
         },
         whiteLabel: [
-            tuya.whitelabel("Moes", "ZM-105B-M", "2 gang smart dimmer module", ["_TZE204_bxoo2swd"]),
+            tuya.whitelabel("Moes", "ZM-105B-M", "2 gang smart dimmer module", ["_TZE200_bxoo2swd", "_TZE204_bxoo2swd"]),
             tuya.whitelabel("KnockautX", "FMD2C018", "2 gang smart dimmer module", ["_TZE200_tsxpl0d0"]),
         ],
     },


### PR DESCRIPTION
I've added the fingerprint of my unit _TZE200_bxoo2swd as another fingerprint for Moes ZM-105B-M, which is a whitelabel TS0601_dimmer_4.

I've tested it via external converter and the functions already defined for ZM-105B-B worked exactly as expected for this fingerprint.

Image for ZM-105B-M already exists, my unit only has a very slightly different arrangement of text but is obviously the same model so I'd skip the extra picture, also since the model name is the same.

Hope everything else is there as needed!