### PR TITLE
fix insufisant space error on sinope TH1123ZB-G2

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -974,7 +974,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TH1124ZB-G2",
         vendor: "Sinopé",
         description: "Zigbee line volt thermostat",
-        extend: [m.electricityMeter()],
+        extend: [m.electricityMeter({energy: {divisor: 1000, multiplier: 1}})],
         meta: {sinopeAlternateBacklightAutoDim: true},
         fromZigbee: [fzLocal.thermostat, fzLocal.sinope, fz.hvac_user_interface, fz.ignore_temperature_report],
         toZigbee: [
@@ -1057,8 +1057,12 @@ export const definitions: DefinitionWithExtend[] = [
                 "hvacUserInterfaceCfg",
                 "msTemperatureMeasurement",
                 "manuSpecificSinope",
+                "seMetering",
+                "haElectricalMeasurement",
             ];
-            await reporting.bind(endpoint, coordinatorEndpoint, binds); // This G2 version has limited memory space
+            // This G2 version has limited memory space
+            // from experimenting we can configure a maximum of 8 reporting entities
+            await reporting.bind(endpoint, coordinatorEndpoint, binds);
             const thermostatDate = new Date();
             const thermostatTimeSec = thermostatDate.getTime() / 1000;
             const thermostatTimezoneOffsetSec = thermostatDate.getTimezoneOffset() * 60;
@@ -1069,9 +1073,8 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.thermostatTemperature(endpoint);
             await reporting.thermostatPIHeatingDemand(endpoint);
             await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
-            await reporting.thermostatSystemMode(endpoint);
+            await reporting.thermostatRunningState(endpoint, {min: 1, max: 0xffff});
 
-            await reporting.temperature(endpoint, {min: 1, max: 0xffff}); // Disable default reporting
             await endpoint.configureReporting("msTemperatureMeasurement", [
                 {
                     attribute: "tolerance",
@@ -1081,8 +1084,17 @@ export const definitions: DefinitionWithExtend[] = [
                 },
             ]);
 
-            // Disable default reporting (not used by Sinope)
-            await reporting.thermostatRunningState(endpoint, {min: 1, max: 0xffff});
+            await reporting.readMeteringMultiplierDivisor(endpoint);
+            await reporting.currentSummDelivered(endpoint, {min: 60, max: 300, change: 10});
+
+            await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
+            await endpoint.configureReporting("haElectricalMeasurement", [
+                {attribute: "rmsVoltage", minimumReportInterval: 60, maximumReportInterval: 300, reportableChange: 5},
+                {attribute: "rmsCurrent", minimumReportInterval: 10, maximumReportInterval: 60, reportableChange: 0.1},
+                {attribute: "activePower", minimumReportInterval: 10, maximumReportInterval: 60, reportableChange: 5},
+            ]);
+
+            // for some older version it migth still work
             try {
                 await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
             } catch {


### PR DESCRIPTION
This INSUFFICIENT_SPACE error was happening again after a recent firmware update
```
z2m: Failed to configure 'sinope thermostat salon', attempt 4 (Error: ZCL command 0x943469fffe283c1c/1 haElectricalMeasurement.configReport([{"minimumReportInterval":10,"maximumReportInterval":65000,"reportableChange":5,"attribute":"activePower"},{"minimumReportInterval":10,"maximumReportInterval":65000,"reportableChange":50,"attribute":"rmsCurrent"},{"minimumReportInterval":10,"maximumReportInterval":65000,"reportableChange":50,"attribute":"rmsVoltage"}], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'INSUFFICIENT_SPACE') at Endpoint.checkStatus (/app/node_modules/.pnpm/zigbee-herdsman@8.0.1/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:461:28) at Endpoint.zclCommand (/app/node_modules/.pnpm/zigbee-herdsman@8.0.1/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:1192:26) at Endpoint.configureReporting (/app/node_modules/.pnpm/zigbee-herdsman@8.0.1/node_modules/zigbee-herdsman/src/controller/model/endpoint.ts:853:9) at setupAttributes (/app/node_modules/.pnpm/zigbee-herdsman-converters@25.98.0/node_modules/zigbee-herdsman-converters/src/lib/modernExtend.ts:183:17) at result.configure (/app/node_modules/.pnpm/zigbee-herdsman-converters@25.98.0/node_modules/zigbee-herdsman-converters/src/lib/modernExtend.ts:2336:29) at Object.configure (/app/node_modules/.pnpm/zigbee-herdsman-converters@25.98.0/node_modules/zigbee-herdsman-converters/src/index.ts:365:21) at Configure.configure (/app/lib/extension/configure.ts:123:13) at Configure.onMQTTMessage (/app/lib/extension/configure.ts:46:25) at EventEmitter.wrappedCallback (/app/lib/eventBus.ts:252:17))
```

I reworked the reporting, ensuring we stay within the limit of the device in its latest revision and making sure we have the electric measurement

The removed systemMode and temperature were not actually reporting anything on those devices, as contrary to the comment, those line didn't "disable" them, but instead used memory space on the device.

I also validate the proper working of the TH1124ZB and TH1123ZB which didn't require any change so left unchanged. I don't have any of the other device, in particular the TH1124ZB-G2 which has similar memory comments in the code, but as I cannot test it, I preferred to leave it untouched.