### PR TITLE
Add new fingerprint _TZE204_3q3maeoo for device PO-BOCO-ELEC

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -19994,7 +19994,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_d6i25bwg","_TZE204_3q3maeoo"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_d6i25bwg", "_TZE204_3q3maeoo"]),
         model: "PO-BOCO-ELEC",
         vendor: "Powernity / Xanlite",
         description: "Pilot wire heating module",


### PR DESCRIPTION
Add Kozii by Xanlite heat wire module support (new fingerprint _TZE204_3q3maeoo on the definition of PO-BOCO-ELEC device)

After test, all functionnalities seems to work as expected.
