### PR TITLE
feat: LiXee ZLinky: reduce poll chunk size default (4→2)

### DIFF
--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1917,7 +1917,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withValueMin(1)
                 .withDescription(
                     "Number of attributes requested from the ZLinky in each poll to reduce Zigbee network load. " +
-                        "Requesting too many at once may exceed the device's limit and cause read errors. Requires Z2M restart. Default: 4.",
+                        "Requesting too many at once may exceed the device's limit and cause read errors. Requires Z2M restart. Default: 2.",
                 ),
             e
                 .text("tic_command_whitelist", ea.SET)
@@ -2017,7 +2017,7 @@ export const definitions: DefinitionWithExtend[] = [
                     ),
                 poll: async (device, options) => {
                     const endpoint = device.getEndpoint(1);
-                    const measurement_poll_chunk = options?.measurement_poll_chunk ? options.measurement_poll_chunk : 4;
+                    const measurement_poll_chunk = options?.measurement_poll_chunk ? options.measurement_poll_chunk : 2;
                     utils.assertNumber(measurement_poll_chunk);
                     const currentExposes = getCurrentConfig(device, options).filter(
                         (e) => !endpoint.configuredReportings.some((r) => r.cluster.name === e.cluster && r.attribute.name === e.att),


### PR DESCRIPTION
Hi,
Depending on the list of attributes and the coordinator model, polling more than 2 attributes can result in Zigbee frames that are too large, causing timeout errors such as:
```
[2026-02-05 02:08:00] warning:  zhc:lixee: Failed to read Zigbee attributes during poll. If you see many of these messages, try reducing 'Measurement poll chunk'. Error: ZCL command 0xcaffe/1 liXeePrivate.read(["currentPrice","message1","message2","statusRegister"], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"manufacturerCode":null,"writeUndiv":false}) failed ({"target":24165,"apsFrame":{"profileId":260,"clusterId":65382,"sourceEndpoint":1,"destinationEndpoint":1,"options":4416,"groupId":0,"sequence":5},"zclSequence":68,"commandIdentifier":1} timed out after 10000ms)
```

This appears particularly problematic when reading multiple `CHAR_STR` attributes together (like `message1`, `message2` and `currentPrice`).

To fix this, reduce the default chunk size from 4 to 2 attributes per poll request.

This change was originally introduced by ZLinky's author @fairecasoimeme in commit 284e855 (#8673). However, that change was subsequently reverted via #8748 (commit 622631f) due to unrelated issues with the `tariffPeriod` attribute. The chunk size reduction itself was not the cause of those problems and should be reintroduced.

See also https://github.com/fairecasoimeme/Zlinky_TIC/issues/377 where @fairecasoimeme explained the root cause and recommended the lower default.
