### PR TITLE
Namron Edge Thermostat expects LOCAL Unix time, not UTC

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -1958,9 +1958,7 @@ export const definitions: DefinitionWithExtend[] = [
                     const endpoint = device.getEndpoint(1);
 
                     // Device expects LOCAL Unix time, not UTC
-                    const localTimeSeconds =
-                        Math.floor(Date.now() / 1000) -
-                        new Date().getTimezoneOffset() * 60;
+                    const localTimeSeconds = Math.floor(Date.now() / 1000) - new Date().getTimezoneOffset() * 60;
 
                     // Device does not asks for the time with binding, therefore we write the time every 24 hours
                     await endpoint.write("hvacThermostat", {


### PR DESCRIPTION
The converter for Namron Edge Thermostat (4512783, 4512784, 4566702) correctly sets the date/time on the device every 24 hours. This time is however UTC, and not local time.  

This pull request sets the Thermostat to the local time, based on the time zone of Z2M.

