### PR TITLE
Refactor threePhase handling for exposes and toZigbee

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2301,7 +2301,7 @@ function genericMeter(args: MeterArgs = {}) {
             exposes.push(e.voltage_phase_b().withAccess(ea.STATE_GET), e.voltage_phase_c().withAccess(ea.STATE_GET));
             toZigbee.push(tz.acvoltage_phase_b, tz.acvoltage_phase_c);
         }
-        if (args.current !== false) {
+        if (args.current) {
             exposes.push(e.current_phase_b().withAccess(ea.STATE_GET), e.current_phase_c().withAccess(ea.STATE_GET));
             toZigbee.push(tz.accurrent_phase_b, tz.accurrent_phase_c);
         }


### PR DESCRIPTION
The original code treated threePhase as a master switch that ignored the specific power: false, voltage: false or current: false settings.

Example:  `m.electricityMeter({power: false, threePhase: true})` would expose the power attributes for phase B and C.  


<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
