### PR TITLE
Add Tuya TS0601 breaker (_TZE204_lb0fsvba) support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2924,6 +2924,98 @@ export const definitions: DefinitionWithExtend[] = [
             tuyaDatapoints: [[16, "state", tuya.valueConverter.onOff]],
         },
     },
+	
+	
+	
+	
+	{
+    fingerprint: tuya.fingerprint('TS0601', ['_TZE204_lb0fsvba']),
+    model: 'TS0601_breaker_lb0fsvba',
+    vendor: 'Tuya',
+    description: 'Smart circuit breaker with metering, leakage, and protection settings',
+    fromZigbee: [tuya.fz.datapoints],
+    toZigbee: [tuya.tz.datapoints],
+    configure: tuya.configureMagicPacket,
+    exposes: [
+        e.switch().withDescription('Circuit breaker on/off'),
+        e.voltage(),
+        e.current(),
+        e.power(),
+        e.temperature().withDescription('Device temperature'),
+
+        // Protections: current/voltage/temperature
+        e.binary('over_current_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overcurrent protection enable'),
+        e.numeric('over_current_threshold', ea.ALL).withUnit('mA').withValueMin(100).withValueMax(630)
+            .withDescription('Overcurrent threshold'),
+
+        e.binary('over_voltage_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overvoltage protection enable'),
+        e.numeric('over_voltage_threshold', ea.ALL).withUnit('V').withValueMin(0).withValueMax(999)
+            .withDescription('Overvoltage threshold'),
+
+        e.binary('under_voltage_breaker', ea.ALL, 'ON', 'OFF').withDescription('Undervoltage protection enable'),
+        e.numeric('under_voltage_threshold', ea.ALL).withUnit('V').withValueMin(0).withValueMax(999)
+            .withDescription('Undervoltage threshold'),
+
+        e.binary('high_temperature_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overtemperature protection enable'),
+        e.numeric('high_temperature_threshold', ea.ALL).withUnit('°C').withDescription('Overtemperature threshold'),
+
+        // Leakage
+        e.binary('leakage_breaker', ea.ALL, 'ON', 'OFF').withDescription('Leakage protection enable'),
+        e.numeric('leakage_current_threshold', ea.ALL).withUnit('mA').withValueMin(10).withValueMax(300)
+            .withDescription('Leakage current threshold'),
+        e.numeric('leakage_current', ea.STATE).withUnit('mA').withDescription('Measured residual/leakage current'),
+
+        // Auto reclose + delays
+        e.binary('auto_reclose', ea.ALL, 'ON', 'OFF').withDescription('Automatic reclosing enable'),
+        e.numeric('reclose_delay', ea.ALL).withUnit('s').withValueMin(1).withValueMax(600)
+            .withDescription('Reclosing delay'),
+        e.numeric('overcurrent_delay', ea.ALL).withUnit('s').withDescription('Overcurrent trip delay'),
+        e.numeric('undercurrent_delay', ea.ALL).withUnit('s').withDescription('Loss-of-current delay'),
+
+        // Energy
+        e.numeric('energy_import', ea.STATE).withUnit('kWh').withDescription('Import/forward energy'),
+        e.numeric('energy_export', ea.STATE).withUnit('kWh').withDescription('Export/reverse energy'),
+    ],
+    meta: {
+        tuyaDatapoints: [
+            [6, null, tuya.valueConverter.phaseVariant2],
+            [16, 'state', tuya.valueConverter.onOff],
+            [103, 'temperature', tuya.valueConverter.raw],
+
+            [17, null, tuya.valueConverter.threshold_2],
+            [17, 'high_temperature_threshold', tuya.valueConverter.threshold_2],
+            [17, 'high_temperature_breaker', tuya.valueConverter.threshold_2],
+
+            [18, null, tuya.valueConverter.threshold_3],
+            [18, 'over_current_threshold', tuya.valueConverter.threshold_3],
+            [18, 'over_current_breaker', tuya.valueConverter.threshold_3],
+            [18, 'over_voltage_threshold', tuya.valueConverter.threshold_3],
+            [18, 'over_voltage_breaker', tuya.valueConverter.threshold_3],
+            [18, 'under_voltage_threshold', tuya.valueConverter.threshold_3],
+            [18, 'under_voltage_breaker', tuya.valueConverter.threshold_3],
+
+            [19, null, tuya.valueConverter.threshold_2],
+            [19, 'leakage_current_threshold', tuya.valueConverter.threshold_2],
+            [19, 'leakage_breaker', tuya.valueConverter.threshold_2],
+
+            [20, 'auto_reclose', tuya.valueConverter.onOff],
+            [21, 'reclose_delay', tuya.valueConverter.raw],
+            [22, 'overcurrent_delay', tuya.valueConverter.raw],
+            [23, 'undercurrent_delay', tuya.valueConverter.raw],
+
+            [1, 'energy_import', tuya.valueConverter.divideBy100],
+            [2, 'energy_export', tuya.valueConverter.divideBy100],
+
+            [15, 'leakage_current', tuya.valueConverter.raw],
+        ],
+    },
+},
+
+	
+	
+	
+	
+	
     {
         // Senoro window sensor variant with 3-state opening on DP101.
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6teua268"]),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2950,12 +2950,13 @@ export const definitions: DefinitionWithExtend[] = [
             e.binary("under_voltage_breaker", ea.ALL, "ON", "OFF").withDescription("Undervoltage protection enable"),
             e.numeric("under_voltage_threshold", ea.ALL).withUnit("V").withValueMin(0).withValueMax(999).withDescription("Undervoltage threshold"),
 
-			e.binary('high_temperature_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overtemperature protection enable'),
-			e.numeric('high_temperature_threshold', ea.ALL)
-				.withUnit('°C')
-				.withValueMin(20)
-				.withValueMax(110)
-				.withDescription('Overtemperature threshold'),
+            e.binary("high_temperature_breaker", ea.ALL, "ON", "OFF").withDescription("Overtemperature protection enable"),
+            e
+                .numeric("high_temperature_threshold", ea.ALL)
+                .withUnit("°C")
+                .withValueMin(20)
+                .withValueMax(110)
+                .withDescription("Overtemperature threshold"),
 
             // Leakage
             e.binary("leakage_breaker", ea.ALL, "ON", "OFF").withDescription("Leakage protection enable"),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2940,7 +2940,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.power(),
             e.temperature().withDescription("Device temperature"),
 
-            // Protections: current/voltage/temperature
+            // Protections: current/voltage/temperature WF
             e.binary("over_current_breaker", ea.ALL, "ON", "OFF").withDescription("Overcurrent protection enable"),
             e.numeric("over_current_threshold", ea.ALL).withUnit("mA").withValueMin(100).withValueMax(630).withDescription("Overcurrent threshold"),
 
@@ -2950,8 +2950,12 @@ export const definitions: DefinitionWithExtend[] = [
             e.binary("under_voltage_breaker", ea.ALL, "ON", "OFF").withDescription("Undervoltage protection enable"),
             e.numeric("under_voltage_threshold", ea.ALL).withUnit("V").withValueMin(0).withValueMax(999).withDescription("Undervoltage threshold"),
 
-            e.binary("high_temperature_breaker", ea.ALL, "ON", "OFF").withDescription("Overtemperature protection enable"),
-            e.numeric("high_temperature_threshold", ea.ALL).withUnit("°C").withDescription("Overtemperature threshold"),
+			e.binary('high_temperature_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overtemperature protection enable'),
+			e.numeric('high_temperature_threshold', ea.ALL)
+				.withUnit('°C')
+				.withValueMin(20)
+				.withValueMax(110)
+				.withDescription('Overtemperature threshold'),
 
             // Leakage
             e.binary("leakage_breaker", ea.ALL, "ON", "OFF").withDescription("Leakage protection enable"),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2971,8 +2971,8 @@ export const definitions: DefinitionWithExtend[] = [
             // Auto reclose + delays
             e.binary("auto_reclose", ea.ALL, "ON", "OFF").withDescription("Automatic reclosing enable"),
             e.numeric("reclose_delay", ea.ALL).withUnit("s").withValueMin(1).withValueMax(600).withDescription("Reclosing delay"),
-            e.numeric("overcurrent_delay", ea.ALL).withUnit("s").withDescription("Overcurrent trip delay"),
-            e.numeric("undercurrent_delay", ea.ALL).withUnit("s").withDescription("Loss-of-current delay"),
+            e.numeric("overcurrent_delay", ea.ALL).withUnit("s").withValueMin(0).withValueMax(600).withDescription("Overcurrent trip delay"),
+            e.numeric("undercurrent_delay", ea.ALL).withUnit("s").withValueMin(0).withValueMax(600).withDescription("Loss-of-current delay"),
 
             // Energy
             e.numeric("energy_import", ea.STATE).withUnit("kWh").withDescription("Import/forward energy"),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2924,98 +2924,90 @@ export const definitions: DefinitionWithExtend[] = [
             tuyaDatapoints: [[16, "state", tuya.valueConverter.onOff]],
         },
     },
-	
-	
-	
-	
-	{
-    fingerprint: tuya.fingerprint('TS0601', ['_TZE204_lb0fsvba']),
-    model: 'TS0601_breaker_lb0fsvba',
-    vendor: 'Tuya',
-    description: 'Smart circuit breaker with metering, leakage, and protection settings',
-    fromZigbee: [tuya.fz.datapoints],
-    toZigbee: [tuya.tz.datapoints],
-    configure: tuya.configureMagicPacket,
-    exposes: [
-        e.switch().withDescription('Circuit breaker on/off'),
-        e.voltage(),
-        e.current(),
-        e.power(),
-        e.temperature().withDescription('Device temperature'),
 
-        // Protections: current/voltage/temperature
-        e.binary('over_current_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overcurrent protection enable'),
-        e.numeric('over_current_threshold', ea.ALL).withUnit('mA').withValueMin(100).withValueMax(630)
-            .withDescription('Overcurrent threshold'),
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_lb0fsvba"]),
+        model: "TS0601_breaker_lb0fsvba",
+        vendor: "Tuya",
+        description: "Smart circuit breaker with metering, leakage, and protection settings",
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.switch().withDescription("Circuit breaker on/off"),
+            e.voltage(),
+            e.current(),
+            e.power(),
+            e.temperature().withDescription("Device temperature"),
 
-        e.binary('over_voltage_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overvoltage protection enable'),
-        e.numeric('over_voltage_threshold', ea.ALL).withUnit('V').withValueMin(0).withValueMax(999)
-            .withDescription('Overvoltage threshold'),
+            // Protections: current/voltage/temperature
+            e.binary("over_current_breaker", ea.ALL, "ON", "OFF").withDescription("Overcurrent protection enable"),
+            e.numeric("over_current_threshold", ea.ALL).withUnit("mA").withValueMin(100).withValueMax(630).withDescription("Overcurrent threshold"),
 
-        e.binary('under_voltage_breaker', ea.ALL, 'ON', 'OFF').withDescription('Undervoltage protection enable'),
-        e.numeric('under_voltage_threshold', ea.ALL).withUnit('V').withValueMin(0).withValueMax(999)
-            .withDescription('Undervoltage threshold'),
+            e.binary("over_voltage_breaker", ea.ALL, "ON", "OFF").withDescription("Overvoltage protection enable"),
+            e.numeric("over_voltage_threshold", ea.ALL).withUnit("V").withValueMin(0).withValueMax(999).withDescription("Overvoltage threshold"),
 
-        e.binary('high_temperature_breaker', ea.ALL, 'ON', 'OFF').withDescription('Overtemperature protection enable'),
-        e.numeric('high_temperature_threshold', ea.ALL).withUnit('°C').withDescription('Overtemperature threshold'),
+            e.binary("under_voltage_breaker", ea.ALL, "ON", "OFF").withDescription("Undervoltage protection enable"),
+            e.numeric("under_voltage_threshold", ea.ALL).withUnit("V").withValueMin(0).withValueMax(999).withDescription("Undervoltage threshold"),
 
-        // Leakage
-        e.binary('leakage_breaker', ea.ALL, 'ON', 'OFF').withDescription('Leakage protection enable'),
-        e.numeric('leakage_current_threshold', ea.ALL).withUnit('mA').withValueMin(10).withValueMax(300)
-            .withDescription('Leakage current threshold'),
-        e.numeric('leakage_current', ea.STATE).withUnit('mA').withDescription('Measured residual/leakage current'),
+            e.binary("high_temperature_breaker", ea.ALL, "ON", "OFF").withDescription("Overtemperature protection enable"),
+            e.numeric("high_temperature_threshold", ea.ALL).withUnit("°C").withDescription("Overtemperature threshold"),
 
-        // Auto reclose + delays
-        e.binary('auto_reclose', ea.ALL, 'ON', 'OFF').withDescription('Automatic reclosing enable'),
-        e.numeric('reclose_delay', ea.ALL).withUnit('s').withValueMin(1).withValueMax(600)
-            .withDescription('Reclosing delay'),
-        e.numeric('overcurrent_delay', ea.ALL).withUnit('s').withDescription('Overcurrent trip delay'),
-        e.numeric('undercurrent_delay', ea.ALL).withUnit('s').withDescription('Loss-of-current delay'),
+            // Leakage
+            e.binary("leakage_breaker", ea.ALL, "ON", "OFF").withDescription("Leakage protection enable"),
+            e
+                .numeric("leakage_current_threshold", ea.ALL)
+                .withUnit("mA")
+                .withValueMin(10)
+                .withValueMax(300)
+                .withDescription("Leakage current threshold"),
+            e.numeric("leakage_current", ea.STATE).withUnit("mA").withDescription("Measured residual/leakage current"),
 
-        // Energy
-        e.numeric('energy_import', ea.STATE).withUnit('kWh').withDescription('Import/forward energy'),
-        e.numeric('energy_export', ea.STATE).withUnit('kWh').withDescription('Export/reverse energy'),
-    ],
-    meta: {
-        tuyaDatapoints: [
-            [6, null, tuya.valueConverter.phaseVariant2],
-            [16, 'state', tuya.valueConverter.onOff],
-            [103, 'temperature', tuya.valueConverter.raw],
+            // Auto reclose + delays
+            e.binary("auto_reclose", ea.ALL, "ON", "OFF").withDescription("Automatic reclosing enable"),
+            e.numeric("reclose_delay", ea.ALL).withUnit("s").withValueMin(1).withValueMax(600).withDescription("Reclosing delay"),
+            e.numeric("overcurrent_delay", ea.ALL).withUnit("s").withDescription("Overcurrent trip delay"),
+            e.numeric("undercurrent_delay", ea.ALL).withUnit("s").withDescription("Loss-of-current delay"),
 
-            [17, null, tuya.valueConverter.threshold_2],
-            [17, 'high_temperature_threshold', tuya.valueConverter.threshold_2],
-            [17, 'high_temperature_breaker', tuya.valueConverter.threshold_2],
-
-            [18, null, tuya.valueConverter.threshold_3],
-            [18, 'over_current_threshold', tuya.valueConverter.threshold_3],
-            [18, 'over_current_breaker', tuya.valueConverter.threshold_3],
-            [18, 'over_voltage_threshold', tuya.valueConverter.threshold_3],
-            [18, 'over_voltage_breaker', tuya.valueConverter.threshold_3],
-            [18, 'under_voltage_threshold', tuya.valueConverter.threshold_3],
-            [18, 'under_voltage_breaker', tuya.valueConverter.threshold_3],
-
-            [19, null, tuya.valueConverter.threshold_2],
-            [19, 'leakage_current_threshold', tuya.valueConverter.threshold_2],
-            [19, 'leakage_breaker', tuya.valueConverter.threshold_2],
-
-            [20, 'auto_reclose', tuya.valueConverter.onOff],
-            [21, 'reclose_delay', tuya.valueConverter.raw],
-            [22, 'overcurrent_delay', tuya.valueConverter.raw],
-            [23, 'undercurrent_delay', tuya.valueConverter.raw],
-
-            [1, 'energy_import', tuya.valueConverter.divideBy100],
-            [2, 'energy_export', tuya.valueConverter.divideBy100],
-
-            [15, 'leakage_current', tuya.valueConverter.raw],
+            // Energy
+            e.numeric("energy_import", ea.STATE).withUnit("kWh").withDescription("Import/forward energy"),
+            e.numeric("energy_export", ea.STATE).withUnit("kWh").withDescription("Export/reverse energy"),
         ],
-    },
-},
+        meta: {
+            tuyaDatapoints: [
+                [6, null, tuya.valueConverter.phaseVariant2],
+                [16, "state", tuya.valueConverter.onOff],
+                [103, "temperature", tuya.valueConverter.raw],
 
-	
-	
-	
-	
-	
+                [17, null, tuya.valueConverter.threshold_2],
+                [17, "high_temperature_threshold", tuya.valueConverter.threshold_2],
+                [17, "high_temperature_breaker", tuya.valueConverter.threshold_2],
+
+                [18, null, tuya.valueConverter.threshold_3],
+                [18, "over_current_threshold", tuya.valueConverter.threshold_3],
+                [18, "over_current_breaker", tuya.valueConverter.threshold_3],
+                [18, "over_voltage_threshold", tuya.valueConverter.threshold_3],
+                [18, "over_voltage_breaker", tuya.valueConverter.threshold_3],
+                [18, "under_voltage_threshold", tuya.valueConverter.threshold_3],
+                [18, "under_voltage_breaker", tuya.valueConverter.threshold_3],
+
+                [19, null, tuya.valueConverter.threshold_2],
+                [19, "leakage_current_threshold", tuya.valueConverter.threshold_2],
+                [19, "leakage_breaker", tuya.valueConverter.threshold_2],
+
+                [20, "auto_reclose", tuya.valueConverter.onOff],
+                [21, "reclose_delay", tuya.valueConverter.raw],
+                [22, "overcurrent_delay", tuya.valueConverter.raw],
+                [23, "undercurrent_delay", tuya.valueConverter.raw],
+
+                [1, "energy_import", tuya.valueConverter.divideBy100],
+                [2, "energy_export", tuya.valueConverter.divideBy100],
+
+                [15, "leakage_current", tuya.valueConverter.raw],
+            ],
+        },
+    },
+
     {
         // Senoro window sensor variant with 3-state opening on DP101.
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6teua268"]),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
Image uploaded to: public/images/devices/TS0601_breaker_lb0fsvba.png
Device: ZBN-DJ-63 smart circuit breaker
Zigbee model: TS0601
Manufacturer: _TZE204_lb0fsvba
Tested with: Zigbee2MQTT 2.7.2
Working features:
switch on/off (DP 16)
voltage/current/power (DP 6)
temperature (DP 103)
leakage current (DP 15)
leakage protection + threshold (DP 19)
overcurrent/overvoltage/undervoltage protections + thresholds (DP 18)
overtemperature protection + threshold (DP 17)
auto reclose + delays (DP 20–23)
energy import/export (DP 1–2)
Notes: Device does not appear to support resetting cumulative energy counters via datapoints.