### PR TITLE
Enhance ENGO thermostat capabilities - adding OFF mode to E40 thermostat

### DIFF
--- a/src/devices/engo.ts
+++ b/src/devices/engo.ts
@@ -498,7 +498,7 @@ export const definitions: DefinitionWithExtend[] = [
                             if (options?.expose_device_state === true) {
                                 return isOn ? "ON" : "OFF";
                             }
-                            meta.state.state = undefined;
+                            return undefined;
                         },
                     },
                 ],


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Updated the system mode options and added expose device state functionality with OFF system mode. Also adding time synchronization capability. Based on EONE model (_TZE204_djurk6p5)
Removing unsupported holiday features.
