### PR TITLE
Fix Shelly remotes binding to coordinator

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1258,10 +1258,11 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fzLocal.one_button_events],
         exposes: [e.action(["single", "double", "triple"])],
         extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}), m.identify()],
-        version: "0.0.1",
+        version: "0.0.2",
         configure: async (device, coordinatorEndpoint, definition) => {
             for (const endpoint of device.endpoints) {
                 await endpoint.bind("genOnOff", coordinatorEndpoint);
+                await endpoint.bind("genScenes", coordinatorEndpoint);
             }
         },
     },
@@ -1273,11 +1274,12 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fzLocal.four_buttons_single_events, fzLocal.four_buttons_hold_events],
         exposes: [e.action(["1_single", "2_single", "3_single", "4_single", "1_hold", "2_hold", "3_hold", "4_hold"])],
         extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}), m.identify()],
-        version: "0.0.1",
+        version: "0.0.2",
         configure: async (device, coordinatorEndpoint, definition) => {
             for (const endpoint of device.endpoints) {
                 await endpoint.bind("genOnOff", coordinatorEndpoint);
                 await endpoint.bind("genLevelCtrl", coordinatorEndpoint);
+                await endpoint.bind("genScenes", coordinatorEndpoint);
             }
         },
     },
@@ -1290,11 +1292,12 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fzLocal.four_buttons_single_events, fzLocal.four_buttons_hold_events],
         exposes: [e.action(["1_single", "2_single", "3_single", "4_single", "1_hold", "2_hold", "3_hold", "4_hold"])],
         extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}), m.identify()],
-        version: "0.0.1",
+        version: "0.0.2",
         configure: async (device, coordinatorEndpoint, definition) => {
             for (const endpoint of device.endpoints) {
                 await endpoint.bind("genOnOff", coordinatorEndpoint);
                 await endpoint.bind("genLevelCtrl", coordinatorEndpoint);
+                await endpoint.bind("genScenes", coordinatorEndpoint);
             }
         },
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
So the coordinator binds were missing from my PR:
- https://github.com/Koenkk/zigbee-herdsman-converters/pull/11409

- hopefully fixes https://github.com/Koenkk/zigbee2mqtt/issues/31069