### PR TITLE
feat(add): EKAT-T3074-6WZ

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4736,6 +4736,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_tdhnhhiy",
             "_TZE204_wskr3up8",
             "_TZE204_gxbdnfrh",
+            "_TZE284_g1enhdsi",
         ]),
         model: "TS0601_switch_6_gang",
         vendor: "Tuya",
@@ -4775,6 +4776,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Nova Digital", "SYZB-6W", "6 gang switch 4x4", ["_TZE284_tdhnhhiy"]),
             tuya.whitelabel("Nova Digital", "FZB-6", "6 gang switch 4x4", ["_TZE204_wskr3up8"]),
             tuya.whitelabel("Nova Digital", "SA-6", "Safira smart switch - 6 gang", ["_TZE204_gxbdnfrh"]),
+            tuya.whitelabel("Ekaza", "EKAT-T3074-6WZ", "6 gang switch", ["_TZE284_g1enhdsi"]),
         ],
     },
     {


### PR DESCRIPTION
Add support for the EKAT-T3074-6WZ from Ekaza, a Tuya whitelabel 6-gang switch.

```json
{
    "id": 20,
    "type": "Router",
    "ieeeAddr": "0xa4c138c41330c8e4",
    "nwkAddr": 47184,
    "manufId": 4417,
    "manufName": "_TZE284_g1enhdsi",
    "powerSource": "Mains (single phase)",
    "modelId": "TS0601",
    "epList": [
        1,
        242
    ],
    "endpoints": {
        "1": {
            "profId": 260,
            "epId": 1,
            "devId": 81,
            "inClusterList": [
                4,
                5,
                61184,
                0,
                60672
            ],
            "outClusterList": [
                25,
                10
            ],
            "clusters": {
                "genBasic": {
                    "attributes": {
                        "65503": "��%1i",
                        "65506": 56,
                        "65508": 0,
                        "65534": 0,
                        "modelId": "TS0601",
                        "manufacturerName": "_TZE284_g1enhdsi",
                        "powerSource": 1,
                        "zclVersion": 3,
                        "appVersion": 78,
                        "stackVersion": 0,
                        "hwVersion": 1,
                        "dateCode": ""
                    }
                }
            },
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        },
        "242": {
            "profId": 41440,
            "epId": 242,
            "devId": 97,
            "inClusterList": [],
            "outClusterList": [
                33
            ],
            "clusters": {},
            "binds": [],
            "configuredReportings": [],
            "meta": {}
        }
    },
    "appVersion": 78,
    "stackVersion": 0,
    "hwVersion": 1,
    "dateCode": "",
    "zclVersion": 3,
    "interviewCompleted": true,
    "interviewState": "SUCCESSFUL",
    "meta": {
        "configured": 332242049
    },
    "lastSeen": 1771325618919
}
```