### PR TITLE
fix: corrections for SBDV writeable custom attributes

### DIFF
--- a/src/devices/sber.ts
+++ b/src/devices/sber.ts
@@ -1,5 +1,5 @@
-import {ClusterDefinition} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import {Zcl} from "zigbee-herdsman";
+import type {ClusterDefinition} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";


### PR DESCRIPTION
Fix for custom attributes of SBDV-* devices:
properly declare writable and not-writable proprietary attributes
