### PR TITLE
fix: lumi: dimmer.mode payload lookup

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -888,7 +888,7 @@ export const numericAttributes2Payload = async (
                 }
                 break;
             case "1289":
-                payload.dimmer_mode = getFromLookup(value, {3: "rgbw", 1: "dual_ct"});
+                payload.dimmer_mode = getFromLookup(value, {1: "dual_ct", 2: "rgb", 3: "rgbw"});
                 break;
             case "1299":
                 if (["ZNXDD01LM"].includes(model.model)) {


### PR DESCRIPTION
lumi.light.agl00x/lumi.light.acn132 are dual cct/rgb devices that use attribute 0x0509 values of 1/2 when reporting device state. 

The current dimmer.mode payload lookup only has values 1/3 which results in the error:

`z2m: Exception while calling fromZigbee converter: Value: '2' not found in: [1, 3]`

whenever a light moves from a cct (1) to rgb (2) state. 

Added 2: "rgb" to lookup to resolve the error.