### PR TITLE
Add Moes Curtain Robot device definition - ADCBZI01

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -23,117 +23,64 @@ const exposesLocal = {
 
 export const definitions: DefinitionWithExtend[] = [
     {
-      fingerprint: tuya.fingerprint("TS030F", ["_TZ3210_sxtfesc6"]),
-      model: "ADCBZI01",
-      vendor: "Moes",
-      description: "Curtain Robot",
-      fromZigbee: [fz.cover_position_tilt, tuya.fz.datapoints],
-      toZigbee: [tz.cover_position_tilt, tz.cover_state, tuya.tz.datapoints],
-      exposes: [
-        e.cover_position(),
-        e.position(),
-        e.battery(),
-        e.illuminance(),
-        e
-          .enum("work_state", ea.STATE, ["standby", "opening", "closing"])
-          .withDescription("Current work state"),
-        e
-          .numeric("total_time", ea.STATE)
-          .withUnit("s")
-          .withDescription("Total operation time"),
-        e
-          .enum("situation_set", ea.STATE_SET, ["fully_open", "fully_close"])
-          .withDescription("Situation control"),
-        e.enum("fault", ea.STATE, ["none"]).withDescription("Fault status"),
-        e
-          .enum("charging_status", ea.STATE, [
-            "none",
-            "uncharged",
-            "charging",
-            "charged",
-          ])
-          .withDescription("Charging status"),
-        e
-          .numeric("open_threshold", ea.STATE_SET)
-          .withValueMin(0)
-          .withValueMax(100)
-          .withDescription("Light threshold for opening"),
-        e
-          .numeric("close_threshold", ea.STATE_SET)
-          .withValueMin(0)
-          .withValueMax(100)
-          .withDescription("Light threshold for closing"),
-        e
-          .numeric("curtain_status", ea.STATE_SET)
-          .withValueMin(0)
-          .withValueMax(255)
-          .withDescription("Curtain status"),
-        e
-          .numeric("total_distance", ea.STATE)
-          .withUnit("m")
-          .withDescription("Total distance traveled"),
-        e
-          .numeric("factory_test", ea.STATE)
-          .withValueMin(0)
-          .withValueMax(100)
-          .withDescription("Factory test feedback"),
-        e
-          .text("custom_week_prog_1", ea.STATE_SET)
-          .withDescription("Custom week program 1"),
-        e
-          .text("custom_week_prog_2", ea.STATE_SET)
-          .withDescription("Custom week program 2"),
-        e
-          .text("custom_week_prog_3", ea.STATE_SET)
-          .withDescription("Custom week program 3"),
-        e
-          .text("custom_week_prog_4", ea.STATE_SET)
-          .withDescription("Custom week program 4"),
-      ],
-      meta: {
-        tuyaDatapoints: [
-          [
-            1,
-            "state",
-            tuya.valueConverterBasic.lookup({ open: 0, stop: 1, close: 2 }),
-          ], // Control - open/stop/close
-          [2, "position", tuya.valueConverter.coverPosition], // Percent control - set position (0-100)
-          [3, "position", tuya.valueConverter.coverPositionInverted], // Percent state - current position (0-100)
-          [
-            7,
-            "work_state",
-            tuya.valueConverterBasic.lookup({ standby: 0, opening: 1, closing: 2 }),
-          ], // Work state
-          [10, "total_time", tuya.valueConverter.raw], // Total time (0-120000)
-          [
-            11,
-            "situation_set",
-            tuya.valueConverterBasic.lookup({ fully_open: 0, fully_close: 1 }),
-          ], // Situation control
-          [12, "fault", tuya.valueConverterBasic.lookup({ none: 0 })], // Fault (only 'none' available)
-          [13, "battery", tuya.valueConverter.raw], // Battery percentage (0-100)
-          [
-            101,
-            "charging_status",
-            tuya.valueConverterBasic.lookup({
-              none: 0,
-              uncharged: 1,
-              charging: 2,
-              charged: 3,
-            }),
-          ], // Charging status
-          [103, "custom_week_prog_1", tuya.valueConverter.raw], // Custom week program 1
-          [104, "custom_week_prog_2", tuya.valueConverter.raw], // Custom week program 2
-          [105, "custom_week_prog_3", tuya.valueConverter.raw], // Custom week program 3
-          [106, "custom_week_prog_4", tuya.valueConverter.raw], // Custom week program 4
-          [107, "illuminance", tuya.valueConverter.raw], // Light intensity (0-100)
-          [108, "open_threshold", tuya.valueConverter.raw], // Open window threshold (0-100)
-          [109, "close_threshold", tuya.valueConverter.raw], // Close window threshold (0-100)
-          [110, "curtain_status", tuya.valueConverter.raw], // Curtain status (0-255)
-          [111, "factory_test", tuya.valueConverter.raw], // Factory test (0-100)
-          [112, "total_distance", tuya.valueConverter.raw], // Total running distance in meters
+        fingerprint: tuya.fingerprint("TS030F", ["_TZ3210_sxtfesc6"]),
+        model: "ADCBZI01",
+        vendor: "Moes",
+        description: "Curtain Robot",
+        fromZigbee: [fz.cover_position_tilt, tuya.fz.datapoints],
+        toZigbee: [tz.cover_position_tilt, tz.cover_state, tuya.tz.datapoints],
+        exposes: [
+            e.cover_position(),
+            e.position(),
+            e.battery(),
+            e.illuminance(),
+            e.enum("work_state", ea.STATE, ["standby", "opening", "closing"]).withDescription("Current work state"),
+            e.numeric("total_time", ea.STATE).withUnit("s").withDescription("Total operation time"),
+            e.enum("situation_set", ea.STATE_SET, ["fully_open", "fully_close"]).withDescription("Situation control"),
+            e.enum("fault", ea.STATE, ["none"]).withDescription("Fault status"),
+            e.enum("charging_status", ea.STATE, ["none", "uncharged", "charging", "charged"]).withDescription("Charging status"),
+            e.numeric("open_threshold", ea.STATE_SET).withValueMin(0).withValueMax(100).withDescription("Light threshold for opening"),
+            e.numeric("close_threshold", ea.STATE_SET).withValueMin(0).withValueMax(100).withDescription("Light threshold for closing"),
+            e.numeric("curtain_status", ea.STATE_SET).withValueMin(0).withValueMax(255).withDescription("Curtain status"),
+            e.numeric("total_distance", ea.STATE).withUnit("m").withDescription("Total distance traveled"),
+            e.numeric("factory_test", ea.STATE).withValueMin(0).withValueMax(100).withDescription("Factory test feedback"),
+            e.text("custom_week_prog_1", ea.STATE_SET).withDescription("Custom week program 1"),
+            e.text("custom_week_prog_2", ea.STATE_SET).withDescription("Custom week program 2"),
+            e.text("custom_week_prog_3", ea.STATE_SET).withDescription("Custom week program 3"),
+            e.text("custom_week_prog_4", ea.STATE_SET).withDescription("Custom week program 4"),
         ],
-      },
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tuya.valueConverterBasic.lookup({open: 0, stop: 1, close: 2})], // Control - open/stop/close
+                [2, "position", tuya.valueConverter.coverPosition], // Percent control - set position (0-100)
+                [3, "position", tuya.valueConverter.coverPositionInverted], // Percent state - current position (0-100)
+                [7, "work_state", tuya.valueConverterBasic.lookup({standby: 0, opening: 1, closing: 2})], // Work state
+                [10, "total_time", tuya.valueConverter.raw], // Total time (0-120000)
+                [11, "situation_set", tuya.valueConverterBasic.lookup({fully_open: 0, fully_close: 1})], // Situation control
+                [12, "fault", tuya.valueConverterBasic.lookup({none: 0})], // Fault (only 'none' available)
+                [13, "battery", tuya.valueConverter.raw], // Battery percentage (0-100)
+                [
+                    101,
+                    "charging_status",
+                    tuya.valueConverterBasic.lookup({
+                        none: 0,
+                        uncharged: 1,
+                        charging: 2,
+                        charged: 3,
+                    }),
+                ], // Charging status
+                [103, "custom_week_prog_1", tuya.valueConverter.raw], // Custom week program 1
+                [104, "custom_week_prog_2", tuya.valueConverter.raw], // Custom week program 2
+                [105, "custom_week_prog_3", tuya.valueConverter.raw], // Custom week program 3
+                [106, "custom_week_prog_4", tuya.valueConverter.raw], // Custom week program 4
+                [107, "illuminance", tuya.valueConverter.raw], // Light intensity (0-100)
+                [108, "open_threshold", tuya.valueConverter.raw], // Open window threshold (0-100)
+                [109, "close_threshold", tuya.valueConverter.raw], // Close window threshold (0-100)
+                [110, "curtain_status", tuya.valueConverter.raw], // Curtain status (0-255)
+                [111, "factory_test", tuya.valueConverter.raw], // Factory test (0-100)
+                [112, "total_distance", tuya.valueConverter.raw], // Total running distance in meters
+            ],
+        },
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_zxkwaztm"]),


### PR DESCRIPTION
Added new device definitions for Moes Curtain Robot including various features and metadata

Extra Details:
- TS030F [_TZ3210_sxtfesc6] (Curtain Robot)
- Model - ADCBZI01
- Make - Moes

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4843
