### PR TITLE
fix: configure IM6001-MPP01 trying to write attr not writable

### DIFF
--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -1,15 +1,11 @@
 import {Zcl} from "zigbee-herdsman";
-
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
 import * as exposes from "../lib/exposes";
-import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend} from "../lib/types";
-
-const NS = "zhc:smartthings";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -308,15 +304,6 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["msTemperatureMeasurement", "genPowerCfg", "manuSpecificSamsungAccelerometer"]);
             await endpoint.write("manuSpecificSamsungAccelerometer", {0: {value: 0x14, type: 0x20}}, options);
             await endpoint.write("genPollCtrl", {checkinInterval: 14400});
-            try {
-                await endpoint.write("genPollCtrl", {longPollInterval: 3600});
-            } catch (error) {
-                if ((error as Error).message.includes("READ_ONLY")) {
-                    logger.debug("Writing `longPollInterval` failed, ignoring...", NS);
-                } else {
-                    throw error;
-                }
-            }
             await reporting.temperature(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
             const payloadA = reporting.payload<"manuSpecificSamsungAccelerometer">("acceleration", 10, constants.repInterval.HOUR, 5);

--- a/test/checkDefinition.test.ts
+++ b/test/checkDefinition.test.ts
@@ -21,7 +21,6 @@ describe("Check definition", () => {
                 1: [
                     ["manuSpecificSamsungAccelerometer", {0: {value: 0x14, type: 0x20}}, {manufacturerCode: Zcl.ManufacturerCode.SAMJIN_CO_LTD}],
                     ["genPollCtrl", {checkinInterval: 14400}],
-                    ["genPollCtrl", {longPollInterval: 3600}],
                 ],
             },
             configureReporting: {


### PR DESCRIPTION
Since it previously was try/catch because of the returned `READ_ONLY` status, I assume just removing the call is the correct behavior. `longPollInterval` is not writable by nature, and no other device appears to customize this behavior, I think that's a safe-enough assumption.

Fixes https://github.com/Koenkk/zigbee-herdsman/issues/1642
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/27140
Fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/8945

TODO: for the config report "edit" not passing the correct manuf code, the custom cluster needs to be moved to ZHC and tailored for each use case (I see 3 with 3 different codes), see https://github.com/Koenkk/zigbee-herdsman/issues/1622