### PR TITLE
fix(sinope): disable unsupported SW2500ZB metering power handling

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -1473,7 +1473,10 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SW2500ZB",
         vendor: "Sinopé",
         description: "Zigbee smart light switch",
-        extend: [m.onOff(), m.electricityMeter({cluster: "metering"})],
+        // Some SW2500ZB firmware variants reject `seMetering` config/reporting and
+        // also fail `instantaneousDemand` reads with UNSUPPORTED_ATTRIBUTE.
+        // Keep metering support for delivered energy, but disable power handling.
+        extend: [m.onOff(), m.electricityMeter({cluster: "metering", configureReporting: false, power: false})],
         fromZigbee: [fzLocal.sinope],
         toZigbee: [
             tzLocal.timer_seconds,


### PR DESCRIPTION
Tested on a physical SW2500ZB running firmware 539.

Observed errors:
- seMetering configure/reporting setup fails with UNSUPPORTED_ATTRIBUTE
- direct reads of seMetering.instantaneousDemand fail with UNSUPPORTED_ATTRIBUTE

Effectively disabled for SW2500ZB:
- reporting configuration for metering attributes
- power handling via seMetering.instantaneousDemand

Kept enabled:
- delivered energy handling via seMetering.currentSummDelivered
- normal on/off switch behavior

Note: on the tested physical device, seMetering.currentSummDelivered also did not seem to produce useful data.

