### PR TITLE
Add support for Sinope HP6000ZB air conditioner

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -644,7 +644,7 @@ export const definitions: DefinitionWithExtend[] = [
                     }
                     return result;
                 },
-            },
+            } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
             {
                 cluster: "manuSpecificSinope",
                 type: ["attributeReport", "readResponse"],
@@ -657,7 +657,7 @@ export const definitions: DefinitionWithExtend[] = [
                     }
                     return result;
                 },
-            },
+            } satisfies Fz.Converter<"manuSpecificSinope", undefined, ["attributeReport", "readResponse"]>,
         ],
         toZigbee: [
             tz.thermostat_local_temperature,


### PR DESCRIPTION
Add support for Sinope HP6000ZB air conditioner
Description:
This PR adds native support for the Sinope HP6000ZB (Mini-split AC interface).

Changes included:

Full implementation of hvacThermostat and hvacFanCtrl clusters.

Added manufacturer-specific cluster 0x119C support for setpoint control.

Critical Bugfix: Implemented a filter for the persistent 28°C setpoint spike. The device occasionally reports 28°C as a fallback value; this filter ignores such reports when they deviate significantly from the current state to prevent erratic automation behavior.
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [TODO](https://github.com/Koenkk/zigbee2mqtt.io/pull/4846/changes/b77aa8c729a5c29127b02100c36c35c5de9753d1)
<img width="360" height="512" alt="Sinope-HP6000ZB" src="https://github.com/user-attachments/assets/e9476818-8aac-4b51-ab96-cfca6e0079c9" />
