### PR TITLE
Fix Battery not being exposed for TECH VNTH-T2 TRV

### DIFF
--- a/src/devices/tech.ts
+++ b/src/devices/tech.ts
@@ -48,6 +48,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Indicates if the frost protection mode is enabled")
                 .withCategory("config"),
             e.valve_alarm(),
+            e.battery(),
             ...tuya.exposes.scheduleAllDays(ea.STATE_SET, "HH:MM/C HH:MM/C HH:MM/C HH:MM/C"),
         ],
         meta: {
@@ -137,6 +138,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Indicates if the frost protection mode is enabled")
                 .withCategory("config"),
             e.valve_alarm(),
+            e.battery(),
             ...tuya.exposes.scheduleAllDays(ea.STATE_SET, "HH:MM/C HH:MM/C HH:MM/C HH:MM/C HH:MM/C HH:MM/C"),
         ],
         meta: {


### PR DESCRIPTION
Hi,
I was trying to figure out the last couple of days why the TECH TRVs I have were showing in z2m, but not ha. Tried basically everything from rediscovering, simply waiting, ...
Today I had the thought to start looking at the z2m device definitions. And lo and behold I discovered, that the data was being collected, but all other users managed to miss that the battery value is missing from the exposed section.
Hence, I've created this PR.
I hope this is correct.