### PR TITLE
Revert "fix: Sinopé TH1123ZB: fix backlight_auto_dim (#11283)"

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -682,7 +682,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .enum("temperature_display_mode", ea.ALL, ["celsius", "fahrenheit"])
                 .withDescription("The temperature format displayed on the thermostat screen"),
             e.enum("time_format", ea.ALL, ["24h", "12h"]).withDescription("The time format featured on the thermostat display"),
-            e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "off"]).withDescription("Control backlight dimming behavior"),
+            e.enum("backlight_auto_dim", ea.ALL, ["on_demand", "sensing"]).withDescription("Control backlight dimming behavior"),
             e.enum("keypad_lockout", ea.ALL, ["unlock", "lock1"]).withDescription("Enables or disables the device’s buttons"),
             e.enum("main_cycle_output", ea.ALL, ["15_sec", "15_min"]).withDescription("The length of the control cycle: 15_sec=normal 15_min=fan"),
             e


### PR DESCRIPTION
This reverts commit 53728058fe45ef1213775cea627ad0d7a368829d
This reverts commit f7dd70bc02ae5779b2bc9093d6a5a7f643370e00
This reverts commit c04e9947a80b014b609f9a66cb0eec0b562b7b6f
(All are the same changeset with different commit numbers, I had a bit of a hard time to track the correct one for some reason).

Related to https://github.com/Koenkk/zigbee2mqtt/issues/29828

PR #11283 was an invalid patch for the TH1123ZG (by @ichabot609), on top of an invalid fix for the TH1123ZG-G2/TH1124ZG-G2 (https://github.com/Koenkk/zigbee-herdsman-converters/pull/10987, by @lemoinem). The original invalid fix was reverted with Koenkk/zigbee-herdsman-converters#11236, making the patch for PR #11283 invalid and creating further issues.

This is simply reverting the invalid patch.
The original issue was solved with Koenkk/zigbee-herdsman-converters#11454 and zigbee-herdsman-converters#11478.

I've notified @ichabot609 here: https://github.com/Koenkk/zigbee2mqtt/issues/29828#issuecomment-3843246122 on Feb 3rd that their patch might create more problems than they solve.

Mentioning a week later (https://github.com/Koenkk/zigbee2mqtt/issues/29828#issuecomment-3880189726) that I would revert their patch since it seems to be causing issues to TH1123ZG users.

Now, almost close to 3 weeks after the first notification and 2 weeks since I mentioned it was actually creating issues and needed to be reverted, it looks like they haven't noticed my messages. So I'm submitting this to have it reverted.

Please note that I don't own a TH1123ZG, and can't test this. I will rely on @jsrich31 who actually has the issue to test this and let me know it doesn't solve the problem.

If @ichabot609 has feeback and/or reservations with my revert, I will be happy to retract it and work with them to find a better fix.
In the meantime, I feel it is better to restore the full range of capabilities I have broken.