### PR TITLE
Support for tint Smart Socket Tower Outdoor

### DIFF
--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -323,11 +323,11 @@ export const definitions: DefinitionWithExtend[] = [
         description: "tint desk lamp, white+color",
         extend: [mullerLichtLight({colorTemp: {range: [153, 555]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
-        {
-        zigbeeModel: ['Power Socket'],
-        model: '404078',
-        vendor: 'MLI',
-        description: 'tint Smart Socket Tower Outdoor',
-        extend: [m.onOff({"powerOnBehavior":false})],
+    {
+        zigbeeModel: ["Power Socket"],
+        model: "404078",
+        vendor: "MLI",
+        description: "tint Smart Socket Tower Outdoor",
+        extend: [m.onOff({powerOnBehavior: false})],
     },
 ];


### PR DESCRIPTION
Adding support for [Müller Licht tint Smart Socket Tower Outdoor](https://www.mueller-licht.de/produktinformationen/artikel/?q=404078)
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4855
