### PR TITLE
Feature/luumr light bulb

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24760,7 +24760,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         model: "TS0502B_LUUMR",
         vendor: "LUUMR",
-        description: "LUUMR Smart LED C35 E14 4.2 W, 470 lm, 2700–6500 K (CCT) – Zigbee candle bulb",
+        description: "LUUMR Smart LED C35 E14 4.2 W, 470 lm – Zigbee candle bulb",
         extend: [
             tuya.modernExtend.tuyaLight({
                 color: false,

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24751,4 +24751,23 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
+    {
+        fingerprint: [
+            {
+                modelID: "TS0502B",
+                manufacturerName: "_TZ3210_claeh5ds",
+            },
+        ],
+        model: "TS0502B_LUUMR",
+        vendor: "LUUMR",
+        description: "LUUMR Smart LED C35 E14 4.2 W, 470 lm, 2700–6500 K (CCT) – Zigbee candle bulb",
+        extend: [
+            tuya.modernExtend.tuyaLight({
+                color: false,
+                colorTemp: {range: [153, 500]},
+                doNotDisturb: false,
+                powerOnBehavior: false,
+            }),
+        ],
+    },
 ];


### PR DESCRIPTION
Added proper support for this light bulb. The old generic/white label implementation lead to strange behavior (in HA at least). Also to subsequent logs piling up:

```
2026-02-24 11:49:36.240 WARNING (MainThread) [homeassistant.components.mqtt.light.schema_json] Invalid color mode 'hs' received for entity

2026-02-24 11:49:44.785 ERROR (MainThread) [homeassistant.helpers.template] Template variable error: 'value_json' is undefined when rendering '{% if value_json.do_not_disturb %}true{% else %}false{% endif %}'

2026-02-24 11:51:18.486 WARNING (MainThread) [homeassistant.helpers.template] Template variable warning: 'dict object' has no attribute 'power_on_behavior' when rendering '{{ value_json.power_on_behavior }}'
```


Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4860
