### PR TITLE
fix: Amina S energy reporting

### DIFF
--- a/src/devices/amina.ts
+++ b/src/devices/amina.ts
@@ -189,7 +189,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Amina Distribution AS",
         description: "Amina S EV Charger",
         ota: true,
-        fromZigbee: [fzLocal.ev_status, fzLocal.alarms],
+        fromZigbee: [fzLocal.ev_status, fzLocal.alarms, fzLocal.poll_energy],
         toZigbee: [tzLocal.ev_status, tzLocal.alarms, tzLocal.charge_limit, tzLocal.charge_limit_with_on_off],
         exposes: [
             e.text("ev_status", ea.STATE_GET).withDescription("Current charging status"),


### PR DESCRIPTION
In e30ace459d7028b2df697fa12ad15616b49b895a, Amina S energy reporting was refactored to use a fromZigbee coverter instead of onEvent() but the new converter was never added to the fromZigbee property so it was never used.
