### PR TITLE
Add Zemismart KES-606US-L3 (_TZ3000_cziew6eu) 3-gang switch

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10470,12 +10470,13 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_lcjsewlo", "_TZ3000_kfkqkjqe"]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_lcjsewlo", "_TZ3000_kfkqkjqe", "_TZ3000_cziew6eu"]),
         model: "TS0726_3_gang",
         vendor: "Tuya",
         description: "3 gang switch with neutral wire",
         fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
         toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode],
+        whiteLabel: [tuya.whitelabel("Zemismart", "KES-606US-L3-EESS", "3 gang switch with neutral", ["_TZ3000_cziew6eu"])],
         exposes: [
             ...[1, 2, 3].map((ep) => e.switch().withEndpoint(`l${ep}`)),
             ...[1, 2, 3].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

Adds a new fingerprint `_TZ3000_cziew6eu` for the Zemismart 3 gang light switch with neutral wire. Tested all 3 endpoints work perfectly.

I'm opening this as a draft because I encountered a `whiteLabel` collision issue during `pnpm test`. The model name `KES-606US-L3` is already used by another definition with a different Zigbee model (not TS0726). 

How should I properly resolve this collision?

Links:
- https://www.zigbee2mqtt.io/devices/KES-606US-L3.html
- https://github.com/Koenkk/zigbee-herdsman-converters/blob/e0b9a5cd3ae9dab55c0908557ab1b8d6ac90b3b2/src/devices/tuya.ts#L6331
- https://www.zemismart.com/products/kes-606us-l1-eess?VariantsId=17581 (Zemismart product page)