### PR TITLE
[Update lumi.switch.b3n01] Remove lumiPower from the device list

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1471,7 +1471,6 @@ export const definitions: DefinitionWithExtend[] = [
                 },
             }),
             lumiElectricityMeter(),
-            lumiPower(),
             lumiPreventReset(),
         ],
     },


### PR DESCRIPTION
This device do not have genAnalogInput cluster, lumiPower will cause error "Error: Device 0x54ef441000abe0f0 has no input cluster genAnalogInput".

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
