### PR TITLE
Enhance extend properties for Aqara light controllers

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2940,13 +2940,13 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Smart dimmer controller T1 Pro",
         extend: [lumiZigbeeOTA(), lumiLight({colorTemp: true, powerOutageMemory: "switch"})],
     },
-    {   
+    {
         zigbeeModel: ["lumi.dimmer.acn003"],
         model: "ZNDDQDQ11LM",
         vendor: "Aqara",
         description: "T1 light strip controller",
         extend: [
-            lumi.lumiModernExtend.lumiLight({colorTemp: true, colorTempRange: [154, 370], color: false, powerOutageMemory: "enum",}),
+            lumi.lumiModernExtend.lumiLight({colorTemp: true, colorTempRange: [154, 370], color: false, powerOutageMemory: "enum"}),
             m.identify(),
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
             lumi.lumiModernExtend.lumiZigbeeOTA(),
@@ -2957,13 +2957,13 @@ export const definitions: DefinitionWithExtend[] = [
             lumi.lumiModernExtend.lumiTransitionCurveCurvature(),
         ],
     },
-    {   
+    {
         zigbeeModel: ["lumi.dimmer.acn004"],
         model: "ZNDDQDQ12LM",
         vendor: "Aqara",
         description: "T1 light strip controller",
         extend: [
-            lumi.lumiModernExtend.lumiLight({colorTemp: true, colorTempRange: [154, 370], color: false, powerOutageMemory: "enum",}),
+            lumi.lumiModernExtend.lumiLight({colorTemp: true, colorTempRange: [154, 370], color: false, powerOutageMemory: "enum"}),
             m.identify(),
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
             lumi.lumiModernExtend.lumiZigbeeOTA(),
@@ -2974,13 +2974,13 @@ export const definitions: DefinitionWithExtend[] = [
             lumi.lumiModernExtend.lumiTransitionCurveCurvature(),
         ],
     },
-    {   
+    {
         zigbeeModel: ["lumi.dimmer.acn005"],
         model: "ZNDDQDQ13LM",
         vendor: "Aqara",
         description: "T1 light strip controller",
         extend: [
-            lumi.lumiModernExtend.lumiLight({colorTemp: true, colorTempRange: [154, 370], color: false, powerOutageMemory: "enum",}),
+            lumi.lumiModernExtend.lumiLight({colorTemp: true, colorTempRange: [154, 370], color: false, powerOutageMemory: "enum"}),
             m.identify(),
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
             lumi.lumiModernExtend.lumiZigbeeOTA(),


### PR DESCRIPTION
Updated the extend properties for multiple Aqara light controllers to include additional features such as dimming range and power source identification. New definition implement the function of powering on brightness transition curve curvature, Off on duration, On off duration.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
<img width="1456" height="1182" alt="image" src="https://github.com/user-attachments/assets/8bcd9cc3-427e-48ac-bbdd-9b53a264ff37" />
