### PR TITLE
Move manuSpecificOsram from ZH to ZHC

### DIFF
--- a/src/lib/ledvance.ts
+++ b/src/lib/ledvance.ts
@@ -5,6 +5,17 @@ import * as m from "./modernExtend";
 
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.OSRAM_SYLVANIA};
 
+interface OsramCluster {
+    attributes: never;
+    commands: {
+        // biome-ignore lint/complexity/noBannedTypes: empty payload
+        saveStartupParams: {};
+        // biome-ignore lint/complexity/noBannedTypes: empty payload
+        resetStartupParams: {};
+    };
+    commandResponses: never;
+}
+
 const ledvanceExtend = {
     addmanuSpecificOsramCluster: () =>
         m.deviceAddCustomCluster("manuSpecificOsram", {


### PR DESCRIPTION
Added manuSpecificOsram to lib/ledvance.ts and added the cluster to all devices with ledvanceLight using extend. 

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

