### PR TITLE
Refactor faults empty string  _TZE284_ajlu4cud

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1780,7 +1780,7 @@ export const definitions: DefinitionWithExtend[] = [
                             };
 
                             if (value === 0) {
-                                return "";
+                                return "no_alarm";
                             }
 
                             for (const [bit, name] of Object.entries(faultMap)) {
@@ -2113,7 +2113,7 @@ export const definitions: DefinitionWithExtend[] = [
                             };
 
                             if (value === 0) {
-                                return "OK";
+                                return "no_alarm";
                             }
 
                             for (const [bit, name] of Object.entries(faultMap)) {


### PR DESCRIPTION
correct fault when is zero for: _TZE284_ajlu4cud

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
