### PR TITLE
fix: LiXee ZLinky: bump definition version to trigger reconfigure

### DIFF
--- a/src/devices/lixee.ts
+++ b/src/devices/lixee.ts
@@ -1872,6 +1872,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZLinky_TIC",
         vendor: "LiXee",
         description: "Lixee ZLinky",
+        version: "0.0.1",
         fromZigbee: [fzLocal.lixee_metering, fz.meter_identification, fzLocal.lixee_ha_electrical_measurement, fzLocal.lixee_private_fz],
         toZigbee: [],
         exposes: (device, options) => {


### PR DESCRIPTION
This ensures existing devices are automatically reconfigured on next
Z2M startup, picking up the tariffPeriod reportable attribute change
from 4741ae3 (#10903), using the reconfigure mechanism introduced in
2192bbb (#11148).

@Koenkk I'd have done it for 2.9.0 if I had known of this new feature. Will  there be another point release soon?