### PR TITLE
Make the attributes in manuSpecificLegrandDevices writeable 

### DIFF
--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -86,9 +86,9 @@ export const legrandExtend = {
             ID: 0xfc01,
             manufacturerCode: Zcl.ManufacturerCode.LEGRAND_GROUP,
             attributes: {
-                deviceMode: {ID: 0x0000, type: Zcl.DataType.DATA16},
-                ledInDark: {ID: 0x0001, type: Zcl.DataType.BOOLEAN},
-                ledIfOn: {ID: 0x0002, type: Zcl.DataType.BOOLEAN},
+                deviceMode: {ID: 0x0000, type: Zcl.DataType.DATA16, write: true},
+                ledInDark: {ID: 0x0001, type: Zcl.DataType.BOOLEAN, write: true},
+                ledIfOn: {ID: 0x0002, type: Zcl.DataType.BOOLEAN, write: true},
             },
             commands: {},
             commandsResponse: {},


### PR DESCRIPTION
Should solve the issue mentioned in https://github.com/Koenkk/zigbee-herdsman-converters/pull/11609#issuecomment-3983713423
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
