### PR TITLE
fix: 3-Phase current exposes missing

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2302,7 +2302,7 @@ function genericMeter(args: MeterArgs = {}) {
             exposes.push(e.voltage_phase_b().withAccess(ea.STATE_GET), e.voltage_phase_c().withAccess(ea.STATE_GET));
             toZigbee.push(tz.acvoltage_phase_b, tz.acvoltage_phase_c);
         }
-        if (args.current) {
+        if (args.current !== false) {
             exposes.push(e.current_phase_b().withAccess(ea.STATE_GET), e.current_phase_c().withAccess(ea.STATE_GET));
             toZigbee.push(tz.accurrent_phase_b, tz.accurrent_phase_c);
         }


### PR DESCRIPTION
Introduced in https://github.com/Koenkk/zigbee-herdsman-converters/pull/11539, should default to true if undefined to keep behavior as previous.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/31250
