### PR TITLE
fix: MCCGQ12LM add missing device_temperature and power_outage_count exposes

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3518,7 +3518,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         fromZigbee: [lumi.fromZigbee.lumi_contact, lumi.fromZigbee.lumi_specific, fz.ias_contact_alarm_1],
         toZigbee: [],
-        exposes: [e.contact(), e.battery(), e.battery_voltage()],
+        exposes: [e.contact(), e.battery(), e.battery_voltage(), e.device_temperature(), e.power_outage_count(false)],
         meta: {battery: {voltageToPercentage: {min: 2850, max: 3000}}},
         extend: [m.quirkCheckinInterval("1_HOUR")],
     },


### PR DESCRIPTION
## Summary

The **MCCGQ12LM** (Aqara Door and window sensor T1, `lumi.magnet.agl02`) already receives `device_temperature` and `power_outage_count` via the existing `lumi.fromZigbee.lumi_specific` converter, but these values are not listed in the `exposes` array. This prevents Home Assistant (and other frontends) from auto-discovering them.

The sibling **MCCGQ11LM** (`lumi.sensor_magnet.aq2`) correctly exposes both fields. This PR aligns the T1 model with the same pattern.

## Changes

**`src/devices/lumi.ts`** — MCCGQ12LM definition:

```diff
- exposes: [e.contact(), e.battery(), e.battery_voltage()],
+ exposes: [e.contact(), e.battery(), e.battery_voltage(), e.device_temperature(), e.power_outage_count(false)],
```

## Testing

- Tested locally on Zigbee2MQTT 2.9.1 (Home Assistant addon) using an external converter with the same change.
- After applying, `device_temperature` and `power_outage_count` appear correctly in:
  - Z2M Exposes tab
  - Home Assistant auto-discovery (device page shows temperature entity under diagnostics)
- The device (`0x54ef4410013e1206`) confirmed reporting `device_temperature: 25` and `power_outage_count: 12` in MQTT payloads.

Made with [Cursor](https://cursor.com)