### PR TITLE
fix(DJT11LM): change sensitivity expose from numeric to enum (select)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2310,7 +2310,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.vibration(),
             e.action(["vibration", "tilt", "drop"]),
             e.numeric("strength", ea.STATE),
-            e.numeric("sensitivity", ea.STATE_SET).withDescription("Sensitivity, 1 = highest, 21 = lowest").withValueMin(1).withValueMax(21),
+            e.enum("sensitivity", ea.STATE_SET, ["low", "medium", "high"]).withDescription("Sensitivity of the vibration sensor"),
             e.angle_axis("angle_x"),
             e.angle_axis("angle_y"),
             e.angle_axis("angle_z"),

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -6171,13 +6171,12 @@ export const toZigbee = {
     lumi_vibration_sensitivity: {
         key: ["sensitivity"],
         convertSet: async (entity, key, value, meta) => {
-            if (isString(value)) {
-                value = getFromLookup(value, {low: 0x15, medium: 0x0b, high: 0x01});
-            }
-            assertNumber(value);
+            assertString(value, key);
+            const stringValue = value.toLowerCase() as "low" | "medium" | "high";
+            const numericValue = getFromLookup(stringValue, {low: 0x15, medium: 0x0b, high: 0x01});
             const options = {...manufacturerOptions.lumi, timeout: 35000};
-            await entity.write("genBasic", {65293: {value, type: 0x20}}, options);
-            return {state: {sensitivity: value}};
+            await entity.write("genBasic", {65293: {value: numericValue, type: 0x20}}, options);
+            return {state: {sensitivity: stringValue}};
         },
     } satisfies Tz.Converter,
     lumi_interlock: {


### PR DESCRIPTION
## Problem

The Aqara Vibration Sensor DJT11LM (`lumi.vibration.aq1`) exposes `sensitivity` as a `numeric` type (range 1-21), which causes Home Assistant to register it as a `number` entity. However, the device state always contains sensitivity as a **string** (`"low"`, `"medium"`, `"high"`), causing a recurring HA warning:

```
WARNING homeassistant.components.mqtt.number
Payload '{"sensitivity":"medium",...}' is not a Number
```

## Root Cause

This asymmetry was introduced by commit [719f27f](https://github.com/Koenkk/zigbee-herdsman-converters/commit/719f27f06a52851e1909ee18d7a14bf35b32718c) (which changed from `e.enum` to `e.numeric` for more precise 1-21 control). However:

- The `fromZigbee` has **no handler** for attribute `65293` (sensitivity) — the device never reports sensitivity back via Zigbee attribute reports
- This means the state cache retains string values (from before the numeric change) and is **never updated** with a numeric value
- The expose says `number`, HA registers a `number` entity, but the published state always contains a string → warning

## Fix

Revert the expose back to `enum` with values `["low", "medium", "high"]`, consistent with what the device actually reports. Update the `lumi_vibration_sensitivity` toZigbee converter to:
- Only accept string values (`assertString`)
- Return the string value in the state (ensuring symmetry between expose type and published state)
- Still write the correct numeric value to the Zigbee attribute

The underlying Zigbee write still uses the correct numeric mapping (`low → 0x15`, `medium → 0x0b`, `high → 0x01`), so device behavior is unchanged.

## Changes

- `src/devices/lumi.ts`: `e.numeric("sensitivity", ea.STATE_SET)` → `e.enum("sensitivity", ea.STATE_SET, ["low", "medium", "high"])`
- `src/lib/lumi.ts`: `lumi_vibration_sensitivity` toZigbee now uses `assertString`, maps to numeric for Zigbee write, returns string in state

## References

- Issue: https://github.com/Koenkk/zigbee2mqtt/issues/3028
- Previous numeric change: commit `719f27f06a52851e1909ee18d7a14bf35b32718c`