### PR TITLE
IKEA VINDSTYRKA - label, unit, remove identify

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1169,7 +1169,6 @@ export const definitions: DefinitionWithExtend[] = [
             m.humidity(),
             m.pm25({reporting: {min: "1_MINUTE", max: "2_MINUTES", change: 2}}),
             ikeaVoc(),
-            m.identify(),
         ],
         ota: true,
     },

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -501,11 +501,12 @@ export function ikeaAirPurifier(): ModernExtend {
 export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMeasurement", IkeaVocIndexMeasurement>>) {
     return m.numeric<"manuSpecificIkeaVocIndexMeasurement", IkeaVocIndexMeasurement>({
         name: "voc_index",
-        label: "VOC index",
+        label: "tVOC",
+        unit: "μg/m³",
         cluster: "manuSpecificIkeaVocIndexMeasurement",
         attribute: "measuredValue",
         reporting: {min: "1_MINUTE", max: "2_MINUTES", change: 1},
-        description: "Sensirion VOC index",
+        description: "Sensirion tVOC",
         access: "STATE",
         ...args,
     });


### PR DESCRIPTION
1. Unit and label fixes https://github.com/Koenkk/zigbee2mqtt/issues/30970

2. Identify has no visible effect

3. When the device boots, it displays and reports 5-8 degrees higher temperature than it should. Then it slowly lowers to normal.
@Koenkk can we somehow ignore the temperature readings for 3-5 minutes after the device boots?