### PR TITLE
Add support for EGLO decorative Zigbee bulb

### DIFF
--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -84,12 +84,24 @@ export const definitions: DefinitionWithExtend[] = [
                     {ID: 3, profileID: 49152, deviceID: 258},
                 ],
             },
+            {
+                type: "Router",
+                manufacturerName: "AwoX",
+                modelID: "TLSR82xx",
+                endpoints: [
+                    {ID: 1, profileID: 260, deviceID: 257},
+                    {ID: 3, profileID: 4751, deviceID: 257},
+                ],
+            },
         ],
-        model: "33951/33948",
+        model: "AwoX-light",
         vendor: "AwoX",
-        description: "LED white",
+        description: "Generic light",
         extend: [m.light()],
-        whiteLabel: [{vendor: "EGLO", model: "12229"}],
+        whiteLabel: [
+            {vendor: "EGLO", model: "12229"},
+            {vendor: "EGLO", model: "12256"},
+        ],
     },
     {
         zigbeeModel: ["ERCU_Zm"],

--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -105,11 +105,4 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [],
         exposes: [e.action(["on", "brightness_move_to_level", "color_temperature_move"])],
     },
-    {
-        fingerprint: [{modelID: "TLSR82xx", manufacturerName: "AwoX"}],
-        model: "12256",
-        vendor: "EGLO",
-        description: "Decorative Zigbee filament bulb (E27, 5.5 W, 2200 K, 500 lm)",
-        extend: [m.deviceEndpoints({endpoints: {1: 1, 3: 3}}), m.light(), m.commandsOnOff()],
-    },
 ];


### PR DESCRIPTION
Adds support for the EGLO 12256 decorative Zigbee filament bulb.

Specifications:
- Socket: E27
- Power: 5.5 W
- Brightness: 500 lm
- Color temperature: 2200 K warm white
- Protocol: Zigbee (EGLO Connect / AwoX firmware)

Fingerprint used:
- modelID: TLSR82xx
- manufacturerName: AwoX

The device advertises the `lightingColorCtrl` cluster but only supports on/off and brightness.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4890