### PR TITLE
Update tuya.ts - Add support for TS0601 water valve (_TZE200_hbnfokum)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -25183,22 +25183,20 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_hbnfokum"]),
-        model: "TS0601_water_valve",
+        model: "TS0601_water_valve_1",
         vendor: "Tuya",
-        description: "Water valve with position control and feedback",
+        description: "Water valve",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
-            e.valve(),
-
-            exposes
+            e.switch(),
+            e
                 .numeric("position", ea.STATE_SET)
                 .withUnit("%")
                 .withValueMin(0)
                 .withValueMax(100)
                 .withValueStep(10)
-                .withDescription("Target valve position (steps of 10%)"),
-
-            exposes
+                .withDescription("Target valve position"),
+            e
                 .numeric("position_current", ea.STATE)
                 .withUnit("%")
                 .withValueMin(0)


### PR DESCRIPTION
This PR adds support for the Tuya TS0601 water valve with position control and feedback.

Fingerprint:
- modelID: TS0601
- manufacturerName: _TZE200_hbnfokum

Supported datapoints:
- DP 1   -> valve state (open/close)
- DP 101 -> target valve position (0–100%, steps of 10%)
- DP 102 -> current valve position (0–100%, steps of 10%, reports real-time feedback)

Exposes:
- valve: open/close
- position: target position (numeric, 0–100%, steps of 10%)
- position_current: current position feedback (numeric, 0–100%, steps of 10%)

Tested behavior:
- The device only supports position steps of 10%. Slider values in Home Assistant are constrained to these steps.
- Reports progressive position updates during valve movement.
- Works with Zigbee2MQTT 2.9.1 and Home Assistant.


Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4891
