### PR TITLE
VINDSTYRKA: revert label & unit, explain VOC index

### DIFF
--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -505,7 +505,7 @@ export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMe
         cluster: "manuSpecificIkeaVocIndexMeasurement",
         attribute: "measuredValue",
         reporting: {min: "1_MINUTE", max: "2_MINUTES", change: 1},
-        description: "Sensirion VOC index",
+        description: "Sensirion VOC index: 100 = average, <100 = less tVOC, >100 = more tVOC",
         access: "STATE",
         ...args,
     });


### PR DESCRIPTION
- mistakes here: https://github.com/Koenkk/zigbee-herdsman-converters/pull/11665
- https://github.com/Koenkk/zigbee2mqtt/issues/30970