### PR TITLE
Shelly remotes: Add toggle to 4 buttons. Add long press to 1 button

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1324,6 +1324,10 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SBBT-104CUS",
         vendor: "Shelly",
         description: "BLU RC Button 4 ZB",
+        whiteLabel: [
+            {vendor: "Shelly", model: "SBBT-004CEU", fingerprint: [{modelID: "SBBT-004CEU"}], description: "BLU Wall Switch 4 ZB"},
+            {vendor: "Shelly", model: "SBBT-104CEU", fingerprint: [{modelID: "SBBT-104CEU"}], description: "BLU Wall Switch 4 ZB DK"},
+        ],
         fromZigbee: [fzLocal.four_buttons_single_events, fzLocal.four_buttons_hold_events, fzLocal.four_buttons_scene_events],
         exposes: [
             e.action([
@@ -1357,24 +1361,6 @@ export const definitions: DefinitionWithExtend[] = [
                 "4_hold",
             ]),
         ],
-        extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}), m.identify()],
-        version: "0.0.2",
-        configure: async (device, coordinatorEndpoint, definition) => {
-            for (const endpoint of device.endpoints) {
-                await endpoint.bind("genOnOff", coordinatorEndpoint);
-                await endpoint.bind("genLevelCtrl", coordinatorEndpoint);
-                await endpoint.bind("genScenes", coordinatorEndpoint);
-            }
-        },
-    },
-    {
-        zigbeeModel: ["BLU Wall Switch 4 ZB"],
-        model: "SBBT-004CEU",
-        vendor: "Shelly",
-        description: "BLU Wall Switch 4 ZB",
-        whiteLabel: [{vendor: "Shelly", model: "SBBT-104CEU", description: "BLU Wall Switch 4 ZB DK"}],
-        fromZigbee: [fzLocal.four_buttons_single_events, fzLocal.four_buttons_hold_events],
-        exposes: [e.action(["1_single", "2_single", "3_single", "4_single", "1_hold", "2_hold", "3_hold", "4_hold"])],
         extend: [m.battery(), m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4}}), m.identify()],
         version: "0.0.2",
         configure: async (device, coordinatorEndpoint, definition) => {


### PR DESCRIPTION
- https://github.com/Koenkk/zigbee2mqtt/issues/31069
- https://github.com/Koenkk/zigbee2mqtt/issues/30941
- https://github.com/Koenkk/zigbee-herdsman-converters/pull/11678

Thanks @Estrobeda! The same scenes should work on the Wall Switch as well.
I renamed long to single_long, and I added toggle mode. Is it ok?

