### PR TITLE
Add support for Avatto N-TVR16 thermostatic valve

### DIFF
--- a/src/devices/avatto.ts
+++ b/src/devices/avatto.ts
@@ -615,7 +615,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Thermostatic radiator valve",
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
-        onEvent: tuya.onEventSetTime,
         configure: tuya.configureMagicPacket,
         exposes: [
             e


### PR DESCRIPTION
Added support for the Avatto N-TVR16 radiator thermostat. Manufacturer ID: _TZE204_vjpaih9f

Verified functionality via external converter:
- System Mode (Off/Heat mapped to DP 2)
- Presets (Manual, Schedule, Night, Holiday, Frost, Boost mapped to DP 2)
- Target Temperature (DP 4)
- Local Temperature (DP 5)
- Battery (DP 6)
- Child Lock (DP 7)
- Running State (DP 101)

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4900
