### PR TITLE
Add support for Acova Madras IHC towel radiator

### DIFF
--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -93,23 +93,13 @@ export const definitions: DefinitionWithExtend[] = [
         model: "IHC-Enki",
         vendor: "Acova",
         description: "Acova Madras IHC towel radiator (Zigbee thermostat)",
-
         extend: [
             m.thermostat({
-                setpoints: {
-                    values: {
-                        occupiedHeatingSetpoint: {min: 7, max: 30, step: 0.5},
-                    },
-                },
-                localTemperatureCalibration: {
-                    values: {min: -5, max: 5, step: 0.1},
-                },
-                systemMode: {
-                    values: ["off", "heat", "auto"],
-                },
+                setpoints: {values: {occupiedHeatingSetpoint: {min: 7, max: 30, step: 0.5}}},
+                localTemperatureCalibration: {values: {min: -5, max: 5, step: 0.1}},
+                systemMode: {values: ["off", "heat", "auto"]},
             }),
         ],
-
         exposes: [
             e
                 .climate()


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation

The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4902

## Description

This PR adds support for the **Acova Madras IHC** (zigbeeModel: `IHC‑Enki`), a Zigbee‑enabled towel radiator using the Acova IHC‑Enki thermostat module.

Support is implemented using `modernExtend.m.thermostat()`, providing a clean and fully compliant implementation of the Zigbee `hvacThermostat` cluster.

The device exposes:
- **local temperature** (`localTemp`)
- **heating setpoint** (`occupiedHeatingSetpoint`)
- **system mode** (`system_mode`: `off`, `heat`, `auto`)
- **local temperature calibration** (`localTemperatureCalibration`)

A complete Zigbee2MQTT `climate` entity is therefore provided:
- ambient temperature
- heating setpoint
- mode: `off`, `heat`, `auto`
- temperature calibration

Energy measurement clusters are **not supported** by the device and therefore intentionally not included.

A picture and documentation PR has been submitted separately to zigbee2mqtt.io.

## Tested

Tested with:
- Zigbee2MQTT v2.9.1
- Acova Madras IHC towel radiator (ref. 3034‑0021‑9217)
- IHC‑Enki Zigbee module

All thermostat functions work correctly:
- reading ambient temperature
- reading & writing heating setpoint
- reading & writing system mode
- reading local temperature calibration
- automatic attribute reporting