### PR TITLE
Shelly 1PM Gen 4 divisor

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1027,10 +1027,35 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            m.electricityMeter({
+                voltage: {divisor: 100},
+                current: {divisor: 1000},
+                power: {divisor: 1},
+                energy: {divisor: 1000},
+                producedEnergy: {divisor: 1000},
+                acFrequency: {divisor: 100},
+            }),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
+        configure: (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+
+            endpoint.saveClusterAttributeKeyValue("haElectricalMeasurement", {
+                acVoltageMultiplier: 1,
+                acVoltageDivisor: 100,
+                acCurrentMultiplier: 1,
+                acCurrentDivisor: 1000,
+                acFrequencyMultiplier: 1,
+                acFrequencyDivisor: 100,
+            });
+
+            endpoint.saveClusterAttributeKeyValue("seMetering", {
+                multiplier: 1,
+                divisor: 1000,
+            });
+        },
     },
     {
         zigbeeModel: ["EM Mini"],

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1030,7 +1030,6 @@ export const definitions: DefinitionWithExtend[] = [
             m.electricityMeter({
                 voltage: {divisor: 100},
                 current: {divisor: 1000},
-                power: {divisor: 1},
                 energy: {divisor: 1000},
                 producedEnergy: {divisor: 1000},
                 acFrequency: {divisor: 100},

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1026,7 +1026,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: "1PM Gen 4",
         extend: [
             m.onOff({powerOnBehavior: false}),
-            m.electricityMeter({producedEnergy: true, acFrequency: true}),
             m.electricityMeter({
                 voltage: {divisor: 100},
                 current: {divisor: 1000},


### PR DESCRIPTION
Shelly 1PM Gen 4 does not report divisors via Zigbee attributes, leading to incorrect values (e.g. 23000V instead of 230V). This PR forces correct divisors in the converter.

<img width="336" height="455" alt="Screenshot 2026-03-10 at 22 53 02" src="https://github.com/user-attachments/assets/85deb5e4-0331-422a-ad19-7ccc5d11c446" />
