### PR TITLE
Add whitelabel for BSEED S-PC86ZPCS11B curtain switch

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4663,6 +4663,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         whiteLabel: [
             tuya.whitelabel("BSEED", "EC-GL86ZPCRS31", "Curtain/blind switch", ["_TZ3000_bs93npae"]),
+            tuya.whitelabel("BSEED", "S-PC86ZPCS11B", "Curtain/blind switch", ["_TZ3000_dojqjapa"]),
             tuya.whitelabel("Danor", "SK-Z802C-US", "Smart curtain/shutter switch", ["_TZ3000_8h7wgocw"]),
             {vendor: "LoraTap", model: "SC400"},
             tuya.whitelabel("LoraTap", "SC500ZB", "Smart curtain/shutter switch", ["_TZ3000_e3vhyirx", "_TZ3000_femsaaua"]),


### PR DESCRIPTION
Impove support for BSEED S-PC86ZPCS11B curtain switch
Device link: https://www.bseed.com/products/bseed-scale-smart-zigbee-curtain-switch-work-with-alex-google-assistant
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4906
