### PR TITLE
Add fingerprint and whitelabel for BSEED S-PC86ZEUSK1B wall socket

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9055,11 +9055,15 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_ysiog9xi",
             "_TZ3000_o1jzcxou",
             "_TZ3210_nhqka112", // https://github.com/Koenkk/zigbee2mqtt/issues/30889
+            "_TZ3000_uyrhiafs",
         ]),
         model: "TS011F_plug_2",
         description: "Smart plug (without power monitoring)",
         vendor: "Tuya",
-        whiteLabel: [tuya.whitelabel("BSEED", "_TZ3000_o1jzcxou", "Wall-mounted electrical EU/FR/UK socket", ["_TZ3000_o1jzcxou"])],
+        whiteLabel: [
+            tuya.whitelabel("BSEED", "_TZ3000_o1jzcxou", "Wall-mounted electrical EU/FR/UK socket", ["_TZ3000_o1jzcxou"]),
+            tuya.whitelabel("BSEED", "S-PC86ZEUSK1B", "Wall-mounted electrical EU socket", ["_TZ3000_uyrhiafs"]),
+        ],
         extend: [
             tuya.modernExtend.tuyaOnOff({
                 powerOutageMemory: true,


### PR DESCRIPTION
Product link: https://www.bseed.com/products/bseed-scale-smart-zigbee-eu-socket-work-with-alexa-google
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4907

Originally it was reported as [TS011F_plug_1](https://www.zigbee2mqtt.io/devices/TS011F_plug_1.html), but it does not provide any power consumption data (returns nulls for Power, Current, Voltage and Energy) and the manufacturer does not say anything about power usage reporting capabilities, so I think it belongs to [TS011F_plug_2](https://www.zigbee2mqtt.io/devices/TS011F_plug_2.html). So added a fingerprint and a whitelabel.