### PR TITLE
fix: rename model TRV603 to AR331 and update descriptions

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3998,9 +3998,9 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_noixx2uz"]),
-        model: "TRV603",
+        model: "AR331",
         vendor: "Tuya",
-        description: "Thermostatic Radiator Valve",
+        description: "Thermostatic radiator valve",
         extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"})],
         exposes: [
             e.battery().withUnit("%"),


### PR DESCRIPTION
fix: rename tuya model TRV603 to AR331 and update description

as mentioned in (https://github.com/Koenkk/zigbee-herdsman-converters/pull/11463)

Link to picture pull request: (https://github.com/Koenkk/zigbee2mqtt.io/pull/4915)
Note: Can't be done yet, because TRV603.png is searched by the build action test workflow and is failing if not present. I will reopen the PR, after this is in the master branch
