### PR TITLE
feat: add Zemismart TS0726 2-gang switch (_TZ3000_icoxotza)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10406,33 +10406,23 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_icoxotza"]),
-        model: "TS0726_2_gang_switch",
-        vendor: "Zemismart",
-        description: "2-gang switch",
-        extend: [
-            tuya.modernExtend.tuyaMagicPacket(),
-            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
-            tuya.modernExtend.tuyaOnOff({
-                endpoints: ["l1", "l2"],
-                powerOnBehavior2: false,
-            }),
-        ],
-        meta: {multiEndpoint: true},
-    },
-    {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3"]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3", "_TZ3000_icoxotza"]),
         model: "TS0726_2_gang",
         vendor: "Tuya",
         description: "2 gang switch with neutral wire",
         fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
         toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode],
-        exposes: [
-            ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
-            ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
-            ...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)),
-            e.action(["scene_1", "scene_2"]),
-        ],
+        exposes: (device) => {
+            const exposes = [
+                ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
+                ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
+            ];
+            if (utils.isDummyDevice(device) || device.manufacturerName !== "_TZ3000_icoxotza") {
+                exposes.push(...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)));
+                exposes.push(e.action(["scene_1", "scene_2"]));
+            }
+            return exposes;
+        },
         endpoint: (device) => {
             return {l1: 1, l2: 2};
         },


### PR DESCRIPTION
Add support for Zemismart TS0726 2-gang switch with manufacturer name `_TZ3000_icoxotza`.

This is a plain 2-gang switch (no scene mode), distinct from the existing `TS0726_2_gang` scene switch variants.

Key notes:
- `tuyaMagicPacket()` is required for independent gang control (without it, both gangs toggle together when controlled remotely while physical buttons work fine)
- Device does not have `manuSpecificTuya` (0xEF00) cluster, only `manuSpecificTuya3` and cluster `57344` (0xE000)
- `switchType` and `backlightMode` return `UNSUPPORTED_ATTRIBUTE`
- Both gangs work independently with this definition
- Physical switches report correct per-endpoint state

Tested on Z2M Edge v2.7.2-1.