### PR TITLE
feat(add): Add VARMBLIXT table/wall (Matter version) lamp support

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -1229,10 +1229,10 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["VARMBLIXT table/wall lamp"],
-        model: "VARMBLIXT table/wall lamp",
-        vendor: "LED Light0x07C2 ",
-        description: "VARMBLIXT table/wall lamp (Matter version)",
-        extend: [m.light({colorTemp: {range: [153, 555]}, color: true})],
+        model: "E2499",
+        vendor: "IKEA",
+        description: "VARMBLIXT table/wall lamp, color/white spectrum, 180 lm",
+        extend: [m.light({colorTemp: {range: [153, 555]}, color: {modes: ["xy", "hs"]}}), m.identify()],
     },
     // #endregion sensors
 ];


### PR DESCRIPTION
## Notes

### Compatibility
The compatibility notes for the IKEA VARMBLIXT apply **only to the Matter-compatible version**.

Although it ships bundled with the IKEA BILRESA remote controller, where pairing would normally occur via TouchLink, it has been discovered that, despite being officially documented as Matter only, the device can also enter **Zigbee pairing mode**.

### Pairing
To put the IKEA VARMBLIXT (Matter-compatible version) into Zigbee pairing mode:

1. Power cycle the lamp **12 times** (It's pretty hard to do it manually, I suggest to use a smart plug if possible).
2. The lamp will flash white a couple of times, confirming it has entered pairing mode.

### Image+Docs pull request
https://github.com/Koenkk/zigbee2mqtt.io/pull/4920