### PR TITLE
Add support for DOMRAEM DOM-Z-105P CCT mode variant

### DIFF
--- a/src/devices/domraem.ts
+++ b/src/devices/domraem.ts
@@ -24,6 +24,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: [158, 495]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
+        fingerprint: [{modelID: "CCT", manufacturerName: "DOMRAEM"}],
+        model: "DOM-Z-105P_CCT",
+        vendor: "DOMRAEM",
+        description: "LED controller 5 in 1",
+        extend: [m.light({colorTemp: {range: [158, 495]}})],
+    },
+    {
         fingerprint: [{modelID: "WW/CW", manufacturerName: "DOMRAEM"}],
         model: "DOM-Z-105P_WW/CW",
         vendor: "DOMRAEM",


### PR DESCRIPTION
Add support for a DOMRAEM DOM-Z-105P controller reporting:

- modelID: CCT
- manufacturerName: DOMRAEM

This appears to be the dual white variant of the 5-in-1 controller, but using a different modelID than the currently supported WW/CW variant.

The device exposes:
- on/off
- brightness
- color temperature

Tested successfully with Zigbee2MQTT using an external converter.

Additional device information:
- Firmware: V0.10
- OUI: Telink Semiconductor

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
