### PR TITLE
fix(weiser): add endpoint mapping for SmartCode 10 locks

### DIFF
--- a/src/devices/weiser.ts
+++ b/src/devices/weiser.ts
@@ -8,6 +8,9 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Weiser",
         description: "SmartCode 10",
         extend: [m.lock({pinCodeCount: 30, readPinCodeOnProgrammingEvent: true}), m.battery()],
+        endpoint: (device) => {
+            return {default: 2};
+        },
     },
     {
         zigbeeModel: ["SMARTCODE_DEADBOLT_10T"],
@@ -15,5 +18,8 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Weiser",
         description: "SmartCode 10 Touch",
         extend: [m.lock({pinCodeCount: 30, readPinCodeOnProgrammingEvent: true}), m.battery()],
+        endpoint: (device) => {
+            return {default: 2};
+        },
     },
 ];


### PR DESCRIPTION
## Summary

- Adds `endpoint: (device) => ({default: 2})` to both Weiser SmartCode 10 (`SMARTCODE_DEADBOLT_10`) and SmartCode 10 Touch (`SMARTCODE_DEADBOLT_10T`) definitions
- These locks expose endpoint 2 (closuresDoorLock) and endpoint 196 (genPowerCfg only). Without the mapping, z2m defaults to endpoint 196, causing all lock commands and state reads to timeout
- Matches the pattern used by Kwikset locks (same hardware) which explicitly target endpoint 2

## Problem

Without an explicit `endpoint()` function, z2m falls back to `device.endpoints[0]`, which resolves to endpoint 196 on these locks. Endpoint 196 only has `genPowerCfg`, so all `closuresDoorLock` commands sent there produce:

\`\`\`
ZCL command 0x.../196 closuresDoorLock.read(["lockState"]) failed
(No ZCL response received - waiting for response TIMEOUT)
\`\`\`

This causes:
- Lock/unlock commands failing or timing out
- State reads returning nulls for battery, sound_volume, auto_relock_time
- Device appearing intermittently unavailable

## Testing

Tested on two physical 9GED18000-009 units via external converter with this fix applied:
- Before fix: ZCL timeouts on every solicited read, null attributes, commands failing
- After fix: All attributes populated, commands succeed instantly, zero errors over a 24-hour soak test (144 polls, ~1400 messages per lock)

## Notes

The Kwikset equivalents (`kwikset.ts`) already handle this correctly via explicit `device.getEndpoint(2)` in their `configure` functions. The Weiser definitions use `modernExtend` (`m.lock()`, `m.battery()`) which delegates endpoint resolution to the framework — hence the need for the `endpoint()` mapping.

Both `SMARTCODE_DEADBOLT_10` and `SMARTCODE_DEADBOLT_10T` are fixed since they share the same hardware architecture and endpoint layout.