### PR TITLE
Add QA QAFZ200, QASZP, update QADZ4DIN, fix QAT44Z6 scenes

### DIFF
--- a/src/devices/qa.ts
+++ b/src/devices/qa.ts
@@ -6,7 +6,6 @@ import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend} from "../lib/types";
-import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;


### PR DESCRIPTION
## Summary
- **QAFZ200** (TS0502B `_TZ3218_op6ztaju`): CCT light controller with custom off handler for proper turn-off behavior at 0% brightness
- **QASZP** (TS011F `_TZ3218_kwht8j5m`): Power sensor with electrical measurement polling, reactive power threshold, and Tuya DP support via `sendData` command
- **QADZ4DIN** (TS0601 `_TZE284_nthhgkd6`): Fix fingerprint, add dimming speed control (slow/middle/fast), limit switch_type to momentary/toggle only
- **QAT44Z6** (TS0601 `_TZE284_ms97nkyy`): Fix scene actions to use `e.action()` with `tuya.valueConverter.static()` so scenes appear as scene_1-6 in Home Assistant (matching QAT42Z3B behavior)

## Test plan
- [x] QAFZ200: ON/OFF, brightness, CCT, 0% brightness fully turns off
- [x] QASZP: Voltage/current/power polling, threshold settings, switch status
- [x] QADZ4DIN: 4-channel dimming, switch type, dimming speed, power on behavior
- [x] QAT44Z6: Scene actions appear as scene_1-6 in Home Assistant automations

🤖 Generated with [Claude Code](https://claude.com/claude-code)