### PR TITLE
Add additional zigbeeModel for KAJPLATS E27 bulb

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -666,7 +666,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         // https://github.com/Koenkk/zigbee2mqtt/issues/30211#issuecomment-3698674562
-        zigbeeModel: ["KAJPLATS E27 WS G95 clear 806lm"],
+        zigbeeModel: ["KAJPLATS E27 WS G95 clear 806lm", "KAJPLATS E27 806lm 95mm smart WS"],
         model: "LED2401G5",
         vendor: "IKEA",
         description: "KAJPLATS E27 bulb, white spectrum, globe, clear, 806 lm",


### PR DESCRIPTION
This is about [this device](https://www.ikea.com/nl/en/p/kajplats-led-bulb-e27-806-lumen-smart-white-spectrum-clear-globe-30611481/), showed up with a different model name for me.


