### PR TITLE
fix(shelly): fix seMetering FAILURE aborting configure and improve reporting intervals for Gen 4 PM devices

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -338,6 +338,27 @@ const shellyModernExtend = {
             {attribute: "acFrequency", minimumReportInterval: 10, maximumReportInterval: 300, reportableChange: 100},
         ]);
     },
+    // Filters out spurious energy=0 reports from Shelly Gen 4 firmware.
+    // The firmware occasionally emits currentSummDelivered=0 which would corrupt
+    // Home Assistant energy statistics (treated as a meter reset). When a valid
+    // previous energy value is known, the zero is replaced by the last good value.
+    shellyGen4EnergyZeroFilter(): ModernExtend {
+        const fzFilter: Fz.Converter<"seMetering", undefined, ["attributeReport", "readResponse"]> = {
+            cluster: "seMetering",
+            type: ["attributeReport", "readResponse"],
+            convert: (model, msg, publish, options, meta) => {
+                if (msg.data.currentSummDelivered !== undefined) {
+                    const multiplier = (msg.endpoint.getClusterAttributeValue("seMetering", "multiplier") as number) || 1;
+                    const divisor = (msg.endpoint.getClusterAttributeValue("seMetering", "divisor") as number) || 1;
+                    const energy = (msg.data.currentSummDelivered * multiplier) / divisor;
+                    if (energy === 0 && (meta.state?.energy as number) > 0) {
+                        return {energy: meta.state.energy as number, produced_energy: (meta.state.produced_energy as number) ?? 0};
+                    }
+                }
+            },
+        };
+        return {fromZigbee: [fzFilter], isModernExtend: true};
+    },
     // Polls seMetering.currentSummDelivered/currentSummReceived periodically because the Shelly
     // Gen 4 firmware rejects configureReporting for seMetering (Status FAILURE).
     shellyGen4EnergyPoll(): ModernExtend {
@@ -1068,6 +1089,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
             shellyModernExtend.shellyGen4EnergyPoll(),
+            shellyModernExtend.shellyGen4EnergyZeroFilter(),
         ],
         configure: shellyModernExtend.shellyGen4ElectricityMeterConfigure,
     },
@@ -1083,6 +1105,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
             shellyModernExtend.shellyGen4EnergyPoll(),
+            shellyModernExtend.shellyGen4EnergyZeroFilter(),
         ],
         configure: shellyModernExtend.shellyGen4ElectricityMeterConfigure,
     },

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -338,6 +338,17 @@ const shellyModernExtend = {
             {attribute: "acFrequency", minimumReportInterval: 10, maximumReportInterval: 300, reportableChange: 100},
         ]);
     },
+    // Polls seMetering.currentSummDelivered/currentSummReceived periodically because the Shelly
+    // Gen 4 firmware rejects configureReporting for seMetering (Status FAILURE).
+    shellyGen4EnergyPoll(): ModernExtend {
+        return m.poll({
+            key: "energy",
+            defaultIntervalSeconds: 300,
+            poll: async (device) => {
+                await device.getEndpoint(1).read("seMetering", ["currentSummDelivered", "currentSummReceived"]);
+            },
+        });
+    },
     shellyPowerFactorInt16Fix(): ModernExtend {
         // Shelly Gen4 devices report haElectricalMeasurement.powerFactor (0x0510) as INT16 (0x29)
         // while zigbee-herdsman defines it as INT8 (0x28). This breaks configureReporting (INVALID_DATA_TYPE).
@@ -1056,6 +1067,7 @@ export const definitions: DefinitionWithExtend[] = [
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
+            shellyModernExtend.shellyGen4EnergyPoll(),
         ],
         configure: shellyModernExtend.shellyGen4ElectricityMeterConfigure,
     },
@@ -1070,6 +1082,7 @@ export const definitions: DefinitionWithExtend[] = [
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
+            shellyModernExtend.shellyGen4EnergyPoll(),
         ],
         configure: shellyModernExtend.shellyGen4ElectricityMeterConfigure,
     },

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -312,6 +312,32 @@ function updateWS90CalculatedValues(device: Zh.Device, payload: {[key: string]: 
 // =============================================================================
 
 const shellyModernExtend = {
+    // Custom configure for Shelly Gen 4 devices with electricity metering.
+    // Uses a 5-minute maximum reporting interval instead of the default MAX (65000 s / ~18 h).
+    // At stable, low loads the change thresholds are rarely crossed, causing haElectricalMeasurement
+    // values to go unreported for many hours. seMetering.configureReporting is intentionally
+    // omitted because Shelly Gen 4 firmware rejects it with Status FAILURE; energy values are
+    // still included in every haElectricalMeasurement report.
+    shellyGen4ElectricityMeterConfigure: async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
+        const endpoint = device.getEndpoint(1);
+        await endpoint.read("haElectricalMeasurement", [
+            "acPowerDivisor",
+            "acPowerMultiplier",
+            "acCurrentDivisor",
+            "acCurrentMultiplier",
+            "acVoltageDivisor",
+            "acVoltageMultiplier",
+            "acFrequencyDivisor",
+            "acFrequencyMultiplier",
+        ]);
+        await endpoint.read("seMetering", ["divisor", "multiplier"]);
+        await endpoint.configureReporting("haElectricalMeasurement", [
+            {attribute: "activePower", minimumReportInterval: 10, maximumReportInterval: 300, reportableChange: 5},
+            {attribute: "rmsCurrent", minimumReportInterval: 10, maximumReportInterval: 300, reportableChange: 50},
+            {attribute: "rmsVoltage", minimumReportInterval: 10, maximumReportInterval: 300, reportableChange: 500},
+            {attribute: "acFrequency", minimumReportInterval: 10, maximumReportInterval: 300, reportableChange: 100},
+        ]);
+    },
     shellyPowerFactorInt16Fix(): ModernExtend {
         // Shelly Gen4 devices report haElectricalMeasurement.powerFactor (0x0510) as INT16 (0x29)
         // while zigbee-herdsman defines it as INT8 (0x28). This breaks configureReporting (INVALID_DATA_TYPE).
@@ -1026,11 +1052,12 @@ export const definitions: DefinitionWithExtend[] = [
         description: "1PM Mini Gen 4",
         extend: [
             m.onOff({powerOnBehavior: false}),
-            m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            m.electricityMeter({producedEnergy: true, acFrequency: true, configureReporting: false}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
+        configure: shellyModernExtend.shellyGen4ElectricityMeterConfigure,
     },
     {
         zigbeeModel: ["1PM"],
@@ -1039,11 +1066,12 @@ export const definitions: DefinitionWithExtend[] = [
         description: "1PM Gen 4",
         extend: [
             m.onOff({powerOnBehavior: false}),
-            m.electricityMeter({producedEnergy: true, acFrequency: true}),
+            m.electricityMeter({producedEnergy: true, acFrequency: true, configureReporting: false}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
         ],
+        configure: shellyModernExtend.shellyGen4ElectricityMeterConfigure,
     },
     {
         zigbeeModel: ["EM Mini"],

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -183,15 +183,25 @@ export async function setupAttributes<Cl extends string | number, Custom extends
         if (configureReporting) {
             await endpoint.bind(cluster, coordinatorEndpoint);
             for (const chunk of chunks) {
-                await endpoint.configureReporting<Cl, Custom>(
-                    cluster,
-                    chunk.map((a) => ({
-                        minimumReportInterval: convertReportingConfigTime(a.min),
-                        maximumReportInterval: convertReportingConfigTime(a.max),
-                        reportableChange: a.change,
-                        attribute: a.attribute,
-                    })),
-                );
+                try {
+                    await endpoint.configureReporting<Cl, Custom>(
+                        cluster,
+                        chunk.map((a) => ({
+                            minimumReportInterval: convertReportingConfigTime(a.min),
+                            maximumReportInterval: convertReportingConfigTime(a.max),
+                            reportableChange: a.change,
+                            attribute: a.attribute,
+                        })),
+                    );
+                } catch (e) {
+                    // Some devices reject configureReporting for certain clusters
+                    // (e.g. Shelly Gen 4 returns FAILURE for seMetering). Log a warning
+                    // and continue so that other clusters are still configured.
+                    logger.warning(
+                        `Failed to configure reporting for cluster '${cluster}' on ` + `${endpoint.getDevice().ieeeAddr}/${endpoint.ID}: ${e}`,
+                        "zhc:modernExtend",
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #11767

## Changes

**`modernExtend.ts`**

Wrap `configureReporting` per-chunk in try/catch. A single cluster rejection (e.g. `FAILURE` from `seMetering` on Shelly Gen 4, or `INVALID_DATA_TYPE` from `powerFactor`) no longer aborts configuration of all other clusters. A warning is logged. Same pattern as the existing try/catch on `endpoint.read`.

**`shelly.ts`** — three new helpers for Gen 4 PM devices (`S4SW-001P16EU`, `S4SW-001P8EU`):

- `shellyGen4ElectricityMeterConfigure`: uses `maximumReportInterval: 300 s` (5 min) instead of `MAX` (65000 s / ~18 h) for `haElectricalMeasurement`; omits `seMetering.configureReporting` since the firmware rejects it
- `shellyGen4EnergyPoll`: polls `seMetering.currentSummDelivered` and `currentSummReceived` every 300 s so energy values stay current without relying on firmware push reports (interval is user-configurable via `energy_poll_interval` device option)
- `shellyGen4EnergyZeroFilter`: filters out spurious `currentSummDelivered=0` reports from the Shelly firmware — when a valid previous energy value is known, the zero is replaced by the last good value to prevent Home Assistant energy statistics corruption

## Tested on

Shelly 1PM Gen 4 (`S4SW-001P16EU`), firmware `20260120-145255/1.7.4`, Z2M 2.4.0, Ember adapter (EFR32MG24)