### PR TITLE
feat: add support for Innr FL 230 C

### DIFF
--- a/src/devices/innr.ts
+++ b/src/devices/innr.ts
@@ -145,8 +145,8 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
     },
-    {    
-    zigbeeModel: ["RB 282 C"],
+    {
+        zigbeeModel: ["RB 282 C"],
         model: "RB 282 C",
         vendor: "Innr",
         description: "E27 bulb RGBW",


### PR DESCRIPTION
feat: add support for Innr FL 230 C

Adds support for Innr FL 230 C RGBW lightstrip.

Tested successfully with Zigbee2MQTT using Ember adapter.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4937
