### PR TITLE
Add solis_action converter for Yale digital lock

### DIFF
--- a/src/devices/yale.ts
+++ b/src/devices/yale.ts
@@ -551,7 +551,7 @@ const fzLocal = {
             const result: ZHTypes.KeyValue = {
                 action: actionLookup[actionCode] ?? "unknown",
                 action_source_name: sourceLookup[actionCode] ?? null,
-                action_user: msg.data[5],
+                action_source_user: msg.data[5],
             };
             if (lockActions.includes(actionCode)) {
                 result.state = "LOCK";
@@ -756,7 +756,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["SOLIS01"],
         model: "SOLIS01",
         vendor: "Yale",
-        description: "Yale Solis digital lock",
+        description: "Solis digital lock",
         fromZigbee: [fzLocal.ymc_action],
         extend: [lockExtend()],
     },


### PR DESCRIPTION
There is still a discrepancy in the battery measurement, I couldn't solve it

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
