### PR TITLE
feat: add Tuya ZD24_Presence_Sensor support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -13384,9 +13384,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withValueStep(1)
                 .withUnit("x")
                 .withDescription("Static detection sensitivity"),
-            e
-                .enum("motion_detection_mode", ea.STATE_SET, ["pir_and_radar", "only_radar", "pir_or_radar"])
-                .withDescription("Motion detection mode"),
+            e.enum("motion_detection_mode", ea.STATE_SET, ["pir_and_radar", "only_radar", "pir_or_radar"]).withDescription("Motion detection mode"),
         ],
         meta: {
             tuyaDatapoints: [


### PR DESCRIPTION
New sensor.

Physical appearance is identical to the [TS0601-PIR-Sensor](https://www.zigbee2mqtt.io/devices/TS0601-PIR-Sensor.html) and the [ZG-204ZM](https://www.zigbee2mqtt.io/devices/ZG-204ZM.html), but datapoints are quite different.

Name is from the converter provided by the seller; I made some changes to entity names and values to better match the other two sensors.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/4952
