### PR TITLE
fix: Move tradfri custom commands (genScenes) from ZH to ZHC

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -7,6 +7,7 @@ import {
     addCustomClusterManuSpecificIkeaUnknown,
     addCustomClusterManuSpecificIkeaVocIndexMeasurement,
     addCustomClusterTradfriButton,
+    addIkeaGenScenesCluster,
     ikeaAirPurifier,
     ikeaArrowClick,
     ikeaBattery,
@@ -967,6 +968,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "TRADFRI remote control",
         extend: [
             addCustomClusterManuSpecificIkeaUnknown(),
+            addIkeaGenScenesCluster(),
             ikeaConfigureRemote(),
             m.identify({isSleepy: true}),
             tradfriCommandsOnOff(),
@@ -985,6 +987,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "IKEA",
         description: "BILRESA remote control with buttons",
         extend: [
+            addIkeaGenScenesCluster(),
             m.battery({voltage: true}),
             m.identify({isSleepy: true}),
             m.commandsOnOff({commands: ["on", "off"]}),
@@ -999,6 +1002,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "IKEA",
         description: "BILRESA remote control with scroll wheel",
         extend: [
+            addIkeaGenScenesCluster(),
             m.battery({voltage: true}),
             m.identify({isSleepy: true}),
             m.commandsOnOff({commands: ["on", "off"]}),
@@ -1013,6 +1017,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "STYRBAR remote control",
         extend: [
             addCustomClusterManuSpecificIkeaUnknown(),
+            addIkeaGenScenesCluster(),
             ikeaConfigureStyrbar(),
             m.identify({isSleepy: true}),
             styrbarCommandOn(),

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -753,7 +753,7 @@ export function ikeaBilresaDouble(): ModernExtend {
                 if (hasAlreadyProcessedMessage(msg, model)) return;
                 return {action: `${msg.data.value === 257 ? "off" : "on"}_double`};
             },
-        } satisfies Fz.Converter<"genScenes", undefined, "commandTradfriArrowSingle">,
+        } satisfies Fz.Converter<"genScenes", IkeaGenScenesCluster, "commandTradfriArrowSingle">,
     ];
 
     return {exposes, fromZigbee, isModernExtend: true};
@@ -775,7 +775,7 @@ export function ikeaArrowClick(args?: {styrbar?: boolean; bind?: boolean}): Mode
                 const direction = msg.data.value === 257 ? "left" : "right";
                 return {action: `arrow_${direction}_click`};
             },
-        } satisfies Fz.Converter<"genScenes", undefined, "commandTradfriArrowSingle">,
+        } satisfies Fz.Converter<"genScenes", IkeaGenScenesCluster, "commandTradfriArrowSingle">,
         {
             cluster: "genScenes",
             type: "commandTradfriArrowHold",
@@ -785,7 +785,7 @@ export function ikeaArrowClick(args?: {styrbar?: boolean; bind?: boolean}): Mode
                 globalStore.putValue(msg.endpoint, "direction", direction);
                 return {action: `arrow_${direction}_hold`};
             },
-        } satisfies Fz.Converter<"genScenes", undefined, "commandTradfriArrowHold">,
+        } satisfies Fz.Converter<"genScenes", IkeaGenScenesCluster, "commandTradfriArrowHold">,
         {
             cluster: "genScenes",
             type: "commandTradfriArrowRelease",
@@ -799,7 +799,7 @@ export function ikeaArrowClick(args?: {styrbar?: boolean; bind?: boolean}): Mode
                     return result;
                 }
             },
-        } satisfies Fz.Converter<"genScenes", undefined, "commandTradfriArrowRelease">,
+        } satisfies Fz.Converter<"genScenes", IkeaGenScenesCluster, "commandTradfriArrowRelease">,
     ];
 
     const result: ModernExtend = {exposes, fromZigbee, isModernExtend: true};
@@ -989,6 +989,44 @@ export function addCustomClusterTradfriButton(): ModernExtend {
             action3: {name: "action3", ID: 0x03, parameters: [{name: "data", type: Zcl.DataType.UINT8, max: 0xff}]},
             action4: {name: "action4", ID: 0x04, parameters: [{name: "data", type: Zcl.DataType.UINT8, max: 0xff}]},
             action6: {name: "action6", ID: 0x06, parameters: [{name: "data", type: Zcl.DataType.UINT8, max: 0xff}]},
+        },
+        commandsResponse: {},
+    });
+}
+
+export interface IkeaGenScenesCluster {
+    attributes: never;
+    commands: {
+        tradfriArrowSingle: {
+            value: number;
+            value2: number;
+        };
+        tradfriArrowHold: {
+            value: number;
+        };
+        tradfriArrowRelease: {
+            value: number;
+        };
+    };
+    commandResponses: never;
+}
+
+export function addIkeaGenScenesCluster(): ModernExtend {
+    return m.deviceAddCustomCluster("genScenes", {
+        name: "genScenes",
+        ID: Zcl.Clusters.genScenes.ID,
+        attributes: {},
+        commands: {
+            tradfriArrowSingle: {
+                name: "tradfriArrowSingle",
+                ID: 0x07,
+                parameters: [
+                    {name: "value", type: Zcl.DataType.UINT16, max: 0xffff},
+                    {name: "value2", type: Zcl.DataType.UINT16, max: 0xffff},
+                ],
+            },
+            tradfriArrowHold: {name: "tradfriArrowHold", ID: 0x08, parameters: [{name: "value", type: Zcl.DataType.UINT16, max: 0xffff}]},
+            tradfriArrowRelease: {name: "tradfriArrowRelease", ID: 0x09, parameters: [{name: "value", type: Zcl.DataType.UINT16, max: 0xffff}]},
         },
         commandsResponse: {},
     });


### PR DESCRIPTION
Added cluster and commands with `m.deviceAddCustomCluster`. Added the cluster definition to four devices. 

see https://github.com/Koenkk/zigbee-herdsman/pull/1714
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

