### PR TITLE
add HS2SS-EF model and fix the HS1MIS illuminance issue

### DIFF
--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -1418,8 +1418,10 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "SceneSwitch-EM-3.0", manufacturerName: "HEIMAN"},
-                      {modelID: "SceneSwitch-EF-3.0", manufacturerName: "HEIMAN"}],
+        fingerprint: [
+            {modelID: "SceneSwitch-EM-3.0", manufacturerName: "HEIMAN"},
+            {modelID: "SceneSwitch-EF-3.0", manufacturerName: "HEIMAN"},
+        ],
         model: "HS2SS",
         vendor: "Heiman",
         description: "Smart scene switch",


### PR DESCRIPTION
Dear Z2M team,
this PR includes:
1.  Add HS2SS-EF model, the functions exactly covers HS2SS-EM
2. fixing legacy illuminance  issue for HS1MIS
3. changing the new HS1SA-E to HS1SA-E-PLUS for identifying.

Would you mind reviewing this? thanks.
