### PR TITLE
Fix Cigol Connect input status reporting

### DIFF
--- a/src/devices/cigol.ts
+++ b/src/devices/cigol.ts
@@ -132,7 +132,8 @@ export const definitions: DefinitionWithExtend[] = [
                     if (ep < 30) label = `Input A-${ep}`;
                     else label = `Input B-${ep - 30}`;
                     exposesArray.push(
-                        e.enum("input", ea.ALL, ["off", "single", "double", "hold"])
+                        e
+                            .enum("input", ea.ALL, ["off", "single", "double", "hold"])
                             .withDescription(`${label} (Off, Single, Double, Hold)`)
                             .withLabel(label)
                             .withEndpoint(`${ep}`),


### PR DESCRIPTION
Fixes an issue in Cigol Connect input status reporting found during internal testing.

The issue affected the cigolInput status reporting function.
Tested locally with:
- pnpm run check --fix
- pnpm run build
- pnpm test

Follow-up to the previously closed Cigol Connect PR.