### PR TITLE
Add Philips Akari downlight black (929004291601 / LCD012)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3960,10 +3960,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ['LCD012'],
-        model: '929004291601',
-        vendor: 'Philips',
-        description: 'Akari downlight (black)',
+        zigbeeModel: ["LCD012"],
+        model: "929004291601",
+        vendor: "Philips",
+        description: "Akari downlight (black)",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {


### PR DESCRIPTION
## What
Add support for the Philips Hue Akari downlight in black (929004291601).

## Device
- **Zigbee model:** LCD012
- **Product SKU:** 929004291601
- **Vendor:** Signify Netherlands B.V. (Philips)
- **Description:** Akari downlight (black housing variant)

## Notes
This is the black housing version of the existing Akari downlight 
(LCD003/8719514344723 and LCD004/8719514382350 already supported).
Identical functionality — color temp (153-500 mireds) + RGB color.
Uses the same `philips.m.light` extend as the white variants.

## Tested
Confirmed working via external converter on Z2M 2.9.1.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
