### PR TITLE
feat(sonoff): add SNZB-02DR2 fahrenheit temperature expose

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -31,6 +31,16 @@ const defaultResponseOptions = {disableDefaultResponse: false};
 const e = exposes.presets;
 const ea = exposes.access;
 
+function deriveFahrenheitFromTemperatureOptions(celsius: number, options: KeyValue) {
+    try {
+        const adjustedCelsius = utils.calibrateAndPrecisionRoundOptions(celsius, options, "temperature");
+        return utils.precisionRound((adjustedCelsius * 9) / 5 + 32, 1);
+    } catch (error) {
+        logger.error(`Failed to derive 'temperature_f' from temperature options: ${(error as Error).message}`, NS);
+        return (celsius * 9) / 5 + 32;
+    }
+}
+
 interface SonoffSnzb02d {
     attributes: {
         comfortTemperatureMax: number;
@@ -3808,6 +3818,21 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.battery({voltage: true, voltageReporting: true}),
             m.temperature(),
+            m.numeric({
+                name: "temperature_f",
+                label: "Temperature (°F)",
+                cluster: "msTemperatureMeasurement",
+                attribute: "measuredValue",
+                description: "Measured temperature value in Fahrenheit",
+                unit: "°F",
+                access: "STATE_GET",
+                reporting: false,
+                fzConvert: (model, msg, publish, options, meta) => {
+                    if (msg.data.measuredValue !== undefined) {
+                        return {temperature_f: deriveFahrenheitFromTemperatureOptions(msg.data.measuredValue / 100.0, options)};
+                    }
+                },
+            }),
             m.humidity(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             m.numeric<"customSonoffSnzb02dr2", SonoffSnzb02dr2>({

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -31,16 +31,6 @@ const defaultResponseOptions = {disableDefaultResponse: false};
 const e = exposes.presets;
 const ea = exposes.access;
 
-function deriveFahrenheitFromTemperatureOptions(celsius: number, options: KeyValue) {
-    try {
-        const adjustedCelsius = utils.calibrateAndPrecisionRoundOptions(celsius, options, "temperature");
-        return utils.precisionRound((adjustedCelsius * 9) / 5 + 32, 1);
-    } catch (error) {
-        logger.error(`Failed to derive 'temperature_f' from temperature options: ${(error as Error).message}`, NS);
-        return (celsius * 9) / 5 + 32;
-    }
-}
-
 interface SonoffSnzb02d {
     attributes: {
         comfortTemperatureMax: number;
@@ -3829,7 +3819,15 @@ export const definitions: DefinitionWithExtend[] = [
                 reporting: false,
                 fzConvert: (model, msg, publish, options, meta) => {
                     if (msg.data.measuredValue !== undefined) {
-                        return {temperature_f: deriveFahrenheitFromTemperatureOptions(msg.data.measuredValue / 100.0, options)};
+                        const celsius = msg.data.measuredValue / 100.0;
+
+                        try {
+                            const adjustedCelsius = utils.calibrateAndPrecisionRoundOptions(celsius, options, "temperature");
+                            return {temperature_f: utils.precisionRound((adjustedCelsius * 9) / 5 + 32, 1)};
+                        } catch (error) {
+                            logger.error(`Failed to derive 'temperature_f' from temperature options: ${(error as Error).message}`, NS);
+                            return {temperature_f: (celsius * 9) / 5 + 32};
+                        }
                     }
                 },
             }),


### PR DESCRIPTION
## Summary

- Improve support for SONOFF SNZB-02DR2 temperature and humidity sensor.
- Add a derived `temperature_f` expose for Fahrenheit reading while keeping the existing `temperature_units` behavior unchanged.

## Changes

- Update `src/devices/sonoff.ts` to add:
  - derived `temperature_f` expose on `msTemperatureMeasurement`
  - `GET` support for `temperature_f`
  - Fahrenheit rounding to one decimal place

## Testing

Tested with Zigbee2MQTT on SONOFF ZBDongle-P.
- Verified pairing/interview.
- Verified read/write of temperature attributes.