### PR TITLE
Update ecolink.ts

### DIFF
--- a/src/devices/ecolink.ts
+++ b/src/devices/ecolink.ts
@@ -1,6 +1,6 @@
 import * as fz from "../converters/fromZigbee";
-import * as m from "../lib/modernExtend";
 import * as exposes from "../lib/exposes";
+import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend} from "../lib/types";
 
@@ -22,10 +22,14 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ['FFZB1-SM-ECO'],
-        model: 'FFZB1-SM-ECO',
-        vendor: 'Ecolink',
-        description: 'Audio Detector: Listens for the siren tone from a UL listed smoke detector in your home and sends signal to your Zigbee HUB',
-        extend: [m.temperature(), m.iasZoneAlarm({zoneType: 'alarm', zoneAttributes: ['alarm_1', 'tamper', 'battery_low']}), m.battery({voltageToPercentage: {min: 2200, max: 3000}, voltage: true, percentageReporting: false})],
+        zigbeeModel: ["FFZB1-SM-ECO"],
+        model: "FFZB1-SM-ECO",
+        vendor: "Ecolink",
+        description: "Audio Detector: Listens for the siren tone from a UL listed smoke detector in your home and sends signal to your Zigbee HUB",
+        extend: [
+            m.temperature(),
+            m.iasZoneAlarm({zoneType: "alarm", zoneAttributes: ["alarm_1", "tamper", "battery_low"]}),
+            m.battery({voltageToPercentage: {min: 2200, max: 3000}, voltage: true, percentageReporting: false}),
+        ],
     },
 ];


### PR DESCRIPTION
Adds support for the Ecolink FFZB1-SM-ECO (FireFighter smoke audio detector).

Key points:
- Device does not report battery unless genPowerCfg reporting is explicitly configured
- This implementation binds genPowerCfg and enables battery voltage reporting
- Voltage is mapped to percentage (2.2V–3.0V)
- Exposes alarm_1, tamper, and battery_low

Tested:
- Alarm detection (siren audio) works reliably
- Battery reporting confirmed after device wake/check-in
- Temperature reporting functional

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [TODO](https://github.com/Koenkk/zigbee2mqtt.io/pull/4956)
