### PR TITLE
Add: Garnea downlight (LTD020)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -748,10 +748,11 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
-        zigbeeModel: ["LTD021", "LTD022"],
+        zigbeeModel: ["LTD020", "LTD021", "LTD022"],
         model: "9290035842",
         vendor: "Philips",
         description: "Garnea White Ambience Downlight",
+        whiteLabel: [{model: "929003123801", vendor: "Philips", description: "Garnea White Ambience Downlight", fingerprint: [{modelID: "LTD020"}]}],
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
@@ -1731,11 +1732,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
-        zigbeeModel: ["LTD020", "LTD008"],
-        model: "929003123801",
+        zigbeeModel: ["LTD008"],
+        model: "929003134801",
         vendor: "Philips",
         description: 'Hue white ambiance 6" downlight',
-        whiteLabel: [{model: "929003123801", vendor: "Philips", description: "Garnea White Ambience Downlight", fingerprint: [{modelID: "LTD020"}]}],
         extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {


### PR DESCRIPTION
- fix: Koenkk/zigbee2mqtt/issues/31512

After some time on Google, LTD008 model seems to be 929003134801
https://www.philips-hue.com/en-us/p/hue-white-ambiance-retrofit-recessed-can-downlight-5-or-6-inch/046677578527

Link to picture pull request: DONE IN
- Koenkk/zigbee2mqtt.io/pull/4962
