### PR TITLE
Move fourNoksHysteresisLow/High custom attributes from ZH to ZHC

### DIFF
--- a/src/devices/bitron.ts
+++ b/src/devices/bitron.ts
@@ -13,7 +13,43 @@ const ea = exposes.access;
 
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.ASTREL_GROUP_SRL};
 
+interface BitronHvacThermostat {
+    attributes: {
+        fourNoksHysteresisHigh: number;
+        fourNoksHysteresisLow: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 const bitron = {
+    extend: {
+        bitronHvacThermostatCluster: () =>
+            m.deviceAddCustomCluster("hvacThermostat", {
+                name: "hvacThermostat",
+                ID: Zcl.Clusters.hvacThermostat.ID,
+                attributes: {
+                    fourNoksHysteresisHigh: {
+                        name: "fourNoksHysteresisHigh",
+                        ID: 0x0101,
+                        type: Zcl.DataType.UINT16,
+                        manufacturerCode: Zcl.ManufacturerCode.ASTREL_GROUP_SRL,
+                        write: true,
+                        max: 0xffff,
+                    },
+                    fourNoksHysteresisLow: {
+                        name: "fourNoksHysteresisLow",
+                        ID: 0x0102,
+                        type: Zcl.DataType.UINT16,
+                        manufacturerCode: Zcl.ManufacturerCode.ASTREL_GROUP_SRL,
+                        write: true,
+                        max: 0xffff,
+                    },
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+    },
     fz: {
         thermostat_hysteresis: {
             cluster: "hvacThermostat",
@@ -33,7 +69,7 @@ const bitron = {
 
                 return result;
             },
-        } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
+        } satisfies Fz.Converter<"hvacThermostat", BitronHvacThermostat, ["attributeReport", "readResponse"]>,
     },
     tz: {
         thermostat_hysteresis: {
@@ -41,19 +77,31 @@ const bitron = {
             convertSet: async (entity, key, value: KeyValueAny, meta) => {
                 const result: KeyValueAny = {state: {hysteresis: {}}};
                 if (value.high != null) {
-                    await entity.write("hvacThermostat", {fourNoksHysteresisHigh: value.high}, manufacturerOptions);
+                    await entity.write<"hvacThermostat", BitronHvacThermostat>(
+                        "hvacThermostat",
+                        {fourNoksHysteresisHigh: value.high},
+                        manufacturerOptions,
+                    );
                     result.state.hysteresis.high = value.high;
                 }
 
                 if (value.low != null) {
-                    await entity.write("hvacThermostat", {fourNoksHysteresisLow: value.low}, manufacturerOptions);
+                    await entity.write<"hvacThermostat", BitronHvacThermostat>(
+                        "hvacThermostat",
+                        {fourNoksHysteresisLow: value.low},
+                        manufacturerOptions,
+                    );
                     result.state.hysteresis.low = value.low;
                 }
 
                 return result;
             },
             convertGet: async (entity, key, meta) => {
-                await entity.read("hvacThermostat", ["fourNoksHysteresisHigh", "fourNoksHysteresisLow"], manufacturerOptions);
+                await entity.read<"hvacThermostat", BitronHvacThermostat>(
+                    "hvacThermostat",
+                    ["fourNoksHysteresisHigh", "fourNoksHysteresisLow"],
+                    manufacturerOptions,
+                );
             },
         } satisfies Tz.Converter,
     },
@@ -227,6 +275,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "AV2010/32",
         vendor: "SMaBiT (Bitron Video)",
         description: "Wireless wall thermostat with relay",
+        extend: [bitron.extend.bitronHvacThermostatCluster()],
         fromZigbee: [fz.thermostat, fz.battery, fz.hvac_user_interface, bitron.fz.thermostat_hysteresis],
         toZigbee: [
             tz.thermostat_control_sequence_of_operation,


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
