### PR TITLE
Add support for _TZE284_tgrzpqf4 TS0601 soil sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4097,6 +4097,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_33bwcga2",
             "_TZE284_wckqztdq",
             "_TZE284_3urschql",
+            "_TZE284_tgrzpqf4",
         ]),
         model: "TS0601_soil_3",
         vendor: "Tuya",


### PR DESCRIPTION
Add support for _TZE284_tgrzpqf4 TS0601 soil sensor

### Description
The device was not recognized by Zigbee2MQTT and required a custom external converter. After testing, it behaves identically to the existing TS0601_soil_3 definition.

### Changes
Added _TZE284_tgrzpqf4 to the fingerprint list of TS0601_soil_3

### Testing
Tested on real hardware with reported values:
```
{
  "temperature": 25.8,
  "soil_moisture": 96,
  "battery": 25
}
```

Closes https://github.com/Koenkk/zigbee2mqtt/issues/31459
