### PR TITLE
Move custom attribute operationalStatus from ZH to ZHC (lib/ubisys.ts)

### DIFF
--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -72,6 +72,7 @@ export interface UbisysClosuresWindowCovering {
         ubisysAdditionalSteps: number;
         ubisysInactivePowerThreshold: number;
         ubisysStartupSteps: number;
+        operationalStatus: number;
     };
     commands: never;
     commandResponses: never;
@@ -528,6 +529,7 @@ export const ubisysModernExtend = {
                     write: true,
                     max: 0xffff,
                 },
+                operationalStatus: {name: "operationalStatus", ID: 0x000a, type: Zcl.DataType.BITMAP8},
             },
             commands: {},
             commandsResponse: {},


### PR DESCRIPTION
Add attribute to existing cluster definition
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
