### PR TITLE
feat(add): Mumubiz CZV20 Zigbee smart water valve

### DIFF
--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -106,8 +106,8 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [tuya.whitelabel("HOBEIAN", "ZG-807Z", "USB signal repeater", ["_TZ3000_piuensvr", "_TZ3000_hgm6k8ku"])],
     },
     {
-        zigbeeModel: ["CK-BL702-MSW-01(7010)", "CK-BL702-MSW-01(7011)-1"],
-        model: "CK-BL702-MSW-01(7010)",
+        zigbeeModel: ["CK-BL702-MSW-01(7011)-1"],
+        model: "CK-BL702-MSW-01(7011)-1",
         vendor: "eWeLink",
         description: "CMARS Zigbee smart plug",
         extend: [m.onOff({skipDuplicateTransaction: true}), m.skipDefaultResponse()],
@@ -443,5 +443,20 @@ export const definitions: DefinitionWithExtend[] = [
             await m.setupAttributes(device, coordinatorEndpoint, "closuresWindowCovering", windowCoveringAttributes);
         },
         ota: true,
+    },
+    {
+        zigbeeModel: ["CK-BL702-MSW-01(7010)"],
+        model: "CZV20",
+        vendor: "Mumubiz",
+        whiteLabel: [
+            {vendor: "eWeLink", model: "CK-BL702-MSW-01(7010)"},
+        ],
+        description: "Zigbee smart water valve",
+        extend: [m.onOff({skipDuplicateTransaction: true}), m.powerOnBehavior(), m.skipDefaultResponse()],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
+            await reporting.onOff(endpoint);
+        },
     },
 ];

--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -448,9 +448,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["CK-BL702-MSW-01(7010)"],
         model: "CZV20",
         vendor: "Mumubiz",
-        whiteLabel: [
-            {vendor: "eWeLink", model: "CK-BL702-MSW-01(7010)"},
-        ],
+        whiteLabel: [{vendor: "eWeLink", model: "CK-BL702-MSW-01(7010)"}],
         description: "Zigbee smart water valve",
         extend: [m.onOff({skipDuplicateTransaction: true}), m.powerOnBehavior(), m.skipDefaultResponse()],
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Add native support for the Mumubiz CZV20 (eWeLink CK-BL702-MSW-01(7010)) Zigbee smart water valve.

## Changes
- Split `CK-BL702-MSW-01(7010)` from the CMARS smart plug entry — it is a different device (water valve vs plug)
- Add new definition for Mumubiz CZV20 with whiteLabel reference to eWeLink
- Features: on/off switch, power-on behavior configuration
- Configure: reporting bind + onOff reporting

## Device Info
- **Vendor:** Mumubiz (eWeLink white-label)
- **Model:** CZV20
- **zigbeeModel:** CK-BL702-MSW-01(7010)
- **Clusters:** genOnOff (endpoint 1)
- **Power source:** Mains (single phase)

Closes Koenkk/zigbee2mqtt#31534