### PR TITLE
feat(sonoff): expose hidden irrigation attributes on SWV gen1

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -4919,11 +4919,6 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["msFlowMeasurement"]);
             await reporting.onOff(endpoint, {min: 1, max: 1800, change: 0});
             await endpoint.read("customClusterEwelink", [0x500c, 0x5011]);
-            try {
-                await endpoint.read("customClusterEwelink", [0x5006, 0x5007, 0x500d, 0x500e, 0x500f, 0x5010]);
-            } catch {
-                // Non-fatal — device may be sleeping (battery-powered)
-            }
         },
     },
     {


### PR DESCRIPTION
The SWV gen1 (fw 1.0.4) already reports several irrigation-related attributes on the eWeLink cluster (0xfc11) but the converter doesn't expose them. The same attributes are already supported on the Hydro ONE (SWV-ZFU/ZFE).

Added attribbutes:
```
- `real_time_irrigation_duration` (0x5006) — session duration in seconds
- `real_time_irrigation_volume` (0x5007) — session volume in liters  
- `irrigation_start_time` (0x500d) — last session start (ISO 8601)
- `irrigation_end_time` (0x500e) — last session end (ISO 8601)
- `daily_irrigation_volume` (0x500f) — daily total in liters
- `valve_work_state` (0x5010) — working/idle
```

One thing worth noting: unlike the Hydro ONE which uses seconds-since-2000 for timestamps, the gen1 SWV reports standard Unix timestamps — so `irrigationStartTime()`/`irrigationEndTime()` helpers couldn't be reused directly.

Tested on my own 2x SWV (fw 1.0.4) with live irrigation. 

All attributes update in real-time when the valve is open.