### PR TITLE
NEO NAS-PS10B2: fix presence_time sentinel value on unconfigured device

### DIFF
--- a/src/devices/neo.ts
+++ b/src/devices/neo.ts
@@ -3,7 +3,7 @@ import * as exposes from "../lib/exposes";
 import * as legacy from "../lib/legacy";
 import * as m from "../lib/modernExtend";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, KeyValue, OnEventData, OnEventType, Zh} from "../lib/types";
 
 const e = exposes.presets;
 const ea = exposes.access;


### PR DESCRIPTION
Device sends 0xFFFFFF08 (-248 signed) on DP 12 at every boot when presence_time has never been configured. Z2M caches this and republishes it with every state update, causing continuous "Invalid value" errors in Home Assistant.
Fix filters out-of-range values to prevent caching, and adds an onEvent handler to restore the last known value after a power cycle.
Fixes #11831