### PR TITLE
Fix -248 value on boot for HPS

### DIFF
--- a/src/devices/neo.ts
+++ b/src/devices/neo.ts
@@ -489,8 +489,8 @@ export const definitions: DefinitionWithExtend[] = [
                     "presence_time",
                     {
                         // Device sends 0xFFFFFF08 as sentinel when presence_time has never been
-                        // configured. Filter it out to prevent HA range errors, and restore
-                        // the last known value on device reboot via the onEvent handler above.
+                        // configured. Filter it out to prevent HA range errors.
+                        // Device will re-report its stored value after reboot via queryOnDeviceAnnounce.
                         from: (v: number) => (v >= NAS_PS10B2_PRESENCE_TIME_MIN && v <= NAS_PS10B2_PRESENCE_TIME_MAX ? v : undefined),
                         to: (v: number) => v,
                     },


### PR DESCRIPTION
The device sends 0xFFFFFF08 (-248 signed) on DP 12 at every boot when presence_time has never been configured. Z2M caches this and republishes it with every state update, causing continuous "Invalid value" errors in Home Assistant.
Fix filters out-of-range values to prevent caching, and adds an onEvent handler to restore the last known value after a power cycle.

Fixes #11831