### PR TITLE
Change _onOffTransitionTime_ unit to seconds

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -622,25 +622,23 @@ export const level_config: Fz.Converter<"genLevelCtrl", undefined, ["attributeRe
 
         // onOffTransitionTime - range 0x0000 to 0xffff - optional
         if (msg.data.onOffTransitionTime !== undefined && msg.data.onOffTransitionTime !== undefined) {
-            result[level_config].on_off_transition_time = Number(msg.data.onOffTransitionTime);
+            result[level_config].on_off_transition_time = Number(msg.data.onOffTransitionTime) / 10;
         }
 
         // onTransitionTime - range 0x0000 to 0xffff - optional
         //                    0xffff = use onOffTransitionTime
         if (msg.data.onTransitionTime !== undefined && msg.data.onTransitionTime !== undefined) {
-            result[level_config].on_transition_time = Number(msg.data.onTransitionTime);
-            if (result[level_config].on_transition_time === 65535) {
+            if (Number(msg.data.onTransitionTime) === 65535) {
                 result[level_config].on_transition_time = "disabled";
-            }
+            } else result[level_config].on_transition_time = Number(msg.data.onTransitionTime) / 10;
         }
 
         // offTransitionTime - range 0x0000 to 0xffff - optional
         //                    0xffff = use onOffTransitionTime
         if (msg.data.offTransitionTime !== undefined && msg.data.offTransitionTime !== undefined) {
-            result[level_config].off_transition_time = Number(msg.data.offTransitionTime);
-            if (result[level_config].off_transition_time === 65535) {
+            if (Number(msg.data.offTransitionTime) === 65535) {
                 result[level_config].off_transition_time = "disabled";
-            }
+            } else result[level_config].off_transition_time = Number(msg.data.offTransitionTime) / 10;
         }
 
         // startUpCurrentLevel - range 0x00 to 0xff - optional

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -753,18 +753,19 @@ export const level_config: Tz.Converter = {
         utils.assertObject(value, key);
         // onOffTransitionTime - range 0x0000 to 0xffff - optional
         if (value.on_off_transition_time != null) {
-            let onOffTransitionTimeValue = Number(value.on_off_transition_time);
+            let onOffTransitionTimeValue = Number(value.on_off_transition_time) * 10;
             if (onOffTransitionTimeValue > 65535) onOffTransitionTimeValue = 65535;
             if (onOffTransitionTimeValue < 0) onOffTransitionTimeValue = 0;
 
             await entity.write("genLevelCtrl", {onOffTransitionTime: onOffTransitionTimeValue}, utils.getOptions(meta.mapped, entity));
-            Object.assign(state, {on_off_transition_time: onOffTransitionTimeValue});
+            Object.assign(state, {on_off_transition_time: onOffTransitionTimeValue / 10});
         }
 
         // onTransitionTime - range 0x0000 to 0xffff - optional
         //                    0xffff = use onOffTransitionTime
         if (value.on_transition_time != null) {
             let onTransitionTimeValue = value.on_transition_time;
+            if (typeof onTransitionTimeValue === "number") onTransitionTimeValue *= 10;
             if (typeof onTransitionTimeValue === "string" && onTransitionTimeValue.toLowerCase() === "disabled") {
                 onTransitionTimeValue = 65535;
             } else {
@@ -779,13 +780,16 @@ export const level_config: Tz.Converter = {
             if (onTransitionTimeValue === 65535) {
                 onTransitionTimeValue = "disabled";
             }
-            Object.assign(state, {on_transition_time: onTransitionTimeValue});
+            Object.assign(state, {
+                on_transition_time: typeof onTransitionTimeValue === "number" ? onTransitionTimeValue / 10 : onTransitionTimeValue,
+            });
         }
 
         // offTransitionTime - range 0x0000 to 0xffff - optional
         //                    0xffff = use onOffTransitionTime
         if (value.off_transition_time != null) {
             let offTransitionTimeValue = value.off_transition_time;
+            if (typeof offTransitionTimeValue === "number") offTransitionTimeValue *= 10;
             if (typeof offTransitionTimeValue === "string" && offTransitionTimeValue.toLowerCase() === "disabled") {
                 offTransitionTimeValue = 65535;
             } else {
@@ -800,7 +804,9 @@ export const level_config: Tz.Converter = {
             if (offTransitionTimeValue === 65535) {
                 offTransitionTimeValue = "disabled";
             }
-            Object.assign(state, {off_transition_time: offTransitionTimeValue});
+            Object.assign(state, {
+                off_transition_time: typeof offTransitionTimeValue === "number" ? offTransitionTimeValue / 10 : offTransitionTimeValue,
+            });
         }
 
         // startUpCurrentLevel - range 0x00 to 0xff - optional

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -394,9 +394,7 @@ export class Light extends Base {
             levelConfig = levelConfig.withFeature(
                 new Numeric("on_off_transition_time", access.ALL)
                     .withLabel("ON/OFF transition time")
-                    .withDescription(
-                        "Represents the time taken to move to or from the target level when On of Off commands are received by an On/Off cluster",
-                    ),
+                    .withDescription("Seconds taken to move to or from the target level when On or Off commands are received by an On/Off cluster"),
             );
         }
         if (features.includes("on_transition_time")) {
@@ -405,7 +403,7 @@ export class Light extends Base {
                     .withLabel("ON transition time")
                     .withPreset("disabled", "disabled", "Use on_off_transition_time value")
                     .withDescription(
-                        "Represents the time taken to move the current level from the minimum level to the maximum level when an On command is received",
+                        "Seconds taken to move the current level from the minimum level to the maximum level when an On command is received",
                     ),
             );
         }
@@ -415,7 +413,7 @@ export class Light extends Base {
                     .withLabel("OFF transition time")
                     .withPreset("disabled", "disabled", "Use on_off_transition_time value")
                     .withDescription(
-                        "Represents the time taken to move the current level from the maximum level to the minimum level when an Off command is received",
+                        "Seconds taken to move the current level from the maximum level to the minimum level when an Off command is received",
                     ),
             );
         }


### PR DESCRIPTION
Zigbee attributes _onOffTransitionTime_, _onTransitionTimeValue_, _offTransitionTime_  need deciseconds.
That is very confusing, so let's use seconds in Zigbee2MQTT, like we usually do.

I only tested _onOffTransitionTime._ Works as expected now.

Why are these checks duplicated inside the same if ?

```ts
if (msg.data.onOffTransitionTime !== undefined && msg.data.onOffTransitionTime !== undefined)
```