### PR TITLE
feat: add light level custom cluster for Shelly SBHT-103C (BLU H&T Display ZB)

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -66,6 +66,16 @@ interface ShellyTRVManualMode {
     commandResponses: never;
 }
 
+interface ShellyLightLevel {
+    attributes: {
+        lightLevel: number;
+        darkThreshold: number;
+        brightThreshold: number;
+    };
+    commands: never;
+    commandResponses: never;
+}
+
 // =============================================================================
 // WS90 Weather Station - Calculated Values (stored in device.meta for persistence)
 // =============================================================================
@@ -1283,7 +1293,54 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SBHT-103C",
         vendor: "Shelly",
         description: "BLU H&T display Zigbee",
-        extend: [m.battery(), m.temperature(), m.humidity()],
+        extend: [
+            m.battery(),
+            m.temperature(),
+            m.humidity(),
+            m.deviceAddCustomCluster("shellyLightLevel", {
+                name: "shellyLightLevel",
+                ID: 0xfc21,
+                manufacturerCode: Zcl.ManufacturerCode.SHELLY,
+                attributes: {
+                    lightLevel: {name: "lightLevel", ID: 0x0000, type: Zcl.DataType.UINT8},
+                    darkThreshold: {name: "darkThreshold", ID: 0x0001, type: Zcl.DataType.UINT24},
+                    brightThreshold: {name: "brightThreshold", ID: 0x0002, type: Zcl.DataType.UINT24},
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+            m.enumLookup<"shellyLightLevel", ShellyLightLevel>({
+                name: "light_level",
+                cluster: "shellyLightLevel",
+                attribute: "lightLevel",
+                lookup: {dark: 0, twilight: 1, bright: 2},
+                description: "Coarse light level",
+                reporting: {min: "1_MINUTE", max: 900, change: 0},
+                access: "STATE_GET",
+            }),
+            m.numeric<"shellyLightLevel", ShellyLightLevel>({
+                name: "dark_threshold",
+                cluster: "shellyLightLevel",
+                attribute: "darkThreshold",
+                valueMin: 0,
+                valueMax: 65535,
+                reporting: false,
+                description: "Lux threshold below which light level is dark",
+                unit: "lx",
+                access: "ALL",
+            }),
+            m.numeric<"shellyLightLevel", ShellyLightLevel>({
+                name: "bright_threshold",
+                cluster: "shellyLightLevel",
+                attribute: "brightThreshold",
+                valueMin: 0,
+                valueMax: 65535,
+                reporting: false,
+                description: "Lux threshold above which light level is bright",
+                unit: "lx",
+                access: "ALL",
+            }),
+        ],
     },
     {
         fingerprint: [{modelID: "BLU Remote Control ZB", manufacturerName: "Shelly"}],


### PR DESCRIPTION
## What

Add support for the manufacturer-specific **Light Level** cluster (`0xFC21`) on the Shelly BLU H&T Display ZB (`SBHT-103C`).

The device definition already existed with `battery`, `temperature`, and `humidity`. This PR adds the missing custom cluster that the device firmware exposes.

## New exposes

| Property | Type | Access | Description |
|---|---|---|---|
| `light_level` | enum (`dark`, `twilight`, `bright`) | STATE_GET | Coarse ambient light level |
| `dark_threshold` | numeric (lx, 0–65535) | ALL | Lux threshold below which light level is "dark" (default: 50) |
| `bright_threshold` | numeric (lx, 0–65535) | ALL | Lux threshold above which light level is "bright" (default: 500) |

## Cluster details

- **Cluster ID:** `0xFC21`
- **Manufacturer code:** `0x1490` (Shelly)
- **Attribute 0x0000** (`lightLevel`): `UINT8`, reportable (min 60s, max 900s). Values: 0=dark, 1=twilight, 2=bright
- **Attribute 0x0001** (`darkThreshold`): `UINT24`, read/write. Default 50
- **Attribute 0x0002** (`brightThreshold`): `UINT24`, read/write. Default 500

## Tested

Tested with a real SBHT-103C device on Zigbee2MQTT 2.8.0. All three new exposes report and function correctly.

## Notes

- No changes to `fromZigbee.ts` or `toZigbee.ts` — uses modern extends exclusively
- Follows the same pattern as other Shelly custom clusters (WS90 wind/UV/rain, TRV manual mode)
