### PR TITLE
Add: New whitelabel TS0210

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11757,6 +11757,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [
             tuya.whitelabel("Niceboy", "ORBIS Vibration Sensor", "Vibration sensor", ["_TYZB01_821siati"]),
             tuya.whitelabel("iHseno", "_TZ3000_lzdjjfss", "Vibration sensor", ["_TZ3000_lzdjjfss"]),
+            tuya.whitelabel("ONENUO", "TS0210_5oy7cysk", "Vibration sensor", ["'_TZ32101000000_5oy7cysk'"]),
         ],
         fromZigbee: [fz.battery, fz.ias_vibration_alarm_1_with_timeout],
         toZigbee: [tz.TS0210_sensitivity],


### PR DESCRIPTION
Add new whitelabel for `TS0210` 

Brand ONENUO
Aliexpress device: [link](https://pt.aliexpress.com/item/1005009477113844.html?spm=a2g0o.order_list.order_list_main.5.90e01802TnQoI1&gatewayAdapt=glo2bra#nav-specification)

Closes https://github.com/Koenkk/zigbee2mqtt/issues/30465, 

Referenced in https://github.com/Koenkk/zigbee2mqtt/issues/28652
