### PR TITLE
feat Sinope TH1300ZB - Expose missing floor_temperature and room_temperature

### DIFF
--- a/src/devices/sinope.ts
+++ b/src/devices/sinope.ts
@@ -1583,11 +1583,9 @@ export const definitions: DefinitionWithExtend[] = [
             // floorTemperature (0x0107) and roomTemperature (0x010D) do not support configureReporting
             // (device returns UNREPORTABLE_ATTRIBUTE). Perform an initial read on pairing; ongoing sync
             // is handled by piggybacking on local_temperature reports in fzLocal.thermostat.
-            await endpoint.read<"manuSpecificSinope", ManuSpecificSinope>(
-                "manuSpecificSinope",
-                ["floorTemperature", "roomTemperature"],
-                {manufacturerCode: Zcl.ManufacturerCode.SINOPE_TECHNOLOGIES},
-            );
+            await endpoint.read<"manuSpecificSinope", ManuSpecificSinope>("manuSpecificSinope", ["floorTemperature", "roomTemperature"], {
+                manufacturerCode: Zcl.ManufacturerCode.SINOPE_TECHNOLOGIES,
+            });
         },
     },
     {


### PR DESCRIPTION
Disclaimer, I am a human with limited knowledge of JS. The external extension referenced later and the code included in this PR has been mostly generated by AI, tested by me and iterating over multiple days of testing and enhancing the code and fixing issues. I'm sure you always take time to review code carefully but please take this into consideration when reviewing this PR.  

I wasn't able to test this exact change as I was unable to modify the file inside my Z2M addon it kept getting rewritten on every restart, I tested the external extension I shared in this bug report: https://github.com/Koenkk/zigbee2mqtt/issues/21243#issuecomment-4158385124 for few days without issue.  I'm more than willing to test it if someone can guide me without breaking my whole production setup ;)

Thanks!

----
## What this PR does

Adds `floor_temperature` and `room_temperature` as native exposed attributes for the Sinopé TH1300ZB Zigbee floor heating thermostat (and its `TH1320ZB-04` whitelabel variant).

Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/21243 

## Background

The TH1300ZB exposes two temperature attributes on the `manuSpecificSinope` cluster (0xff01) that Z2M was not surfacing:

- `floorTemperature` (attribute 0x0107, INT16, manufacturer code 0x119C) — the temperature measured by the floor probe
- `roomTemperature` (attribute 0x010D, INT16, manufacturer code 0x119C) — the ambient room temperature measured by the internal sensor

These are distinct from `local_temperature` (reported via `hvacThermostat`), which reflects whichever sensor the thermostat is currently using for control depending on `floor_control_mode`.

## Why polling is required

Both attributes return `UNREPORTABLE_ATTRIBUTE` when `configureReporting` is attempted — the device does not support automatic push for these attributes. They must be read on demand via a direct ZCL read with the Sinopé manufacturer code.

## Implementation

**Piggyback read on `local_temperature`:** Inside `fzLocal.thermostat`, when `localTemp` is present in the message and the device model is `TH1300ZB`, a fire-and-forget ZCL read of `floorTemperature` and `roomTemperature` is triggered on the same endpoint. The `.catch()` ensures a failed read never disrupts `local_temperature` reporting. The `readResponse` is decoded by the existing `fzLocal.sinope` converter which already handled both attributes.

**Initial read on pairing:** The `configure` function performs an initial read of both attributes immediately after pairing so values are available without waiting for the first `local_temperature` report.

**Exposes:** Both attributes are exposed as `ea.STATE` (read-only). `ea.STATE_GET` was considered but rejected — the standard Z2M `/get` path does not pass the required manufacturer code, so advertising get support would be misleading.

## Testing

Tested on a real TH1300ZB (IEEE `0x500b91400006ae67`, Z2M 2.9.1, HA OS):

- Confirmed `floorTemperature` and `roomTemperature` are readable via direct ZCL read with `manufacturerCode: 0x119C`
- Confirmed `configureReporting` returns `UNREPORTABLE_ATTRIBUTE` for both attributes
- Validated the piggyback approach via a Z2M external extension that used the identical read mechanism — values updated correctly in lockstep with every `local_temperature` change
- Verified that `floor_temperature` tracks `local_temperature` when the thermostat is in `floor` control mode
- Cross-referenced attribute IDs and manufacturer code against the SmartThings Sinopé driver source and ZHA quirks

## References

- **ZHA quirks (Sinopé TH1300ZB):** https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/sinope/thermostat.py — confirmed attribute IDs `0x0107` (floorTemperature) and `0x010D` (roomTemperature) on cluster `0xff01` with manufacturer code `0x119C`
- **SmartThings driver (Sinopé TH1300ZB v1.0.5):** `Sinope_Technologies_TH1300ZB_V_1_0_5` — confirmed same attribute IDs and manufacturer code, and that the controller is expected to poll these attributes rather than rely on automatic reporting
- **Z2M issue:** #21243 — documents the missing attributes and user requests for this feature