### PR TITLE
Add support for Mill Smart Floor Thermostat WiFi & Zigbee

### DIFF
--- a/src/devices/mill.ts
+++ b/src/devices/mill.ts
@@ -1,9 +1,5 @@
-import * as fz from "../converters/fromZigbee";
-import * as tz from "../converters/toZigbee";
-import * as exposes from "../lib/exposes";
+import * as m from "../lib/modernExtend";
 import type {DefinitionWithExtend} from "../lib/types";
-
-const e = exposes.presets;
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -11,18 +7,37 @@ export const definitions: DefinitionWithExtend[] = [
         model: "Mill-gen-4",
         vendor: "Mill",
         description: "WiFi heating panel gen4",
-        fromZigbee: [fz.thermostat, fz.identify],
-        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_system_mode, tz.identify],
-        exposes: [e.climate().withSetpoint("occupied_heating_setpoint", 5, 35, 0.5).withLocalTemperature().withSystemMode(["off", "heat"])],
+        extend: [
+            m.identify(),
+            m.thermostat({
+                setpoints: {
+                    values: {
+                        occupiedHeatingSetpoint: {min: 5, max: 35, step: 0.5},
+                    },
+                },
+                systemMode: {
+                    values: ["off", "heat"],
+                },
+            }),
+        ],
     },
     {
         fingerprint: [{manufacturerName: "Mill International\u0000Threa"}, {manufacturerName: "Mill InternationalThrea"}],
         zigbeeModel: ["Mill International\u0000Threa", "Mill InternationalThrea"],
-        model: "mill_smart_floor_thermostat",
+        model: "MFTWIFI",
         vendor: "Mill",
         description: "Mill Smart Floor Thermostat WiFi & Zigbee",
-        fromZigbee: [fz.thermostat],
-        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_system_mode],
-        exposes: [e.climate().withSetpoint("occupied_heating_setpoint", 5, 35, 0.5).withLocalTemperature().withSystemMode(["off", "heat"])],
+        extend: [
+            m.thermostat({
+                setpoints: {
+                    values: {
+                        occupiedHeatingSetpoint: {min: 5, max: 35, step: 0.5},
+                    },
+                },
+                systemMode: {
+                    values: ["off", "heat"],
+                },
+            }),
+        ],
     },
 ];

--- a/src/devices/mill.ts
+++ b/src/devices/mill.ts
@@ -26,7 +26,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["Mill International\u0000Threa", "Mill InternationalThrea"],
         model: "MFTWIFI",
         vendor: "Mill",
-        description: "Mill Smart Floor Thermostat WiFi & Zigbee",
+        description: "Smart floor thermostat WiFi & Zigbee",
         extend: [
             m.thermostat({
                 setpoints: {

--- a/src/devices/mill.ts
+++ b/src/devices/mill.ts
@@ -15,4 +15,17 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_system_mode, tz.identify],
         exposes: [e.climate().withSetpoint("occupied_heating_setpoint", 5, 35, 0.5).withLocalTemperature().withSystemMode(["off", "heat"])],
     },
+    {
+        fingerprint: [
+            {manufacturerName: "Mill International\u0000Threa"},
+            {manufacturerName: "Mill InternationalThrea"},
+        ],
+        zigbeeModel: ["Mill International\u0000Threa", "Mill InternationalThrea"],
+        model: "mill_smart_floor_thermostat",
+        vendor: "Mill",
+        description: "Mill Smart Floor Thermostat WiFi & Zigbee",
+        fromZigbee: [fz.thermostat],
+        toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_system_mode],
+        exposes: [e.climate().withSetpoint("occupied_heating_setpoint", 5, 35, 0.5).withLocalTemperature().withSystemMode(["off", "heat"])],
+    },
 ];

--- a/src/devices/mill.ts
+++ b/src/devices/mill.ts
@@ -16,10 +16,7 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.climate().withSetpoint("occupied_heating_setpoint", 5, 35, 0.5).withLocalTemperature().withSystemMode(["off", "heat"])],
     },
     {
-        fingerprint: [
-            {manufacturerName: "Mill International\u0000Threa"},
-            {manufacturerName: "Mill InternationalThrea"},
-        ],
+        fingerprint: [{manufacturerName: "Mill International\u0000Threa"}, {manufacturerName: "Mill InternationalThrea"}],
         zigbeeModel: ["Mill International\u0000Threa", "Mill InternationalThrea"],
         model: "mill_smart_floor_thermostat",
         vendor: "Mill",


### PR DESCRIPTION
## Add support for Mill Smart Floor Thermostat WiFi & Zigbee

This PR adds support for a Mill floor thermostat to `src/devices/mill.ts`.

### Device identification

The device was matched with the following identifiers:

* `manufacturerName: "Mill International\u0000Threa"`
* `manufacturerName: "Mill InternationalThrea"`
* `zigbeeModel: "Mill International\u0000Threa"`
* `zigbeeModel: "Mill InternationalThrea"`

### Supported features confirmed

The following standard thermostat features were tested and confirmed working:

* local temperature
* occupied heating setpoint
* system mode (`off`, `heat`)

### Implementation details

This uses the standard thermostat converters only:

* `fromZigbee: [fz.thermostat]`
* `toZigbee: [tz.thermostat_occupied_heating_setpoint, tz.thermostat_system_mode]`

No custom converter was added because the device responded correctly to the standard thermostat functionality.

### Notes

I tested additional attributes and vendor-like thermostat attributes, including attempts to expose separate floor temperature, but those returned unsupported or `N/A` on this device over Zigbee. So this PR intentionally keeps support limited to the features that were actually verified working.

### Existing external converter used for validation

The device was first validated with a working external converter in Zigbee2MQTT before converting it into the repository device definition.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
