### PR TITLE
Add Chameleon Technology CT101xxxx

### DIFF
--- a/src/devices/chameleon_technology.ts
+++ b/src/devices/chameleon_technology.ts
@@ -1,0 +1,16 @@
+import * as exposes from "../lib/exposes";
+import * as m from "../lib/modernExtend";
+import type {DefinitionWithExtend} from "../lib/types";
+
+const e = exposes.presets;
+
+export const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ["CT101xxxx"],
+        model: "CT101xxxx",
+        vendor: "Chameleon Technology",
+        description: "Energy Clamp",
+        extend: [m.battery(), m.deviceTemperature(), m.electricityMeter({power: false, voltage: false})],
+        exposes: [e.power()],
+    },
+];

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -45,6 +45,7 @@ import {definitions as casaia} from "./casaia";
 import {definitions as cel} from "./cel";
 import {definitions as centralite} from "./centralite";
 import {definitions as chacon} from "./chacon";
+import {definitions as chameleonTechnology} from "./chameleon_technology";
 import {definitions as cigol} from "./cigol";
 import {definitions as cleode} from "./cleode";
 import {definitions as cleverio} from "./cleverio";
@@ -418,6 +419,7 @@ const definitions: DefinitionWithExtend[] = [
     ...cel,
     ...centralite,
     ...chacon,
+    ...chameleonTechnology,
     ...cigol,
     ...cleode,
     ...cleverio,


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
- docs: https://github.com/Koenkk/zigbee2mqtt.io/pull/4993
- fixes: https://github.com/Koenkk/zigbee2mqtt/issues/31598

Weird stuff going on there. Device gives power data. But when it's read manually / configured to report, it fails with unsupported_attribute

PS. I think the automated definition should be improved for electricity meter