### PR TITLE
Add support for Moes Star Feather TS0601 curtain switch (_TZE284_upt8…

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -84,32 +84,6 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
-        model: "MOES_TS0601_curtain_switch",
-        vendor: "Moes/Tuya",
-        description: "Star Feather Zigbee curtain switch",
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
-        onEvent: tuya.onEventSetTime,
-        configure: tuya.configureMagicPacket,
-        options: [exposes.options.invert_cover()],
-        exposes: [e.cover_position().setAccess("position", ea.STATE_SET)],
-        meta: {
-            tuyaDatapoints: [
-                [
-                    1,
-                    "state",
-                    tuya.valueConverterBasic.lookup({
-                        OPEN: tuya.enum(0),
-                        STOP: tuya.enum(1),
-                        CLOSE: tuya.enum(2),
-                    }),
-                ],
-                [2, "position", tuya.valueConverter.coverPosition],
-            ],
-        },
-    },
-    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_zxkwaztm"]),
         model: "ZHT-S03",
         vendor: "Moes",
@@ -465,6 +439,21 @@ export const definitions: DefinitionWithExtend[] = [
                 l2: 1,
                 l3: 1,
             };
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
+        model: "ZS-SF-EUC-WH-MS",
+        vendor: "Moes",
+        description: "Star feather Zigbee curtain switch",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        options: [exposes.options.invert_cover()],
+        exposes: [e.cover_position().setAccess("position", ea.STATE_SET)],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tuya.valueConverterBasic.lookup({OPEN: tuya.enum(0), STOP: tuya.enum(1), CLOSE: tuya.enum(2)})],
+                [2, "position", tuya.valueConverter.coverPosition],
+            ],
         },
     },
     {

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -84,6 +84,26 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+    fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
+    model: "ZSFE_CURTAIN_SWITCH",
+    vendor: "Moes",
+    description: "Star Feather Zigbee smart curtain switch",
+    fromZigbee: [fz.cover_position_tilt, tuya.fz.datapoints],
+    toZigbee: [tz.cover_position_tilt, tz.cover_state, tuya.tz.datapoints],
+    exposes: [
+        e.cover_position(),
+        e.position(),
+    ],
+    meta: {
+        tuyaDatapoints: [
+            [1, "state", tuya.valueConverterBasic.lookup({open: 0, stop: 1, close: 2})],
+            [2, "position", tuya.valueConverter.coverPosition],
+        ],
+    },
+    onEvent: tuya.onEventSetTime,
+    configure: tuya.configureMagicPacket,
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_zxkwaztm"]),
         model: "ZHT-S03",
         vendor: "Moes",

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -84,24 +84,21 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-    fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
-    model: "ZSFE_CURTAIN_SWITCH",
-    vendor: "Moes",
-    description: "Star Feather Zigbee smart curtain switch",
-    fromZigbee: [fz.cover_position_tilt, tuya.fz.datapoints],
-    toZigbee: [tz.cover_position_tilt, tz.cover_state, tuya.tz.datapoints],
-    exposes: [
-        e.cover_position(),
-        e.position(),
-    ],
-    meta: {
-        tuyaDatapoints: [
-            [1, "state", tuya.valueConverterBasic.lookup({open: 0, stop: 1, close: 2})],
-            [2, "position", tuya.valueConverter.coverPosition],
-        ],
-    },
-    onEvent: tuya.onEventSetTime,
-    configure: tuya.configureMagicPacket,
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
+        model: "ZSFE_CURTAIN_SWITCH",
+        vendor: "Moes",
+        description: "Star Feather Zigbee smart curtain switch",
+        fromZigbee: [fz.cover_position_tilt, tuya.fz.datapoints],
+        toZigbee: [tz.cover_position_tilt, tz.cover_state, tuya.tz.datapoints],
+        exposes: [e.cover_position(), e.position()],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tuya.valueConverterBasic.lookup({open: 0, stop: 1, close: 2})],
+                [2, "position", tuya.valueConverter.coverPosition],
+            ],
+        },
+        onEvent: tuya.onEventSetTime,
+        configure: tuya.configureMagicPacket,
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_zxkwaztm"]),

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -84,29 +84,31 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-    fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
-    model: "MOES_TS0601_curtain_switch",
-    vendor: "Moes/Tuya",
-    description: "Star Feather Zigbee curtain switch",
-    fromZigbee: [tuya.fz.datapoints],
-    toZigbee: [tuya.tz.datapoints],
-    onEvent: tuya.onEventSetTime,
-    configure: tuya.configureMagicPacket,
-    options: [exposes.options.invert_cover()],
-    exposes: [
-        e.cover_position().setAccess("position", ea.STATE_SET),
-    ],
-    meta: {
-        tuyaDatapoints: [
-            [1, "state", tuya.valueConverterBasic.lookup({
-                OPEN: tuya.enum(0),
-                STOP: tuya.enum(1),
-                CLOSE: tuya.enum(2),
-            })],
-            [2, "position", tuya.valueConverter.coverPosition],
-        ],
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
+        model: "MOES_TS0601_curtain_switch",
+        vendor: "Moes/Tuya",
+        description: "Star Feather Zigbee curtain switch",
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        onEvent: tuya.onEventSetTime,
+        configure: tuya.configureMagicPacket,
+        options: [exposes.options.invert_cover()],
+        exposes: [e.cover_position().setAccess("position", ea.STATE_SET)],
+        meta: {
+            tuyaDatapoints: [
+                [
+                    1,
+                    "state",
+                    tuya.valueConverterBasic.lookup({
+                        OPEN: tuya.enum(0),
+                        STOP: tuya.enum(1),
+                        CLOSE: tuya.enum(2),
+                    }),
+                ],
+                [2, "position", tuya.valueConverter.coverPosition],
+            ],
+        },
     },
-},
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_zxkwaztm"]),
         model: "ZHT-S03",

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -84,22 +84,29 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
-        model: "ZSFE_CURTAIN_SWITCH",
-        vendor: "Moes",
-        description: "Star Feather Zigbee smart curtain switch",
-        fromZigbee: [fz.cover_position_tilt, tuya.fz.datapoints],
-        toZigbee: [tz.cover_position_tilt, tz.cover_state, tuya.tz.datapoints],
-        exposes: [e.cover_position(), e.position()],
-        meta: {
-            tuyaDatapoints: [
-                [1, "state", tuya.valueConverterBasic.lookup({open: 0, stop: 1, close: 2})],
-                [2, "position", tuya.valueConverter.coverPosition],
-            ],
-        },
-        onEvent: tuya.onEventSetTime,
-        configure: tuya.configureMagicPacket,
+    fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
+    model: "MOES_TS0601_curtain_switch",
+    vendor: "Moes/Tuya",
+    description: "Star Feather Zigbee curtain switch",
+    fromZigbee: [tuya.fz.datapoints],
+    toZigbee: [tuya.tz.datapoints],
+    onEvent: tuya.onEventSetTime,
+    configure: tuya.configureMagicPacket,
+    options: [exposes.options.invert_cover()],
+    exposes: [
+        e.cover_position().setAccess("position", ea.STATE_SET),
+    ],
+    meta: {
+        tuyaDatapoints: [
+            [1, "state", tuya.valueConverterBasic.lookup({
+                OPEN: tuya.enum(0),
+                STOP: tuya.enum(1),
+                CLOSE: tuya.enum(2),
+            })],
+            [2, "position", tuya.valueConverter.coverPosition],
+        ],
     },
+},
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_zxkwaztm"]),
         model: "ZHT-S03",


### PR DESCRIPTION
Adds support for the Moes Star Feather Zigbee curtain switch.

Fingerprint:
- modelID: `TS0601`
- manufacturerName: `_TZE284_upt8lzi0`

Tested working features:
- open
- close
- stop
- position control
- position reporting

Mapped datapoints:
- DP 1 = state
- DP 2 = position

Product page:
https://moeshouse.com/products/star-feather-zigbee-smart-curtain-switch-anti-glare-touch-panel
