### PR TITLE
Fix Namron Simplify Remote

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -11,6 +11,7 @@ import * as store from "../lib/store";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend, Fz, KeyValue, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
+import * as zosung from "../lib/zosung";
 
 const ea = exposes.access;
 const e = exposes.presets;
@@ -2105,7 +2106,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "4512793",
         vendor: "Namron",
         description: "Simplify 6-button remote with battery",
-        extend: [m.battery()],
+        extend: [m.battery(), zosung.zosungExtend.addZosungIRControlCluster()],
         fromZigbee: [fzNamronSimplifyRemote],
         toZigbee: [],
         exposes: [

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -11,7 +11,6 @@ import * as store from "../lib/store";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend, Fz, KeyValue, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
-import * as zosung from "../lib/zosung";
 
 const ea = exposes.access;
 const e = exposes.presets;
@@ -145,14 +144,14 @@ const simplify_col = (n: number) => Math.floor((n - 1) / 2) + 1;
 const simplify_sub = (n: number) => (n % 2 === 1 ? "up" : "down");
 
 // Minimal custom-cluster shape to satisfy Fz.Converter generic constraints
-type ZosungIRCustomCluster = {
+type NamronPrivateE004 = {
     attributes: Record<string, never>;
     commands: Record<string, never>;
     commandResponses: Record<string, never>;
 };
 
 // Helper to safely parse bytes from msg without any/unknown
-function parseZosungIRBytes(msg: Fz.Message<"zosungIRControl", ZosungIRCustomCluster, ["raw"]>): number[] {
+function parseNamronBytes(msg: Fz.Message<"namronPrivateE004", NamronPrivateE004, ["raw"]>): number[] {
     type RawContainer = {data?: number[]};
     type DataShape = RawContainer | number[] | Record<string, number>;
     const m = msg as {type?: string; data?: DataShape};
@@ -182,11 +181,11 @@ function parseZosungIRBytes(msg: Fz.Message<"zosungIRControl", ZosungIRCustomClu
     return [];
 }
 
-const fzNamronSimplifyRemote: Fz.Converter<"zosungIRControl", ZosungIRCustomCluster, ["raw"]> = {
-    cluster: "zosungIRControl",
+const fzNamronSimplifyRemote: Fz.Converter<"namronPrivateE004", NamronPrivateE004, ["raw"]> = {
+    cluster: "namronPrivateE004",
     type: ["raw"],
     convert(model, msg, publish, _options, meta) {
-        const bytes = parseZosungIRBytes(msg);
+        const bytes = parseNamronBytes(msg);
         if (bytes.length === 0) return;
 
         const btn = bytes.at(-2);
@@ -2106,7 +2105,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "4512793",
         vendor: "Namron",
         description: "Simplify 6-button remote with battery",
-        extend: [m.battery(), zosung.zosungExtend.addZosungIRControlCluster()],
+        extend: [m.battery(), namron.namronExtend.addCustomClusterNamronPrivateE004()],
         fromZigbee: [fzNamronSimplifyRemote],
         toZigbee: [],
         exposes: [

--- a/src/lib/namron.ts
+++ b/src/lib/namron.ts
@@ -429,3 +429,14 @@ export const edgeThermostat = {
             }),
     },
 };
+
+export const namronExtend = {
+    addCustomClusterNamronPrivateE004: () =>
+        modernExtend.deviceAddCustomCluster("namronPrivateE004", {
+            name: "namronPrivateE004",
+            ID: 0xe004,
+            attributes: {},
+            commands: {},
+            commandsResponse: {},
+        }),
+};


### PR DESCRIPTION
Users reports no actions from this remote:

```
[2026-04-06 12:16:22] debug:     z2m: Received Zigbee message from '0x04e3e5fffe7c3ef9', type 'raw', cluster '57348', data '{"data":[25,75,0,2,1],"type":"Buffer"}' from endpoint 1 with groupID 0
[2026-04-06 12:16:22] debug:     z2m: No converter available for '4512793' with cluster '57348' and type 'raw' and data '{"data":[25,75,0,2,1],"type":"Buffer"}'
```

I think this fixes it, @svhelge can you check?

- fixes https://github.com/Koenkk/zigbee2mqtt/issues/31624