### PR TITLE
fix EMIZB-132: AddCustomDevelcoSeMeteringCluster - attribute develcoInterfaceMode was not defined

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -337,6 +337,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             develcoModernExtend.emizb132DivisorInjector(),
             develcoModernExtend.emizb132InterfaceMode(),
+            develcoModernExtend.addCustomDevelcoSeMeteringCluster(),
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
             m.numeric<"haElectricalMeasurement", undefined>({


### PR DESCRIPTION
Add custom attribute develcoInterfaceMode (in cluster seMetering) to the device. Should hopefully fix the issue related to develcioInterfaceMode mentioned here https://github.com/Koenkk/zigbee-herdsman-converters/pull/11717#issuecomment-4189289517

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
