### PR TITLE
Fix LIDL bulbs part 1

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5654,7 +5654,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "RGB+CCT light controller",
         extend: [
-            tuya.modernExtend.tuyaBase(),
             tuya.modernExtend.tuyaLight({
                 colorTemp: {range: undefined},
                 color: true,


### PR DESCRIPTION
There's more work needed here. Device uses some crazy custom commands, that I need to implement. 
But this is enough to _prevent_ locking the bulb into color temp mode
- https://github.com/Koenkk/zigbee-herdsman-converters/issues/11872