### PR TITLE
EMIZB-132: Simplify and hopefully improve the power issue

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -7,7 +7,7 @@ import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz, KeyValue, Tz} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValue, KeyValueAny, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
@@ -123,19 +123,33 @@ const develco = {
                 return state;
             },
         } satisfies Fz.Converter<"ssIasZone", DevelcoIasZone, ["attributeReport", "readResponse"]>,
-        fixInvalidMeteringValuesEmizb132: {
+        metering_emizb132: {
             cluster: "seMetering",
             type: ["attributeReport", "readResponse"],
-            // Data filtering for currentSummDelivered (energy)
             convert: (model, msg, publish, options, meta) => {
-                const value = msg.data["currentSummDelivered"];
-                if (value === 0 || value === 0xffffffffffff || Number.isNaN(value)) {
-                    return;
+                if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+                const payload: KeyValueAny = {};
+                const multiplier = 1; // msg.endpoint.getClusterAttributeValue("seMetering", "multiplier") as number;
+                const divisor = 1000; // msg.endpoint.getClusterAttributeValue("seMetering", "divisor") as number;
+                const factor = multiplier && divisor ? multiplier / divisor : null;
+
+                if (msg.data.currentSummDelivered !== undefined) {
+                    const value = msg.data.currentSummDelivered;
+                    if (value === 0 || value === 0xffffffffffff || Number.isNaN(value)) {
+                        return;
+                    }
+                    const property = utils.postfixWithEndpointName("energy", msg, model, meta);
+                    payload[property] = value * (factor ?? 1);
                 }
-                return fz.metering.convert(model, msg, publish, options, meta);
+                if (msg.data.currentSummReceived !== undefined) {
+                    const value = msg.data.currentSummReceived;
+                    const property = utils.postfixWithEndpointName("produced_energy", msg, model, meta);
+                    payload[property] = value * (factor ?? 1);
+                }
+                return payload;
             },
         } satisfies Fz.Converter<"seMetering", undefined, ["attributeReport", "readResponse"]>,
-        correctCurrentDivisorEmizb132: {
+        electrical_measurement_emizb132: {
             cluster: "haElectricalMeasurement",
             type: ["attributeReport", "readResponse"],
             convert: (model, msg, publish, options, meta) => {
@@ -146,23 +160,20 @@ const develco = {
                     kaifa_and_kamstrup: {value: 0x0203, acCurrentDivisor: 1000},
                 };
                 const result = fz.electrical_measurement.convert(model, msg, publish, options, meta) as KeyValue;
-                logger.info(`EMIZB-132 RAW DATA: ${JSON.stringify(msg.data)}`, "zhc:develco");
+                // Divisor for current depends on interface_mode, adjust converted values
                 if (result && typeof result === "object") {
                     const currentMode = (meta.state?.interface_mode as string) || "norwegian_han";
-                    const divisor = interfaceModeLookup[currentMode]?.acCurrentDivisor || 100;
-                    const clusterDivisor = msg.data["acCurrentDivisor"];
-                    logger.info(
-                        `EMIZB-132 DEBUG: Base current: ${result.current}, Mode: ${currentMode}, Target Divisor: ${divisor}, CluserDivisor: ${clusterDivisor}`,
-                        "zhc:develco",
-                    );
+                    const divisor = interfaceModeLookup[currentMode]?.acCurrentDivisor || 10;
+                    const clusterDivisor = msg.endpoint.getClusterAttributeValue("haElectricalMeasurement", "acCurrentDivisor") as number;
+
                     if (result.current !== undefined) {
-                        result.current = msg.data["rmsCurrent"] / divisor;
+                        result.current = ((result.current as number) * clusterDivisor) / divisor;
                     }
                     if (result.current_phase_b !== undefined) {
-                        result.current_phase_b = msg.data["rmsCurrentPhB"] / divisor;
+                        result.current_phase_b = ((result.current_phase_b as number) * clusterDivisor) / divisor;
                     }
                     if (result.current_phase_c !== undefined) {
-                        result.current_phase_c = msg.data["rmsCurrentPhC"] / divisor;
+                        result.current_phase_c = ((result.current_phase_c as number) * clusterDivisor) / divisor;
                     }
                 }
                 return result;
@@ -335,8 +346,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Wattle AMS HAN power-meter sensor",
         ota: true,
         extend: [
-            develcoModernExtend.emizb132DivisorInjector(),
-            develcoModernExtend.emizb132InterfaceMode(),
             develcoModernExtend.addCustomDevelcoSeMeteringCluster(),
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
@@ -356,14 +365,29 @@ export const definitions: DefinitionWithExtend[] = [
                 unit: "VAr",
                 access: "STATE_GET",
             }),
+            m.enumLookup<"seMetering", DevelcoSeMetering>({
+                name: "interface_mode",
+                cluster: "seMetering",
+                attribute: "develcoInterfaceMode",
+                description: "Specifies the configuration of the external HAN port interface.",
+                entityCategory: "config",
+                access: "ALL",
+                lookup: {
+                    norwegian_han: 0x0200,
+                    norwegian_han_extra_load: 0x0201,
+                    aidon_meter: 0x0202,
+                    kaifa_and_kamstrup: 0x0203,
+                },
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.DEVELCO},
+            }),
             m.electricityMeter({
                 power: false,
                 voltage: {divisor: 10},
                 current: {divisor: 10},
                 threePhase: true,
                 energy: {divisor: 1000, multiplier: 1},
-                fzMetering: develco.fz.fixInvalidMeteringValuesEmizb132, // avoid invalid values for currentSummDelivered (energy)
-                // fzElectricalMeasurement: develco.fz.correctCurrentDivisorEmizb132,
+                fzMetering: develco.fz.metering_emizb132,
+                fzElectricalMeasurement: develco.fz.electrical_measurement_emizb132,
             }),
         ],
     },

--- a/src/lib/develco.ts
+++ b/src/lib/develco.ts
@@ -6,13 +6,6 @@ import {exposeEndpoints} from "./utils";
 
 const manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.DEVELCO};
 
-const emizb132InterfaceModeLookup: Record<string, {payload: number; divisor: number}> = {
-    norwegian_han: {payload: 0x0200, divisor: 10},
-    norwegian_han_extra_load: {payload: 0x0201, divisor: 10},
-    aidon_meter: {payload: 0x0202, divisor: 10},
-    kaifa_and_kamstrup: {payload: 0x0203, divisor: 1000},
-};
-
 export interface DevelcoGenBasic {
     attributes: {
         develcoPrimarySwVersion: Buffer;
@@ -585,89 +578,6 @@ export const develcoModernExtend = {
             isModernExtend: true,
             exposes,
             toZigbee,
-        };
-    },
-    emizb132InterfaceMode: (): ModernExtend => {
-        const exposes = [
-            e
-                .enum("interface_mode", ea.ALL, Object.keys(emizb132InterfaceModeLookup))
-                .withDescription("Specifies the configuration of the external HAN port interface."),
-        ];
-
-        // Using the internal type from ModernExtend solves the generic requirement
-        const fromZigbee: ModernExtend["fromZigbee"] = [
-            {
-                cluster: "seMetering",
-                type: ["attributeReport", "readResponse"],
-                convert: (model, msg, publish, options, meta) => {
-                    const value = msg.data.develcoInterfaceMode ?? msg.data[0x0000];
-                    if (value !== undefined) {
-                        const mode = Object.keys(emizb132InterfaceModeLookup).find((key) => emizb132InterfaceModeLookup[key].payload === value);
-                        return mode ? {interface_mode: mode} : undefined;
-                    }
-                },
-            },
-        ];
-
-        const toZigbee: ModernExtend["toZigbee"] = [
-            {
-                key: ["interface_mode"],
-                convertSet: async (entity, key, value, meta) => {
-                    const modeData = emizb132InterfaceModeLookup[value as string];
-                    if (!modeData) throw new Error(`Invalid interface_mode: ${value}`);
-
-                    const endpoint = meta.device.getEndpoint(2);
-
-                    // 1. Write the mode to the device using Enum8 (0x30)
-                    // We use 0x30 to avoid the 'INVALID_DATA_TYPE' error seen with 0x21
-                    await endpoint.write<"seMetering", DevelcoSeMetering>(
-                        "seMetering",
-                        // {develcoInterfaceMode: {value: modeData.payload, type: Zcl.DataType.ENUM16}},
-                        {develcoInterfaceMode: modeData.payload},
-                        {manufacturerCode: Zcl.ManufacturerCode.DEVELCO},
-                    );
-                    // We prime the haElectricalMeasurement cache so that the very next current reading is divided by the correct number.
-                    const cache = {
-                        acCurrentDivisor: modeData.divisor,
-                        acCurrentMultiplier: 1,
-                    };
-                    endpoint.saveClusterAttributeKeyValue("haElectricalMeasurement", cache);
-
-                    // logger.info(`EMIZB-132: Mode set to ${value}. Divisor cache updated to ${modeData.divisor}.`, "zhc:develco");
-                    return {state: {interface_mode: value}};
-                },
-                convertGet: async (entity, key, meta) => {
-                    await meta.device.getEndpoint(2).read<"seMetering", DevelcoSeMetering>("seMetering", ["develcoInterfaceMode"]);
-                },
-            },
-        ];
-
-        return {
-            exposes,
-            fromZigbee,
-            toZigbee,
-            isModernExtend: true as const,
-        };
-    },
-    emizb132DivisorInjector: (): ModernExtend => {
-        return {
-            fromZigbee: [
-                {
-                    cluster: "haElectricalMeasurement",
-                    type: ["attributeReport", "readResponse"],
-                    convert: (model, msg, publish, options, meta) => {
-                        const mode = (meta.state?.interface_mode as string) || "norwegian_han";
-                        const divisor = emizb132InterfaceModeLookup[mode]?.divisor || 10;
-
-                        msg.endpoint.saveClusterAttributeKeyValue("haElectricalMeasurement", {
-                            acCurrentDivisor: divisor,
-                            acCurrentMultiplier: 1,
-                        });
-                        return undefined;
-                    },
-                } as Fz.Converter<"haElectricalMeasurement", undefined, undefined>,
-            ],
-            isModernExtend: true as const,
         };
     },
 };


### PR DESCRIPTION
Enforce that only energy is read from seMetering by implementing `fzMetering: develco.fz.metering_emizb132`. Hard code the divisor for energy.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

