### PR TITLE
Add support for Aqara Shutter Switch H2 EU (DS-K02D/DS-K02E)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -7,7 +7,7 @@ import type {ManuSpecificLumi} from "../lib/lumi";
 import * as lumi from "../lib/lumi";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, Zh} from "../lib/types";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -64,6 +64,24 @@ const {
 
 const NS = "zhc:lumi";
 const {manufacturerCode} = lumi;
+const aqaraH2EuShutterSwitchEndpoints = {top_wireless_button: 3, bottom_wireless_button: 4} as const;
+type AqaraH2EuShutterSwitchEndpointName = keyof typeof aqaraH2EuShutterSwitchEndpoints;
+const aqaraH2EuShutterSwitchEndpointNames: AqaraH2EuShutterSwitchEndpointName[] = ["top_wireless_button", "bottom_wireless_button"];
+const aqaraH2EuShutterSwitchActionLookup = {hold: 0, single: 1, double: 2, release: 255};
+const aqaraH2EuShutterSwitchMultiEndpointSkip = ["energy", "position", "state", "tilt"];
+const aqaraH2EuShutterSwitchMultiClickAttribute = 0x0286;
+
+async function configureAqaraH2EuShutterSwitch(device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) {
+    for (const endpointName of aqaraH2EuShutterSwitchEndpointNames) {
+        const endpoint = device.getEndpoint(aqaraH2EuShutterSwitchEndpoints[endpointName]);
+        await reporting.bind(endpoint, coordinatorEndpoint, ["manuSpecificLumi", "genMultistateInput"]);
+        await endpoint.configureReporting("genMultistateInput", reporting.payload("presentValue", 0, 3600, 1));
+        // Initialize Aqara's per-button multi-click setting on startup.
+        await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [aqaraH2EuShutterSwitchMultiClickAttribute], {
+            manufacturerCode,
+        });
+    }
+}
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -4840,6 +4858,29 @@ export const definitions: DefinitionWithExtend[] = [
             lumiLockRelay({description: "Lock right switch", endpointName: "right"}),
             lumiMultiClick({description: "Multi-click mode for left down button", endpointName: "left_down"}),
             lumiMultiClick({description: "Multi-click mode for right down button", endpointName: "right_down"}),
+        ],
+    },
+    {
+        zigbeeModel: ["lumi.switch.aeu003"],
+        model: "DS-K02D/DS-K02E",
+        vendor: "Aqara",
+        description: "Aqara Shutter Switch H2 EU",
+        configure: configureAqaraH2EuShutterSwitch,
+        extend: [
+            lumi.modernExtend.addManuSpecificLumiCluster(),
+            lumiZigbeeOTA(),
+            m.deviceEndpoints({
+                endpoints: aqaraH2EuShutterSwitchEndpoints,
+                multiEndpointSkip: aqaraH2EuShutterSwitchMultiEndpointSkip,
+            }),
+            m.electricityMeter({cluster: "metering", power: false, energy: {divisor: 1000}}),
+            m.windowCovering({controls: ["lift"], coverInverted: true, configureReporting: true}),
+            lumiAction({
+                actionLookup: aqaraH2EuShutterSwitchActionLookup,
+                endpointNames: aqaraH2EuShutterSwitchEndpointNames,
+            }),
+            lumiMultiClick({description: "Multi-click mode for top wireless button", endpointName: "top_wireless_button"}),
+            lumiMultiClick({description: "Multi-click mode for bottom wireless button", endpointName: "bottom_wireless_button"}),
         ],
     },
     {

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -4865,6 +4865,13 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DS-K02D/DS-K02E",
         vendor: "Aqara",
         description: "Aqara Shutter Switch H2 EU",
+        meta: {
+            overrideHaDiscoveryPayload: (payload) => {
+                if (payload.position_topic && payload.set_position_topic) {
+                    payload.device_class = "shutter";
+                }
+            },
+        },
         configure: configureAqaraH2EuShutterSwitch,
         extend: [
             lumi.modernExtend.addManuSpecificLumiCluster(),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5012

## Summary

This PR adds support for the **Aqara Shutter Switch H2 EU (DS-K02D/DS-K02E)** (`lumi.switch.aeu003`).

## Supported features

- Cover control and position reporting
- Home Assistant cover discovery with `device_class: shutter`
- Wireless button actions on endpoints 3 and 4:
  - `single_top_wireless_button`
  - `double_top_wireless_button`
  - `hold_top_wireless_button`
  - `release_top_wireless_button`
  - `single_bottom_wireless_button`
  - `double_bottom_wireless_button`
  - `hold_bottom_wireless_button`
  - `release_bottom_wireless_button`
- Multi-click configuration for both wireless buttons
- Energy reporting
- OTA support

## Notes

- This PR intentionally exposes only verified metering support for the **Aqara Shutter Switch H2 EU**.
- `power`, `current`, and `voltage` are not exposed because they could not be validated reliably on this model.
- The Home Assistant discovery payload is overridden for the cover entity so the device is classified as a `shutter`.
- The implementation follows the upstream `lumi.ts` patterns and keeps the Aqara-specific `configure` logic limited to the validated button and multi-click setup.

## Validation

Tested on a real **Aqara Shutter Switch H2 EU (DS-K02D/DS-K02E)** with:

- cover movement and position reporting
- correct Home Assistant shutter entity/icon via `device_class: shutter`
- top wireless button: single, double, hold, release
- bottom wireless button: single, double, hold, release
- Home Assistant native device triggers for the wireless actions
- `energy` entity presence
- OTA entity presence and update check flow

Local checks run in `zigbee-herdsman-converters`:

- `pnpm check`
- `pnpm test`
- `pnpm build`

## Related

- Closes https://github.com/Koenkk/zigbee2mqtt/issues/30514
- Related earlier draft: https://github.com/Koenkk/zigbee-herdsman-converters/pull/11431
