### PR TITLE
fix: use correct final position for ZNCLBL01LM after stop

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -44,6 +44,7 @@ import {
 const NS = "zhc:lumi";
 const e = exposes.presets;
 const ea = exposes.access;
+const ZNCLBL01LM_RUNNING_STORE_KEY = "ZNCLBL01LM_running";
 
 declare type Day = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
 
@@ -220,6 +221,13 @@ export const numericAttributes2Payload = async (
     dataObject: KeyValue,
 ) => {
     let payload: KeyValue = {};
+    const znclbl01lm1057Value = model.model === "ZNCLBL01LM" && typeof dataObject["1057"] === "number" ? dataObject["1057"] : undefined;
+    const znclbl01lmStopInCurrentPayload = znclbl01lm1057Value === 2;
+    const znclbl01lmRunningInCurrentPayload = znclbl01lm1057Value !== undefined && znclbl01lm1057Value < 2;
+    const znclbl01lmStoredRunning =
+        model.model === "ZNCLBL01LM" ? globalStore.getValue(msg.endpoint, ZNCLBL01LM_RUNNING_STORE_KEY, undefined) : undefined;
+    const shouldSuppressInStopPayload = znclbl01lmStopInCurrentPayload;
+    const shouldSuppressWhileStopped = znclbl01lmStoredRunning === false && !znclbl01lmRunningInCurrentPayload;
 
     for (const [key, value] of Object.entries(dataObject)) {
         switch (key) {
@@ -518,6 +526,9 @@ export const numericAttributes2Payload = async (
                 if (["RTCGQ14LM"].includes(model.model)) {
                     payload.trigger_indicator = value === 1;
                 } else if (["ZNCLBL01LM"].includes(model.model)) {
+                    if (shouldSuppressInStopPayload || shouldSuppressWhileStopped) {
+                        break;
+                    }
                     assertNumber(value);
                     const position = options.invert_cover ? 100 - value : value;
                     payload.position = position;
@@ -876,12 +887,22 @@ export const numericAttributes2Payload = async (
                 break;
             case "1057":
                 if (["ZNCLBL01LM"].includes(model.model)) {
+                    const previousRunning = globalStore.getValue(msg.endpoint, ZNCLBL01LM_RUNNING_STORE_KEY, undefined);
                     payload.motor_state = getFromLookup(
                         value,
                         options.invert_cover ? {0: "opening", 1: "closing", 2: "stopped"} : {0: "closing", 1: "opening", 2: "stopped"},
                     );
                     assertNumber(value);
                     payload.running = value < 2;
+                    globalStore.putValue(msg.endpoint, ZNCLBL01LM_RUNNING_STORE_KEY, payload.running);
+
+                    if (!payload.running && previousRunning !== false) {
+                        // After stop, read the final position.
+                        // Attr 107 can still be stale near the end.
+                        msg.endpoint
+                            .read("closuresWindowCovering", ["currentPositionLiftPercentage"])
+                            .catch((error) => logger.error(`Failed to read position '${msg.device.ieeeAddr}' (${error})`, NS));
+                    }
                 }
                 break;
             case "1061":

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -221,13 +221,6 @@ export const numericAttributes2Payload = async (
     dataObject: KeyValue,
 ) => {
     let payload: KeyValue = {};
-    const znclbl01lm1057Value = model.model === "ZNCLBL01LM" && typeof dataObject["1057"] === "number" ? dataObject["1057"] : undefined;
-    const znclbl01lmStopInCurrentPayload = znclbl01lm1057Value === 2;
-    const znclbl01lmRunningInCurrentPayload = znclbl01lm1057Value !== undefined && znclbl01lm1057Value < 2;
-    const znclbl01lmStoredRunning =
-        model.model === "ZNCLBL01LM" ? globalStore.getValue(msg.endpoint, ZNCLBL01LM_RUNNING_STORE_KEY, undefined) : undefined;
-    const shouldSuppressInStopPayload = znclbl01lmStopInCurrentPayload;
-    const shouldSuppressWhileStopped = znclbl01lmStoredRunning === false && !znclbl01lmRunningInCurrentPayload;
 
     for (const [key, value] of Object.entries(dataObject)) {
         switch (key) {
@@ -526,6 +519,12 @@ export const numericAttributes2Payload = async (
                 if (["RTCGQ14LM"].includes(model.model)) {
                     payload.trigger_indicator = value === 1;
                 } else if (["ZNCLBL01LM"].includes(model.model)) {
+                    // https://github.com/Koenkk/zigbee-herdsman-converters/pull/11911
+                    const value1057 = typeof dataObject["1057"] === "number" ? dataObject["1057"] : undefined;
+                    const storedRunning = globalStore.getValue(msg.endpoint, ZNCLBL01LM_RUNNING_STORE_KEY, undefined);
+                    const payloadRunning = value1057 !== undefined && value1057 < 2;
+                    const shouldSuppressInStopPayload = value1057 === 2;
+                    const shouldSuppressWhileStopped = storedRunning === false && !payloadRunning;
                     if (shouldSuppressInStopPayload || shouldSuppressWhileStopped) {
                         break;
                     }
@@ -896,6 +895,7 @@ export const numericAttributes2Payload = async (
                     payload.running = value < 2;
                     globalStore.putValue(msg.endpoint, ZNCLBL01LM_RUNNING_STORE_KEY, payload.running);
 
+                    // https://github.com/Koenkk/zigbee-herdsman-converters/pull/11911
                     if (!payload.running && previousRunning !== false) {
                         // After stop, read the final position.
                         // Attr 107 can still be stale near the end.

--- a/test/lumi.test.ts
+++ b/test/lumi.test.ts
@@ -1,7 +1,189 @@
-import {describe, expect, it} from "vitest";
-import {fromZigbee, type TrvScheduleConfig, trv} from "../src/lib/lumi";
+import {beforeEach, describe, expect, it} from "vitest";
+import {fromZigbee, numericAttributes2Payload, type TrvScheduleConfig, trv} from "../src/lib/lumi";
+import * as globalStore from "../src/lib/store";
+import type {Definition, Fz} from "../src/lib/types";
+import {mockDevice} from "./utils";
 
 describe("lib/lumi", () => {
+    describe("ZNCLBL01LM terminal position readback", () => {
+        const znclbl01lmDefinition = {model: "ZNCLBL01LM"} as Definition;
+
+        const createCurtainMessage = () => {
+            const device = mockDevice({modelID: "lumi.curtain.acn003", endpoints: [{ID: 1}]});
+            const msg = {data: {}, device, endpoint: device.endpoints[0]} as Fz.Message<"manuSpecificLumi", undefined, "attributeReport">;
+
+            return {device, msg};
+        };
+
+        beforeEach(() => {
+            globalStore.clear();
+        });
+
+        it.each([
+            {invert_cover: false, attr107Position: 99, expectedPosition: 99, expectedState: "OPEN"},
+            {invert_cover: true, attr107Position: 1, expectedPosition: 99, expectedState: "CLOSE"},
+        ])("uses attr 107 for movement updates when invert_cover=$invert_cover", async ({
+            invert_cover,
+            attr107Position,
+            expectedPosition,
+            expectedState,
+        }) => {
+            const {msg} = createCurtainMessage();
+
+            const payload = await numericAttributes2Payload(msg, {} as Fz.Meta, znclbl01lmDefinition, {invert_cover}, {107: attr107Position});
+
+            expect(payload).toStrictEqual({position: expectedPosition, state: expectedState});
+        });
+
+        it.each([
+            {invert_cover: false, staleTerminalPosition: 99},
+            {invert_cover: true, staleTerminalPosition: 1},
+        ])("ignores attr 107 in a same-message stop payload when invert_cover=$invert_cover", async ({invert_cover, staleTerminalPosition}) => {
+            const {device, msg} = createCurtainMessage();
+
+            const stoppedPayload = await numericAttributes2Payload(
+                msg,
+                {} as Fz.Meta,
+                znclbl01lmDefinition,
+                {invert_cover},
+                {107: staleTerminalPosition, 1057: 2},
+            );
+
+            expect(stoppedPayload).toMatchObject({motor_state: "stopped", running: false});
+            expect(stoppedPayload).not.toHaveProperty("position");
+            expect(device.endpoints[0].read).toHaveBeenCalledWith("closuresWindowCovering", ["currentPositionLiftPercentage"]);
+
+            const stalePayload = await numericAttributes2Payload(
+                msg,
+                {} as Fz.Meta,
+                znclbl01lmDefinition,
+                {invert_cover},
+                {107: staleTerminalPosition},
+            );
+
+            expect(stalePayload).toStrictEqual({});
+        });
+
+        it("reads final position only when changing to stopped", async () => {
+            const {device, msg} = createCurtainMessage();
+
+            await numericAttributes2Payload(msg, {} as Fz.Meta, znclbl01lmDefinition, {invert_cover: false}, {1057: 2});
+
+            await numericAttributes2Payload(msg, {} as Fz.Meta, znclbl01lmDefinition, {invert_cover: false}, {1057: 2});
+
+            expect(device.endpoints[0].read).toHaveBeenCalledTimes(1);
+        });
+
+        it.each([
+            {
+                invert_cover: false,
+                runningStateValue: 1,
+                resumedAttr107Position: 80,
+                expectedPayload: {position: 80, state: "OPEN", motor_state: "opening", running: true},
+            },
+            {
+                invert_cover: true,
+                runningStateValue: 0,
+                resumedAttr107Position: 20,
+                expectedPayload: {position: 80, state: "CLOSE", motor_state: "opening", running: true},
+            },
+        ])("uses attr 107 in the first same-message resume payload when invert_cover=$invert_cover", async ({
+            invert_cover,
+            runningStateValue,
+            resumedAttr107Position,
+            expectedPayload,
+        }) => {
+            const {device, msg} = createCurtainMessage();
+
+            await numericAttributes2Payload(msg, {} as Fz.Meta, znclbl01lmDefinition, {invert_cover}, {1057: 2});
+
+            const resumedPayload = await numericAttributes2Payload(
+                msg,
+                {} as Fz.Meta,
+                znclbl01lmDefinition,
+                {invert_cover},
+                {107: resumedAttr107Position, 1057: runningStateValue},
+            );
+
+            expect(resumedPayload).toStrictEqual(expectedPayload);
+            expect(device.endpoints[0].read).toHaveBeenCalledTimes(1);
+        });
+
+        it.each([
+            {
+                invert_cover: false,
+                readbackPosition: 37,
+                staleTerminalPosition: 99,
+                expectedReadbackPayload: {position: 37, state: "OPEN"},
+            },
+            {
+                invert_cover: true,
+                readbackPosition: 37,
+                staleTerminalPosition: 1,
+                expectedReadbackPayload: {position: 63, state: "CLOSE"},
+            },
+        ])("keeps attr 107 ignored after readback while stopped when invert_cover=$invert_cover", async ({
+            invert_cover,
+            readbackPosition,
+            staleTerminalPosition,
+            expectedReadbackPayload,
+        }) => {
+            const {device, msg} = createCurtainMessage();
+
+            await numericAttributes2Payload(msg, {} as Fz.Meta, znclbl01lmDefinition, {invert_cover}, {1057: 2});
+
+            const readbackPayload = fromZigbee.lumi_curtain_position_tilt.convert(
+                znclbl01lmDefinition,
+                {
+                    data: {currentPositionLiftPercentage: readbackPosition},
+                    endpoint: device.endpoints[0],
+                } as Fz.Message<"closuresWindowCovering", undefined, "readResponse">,
+                null,
+                {invert_cover},
+                {} as Fz.Meta,
+            );
+
+            expect(readbackPayload).toStrictEqual(expectedReadbackPayload);
+
+            const lateAttr107Payload = await numericAttributes2Payload(
+                msg,
+                {} as Fz.Meta,
+                znclbl01lmDefinition,
+                {invert_cover},
+                {107: staleTerminalPosition},
+            );
+
+            expect(lateAttr107Payload).toStrictEqual({});
+        });
+
+        it.each([
+            {invert_cover: false, runningStateValue: 1, resumedAttr107Position: 99, expectedPosition: 99, expectedState: "OPEN"},
+            {invert_cover: true, runningStateValue: 0, resumedAttr107Position: 1, expectedPosition: 99, expectedState: "CLOSE"},
+        ])("uses attr 107 again after a later resume when invert_cover=$invert_cover", async ({
+            invert_cover,
+            runningStateValue,
+            resumedAttr107Position,
+            expectedPosition,
+            expectedState,
+        }) => {
+            const {msg} = createCurtainMessage();
+
+            await numericAttributes2Payload(msg, {} as Fz.Meta, znclbl01lmDefinition, {invert_cover}, {1057: 2});
+
+            await numericAttributes2Payload(msg, {} as Fz.Meta, znclbl01lmDefinition, {invert_cover}, {1057: runningStateValue});
+
+            const resumedPayload = await numericAttributes2Payload(
+                msg,
+                {} as Fz.Meta,
+                znclbl01lmDefinition,
+                {invert_cover},
+                {107: resumedAttr107Position},
+            );
+
+            expect(resumedPayload).toStrictEqual({position: expectedPosition, state: expectedState});
+        });
+    });
+
     describe("trv", () => {
         const factoryDefaultScheduleData = "043e01e0000009600438000006a405640000089881e000000898";
         const factoryDefaultSchedule: TrvScheduleConfig = {


### PR DESCRIPTION
## Summary
- when `ZNCLBL01LM` changes from running to stopped through attr `1057`, read `closuresWindowCovering.currentPositionLiftPercentage` and use that as the final result
- keep attr `107` for movement updates, including the first update when movement starts again
- while the motor is stopped, do not use attr `107` as the final source for `position` / `state`
- add tests for stop reports, repeated stop reports, stopped-state suppression, resume behavior, and both `invert_cover` directions

## Why
For `ZNCLBL01LM`, `position` / `state` can come from two places:
- manufacturer attr `107`
- `closuresWindowCovering.currentPositionLiftPercentage`

The problem is that near the end of movement, attr `107` can stay stale after the motor has already stopped.
When that happens, it can overwrite the real final state.

I ran into this in real use.
The cover could stay in a moving state with a near-end position, instead of settling to a clean final state.
That broke automations that depend on the final cover state being correct.

A simple idea would be to normalize `1 -> 0` and `99 -> 100`.
I did think about that, but I do not think that is the right fix here.

That would only hide the symptom.
It would still leave attr `107` in charge of the final state while the motor is stopped.

It is also risky, because `1` and `99` are not always wrong.
They can be real near-end positions.

This patch fixes the real problem instead.
It keeps attr `107` for movement updates, but after stop it reads the standard window covering position and uses that as the final result.

## Notes
- only `ZNCLBL01LM` is changed
- this patch does not add `1 -> 0` or `99 -> 100` normalization