### PR TITLE
feat: add _TZ3000_viqwamhn to TS011F_din_smart_relay_polling

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11838,7 +11838,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_qeuvnohg", "_TZ3000_6l1pjfqe", "_TZ3000_2iiimqs9"]),
+        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_qeuvnohg", "_TZ3000_6l1pjfqe", "_TZ3000_2iiimqs9", "_TZ3000_viqwamhn"]),
         model: "TS011F_din_smart_relay_polling",
         description: "Din smart relay (with power monitoring via polling)",
         vendor: "Tuya",


### PR DESCRIPTION
## Summary

Add fingerprint `_TZ3000_viqwamhn` to `TS011F_din_smart_relay_polling` device definition.

This Tuya DIN rail relay is currently misidentified as `TS011F_plug_3` ("Smart plug with power monitoring by polling"). It is physically a DIN rail mounted relay switch with power monitoring, identical in function to the other `TS011F_din_smart_relay_polling` devices.

## Device info

```
Zigbee model: TS011F
Manufacturer: _TZ3000_viqwamhn
Power source: Mains (single phase)
Type: Router
Clusters (endpoint 1):
  Input: genBasic, genIdentify, genGroups, genScenes, genOnOff, seMetering, haElectricalMeasurement, msTemperatureMeasurement, 57344, manuSpecificTuya3
  Output: genOta, genTime
```

## Changes

One-line change in `src/devices/tuya.ts` — added `_TZ3000_viqwamhn` to the existing fingerprint array for `TS011F_din_smart_relay_polling`.