### PR TITLE
Update lonsonho.ts

### DIFF
--- a/src/devices/lonsonho.ts
+++ b/src/devices/lonsonho.ts
@@ -96,9 +96,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "X701A",
         vendor: "Lonsonho",
         description: "1 gang switch with backlight",
-        whiteLabel: [
-            tuya.whitelabel("Lonsonho", "X701A", "1 gang switch with backlight", ["_TZ3000_ehgouyvu"]),
-        ],
+        whiteLabel: [tuya.whitelabel("Lonsonho", "X701A", "1 gang switch with backlight", ["_TZ3000_ehgouyvu"])],
         extend: [tuya.modernExtend.tuyaOnOff({indicatorMode: true})],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);

--- a/src/devices/lonsonho.ts
+++ b/src/devices/lonsonho.ts
@@ -96,6 +96,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "X701A",
         vendor: "Lonsonho",
         description: "1 gang switch with backlight",
+        whiteLabel: [
+            tuya.whitelabel("Lonsonho", "X701A", "1 gang switch with backlight", ["_TZ3000_ehgouyvu"]),
+        ],
         extend: [tuya.modernExtend.tuyaOnOff({indicatorMode: true})],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);

--- a/src/devices/lonsonho.ts
+++ b/src/devices/lonsonho.ts
@@ -92,11 +92,10 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_t3s9qmmg"]),
+        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_t3s9qmmg", "_TZ3000_ehgouyvu"]),
         model: "X701A",
         vendor: "Lonsonho",
         description: "1 gang switch with backlight",
-        whiteLabel: [tuya.whitelabel("Lonsonho", "X701A", "1 gang switch with backlight", ["_TZ3000_ehgouyvu"])],
         extend: [tuya.modernExtend.tuyaOnOff({indicatorMode: true})],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);


### PR DESCRIPTION
Switch Lonsonho X701A detected as Tuya TS0001. Adding model to whitelabel.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

