### PR TITLE
ci: use CODEOWNERS for external review gating

### DIFF
--- a/.github/workflows/requires_review.yml
+++ b/.github/workflows/requires_review.yml
@@ -22,7 +22,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        # Check if PR has external-reviewer-approved label
+        # Skip if PR already has the approval label
         LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
         for label in $LABELS; do
           if [[ "$label" == "external-reviewer-approved" ]]; then
@@ -30,34 +30,63 @@ jobs:
           fi
         done
 
-        # No external-reviewer-approved label, check if files that require
-        # external review have been modified
+        # Build reviewer map from CODEOWNERS
+        declare -a PATTERNS=()
+        declare -A PATTERN_REVIEWERS=()
+        while IFS= read -r line; do
+          line="${line%%#*}"
+          [[ -z "${line// }" ]] && continue
+          read -r pattern owners <<< "$line"
+          PATTERNS+=("$pattern")
+          PATTERN_REVIEWERS["$pattern"]="$owners"
+        done < CODEOWNERS
 
-        # Get list of changed files
         CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }})
-        
-        # List of files that require review
-        declare -A FILE_REVIEWERS=(
-          ["src/devices/vesternet.ts"]="@martyn-vesternet"
-          ["src/devices/candeo.ts"]="@candeodevelopment / @dhc25"
-          ["src/devices/inovelli.ts"]="@InovelliUSA / @rohankapoorcom"
-          ["src/devices/efekta.ts"]="@smartboxchannel"
-        )
-        
-        # Flag to track if forbidden files were modified
+
         MATCH=false
-        
-        # Check each changed file against requires review list
+        declare -A MATCHED_REVIEWERS=()
+
+        shopt -s extglob
         for file in $CHANGED_FILES; do
-          for pattern in "${!FILE_REVIEWERS[@]}"; do
-            if [[ $file == $pattern || $file == $pattern* ]]; then
-              echo "::error::Review required for '$file' by '${FILE_REVIEWERS[$pattern]}'"
+          for pattern in "${PATTERNS[@]}"; do
+            # CODEOWNERS patterns: leading "/" anchors to root (strip it for
+            # matching against repo-relative paths), otherwise match anywhere.
+            glob="$pattern"
+            [[ "$glob" == /* ]] && glob="${glob:1}"
+
+            if [[ $file == $glob ]]; then
+              reviewers="${PATTERN_REVIEWERS[$pattern]}"
+              echo "::error::Review required for '$file' by '$reviewers'"
+              MATCHED_REVIEWERS["$reviewers"]+="$file"$'\n'
               MATCH=true
             fi
           done
         done
-        
-        # Fail the workflow if forbidden files were changed
+
+        # Post a comment tagging the owners (only once per PR)
         if [ "$MATCH" = true ]; then
+          MARKER="<!-- requires-external-review -->"
+          EXISTING=$(gh pr view $PR_NUMBER --json comments \
+            --jq ".comments[].body | select(contains(\"$MARKER\"))" || true)
+
+          if [ -z "$EXISTING" ]; then
+            BODY="$MARKER"$'\n'
+            BODY+="## External review required"$'\n\n'
+            BODY+="This PR modifies files that require review from their code owners before merging."$'\n\n'
+
+            for reviewers in "${!MATCHED_REVIEWERS[@]}"; do
+              FILES="${MATCHED_REVIEWERS[$reviewers]}"
+              BODY+="**$reviewers**:"$'\n'
+              while IFS= read -r f; do
+                [[ -n "$f" ]] && BODY+="- \`$f\`"$'\n'
+              done <<< "$FILES"
+              BODY+=$'\n'
+            done
+
+            BODY+="Once reviewed, add the \`external-reviewer-approved\` label to unblock this check."
+
+            gh pr comment $PR_NUMBER --body "$BODY"
+          fi
+
           exit 1
         fi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# External code owners — changes to these paths require review from the listed
+# owners before merging.  The requires_review.yml workflow enforces this gate
+# and posts a comment tagging the owners when unreviewed changes are detected.
+#
+# Syntax follows GitHub CODEOWNERS (glob patterns, @-prefixed GitHub handles).
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+src/devices/vesternet.ts    @martyn-vesternet
+src/devices/candeo.ts       @candeodevelopment @dhc25
+src/devices/inovelli.ts     @InovelliUSA @rohankapoorcom
+src/lib/inovelli.ts         @InovelliUSA @rohankapoorcom
+test/inovelli.test.ts       @InovelliUSA @rohankapoorcom
+src/devices/efekta.ts       @smartboxchannel


### PR DESCRIPTION
## Summary

- Introduces a `CODEOWNERS` file at the repo root as the single source of truth for file-to-reviewer mappings.
- Rewrites the `requires_review.yml` workflow to parse `CODEOWNERS` at runtime instead of maintaining a hardcoded associative array.
- The workflow now matches changed files using bash glob patterns (supports CODEOWNERS glob syntax).
- On first detection of owned files in a PR, the workflow **posts a comment tagging the code owners**, so they get a GitHub notification even without write access to the repo.
- Subsequent pushes to the same PR skip the duplicate comment (detected via an HTML marker).
- Adds `src/lib/inovelli.ts` and `test/inovelli.test.ts` to the Inovelli ownership alongside the existing `src/devices/inovelli.ts`.

## How it works

For example, if someone opens a PR that changes `src/lib/inovelli.ts`:

1. The workflow parses `CODEOWNERS` and finds `src/lib/inovelli.ts @InovelliUSA @rohankapoorcom`.
2. It matches the changed file against that pattern.
3. It posts a PR comment:
   > **@InovelliUSA @rohankapoorcom**:
   > - `src/lib/inovelli.ts`
   >
   > Once reviewed, add the `external-reviewer-approved` label to unblock this check.
4. The check **fails** (red status on the PR).
5. On subsequent pushes, the file still matches and the check still fails, but no duplicate comment is posted.
6. Once a maintainer adds the `external-reviewer-approved` label, the workflow re-runs via the `labeled` trigger and **exits successfully** (green status).

## Adding new owners

To gate a new file or vendor, just add a line to `CODEOWNERS` — no workflow changes needed:
```
src/devices/newvendor.ts    @vendor-github-handle
```

## Test plan

- [ ] Verify workflow parses `CODEOWNERS` correctly (blank lines, comments, whitespace)
- [ ] Verify glob matching works for exact paths
- [ ] Verify comment is posted with correct owners and file list
- [ ] Verify duplicate comments are not posted on subsequent pushes
- [ ] Verify `external-reviewer-approved` label bypasses the check
- [ ] Verify existing vendors (Vesternet, Candeo, Efekta) still trigger correctly


Made with [Cursor](https://cursor.com)