### PR TITLE
fix: Bosch BMCT-SLZ: missing action in decoupled mode

### DIFF
--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -1439,6 +1439,15 @@ export const boschBmctExtend = {
                 },
             },
         ];
+
+        const reportActionExtend = boschBmctExtend.reportSwitchAction({
+            switchTypeLookup: stateSwitchType,
+            hasDualSwitchInputs: true,
+        });
+        if (reportActionExtend.fromZigbee !== undefined) {
+            fromZigbee.push(...reportActionExtend.fromZigbee);
+        }
+
         return {
             fromZigbee,
             toZigbee,


### PR DESCRIPTION
### Description

Fixes #11882

Fixes missing `state action` reporting in decoupled mode for BMCT-SLZ.


### Changes

- Add reportSwitchAction to slzExtends

### Tested

- Device: BMCT-SLZ
- Verified that actions are now published correctly via MQTT
- Tested in Zigbee2MQTT

