### PR TITLE
fix(ci): grant pull-requests write for requires_review workflow

### DIFF
--- a/.github/workflows/requires_review.yml
+++ b/.github/workflows/requires_review.yml
@@ -9,6 +9,10 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   requires-external-review:
     runs-on: ubuntu-latest
@@ -85,7 +89,8 @@ jobs:
 
             BODY+="Once reviewed, add the \`external-reviewer-approved\` label to unblock this check."
 
-            gh pr comment $PR_NUMBER --body "$BODY"
+            # Fork PRs may still get a read-only token; do not fail the job on comment alone.
+            gh pr comment $PR_NUMBER --body "$BODY" || echo "::warning::Could not post PR comment (token may lack pull-requests:write for this PR). Check logs for required reviewers."
           fi
 
           exit 1


### PR DESCRIPTION
Sorry for the regression introduced in [#11924](https://github.com/Koenkk/zigbee-herdsman-converters/pull/11924): the updated `requires_review` workflow posts a PR comment so code owners get notified, but I did not grant `pull-requests: write` on the workflow. The default `GITHUB_TOKEN` then could not call `addComment`, which surfaced as **GraphQL: Resource not accessible by integration (addComment)** and could abort the step before the intended review gate.

## Changes

- Declare `permissions: contents: read` and `pull-requests: write` so `gh pr comment` is allowed when the repository policy permits it (same idea as `ci.yml`).
- If commenting still fails (e.g. some fork PRs with a read-only token), log a workflow warning instead of failing the job on that step alone; the check still fails with `exit 1` until `external-reviewer-approved` is applied.
