### PR TITLE
fix: replace hardcoded powerSource strings by proper ZCL type.

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -35,6 +35,7 @@ import type {
     LevelConfigFeatures,
     ModernExtend,
     OnEvent,
+    PowerSource,
     Range,
     Tz,
     Zh,
@@ -307,7 +308,7 @@ export function forceDeviceType(args: {type: "EndDevice" | "Router"}): ModernExt
     return {configure, isModernExtend: true};
 }
 
-export function forcePowerSource(args: {powerSource: "Mains (single phase)" | "Battery"}): ModernExtend {
+export function forcePowerSource(args: {powerSource: PowerSource}): ModernExtend {
     const configure: Configure[] = [
         (device, coordinatorEndpoint, definition) => {
             device.powerSource = args.powerSource;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,7 @@ import type {
     TCustomClusterPayload,
     ZigbeeOtaImageMeta,
 } from "zigbee-herdsman/dist/controller/tstype";
-import type {Header as ZHZclHeader} from "zigbee-herdsman/dist/zspec/zcl";
+import type {Header as ZHZclHeader, PowerSource as ZHZclPowerSource} from "zigbee-herdsman/dist/zspec/zcl";
 import type {TClusterAttributeKeys, TClusterPayload, TPartialClusterAttributes} from "zigbee-herdsman/dist/zspec/zcl/definition/clusters-types";
 import type {FrameControl} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import type * as exposes from "./exposes";
@@ -21,6 +21,7 @@ export interface Logger {
 
 export type Range = [number, number];
 export type ValuesOf<T> = T[keyof T];
+export type PowerSource = keyof typeof ZHZclPowerSource;
 export interface KeyValue {
     [s: string]: unknown;
 }
@@ -58,7 +59,7 @@ export interface Fingerprint {
     hardwareVersion?: number;
     manufacturerName?: string;
     modelID?: string;
-    powerSource?: "Battery" | "Mains (single phase)";
+    powerSource?: PowerSource;
     softwareBuildID?: string;
     stackVersion?: number;
     zclVersion?: number;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,6 +13,7 @@ import type {
     Fz,
     KeyValue,
     KeyValueAny,
+    PowerSource,
     Publish,
     Tz,
     Zh,
@@ -679,7 +680,7 @@ export function getFromLookupByValue(value: unknown, lookup: Record<string, unkn
     return defaultValue;
 }
 
-export function configureSetPowerSourceWhenUnknown(powerSource: "Battery" | "Mains (single phase)"): Configure {
+export function configureSetPowerSourceWhenUnknown(powerSource: PowerSource): Configure {
     return (device: Zh.Device): void => {
         if (!device.powerSource || device.powerSource === "Unknown") {
             logger.debug(`Device has no power source, forcing to '${powerSource}'`, NS);


### PR DESCRIPTION
This became needed to avoid type errors, for a device integration I'm working on that uses another power source string.
I figured I might as well propose this here now.