### PR TITLE
fix(ci): run external review gate with pull_request_target

### DIFF
--- a/.github/workflows/requires_review.yml
+++ b/.github/workflows/requires_review.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - ready_for_review
       - labeled
       - unlabeled
 

--- a/.github/workflows/requires_review.yml
+++ b/.github/workflows/requires_review.yml
@@ -1,7 +1,7 @@
 name: Requires external review
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Check for files that require external review
       env:
@@ -45,7 +45,8 @@ jobs:
           PATTERN_REVIEWERS["$pattern"]="$owners"
         done < CODEOWNERS
 
-        CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }})
+        # pull_request_target runs in base-repo context; get changed files from the PR API.
+        CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')
 
         MATCH=false
         declare -A MATCHED_REVIEWERS=()


### PR DESCRIPTION
## Why this change is needed

The `requires_review` workflow enforces CODEOWNERS-based external review and posts a PR comment tagging owners. On fork-based PRs, the `pull_request` event often executes with a read-only `GITHUB_TOKEN`, so `gh pr comment` can fail with:

- `GraphQL: Resource not accessible by integration (addComment)`

That leaves reviewers untagged and makes the gate harder to use in practice.

## Why previous attempts didn't fully solve it

A previous fix added workflow permissions (`pull-requests: write`) and made the comment call non-fatal. That improved resilience, but it still depended on the token granted under the `pull_request` event. For fork PRs, GitHub can still provide a read-only token despite requested permissions, so comment posting remained blocked.

Related:
* https://github.com/Koenkk/zigbee-herdsman-converters/pull/11944
* https://github.com/Koenkk/zigbee-herdsman-converters/pull/11924

## What this change does

- Switches the workflow trigger to `pull_request_target`.
- Keeps minimal required permissions (`contents: read`, `pull-requests: write`).
- Uses the PR API (`gh pr view --json files`) to get changed files instead of relying on a git diff of PR head.

This keeps the job in base-repo context for reliable commenting while avoiding execution/diff logic tied to untrusted PR head code.

Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

## Test plan

- Open or update a fork-based PR that touches a CODEOWNERS-gated file.
- Verify the workflow emits the expected gate error annotation.
- Verify the workflow can post (or detect existing) gate comment with tagged owners.
- Add `external-reviewer-approved` and verify the check turns green.

Made with [Cursor](https://cursor.com)