### PR TITLE
Add Vesternet Zigbee Motion Sensor support

### DIFF
--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -320,7 +320,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["VES-ZB-PIR-21"],
-        model: "ES-ZB-PIR-21",
+        model: "VES-ZB-PIR-21",
         vendor: "Vesternet",
         description: "Zigbee motion sensor",
         extend: [m.battery(), m.iasZoneAlarm({zoneType: "occupancy", zoneAttributes: ["alarm_1", "alarm_2", "tamper", "battery_low"]})],

--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -268,7 +268,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.batteryPercentageRemaining(device.getEndpoint(1));
         },
     },
-    {   
+    {
         fingerprint: [
             {modelID: "ZG2833K8_EU05", softwareBuildID: "2.5.3_r20"},
             {modelID: "ZG2833K8_EU05", softwareBuildID: "2.7.6_r25"},
@@ -319,12 +319,10 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ['VES-ZB-PIR-21'],
-        model: 'Zigbee Motion Sensor',
-        vendor: 'Vesternet',
-        description: 'Vesternet Zigbee Motion Sensor',
-        extend: [m.battery(), m.iasZoneAlarm({"zoneType":"generic","zoneAttributes":["alarm_1","alarm_2","tamper","battery_low"]})],
-    },   
-};
-
+        zigbeeModel: ["VES-ZB-PIR-21"],
+        model: "ES-ZB-PIR-21",
+        vendor: "Vesternet",
+        description: "Zigbee motion sensor",
+        extend: [m.battery(), m.iasZoneAlarm({zoneType: "occupancy", zoneAttributes: ["alarm_1", "alarm_2", "tamper", "battery_low"]})],
+    },
 ];

--- a/src/devices/vesternet.ts
+++ b/src/devices/vesternet.ts
@@ -268,7 +268,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.batteryPercentageRemaining(device.getEndpoint(1));
         },
     },
-    {
+    {   
         fingerprint: [
             {modelID: "ZG2833K8_EU05", softwareBuildID: "2.5.3_r20"},
             {modelID: "ZG2833K8_EU05", softwareBuildID: "2.7.6_r25"},
@@ -318,4 +318,13 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.batteryPercentageRemaining(device.getEndpoint(1));
         },
     },
+    {
+        zigbeeModel: ['VES-ZB-PIR-21'],
+        model: 'Zigbee Motion Sensor',
+        vendor: 'Vesternet',
+        description: 'Vesternet Zigbee Motion Sensor',
+        extend: [m.battery(), m.iasZoneAlarm({"zoneType":"generic","zoneAttributes":["alarm_1","alarm_2","tamper","battery_low"]})],
+    },   
+};
+
 ];


### PR DESCRIPTION
NOTE: This device is based on the similar Shyugi MotionSensor-ZB3.0

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: 
https://github.com/kingswindsor/zigbee2mqtt.io/blob/master/public/images/devices/Vesternet%20Zigbee%20Motion%20Sensor.png