### PR TITLE
Add Philips Hue Festavia globe outdoor string lights (21m, 30 bulbs)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -170,6 +170,19 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light()],
     },
     {
+        zigbeeModel: ["LCX027"],
+        model: "929004582001",
+        vendor: "Philips",
+        description: "Hue Festavia globe outdoor string lights (21 meter with 30 bulbs)",
+        extend: [
+            philips.m.light({
+                colorTemp: {range: [50, 1000]},
+                color: {modes: ["xy", "hs"], enhancedHue: true},
+                gradient: {extraEffects: ["sparkle", "opal", "glisten"]},
+            }),
+        ],
+    },
+    {
         zigbeeModel: ["LCX028"],
         model: "929004581901",
         vendor: "Philips",


### PR DESCRIPTION
Added support for Hue Festavia globe outdoor string lights with model 929004582001 (21m, 30 bulbs).

This is a copy of the 14m one, and we can reuse the same picture as the 14m.
