### PR TITLE
fix: Emit state from genBinaryInput fixing refresh on btcino k4001c

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2930,11 +2930,13 @@ export const diyruz_rspm: Fz.Converter<"genOnOff", undefined, ["attributeReport"
     },
 };
 // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const K4003C_binary_input: Fz.Converter<"genBinaryInput", undefined, "attributeReport"> = {
+export const K4003C_binary_input: Fz.Converter<"genBinaryInput", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "genBinaryInput",
-    type: "attributeReport",
+    type: ["attributeReport", "readResponse"],
     convert: (model, msg, publish, options, meta) => {
-        return {action: msg.data.presentValue === 1 ? "off" : "on"};
+        if (msg.data.presentValue === undefined) return;
+        const isOn = Boolean(msg.data.presentValue);
+        return {action: isOn ? "on" : "off", state: isOn ? "ON" : "OFF"};
     },
 };
 export const enocean_ptm215z: Fz.Converter<"greenPower", undefined, ["commandNotification", "commandCommissioningNotification"]> = {

--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -20,6 +20,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tzLegrand.K4003C_state, tzLegrand.led_mode, tzLegrand.identify],
         extend: [legrandExtend.addLegrandDevicesCluster()],
         exposes: [e.switch(), e.action(["identify", "on", "off"]), eLegrand.identify(), eLegrand.ledInDark(), eLegrand.ledIfOn()],
+        version: "0.0.1",
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "genOnOff", "genBinaryInput"]);

--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -16,13 +16,16 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "BTicino",
         description: "Light switch with neutral",
         ota: true,
-        fromZigbee: [fz.identify, fz.on_off, fz.K4003C_binary_input, fzLegrand.cluster_fc01],
-        toZigbee: [tz.on_off, tzLegrand.led_mode, tzLegrand.identify],
+        fromZigbee: [fz.identify, fz.K4003C_binary_input, fzLegrand.cluster_fc01],
+        toZigbee: [tzLegrand.K4003C_state, tzLegrand.led_mode, tzLegrand.identify],
         extend: [legrandExtend.addLegrandDevicesCluster()],
         exposes: [e.switch(), e.action(["identify", "on", "off"]), eLegrand.identify(), eLegrand.ledInDark(), eLegrand.ledIfOn()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "genOnOff", "genBinaryInput"]);
+            await endpoint.configureReporting("genBinaryInput", [
+                {attribute: "presentValue", minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},
+            ]);
         },
     },
     {

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -266,6 +266,20 @@ export const tzLegrand = {
             },
         } satisfies Tz.Converter;
     },
+    // biome-ignore lint/style/useNamingConvention: model-specific converter
+    K4003C_state: {
+        key: ["state"],
+        convertSet: async (entity, key, value, meta) => {
+            const cmd = String(value).toUpperCase();
+            const command = cmd === "TOGGLE" ? "toggle" : cmd === "ON" ? "on" : "off";
+            await entity.command("genOnOff", command, {}, {});
+            if (cmd === "TOGGLE") return {};
+            return {state: {state: cmd}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read("genBinaryInput", ["presentValue"]);
+        },
+    } satisfies Tz.Converter,
     led_mode: {
         key: ["led_in_dark", "led_if_on"],
         convertSet: async (entity, key, value, meta) => {


### PR DESCRIPTION
## Summary

The BTicino K4001C light switch on latest firmware (4408831) seems to have decoupled the `genOnOff.onOff` attribute from the actual relay state - only `genBinaryInput.presentValue` reflects reality. Result: pressing the physical button toggles the relay and emits `action` events, but `state` in z2m never updates, and the Refresh button in the UI snaps state back to the wrong value.

Also described here https://github.com/Koenkk/zigbee2mqtt/issues/29243.

Validated against a real K40001C switch.

Happy to apply any changes you deem necesary.