### PR TITLE
fix(smarli): remove endpoint name from COV1 single-channel cover

### DIFF
--- a/src/devices/smarli.ts
+++ b/src/devices/smarli.ts
@@ -31,12 +31,11 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "smarli.",
         description: "Zigbee curtain control module",
         extend: [
-            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}),
+            m.deviceEndpoints({endpoints: {"3": 3}}),
             m.windowCovering({
                 controls: ["lift", "tilt"],
                 coverInverted: true,
                 configureReporting: true,
-                endpointNames: ["1"],
             }),
             m.electricityMeter({endpointNames: ["3"]}),
             m.enumLookup({


### PR DESCRIPTION
endpoint name is unnecessary on non-multi-channel-devices and only adds noise to naming conventions. remove to achieve null value. e.g. relevant for home assistant original_name, which is used to construct names and IDs