### PR TITLE
lincukoo: Add _TZE284_sndkanfr fingerprint for SZLMR10

### DIFF
--- a/src/devices/lincukoo.ts
+++ b/src/devices/lincukoo.ts
@@ -111,7 +111,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_sndkanfr", "_TZE204_bjf8qum1"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_sndkanfr", "_TZE204_bjf8qum1", "_TZE284_sndkanfr"]),
         model: "SZLMR10",
         vendor: "Lincukoo",
         description: "Human Motion & Presence Sensor",


### PR DESCRIPTION
Adds support for a new Tuya manufacturer variant `_TZE284_sndkanfr` for the Lincukoo Human Motion & Presence Sensor (SZLMR10).

The device uses the same model but a different manufacturerName, causing it to not match the existing fingerprint.

No functional changes, only extends the fingerprint list.