### PR TITLE
Implement converters for HD-T1000 thermostat features

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26255,24 +26255,133 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
-            e
-                .climate()
-                .withSystemMode(["off", "heat"], ea.STATE_SET)
-                .withRunningState(["idle", "heat"], ea.STATE)
-                .withLocalTemperature(ea.STATE)
-                .withSetpoint("current_heating_setpoint", 5, 35, 0.5, ea.STATE_SET),
-            e.enum("work_mode", ea.STATE_SET, ["manual", "schedule"]),
-            e.binary("child_lock", ea.STATE_SET, true, false),
-        ],
-        meta: {
-            tuyaDatapoints: [
-                [1, "system_mode", tuya.valueConverterBasic.lookup({heat: true, off: false})],
-                [2, "work_mode", tuya.valueConverterBasic.lookup({manual: tuya.enum(0), schedule: tuya.enum(1)})],
-                [3, "running_state", tuya.valueConverterBasic.lookup({heat: 0, idle: 1})],
-                [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
-                [24, "local_temperature", tuya.valueConverter.divideBy10],
-                [40, "child_lock", tuya.valueConverter.raw],
+        e.climate()
+            .withSystemMode(['off', 'heat'], ea.STATE_SET)
+            .withRunningState(['idle', 'heat'], ea.STATE)
+            .withLocalTemperature(ea.STATE)
+            .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
+            .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET),
+
+        e.enum('work_mode', ea.STATE_SET, ['manual', 'schedule']),
+        e.binary('child_lock', ea.STATE_SET, true, false),
+
+        e.binary('frost_protection', ea.STATE_SET, true, false),
+        e.binary('window_detection', ea.STATE_SET, true, false),
+
+        e.numeric('max_air_temperature', ea.STATE_SET)
+            .withUnit('°C')
+            .withValueMin(35)
+            .withValueMax(95)
+            .withValueStep(0.5),
+
+        e.numeric('max_floor_temperature', ea.STATE_SET)
+            .withUnit('°C')
+            .withValueMin(5)
+            .withValueMax(60)
+            .withValueStep(0.5),
+
+        e.numeric('deadzone_temperature', ea.STATE_SET)
+            .withUnit('°C')
+            .withValueMin(0.5)
+            .withValueMax(5)
+            .withValueStep(0.5),
+
+        e.numeric('window_detection_time', ea.STATE_SET)
+            .withUnit('min')
+            .withValueMin(2)
+            .withValueMax(30)
+            .withValueStep(1),
+
+        e.numeric('window_detection_temperature', ea.STATE_SET)
+            .withUnit('°C')
+            .withValueMin(2)
+            .withValueMax(4)
+            .withValueStep(1),
+
+        e.numeric('window_detection_recovery_time', ea.STATE_SET)
+            .withUnit('min')
+            .withValueMin(10)
+            .withValueMax(60)
+            .withValueStep(1),
+    ],
+    meta: {
+        tuyaDatapoints: [
+            [
+                1,
+                'system_mode',
+                tuya.valueConverterBasic.lookup({'heat': true, 'off': false}),
             ],
-        },
+            [
+                2,
+                'work_mode',
+                tuya.valueConverterBasic.lookup({'manual': tuya.enum(0), 'schedule': tuya.enum(1)}),
+            ],
+            [
+                3,
+                'running_state',
+                tuya.valueConverterBasic.lookup({'heat': 0, 'idle': 1}),
+            ],
+            [
+                10,
+                'frost_protection',
+                tuya.valueConverter.raw,
+            ],
+            [
+                8,
+                'window_detection',
+                tuya.valueConverter.raw,
+            ],
+            [
+                16,
+                'current_heating_setpoint',
+                tuya.valueConverter.divideBy10,
+            ],
+            [
+                19,
+                'max_air_temperature',
+                tuya.valueConverter.divideBy10,
+            ],
+            [
+                24,
+                'local_temperature',
+                tuya.valueConverter.divideBy10,
+            ],
+            [
+                27,
+                'local_temperature_calibration',
+                tuya.valueConverter.raw,
+            ],
+            [
+                40,
+                'child_lock',
+                tuya.valueConverter.raw,
+            ],
+            [
+                101,
+                'max_floor_temperature',
+                tuya.valueConverter.divideBy10,
+            ],
+            [
+                102,
+                'deadzone_temperature',
+                tuya.valueConverter.divideBy10,
+            ],
+            [
+                104,
+                'window_detection_time',
+                tuya.valueConverter.raw,
+            ],
+            [
+                105,
+                'window_detection_temperature',
+                tuya.valueConverter.raw,
+            ],
+            [
+                106,
+                'window_detection_recovery_time',
+                tuya.valueConverter.raw,
+            ],
+        ],
+    },
     },
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1075,11 +1075,9 @@ const tzLocal = {
                 schedule: 1,
             };
 
-            if (!(value in lookup)) {
-                throw new Error(`Invalid work_mode: ${value}`);
-            }
+            const mode = utils.getFromLookup(value, lookup);
 
-            await tuya.sendDataPointEnum(entity, 2, lookup[value]);
+            await tuya.sendDataPointEnum(entity, 2, mode);
 
             return {
                 state: {
@@ -26309,7 +26307,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Floor thermostat",
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tzLocal.hd_t1000_current_heating_setpoint, tzLocal.hd_t1000_work_mode, tzLocal.hd_t1000_child_lock, tuya.tz.datapoints],
-        onEvent: tuya.onEventSetTime,
         configure: tuya.configureMagicPacket,
         exposes: [
             e
@@ -26328,7 +26325,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [3, "running_state", tuya.valueConverterBasic.lookup({heat: 0, idle: 1})],
                 [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
                 [24, "local_temperature", tuya.valueConverter.divideBy10],
-                [40, "child_lock", tuya.valueConverter.trueFalse],
+                [40, "child_lock", tuya.valueConverter.trueFalse1],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26255,133 +26255,50 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
-        e.climate()
-            .withSystemMode(['off', 'heat'], ea.STATE_SET)
-            .withRunningState(['idle', 'heat'], ea.STATE)
-            .withLocalTemperature(ea.STATE)
-            .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
-            .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET),
+            e
+                .climate()
+                .withSystemMode(["off", "heat"], ea.STATE_SET)
+                .withRunningState(["idle", "heat"], ea.STATE)
+                .withLocalTemperature(ea.STATE)
+                .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
+                .withSetpoint("current_heating_setpoint", 5, 35, 0.5, ea.STATE_SET),
 
-        e.enum('work_mode', ea.STATE_SET, ['manual', 'schedule']),
-        e.binary('child_lock', ea.STATE_SET, true, false),
+            e.enum("work_mode", ea.STATE_SET, ["manual", "schedule"]),
+            e.binary("child_lock", ea.STATE_SET, true, false),
 
-        e.binary('frost_protection', ea.STATE_SET, true, false),
-        e.binary('window_detection', ea.STATE_SET, true, false),
+            e.binary("frost_protection", ea.STATE_SET, true, false),
+            e.binary("window_detection", ea.STATE_SET, true, false),
 
-        e.numeric('max_air_temperature', ea.STATE_SET)
-            .withUnit('°C')
-            .withValueMin(35)
-            .withValueMax(95)
-            .withValueStep(0.5),
+            e.numeric("max_air_temperature", ea.STATE_SET).withUnit("°C").withValueMin(35).withValueMax(95).withValueStep(0.5),
 
-        e.numeric('max_floor_temperature', ea.STATE_SET)
-            .withUnit('°C')
-            .withValueMin(5)
-            .withValueMax(60)
-            .withValueStep(0.5),
+            e.numeric("max_floor_temperature", ea.STATE_SET).withUnit("°C").withValueMin(5).withValueMax(60).withValueStep(0.5),
 
-        e.numeric('deadzone_temperature', ea.STATE_SET)
-            .withUnit('°C')
-            .withValueMin(0.5)
-            .withValueMax(5)
-            .withValueStep(0.5),
+            e.numeric("deadzone_temperature", ea.STATE_SET).withUnit("°C").withValueMin(0.5).withValueMax(5).withValueStep(0.5),
 
-        e.numeric('window_detection_time', ea.STATE_SET)
-            .withUnit('min')
-            .withValueMin(2)
-            .withValueMax(30)
-            .withValueStep(1),
+            e.numeric("window_detection_time", ea.STATE_SET).withUnit("min").withValueMin(2).withValueMax(30).withValueStep(1),
 
-        e.numeric('window_detection_temperature', ea.STATE_SET)
-            .withUnit('°C')
-            .withValueMin(2)
-            .withValueMax(4)
-            .withValueStep(1),
+            e.numeric("window_detection_temperature", ea.STATE_SET).withUnit("°C").withValueMin(2).withValueMax(4).withValueStep(1),
 
-        e.numeric('window_detection_recovery_time', ea.STATE_SET)
-            .withUnit('min')
-            .withValueMin(10)
-            .withValueMax(60)
-            .withValueStep(1),
-    ],
-    meta: {
-        tuyaDatapoints: [
-            [
-                1,
-                'system_mode',
-                tuya.valueConverterBasic.lookup({'heat': true, 'off': false}),
-            ],
-            [
-                2,
-                'work_mode',
-                tuya.valueConverterBasic.lookup({'manual': tuya.enum(0), 'schedule': tuya.enum(1)}),
-            ],
-            [
-                3,
-                'running_state',
-                tuya.valueConverterBasic.lookup({'heat': 0, 'idle': 1}),
-            ],
-            [
-                10,
-                'frost_protection',
-                tuya.valueConverter.raw,
-            ],
-            [
-                8,
-                'window_detection',
-                tuya.valueConverter.raw,
-            ],
-            [
-                16,
-                'current_heating_setpoint',
-                tuya.valueConverter.divideBy10,
-            ],
-            [
-                19,
-                'max_air_temperature',
-                tuya.valueConverter.divideBy10,
-            ],
-            [
-                24,
-                'local_temperature',
-                tuya.valueConverter.divideBy10,
-            ],
-            [
-                27,
-                'local_temperature_calibration',
-                tuya.valueConverter.raw,
-            ],
-            [
-                40,
-                'child_lock',
-                tuya.valueConverter.raw,
-            ],
-            [
-                101,
-                'max_floor_temperature',
-                tuya.valueConverter.divideBy10,
-            ],
-            [
-                102,
-                'deadzone_temperature',
-                tuya.valueConverter.divideBy10,
-            ],
-            [
-                104,
-                'window_detection_time',
-                tuya.valueConverter.raw,
-            ],
-            [
-                105,
-                'window_detection_temperature',
-                tuya.valueConverter.raw,
-            ],
-            [
-                106,
-                'window_detection_recovery_time',
-                tuya.valueConverter.raw,
-            ],
+            e.numeric("window_detection_recovery_time", ea.STATE_SET).withUnit("min").withValueMin(10).withValueMax(60).withValueStep(1),
         ],
-    },
+        meta: {
+            tuyaDatapoints: [
+                [1, "system_mode", tuya.valueConverterBasic.lookup({heat: true, off: false})],
+                [2, "work_mode", tuya.valueConverterBasic.lookup({manual: tuya.enum(0), schedule: tuya.enum(1)})],
+                [3, "running_state", tuya.valueConverterBasic.lookup({heat: 0, idle: 1})],
+                [10, "frost_protection", tuya.valueConverter.raw],
+                [8, "window_detection", tuya.valueConverter.raw],
+                [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
+                [19, "max_air_temperature", tuya.valueConverter.divideBy10],
+                [24, "local_temperature", tuya.valueConverter.divideBy10],
+                [27, "local_temperature_calibration", tuya.valueConverter.raw],
+                [40, "child_lock", tuya.valueConverter.raw],
+                [101, "max_floor_temperature", tuya.valueConverter.divideBy10],
+                [102, "deadzone_temperature", tuya.valueConverter.divideBy10],
+                [104, "window_detection_time", tuya.valueConverter.raw],
+                [105, "window_detection_temperature", tuya.valueConverter.raw],
+                [106, "window_detection_recovery_time", tuya.valueConverter.raw],
+            ],
+        },
     },
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26251,9 +26251,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "HD-T1000",
         vendor: "Heat Decor",
         description: "Floor thermostat",
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
-        configure: tuya.configureMagicPacket,
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             e
                 .climate()
@@ -26262,23 +26260,15 @@ export const definitions: DefinitionWithExtend[] = [
                 .withLocalTemperature(ea.STATE)
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
                 .withSetpoint("current_heating_setpoint", 5, 35, 0.5, ea.STATE_SET),
-
             e.enum("work_mode", ea.STATE_SET, ["manual", "schedule"]),
             e.binary("child_lock", ea.STATE_SET, true, false),
-
             e.binary("frost_protection", ea.STATE_SET, true, false),
             e.binary("window_detection", ea.STATE_SET, true, false),
-
             e.numeric("max_air_temperature", ea.STATE_SET).withUnit("°C").withValueMin(35).withValueMax(95).withValueStep(0.5),
-
             e.numeric("max_floor_temperature", ea.STATE_SET).withUnit("°C").withValueMin(5).withValueMax(60).withValueStep(0.5),
-
             e.numeric("deadzone_temperature", ea.STATE_SET).withUnit("°C").withValueMin(0.5).withValueMax(5).withValueStep(0.5),
-
             e.numeric("window_detection_time", ea.STATE_SET).withUnit("min").withValueMin(2).withValueMax(30).withValueStep(1),
-
             e.numeric("window_detection_temperature", ea.STATE_SET).withUnit("°C").withValueMin(2).withValueMax(4).withValueStep(1),
-
             e.numeric("window_detection_recovery_time", ea.STATE_SET).withUnit("min").withValueMin(10).withValueMax(60).withValueStep(1),
         ],
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26267,7 +26267,7 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaDatapoints: [
                 [1, "system_mode", tuya.valueConverterBasic.lookup({heat: true, off: false})],
-                [2, "work_mode", tuya.valueConverterBasic.lookup({"manual": tuya.enum(0), "schedule": tuya.enum(1)})],
+                [2, "work_mode", tuya.valueConverterBasic.lookup({manual: tuya.enum(0), schedule: tuya.enum(1)})],
                 [3, "running_state", tuya.valueConverterBasic.lookup({heat: 0, idle: 1})],
                 [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
                 [24, "local_temperature", tuya.valueConverter.divideBy10],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -537,7 +537,6 @@ const tzLocal = {
             await entity.command<"manuSpecificTuyaE001", "setCountdown", Ts0049Countdown>("manuSpecificTuyaE001", "setCountdown", {data});
         },
     } satisfies Tz.Converter,
-
     ts110eCountdown: {
         key: ["countdown"],
         convertSet: async (entity, key, value, meta) => {
@@ -1047,6 +1046,62 @@ const tzLocal = {
                 default: // Unknown key
                     logger.warning(`Unhandled key ${key}`, NS);
             }
+        },
+    } satisfies Tz.Converter,
+    hd_t1000_current_heating_setpoint: {
+        key: ['current_heating_setpoint'],
+        convertSet: async (entity, key, value, meta) => {
+            const num = Number(value);
+
+            if (!Number.isFinite(num)) {
+                throw new Error(`Invalid current_heating_setpoint: ${value}`);
+            }
+
+            const scaled = Math.round(num * 10);
+            await tuya.sendDataPointValue(entity, 16, scaled);
+
+            return {
+                state: {
+                    current_heating_setpoint: num,
+                },
+            };
+        },
+    } satisfies Tz.Converter,
+    hd_t1000_work_mode: {
+        key: ['work_mode'],
+        convertSet: async (entity, key, value, meta) => {
+            const lookup = {
+                manual: 0,
+                schedule: 1,
+            };
+
+            if (!(value in lookup)) {
+                throw new Error(`Invalid work_mode: ${value}`);
+            }
+
+            await tuya.sendDataPointEnum(entity, 2, lookup[value]);
+
+            return {
+                state: {
+                    work_mode: value,
+                },
+            };
+        },
+    } satisfies Tz.Converter,
+    hd_t1000_child_lock: {
+        key: ['child_lock'],
+        convertSet: async (entity, key, value, meta) => {
+            if (typeof value !== 'boolean') {
+                throw new Error(`Invalid child_lock: ${value}. Expected boolean.`);
+            }
+
+            await tuya.sendDataPointBool(entity, 40, value);
+
+            return {
+                state: {
+                    child_lock: value,
+                },
+            };
         },
     } satisfies Tz.Converter,
 };
@@ -26247,4 +26302,64 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
+    {
+        fingerprint: [
+            {modelID: 'TS0601', manufacturerName: '_TZE200_spyvfeti'},
+        ],
+        model: 'HD-T1000',
+        vendor: 'Heat Decor',
+        description: 'Floor thermostat',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [
+            tzLocal.hd_t1000_current_heating_setpoint,
+            tzLocal.hd_t1000_work_mode,
+            tzLocal.hd_t1000_child_lock,
+            tuya.tz.datapoints,
+        ],
+        onEvent: tuya.onEventSetTime,
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            e.climate()
+                .withSystemMode(['off', 'heat'], ea.STATE_SET)
+                .withRunningState(['idle', 'heat'], ea.STATE)
+                .withLocalTemperature(ea.STATE)
+                .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET),
+            e.enum('work_mode', ea.STATE_SET, ['manual', 'schedule']),
+            e.binary('child_lock', ea.STATE_SET, true, false),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [
+                    1,
+                    'system_mode',
+                    tuya.valueConverterBasic.lookup({'heat': true, 'off': false}),
+                ],
+                [
+                    2,
+                    'work_mode',
+                    tuya.valueConverterBasic.lookup({'manual': 0, 'schedule': 1}),
+                ],
+                [
+                    3,
+                    'running_state',
+                    tuya.valueConverterBasic.lookup({'heat': 0, 'idle': 1}),
+                ],
+                [
+                    16,
+                    'current_heating_setpoint',
+                    tuya.valueConverter.divideBy10,
+                ],
+                [
+                    24,
+                    'local_temperature',
+                    tuya.valueConverter.divideBy10,
+                ],
+                [
+                    40,
+                    'child_lock',
+                    tuya.valueConverter.trueFalse,
+                ],
+            ],
+        },
+    }
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1048,60 +1048,6 @@ const tzLocal = {
             }
         },
     } satisfies Tz.Converter,
-    hd_t1000_current_heating_setpoint: {
-        key: ["current_heating_setpoint"],
-        convertSet: async (entity, key, value, meta) => {
-            const num = Number(value);
-
-            if (!Number.isFinite(num)) {
-                throw new Error(`Invalid current_heating_setpoint: ${value}`);
-            }
-
-            const scaled = Math.round(num * 10);
-            await tuya.sendDataPointValue(entity, 16, scaled);
-
-            return {
-                state: {
-                    current_heating_setpoint: num,
-                },
-            };
-        },
-    } satisfies Tz.Converter,
-    hd_t1000_work_mode: {
-        key: ["work_mode"],
-        convertSet: async (entity, key, value, meta) => {
-            const lookup = {
-                manual: 0,
-                schedule: 1,
-            };
-
-            const mode = utils.getFromLookup(value, lookup);
-
-            await tuya.sendDataPointEnum(entity, 2, mode);
-
-            return {
-                state: {
-                    work_mode: value,
-                },
-            };
-        },
-    } satisfies Tz.Converter,
-    hd_t1000_child_lock: {
-        key: ["child_lock"],
-        convertSet: async (entity, key, value, meta) => {
-            if (typeof value !== "boolean") {
-                throw new Error(`Invalid child_lock: ${value}. Expected boolean.`);
-            }
-
-            await tuya.sendDataPointBool(entity, 40, value);
-
-            return {
-                state: {
-                    child_lock: value,
-                },
-            };
-        },
-    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -26306,7 +26252,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Heat Decor",
         description: "Floor thermostat",
         fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tzLocal.hd_t1000_current_heating_setpoint, tzLocal.hd_t1000_work_mode, tzLocal.hd_t1000_child_lock, tuya.tz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
             e
@@ -26321,11 +26267,11 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaDatapoints: [
                 [1, "system_mode", tuya.valueConverterBasic.lookup({heat: true, off: false})],
-                [2, "work_mode", tuya.valueConverterBasic.lookup({manual: 0, schedule: 1})],
+                [2, "work_mode", tuya.valueConverterBasic.lookup({"manual": tuya.enum(0), "schedule": tuya.enum(1)})],
                 [3, "running_state", tuya.valueConverterBasic.lookup({heat: 0, idle: 1})],
                 [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
                 [24, "local_temperature", tuya.valueConverter.divideBy10],
-                [40, "child_lock", tuya.valueConverter.trueFalse1],
+                [40, "child_lock", tuya.valueConverter.raw],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1049,7 +1049,7 @@ const tzLocal = {
         },
     } satisfies Tz.Converter,
     hd_t1000_current_heating_setpoint: {
-        key: ['current_heating_setpoint'],
+        key: ["current_heating_setpoint"],
         convertSet: async (entity, key, value, meta) => {
             const num = Number(value);
 
@@ -1068,7 +1068,7 @@ const tzLocal = {
         },
     } satisfies Tz.Converter,
     hd_t1000_work_mode: {
-        key: ['work_mode'],
+        key: ["work_mode"],
         convertSet: async (entity, key, value, meta) => {
             const lookup = {
                 manual: 0,
@@ -1089,9 +1089,9 @@ const tzLocal = {
         },
     } satisfies Tz.Converter,
     hd_t1000_child_lock: {
-        key: ['child_lock'],
+        key: ["child_lock"],
         convertSet: async (entity, key, value, meta) => {
-            if (typeof value !== 'boolean') {
+            if (typeof value !== "boolean") {
                 throw new Error(`Invalid child_lock: ${value}. Expected boolean.`);
             }
 
@@ -26303,63 +26303,33 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [
-            {modelID: 'TS0601', manufacturerName: '_TZE200_spyvfeti'},
-        ],
-        model: 'HD-T1000',
-        vendor: 'Heat Decor',
-        description: 'Floor thermostat',
+        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE200_spyvfeti"}],
+        model: "HD-T1000",
+        vendor: "Heat Decor",
+        description: "Floor thermostat",
         fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [
-            tzLocal.hd_t1000_current_heating_setpoint,
-            tzLocal.hd_t1000_work_mode,
-            tzLocal.hd_t1000_child_lock,
-            tuya.tz.datapoints,
-        ],
+        toZigbee: [tzLocal.hd_t1000_current_heating_setpoint, tzLocal.hd_t1000_work_mode, tzLocal.hd_t1000_child_lock, tuya.tz.datapoints],
         onEvent: tuya.onEventSetTime,
         configure: tuya.configureMagicPacket,
         exposes: [
-            e.climate()
-                .withSystemMode(['off', 'heat'], ea.STATE_SET)
-                .withRunningState(['idle', 'heat'], ea.STATE)
+            e
+                .climate()
+                .withSystemMode(["off", "heat"], ea.STATE_SET)
+                .withRunningState(["idle", "heat"], ea.STATE)
                 .withLocalTemperature(ea.STATE)
-                .withSetpoint('current_heating_setpoint', 5, 35, 0.5, ea.STATE_SET),
-            e.enum('work_mode', ea.STATE_SET, ['manual', 'schedule']),
-            e.binary('child_lock', ea.STATE_SET, true, false),
+                .withSetpoint("current_heating_setpoint", 5, 35, 0.5, ea.STATE_SET),
+            e.enum("work_mode", ea.STATE_SET, ["manual", "schedule"]),
+            e.binary("child_lock", ea.STATE_SET, true, false),
         ],
         meta: {
             tuyaDatapoints: [
-                [
-                    1,
-                    'system_mode',
-                    tuya.valueConverterBasic.lookup({'heat': true, 'off': false}),
-                ],
-                [
-                    2,
-                    'work_mode',
-                    tuya.valueConverterBasic.lookup({'manual': 0, 'schedule': 1}),
-                ],
-                [
-                    3,
-                    'running_state',
-                    tuya.valueConverterBasic.lookup({'heat': 0, 'idle': 1}),
-                ],
-                [
-                    16,
-                    'current_heating_setpoint',
-                    tuya.valueConverter.divideBy10,
-                ],
-                [
-                    24,
-                    'local_temperature',
-                    tuya.valueConverter.divideBy10,
-                ],
-                [
-                    40,
-                    'child_lock',
-                    tuya.valueConverter.trueFalse,
-                ],
+                [1, "system_mode", tuya.valueConverterBasic.lookup({heat: true, off: false})],
+                [2, "work_mode", tuya.valueConverterBasic.lookup({manual: 0, schedule: 1})],
+                [3, "running_state", tuya.valueConverterBasic.lookup({heat: 0, idle: 1})],
+                [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
+                [24, "local_temperature", tuya.valueConverter.divideBy10],
+                [40, "child_lock", tuya.valueConverter.trueFalse],
             ],
         },
-    }
+    },
 ];


### PR DESCRIPTION
Added converters for current heating setpoint, work mode, and child lock for HD-T1000 thermostat.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5033
