### PR TITLE
Updated zigbeeModel for Hue Iris (Generation 2)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2419,7 +2419,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
-        zigbeeModel: ["LLC006"],
+        zigbeeModel: ["LLC006", "7099930PH"],
         model: "7099930PH",
         vendor: "Philips",
         description: "Hue Iris (Generation 2)",


### PR DESCRIPTION
Added additional zigbeeModel as some Hue Iris (Gen2) report the additional code.
Tested with my two old Hue Iris Gen 2.

(added no image as this extends an existing device)
