### PR TITLE
feat(danfoss): declare ota: true for Icon2

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1579,6 +1579,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "Icon2",
         vendor: "Danfoss",
         description: "Icon2 Main Controller, Room Thermostat or Sensor",
+        ota: true,
         extend: [danfossExtend.addDanfossHvacThermostatCluster(), danfossExtend.addDanfossHaDiagnosticCluster()],
         fromZigbee: [
             fzLocal.danfoss_icon_battery,


### PR DESCRIPTION
Enables Z2M to auto-discover for Icon2 firmware via the community OTA index.
Removes the "No official OTA support" banner.

Companion to Koenkk/zigbee-OTA#1148.
