### PR TITLE
Restore Power On behavior for GL-B-003P

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -1063,7 +1063,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "GL-B-003P",
         vendor: "Gledopto",
         description: "Zigbee 7W E26/E27 Bulb RGB+CCT (pro)",
-        extend: [gledoptoLight({colorTemp: {range: [155, 495]}, turnsOffAtBrightness1: true})],
+        extend: [gledoptoLight({colorTemp: {range: [155, 495]}, turnsOffAtBrightness1: true, powerOnBehavior:true})],
     },
     {
         zigbeeModel: ["GL-FL-004TZS"],

--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -1063,7 +1063,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "GL-B-003P",
         vendor: "Gledopto",
         description: "Zigbee 7W E26/E27 Bulb RGB+CCT (pro)",
-        extend: [gledoptoLight({colorTemp: {range: [155, 495]}, turnsOffAtBrightness1: true, powerOnBehavior:true})],
+        extend: [gledoptoLight({colorTemp: {range: [155, 495]}, turnsOffAtBrightness1: true, powerOnBehavior: true})],
     },
     {
         zigbeeModel: ["GL-FL-004TZS"],


### PR DESCRIPTION
Wrote '{"startUpOnOff":0}' to 'genOnOff'
Wrote '{"startUpOnOff":1}' to 'genOnOff'

Power On behavior works for this device based on my own test.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
