### PR TITLE
fix(detect): Detect `_TZ3210_2uollq9d` as BSEED TS011F_plug_1_2

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9358,6 +9358,7 @@ export const definitions: DefinitionWithExtend[] = [
                 "_TZ3000_4ux0ondb",
                 "_TZ3000_b28wrpvx",
                 "_TZ3000_2uollq9d",
+                "_TZ3210_2uollq9d",
                 "_TZ3210_zifx0xoj",
                 "_TZ3000_ko6v90pg",
             ]),


### PR DESCRIPTION
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/28785#issuecomment-3634152028

@TakissX will be detected correctly now!
> I also have a BSEED "TS011F _TZ3210_2uollq9d", it has been recognized as Tuya "TS011F_plug_1" and everything works as it should. The only problem is that it is not listed as BSEED and does not have its photo.

