### PR TITLE
Revert "fix(detect): Detect `_TZB210_ue01a0s2` as MiBoxer E2-ZR (#11990)"

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5622,7 +5622,7 @@ export const definitions: DefinitionWithExtend[] = [
                 "_TZB210_lmqquxus",
                 "_TZB210_ue01a0s2",
             ]),
-            tuya.whitelabel("MiBoxer", "E2-ZR", "2 in 1 LED controller", ["_TZB210_ayx58ft5", "_TZB210_eiwanbeb", "_TZB210_ue01a0s2"]),
+            tuya.whitelabel("MiBoxer", "E2-ZR", "2 in 1 LED controller", ["_TZB210_ayx58ft5", "_TZB210_eiwanbeb"]),
             tuya.whitelabel("MiBoxer", "PZ2", "2 in 1 LED controller", ["_TZB210_0bkzabht"]),
             tuya.whitelabel("Lidl", "14156408L", "Livarno Lux smart LED ceiling light", ["_TZ3210_c2iwpxf1"]),
             tuya.whitelabel("EcoDim", "ED-10032", "Zigbee LED filament lamp dimmable E27, bulb A60, Smokey 2000K-4000K", ["_TZ3210_09hzmirw"]),


### PR DESCRIPTION
- revert https://github.com/Koenkk/zigbee-herdsman-converters/pull/11990

This caused a conflict. Device is part of two whiteLabels now. It's 2 lines above.

It's common that manufacturers reuse the same firmware on multiple devices. 
@mikelauskas This is only a cosmetic change. You can change the picture in your Z2M instance.