### PR TITLE
feat(add): 929004277004

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4960,7 +4960,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["929004276902", "929004277002", "929004277102"],
+        zigbeeModel: ["929004276902", "929004277002", "929004277004", "929004277102"],
         model: "929004276902",
         vendor: "Philips",
         description: "Hue Neon Outdoor Lightstrip (3m)",
@@ -4970,6 +4970,12 @@ export const definitions: DefinitionWithExtend[] = [
                 vendor: "Philips",
                 description: "Hue Neon Outdoor Lightstrip (5m)",
                 fingerprint: [{modelID: "929004277002"}],
+            },
+            {
+                model: "929004277004",
+                vendor: "Philips",
+                description: "Hue Neon Outdoor Lightstrip (5m)",
+                fingerprint: [{modelID: "929004277004"}],
             },
             {
                 model: "929004277102",


### PR DESCRIPTION
Adds `929004277004` as a white-label of the existing Hue Neon Outdoor Lightstrip family (sibling of the existing `929004277002` 5m entry).

**Observed in the wild**: Devices reporting model ID `929004277004` encountered on a production Home Assistant installation in Australia; likely a regional SKU variant of the 5m model.

**Device fingerprint** (from bridge/devices of an affected device):
- `manufacturerName`: `Signify Netherlands B.V.`
- `modelID`: `929004277004`
- `softwareBuildID`: `1.129.5`
- Endpoints: EP 11 (input: `genBasic, genIdentify, genGroups, genScenes, genOnOff, genLevelCtrl, touchlink, manuSpecificPhilips2, lightingColorCtrl, manuSpecificPhilips3, 64516`; output: `genOta`), EP 242 (output: `greenPower`)
- `powerSource`: Mains, `type`: Router
- `supports_ota`: true

Clusters are identical to the existing 5m (`929004277002`) definition. Verified working against the existing `philips.m.light({...})` extend (colorTemp 50-1000, xy+hs with enhancedHue, gradient with extraEffects) on two units in production. OTA resolves to the Hue `100B-0118-01002000-PixelLum-EFR32MG21.zigbee` image as expected for this product family.

**Local verification**:
- `pnpm run build` ✓
- `pnpm run check` ✓ (one info-level notice on unrelated biome schema version mismatch in `biome.json`)
- `pnpm test` ✓ (491 tests passed)