### PR TITLE
fix(detect): Detect `_TZE284_awepdiwi` as NEO NAS-STH02B2

### DIFF
--- a/src/devices/neo.ts
+++ b/src/devices/neo.ts
@@ -306,7 +306,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_rqcuwlsa"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_rqcuwlsa", "_TZE284_awepdiwi"]),
         model: "NAS-STH02B2",
         vendor: "NEO",
         description: "Soil moisture, temperature, and ec",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4036,7 +4036,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_g2e6cpnw", "_TZE284_sgabhwa6", "_TZE284_awepdiwi"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_g2e6cpnw", "_TZE284_sgabhwa6"]),
         model: "TS0601_soil_2",
         vendor: "Tuya",
         description: "Soil sensor",


### PR DESCRIPTION
Picked from Discord
> icetail — 19:09
Hi. i need help and dont know where to begin.. 😉
i have a https://www.zigbee2mqtt.io/devices/NAS-STH02B2.html
but it gets detected as a https://www.zigbee2mqtt.io/devices/TS0601_soil_2.html
What do/can i do now?
This? _TZE284_awepdiwi

Datapoints and info from Tuya portal:
- [_TZE284_sgabhwa6-_TZE284_g2e6cpnw.md](https://github.com/user-attachments/files/27021243/_TZE284_sgabhwa6-_TZE284_g2e6cpnw.md)
- [_TZE284_awepdiwi-_TZE284_rqcuwlsa.md](https://github.com/user-attachments/files/27021244/_TZE284_awepdiwi-_TZE284_rqcuwlsa.md)