### PR TITLE
Fix fz MoveToLevel 255

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1430,7 +1430,7 @@ export const command_move_to_level: Fz.Converter<"genLevelCtrl", undefined, ["co
         if (hasAlreadyProcessedMessage(msg, model)) return;
         const payload: KeyValueAny = {
             action: postfixWithEndpointName("brightness_move_to_level", msg, model, meta),
-            action_level: msg.data.level,
+            action_level: msg.data.level || 254,
             action_transition_time: msg.data.transtime / 100,
         };
         addActionGroup(payload, msg, model);


### PR DESCRIPTION
- part 1 of reviving https://github.com/Koenkk/zigbee-herdsman-converters/pull/11244

Another undefined value case 🙂 

[Bilresa scroll-wheel remote](https://www.zigbee2mqtt.io/devices/E2490.html) sends _MoveToLevel_ commands while rotating the wheel.
The level parameter ranges from 1 to 255! (max should be 254 instead)

**255 is undefined -> comes up as null in Z2M.**

<img width="522" alt="image" src="https://github.com/user-attachments/assets/38b897d7-debd-4928-b75f-67b75745352e" />

<img width="522" alt="Screenshot From 2026-04-24 21-57-28" src="https://github.com/user-attachments/assets/5466c0ca-f0d2-4304-94f4-177bfbc19711" />
<p></p>

Where's the correct place to fix this? Generic fz converter or device-specific?

---

Note1: My lightbulbs seem to not care. They set level 254 on receipt of 255 (with success response).

Note2: Clicking 100% brightness in WF sends 255 on mqtt @Nerivec (but down the line it gets corrected to 254)