### PR TITLE
Aqara W600: Add battery, valve alarm and open window indicators. Correct wrong naming.

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5644,7 +5644,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: ["OFF", 0],
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0273, type: 0x20},
-                description: "Enables/disables window detection on the device",
+                description: "Enable or disable open window detection. When enabled, the window_open is set to true if an open window is detected",
                 access: "ALL",
                 label: "Open window detection",
                 entityCategory: "config",

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -60,6 +60,7 @@ const {
     lumiPreventLeave,
     lumiExternalSensor,
     w600ExternalTempSensor,
+    w600Heartbeat,
     w600PresetTemperatureTable,
     w600Schedule,
     w600Thermostat,
@@ -5578,11 +5579,16 @@ export const definitions: DefinitionWithExtend[] = [
                 if (typeof payload.value_template === "string" && payload.value_template.includes("value_json.schedule_upload_status")) {
                     payload.icon = "mdi:upload-multiple";
                 }
+
+                if (typeof payload.value_template === "string" && payload.value_template.includes("value_json.calibrated")) {
+                    payload.icon = "mdi:tune";
+                }
             },
         },
         extend: [
             lumi.modernExtend.addManuSpecificLumiCluster(),
             m.customTimeResponse("2000_LOCAL"),
+            w600Heartbeat(),
             w600Thermostat(),
             w600ExternalTempSensor(),
             m.enumLookup<"manuSpecificLumi", ManuSpecificLumi>({
@@ -5590,8 +5596,10 @@ export const definitions: DefinitionWithExtend[] = [
                 lookup: {start: 1},
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0270, type: Zcl.DataType.UINT8},
-                description: "Calibrates the valve",
-                access: "ALL",
+                description: "Start valve calibration",
+                access: "SET",
+                label: "Calibrate",
+                entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.enumLookup<"manuSpecificLumi", ManuSpecificLumi>({
@@ -5599,18 +5607,22 @@ export const definitions: DefinitionWithExtend[] = [
                 lookup: {not_ready: 0, ready: 1, error: 2, in_progress: 3},
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x027b, type: Zcl.DataType.UINT8},
-                description: "State of calibrate",
+                description: "Valve calibration state",
                 access: "STATE_GET",
+                label: "Calibration status",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.binary<"manuSpecificLumi", ManuSpecificLumi>({
-                name: "valve_detection",
+                name: "temperature_control_abnormal_notification",
                 valueOn: ["ON", 1],
                 valueOff: ["OFF", 0],
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0274, type: 0x20},
-                description: "Determines if temperature control abnormalities should be detected",
+                description:
+                    "Enable or disable reporting of abnormal temperature control status. When enabled, the valve alarm is set to true if an abnormality is detected",
                 access: "ALL",
+                label: "Temperature control abnormal notification",
+                entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.binary<"manuSpecificLumi", ManuSpecificLumi>({
@@ -5619,8 +5631,10 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: ["OFF", 0],
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0330, type: 0x20},
-                description: "Display flip",
+                description: "Flip the display orientation",
                 access: "ALL",
+                label: "Display flip",
+                entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             w600Schedule(),
@@ -5632,6 +5646,8 @@ export const definitions: DefinitionWithExtend[] = [
                 attribute: {ID: 0x0273, type: 0x20},
                 description: "Enables/disables window detection on the device",
                 access: "ALL",
+                label: "Open window detection",
+                entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.binary<"manuSpecificLumi", ManuSpecificLumi>({
@@ -5640,8 +5656,10 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: ["UNLOCK", 0],
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0277, type: 0x20},
-                description: "Enables/disables physical input on the device",
+                description: "Lock or unlock the physical controls on the device",
                 access: "ALL",
+                label: "Child lock",
+                entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.numeric<"manuSpecificLumi", ManuSpecificLumi>({
@@ -5671,6 +5689,7 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "manuSpecificLumi",
                 attribute: {ID: 0x0360, type: Zcl.DataType.SINGLE_PREC},
                 description: "Position of the valve, 100% is fully open",
+                label: "Valve position",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
             m.identify(),

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -3579,6 +3579,7 @@ export const lumiModernExtend = {
         } satisfies ModernExtend;
     },
     w600ExternalTempSensor: (): ModernExtend => createW600ExternalTempSensor(),
+    w600Heartbeat: (): ModernExtend => createW600Heartbeat(),
     w600Thermostat: (): ModernExtend => createW600Thermostat(),
     w600Schedule: (): ModernExtend => createW600Schedule(),
     w600WeeklySchedule: (): ModernExtend => createW600WeeklySchedule(),
@@ -3644,6 +3645,7 @@ const W600_ATTR_PRESET = 0x0311;
 const W600_ATTR_PRESET_TEMPERATURE_TABLE = 0x0317;
 const W600_ATTR_SENSOR_SOURCE = 0x0280;
 const W600_ATTR_SENSOR_BINDING = 0xfff2;
+const W600_ATTR_HEARTBEAT = 0x00f7;
 const W600_EXTERNAL_TEMP_SENSOR = Buffer.from("00158d00019d1b98", "hex");
 const W600_PRESET_TABLE_STORE_KEY = "w600PresetTemperatureTable";
 const W600_SENSOR_BINDING_COUNTER_STORE_KEY = "w600SensorBindingCounter";
@@ -3863,6 +3865,79 @@ function parseW600ExternalTemperatureInput(value: unknown, key: string) {
     return Math.round(numeric * 100);
 }
 
+function decodeW600Heartbeat(buffer: Buffer) {
+    const heartbeat: KeyValue = {};
+    let offset = 0;
+
+    while (offset + 2 <= buffer.length) {
+        const key = buffer.readUInt8(offset);
+        const type = buffer.readUInt8(offset + 1);
+        offset += 2;
+
+        switch (type) {
+            case Zcl.DataType.BOOLEAN:
+            case Zcl.DataType.UINT8:
+            case Zcl.DataType.ENUM8:
+                if (offset + 1 > buffer.length) return heartbeat;
+                heartbeat[key] = buffer.readUInt8(offset);
+                offset += 1;
+                break;
+            case Zcl.DataType.INT8:
+                if (offset + 1 > buffer.length) return heartbeat;
+                heartbeat[key] = buffer.readInt8(offset);
+                offset += 1;
+                break;
+            case Zcl.DataType.UINT16:
+            case Zcl.DataType.ENUM16:
+                if (offset + 2 > buffer.length) return heartbeat;
+                heartbeat[key] = buffer.readUInt16LE(offset);
+                offset += 2;
+                break;
+            case Zcl.DataType.INT16:
+                if (offset + 2 > buffer.length) return heartbeat;
+                heartbeat[key] = buffer.readInt16LE(offset);
+                offset += 2;
+                break;
+            case Zcl.DataType.UINT32:
+                if (offset + 4 > buffer.length) return heartbeat;
+                heartbeat[key] = buffer.readUInt32LE(offset);
+                offset += 4;
+                break;
+            case Zcl.DataType.OCTET_STR: {
+                if (offset + 1 > buffer.length) return heartbeat;
+                const length = buffer.readUInt8(offset);
+                offset += 1;
+
+                if (offset + length > buffer.length) return heartbeat;
+                heartbeat[key] = buffer.subarray(offset, offset + length);
+                offset += length;
+                break;
+            }
+            default:
+                logger.debug(`Unsupported W600 heartbeat type 0x${type.toString(16)} for sub-key 0x${key.toString(16)}`, W600_NS);
+                return heartbeat;
+        }
+    }
+
+    return heartbeat;
+}
+
+function decodeW600Heartbeat9c(buffer: Buffer) {
+    if (buffer.length < 8) {
+        return undefined;
+    }
+
+    const windowOpenStatus = buffer[4];
+    const windowOpen = windowOpenStatus === 0x00 ? false : windowOpenStatus === 0x0d || windowOpenStatus === 0x0e ? true : undefined;
+    const valveAlarm =
+        windowOpenStatus === 0x10 ? true : windowOpenStatus === 0x00 || windowOpenStatus === 0x0d || windowOpenStatus === 0x0e ? false : undefined;
+
+    return {
+        valveAlarm,
+        windowOpen,
+    };
+}
+
 function parseW600BinaryEnabled(value: unknown) {
     if (value === 1 || value === true) {
         return true;
@@ -4032,6 +4107,58 @@ function buildW600ExternalTemperaturePayload(entity: Zh.Endpoint, centiDegrees: 
     temperatureBuffer.writeFloatBE(centiDegrees, 0);
 
     return buildW600SensorPayload(entity, 0x05, Buffer.concat([W600_EXTERNAL_TEMP_SENSOR, W600_SENSOR_BINDING_MARKER, temperatureBuffer]));
+}
+
+function createW600Heartbeat(): ModernExtend {
+    return {
+        exposes: [
+            e.battery().withDescription("Battery percentage"),
+            e.valve_alarm().withDescription("Indicates whether temperature control abnormal notification has reported an active alert"),
+            e.binary("window_open", ea.STATE, true, false).withDescription("Indicates whether open window detection has reported an open window"),
+        ],
+        fromZigbee: [
+            {
+                cluster: W600_LUMI_CLUSTER,
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg, publish, options, meta) => {
+                    const value = msg.data[W600_ATTR_HEARTBEAT];
+
+                    if (!Buffer.isBuffer(value)) {
+                        return;
+                    }
+
+                    const heartbeat = decodeW600Heartbeat(value);
+                    const result: KeyValue = {};
+
+                    if (typeof heartbeat[0x0d] === "number" && Number.isFinite(heartbeat[0x0d])) {
+                        const device = meta.device ?? msg.device;
+                        device.softwareBuildID = trv.decodeFirmwareVersionString(heartbeat[0x0d] as number);
+                    }
+
+                    if (typeof heartbeat[0x18] === "number" && Number.isFinite(heartbeat[0x18])) {
+                        result.battery = Math.max(0, Math.min(100, heartbeat[0x18] as number));
+                    }
+
+                    if (Buffer.isBuffer(heartbeat[0x9c])) {
+                        const heartbeat9c = decodeW600Heartbeat9c(heartbeat[0x9c] as Buffer);
+
+                        if (heartbeat9c) {
+                            if (typeof heartbeat9c.valveAlarm === "boolean") {
+                                result.valve_alarm = heartbeat9c.valveAlarm;
+                            }
+
+                            if (typeof heartbeat9c.windowOpen === "boolean") {
+                                result.window_open = heartbeat9c.windowOpen;
+                            }
+                        }
+                    }
+
+                    return Object.keys(result).length > 0 ? result : undefined;
+                },
+            } satisfies Fz.Converter<"manuSpecificLumi", ManuSpecificLumi, ["attributeReport", "readResponse"]>,
+        ],
+        isModernExtend: true,
+    };
 }
 
 function deriveW600SystemMode(args: {heatingEnabled: boolean | undefined; scheduleEnabled: boolean | undefined}) {


### PR DESCRIPTION
## Summary

This PR adds a partial heartbeat converter for the Aqara W600 TRV and corrects few things.

- Decode W600 heartbeat reports from `manuSpecificLumi` attribute `0x00f7`.
- Publish user-facing heartbeat state for `battery` (🎉), `valve_alarm`, and `window_open`.
- Update `device.softwareBuildID` from the heartbeat firmware key.
- Rename `valve_detection` to `temperature_control_abnormal_notification` (following Aqara app semantics).
- Fix the `calibrate` action so it is SET-only and does not try to decode the idle read value as button state (fixes error reported in https://github.com/Koenkk/zigbee-herdsman-converters/pull/11991#issuecomment-4290977690)
- Improve W600 labels/descriptions/categories where they were misleading.

## Heartbeat Behavior

The W600 heartbeat uses the same general Lumi manufacturer cluster/attribute pattern as Aqara TRVs, but the embedded keys are W600-specific. This PR reuses existing Lumi helpers where they fit, especially `trv.decodeFirmwareVersionString`, and adds only a small parser for the W600 heartbeat structure and `0x9c` status block.

The exposed heartbeat surface is intentionally small:

- `battery`: decoded from heartbeat key `0x18`.
- `valve_alarm`: decoded from the W600 `0x9c` status block; this becomes true when temperature control abnormal notification is enabled and an abnormality is detected.
- `window_open`: decoded from the W600 `0x9c` status block; this becomes true when open window detection is enabled and an open window condition is detected.

There are more keys in the heartbeat, but I focused on essentials.


## Calibration Bug Fix

Before this PR, `calibrate` was exposed with read access even though it is really an action. When Zigbee2MQTT/Home Assistant read `0x0270`, the device could answer with idle value `0`. The enum only defines the start command as `1`, so the read response could throw:

```text
Expected one of: 1, got: '0'
```

This PR makes `calibrate` SET-only. The button remains usable for starting calibration, and calibration state stays represented by the separate `calibrated` property from `0x027b`, which the captures show reporting progress/complete states.

## Public Interface Changes

- Adds `battery`, `valve_alarm`, and `window_open` heartbeat-derived state.
- Renames `valve_detection` to `temperature_control_abnormal_notification`.
- Removes the old `valve_detection` name without a compatibility alias.
- Keeps `calibrate` as an action only; calibration status remains under `calibrated`.
