### PR TITLE
feat(danfoss): add system_status_code, preheat_time, PreHeatCommand, fix time sync and running_state for Ally TRV

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -963,6 +963,15 @@ const danfossExtend = {
             },
         });
 
+        extend.toZigbee.push({
+            key: ["running_state"],
+            convertGet: async (entity, key, meta) => {
+                await entity.read<"hvacThermostat", DanfossHvacThermostat>("hvacThermostat", ["danfossHeatRequired"], {
+                    manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S,
+                });
+            },
+        });
+
         extend.configure.push(
             m.setupConfigureForReading<"hvacThermostat", undefined>("hvacThermostat", ["systemMode"]),
             m.setupConfigureForReading<"hvacUserInterfaceCfg", undefined>("hvacUserInterfaceCfg", ["keypadLockout"]),

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1,4 +1,4 @@
-import {Zcl} from "zigbee-herdsman";
+import {getTimeClusterAttributes, Zcl} from "zigbee-herdsman";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as constants from "../lib/constants";
@@ -12,12 +12,22 @@ import {postfixWithEndpointName, precisionRound} from "../lib/utils";
 const e = exposes.presets;
 const ea = exposes.access;
 
-const setTime = async (device: Zh.Device) => {
+const setTime = async (device: Zh.Device, sendPolicy?: "immediate" | "queue") => {
     const endpoint = device.getEndpoint(1);
-    const time = Math.round((Date.now() - constants.OneJanuary2000) / 1000);
-    // Time-master + synchronised
-    const values = {timeStatus: 1, time: time, timeZone: new Date().getTimezoneOffset() * -1 * 60};
-    await endpoint.write("genTime", values);
+    const {time, timeZone, dstStart, dstEnd, dstShift} = getTimeClusterAttributes();
+
+    await endpoint.write(
+        "genTime",
+        {
+            time,
+            timeStatus: 0x02, // bit 1 = synchronized (per Danfoss spec §1.2)
+            timeZone,
+            dstStart,
+            dstEnd,
+            dstShift,
+        },
+        sendPolicy ? {sendPolicy} : undefined,
+    );
 };
 
 interface DanfossHvacThermostat {
@@ -1358,7 +1368,13 @@ export const definitions: DefinitionWithExtend[] = [
             danfossExtend.danfossAdaptionRunSettings(),
             danfossExtend.danfossAdaptionRunControl(),
             danfossExtend.danfossRegulationSetpointOffset(),
-            m.writeTimeDaily({endpointId: 1}),
+            m.poll({
+                key: "danfossTime",
+                defaultIntervalSeconds: 60 * 60 * 24, // 24 hours
+                poll: async (device) => {
+                    await setTime(device, "queue");
+                },
+            }),
         ],
         exposes: [
             e

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1367,7 +1367,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withCategory("diagnostic"),
         ],
         fromZigbee: [fz.thermostat_weekly_schedule],
-        toZigbee: [tz.thermostat_clear_weekly_schedule],
+        toZigbee: [tz.thermostat_clear_weekly_schedule, tzLocal.danfoss_system_status_code, tzLocal.danfoss_preheat_command],
     },
     {
         fingerprint: [

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1382,8 +1382,26 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Diagnostic status bitmap (bit 9 = time/clock lost).")
                 .withCategory("diagnostic"),
         ],
-        fromZigbee: [fz.thermostat_weekly_schedule],
+        fromZigbee: [fz.thermostat_weekly_schedule, fzLocal.danfoss_system_status_code],
         toZigbee: [tz.thermostat_clear_weekly_schedule, tzLocal.danfoss_system_status_code, tzLocal.danfoss_preheat_command],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            const options = {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S};
+            await reporting.bind(endpoint, coordinatorEndpoint, ["haDiagnostic"]);
+            await endpoint.configureReporting<"haDiagnostic", DanfossHaDiagnostic>(
+                "haDiagnostic",
+                [
+                    {
+                        attribute: "danfossSystemStatusCode",
+                        minimumReportInterval: 0,
+                        maximumReportInterval: constants.repInterval.HOUR,
+                        reportableChange: 1,
+                    },
+                ],
+                options,
+            );
+            await endpoint.read<"haDiagnostic", DanfossHaDiagnostic>("haDiagnostic", ["danfossSystemStatusCode"], options);
+        },
     },
     {
         fingerprint: [

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -799,6 +799,16 @@ const danfossExtend = {
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S},
             ...args,
         }),
+    danfossPreheatTime: (args?: Partial<m.NumericArgs<"hvacThermostat", DanfossHvacThermostat>>) =>
+        m.numeric<"hvacThermostat", DanfossHvacThermostat>({
+            name: "preheat_time",
+            cluster: "hvacThermostat",
+            attribute: "danfossPreheatTime",
+            description: "Timestamp of the scheduled setpoint currently being preheated to (read-only)",
+            access: "STATE_GET",
+            zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S},
+            ...args,
+        }),
     danfossAdaptionRunStatus: (args?: Partial<m.EnumLookupArgs<"hvacThermostat", DanfossHvacThermostat>>) =>
         m.enumLookup<"hvacThermostat", DanfossHvacThermostat>({
             name: "adaptation_run_status",
@@ -1315,6 +1325,7 @@ export const definitions: DefinitionWithExtend[] = [
             danfossExtend.danfossLoadRoomMean(),
             danfossExtend.danfossLoadEstimate(),
             danfossExtend.danfossPreheatStatus(),
+            danfossExtend.danfossPreheatTime(),
             danfossExtend.danfossAdaptionRunStatus(),
             danfossExtend.danfossAdaptionRunSettings(),
             danfossExtend.danfossAdaptionRunControl(),

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1029,6 +1029,15 @@ const tzLocal = {
     } satisfies Tz.Converter,
     danfoss_system_status_code: {
         key: ["system_status_code"],
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertNumber(value, key);
+            await entity.write<"haDiagnostic", DanfossHaDiagnostic>(
+                "haDiagnostic",
+                {danfossSystemStatusCode: value},
+                {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S},
+            );
+            return {state: {system_status_code: value}};
+        },
         convertGet: async (entity, key, meta) => {
             await entity.read<"haDiagnostic", DanfossHaDiagnostic>("haDiagnostic", ["danfossSystemStatusCode"], {
                 manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S,
@@ -1238,6 +1247,17 @@ const fzLocal = {
             return result;
         },
     } satisfies Fz.Converter<"hvacUserInterfaceCfg", DanfossHvacUserInterfaceCfg, ["attributeReport", "readResponse"]>,
+    danfoss_system_status_code: {
+        cluster: "haDiagnostic",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValueAny = {};
+            if (msg.data.danfossSystemStatusCode !== undefined) {
+                result.system_status_code = msg.data.danfossSystemStatusCode;
+            }
+            return result;
+        },
+    } satisfies Fz.Converter<"haDiagnostic", DanfossHaDiagnostic, ["attributeReport", "readResponse"]>,
 };
 
 export const definitions: DefinitionWithExtend[] = [
@@ -1256,6 +1276,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             danfossExtend.addDanfossHvacThermostatCluster(),
             danfossExtend.addDanfossHvacUserInterfaceCfgCluster(),
+            danfossExtend.addDanfossHaDiagnosticCluster(),
             danfossExtend.danfossThermostat({
                 setpoints: {values: {occupiedHeatingSetpoint: {min: 5, max: 35, step: 0.5}}},
                 piHeatingDemand: {values: true},
@@ -1299,6 +1320,12 @@ export const definitions: DefinitionWithExtend[] = [
             danfossExtend.danfossAdaptionRunControl(),
             danfossExtend.danfossRegulationSetpointOffset(),
             m.writeTimeDaily({endpointId: 1}),
+        ],
+        exposes: [
+            e
+                .numeric("system_status_code", ea.STATE_GET)
+                .withDescription("Diagnostic status bitmap (bit 9 = time/clock lost).")
+                .withCategory("diagnostic"),
         ],
         fromZigbee: [fz.thermostat_weekly_schedule],
         toZigbee: [tz.thermostat_clear_weekly_schedule],

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -58,6 +58,10 @@ interface DanfossHvacThermostat {
             setpointType: number;
             setpoint: number;
         };
+        danfossPreHeatCommand: {
+            type: number;
+            timestamp: number;
+        };
     };
     commandResponses: never;
 }
@@ -329,6 +333,14 @@ const danfossExtend = {
                     parameters: [
                         {name: "setpointType", type: Zcl.DataType.ENUM8, max: 0xff},
                         {name: "setpoint", type: Zcl.DataType.INT16, min: -32768, max: 32767},
+                    ],
+                },
+                danfossPreHeatCommand: {
+                    name: "danfossPreHeatCommand",
+                    ID: 0x42,
+                    parameters: [
+                        {name: "type", type: Zcl.DataType.ENUM8, max: 0xff},
+                        {name: "timestamp", type: Zcl.DataType.UINT32},
                     ],
                 },
             },
@@ -1035,6 +1047,22 @@ const tzLocal = {
             await entity.read<"hvacThermostat", DanfossHvacThermostat>("hvacThermostat", ["danfossIcon2PreHeatStatus"], {
                 manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S,
             });
+        },
+    } satisfies Tz.Converter,
+    danfoss_preheat_command: {
+        key: ["preheat_command"],
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertObject(value);
+            const payload = {
+                type: 0x00, // Force preheat
+                timestamp: value.timestamp,
+            };
+            await entity.command<"hvacThermostat", "danfossPreHeatCommand", DanfossHvacThermostat>(
+                "hvacThermostat",
+                "danfossPreHeatCommand",
+                payload,
+                {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S},
+            );
         },
     } satisfies Tz.Converter,
     danfoss_system_status_code: {


### PR DESCRIPTION

## Summary

Add missing diagnostic attributes, preheat coordination command, fix time synchronization, and fix `running_state` get for the Danfoss Ally TRV (`014G2461`).

## Changes

### New features
- **`system_status_code`** — Expose `haDiagnostic` cluster attribute 0x4000 as a numeric diagnostic entity (raw BITMAP16). After a battery pull, the TRV reports `512` (bit 9 = E10 "Invalid clock information") which allows integrations to pro-actively sync time.
- Preheat Coordination for rooms with multiple TRVs
  - **`preheat_time`** — Expose `danfossPreheatTime` (0x4050, UINT32) as a read-only diagnostic via new `danfossExtend.danfossPreheatTime()`. Returns the timestamp of the setpoint currently being preheated to (0 when idle).
  - **`preheat_command`** — Register `danfossPreHeatCommand` (0x42) in the hvacThermostat cluster commands and add a `toZigbee` converter. Sends `{"type": 0, "timestamp": <value>}` to force a TRV into preheat mode for multi-TRV coordination.

### Bug fixes
- **Time sync: write all 6 `genTime` attributes** — `setTime()` now uses `getTimeClusterAttributes()` from zigbee-herdsman to write `time`, `timeStatus`, `timeZone`, `dstStart`, `dstEnd`, `dstShift`.
- **Time sync: fix daily write** — Replace `m.writeTimeDaily()` with `m.poll()` calling the fixed `setTime()` with `sendPolicy: "queue"`.
- **`running_state` get** — Add `toZigbee` converter inside `danfossThermostat()` that reads `danfossHeatRequired` (manufacturer-specific). Previously produced "No converter available" error. This issue was made visible by #11747, wasn't working before either since `tz.thermostat_running_state` read the standard `runningState` attribute which Danfoss doesn't support.

## Tested on hardware

Tested on real Danfoss Ally TRVs (firmware v32, model eTRV0103).

## Notes
- `setTime()` should be Ally-specific only
- `danfossHeatRequired` is used instead of `danfossOutputStatus` because Ally doesn't support `danfossOutputStatus` (`UNSUPPORTED_ATTRIBUTE`)
- `system_status_code` expose uses `ea.STATE_GET` with `diagnostic` category; write-to-clear works via `toZigbee` `convertSet` only (HA UI shows read-only, clearing is an automation task)