### PR TITLE
Add support for Alcantara3 heater in Acova

### DIFF
--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -44,6 +44,39 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: [
+            "ALCANTARA3"
+        ],
+        model: "ALCANTARA3",
+        vendor: "Acova",
+        description: "Alcantara 3 heater",
+        fromZigbee: [fz.thermostat, fz.hvac_user_interface],
+        toZigbee: [
+            tz.thermostat_local_temperature,
+            tz.thermostat_system_mode,
+            tz.thermostat_occupied_heating_setpoint,
+            tz.thermostat_unoccupied_heating_setpoint,
+            tz.thermostat_running_state,
+        ],
+        exposes: [
+            e
+                .climate()
+                .withSetpoint("occupied_heating_setpoint", 7, 28, 0.5)
+                .withSetpoint("unoccupied_heating_setpoint", 7, 28, 0.5)
+                .withLocalTemperature()
+                .withSystemMode(["off", "heat", "auto"])
+                .withRunningState(["idle", "heat"]),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "hvacThermostat"]);
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatRunningState(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatUnoccupiedHeatingSetpoint(endpoint);
+        },
+    },
+    {
+        zigbeeModel: [
             "PERCALE2 D1.00P1.01Z1.00",
             "PERCALE2 D1.00P1.02Z1.00",
             "PERCALE2 D1.00P1.03Z1.00",

--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -43,9 +43,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: [
-            "ALCANTARA3"
-        ],
+        zigbeeModel: ["ALCANTARA3"],
         model: "ALCANTARA3",
         vendor: "Acova",
         description: "Alcantara 3 heater",


### PR DESCRIPTION

Add support for Alcantara3 : 
I basically copied what was implemented for Alcantara2.  
Tested today = ok.

Basically seems the same device than Alcantara2. 

Here the picture of the device : 
<img width="698" height="904" alt="Capture d’écran du 2026-04-26 18-13-00" src="https://github.com/user-attachments/assets/8ab0412d-f329-4de0-bb9d-02b0a5648d15" />
