### PR TITLE
Add support for TS0003 device with 2 switches and 1 socket

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6695,6 +6695,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_uilitwsy",
             "_TZ3000_66fekqhh",
             "_TZ3000_ok0ggpk7",
+            "_TZ3210_ok0ggpk7",
             "_TZ3000_aknpkt02",
             "_TZ3000_nwidmc4n",
             "_TZ3000_pfc7i3kt",
@@ -6708,12 +6709,12 @@ export const definitions: DefinitionWithExtend[] = [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
             tuya.modernExtend.tuyaOnOff({
                 onOffCountdown: (m) => m !== "_TZ3000_pfc7i3kt",
-                powerOnBehavior2: (m) => m !== "_TZ3000_nwidmc4n",
+                powerOnBehavior2: (m) => m !== "_TZ3000_nwidmc4n" && m !== "_TZ3210_ok0ggpk7",
                 indicatorMode: (m) => m !== "_TZ3000_nwidmc4n" && m !== "_TZ3000_pfc7i3kt",
-                inchingSwitch: (m) => m !== "_TZ3000_pfc7i3kt",
+                inchingSwitch: (m) => m !== "_TZ3000_pfc7i3kt" && m !== "_TZ3210_ok0ggpk7",
                 backlightModeOffOn: (m) => m !== "_TZ3000_pfc7i3kt",
                 endpoints: ["l1", "l2", "l3"],
-                powerOutageMemory: (m) => m === "_TZ3000_nwidmc4n",
+                powerOutageMemory: (m) => m === "_TZ3000_nwidmc4n" || m === "_TZ3210_ok0ggpk7",
                 switchType: (m) => m === "_TZ3000_nwidmc4n" || m === "_TZ3000_pfc7i3kt",
             }),
         ],
@@ -6732,31 +6733,8 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("AVATTO", "ZBTS60-03", "3 gang switch module with backlight", ["_TZ3000_nwidmc4n"]),
             tuya.whitelabel("Tuya", "M10Z", "2 gang switch with 20A power socket", ["_TZ3000_lubfc1t5"]),
             tuya.whitelabel("Zemismart", "ZMO-606-S2", "Smart 2 gangs switch with outlet", ["_TZ3000_aknpkt02"]),
+            tuya.whitelabel("Nova Digital", "NTZB-02", "2 switches and 1 socket with backlight", ["_TZ3210_ok0ggpk7"]),
         ],
-    },
-    {
-        fingerprint: tuya.fingerprint("TS0003", ["_TZ3210_ok0ggpk7"]),
-        model: "TS0003_2_switch_1_socket_tz3210",
-        vendor: "Nova Digital",
-        description: "2 switches and 1 socket with backlight",
-        extend: [
-            tuya.modernExtend.tuyaBase(),
-            tuya.modernExtend.tuyaMagicPacket(),
-            m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
-            tuya.modernExtend.tuyaOnOff({
-                endpoints: ["l1", "l2", "l3"],
-                onOffCountdown: true,
-                powerOutageMemory: true,
-                indicatorMode: true,
-                backlightModeOffOn: true,
-            }),
-        ],
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
-            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
-            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ["genOnOff"]);
-        },
     },
     {
         fingerprint: tuya.fingerprint("TS0003", ["_TZ3000_fawk5xjv", "_TZ3000_bvij6kod", "_TZ3000_aracgljk"]),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6735,6 +6735,30 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        fingerprint: tuya.fingerprint("TS0003", ["_TZ3210_ok0ggpk7"]),
+        model: "TS0003_2_switch_1_socket_tz3210",
+        vendor: "Nova Digital",
+        description: "2 switches and 1 socket with backlight",
+        extend: [
+            tuya.modernExtend.tuyaBase(),
+            tuya.modernExtend.tuyaMagicPacket(),
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
+            tuya.modernExtend.tuyaOnOff({
+                endpoints: ["l1", "l2", "l3"],
+                onOffCountdown: true,
+                powerOutageMemory: true,
+                indicatorMode: true,
+                backlightModeOffOn: true,
+            }),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
+            await reporting.bind(device.getEndpoint(3), coordinatorEndpoint, ["genOnOff"]);
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0003", ["_TZ3000_fawk5xjv", "_TZ3000_bvij6kod", "_TZ3000_aracgljk"]),
         model: "NFZB-03",
         vendor: "Nova Digital",


### PR DESCRIPTION
Adds support for a Nova Digital Zigbee device sold in Brazil as “Interruptor com Tomada Zigbee - duas teclas físicas”.

Device information:
- Zigbee model: TS0003
- Manufacturer name: _TZ3210_ok0ggpk7
- Vendor: Nova Digital
- Physical device: 2 switches + 1 socket
- Exposed as 3 on/off endpoints: l1, l2, l3

Confirmed working:
- state_l1 / state_l2 / state_l3
- Physical button press updates Zigbee2MQTT and Home Assistant state
- Commands from Zigbee2MQTT/Home Assistant update the physical device state
- Countdown per endpoint
- Global power-on behavior through relay_status / powerOutageMemory
- Indicator mode
- Backlight mode

Tuya Platform datapoints confirmed:
- 1: Switch 1
- 2: Plug2
- 3: Plug
- 7: Countdown 1
- 8: Countdown Switch 2
- 9: Timer 3
- 14: Relay Status
- 15: Indicator mode
- 16: backlight switch
- 19: Delay-off Schedule
- 209: Cycle Timing
- 210: Random Timing

Notes:
- relay_status is global for the whole device.
- The device does not support per-endpoint power-on behavior.
- Inching was not added because switch_inching is exposed by Tuya as a global string field and was not confirmed working correctly.

Related image PR:
https://github.com/Koenkk/zigbee2mqtt.io/pull/5050