### PR TITLE
fix: Paulmann 500.45: remove color support

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -243,7 +243,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "500.45",
         vendor: "Paulmann",
         description: "SmartHome Zigbee Pendulum Light Aptare",
-        extend: [m.light({color: {applyRedFix: true}})],
+        extend: [m.light()],
     },
     {
         zigbeeModel: ["500.48"],


### PR DESCRIPTION
Color added by mistake here: https://github.com/Koenkk/zigbee-herdsman-converters/commit/588b0353bd9246a947922d78d21b778f8a255068

- continuation of https://github.com/Koenkk/zigbee-herdsman-converters/issues/12025