### PR TITLE
Add NovaDigital TS0002_1_switch_1_socket_tz3210 device support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6636,8 +6636,6 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
 
-
-
     {
         // TS0002 2 gang switch module with all available features. This is the default for TS0002 devices.
         model: "TS0002",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6658,7 +6658,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
         },
     },
-    
+
     {
         // TS0002 2 gang switch module with all available features. This is the default for TS0002 devices.
         model: "TS0002",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6654,7 +6654,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
         },
     },
-    
+
     {
         // TS0002 2 gang switch module with all available features. This is the default for TS0002 devices.
         model: "TS0002",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6566,7 +6566,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Aubess", "TMZ02", "2 gang switch", ["_TZ3000_lmlsduws"]),
             tuya.whitelabel("RSH", "TS0002_basic_2", "2 gang switch", ["_TZ3000_zbfya6h0"]),
             tuya.whitelabel("EKAZA", "EKAC-T3092Z", "2 gang switch", ["_TZ3000_hznzbl0x"]),
-            tuya.whitelabel("Nova Digital", "TS0002_1_switch_1_socket_tz3210", "1 switch and 1 socket with backlight", ["_TZ3210_6smingw0"]),
+            tuya.whitelabel("Nova Digital", "NTZB-01", "1 switch and 1 socket with backlight", ["_TZ3210_6smingw0"]),
         ],
         extend: [
             tuya.modernExtend.tuyaBase(),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6648,17 +6648,13 @@ export const definitions: DefinitionWithExtend[] = [
                 backlightModeOffOn: true,
             }),
         ],
-        endpoint: (device) => {
-            return {l1: 1, l2: 2};
-        },
-        meta: {multiEndpoint: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
         },
     },
-
+    
     {
         // TS0002 2 gang switch module with all available features. This is the default for TS0002 devices.
         model: "TS0002",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6631,6 +6631,34 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("RoomsAI", "37022463-2", "2 Gang switch with backlight", ["_TZ3000_ogpla3lh"]),
         ],
     },
+
+    {
+        fingerprint: tuya.fingerprint("TS0002", ["_TZ3210_6smingw0"]),
+        model: "TS0002_1_switch_1_socket_tz3210",
+        vendor: "Nova Digital",
+        description: "1 switch and 1 socket with backlight",
+        extend: [
+            tuya.modernExtend.tuyaBase(),
+            tuya.modernExtend.tuyaMagicPacket(),
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
+            tuya.modernExtend.tuyaOnOff({
+                endpoints: ["l1", "l2"],
+                onOffCountdown: true,
+                indicatorMode: true,
+                backlightModeOffOn: true,
+            }),
+        ],
+        endpoint: (device) => {
+            return {l1: 1, l2: 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
+        },
+    },
+    
     {
         // TS0002 2 gang switch module with all available features. This is the default for TS0002 devices.
         model: "TS0002",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6551,6 +6551,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_fbjdkph9",
             "_TZ3000_zbfya6h0",
             "_TZ3000_hznzbl0x",
+            "_TZ3210_6smingw0",
         ]),
         model: "TS0002_basic",
         vendor: "Tuya",
@@ -6565,14 +6566,17 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Aubess", "TMZ02", "2 gang switch", ["_TZ3000_lmlsduws"]),
             tuya.whitelabel("RSH", "TS0002_basic_2", "2 gang switch", ["_TZ3000_zbfya6h0"]),
             tuya.whitelabel("EKAZA", "EKAC-T3092Z", "2 gang switch", ["_TZ3000_hznzbl0x"]),
+            tuya.whitelabel("Nova Digital", "TS0002_1_switch_1_socket_tz3210", "1 switch and 1 socket with backlight", ["_TZ3210_6smingw0"]),
         ],
         extend: [
             tuya.modernExtend.tuyaBase(),
             tuya.modernExtend.tuyaOnOff({
                 switchType: true,
                 endpoints: ["l1", "l2"],
-                powerOutageMemory: true,
-                onOffCountdown: (m) => m === "_TZ3000_hznzbl0x",
+                powerOutageMemory: (m) => m !== "_TZ3210_6smingw0",
+                onOffCountdown: (m) => m === "_TZ3000_hznzbl0x" || m === "_TZ3210_6smingw0",
+                indicatorMode: (m) => m === "_TZ3210_6smingw0",
+                backlightModeOffOn: (m) => m === "_TZ3210_6smingw0",
             }),
         ],
         endpoint: (device) => {
@@ -6632,28 +6636,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
 
-    {
-        fingerprint: tuya.fingerprint("TS0002", ["_TZ3210_6smingw0"]),
-        model: "TS0002_1_switch_1_socket_tz3210",
-        vendor: "Nova Digital",
-        description: "1 switch and 1 socket with backlight",
-        extend: [
-            tuya.modernExtend.tuyaBase(),
-            tuya.modernExtend.tuyaMagicPacket(),
-            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
-            tuya.modernExtend.tuyaOnOff({
-                endpoints: ["l1", "l2"],
-                onOffCountdown: true,
-                indicatorMode: true,
-                backlightModeOffOn: true,
-            }),
-        ],
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
-            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
-        },
-    },
+
 
     {
         // TS0002 2 gang switch module with all available features. This is the default for TS0002 devices.


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#31793

Added support for TS0002_1_switch_1_socket_tz3210 device with backlight features.

Adds a dedicated converter for TS0002 / _TZ3210_6smingw0 before the generic TS0002 definition.

This device is physically 1 switch + 1 socket and should not expose power-on behavior or inching, as those features were not supported/validated for this variant.


Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5053
