### PR TITLE
Add AOYAN AY-303Z soil moisture sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22306,6 +22306,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "CS-201Z",
         vendor: "COOLO",
         description: "Soil moisture sensor",
+        whiteLabel: [
+            {
+                fingerprint: [{modelID: "AY-303Z", manufacturerName: "AOYAN  "}],
+                model: "AY-303Z",
+                vendor: "AOYAN",
+                description: "Soil moisture sensor",
+            },
+        ],
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             e.dry(),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22301,19 +22301,11 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-303Z"],
+        zigbeeModel: ["ZG-303Z", "AY-303Z"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_npj9bug3", "_TZE200_wrmhp6b3"]),
         model: "CS-201Z",
         vendor: "COOLO",
         description: "Soil moisture sensor",
-        whiteLabel: [
-            {
-                fingerprint: [{modelID: "AY-303Z", manufacturerName: "AOYAN  "}],
-                model: "AY-303Z",
-                vendor: "AOYAN",
-                description: "Soil moisture sensor",
-            },
-        ],
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             e.dry(),


### PR DESCRIPTION
Adds AOYAN AY-303Z as a white-label variant of COOLO CS-201Z.

Tested with Zigbee2MQTT 2.9.2.

Device info:
- Zigbee model: AY-303Z
- Manufacturer name: AOYAN  
- Firmware version: 0126082025
- Uses the same Tuya datapoints as CS-201Z.

The device exposes temperature, humidity, soil_moisture, dry, battery, temperature_unit, calibration settings, sampling settings, and soil_warning.