### PR TITLE
New variant of Tuya IH-K009 (without display)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5747,7 +5747,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.battery()],
         exposes: [e.temperature(), e.humidity(), e.battery_voltage()],
         configure: tuya.configureMagicPacket,
-        whiteLabel: [tuya.whitelabel("Tuya", "RSH-HS06_1", "Temperature & humidity sensor", ["_TZ3000_zl1kmjqx"])],
+        whiteLabel: [
+            tuya.whitelabel("Tuya", "RSH-HS06_1", "Temperature & humidity sensor", ["_TZ3000_zl1kmjqx"]),
+            tuya.whitelabel("Tuya", "ZG-227ZL", "Temperature & humidity sensor", ["HOBEIAN"]),
+        ],
     },
     {
         fingerprint: tuya.fingerprint("SM0201", ["_TYZB01_cbiezpds", "_TYZB01_zqvwka4k"]),


### PR DESCRIPTION
I followed the docs.

The physical device is:
- a temperature/humidity without display
- its look is exactly this: https://www.zigbee2mqtt.io/devices/IH-K009.html
- the data inside zigbee2mqtt is:
  - Zigbee Model ZG-227Z   HOBEIAN
  - Definition (Zigbee2MQTT) ZG-227ZL    Temperature & humidity LCD sensor (Tuya)

The current icon is the one with the display: https://www.zigbee2mqtt.io/devices/ZG-227ZL.html

This PR adds a new whitelabel for the model "IH-K009"

I hope to have correctly understood the procedure :)
