### PR TITLE
Fix #31733 - update tuya.ts

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3558,7 +3558,8 @@ export const definitions: DefinitionWithExtend[] = [
             moveToLevelWithOnOffDisable: (e) =>
                 e.getDevice().manufacturerName === "_TZB210_uoiqhjqe" ||
                 e.getDevice().manufacturerName === "_TZB210_417ikxay" ||
-                e.getDevice().manufacturerName === "_TZB210_qzsxaqqe",
+                e.getDevice().manufacturerName === "_TZB210_qzsxaqqe" ||
+                e.getDevice().manufacturerName === "_TZB210_u3ri0968", // https://github.com/Koenkk/zigbee2mqtt/issues/31733
         },
         toZigbee: [tzLocal.TS0505B_1_transitionFixesOnOffBrightness],
         configure: (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Update tuya.ts to fix [#31733](https://github.com/Koenkk/zigbee2mqtt/issues/31733) - FUT037Z+  / _TZB210_u3ri0968 device that resets to CCT after turning ON and OFF again. 

Device should use "moveToLevelWithOnOffDisable" to work properly and maintain RGB color. Same issue as discussed in: [#30584](https://github.com/Koenkk/zigbee2mqtt/issues/30584).

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->