### PR TITLE
fix(danfoss): Ally - automatically sync time after rejoin, remove convertSet,  human-readable errors

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -981,6 +981,16 @@ const danfossExtend = {
         );
         return extend;
     },
+    danfossTimeSyncOnAnnounce: (): ModernExtend => ({
+        isModernExtend: true,
+        onEvent: [
+            async (event) => {
+                if (event.type === "deviceAnnounce") {
+                    await setTime(event.data.device, "queue");
+                }
+            },
+        ],
+    }),
 };
 
 const tzLocal = {
@@ -1375,9 +1385,10 @@ export const definitions: DefinitionWithExtend[] = [
             danfossExtend.danfossAdaptionRunSettings(),
             danfossExtend.danfossAdaptionRunControl(),
             danfossExtend.danfossRegulationSetpointOffset(),
+            danfossExtend.danfossTimeSyncOnAnnounce(),
             m.poll({
                 key: "danfossTime",
-                defaultIntervalSeconds: 60 * 60 * 24, // 24 hours
+                defaultIntervalSeconds: 60 * 60 * 24,
                 poll: async (device) => {
                     await setTime(device, "queue");
                 },

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1086,15 +1086,6 @@ const tzLocal = {
     } satisfies Tz.Converter,
     danfoss_system_status_code: {
         key: ["system_status_code"],
-        convertSet: async (entity, key, value, meta) => {
-            utils.assertNumber(value, key);
-            await entity.write<"haDiagnostic", DanfossHaDiagnostic>(
-                "haDiagnostic",
-                {danfossSystemStatusCode: value},
-                {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S},
-            );
-            return {state: {system_status_code: value}};
-        },
         convertGet: async (entity, key, meta) => {
             await entity.read<"haDiagnostic", DanfossHaDiagnostic>("haDiagnostic", ["danfossSystemStatusCode"], {
                 manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S,
@@ -1310,7 +1301,14 @@ const fzLocal = {
         convert: (model, msg, publish, options, meta) => {
             const result: KeyValueAny = {};
             if (msg.data.danfossSystemStatusCode !== undefined) {
-                result.system_status_code = msg.data.danfossSystemStatusCode;
+                const code = msg.data.danfossSystemStatusCode;
+                const errors: string[] = [];
+                for (const [bit, name] of Object.entries(constants.danfossAllySystemStatusCode)) {
+                    if (code & (1 << Number(bit))) {
+                        errors.push(name);
+                    }
+                }
+                result.system_status_code = errors.length > 0 ? errors.join(",") : "ok";
             }
             return result;
         },
@@ -1387,8 +1385,8 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         exposes: [
             e
-                .numeric("system_status_code", ea.STATE_GET)
-                .withDescription("Diagnostic status bitmap (bit 9 = time/clock lost).")
+                .text("system_status_code", ea.STATE_GET)
+                .withDescription("Diagnostic error codes (e.g. 'invalid_clock_information,low_battery'). 'ok' when no errors.")
                 .withCategory("diagnostic"),
         ],
         fromZigbee: [fz.thermostat_weekly_schedule, fzLocal.danfoss_system_status_code],

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -211,6 +211,20 @@ export const danfossSystemStatusCode: KeyValueNumberString = {
     258: "error_on_one_or_more_output",
 };
 
+export const danfossAllySystemStatusCode: KeyValueNumberString = {
+    0: "top_pcb_sensor_error",
+    1: "side_pcb_sensor_error",
+    2: "non_volatile_memory_error",
+    3: "unknown_hw_error",
+    5: "motor_error",
+    7: "invalid_internal_communication",
+    9: "invalid_clock_information",
+    11: "radio_communication_error",
+    12: "encoder_jammed",
+    13: "low_battery",
+    14: "critical_low_battery",
+};
+
 export const danfossHeatsupplyRequest: KeyValueNumberString = {
     0: "none",
     1: "heat_supply_request",


### PR DESCRIPTION
- **Sync time on `deviceAnnounce`** — Add `danfossTimeSyncOnAnnounce` ModernExtend that calls `setTime()` when the TRV rejoins the network (e.g. after battery change) to prevent waiting until the next 24-hour poll.
- **Remove `convertSet`** — The Danfoss Programming guide (§1.2) does not prescribe writing to `system_status_code`. The prescribed recovery for E10 (time lost) is to write time to `genTime`, after which the TRV auto-clears E10 within ~15 seconds.
- **Decode bitmap to human-readable error names** — Replace the raw numeric value (e.g. `512`) with a comma-separated list of active error names from the Danfoss' Programming guide §1.5 error table (e.g. `invalid_clock_information`). Returns `ok` when no errors are active. Change expose from `e.numeric()` to `e.text()`.

Follow-up to #12026.

## Changes

- `tzLocal.danfoss_system_status_code`: Remove `convertSet`, keep `convertGet`
- `fzLocal.danfoss_system_status_code`: Decode `BITMAP16` to comma-separated error names
- Ally TRV expose: Change from `e.numeric()` to `e.text()`, update description

## Error code mapping

| Bit | Code | Name |
|-----|------|------|
| 0 | E1 | `top_pcb_sensor_error` |
| 1 | E2 | `side_pcb_sensor_error` |
| 2 | E3 | `non_volatile_memory_error` |
| 3 | E4 | `unknown_hw_error` |
| 5 | E6 | `motor_error` |
| 7 | E8 | `invalid_internal_communication` |
| 9 | E10 | `invalid_clock_information` |
| 11 | E12 | `radio_communication_error` |
| 12 | E13 | `encoder_jammed` |
| 13 | E14 | `low_battery` |
| 14 | E15 | `critical_low_battery` |