### PR TITLE
Shelly: Expose switch inputs and input mode configuration for Gen4 1/1PM/1PM Mini/2PM

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -377,6 +377,8 @@ const shellyModernExtend = {
 
         const featureDev = features.includes("Dev");
         const featurePowerstripUI = features.includes("PowerstripUI");
+        const featureTwoPMInputMode = features.includes("2PMInputMode");
+        const featureOnePMInputMode = features.includes("1PMInputMode");
 
         // Generic helper functions
         const validateTime = (value: string) => {
@@ -649,6 +651,36 @@ const shellyModernExtend = {
         if (featurePowerstripUI) {
             exposes.push(...exposesPowerstripUI);
             toZigbee.push(...toZigbeePowerstripUI);
+        }
+        if (featureTwoPMInputMode) {
+            const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
+            exposes.push(
+                e.enum("switch_mode", ea.STATE_SET, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint("sw1"),
+                e.enum("switch_mode", ea.STATE_SET, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint("sw2"),
+            );
+            toZigbee.push({
+                key: ["switch_mode"],
+                convertSet: async (entity, key, value, meta) => {
+                    const switchId = meta.endpoint_name === "sw1" ? 0 : 1;
+                    const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
+                    await rpcSend(ep, "Switch.SetConfig", {id: switchId, config: {in_mode: value}});
+                    return {state: {[`switch_mode_${meta.endpoint_name}`]: value}};
+                },
+            });
+        }
+        if (featureOnePMInputMode) {
+            const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
+            exposes.push(
+                e.enum("switch_mode", ea.STATE_SET, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint("sw1"),
+            );
+            toZigbee.push({
+                key: ["switch_mode"],
+                convertSet: async (entity, key, value, meta) => {
+                    const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
+                    await rpcSend(ep, "Switch.SetConfig", {id: 0, config: {in_mode: value}});
+                    return {state: {switch_mode_sw1: value}};
+                },
+            });
         }
         return {exposes, fromZigbee, toZigbee, isModernExtend: true};
     },
@@ -1039,12 +1071,36 @@ const fzLocal = {
         },
     } satisfies Fz.Converter<"genScenes", undefined, ["commandRecall"]>,
 
+    one_switch_input_events: {
+        cluster: "genOnOff",
+        type: ["commandOn", "commandOff", "commandToggle"],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.endpoint.ID !== 2) return {};
+            const event = utils.getFromLookup(msg.type, {
+                commandOn: "input_1_on",
+                commandOff: "input_1_off",
+                commandToggle: "input_1_toggle",
+            });
+            return {action: event};
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["commandOn", "commandOff", "commandToggle"]>,
+
+    one_switch_input_scene_events: {
+        cluster: "genScenes",
+        type: ["commandRecall"],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.endpoint.ID !== 2) return {};
+            const event = utils.getFromLookup(`${msg.data.sceneid}`, {"5": "input_1_toggle", "11": "input_1_hold"});
+            return {action: event};
+        },
+    } satisfies Fz.Converter<"genScenes", undefined, ["commandRecall"]>,
+
     switch_input_type: {
         cluster: "genOnOffSwitchCfg",
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
             if (!Object.hasOwn(msg.data, "switchType")) return {};
-            const epName = utils.getFromLookup(msg.endpoint.ID, {3: "sw1", 4: "sw2"});
+            const epName = utils.getFromLookup(msg.endpoint.ID, {2: "sw1", 3: "sw1", 4: "sw2"});
             if (!epName) return {};
             return {[`switch_type_${epName}`]: utils.getFromLookup(msg.data.switchType as number, {0: "toggle", 1: "momentary"})};
         },
@@ -1077,7 +1133,28 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S4SW-001X8EU",
         vendor: "Shelly",
         description: "1 Mini Gen 4",
-        extend: [m.onOff({powerOnBehavior: false}), ...shellyModernExtend.shellyCustomClusters(), shellyModernExtend.shellyWiFiSetup()],
+        ota: true,
+        fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
+        toZigbee: [tzLocal.switch_input_type],
+        exposes: [
+            e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_hold"]),
+            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
+        ],
+        extend: [
+            m.deviceEndpoints({endpoints: {sw1: 2}}),
+            m.onOff({powerOnBehavior: false}),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
+            shellyModernExtend.shellyWiFiSetup(),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const ep = device.getEndpoint(2);
+            if (ep) {
+                await ep.bind("genOnOff", coordinatorEndpoint);
+                await ep.bind("genScenes", coordinatorEndpoint);
+                await ep.read("genOnOffSwitchCfg", ["switchType"]);
+            }
+        },
     },
     {
         fingerprint: [{modelID: "1", manufacturerName: "Shelly"}],
@@ -1091,13 +1168,30 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S4SW-001P8EU",
         vendor: "Shelly",
         description: "1PM Mini Gen 4",
+        ota: true,
+        fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
+        toZigbee: [tzLocal.switch_input_type],
+        exposes: [
+            e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_hold"]),
+            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
+        ],
         extend: [
+            m.deviceEndpoints({endpoints: {sw1: 2}}),
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter({producedEnergy: true, acFrequency: true}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
+        configure: async (device, coordinatorEndpoint) => {
+            const ep = device.getEndpoint(2);
+            if (ep) {
+                await ep.bind("genOnOff", coordinatorEndpoint);
+                await ep.bind("genScenes", coordinatorEndpoint);
+                await ep.read("genOnOffSwitchCfg", ["switchType"]);
+            }
+        },
     },
     {
         zigbeeModel: ["1PM"],
@@ -1165,6 +1259,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.deviceEndpoints({endpoints: {sw1: 3, sw2: 4}}),
             m.windowCovering({controls: ["lift", "tilt"]}),
             ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyRPCSetup(["2PMInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
         configure: async (device, coordinatorEndpoint) => {
@@ -1223,6 +1318,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyRPCSetup(["2PMInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
The external converter for the Shelly 1 Mini Gen4 has been tested by @Chicchi7393 in #12011 .

I assume the 1PM and 1PM Mini expose the same endpoint and behave identically, but this is untested as I haven't received the 2.0.0-beta1 firmware on my devices yet.

I also included an RPC-based converter for configuring non-standard switch input modes (follow, flip, detached, cycle, activation) as well as ZCL-based switch_type configuration (toggle/momentary via genOnOffSwitchCfg). Both apply to the 1 Mini, 1PM Mini, 1PM Gen4, and 2PM Gen4.