### PR TITLE
fix(sonoff): SONOFF S60ZBTPF and S60ZBTPG prevent threshold protections from being enabled on first pairing

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -18,7 +18,7 @@ import {
     YEAR_2000_IN_UTC,
 } from "../lib/sonoff";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, Expose, Fz, KeyValue, KeyValueAny, ModernExtend, OnEvent, Tz, Zh} from "../lib/types";
+import type {DefinitionWithExtend, Expose, Fz, KeyValue, KeyValueAny, ModernExtend, OnEvent, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const {ewelinkAction, ewelinkBattery} = ewelinkModernExtend;
@@ -1288,35 +1288,6 @@ const sonoffExtend = {
 
         return payloadValue.slice(0, index);
     },
-    applyS60DefaultOverloadProtection: async (device: Zh.Device, powerMaxLimit: number, currentMaxLimit: number): Promise<void> => {
-        if (device.meta.s60DefaultOverloadProtectionApplied === true) {
-            return;
-        }
-
-        const endpoint = device.getEndpoint(1);
-        const payloadValue = sonoffExtend.buildOverloadProtectionPayload(
-            {
-                enable_max_voltage: "ENABLE",
-                enable_min_current: "ENABLE",
-                enable_min_power: "ENABLE",
-                enable_min_voltage: "ENABLE",
-                max_current: currentMaxLimit,
-                max_power: powerMaxLimit,
-                max_voltage: 277,
-                min_current: 0.1,
-                min_power: 0.1,
-                min_voltage: 165,
-            },
-            powerMaxLimit,
-            currentMaxLimit,
-        );
-
-        // The private payload always carries max current and power values as well.
-        await endpoint.write("customClusterEwelink", {[0x7003]: {value: payloadValue, type: 0x42}}, defaultResponseOptions);
-        await endpoint.read("customClusterEwelink", [0x7003], defaultResponseOptions);
-        device.meta.s60DefaultOverloadProtectionApplied = true;
-        device.save();
-    },
     overloadProtection: (powerMaxLimit: number, currentMaxLimit: number): ModernExtend => {
         const exposes = e
             .composite("overload_protection", "overload_protection", ea.ALL)
@@ -1527,20 +1498,6 @@ const sonoffExtend = {
             exposes: [exposes],
             toZigbee,
             fromZigbee,
-            isModernExtend: true,
-        };
-    },
-    s60OverloadProtection: (powerMaxLimit: number, currentMaxLimit: number): ModernExtend => {
-        const overloadProtection = sonoffExtend.overloadProtection(powerMaxLimit, currentMaxLimit);
-
-        return {
-            ...overloadProtection,
-            configure: [
-                ...(overloadProtection.configure ?? []),
-                async (device) => {
-                    await sonoffExtend.applyS60DefaultOverloadProtection(device, powerMaxLimit, currentMaxLimit);
-                },
-            ],
             isModernExtend: true,
         };
     },
@@ -4688,7 +4645,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0],
                 valueOn: [true, 1],
             }),
-            sonoffExtend.s60OverloadProtection(4000, 17),
+            sonoffExtend.overloadProtection(4000, 17),
         ],
         ota: true,
         configure: async (device, coordinatorEndpoint) => {
@@ -4815,7 +4772,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueOff: [false, 0],
                 valueOn: [true, 1],
             }),
-            sonoffExtend.s60OverloadProtection(3250, 14),
+            sonoffExtend.overloadProtection(3250, 14),
         ],
         ota: true,
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
This PR fixes the default threshold protection configuration for the affected SONOFF device definition.

Previously, when the device was added for the first time in Zigbee2MQTT 2.9.2, the minimum threshold protections could be enabled by default and set to very low values:

- Min Power: 0.1W
- Min Current: 0.1A

As a result, the device could automatically turn off when no load was detected, which led to the issue reported in:
https://github.com/Koenkk/zigbee2mqtt/issues/31604

This behavior was caused by the ZHC device definition, not by the firmware itself. The firmware that was previously removed in:
https://github.com/Koenkk/zigbee-OTA/pull/1104

was therefore not the root cause of the issue.

This PR corrects the device definition to avoid enabling these threshold protections unintentionally during the initial device configuration.

For users who are still affected after upgrading, please update to Zigbee2MQTT 2.9.3 or later once available, remove the device, and pair it again.

If the issue still persists, users can manually reset the threshold configuration by:

1. Enabling all threshold protections.
2. Setting the thresholds to their respective Min/Max values:
   - Min Power: 0.1W, Max Power: 3250W
   - Min Voltage: AC165V, Max Voltage: AC277V
   - Min Current: 0.1A, Max Current: 14A
3. Saving the configuration.
4. **Disabling all threshold protections again and saving once more**.

We apologize for the inconvenience and confusion caused by this issue.