### PR TITLE
fix(ZY-M100-24GV3): drop bogus 0 sensitivity reads from device

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -16880,12 +16880,17 @@ export const definitions: DefinitionWithExtend[] = [
                         },
                     },
                 ],
-                [2, "move_sensitivity", tuya.valueConverter.raw],
+                // Firmware periodically reports sensitivity as 0 even when a valid value is stored;
+                // dropping the 0 on read keeps the entity at its last good state, prevents Z2M from
+                // caching/writing-back 0 to the device, and silences the mqtt.number validation flood
+                // (range 1.0-10.0). See zigbee2mqtt#24049, #26672, #27357. Replaces the silent loss
+                // introduced by the min(0)->min(1) tightening in PR #8674.
+                [2, "move_sensitivity", {from: (v: number) => (v === 0 ? undefined : v), to: (v: number) => v}],
                 [3, "detection_distance_min", tuya.valueConverter.divideBy100],
                 [4, "detection_distance_max", tuya.valueConverter.divideBy100],
                 [9, "distance", tuya.valueConverter.divideBy10],
                 [101, "find_switch", tuya.valueConverter.onOff],
-                [102, "presence_sensitivity", tuya.valueConverter.raw],
+                [102, "presence_sensitivity", {from: (v: number) => (v === 0 ? undefined : v), to: (v: number) => v}],
                 [103, "illuminance", tuya.valueConverter.raw],
                 [105, "presence_timeout", tuya.valueConverter.raw],
             ],


### PR DESCRIPTION
## Summary

The ZY-M100-24GV3 (Tuya `_TZE204_ya4ft0w4` / `_TZE200_ya4ft0w4` / `_TZE204_gkfbdvyx` / `_TZE200_gkfbdvyx`) has a long-running bug where the radar firmware periodically reports `move_sensitivity` and `presence_sensitivity` as `0` in DP packets, even when a valid sensitivity is configured. This patch ignores the bogus 0 reads at the converter layer.

The exposed range stays as documented (`min=1, max=10`) — no public-API change. Only the read path filters the value.

This is intended to fix the following long-standing user reports, all describing the same underlying behaviour:

- [Koenkk/zigbee2mqtt#24049](https://github.com/Koenkk/zigbee2mqtt/issues/24049) — TS0601 / `_TZE204_ya4ft0w4` "Invalid value for number `***` move_sensitivity / presence_sensitivity: 0 (range 1.0 - 10.0)"
- [Koenkk/zigbee2mqtt#26672](https://github.com/Koenkk/zigbee2mqtt/issues/26672) — Tuya ZY-M100-24GV3 move/presence sensitivity reset to 0
- [Koenkk/zigbee2mqtt#27357](https://github.com/Koenkk/zigbee2mqtt/issues/27357) — "Invalid value for number (sensitivity)"

All three were closed *not planned* without an actionable fix — this PR is intended to give them one. If maintainers are happy with the approach, those issues can be reopened and linked, then closed as fixed when this lands.

## Symptoms users see today

1. **Home Assistant log flood** at `~11 lines/sec`:
   ```
   ERROR (MainThread) [homeassistant.components.mqtt.number] Invalid value
     for number.<area>_motion_(move|presence)_sensitivity: 0 (range 1.0 - 10.0)
   ```
   Reported by multiple users across [zigbee2mqtt#24049](https://github.com/Koenkk/zigbee2mqtt/issues/24049), [#26672](https://github.com/Koenkk/zigbee2mqtt/issues/26672), [#27357](https://github.com/Koenkk/zigbee2mqtt/issues/27357). One reporter measured ~80,000 entries/day.

2. **Sensitivity entities stuck at `unknown`** in Home Assistant — the validator rejects every value the device sends, so the entity never receives a state.

3. **Apparent "settings being lost" after a service restart.** This is the symptom that motivated [#8674](https://github.com/Koenkk/zigbee-herdsman-converters/pull/8674) ("fix TZE200/TZE204_ya4ft0w4 forgetting settings"), which tightened `withValueMin` from 0 → 1. That change made (1) and (2) strictly worse without addressing the source of the bogus reads.

## Why the firmware-emits-0 theory is well supported

I can't fully prove a closed-firmware bug, but three pieces of evidence point the same way:

- **Detection still works during the 0-flood.** On my own four sensors, `binary_sensor.<area>_motion_presence` is actively flipping `on`/`off` with normal sensitivity behaviour while the sensitivity entities read `unknown`. If the firmware were genuinely operating at sensitivity 0, detection would be either disabled or pinned to maximum — neither matches what we see. The most plausible reading: the firmware *has* a valid sensitivity stored internally, but emits `0` in the DP report as a placeholder/uninitialised field for that packet.
- **Cadence pattern.** ~11 reports/sec carrying the same value isn't a real settings change — it's a heartbeat re-publishing whatever's in the DP buffer.
- **PR #8674's framing** ("settings get lost at service restart") fits a cache → write-back loop more cleanly than firmware flash corruption: device emits 0 → Z2M caches 0 in retained MQTT state → Z2M (or another client following retained state) writes 0 back to the device on the next reconfigure → only then does the device adopt 0 as its real value.

If this read is right, dropping the 0 at the converter prevents the cache pollution, which in turn prevents the write-back, which is the whole loop.

## What this patch does

`src/devices/tuya.ts`, two datapoint converters in the V3 entry only:

```ts
[2,   "move_sensitivity",     {from: (v: number) => (v === 0 ? undefined : v), to: (v: number) => v}],
[102, "presence_sensitivity", {from: (v: number) => (v === 0 ? undefined : v), to: (v: number) => v}],
```

Returning `undefined` from a `from` converter is the existing pattern in this file (precedent: `mode_state` converter at `src/devices/tuya.ts:22646` and similar). The `datapoints` dispatcher at `src/lib/tuya.ts:2778` does:

```ts
result[dpEntry[1]] = dpEntry[2].from(value, meta, options, publish, msg);
```

The assignment is unconditional, so when `from` returns `undefined` the dispatcher sets `result.move_sensitivity = undefined` — the key is present on the object with value `undefined`, **not omitted from the object**. Two consequences worth being explicit about:

1. **MQTT payload (what HA's validator sees):** `JSON.stringify` skips keys whose value is `undefined`, so the publish to MQTT omits the key entirely. HA's `mqtt.number` validator never receives a `0` for that attribute. The ~11/sec validation flood stops, and no `0` ends up in retained state.
2. **Z2M's internal cached state:** the merge that follows sets the cache to `undefined` for that attribute on a 0-report. A previously cached non-zero value is therefore not preserved across a 0-report — it is replaced with `undefined`, and HA may render the entity as `unknown` until the next non-zero report lands. (An earlier draft of this description claimed "last-good value is retained" — that was inaccurate; the value is not *replaced with 0*, but it does become `undefined` for that cycle.) The next valid report restores the entity.

This is still strictly better than the status quo (no 0 reaches HA; no 0 round-trips through retained state and back to the device on reconfigure), but reviewers should know the cache is touched, not skipped.

If a "truly skip the DP without touching the cache" semantics is preferable, it can be achieved by moving these two DPs into a multi-key entry that returns `{}` rather than `{key: undefined}` — happy to refactor to that shape if maintainers prefer.

The `to` direction is unchanged — writes still go through cleanly so the existing `withValueMin(1)` / `withValueMax(10)` validation on writes is preserved.

## Why this is asymmetric to V2

The sibling `ZY-M100-24GV2` (`_TZE204_7gclukjs`, line 16744) has `withValueMin(0)` and does not exhibit this flooding for users. That established that accepting 0 was tenable behaviour for this family pre-#8674. This patch keeps `min=1` (V3's documented spec since #8674) but stops the validator ever seeing 0, achieving the same operational result without re-opening 0 as a "valid" exposed value users can set.

## What this does NOT do

- It doesn't fix the underlying firmware bug — Tuya's MCU on `_TZE204_ya4ft0w4` will likely keep emitting 0s in its periodic reports. There's no firmware update for this SKU in the [`Koenkk/zigbee-OTA`](https://github.com/Koenkk/zigbee-OTA) curated index, and the manufacturer codes don't appear there at all.
- If the 0-emission were ever to coincide with a real settings loss in flash, this filter would mask it. Given the evidence above (working detection, no correlation with restarts on my devices) I don't believe that's what's happening, but reviewers should push back if they have counter-evidence.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm run build` — succeeds, all 4243 device definitions process.
- `pnpm test test/tuya.test.ts` — passes. Includes new unit tests that assert the exact converter behaviour above: 0-valued DP reports produce `{move_sensitivity: undefined}` / `{presence_sensitivity: undefined}` (key present on the result object, value `undefined`, `JSON.stringify` → `"{}"`); non-zero reports pass through unchanged.
- `pnpm test test/checkDefinition.test.ts` — passes.
- `pnpm exec biome check src/devices/tuya.ts` — clean.
- Verified manually that the dispatcher path at `src/lib/tuya.ts:2778` handles `undefined` correctly (precedent at `src/devices/tuya.ts:22646`, `:22657`, `:22664`).

## Refs

Issues this is intended to fix (all in `Koenkk/zigbee2mqtt`, all closed *not planned* without resolution):

- Fixes Koenkk/zigbee2mqtt#24049
- Fixes Koenkk/zigbee2mqtt#26672
- Fixes Koenkk/zigbee2mqtt#27357

Related PRs in this repo:

- Reverses the side-effect of #8674 (which set `withValueMin(1)` to try to address #24049, but worsened the validation flood without addressing the source)
- Original V3 device addition: #7909