### PR TITLE
 fix: Wirenboard WB-MSW-ZIGBEE v.4: register missing Sprut custom clusters

### DIFF
--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -889,8 +889,10 @@ export const definitions: DefinitionWithExtend[] = [
             addSprutVocCluster(),
             addSprutNoiseCluster(),
             addSprutIrBlasterCluster(),
+            addSprutMsRelativeHumidityCluster(),
             addSprutMsOccupancySensingCluster(),
             addSprutMsTemperatureMeasurementCluster(),
+            addSprutMsCO2Cluster(),
             m.deviceAddCustomCluster("genBasic", {
                 name: "genBasic",
                 ID: 0,


### PR DESCRIPTION
## Summary
 After #11778 ("Move Sprut attributes from ZH to ZHC") the `th_heater`
 expose disappeared on `WB-MSW-ZIGBEE v.4` (`WBMSW4`) and reading
 `sprutHeater` from the `msRelativeHumidity` cluster via the dev
 console no longer returns the attribute by name.
 
 ### Root cause
 That PR replaced the previously hard-coded Sprut attributes in
 `zigbee-herdsman` with per-device `deviceAddCustomCluster(...)`
 helpers in `src/devices/wirenboard.ts`:
 
 - `addSprutMsRelativeHumidityCluster` (`sprutHeater`)
 - `addSprutMsOccupancySensingCluster` (`sprutOccupancyLevel`,
   `sprutOccupancySensitivity`)
 - `addSprutMsTemperatureMeasurementCluster` (`sprutTemperatureOffset`)
 - `addSprutMsCO2Cluster` (`sprutCO2Calibration`,
   `sprutCO2AutoCalibration`)
 
 All four helpers were added to the `extend` array of WBMSW3, but for
 WBMSW4 only `addSprutMsOccupancySensingCluster()` and
 `addSprutMsTemperatureMeasurementCluster()` were added.
 `addSprutMsRelativeHumidityCluster()` was missed even though
 `sprutThHeater()` (which uses `cluster: "msRelativeHumidity"`,
 `attribute: "sprutHeater"`) is still in the same `extend` array.
 Without the custom cluster registration the `sprutHeater` attribute
 is unknown on this device, so the `th_heater` expose can no longer
 read/write it, and a manual `read msRelativeHumidity sprutHeater`
 from the dev console no longer resolves the attribute by name.
 
 `addSprutMsCO2Cluster()` was also missing, leaving the device
 inconsistent with WBMSW3 even though WBMSW4 does not currently
 expose the Sprut-specific CO2 calibration attributes — adding it
 keeps both definitions aligned and avoids a similar regression if
 those exposes are added later.
 
 ### Fix
 Add `addSprutMsRelativeHumidityCluster()` and `addSprutMsCO2Cluster()`
 to the `extend` array of the `WBMSW4` definition, in the same order
 as for WBMSW3. No other changes.
 
 Reproduces on `zigbee2mqtt` 2.9.x.
 
 ### Verification
 - `npm run build` — OK
 - `npm test` — 552 / 552 passed
 - `npx biome check src/devices/wirenboard.ts` — OK