### PR TITLE
Add missing QA IR remote fingerprints to ZS06

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -13022,6 +13022,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3290_nba3knpsarkawgnt",
             "_TZ3290_8xzb2ghn",
             "_TZ3290_s6ezpa3j",
+            "_TZ3290_yac64inudpovoaba",
         ]),
         model: "ZS06",
         vendor: "Tuya",
@@ -13039,11 +13040,8 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [ez.learn_ir_code(), ez.learned_ir_code(), ez.ir_code_to_send()],
         whiteLabel: [
             tuya.whitelabel("Tuya", "UFO-R4Z", "Universal smart IR remote control", ["_TZ3290_rlkmy85q4pzoxobl"]),
-            tuya.whitelabel("QA", "QAIRZPRO", "Infrared hub pro", [
-                "_TZ3290_jxvzqatwgsaqzx1u",
-                "_TZ3290_lypnqvlem5eq1ree",
-                "_TZ3290_yac64inudpovoaba",
-            ]),
+            tuya.whitelabel("QA", "QAIRZPRO", "Infrared hub pro", ["_TZ3290_jxvzqatwgsaqzx1u", "_TZ3290_lypnqvlem5eq1ree"]),
+            tuya.whitelabel("QA", "QAIRZM2", "Zigbee smart IR remote control", ["_TZ3290_yac64inudpovoaba"]),
             tuya.whitelabel("Zemismart", "ZM-18-USB", "Universal smart IR remote control", ["_TZ3290_uc8lwbi2"]),
             tuya.whitelabel("Zemismart", "ZXMIR-02", "Universal smart IR remote control", ["_TZ3290_8xzb2ghn"]),
             tuya.whitelabel("Ekaza", "EKAT-T304Z", "Universal smart IR remote control", ["_TZ3290_s6ezpa3j"]),


### PR DESCRIPTION
Add _TZ3290_yac64inudpovoaba (QAIRZPRO) and
_TZ3290_acv1iuslxi3shaaj (QAIRZM22) to ZS06 fingerprint list. These codes were in whiteLabel but missing from fingerprint, preventing device detection. Also add QAIRZM22 whiteLabel entry.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
