### PR TITLE
Shelly Power Strip 4 Gen4 (S4PL-00416EU) - add per-socket power_on_behavior

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -694,7 +694,7 @@ const shellyModernExtend = {
                     const switchId = meta.endpoint_name === "sw1" ? 0 : 1;
                     const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
                     await rpcSend(ep, "Switch.SetConfig", {id: switchId, config: {in_mode: value}});
-                    return {state: {[`switch_mode_${meta.endpoint_name}`]: value}};
+                    return {state: {switch_mode: value}};
                 },
             });
         }
@@ -708,7 +708,7 @@ const shellyModernExtend = {
                 convertSet: async (entity, key, value, meta) => {
                     const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
                     await rpcSend(ep, "Switch.SetConfig", {id: 0, config: {in_mode: value}});
-                    return {state: {switch_mode_sw1: value}};
+                    return {state: {switch_mode: value}};
                 },
             });
         }
@@ -1144,7 +1144,7 @@ const tzLocal = {
             const lookup = {toggle: 0, momentary: 1} as const;
             const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
             await ep.write("genOnOffSwitchCfg", {switchType: utils.getFromLookup(value as string, lookup)});
-            return {state: {[`switch_type_${meta.endpoint_name}`]: value}};
+            return {state: {switch_type: value}};
         },
         convertGet: async (entity, key, meta) => {
             const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -377,6 +377,7 @@ const shellyModernExtend = {
 
         const featureDev = features.includes("Dev");
         const featurePowerstripUI = features.includes("PowerstripUI");
+        const featurePowerstripPowerOnBehavior = features.includes("PowerstripPowerOnBehavior");
         const featureTwoPMInputMode = features.includes("2PMInputMode");
         const featureOnePMInputMode = features.includes("1PMInputMode");
 
@@ -651,6 +652,35 @@ const shellyModernExtend = {
         if (featurePowerstripUI) {
             exposes.push(...exposesPowerstripUI);
             toZigbee.push(...toZigbeePowerstripUI);
+        }
+        if (featurePowerstripPowerOnBehavior) {
+            const powerOnBehaviorValues = ["off", "on", "previous", "match_input"];
+            for (const channel of [1, 2, 3, 4]) {
+                exposes.push(
+                    e
+                        .enum("power_on_behavior", ea.STATE_SET, powerOnBehaviorValues)
+                        .withDescription("Behavior of the socket after a power outage. 'previous' restores the last known state.")
+                        .withCategory("config")
+                        .withEndpoint(String(channel)),
+                );
+            }
+            toZigbee.push({
+                key: ["power_on_behavior"],
+                convertSet: async (entity, key, value, meta) => {
+                    utils.assertString(value, key);
+                    utils.assertString(meta.endpoint_name, "endpoint_name");
+                    utils.assertEndpoint(entity);
+                    const switchId = Number(meta.endpoint_name) - 1;
+                    // shellyRPCCluster lives on a dedicated endpoint (239), but this expose is per-channel.
+                    // determineEndpoint() would return the per-channel endpoint when endpoint_name is set,
+                    // so we explicitly resolve the RPC endpoint via the device.
+                    const ep = entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
+                    if (!ep) throw new Error(`Shelly RPC endpoint ${SHELLY_ENDPOINT_ID} not found`);
+                    const shellyValue = value === "previous" ? "restore_last" : value;
+                    await rpcSend(ep, "Switch.SetConfig", {id: switchId, config: {initial_state: shellyValue}});
+                    return {state: {power_on_behavior: value}};
+                },
+            });
         }
         if (featureTwoPMInputMode) {
             const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
@@ -1366,7 +1396,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
-            shellyModernExtend.shellyRPCSetup(["PowerstripUI"]),
+            shellyModernExtend.shellyRPCSetup(["PowerstripUI", "PowerstripPowerOnBehavior"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
     },


### PR DESCRIPTION
# Shelly Power Strip 4 Gen4: per-socket `power_on_behavior`

> **Disclosure:** drafted by an AI coding assistant under my direction. Every step (RPC reverse-engineering, the patch, type/lint/test runs, live verification on real hardware) was reviewed by me.

## What & why

Adds a `PowerstripPowerOnBehavior` flag to `shellyRPCSetup()`, enabled for **S4PL-00416EU**, exposing a per-channel `power_on_behavior` enum (`off`/`on`/`previous`/`match_input`). Default firmware leaves all sockets `off` after any power loss, which users perceive as the strip [randomly switching off](https://community.shelly.cloud/topic/11999-unexpected-switch-off/); `previous` makes them resume their previous state.

The standard `startUpOnOff` (0x4003) attribute returns `UNSUPPORTED_ATTRIBUTE` on this device, so `m.onOff({powerOnBehavior: true})` is not usable. The setting is sent via `Switch.SetConfig` over `shellyRPCCluster` (endpoint 239), with z2m's `previous` mapped to Shelly's `restore_last`.

Resolves [Koenkk/zigbee2mqtt#30869](https://github.com/Koenkk/zigbee2mqtt/issues/30869). Companion docs PR: **Koenkk/zigbee2mqtt.io#5072**.

## Tested live on a real S4PL-00416EU

Set `power_on_behavior_{1..4} = previous` over MQTT, then queried Shelly's HTTP RPC API directly to confirm what landed in NVRAM:

```text
$ for i in 0 1 2 3; do echo -n "switch:$i  "; curl -s "http://<ip>/rpc/Switch.GetConfig?id=$i" | jq -r '"initial_state: \(.initial_state)"'; done
switch:0  initial_state: restore_last
switch:1  initial_state: restore_last
switch:2  initial_state: restore_last
switch:3  initial_state: restore_last
```

Round-tripped one channel `previous → off → previous` (verified on each side), `npm run check` / `tsc --noEmit` / `npm test` (552/552) all pass.

## Implementation notes

- **Endpoint resolution.** `determineEndpoint(entity, meta, "shellyRPCCluster")` returns the calling endpoint when `meta.endpoint_name` is set, so for a per-channel expose it would route the write to the wrong endpoint instead of the RPC endpoint 239. The converter explicitly resolves `entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID)`.
- **No read-back.** `shellyRPCCluster` reads are unreliable on this firmware (existing `shellyRPCBugFixed = false` in this file). The expose is `ea.STATE_SET` with optimistic state. The setting is persisted in NVRAM.
- **Naming.** Standard z2m `previous`/`off`/`on`/`match_input`, translated to Shelly's `restore_last` internally, so this looks like every other `power_on_behavior` from a user perspective.

## Latent suffix bug fixed in this PR (commit 2)

Spotted in the same file: three pre-existing per-endpoint converters (`featureTwoPMInputMode`, `featureOnePMInputMode`, `tzLocal.switch_input_type`) returned a `state` key already suffixed with the endpoint name (e.g. `switch_mode_sw1`), which z2m's publish.js then suffixes a second time → `switch_mode_sw1_sw1` in MQTT. Commit 2 drops the manual suffix in all three. No S4SW-* hardware on hand for empirical verification, but the fix is symmetric to the new converter above (which is verified).

## References

- [Koenkk/zigbee2mqtt#30869](https://github.com/Koenkk/zigbee2mqtt/issues/30869), [Koenkk/zigbee2mqtt#28718](https://github.com/Koenkk/zigbee2mqtt/issues/28718), [Koenkk/zigbee-herdsman-converters#10082](https://github.com/Koenkk/zigbee-herdsman-converters/pull/10082)
- Shelly RPC docs: https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen4/ShellyPowerStripG4

CC reviewers / testers from the related issue: @Humberd @FaboulousSan @nstefy
