### PR TITLE
Tuya TLC2206: fix power source

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20590,6 +20590,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "Water level sensor",
         extend: [m.forcePowerSource({powerSource: "Mains (single phase)"}), tuya.modernExtend.tuyaBase({dp: true, forceTimeUpdates: true})],
+        version: "0.0.1",
         exposes: [
             e.numeric("liquid_level_percent", ea.STATE).withUnit("%").withDescription("Liquid level ratio"),
             e.numeric("liquid_depth", ea.STATE).withUnit("cm").withDescription("Liquid depth"),


### PR DESCRIPTION
`forcePowerSource` was added to this device without bumping the version (idk if version existed 1 year ago) - so devices already paired didn't receive the fix until manual reconfigure

- https://github.com/Koenkk/zigbee2mqtt/issues/31819