### PR TITLE
fix: Novato ZIS-01P: correct Tuya datapoint indices

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -25215,7 +25215,7 @@ export const definitions: DefinitionWithExtend[] = [
             e
                 .numeric("radar_threshold", ea.STATE_SET)
                 .withCategory("config")
-                .withDescription("Radar detection threshold, advanced calibration (factory default: 20)")
+                .withDescription("Radar detection threshold, advanced calibration (factory default: 15; manufacturer-recommended range: 10-15)")
                 .withValueMin(5)
                 .withValueMax(255)
                 .withValueStep(1),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -25207,7 +25207,7 @@ export const definitions: DefinitionWithExtend[] = [
             e
                 .numeric("delay_time", ea.STATE_SET)
                 .withUnit("s")
-                .withDescription("Time delay before reporting no presence")
+                .withDescription("Time delay before reporting no presence (factory default: 30 s)")
                 .withValueMin(10)
                 .withValueMax(9600)
                 .withValueStep(1),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -25187,8 +25187,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.battery(),
             e
                 .numeric("presence_distance", ea.STATE_SET)
-                .withUnit("m")
-                .withDescription("Maximum detection distance")
+                .withDescription("Maximum detection distance (1=~2m, 2=~4m, 3=~6m)")
                 .withValueMin(1)
                 .withValueMax(3)
                 .withValueStep(1),
@@ -25210,21 +25209,37 @@ export const definitions: DefinitionWithExtend[] = [
                 .withUnit("s")
                 .withDescription("Time delay before reporting no presence")
                 .withValueMin(10)
-                .withValueMax(600)
-                .withValueStep(10),
+                .withValueMax(9600)
+                .withValueStep(1),
             e.binary("led_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable or disable LED indicator"),
+            e
+                .numeric("radar_threshold", ea.STATE_SET)
+                .withCategory("config")
+                .withDescription("Radar detection threshold, advanced calibration (factory default: 20)")
+                .withValueMin(5)
+                .withValueMax(255)
+                .withValueStep(1),
+            e
+                .numeric("pir_threshold", ea.STATE_SET)
+                .withCategory("config")
+                .withDescription("PIR detection threshold, advanced calibration (factory default: 20)")
+                .withValueMin(1)
+                .withValueMax(250)
+                .withValueStep(1),
         ],
         meta: {
             tuyaDatapoints: [
                 [1, "occupancy", tuya.valueConverter.trueFalse1],
-                [101, "presence_distance", tuya.valueConverter.raw],
-                [102, "presence_sensitivity", tuya.valueConverter.raw],
-                [103, "radar_switch", tuya.valueConverter.onOff],
-                [104, "pir_sensitivity", tuya.valueConverter.raw],
-                [105, "delay_time", tuya.valueConverter.raw],
+                [102, "presence_distance", tuya.valueConverter.raw],
+                [103, "presence_sensitivity", tuya.valueConverter.raw],
+                [104, "radar_switch", tuya.valueConverter.onOff],
+                [105, "pir_sensitivity", tuya.valueConverter.raw],
+                [106, "delay_time", tuya.valueConverter.raw],
                 [107, "led_switch", tuya.valueConverter.onOff],
                 [108, "illuminance", tuya.valueConverter.raw],
                 [109, "battery", tuya.valueConverter.raw],
+                [160, "pir_threshold", tuya.valueConverter.raw],
+                [164, "radar_threshold", tuya.valueConverter.raw],
             ],
         },
     },


### PR DESCRIPTION
## What

Fixes the Novato ZIS-01P (PIR + mmWave radar) presence sensor converter so its settings actually work.

The previously merged converter mapped Tuya datapoints off-by-one. After a factory reset on `_TZE284_who1jxwd`, the device reports its settings on DPs 102–106 (not 101–105). With the wrong DPs, sensitivity / distance / delay writes silently failed.

## Changes

Datapoint corrections (verified via factory reset):

| Setting | Old DP | Correct DP |
|---|---|---|
| `presence_distance` | 101 | **102** |
| `presence_sensitivity` | 102 | **103** |
| `radar_switch` | 103 | **104** |
| `pir_sensitivity` | 104 | **105** |
| `delay_time` | 105 | **106** |

Other fixes:
- `delay_time` max raised from 600 s to 9600 s (matches device's actual range; factory default is 30 s).
- `presence_distance` unit `"m"` removed — it is a 1–3 step selector, not a meter value. Description clarified to show the approximate distances per step (1 ≈ 2 m, 2 ≈ 4 m, 3 ≈ 6 m).

New advanced calibration exposes (under `config` category):
- `radar_threshold` – DP 164, range 5–255, factory default 15 (manufacturer-recommended range: 10–15).
- `pir_threshold` – DP 160, range 1–250, factory default 20.

These are useful when the sensor is in an environment where the default sensitivity steps aren’t enough to suppress false alarms.

## Tested

Factory-reset on `_TZE284_who1jxwd` and observed reported DP values; verified that writing each setting now takes effect.