### PR TITLE
Fix missing 'producedEnergy' for EMIZB-132

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -389,7 +389,7 @@ export const definitions: DefinitionWithExtend[] = [
                 current: {divisor: 10},
                 threePhase: true,
                 energy: {divisor: 1000, multiplier: 1},
-                producedEnergy: true,
+                producedEnergy: {divisor: 1000, multiplier: 1},
                 fzMetering: develco.fz.metering_emizb132,
                 fzElectricalMeasurement: develco.fz.electrical_measurement_emizb132,
             }),

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -389,6 +389,7 @@ export const definitions: DefinitionWithExtend[] = [
                 current: {divisor: 10},
                 threePhase: true,
                 energy: {divisor: 1000, multiplier: 1},
+                producedEnergy: true,
                 fzMetering: develco.fz.metering_emizb132,
                 fzElectricalMeasurement: develco.fz.electrical_measurement_emizb132,
             }),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

