### PR TITLE
fix(k4003c): Revert broken state reporting

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2930,13 +2930,11 @@ export const diyruz_rspm: Fz.Converter<"genOnOff", undefined, ["attributeReport"
     },
 };
 // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const K4003C_binary_input: Fz.Converter<"genBinaryInput", undefined, ["attributeReport", "readResponse"]> = {
+export const K4003C_binary_input: Fz.Converter<"genBinaryInput", undefined, "attributeReport"> = {
     cluster: "genBinaryInput",
-    type: ["attributeReport", "readResponse"],
+    type: "attributeReport",
     convert: (model, msg, publish, options, meta) => {
-        if (msg.data.presentValue === undefined) return;
-        const isOn = Boolean(msg.data.presentValue);
-        return {action: isOn ? "on" : "off", state: isOn ? "ON" : "OFF"};
+        return {action: msg.data.presentValue === 1 ? "off" : "on"};
     },
 };
 export const enocean_ptm215z: Fz.Converter<"greenPower", undefined, ["commandNotification", "commandCommissioningNotification"]> = {

--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -16,17 +16,13 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "BTicino",
         description: "Light switch with neutral",
         ota: true,
-        fromZigbee: [fz.identify, fz.K4003C_binary_input, fzLegrand.cluster_fc01],
-        toZigbee: [tzLegrand.K4003C_state, tzLegrand.led_mode, tzLegrand.identify],
+        fromZigbee: [fz.identify, fz.on_off, fz.K4003C_binary_input, fzLegrand.cluster_fc01],
+        toZigbee: [tz.on_off, tzLegrand.led_mode, tzLegrand.identify],
         extend: [legrandExtend.addLegrandDevicesCluster()],
         exposes: [e.switch(), e.action(["identify", "on", "off"]), eLegrand.identify(), eLegrand.ledInDark(), eLegrand.ledIfOn()],
-        version: "0.0.1",
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "genOnOff", "genBinaryInput"]);
-            await endpoint.configureReporting("genBinaryInput", [
-                {attribute: "presentValue", minimumReportInterval: 0, maximumReportInterval: 3600, reportableChange: 0},
-            ]);
         },
     },
     {

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -266,20 +266,6 @@ export const tzLegrand = {
             },
         } satisfies Tz.Converter;
     },
-    // biome-ignore lint/style/useNamingConvention: model-specific converter
-    K4003C_state: {
-        key: ["state"],
-        convertSet: async (entity, key, value, meta) => {
-            const cmd = String(value).toUpperCase();
-            const command = cmd === "TOGGLE" ? "toggle" : cmd === "ON" ? "on" : "off";
-            await entity.command("genOnOff", command, {}, {});
-            if (cmd === "TOGGLE") return {};
-            return {state: {state: cmd}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.read("genBinaryInput", ["presentValue"]);
-        },
-    } satisfies Tz.Converter,
     led_mode: {
         key: ["led_in_dark", "led_if_on"],
         convertSet: async (entity, key, value, meta) => {


### PR DESCRIPTION
Fixes state reporting for Legrand / BTcino K4003C switches introduced by mistake in https://github.com/Koenkk/zigbee-herdsman-converters/pull/11957