### PR TITLE
Add Profalux MAI-ZTP22C cover remote and MOT-C2Z10 cover

### DIFF
--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -85,7 +85,7 @@ export const definitions: DefinitionWithExtend[] = [
             "MOT-C1Z10F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
             "MOT-C1Z20F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
             "MOT-C1Z30F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
-            "MOT-C2Z10"
+            "MOT-C2Z10",
         ],
         model: "MOT-CxZxxC/F",
         vendor: "Profalux",

--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -85,8 +85,9 @@ export const definitions: DefinitionWithExtend[] = [
             "MOT-C1Z10F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
             "MOT-C1Z20F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
             "MOT-C1Z30F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            "MOT-C2Z10"
         ],
-        model: "MOT-C1ZxxC/F",
+        model: "MOT-CxZxxC/F",
         vendor: "Profalux",
         description: "Cover",
         extend: [profaluxExtend.addManuSpecificProfalux1Cluster()],
@@ -148,8 +149,8 @@ export const definitions: DefinitionWithExtend[] = [
         // Newer remotes. These expose a bunch of things but they are bound to
         // the cover and don't seem to communicate with the coordinator, so
         // nothing is likely to be doable in Z2M.
-        zigbeeModel: ["MAI-ZTP20F", "MAI-ZTP20C"],
-        model: "MAI-ZTP20",
+        zigbeeModel: ["MAI-ZTP20F", "MAI-ZTP20C", "MAI-ZTP22C"],
+        model: "MAI-ZTP2xC/F",
         vendor: "Profalux",
         description: "Cover remote",
         extend: [


### PR DESCRIPTION
Add MAI-ZTP22C cover remote and MOT-C2Z10 cover

I have a doubt on zigbeemodel typo. Woks fine on my side with "MOT-C2Z10", but is shown as "MOT-C2Z10\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000" in my Jeedom JeeZigBee.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: (https://github.com/Koenkk/zigbee2mqtt.io/pull/5088)
