### PR TITLE
[_TZB210_rs0ufzwg] use `moveToLevelWithOnOffDisable` 

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3564,7 +3564,8 @@ export const definitions: DefinitionWithExtend[] = [
                 e.getDevice().manufacturerName === "_TZB210_uoiqhjqe" ||
                 e.getDevice().manufacturerName === "_TZB210_417ikxay" ||
                 e.getDevice().manufacturerName === "_TZB210_qzsxaqqe" ||
-                e.getDevice().manufacturerName === "_TZB210_u3ri0968", // https://github.com/Koenkk/zigbee2mqtt/issues/31733
+                e.getDevice().manufacturerName === "_TZB210_u3ri0968" || // https://github.com/Koenkk/zigbee2mqtt/issues/31733
+                e.getDevice().manufacturerName === "_TZB210_rs0ufzwg", // https://github.com/Koenkk/zigbee2mqtt/issues/31872
         },
         toZigbee: [tzLocal.TS0505B_1_transitionFixesOnOffBrightness],
         configure: (device, coordinatorEndpoint) => {


### PR DESCRIPTION
fixes https://github.com/Koenkk/zigbee2mqtt/issues/31872

tested with external_converter: 

```js
import * as m from "zigbee-herdsman-converters/lib/modernExtend";
import * as tuya from "zigbee-herdsman-converters/lib/tuya";

export default {
    zigbeeModel: ["TS0505B"],
    model: "TS0505B",
    vendor: "_TZB210_rs0ufzwg",
    description: "Automatically generated definition",
    extend: [
        tuya.modernExtend.tuyaLight({
            colorTemp: {range: [153, 500]},
            color: true,
        }),
    ],
    // https://github.com/Koenkk/zigbee2mqtt/issues/30584
    meta: {
        applyRedFix: true, // https://github.com/Koenkk/zigbee-herdsman-converters/issues/11467
        moveToLevelWithOnOffDisable: (e) =>
            e.getDevice().manufacturerName === "_TZB210_uoiqhjqe" ||
            e.getDevice().manufacturerName === "_TZB210_417ikxay" ||
            e.getDevice().manufacturerName === "_TZB210_qzsxaqqe" ||
            e.getDevice().manufacturerName === "_TZB210_u3ri0968" || // https://github.com/Koenkk/zigbee2mqtt/issues/31733
            e.getDevice().manufacturerName === "_TZB210_rs0ufzwg",
    },
    configure: (device, coordinatorEndpoint) => {
        device.getEndpoint(1).saveClusterAttributeKeyValue("lightingColorCtrl", {
            colorCapabilities: 29,
        });
    },
};

```