### PR TITLE
fix: don't use manuSpecificPhilips2 path for mixed groups

### DIFF
--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -261,24 +261,31 @@ const philipsModernExtend = {
                 // Resolve control mode: explicit option wins; otherwise default to standard converters.
                 const nativeControl = (meta.options as KeyValueAny).hue_native_control === true;
 
-                // Check if device supports the manuSpecificPhilips2 cluster.
+                // Check if entity supports the manuSpecificPhilips2 cluster.
+                // For groups, all members must support it — otherwise non-Hue members
+                // would silently ignore the manufacturer-specific command.
                 // Wrapped in try-catch because supportsInputCluster may throw for
                 // custom clusters not in the cluster registry (e.g. in test mocks).
+                const endpointSupportsPhilips2 = (ep: Zh.Endpoint): boolean => {
+                    try {
+                        return ep.supportsInputCluster("manuSpecificPhilips2");
+                    } catch {
+                        return false;
+                    }
+                };
                 let hasPhilips2Cluster = false;
                 if (utils.isEndpoint(entity)) {
-                    try {
-                        hasPhilips2Cluster = entity.supportsInputCluster("manuSpecificPhilips2");
-                    } catch {
-                        hasPhilips2Cluster = false;
-                    }
+                    hasPhilips2Cluster = endpointSupportsPhilips2(entity);
+                } else if (utils.isGroup(entity)) {
+                    hasPhilips2Cluster = entity.members.length > 0 && entity.members.every(endpointSupportsPhilips2);
                 }
 
                 // Delegate to standard converters if:
-                //   - Device doesn't support manuSpecificPhilips2 cluster (old bulbs), OR
+                //   - Entity doesn't support manuSpecificPhilips2 cluster (old bulbs, or mixed groups), OR
                 //   - User hasn't opted into native Philips2 control (default)
                 // This mimics Z2M's own per-key dispatch so a single message routes
                 // each key to the appropriate converter.
-                const mustDelegate = (utils.isEndpoint(entity) && !hasPhilips2Cluster) || !nativeControl;
+                const mustDelegate = !hasPhilips2Cluster || !nativeControl;
 
                 if (mustDelegate) {
                     const used = new Set<Tz.Converter>();
@@ -530,15 +537,20 @@ const philipsModernExtend = {
                 }
             },
             convertGet: async (entity, key, meta) => {
+                const endpointSupportsPhilips2 = (ep: Zh.Endpoint): boolean => {
+                    try {
+                        return ep.supportsInputCluster("manuSpecificPhilips2");
+                    } catch {
+                        return false;
+                    }
+                };
                 let hasPhilips2Cluster = false;
                 if (utils.isEndpoint(entity)) {
-                    try {
-                        hasPhilips2Cluster = entity.supportsInputCluster("manuSpecificPhilips2");
-                    } catch {
-                        hasPhilips2Cluster = false;
-                    }
+                    hasPhilips2Cluster = endpointSupportsPhilips2(entity);
+                } else if (utils.isGroup(entity)) {
+                    hasPhilips2Cluster = entity.members.length > 0 && entity.members.every(endpointSupportsPhilips2);
                 }
-                if (utils.isEndpoint(entity) && !hasPhilips2Cluster) {
+                if (!hasPhilips2Cluster) {
                     for (const tz of toZigbee) {
                         if (tz.key.includes(key) && tz.convertGet) {
                             return await tz.convertGet(entity, key, meta);

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -9,7 +9,7 @@ import * as light from "./light";
 import {logger} from "./logger";
 import * as modernExtend from "./modernExtend";
 import * as globalStore from "./store";
-import type {Configure, Expose, Fz, KeyValue, KeyValueAny, ModernExtend, Tz} from "./types";
+import type {Configure, Expose, Fz, KeyValue, KeyValueAny, ModernExtend, Tz, Zh} from "./types";
 import * as utils from "./utils";
 import {determineEndpoint, exposeEndpoints, hasAlreadyProcessedMessage, isObject, numberWithinRange} from "./utils";
 


### PR DESCRIPTION
With Hue native control enabled, sending commands to a group with some Hue bulbs went via manuSpecificPhilips2 regardless of group composition. For mixed groups (Hue and non-Hue bulbs), this can fail (e.g., if trying to set effects).

(See https://github.com/Koenkk/zigbee-herdsman-converters/pull/12008#issuecomment-4362609833, https://github.com/Koenkk/zigbee-herdsman-converters/pull/11655#issuecomment-4367752248, and nearby discussion.)

When `hue_native_control` is enabled, color/brightness/etc. commands go out as manuSpecificPhilips2 writes. For groups, this only works if every member supports the cluster.

Fix checks all group members and falls back to standard ZCL converters if any member doesn't support manuSpecificPhilips2.

(If you experience this issue, disable Hue native control for the groups, or create Hue-only groups to send commands to.)