### PR TITLE
fix(danfoss): rename adaptionRunControl state none to idle (HA MQTT display issue)

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -867,7 +867,7 @@ const danfossExtend = {
             attribute: "danfossAdaptionRunControl",
             description: "Adaptation run control: Initiate Adaptation Run or Cancel Adaptation Run",
             lookup: {
-                none: 0,
+                idle: 0,
                 initiate_adaptation: 1,
                 cancel_adaptation: 2,
             },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -146,7 +146,7 @@ export const danfossAdaptionRunStatus: KeyValueNumberString = {
 };
 
 export const danfossAdaptionRunControl: KeyValueNumberString = {
-    0: "none",
+    0: "idle",
     1: "initiate_adaptation",
     2: "cancel_adaptation",
 };


### PR DESCRIPTION
This fixes an issue where none would display as unknown on the MQTT device.
Before:
<img width="511" height="94" alt="danfoss_z2m_adaption_run_control_before" src="https://github.com/user-attachments/assets/f7ef1c74-6700-4199-8ec8-18888b8fea69" />
<img width="325" height="205" alt="danfoss_adaptation_run_control_before" src="https://github.com/user-attachments/assets/ec51070e-ba57-43b0-8161-5ab091b3031f" /> 

After:
<img width="462" height="96" alt="danfoss_z2m_adaption_run_control_after" src="https://github.com/user-attachments/assets/d94fe9ef-d852-4e32-91b9-fa3167117824" />
<img width="305" height="193" alt="danfoss_adaptation_run_control_after" src="https://github.com/user-attachments/assets/74cf76c2-baeb-4769-b001-3ae59407c5d8" />
