### PR TITLE
Add Philips Hue Flux Outdoor strip light model 929004611102

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -5007,10 +5007,25 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
-        zigbeeModel: ["929004611002"],
+        zigbeeModel: ["929004611002","929004611102"],
         model: "929004611002",
         vendor: "Philips",
         description: "Hue Flux Outdoor strip light (6m)",
-        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+        whiteLabel: [
+            {
+                model: "929004611102",
+                vendor: "Philips",
+                description: "Hue Flux Outdoor strip light (10m)",
+                fingerprint: [{modelID: "929004611102"}],
+            },
+
+        ],
+        extend: [
+            philips.m.light({
+                colorTemp: {range: [50, 1000]},
+                color: {modes: ["xy", "hs"], enhancedHue: true},
+                gradient: {extraEffects: ["sparkle", "opal", "glisten", "prism", "underwater", "cosmos", "sunbeam", "enchant"]},
+            }),
+        ],    
     },
 ];

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -5007,7 +5007,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
-        zigbeeModel: ["929004611002","929004611102"],
+        zigbeeModel: ["929004611002", "929004611102"],
         model: "929004611002",
         vendor: "Philips",
         description: "Hue Flux Outdoor strip light (6m)",
@@ -5018,7 +5018,6 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Hue Flux Outdoor strip light (10m)",
                 fingerprint: [{modelID: "929004611102"}],
             },
-
         ],
         extend: [
             philips.m.light({
@@ -5026,6 +5025,6 @@ export const definitions: DefinitionWithExtend[] = [
                 color: {modes: ["xy", "hs"], enhancedHue: true},
                 gradient: {extraEffects: ["sparkle", "opal", "glisten", "prism", "underwater", "cosmos", "sunbeam", "enchant"]},
             }),
-        ],    
+        ],
     },
 ];


### PR DESCRIPTION
Added support for a new Philips Hue Flux Outdoor (10m) strip light model and updated the zigbeeModel array.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://www.zigbee2mqtt.io/images/devices/929004611002.png
