### PR TITLE
Modify temperature and humidity reporting settings for Plugwise Emma Pro 170-01

### DIFF
--- a/src/devices/plugwise.ts
+++ b/src/devices/plugwise.ts
@@ -387,6 +387,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "170-01",
         vendor: "Plugwise",
         description: "Emma Wired Pro / Emma Wireless",
+        version: "0.0.1",
         extend: [
             plugwiseExtend.plugwiseHvacThermostatCluster(),
             plugwiseExtend.applicationFaultCodeStatus(),

--- a/src/devices/plugwise.ts
+++ b/src/devices/plugwise.ts
@@ -392,7 +392,7 @@ export const definitions: DefinitionWithExtend[] = [
             plugwiseExtend.applicationFaultCodeStatus(),
             plugwiseExtend.oemFaultCode(),
             m.temperature({
-                reporting: {min: "1_SECOND", max: 870, change: 0.1},
+                reporting: {min: "1_SECOND", max: 870, change: 10},
             }),
             m.thermostat({
                 setpoints: {
@@ -415,9 +415,7 @@ export const definitions: DefinitionWithExtend[] = [
                     configure: {reporting: {min: "1_SECOND", max: 870, change: 0}},
                 },
             }),
-            m.humidity({
-                reporting: {min: "10_SECONDS", max: 870, change: 3},
-            }),
+            m.humidity(),
             m.numeric({
                 name: "outdoor_temperature",
                 cluster: "hvacThermostat",


### PR DESCRIPTION
For Plugwise Emma Pro 170-01 I've updated temperature reporting change value from 0.1 to 10 as 0.1 is invalid. 
Humidity reporting is set to false as I got 'INVALID_VALUE' error messages during configuration of the device.

After these changes both the 'local temperature' and 'humidity' values are being reported almost instantly by the Emma, before these values hardly ever updated.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
