### PR TITLE
Fix Schneider Pilot Mode

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -624,8 +624,8 @@ const schneiderElectricExtend = {
             entityCategory: "config",
             access: "ALL",
             lookup: {
-                contactor: 1,
-                pilot: 3,
+                Contactor: 1,
+                Pilot: 3,
             },
             zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.SCHNEIDER_ELECTRIC},
             ...args,


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
The Schneider Pilot Mode isn't registered correctly since there is an issue with the options.
This change should set the contactor mode to Contactor and pilot mode to Pilot, registering it correctly.

Zigbee2MQTT state:
```YAML
{
    "keypad_lockout": "unlock",
    "last_seen": "2026-03-06T06:33:01+01:00",
    "linkquality": 25,
    "local_temperature": 18.38,
    "occupancy": true,
    "occupied_cooling_setpoint": 22,
    "occupied_heating_setpoint": 18,
    "pi_cooling_demand": 0,
    "pi_heating_demand": 0,
    "running_state": "idle",
    "schneider_pilot_mode": "contactor",
    "system_mode": "heat",
    "temperature": 18.41,
    "temperature_display_mode": "celsius"
}
```
Home Assistant error:
`Invalid option for select.thermostat_schneider_pilot_mode: 'contactor' (valid options: ['Contactor', 'Pilot'])`

MQTT info:
```YAML
{
  "availability": [
    {
      "topic": "zigbee2mqtt/bridge/state",
      "value_template": "{{ value_json.state }}"
    },
    {
      "topic": "zigbee2mqtt/Thermostat/availability",
      "value_template": "{{ value_json.state }}"
    }
  ],
  "availability_mode": "all",
  "command_topic": "zigbee2mqtt/Thermostat/set/schneider_pilot_mode",
  "default_entity_id": "select.thermostat_schneider_pilot_mode",
  "device": {
    "identifiers": [
      "zigbee2mqtt_0xXXXXXXXXXXXXXXXX"
    ],
    "manufacturer": "Schneider Electric",
    "model": "Wiser Odace Smart thermostat",
    "model_id": "S520619",
    "name": "Thermostat",
    "via_device": "zigbee2mqtt_bridge"
  },
  "entity_category": "config",
  "name": "Schneider pilot mode",
  "object_id": "thermostat_schneider_pilot_mode",
  "options": [
    "Contactor",
    "Pilot"
  ],
  "origin": {
    "name": "Zigbee2MQTT",
    "sw": "2.9.1",
    "url": "https://www.zigbee2mqtt.io"
  },
  "state_topic": "zigbee2mqtt/Thermostat",
  "unique_id": "0xXXXXXXXXXXXXXXXX_schneider_pilot_mode_zigbee2mqtt",
  "value_template": "{{ value_json.schneider_pilot_mode }}"
}
```