### PR TITLE
Adds AOYAN AY-302Z soil moisture sensor.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22375,12 +22375,12 @@ export const definitions: DefinitionWithExtend[] = [
                 tuya.exposes.soilWarning(),
                 e.battery(),
             ];
-    
+
             if (device?.modelID !== "AY-302Z") {
                 exposes.splice(2, 0, e.humidity());
                 exposes.splice(6, 0, tuya.exposes.humidityCalibration());
             }
-    
+
             return exposes;
         },
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22356,26 +22356,33 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-303Z", "AY-303Z"],
+        zigbeeModel: ["ZG-303Z", "AY-303Z", "AY-302Z"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_npj9bug3", "_TZE200_wrmhp6b3"]),
         model: "CS-201Z",
         vendor: "COOLO",
         description: "Soil moisture sensor",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
-        exposes: [
-            e.dry(),
-            e.temperature(),
-            e.humidity(),
-            e.soil_moisture(),
-            tuya.exposes.temperatureUnit(),
-            tuya.exposes.temperatureCalibration(),
-            tuya.exposes.humidityCalibration(),
-            tuya.exposes.soilCalibration(),
-            tuya.exposes.temperatureSampling(),
-            tuya.exposes.soilSampling(),
-            tuya.exposes.soilWarning(),
-            e.battery(),
-        ],
+        exposes: (device) => {
+            const exposes = [
+                e.dry(),
+                e.temperature(),
+                e.soil_moisture(),
+                tuya.exposes.temperatureUnit(),
+                tuya.exposes.temperatureCalibration(),
+                tuya.exposes.soilCalibration(),
+                tuya.exposes.temperatureSampling(),
+                tuya.exposes.soilSampling(),
+                tuya.exposes.soilWarning(),
+                e.battery(),
+            ];
+    
+            if (device?.modelID !== "AY-302Z") {
+                exposes.splice(2, 0, e.humidity());
+                exposes.splice(6, 0, tuya.exposes.humidityCalibration());
+            }
+    
+            return exposes;
+        },
         meta: {
             tuyaDatapoints: [
                 [106, "dry", tuya.valueConverter.raw],


### PR DESCRIPTION
Tested with Zigbee2MQTT.

Device info:

Zigbee model: AY-302Z
Manufacturer name: AOYAN
Uses the same Tuya datapoints as CS-201Z except humidity and humidity_calibration are not exposed.

