### PR TITLE
Adds AOYAN AY-302Z soil moisture sensor.

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22356,26 +22356,33 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-303Z", "AY-303Z"],
+        zigbeeModel: ["ZG-303Z", "AY-303Z", "AY-302Z"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_npj9bug3", "_TZE200_wrmhp6b3"]),
         model: "CS-201Z",
         vendor: "COOLO",
         description: "Soil moisture sensor",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
-        exposes: [
-            e.dry(),
-            e.temperature(),
-            e.humidity(),
-            e.soil_moisture(),
-            tuya.exposes.temperatureUnit(),
-            tuya.exposes.temperatureCalibration(),
-            tuya.exposes.humidityCalibration(),
-            tuya.exposes.soilCalibration(),
-            tuya.exposes.temperatureSampling(),
-            tuya.exposes.soilSampling(),
-            tuya.exposes.soilWarning(),
-            e.battery(),
-        ],
+        exposes: (device) => {
+            const exposes = [
+                e.dry(),
+                e.temperature(),
+                e.soil_moisture(),
+                tuya.exposes.temperatureUnit(),
+                tuya.exposes.temperatureCalibration(),
+                tuya.exposes.soilCalibration(),
+                tuya.exposes.temperatureSampling(),
+                tuya.exposes.soilSampling(),
+                tuya.exposes.soilWarning(),
+                e.battery(),
+            ];
+    
+            if (device?.zh?.modelID !== "AY-302Z") {
+                exposes.splice(2, 0, e.humidity());
+                exposes.splice(6, 0, tuya.exposes.humidityCalibration());
+            }
+    
+            return exposes;
+        },
         meta: {
             tuyaDatapoints: [
                 [106, "dry", tuya.valueConverter.raw],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22375,12 +22375,12 @@ export const definitions: DefinitionWithExtend[] = [
                 tuya.exposes.soilWarning(),
                 e.battery(),
             ];
-    
+
             if (device?.zh?.modelID !== "AY-302Z") {
                 exposes.splice(2, 0, e.humidity());
                 exposes.splice(6, 0, tuya.exposes.humidityCalibration());
             }
-    
+
             return exposes;
         },
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22375,12 +22375,14 @@ export const definitions: DefinitionWithExtend[] = [
                 tuya.exposes.soilWarning(),
                 e.battery(),
             ];
-
-            if (device?.zh?.modelID !== "AY-302Z") {
+        
+            const isAY302Z = device !== undefined && "modelID" in device && device.modelID === "AY-302Z";
+        
+            if (!isAY302Z) {
                 exposes.splice(2, 0, e.humidity());
                 exposes.splice(6, 0, tuya.exposes.humidityCalibration());
             }
-
+        
             return exposes;
         },
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22375,14 +22375,14 @@ export const definitions: DefinitionWithExtend[] = [
                 tuya.exposes.soilWarning(),
                 e.battery(),
             ];
-        
+
             const isAY302Z = device !== undefined && "modelID" in device && device.modelID === "AY-302Z";
-        
+
             if (!isAY302Z) {
                 exposes.splice(2, 0, e.humidity());
                 exposes.splice(6, 0, tuya.exposes.humidityCalibration());
             }
-        
+
             return exposes;
         },
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -14,7 +14,7 @@ import * as globalStore from "../lib/store";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend, Expose, Fz, KeyValue, KeyValueAny, Tz, Zh} from "../lib/types";
 import * as utils from "../lib/utils";
-import {addActionGroup, hasAlreadyProcessedMessage, postfixWithEndpointName} from "../lib/utils";
+import {addActionGroup, hasAlreadyProcessedMessage, isDummyDevice, postfixWithEndpointName} from "../lib/utils";
 import * as zosung from "../lib/zosung";
 
 const NS = "zhc:tuya";
@@ -22376,9 +22376,7 @@ export const definitions: DefinitionWithExtend[] = [
                 e.battery(),
             ];
 
-            const isAY302Z = device !== undefined && "modelID" in device && device.modelID === "AY-302Z";
-
-            if (!isAY302Z) {
+            if (!isDummyDevice(device) && device.modelID !== "AY-302Z") {
                 exposes.splice(2, 0, e.humidity());
                 exposes.splice(6, 0, tuya.exposes.humidityCalibration());
             }


### PR DESCRIPTION
Adds AOYAN AY-302Z soil moisture sensor.

Tested with Zigbee2MQTT.

Device info:

Zigbee model: AY-302Z
Manufacturer name: AOYAN
Uses the same Tuya datapoints as CS-201Z except humidity and humidity_calibration are not exposed.

