### PR TITLE
fix(ignore): Fix Profalux whiteLabels (part 3)

### DIFF
--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -119,7 +119,7 @@ export const definitions: DefinitionWithExtend[] = [
         endpoint: (device) => {
             return {default: 2};
         },
-        whiteLabel: [{model: "MOT-C2Z10", vendor: "Profalux"}],
+        whiteLabel: [{model: "MOT-C2Z10", vendor: "Profalux", fingerprint: [{modelID: "MOT-C2Z10"}]}],
     },
     {
         // Identify older covers based on their fingerprint. These do not
@@ -160,7 +160,7 @@ export const definitions: DefinitionWithExtend[] = [
             // Poll battery voltage as reporting doesn't work
             mLocal.pollBatteryVoltage(),
         ],
-        whiteLabel: [{model: "MAI-ZTP22C", vendor: "Profalux"}],
+        whiteLabel: [{model: "MAI-ZTP22C", vendor: "Profalux", fingerprint: [{modelID: "MAI-ZTP22C"}]}],
     },
     {
         // Newer remotes. These expose a bunch of things but they are bound to


### PR DESCRIPTION
@residentphil74-hub we also need to add `fingerprint`.
This assigns the custom Z2M `whiteLabel` to the specific `zigbeeModel (modelID)` reported by the device.

- part 1: https://github.com/Koenkk/zigbee-herdsman-converters/pull/12098
- part 2: https://github.com/Koenkk/zigbee-herdsman-converters/pull/12108
- images: https://github.com/Koenkk/zigbee2mqtt.io/pull/5088