### PR TITLE
refactor(inovelli): split m.device into m.parameters/ledEffects/buttonTaps

### DIFF
--- a/src/devices/inovelli.ts
+++ b/src/devices/inovelli.ts
@@ -14,11 +14,11 @@ export const definitions: DefinitionWithExtend[] = [
                 multiEndpointSkip: ["state", "voltage", "power", "current", "energy", "brightness", "temperature", "humidity"],
             }),
             inovelli.m.light(),
-            inovelli.m.device({
-                model: inovelli.Model.VZM30,
+            inovelli.m.ledEffects(),
+            inovelli.m.buttonTaps(),
+            inovelli.m.parameters({
                 attrs: [{attributes: inovelli.VZM30_ATTRIBUTES, clusterName: inovelli.CLUSTER_NAME}],
-                supportsLedEffects: true,
-                supportsButtonTaps: true,
+                model: inovelli.Model.VZM30,
             }),
             inovelli.m.addCustomCluster(),
             m.identify(),
@@ -40,11 +40,11 @@ export const definitions: DefinitionWithExtend[] = [
                 multiEndpointSkip: ["state", "power", "energy", "brightness"],
             }),
             inovelli.m.light(),
-            inovelli.m.device({
-                model: inovelli.Model.VZM31,
+            inovelli.m.ledEffects(),
+            inovelli.m.buttonTaps(),
+            inovelli.m.parameters({
                 attrs: [{attributes: inovelli.VZM31_ATTRIBUTES, clusterName: inovelli.CLUSTER_NAME}],
-                supportsLedEffects: true,
-                supportsButtonTaps: true,
+                model: inovelli.Model.VZM31,
             }),
             inovelli.m.addCustomCluster(),
             m.identify(),
@@ -69,14 +69,14 @@ export const definitions: DefinitionWithExtend[] = [
                 multiEndpointSkip: ["state", "voltage", "power", "current", "energy", "brightness", "illuminance", "occupancy"],
             }),
             inovelli.m.light(),
-            inovelli.m.device({
-                model: inovelli.Model.VZM32,
+            inovelli.m.ledEffects(),
+            inovelli.m.buttonTaps(),
+            inovelli.m.parameters({
                 attrs: [
                     {attributes: inovelli.VZM32_ATTRIBUTES, clusterName: inovelli.CLUSTER_NAME},
                     {attributes: inovelli.VZM32_MMWAVE_ATTRIBUTES, clusterName: inovelli.MMWAVE_CLUSTER_NAME},
                 ],
-                supportsLedEffects: true,
-                supportsButtonTaps: true,
+                model: inovelli.Model.VZM32,
             }),
             inovelli.m.mmWave(),
             inovelli.m.addCustomCluster(),
@@ -98,11 +98,11 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Fan controller",
         extend: [
             inovelli.m.fan({endpointId: 1}),
-            inovelli.m.device({
-                model: inovelli.Model.VZM35,
+            inovelli.m.ledEffects(),
+            inovelli.m.buttonTaps(),
+            inovelli.m.parameters({
                 attrs: [{attributes: inovelli.VZM35_ATTRIBUTES, clusterName: inovelli.CLUSTER_NAME}],
-                supportsLedEffects: true,
-                supportsButtonTaps: true,
+                model: inovelli.Model.VZM35,
             }),
             inovelli.m.addCustomCluster(),
             m.identify(),
@@ -119,12 +119,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             inovelli.m.light({splitValuesByEndpoint: true}),
             inovelli.m.fan({endpointId: 2, splitValuesByEndpoint: true}),
-            inovelli.m.device({
-                model: inovelli.Model.VZM36,
+            inovelli.m.parameters({
                 attrs: [{attributes: inovelli.VZM36_ATTRIBUTES, clusterName: inovelli.CLUSTER_NAME}],
-                supportsLedEffects: false,
+                model: inovelli.Model.VZM36,
                 splitValuesByEndpoint: true,
-                supportsButtonTaps: false,
             }),
             inovelli.m.addCustomCluster(),
             m.identify(),

--- a/src/lib/inovelli.ts
+++ b/src/lib/inovelli.ts
@@ -612,31 +612,17 @@ const inovelliExtend = {
             },
         });
     },
-    device: ({
-        model,
+    parameters: ({
         attrs,
-        supportsLedEffects,
-        supportsButtonTaps,
+        model,
         splitValuesByEndpoint = false,
     }: {
-        model: Model;
         attrs: Array<{attributes: {[s: string]: Attribute}; clusterName: typeof INOVELLI_CLUSTER_NAME | typeof INOVELLI_MMWAVE_CLUSTER_NAME}>;
-        supportsLedEffects?: boolean;
-        supportsButtonTaps: boolean;
+        model: Model;
         splitValuesByEndpoint?: boolean;
     }): ModernExtend => {
         const fromZigbee: NonNullable<ModernExtend["fromZigbee"]> = [];
         const toZigbee: Tz.Converter[] = [];
-        const staticExposes: Expose[] = [];
-
-        if (supportsLedEffects) {
-            fromZigbee.push(fzLocal.led_effect_complete);
-            toZigbee.push(tzLocal.inovelli_led_effect, tzLocal.inovelli_individual_led_effect);
-            staticExposes.push(exposeLedEffects(), exposeIndividualLedEffects(), exposeLedEffectComplete());
-        }
-        if (supportsButtonTaps) {
-            staticExposes.push(e.action(BUTTON_TAP_SEQUENCES));
-        }
 
         for (const attr of attrs) {
             fromZigbee.push(fzLocal.inovelli(attr.attributes, attr.clusterName, splitValuesByEndpoint, model));
@@ -666,15 +652,17 @@ const inovelliExtend = {
                 const endpoint = device.getEndpoint(1);
                 await reporting.bind(endpoint, coordinatorEndpoint, [INOVELLI_CLUSTER_NAME]);
 
-                // Bind for Button Event Reporting
-                const endpoint2 = device.getEndpoint(2);
-                await reporting.bind(endpoint2, coordinatorEndpoint, [INOVELLI_CLUSTER_NAME]);
+                let endpoint2: Zh.Endpoint | undefined;
+                if (splitValuesByEndpoint) {
+                    endpoint2 = device.getEndpoint(2);
+                    await reporting.bind(endpoint2, coordinatorEndpoint, [INOVELLI_CLUSTER_NAME]);
+                }
 
                 const fw = device.softwareBuildID ? parseFirmwareVersion(device.softwareBuildID) : undefined;
 
                 for (const attr of attrs) {
                     const filtered = adjustAttributesForDevice(attr.attributes, model, fw);
-                    if (!splitValuesByEndpoint) {
+                    if (!splitValuesByEndpoint || !endpoint2) {
                         await chunkedRead(endpoint, Object.keys(filtered), attr.clusterName);
                     } else {
                         await chunkedRead(
@@ -712,7 +700,29 @@ const inovelliExtend = {
         return {
             fromZigbee,
             toZigbee,
-            exposes: [...staticExposes, dynamicExposes],
+            exposes: [dynamicExposes],
+            configure,
+            isModernExtend: true,
+        };
+    },
+    ledEffects: (): ModernExtend => {
+        return {
+            fromZigbee: [fzLocal.led_effect_complete],
+            toZigbee: [tzLocal.inovelli_led_effect, tzLocal.inovelli_individual_led_effect],
+            exposes: [exposeLedEffects(), exposeIndividualLedEffects(), exposeLedEffectComplete()],
+            isModernExtend: true,
+        };
+    },
+    buttonTaps: (): ModernExtend => {
+        const configure: Configure[] = [
+            async (device, coordinatorEndpoint, definition) => {
+                const endpoint2 = device.getEndpoint(2);
+                await reporting.bind(endpoint2, coordinatorEndpoint, [INOVELLI_CLUSTER_NAME]);
+            },
+        ];
+        return {
+            fromZigbee: [fzLocal.button_taps],
+            exposes: [e.action(BUTTON_TAP_SEQUENCES)],
             configure,
             isModernExtend: true,
         };
@@ -2630,45 +2640,40 @@ const fzLocal = {
     ) =>
         ({
             cluster: cluster,
-            type: ["raw", "readResponse", "attributeReport"],
+            type: ["readResponse", "attributeReport"],
             convert: (model, msg, publish, options, meta) => {
-                if (msg.type === "raw" && msg.endpoint.ID === 2 && msg.data[4] === 0x00) {
-                    // Scene Event
-                    // # byte 1 - msg.data[6]
-                    // # 0 - pressed
-                    // # 1 - released
-                    // # 2 - held
-                    // # 3 - 2x
-                    // # 4 - 3x
-                    // # 5 - 4x
-                    // # 6 - 5x
-
-                    // # byte 2 - msg.data[5]
-                    // # 1 - down button
-                    // # 2 - up button
-                    // # 3 - config button
-
-                    const button = buttonLookup[msg.data[5]];
-                    const action = clickLookup[msg.data[6]];
-                    return {action: `${button}_${action}`};
-                }
-                if (msg.type === "readResponse" || msg.type === "attributeReport") {
-                    const result: KeyValue = {};
-                    for (const c of Object.keys(msg.data)) {
-                        const key = splitValuesByEndpoint ? `${c}_${msg.endpoint.ID}` : c;
-                        const raw = (msg.data as Record<string | number, unknown>)[c];
-                        if (attributes[key] && attributes[key].displayType === "enum") {
-                            const valueMap = resolveValueMap(attributes[key], deviceModel);
-                            result[key] = valueMap ? Object.keys(valueMap).find((k) => valueMap[k] === raw) : raw;
-                        } else {
-                            result[key] = raw;
-                        }
+                const result: KeyValue = {};
+                for (const c of Object.keys(msg.data)) {
+                    const key = splitValuesByEndpoint ? `${c}_${msg.endpoint.ID}` : c;
+                    const raw = (msg.data as Record<string | number, unknown>)[c];
+                    if (attributes[key] && attributes[key].displayType === "enum") {
+                        const valueMap = resolveValueMap(attributes[key], deviceModel);
+                        result[key] = valueMap ? Object.keys(valueMap).find((k) => valueMap[k] === raw) : raw;
+                    } else {
+                        result[key] = raw;
                     }
-                    return result;
                 }
-                return msg.data;
+                return result;
             },
-        }) satisfies Fz.Converter<typeof cluster, undefined, ["raw", "readResponse", "attributeReport"]>,
+        }) satisfies Fz.Converter<typeof cluster, undefined, ["readResponse", "attributeReport"]>,
+    /**
+     * Decodes raw button-tap scene frames sent by the device on endpoint 2 of `manuSpecificInovelli`.
+     *
+     * Frame layout (bytes 4-6 are the scene tuple, the rest of the frame is ignored here):
+     *   data[4]: marker — must be 0x00, otherwise the frame is a different opcode.
+     *   data[5]: button index (`buttonLookup`): 1=down, 2=up, 3=config, 4-6=aux_*.
+     *   data[6]: tap kind (`clickLookup`): 0=pressed, 1=released, 2=held, 3-6=2x..5x.
+     */
+    button_taps: {
+        cluster: INOVELLI_CLUSTER_NAME,
+        type: ["raw"],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.endpoint.ID !== 2 || msg.data[4] !== 0x00) return;
+            const button = buttonLookup[msg.data[5]];
+            const action = clickLookup[msg.data[6]];
+            return {action: `${button}_${action}`};
+        },
+    } satisfies Fz.Converter<typeof INOVELLI_CLUSTER_NAME, undefined, ["raw"]>,
     fan_mode: (endpointId: number) =>
         ({
             cluster: "genLevelCtrl",

--- a/test/inovelli.test.ts
+++ b/test/inovelli.test.ts
@@ -1860,15 +1860,16 @@ describe("Inovelli VZM31-SN definition integration", () => {
             model: "VZM31-SN",
             device,
             meta: {multiEndpoint: true, multiEndpointSkip: ["state", "power", "energy", "brightness"]},
-            // 8 converters: light (on_off EP1 + brightness + level_config + power_on_behavior), device (led_effect_complete + main),
-            // electricityMeter (electrical_measurement + metering).
+            // 9 converters: light (on_off EP1 + brightness + level_config + power_on_behavior), ledEffects (led_effect_complete),
+            // buttonTaps (raw EP2 scene parser), parameters (attribute reports), electricityMeter (electrical_measurement + metering).
             fromZigbeeFingerprint: [
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
                 {cluster: "manuSpecificInovelli", type: ["commandLedEffectComplete"]},
-                {cluster: "manuSpecificInovelli", type: ["raw", "readResponse", "attributeReport"]},
+                {cluster: "manuSpecificInovelli", type: ["raw"]},
+                {cluster: "manuSpecificInovelli", type: ["readResponse", "attributeReport"]},
                 {cluster: "haElectricalMeasurement", type: ["attributeReport", "readResponse"]},
                 {cluster: "seMetering", type: ["attributeReport", "readResponse"]},
             ],
@@ -2082,14 +2083,15 @@ describe("Inovelli VZM30-SN definition integration", () => {
                 multiEndpoint: true,
                 multiEndpointSkip: ["state", "voltage", "power", "current", "energy", "brightness", "temperature", "humidity"],
             },
-            // Same 8 converters as VZM31-SN plus temperature + humidity measurement converters.
+            // Same 9 converters as VZM31-SN plus temperature + humidity measurement converters.
             fromZigbeeFingerprint: [
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
                 {cluster: "manuSpecificInovelli", type: ["commandLedEffectComplete"]},
-                {cluster: "manuSpecificInovelli", type: ["raw", "readResponse", "attributeReport"]},
+                {cluster: "manuSpecificInovelli", type: ["raw"]},
+                {cluster: "manuSpecificInovelli", type: ["readResponse", "attributeReport"]},
                 {cluster: "haElectricalMeasurement", type: ["attributeReport", "readResponse"]},
                 {cluster: "seMetering", type: ["attributeReport", "readResponse"]},
                 {cluster: "msTemperatureMeasurement", type: ["attributeReport", "readResponse"]},
@@ -2293,8 +2295,9 @@ describe("Inovelli VZM32-SN definition integration", () => {
                 multiEndpoint: true,
                 multiEndpointSkip: ["state", "voltage", "power", "current", "energy", "brightness", "illuminance", "occupancy"],
             },
-            // 15 converters: light (on_off EP1 + brightness + level_config + power_on_behavior), device (led_effect_complete + main),
-            // mmWave (main attr report + 3 command converters: anyone_in_reporting_area, report_areas, report_target_info),
+            // 16 converters: light (on_off EP1 + brightness + level_config + power_on_behavior), ledEffects (led_effect_complete),
+            // buttonTaps (raw EP2 scene parser), parameters (INOVELLI + INOVELLI_MMWAVE attribute reports),
+            // mmWave (3 command converters: anyone_in_reporting_area, report_areas, report_target_info),
             // electricityMeter (electrical_measurement + metering), illuminance (measured + raw), occupancy.
             fromZigbeeFingerprint: [
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
@@ -2302,8 +2305,9 @@ describe("Inovelli VZM32-SN definition integration", () => {
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
                 {cluster: "manuSpecificInovelli", type: ["commandLedEffectComplete"]},
-                {cluster: "manuSpecificInovelli", type: ["raw", "readResponse", "attributeReport"]},
-                {cluster: "manuSpecificInovelliMMWave", type: ["raw", "readResponse", "attributeReport"]},
+                {cluster: "manuSpecificInovelli", type: ["raw"]},
+                {cluster: "manuSpecificInovelli", type: ["readResponse", "attributeReport"]},
+                {cluster: "manuSpecificInovelliMMWave", type: ["readResponse", "attributeReport"]},
                 {cluster: "manuSpecificInovelliMMWave", type: ["commandAnyoneInReportingArea"]},
                 {
                     cluster: "manuSpecificInovelliMMWave",
@@ -2608,14 +2612,16 @@ describe("Inovelli VZM35-SN definition integration", () => {
             device,
             // VZM35-SN does not use m.deviceEndpoints(), so no multiEndpoint meta is set (definition.meta is undefined).
             meta: undefined,
-            // 5 converters: fan (fan_mode + breeze_mode + fan_state), device (led_effect_complete + main).
-            // No light/electricityMeter/etc. extends, so the custom cluster is the only "attrs" source.
+            // 6 converters: fan (fan_mode + breeze_mode + fan_state), ledEffects (led_effect_complete),
+            // buttonTaps (raw EP2 scene parser), parameters (attribute reports). No light/electricityMeter/etc.
+            // extends, so the custom cluster is the only "attrs" source.
             fromZigbeeFingerprint: [
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "manuSpecificInovelli", type: ["attributeReport", "readResponse"]},
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
                 {cluster: "manuSpecificInovelli", type: ["commandLedEffectComplete"]},
-                {cluster: "manuSpecificInovelli", type: ["raw", "readResponse", "attributeReport"]},
+                {cluster: "manuSpecificInovelli", type: ["raw"]},
+                {cluster: "manuSpecificInovelli", type: ["readResponse", "attributeReport"]},
             ],
             toZigbeeKeysContain: [
                 // fan() extend
@@ -2773,14 +2779,14 @@ describe("Inovelli VZM36 definition integration", () => {
             // VZM36 defines `fromZigbee: []` on the definition, so every fz converter comes from extends:
             // 2 from light (on_off_for_endpoint(1) + brightness; no level_config/power_on_behavior in split mode)
             // 3 from fan (fan_mode(2) + breeze_mode(2) + fan_state(2))
-            // 1 from device (inovelli -- no led_effect_complete since supportsLedEffects=false)
+            // 1 from parameters (attribute reports -- no ledEffects/buttonTaps for the canopy module)
             fromZigbeeFingerprint: [
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "genLevelCtrl", type: ["attributeReport", "readResponse"]},
                 {cluster: "manuSpecificInovelli", type: ["attributeReport", "readResponse"]},
                 {cluster: "genOnOff", type: ["attributeReport", "readResponse"]},
-                {cluster: "manuSpecificInovelli", type: ["raw", "readResponse", "attributeReport"]},
+                {cluster: "manuSpecificInovelli", type: ["readResponse", "attributeReport"]},
             ],
             toZigbeeKeysContain: [
                 // light() extend (split)


### PR DESCRIPTION
## Summary

Decomposes the monolithic `inovelli.m.device` modern extend into three single-responsibility extends — `inovelli.m.parameters`, `inovelli.m.ledEffects`, and `inovelli.m.buttonTaps` — and migrates the five existing Inovelli definitions (VZM30-SN, VZM31-SN, VZM32-SN, VZM35-SN, VZM36) to compose them explicitly.

`m.device` had grown to span four concerns (parameter-map fz/tz/exposes/configure, LED effects, button-tap scene reporting, and EP1/EP2 chunked reads) gated by feature flags. Splitting it makes each device's `extend: [...]` declarative about what features it actually supports — VZM36 ends up only with `m.parameters`, while the rest combine all three. As a follow-up, this also splits `fzLocal.inovelli` so attribute reports and raw button-tap frames are decoded by separate converters.

No runtime behavior changes for any device. All 552 tests pass (incl. 187 Inovelli tests).

## Changes

### `src/lib/inovelli.ts`

- **New `inovelli.m.parameters({attrs, model, splitValuesByEndpoint?})`** — owns the user-facing parameter map. Always binds EP1 to `manuSpecificInovelli` for chunked reads, and (only in `splitValuesByEndpoint` mode) also binds EP2 for the `_1`/`_2` demultiplexed reads. Wires `fzLocal.inovelli` for fz, plus `tzLocal.inovelli_parameters` and `tzLocal.inovelli_parameters_read_only` for tz, and the `dynamicExposes` callback.
- **New `inovelli.m.ledEffects()`** — registers `fzLocal.led_effect_complete`, the two `tzLocal.inovelli_(individual_)led_effect` converters, and the three LED-effect exposes. No configure step.
- **New `inovelli.m.buttonTaps()`** — binds EP2 to `manuSpecificInovelli` (for scene event reporting), wires the new `fzLocal.button_taps` raw parser, and exposes `e.action(BUTTON_TAP_SEQUENCES)`.
- **Removed `inovelli.m.device`** — fully replaced by the three extends above. The `supportsLedEffects` / `supportsButtonTaps` flags are gone; presence in the device's `extend: [...]` array is now the source of truth.
- **Split `fzLocal.inovelli`** — previously handled `["raw", "readResponse", "attributeReport"]` with a runtime branch on `msg.type === \"raw\"` for button-tap parsing. Now scoped to `["readResponse", "attributeReport"]` only, with all the EP2 raw-frame logic moved to a new sibling converter `fzLocal.button_taps` (which `m.buttonTaps()` registers). The new converter has a JSDoc block documenting the wire-level frame layout (`data[4]` marker, `data[5]` button index, `data[6]` tap kind) since those magic indices aren't self-explanatory.

### EP2 binding split

The original `m.device` always bound EP2 to `manuSpecificInovelli` unconditionally — that single bind served two purposes: receiving button-tap scene events (VZM30/31/32/35) **and** enabling chunked reads on EP2 in split-endpoint mode (VZM36). The split distributes the bind to where it actually belongs:

- For VZM30/31/32/35 (have button taps, no split): `m.buttonTaps()` binds EP2.
- For VZM36 (no button taps, split=true): `m.parameters()` binds EP2 inside the `splitValuesByEndpoint` branch.

No device ends up double-binding EP2.

### `src/devices/inovelli.ts`

All five definitions migrated:

```ts
// before
inovelli.m.device({
    model: inovelli.Model.VZM30,
    attrs: [{attributes: inovelli.VZM30_ATTRIBUTES, clusterName: inovelli.CLUSTER_NAME}],
    supportsLedEffects: true,
    supportsButtonTaps: true,
}),

// after
inovelli.m.ledEffects(),
inovelli.m.buttonTaps(),
inovelli.m.parameters({
    attrs: [{attributes: inovelli.VZM30_ATTRIBUTES, clusterName: inovelli.CLUSTER_NAME}],
    model: inovelli.Model.VZM30,
}),
```

VZM36 simplifies the most — no more `supportsLedEffects: false` / `supportsButtonTaps: false` flag clutter, just `m.parameters({..., splitValuesByEndpoint: true})`.

### `test/inovelli.test.ts`

`fromZigbeeFingerprint` arrays for all five devices updated to reflect the converter splits:

- The single `manuSpecificInovelli` entry with `type: ["raw", "readResponse", "attributeReport"]` is now two entries — one per converter (`["raw"]` from `buttonTaps`, `["readResponse", "attributeReport"]` from `parameters`).
- VZM36's fingerprint loses the raw entry entirely (no button taps).
- The pre-existing \"N converters: ...\" comments above each fingerprint were updated from `device (led_effect_complete + main)` wording to enumerate the new extends (`ledEffects (led_effect_complete), buttonTaps (raw EP2 scene parser), parameters (attribute reports)`).

## Test plan

- [x] `pnpm run check`
- [x] `pnpm run build`
- [x] `pnpm test` (552/552 passing, including all 187 Inovelli tests)

Made with [Cursor](https://cursor.com)