### PR TITLE
docs(Legrand 412170): clarify device_mode description & warn of  factory default

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -102,7 +102,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.power().withAccess(ea.STATE_GET),
             e
                 .enum("device_mode", ea.ALL, ["switch", "auto"])
-                .withDescription("switch: allow on/off, auto will use wired action via C1/C2 on teleruptor with buttons"),
+                .withDescription("Factory default is 'auto' - set to 'switch' for predictable operation. switch: normal on/off mode, momentary push-buttons on C1/C2 toggle the relay cleanly. auto: produces erratic behavior (auto mode appears to be a leftover from reusing code from Legrand 412171)"),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -102,7 +102,9 @@ export const definitions: DefinitionWithExtend[] = [
             e.power().withAccess(ea.STATE_GET),
             e
                 .enum("device_mode", ea.ALL, ["switch", "auto"])
-                .withDescription("Factory default is 'auto' - set to 'switch' for predictable operation. switch: normal on/off mode, momentary push-buttons on C1/C2 toggle the relay cleanly. auto: produces erratic behavior (auto mode appears to be a leftover from reusing code from Legrand 412171)"),
+                .withDescription(
+                    "Factory default is 'auto' - set to 'switch' for predictable operation. switch: normal on/off mode, momentary push-buttons on C1/C2 toggle the relay cleanly. auto: produces erratic behavior (auto mode appears to be a leftover from reusing code from Legrand 412171)",
+                ),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -103,7 +103,7 @@ export const definitions: DefinitionWithExtend[] = [
             e
                 .enum("device_mode", ea.ALL, ["switch", "auto"])
                 .withDescription(
-                    "Factory default is 'auto' - set to 'switch' for predictable operation. switch: normal on/off mode, momentary push-buttons on C1/C2 toggle the relay cleanly. auto: produces erratic behavior (auto mode appears to be a leftover from reusing code from Legrand 412171)",
+                    "Switch: normal on/off mode, momentary push-buttons on C1/C2 toggle the relay cleanly (recommended). auto: produces erratic behavior.",
                 ),
         ],
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
This PR updates only the `device_mode` description text, clarifying that `switch` is the working mode and `auto` produces erratic behavior, without removing the `auto` value or auto-writing `switch` during configure, since either could regress installations we don't know about.

Essentially the 412170 does not actually have a 'auto' device mode, despite the firmware apparently accepting value 4 for 'auto' mode on cluster 0xfc01 without error.

Why not remove the auto value altogether? 

Because it has been exposed for 5+ years, and more importantly, being able to set device_mode back to switch is what makes the device usable in the first place. Whatever the firmware factory default actually is, it is not switch, and only after explicitly setting device_mode to switch does the device behave correctly with Legrand's documented wiring (tested on 2 new factory sealed devices).

Just to be clear, this only affects Legrand's L to C1 wiring method, Legrand's C1 to C2 "dry-contact" method still seems to work even in default device_mode.

Testing on a 412170 (firmware 104) shows:

- **`switch` mode:** momentary push-buttons wired L to C1 (per Legrand's instruction sheet) toggle the relay cleanly. Dry contact between C1/C2 also works. Zigbee on/off works.

- **`auto` mode:** erratic relay behavior with the L to C1 push-button wiring method. The C1 to C2 wiring method still works. Zigbee on/off works.

- The firmware default is **not** `switch`. New installations misbehave with L to C1 wiring until the user manually sets `device_mode` to `switch`. I experienced this on a fresh device, and a Wireshark capture of a second factory-sealed 412170 paired to the **official Legrand Gateway** confirms the gateway never reads or writes cluster `0xfc01` either, so the same trap exists on the official integration path.

- The `auto` value seems leftover firmware inherited when the 412170 entry was cloned from the 412171 contactor (which has an auto mode) in #2297 (Feb 2021).  **Legrand Home+Control app:** exposes an "Off-peak / peak time" toggle for the 412171, no equivalent for the 412170.
- **OnOff cluster behavior:** on the 412171, OnOff is disabled while in `auto`; on the 412170, OnOff keeps working in either mode - i.e. `auto` has no functional effect on relay control.
- It was always assumed that the 412171 ships in auto mode, but for the 412170 your guess is as good as mine. It's probably not 'auto', since the device does not have a auto mode, and it's not 'switch', as by default we have erratic behavior which can be eliminated by setting device_mode 'switch'.

Related: Koenkk/zigbee2mqtt#14812 (same `device_mode`/`auto` confusion on the 412171 contactor, description rewritten in #4951).

Companion docs PR: Koenkk/zigbee2mqtt.io#5102.

