### PR TITLE
Add Heiman HS8OS ceiling embedded occupancy sensor

### DIFF
--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -3055,4 +3055,28 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         ota: true,
     },
+    {
+        zigbeeModel: ["HS8OS-N-3.0", "HS8OS-EM-3.0", "HS8OS-EF-3.0", "HS8OS-EF1-3.0", "HS8OS-EF2-3.0"],
+        model: "HS8OS",
+        vendor: "HEIMAN",
+        description: "Ceiling embedded occupancy sensor",
+        extend: [
+            m.illuminance(),
+            m.occupancy({ultrasonicConfig: ["otu_delay"]}),
+            m.identify(),
+            m.numeric({
+                name: "illuminance_threshold",
+                cluster: "msIlluminanceMeasurement",
+                attribute: {ID: 0xf000, type: Zcl.DataType.INT16},
+                description: "Controls illuminance threshold for sending commands",
+                valueMin: 0,
+                valueMax: 1000,
+                unit: "lx",
+                entityCategory: "config",
+                access: "ALL",
+                zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.HEIMAN_TECHNOLOGY_CO_LTD},
+            }),
+        ],
+        ota: true,
+    },
 ];

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -2330,46 +2330,6 @@ export const definitions: DefinitionWithExtend[] = [
         endpoint: (device) => ({default: 1}),
     },
     {
-        zigbeeModel: ["HS8OS-EF1-3.0"],
-        model: "HS8OS-EF1-3.0",
-        vendor: "Heiman",
-        description: "Human presence sensor",
-        extend: [
-            m.occupancy(),
-            heimanExtend.heimanClusterRadar(),
-            heimanExtend.heimanClusterRadarActiveIndicatorExtend(),
-            heimanExtend.heimanClusterRadarSensitivityExtend(),
-            heimanExtend.heimanClusterLegacyIlluminanceExtend(),
-
-            m.numeric({
-                name: "radar_delay_time",
-                cluster: 0x0406,
-                attribute: {ID: 0x0020, type: 0x21},
-                description: "Occupied to unoccupied delay",
-                valueMin: 60,
-                valueMax: 3600,
-                access: "ALL",
-            }),
-        ],
-        fromZigbee: [],
-        toZigbee: [],
-        ota: true,
-        exposes: [],
-        configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, [
-                "msOccupancySensing",
-                "msIlluminanceMeasurement",
-                "heimanClusterRadar",
-                "haDiagnostic",
-            ]);
-            await endpoint.read("msIlluminanceMeasurement", ["measuredValue"]);
-            await endpoint.read("msOccupancySensing", ["ultrasonicOToUDelay"]);
-            await endpoint.read("heimanClusterRadar", [0xf001, 0xf002], {manufacturerCode: Zcl.ManufacturerCode.HEIMAN_TECHNOLOGY_CO_LTD});
-        },
-        endpoint: (device) => ({default: 1}),
-    },
-    {
         zigbeeModel: ["HS8MIS-EF1-3.0"],
         model: "HS8MIS-EF1-3.0",
         vendor: "Heiman",


### PR DESCRIPTION
Adds official device support for the Heiman HS8OS ceiling-embedded occupancy sensor (model HS8OS-EF1-3.0 and variants).

Features:
- Illuminance measurement
- Occupancy detection with ultrasonic OTU delay config
- Identify
- Illuminance threshold (manufacturer-specific attribute 0xf000)
- OTA updates

Fixes: Koenkk/zigbee2mqtt#22029

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
