### PR TITLE
feat: expose power_on_behavior for Woolley BSD29/BSD59

### DIFF
--- a/src/devices/woolley.ts
+++ b/src/devices/woolley.ts
@@ -36,8 +36,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "BSD29/BSD59",
         vendor: "Woolley",
         description: "Zigbee 3.0 smart plug",
-        fromZigbee: [fz.on_off_skip_duplicate_transaction, fzLocal.BSD29],
-        toZigbee: [tz.on_off],
+        fromZigbee: [fz.on_off_skip_duplicate_transaction, fzLocal.BSD29, fz.power_on_behavior],
+        toZigbee: [tz.on_off, tz.power_on_behavior],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
@@ -45,7 +45,7 @@ export const definitions: DefinitionWithExtend[] = [
             device.powerSource = "Mains (single phase)";
             device.save();
         },
-        exposes: [e.power(), e.current(), e.voltage(), e.switch()],
+        exposes: [e.power(), e.current(), e.voltage(), e.switch(), e.power_on_behavior()],
         onEvent: (event) => {
             if (event.type === "start") {
                 event.data.device.customReadResponse = (frame) => {


### PR DESCRIPTION
The Woolley BSD29/BSD59 (model CK-BL702-SWP-01(7020)) smart plug supports the standard Zigbee genOnOff.startUpOnOff attribute, but it was not previously exposed in Zigbee2MQTT.

This PR adds support for power_on_behavior by:

Adding fz.power_on_behavior to fromZigbee for state reporting.
Adding tz.power_on_behavior to toZigbee for command support.
Adding exposes.power_on_behavior() to the device definition.
Verified with the following values:

off (0)
on (1)
previous (255)
The device correctly remembers and applies the behavior after a mains power restoration.