### PR TITLE
fix: Inovelli: batch all keys from combined SET payloads

### DIFF
--- a/src/lib/inovelli.ts
+++ b/src/lib/inovelli.ts
@@ -2340,29 +2340,43 @@ const tzLocal = {
         ({
             key: Object.keys(attributes).filter((a) => !attributes[a].readOnly),
             convertSet: async (entity, key, value, meta) => {
-                const {entityToUse} = resolveEndpointAndKey(entity, key, meta);
+                // Walk meta.message rather than just `key`: Z2M dispatches this converter once per SET payload,
+                // so writing only `key` silently drops every other Inovelli key (issue #11698). Bucket by the
+                // resolved endpoint so VZM36 _1/_2 suffixed keys still route correctly.
+                const buckets = new Map<Zh.Endpoint | Zh.Group, {payload: {[id: number]: {value: unknown; type: number}}; state: KeyValue}>();
 
-                if (!(key in attributes)) {
+                for (const [msgKey, msgValue] of Object.entries(meta.message)) {
+                    const attribute = attributes[msgKey];
+                    if (!attribute || attribute.readOnly) {
+                        continue;
+                    }
+
+                    const {entityToUse} = resolveEndpointAndKey(entity, msgKey, meta);
+                    const valueMap = resolveValueMap(attribute, model);
+                    const writeValue = attribute.displayType === "enum" ? valueMap?.[msgValue as string] : msgValue;
+
+                    let bucket = buckets.get(entityToUse);
+                    if (!bucket) {
+                        bucket = {payload: {}, state: {}};
+                        buckets.set(entityToUse, bucket);
+                    }
+                    bucket.payload[attribute.id] = {value: writeValue, type: attribute.dataType};
+                    bucket.state[msgKey] = msgValue;
+                }
+
+                if (buckets.size === 0) {
                     return;
                 }
 
-                const valueMap = resolveValueMap(attributes[key], model);
-                const payload = {
-                    [attributes[key].id]: {
-                        value: attributes[key].displayType === "enum" ? valueMap?.[value as string] : value,
-                        type: attributes[key].dataType,
-                    },
-                };
+                const combinedState: KeyValue = {};
+                for (const [entityToUse, bucket] of buckets) {
+                    await entityToUse.write(cluster, bucket.payload, {
+                        manufacturerCode: INOVELLI,
+                    });
+                    Object.assign(combinedState, bucket.state);
+                }
 
-                await entityToUse.write(cluster, payload, {
-                    manufacturerCode: INOVELLI,
-                });
-
-                return {
-                    state: {
-                        [key]: value,
-                    },
-                };
+                return {state: combinedState};
             },
             convertGet: async (entity, key, meta) => {
                 const {entityToUse, keyToUse} = resolveEndpointAndKey(entity, key, meta);

--- a/test/inovelli.test.ts
+++ b/test/inovelli.test.ts
@@ -316,6 +316,101 @@ describe("Inovelli toZigbee converters", () => {
             const result = await converter.convertSet(endpoint, "nonExistentKey", 42, meta);
             expect(result).toBeUndefined();
         });
+
+        // Regression test for https://github.com/Koenkk/zigbee-herdsman-converters/issues/11698
+        it("convertSet should write all matching keys from meta.message in one batched payload", async () => {
+            const {device, definition} = await setupVZM31();
+            const converter = findTzConverter(definition, "defaultLevelLocal");
+            const endpoint = device.getEndpoint(1);
+            const meta = buildMeta(device, {
+                mapped: definition,
+                message: {defaultLevelLocal: 100, defaultLevelRemote: 100},
+            });
+
+            const result = await converter.convertSet(endpoint, "defaultLevelLocal", 100, meta);
+
+            expect(endpoint.write).toHaveBeenCalledTimes(1);
+            expect(endpoint.write).toHaveBeenCalledWith(
+                "manuSpecificInovelli",
+                {
+                    13: {value: 100, type: expect.any(Number)},
+                    14: {value: 100, type: expect.any(Number)},
+                },
+                {manufacturerCode: 0x122f},
+            );
+            expect(result).toStrictEqual({state: {defaultLevelLocal: 100, defaultLevelRemote: 100}});
+        });
+
+        it("convertSet should batch keys regardless of the order they appear in meta.message", async () => {
+            const {device, definition} = await setupVZM31();
+            const converter = findTzConverter(definition, "defaultLevelLocal");
+            const endpoint = device.getEndpoint(1);
+            const meta = buildMeta(device, {
+                mapped: definition,
+                message: {defaultLevelRemote: 50, defaultLevelLocal: 50},
+            });
+
+            const result = await converter.convertSet(endpoint, "defaultLevelRemote", 50, meta);
+
+            expect(endpoint.write).toHaveBeenCalledTimes(1);
+            expect(endpoint.write).toHaveBeenCalledWith(
+                "manuSpecificInovelli",
+                {
+                    13: {value: 50, type: expect.any(Number)},
+                    14: {value: 50, type: expect.any(Number)},
+                },
+                {manufacturerCode: 0x122f},
+            );
+            expect(result).toStrictEqual({state: {defaultLevelRemote: 50, defaultLevelLocal: 50}});
+        });
+
+        it("convertSet should ignore unknown and read-only keys when batching", async () => {
+            const {device, definition} = await setupVZM31();
+            const converter = findTzConverter(definition, "defaultLevelLocal");
+            const endpoint = device.getEndpoint(1);
+            const meta = buildMeta(device, {
+                mapped: definition,
+                message: {
+                    defaultLevelLocal: 75,
+                    nonExistentKey: 42,
+                    // internalTemperature is a read-only attribute on the same cluster
+                    internalTemperature: 99,
+                },
+            });
+
+            const result = await converter.convertSet(endpoint, "defaultLevelLocal", 75, meta);
+
+            expect(endpoint.write).toHaveBeenCalledTimes(1);
+            expect(endpoint.write).toHaveBeenCalledWith(
+                "manuSpecificInovelli",
+                {13: {value: 75, type: expect.any(Number)}},
+                {manufacturerCode: 0x122f},
+            );
+            expect(result).toStrictEqual({state: {defaultLevelLocal: 75}});
+        });
+
+        it("convertSet should map enum values when batched alongside numeric values", async () => {
+            const {device, definition} = await setupVZM31();
+            const converter = findTzConverter(definition, "switchType");
+            const endpoint = device.getEndpoint(1);
+            const meta = buildMeta(device, {
+                mapped: definition,
+                message: {switchType: "3-Way Dumb Switch", dimmingSpeedUpRemote: 50},
+            });
+
+            const result = await converter.convertSet(endpoint, "switchType", "3-Way Dumb Switch", meta);
+
+            expect(endpoint.write).toHaveBeenCalledTimes(1);
+            expect(endpoint.write).toHaveBeenCalledWith(
+                "manuSpecificInovelli",
+                {
+                    1: {value: 50, type: expect.any(Number)},
+                    22: {value: 1, type: expect.any(Number)},
+                },
+                {manufacturerCode: 0x122f},
+            );
+            expect(result).toStrictEqual({state: {switchType: "3-Way Dumb Switch", dimmingSpeedUpRemote: 50}});
+        });
     });
 
     describe("VZM36 endpoint resolution", () => {
@@ -331,6 +426,37 @@ describe("Inovelli toZigbee converters", () => {
 
             expect(ep2.write).toHaveBeenCalledWith("manuSpecificInovelli", {1: {value: 25, type: expect.any(Number)}}, {manufacturerCode: 0x122f});
             expect(ep1.write).not.toHaveBeenCalled();
+        });
+
+        it("convertSet should bucket combined _1 / _2 keys to their respective endpoints", async () => {
+            const {device, definition} = await setupVZM36();
+            const converter = findTzConverter(definition, "defaultLevelRemote_1");
+            const ep1 = device.getEndpoint(1);
+            const ep2 = device.getEndpoint(2);
+            const meta = buildMeta(device, {
+                mapped: definition,
+                message: {
+                    // biome-ignore lint/style/useNamingConvention: matches device attribute key format
+                    defaultLevelRemote_1: 80,
+                    // biome-ignore lint/style/useNamingConvention: matches device attribute key format
+                    defaultLevelRemote_2: 40,
+                },
+            });
+
+            const result = await converter.convertSet(ep1, "defaultLevelRemote_1", 80, meta);
+
+            expect(ep1.write).toHaveBeenCalledTimes(1);
+            expect(ep1.write).toHaveBeenCalledWith("manuSpecificInovelli", {14: {value: 80, type: expect.any(Number)}}, {manufacturerCode: 0x122f});
+            expect(ep2.write).toHaveBeenCalledTimes(1);
+            expect(ep2.write).toHaveBeenCalledWith("manuSpecificInovelli", {14: {value: 40, type: expect.any(Number)}}, {manufacturerCode: 0x122f});
+            expect(result).toStrictEqual({
+                state: {
+                    // biome-ignore lint/style/useNamingConvention: matches device attribute key format
+                    defaultLevelRemote_1: 80,
+                    // biome-ignore lint/style/useNamingConvention: matches device attribute key format
+                    defaultLevelRemote_2: 40,
+                },
+            });
         });
 
         it("convertGet with suffixed key should read from the correct endpoint", async () => {


### PR DESCRIPTION
## Summary

Fixes #11698.

`inovelli_parameters` is a single shared `Tz.Converter` whose `key` array lists every writable Inovelli attribute, but its `convertSet` only wrote the one `key` it was called with. Z2M's publish loop dispatches any given converter at most once per endpoint per payload, so every Inovelli key after the first in a combined SET like `{"defaultLevelLocal": 100, "defaultLevelRemote": 100}` was silently dropped (this is exactly the symptom reported in #11698).

This PR rewrites `convertSet` to walk `meta.message` and bucket every writable key by its resolved endpoint, then emit one multi-attribute write per bucket.

- Combined payloads now write every accepted key.
- VZM36's `_1` / `_2` suffixed keys still route to the correct endpoint because bucketing uses `resolveEndpointAndKey`.
- An N-key payload on a single endpoint collapses from N OTA writes to 1.
- Read-only and unknown keys in the same payload are skipped, and they are also excluded from the returned optimistic `state` so it stays honest.
- `convertGet` is intentionally left single-key — Z2M's GET path already calls it per key, and pre-batching reads would be a behavior change.

## Test plan

- [x] `pnpm test` — all 561 tests pass (192 in `test/inovelli.test.ts`)
- [x] `pnpm run build`
- [x] Added unit tests on `VZM31-SN`:
  - Combined `{defaultLevelLocal, defaultLevelRemote}` produces a single write with both attribute IDs (the exact repro from #11698).
  - Reverse key order produces the same single batched write.
  - Mixed unknown + read-only keys are filtered out; only the writable key is sent.
  - Mixed enum + numeric keys both go through, with the enum value mapped correctly.
- [x] Added unit test on `VZM36`: combined `{defaultLevelRemote_1, defaultLevelRemote_2}` produces two writes — one to ep1, one to ep2.
- [x] Pre-existing tests for single-key writes, suffixed-key endpoint resolution, and the read-only converter still pass unchanged.

Link to picture pull request: N/A (no new device).

Made with [Cursor](https://cursor.com)