### PR TITLE
Update tuya.ts feat: add support for Nova Digital ZBCMR-02 curtain motor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26945,4 +26945,45 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
     },
+
+    {
+        fingerprint: [
+            {
+                modelID: 'TS0105',
+                manufacturerName: '_TZE600_5cu64znk',
+            },
+        ],
+        model: 'ZBCMR-02',
+        vendor: 'Nova Digital',
+        description: 'Zigbee curtain motor',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        exposes: [
+            e.cover_position(),
+        ],
+        meta: {
+            coverInverted: false,
+            tuyaDatapoints: [
+                [
+                    1,
+                    'state',
+                    tuya.valueConverterBasic.lookup({
+                        OPEN: tuya.enum(0),
+                        STOP: tuya.enum(1),
+                        CLOSE: tuya.enum(2),
+                    }),
+                ],
+                [
+                    2,
+                    'position',
+                    tuya.valueConverter.raw,
+                ],
+                [
+                    3,
+                    'position',
+                    tuya.valueConverter.raw,
+                ],
+            ],
+        },
+    },
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26949,40 +26949,30 @@ export const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: [
             {
-                modelID: 'TS0105',
-                manufacturerName: '_TZE600_5cu64znk',
+                modelID: "TS0105",
+                manufacturerName: "_TZE600_5cu64znk",
             },
         ],
-        model: 'ZBCMR-02',
-        vendor: 'Nova Digital',
-        description: 'Zigbee curtain motor',
+        model: "ZBCMR-02",
+        vendor: "Nova Digital",
+        description: "Zigbee curtain motor",
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
-        exposes: [
-            e.cover_position(),
-        ],
+        exposes: [e.cover_position()],
         meta: {
             coverInverted: false,
             tuyaDatapoints: [
                 [
                     1,
-                    'state',
+                    "state",
                     tuya.valueConverterBasic.lookup({
                         OPEN: tuya.enum(0),
                         STOP: tuya.enum(1),
                         CLOSE: tuya.enum(2),
                     }),
                 ],
-                [
-                    2,
-                    'position',
-                    tuya.valueConverter.raw,
-                ],
-                [
-                    3,
-                    'position',
-                    tuya.valueConverter.raw,
-                ],
+                [2, "position", tuya.valueConverter.raw],
+                [3, "position", tuya.valueConverter.raw],
             ],
         },
     },


### PR DESCRIPTION
## Added support for Nova Digital ZBCMR-02 curtain motor

This PR adds support for the Nova Digital ZBCMR-02 Zigbee curtain motor.

### Fingerprint

* Model ID: `TS0105`
* Manufacturer: `_TZE600_5cu64znk`

### Supported features

* Open
* Close
* Stop
* Position control
* Position state reporting
* Home Assistant cover entity support

### Notes

The device uses Tuya datapoints:

* DP 1: state control
* DP 2: target position
* DP 3: reported position

Battery reporting is currently unsupported. The device does not expose standard Zigbee battery clusters and no reliable Tuya datapoint has been identified yet.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5110
