### PR TITLE
Enable OTA for Hue wall switch modules

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -2824,6 +2824,7 @@ export const definitions: DefinitionWithExtend[] = [
             const options = {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V, disableDefaultResponse: true};
             await endpoint.write("genBasic", {52: {value: 0, type: 48}}, options);
         },
+        ota: true,
     },
     {
         zigbeeModel: ["RWL020", "RWL021"],


### PR DESCRIPTION
Was there a specific reason not to enable OTA for the Hue wall switch modules? Otherwise, I think we should allow updates (and downgrades, though there is no public image for the "good" FW version for the RDM001).