### PR TITLE
Add support for EGLO 901471 ROVITO-Z ceiling light

### DIFF
--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -28,21 +28,21 @@ export const definitions: DefinitionWithExtend[] = [
     },
 
     {
-    zigbeeModel: ["EBF-RGB-ZMB-CLB"],
-    model: "901471",
-    vendor: "EGLO",
-    description: "ROVITO-Z ceiling light",
-    extend: [
-        m.deviceEndpoints({endpoints: {1: 1, 3: 3}}),
-        m.light({
-            colorTemp: {range: [153, 370]},
-            color: {modes: ["xy", "hs"], enhancedHue: true},
-        }),
-        m.commandsOnOff(),
-        m.commandsLevelCtrl(),
-        m.commandsColorCtrl(),
-    ],
-},
+        zigbeeModel: ["EBF-RGB-ZMB-CLB"],
+        model: "901471",
+        vendor: "EGLO",
+        description: "ROVITO-Z ceiling light",
+        extend: [
+            m.deviceEndpoints({endpoints: {1: 1, 3: 3}}),
+            m.light({
+                colorTemp: {range: [153, 370]},
+                color: {modes: ["xy", "hs"], enhancedHue: true},
+            }),
+            m.commandsOnOff(),
+            m.commandsLevelCtrl(),
+            m.commandsColorCtrl(),
+        ],
+    },
     {
         zigbeeModel: ["ESMLFzm_w6_TW"],
         model: "12242",

--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -26,6 +26,23 @@ export const definitions: DefinitionWithExtend[] = [
         description: "ROVITO-Z ceiling light",
         extend: [m.light({colorTemp: {range: [153, 370]}, color: true})],
     },
+
+    {
+    zigbeeModel: ["EBF-RGB-ZMB-CLB"],
+    model: "901471",
+    vendor: "EGLO",
+    description: "ROVITO-Z ceiling light",
+    extend: [
+        m.deviceEndpoints({endpoints: {1: 1, 3: 3}}),
+        m.light({
+            colorTemp: {range: [153, 370]},
+            color: {modes: ["xy", "hs"], enhancedHue: true},
+        }),
+        m.commandsOnOff(),
+        m.commandsLevelCtrl(),
+        m.commandsColorCtrl(),
+    ],
+},
     {
         zigbeeModel: ["ESMLFzm_w6_TW"],
         model: "12242",


### PR DESCRIPTION
Adds support for EGLO 901471 / ROVITO-Z ceiling light.

The device is sold as EGLO 901471 / ROVITO-Z but reports as:
- Zigbee model: EBF-RGB-ZMB-CLB
- Manufacturer: AwoX

Tested with two devices in Zigbee2MQTT.
Working features:
- on/off
- brightness
- color temperature
- xy color
- effects
- power-on behavior

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
