### PR TITLE
Refactor Stelpro global converters to local scope

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -18,8 +18,6 @@ const manufacturerOptions = {
     hue: {manufacturerCode: Zcl.ManufacturerCode.SIGNIFY_NETHERLANDS_B_V},
     ikea: {manufacturerCode: Zcl.ManufacturerCode.IKEA_OF_SWEDEN},
     sinope: {manufacturerCode: Zcl.ManufacturerCode.SINOPE_TECHNOLOGIES},
-    stello: {manufacturerCode: Zcl.ManufacturerCode.STELPRO},
-    stelpro: {manufacturerCode: Zcl.ManufacturerCode.STELPRO},
     tint: {manufacturerCode: Zcl.ManufacturerCode.MUELLER_LICHT_INTERNATIONAL_INC},
     legrand: {manufacturerCode: Zcl.ManufacturerCode.LEGRAND_GROUP, disableDefaultResponse: true},
 };
@@ -2565,26 +2563,6 @@ export const eurotronic_mirror_display: Tz.Converter = {
     },
     convertGet: async (entity, key, meta) => {
         await entity.read("hvacThermostat", [0x4008], manufacturerOptions.eurotronic);
-    },
-};
-export const stelpro_peak_demand_event_icon: Tz.Converter = {
-    key: ["peak_demand_icon"],
-    convertSet: async (entity, key, value, meta) => {
-        const hours = Number(value);
-        const seconds = hours * 3600;
-        if (seconds < 0 || seconds > 65535) {
-            throw new Error("Peak demand duration must be between 0 and 18 hours");
-        }
-
-        const payload = {
-            16645: {
-                value: seconds,
-                type: Zcl.DataType.UINT16,
-            },
-        };
-
-        await entity.write("hvacThermostat", payload);
-        return {state: {[key]: hours}};
     },
 };
 export const DTB190502A1_LED: Tz.Converter = {

--- a/src/devices/stello.ts
+++ b/src/devices/stello.ts
@@ -3,32 +3,11 @@ import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz} from "../lib/types";
+import type {DefinitionWithExtend} from "../lib/types";
 import * as stelpro from "./stelpro";
 
 const e = exposes.presets;
 const ea = exposes.access;
-
-const fzLocal = {
-    power: {
-        cluster: "hvacThermostat",
-        type: ["attributeReport", "readResponse"],
-        convert: (model, msg, publish, options, meta) => {
-            if (msg.data["16392"] !== undefined) {
-                return {power: msg.data["16392"]};
-            }
-        },
-    } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
-    energy: {
-        cluster: "hvacThermostat",
-        type: ["attributeReport", "readResponse"],
-        convert: (model, msg, publish, options, meta) => {
-            if (msg.data["16393"] !== undefined) {
-                return {energy: Number.parseFloat(msg.data["16393"] as string) / 1000};
-            }
-        },
-    } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
-};
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -37,7 +16,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Stello",
         description: "Hilo thermostat",
         extend: [stelpro.stelproExtend.addStelproHvacThermostatCluster()],
-        fromZigbee: [stelpro.fzLocal.stelpro_thermostat, fz.hvac_user_interface, fzLocal.power, fzLocal.energy],
+        fromZigbee: [stelpro.fzLocal.stelpro_thermostat, fz.hvac_user_interface, stelpro.fzLocal.power, stelpro.fzLocal.energy],
         toZigbee: [
             tz.thermostat_local_temperature,
             tz.thermostat_occupancy,
@@ -46,8 +25,8 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tz.stelpro_peak_demand_event_icon,
-            stelpro.tzLocal.stelpro_thermostat_outdoor_temperature,
+            stelpro.tzLocal.peak_demand_event_icon,
+            stelpro.tzLocal.thermostat_outdoor_temperature,
         ],
         exposes: [
             e.local_temperature(),
@@ -93,7 +72,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Stello",
         description: "Hilo water heater controller",
         extend: [m.onOff({powerOnBehavior: false}), m.electricityMeter({cluster: "metering"})],
-        toZigbee: [tz.stelpro_peak_demand_event_icon],
+        toZigbee: [stelpro.tzLocal.peak_demand_event_icon],
         exposes: [
             e
                 .numeric("peak_demand_icon", ea.SET)

--- a/src/devices/stelpro.ts
+++ b/src/devices/stelpro.ts
@@ -14,14 +14,17 @@ const ea = exposes.access;
 interface StelproHvacThermostat {
     attributes: {
         stelproOutdoorTemp: number;
+        power: number;
+        energy: number;
         stelproSystemMode: number;
+        peakDemandIcon: number;
     };
     commands: never;
     commandResponses: never;
 }
 
 export const tzLocal = {
-    stelpro_thermostat_outdoor_temperature: {
+    thermostat_outdoor_temperature: {
         key: ["outdoor_temperature_display"],
         convertSet: async (entity, key, value, meta) => {
             utils.assertNumber(value, key);
@@ -31,6 +34,18 @@ export const tzLocal = {
             await entity.write<"hvacThermostat", StelproHvacThermostat>("hvacThermostat", {stelproOutdoorTemp: value * 100});
         },
     } satisfies Tz.Converter,
+    peak_demand_event_icon: {
+        key: ["peak_demand_icon"],
+        convertSet: async (entity, key, value, meta) => {
+            const hours = Number(value);
+            const seconds = hours * 3600;
+            if (seconds < 0 || seconds > 65535) {
+                throw new Error("Peak demand duration must be between 0 and 18 hours");
+            }
+            await entity.write<"hvacThermostat", StelproHvacThermostat>("hvacThermostat", {peakDemandIcon: seconds});
+            return {state: {[key]: hours}};
+        },
+    } satisfies Tz.Converter,
 };
 
 export const fzLocal = {
@@ -38,20 +53,20 @@ export const fzLocal = {
         cluster: "hvacThermostat",
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
-            if (msg.data["16392"] !== undefined) {
-                return {power: msg.data["16392"]};
+            if (msg.data.power !== undefined) {
+                return {power: msg.data.power};
             }
         },
-    } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
+    } satisfies Fz.Converter<"hvacThermostat", StelproHvacThermostat, ["attributeReport", "readResponse"]>,
     energy: {
         cluster: "hvacThermostat",
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
-            if (msg.data["16393"] !== undefined) {
-                return {energy: Number.parseFloat(msg.data["16393"] as string) / 1000};
+            if (msg.data.energy !== undefined) {
+                return {energy: msg.data.energy / 1000};
             }
         },
-    } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
+    } satisfies Fz.Converter<"hvacThermostat", StelproHvacThermostat, ["attributeReport", "readResponse"]>,
     stelpro_thermostat: {
         cluster: "hvacThermostat",
         type: ["attributeReport", "readResponse"],
@@ -76,7 +91,10 @@ export const stelproExtend = {
             ID: Zcl.Clusters.hvacThermostat.ID,
             attributes: {
                 stelproOutdoorTemp: {name: "stelproOutdoorTemp", ID: 0x4001, type: Zcl.DataType.INT16, write: true, min: -32768, max: 32767},
+                power: {name: "power", ID: 0x4008, type: Zcl.DataType.UINT16},
+                energy: {name: "energy", ID: 0x4009, type: Zcl.DataType.UINT32},
                 stelproSystemMode: {name: "stelproSystemMode", ID: 0x401c, type: Zcl.DataType.ENUM8, write: true, max: 0xff},
+                peakDemandIcon: {name: "peakDemandIcon", ID: 0x4105, type: Zcl.DataType.UINT16, write: true},
             },
             commands: {},
             commandsResponse: {},
@@ -99,8 +117,8 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tz.stelpro_peak_demand_event_icon,
-            tzLocal.stelpro_thermostat_outdoor_temperature,
+            tzLocal.peak_demand_event_icon,
+            tzLocal.thermostat_outdoor_temperature,
         ],
         exposes: [
             e.keypad_lockout(),
@@ -155,7 +173,7 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tzLocal.stelpro_thermostat_outdoor_temperature,
+            tzLocal.thermostat_outdoor_temperature,
         ],
         exposes: [
             e.local_temperature(),
@@ -205,7 +223,7 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tzLocal.stelpro_thermostat_outdoor_temperature,
+            tzLocal.thermostat_outdoor_temperature,
         ],
         exposes: [
             e.local_temperature(),
@@ -255,7 +273,7 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tzLocal.stelpro_thermostat_outdoor_temperature,
+            tzLocal.thermostat_outdoor_temperature,
         ],
         exposes: [
             e.local_temperature(),
@@ -361,7 +379,7 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_keypad_lockout,
             tz.thermostat_system_mode,
             tz.thermostat_running_state,
-            tzLocal.stelpro_thermostat_outdoor_temperature,
+            tzLocal.thermostat_outdoor_temperature,
         ],
         exposes: [
             e.local_temperature(),


### PR DESCRIPTION
Refactor Stelpro thermostat device support by consolidating code organization and moving device-specific converters from the main toZigbee.ts file into the stelpro.ts module. 
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

