### PR TITLE
Add 10G mmWave 4-in-1 sensor support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26876,19 +26876,17 @@ export const definitions: DefinitionWithExtend[] = [
             e.temperature(),
             e.humidity(),
             e.illuminance(),
-            e.numeric("radar_sensitivity", ea.STATE_SET)
-                .withValueMin(0)
-                .withValueMax(10)
-                .withValueStep(1)
-                .withDescription("Radar sensitivity"),
+            e.numeric("radar_sensitivity", ea.STATE_SET).withValueMin(0).withValueMax(10).withValueStep(1).withDescription("Radar sensitivity"),
             e.enum("pir_sensitivity", ea.STATE_SET, ["low", "middle", "high"]).withDescription("PIR sensitivity"),
-            e.numeric("pir_delay", ea.STATE_SET)
+            e
+                .numeric("pir_delay", ea.STATE_SET)
                 .withValueMin(10)
                 .withValueMax(180)
                 .withValueStep(1)
                 .withUnit("s")
                 .withDescription("PIR delay before reporting absence"),
-            e.numeric("detection_range", ea.STATE_SET)
+            e
+                .numeric("detection_range", ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(10)
                 .withValueStep(1)

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26864,4 +26864,59 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
     },
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_gnpflcoq"]),
+        model: "TZE284_gnpflcoq",
+        vendor: "Tuya",
+        description: "10G mmWave 4-in-1 sensor (presence, temperature, humidity, illuminance)",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [
+            e.presence(),
+            e.battery(),
+            e.temperature(),
+            e.humidity(),
+            e.illuminance(),
+            e.numeric("radar_sensitivity", ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(10)
+                .withValueStep(1)
+                .withDescription("Radar sensitivity"),
+            e.enum("pir_sensitivity", ea.STATE_SET, ["low", "middle", "high"]).withDescription("PIR sensitivity"),
+            e.numeric("pir_delay", ea.STATE_SET)
+                .withValueMin(10)
+                .withValueMax(180)
+                .withValueStep(1)
+                .withUnit("s")
+                .withDescription("PIR delay before reporting absence"),
+            e.numeric("detection_range", ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(10)
+                .withValueStep(1)
+                .withUnit("m")
+                .withDescription("Detection range"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                // Confirmed on appVersion 80. DP1 is inverted: 0 = present, 1 = absent.
+                [1, "presence", tuya.valueConverter.trueFalse0],
+                [4, "battery", tuya.valueConverter.raw],
+                [7, "temperature", tuya.valueConverter.divideBy10],
+                [8, "humidity", tuya.valueConverter.raw],
+                [11, "illuminance", tuya.valueConverter.raw],
+                // These settings are write-only on the tested firmware.
+                [2, "radar_sensitivity", tuya.valueConverter.raw],
+                [
+                    9,
+                    "pir_sensitivity",
+                    tuya.valueConverterBasic.lookup({
+                        low: tuya.enum(0),
+                        middle: tuya.enum(1),
+                        high: tuya.enum(2),
+                    }),
+                ],
+                [12, "pir_delay", tuya.valueConverter.raw],
+                [13, "detection_range", tuya.valueConverter.raw],
+            ],
+        },
+    },
 ];


### PR DESCRIPTION
Adds support for the Tuya TS0601 `_TZE284_gnpflcoq` 10G mmWave 4-in-1 sensor.

Tested with an external converter on firmware appVersion 80.

Working:
- Presence
- Battery
- Temperature
- Humidity
- Illuminance
- Radar sensitivity
- PIR sensitivity
- PIR delay
- Detection range

Notes:
- DP1 is inverted: raw `0` means present and raw `1` means absent.
- DP2, DP9, DP12, and DP13 are write-only on the tested firmware.
- DP12 controls the PIR delay before reporting absence.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
