### PR TITLE
giex: improve GX03 2-zone valve logic and bootstrapping

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20718,9 +20718,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "GX03",
         vendor: "GIEX",
         description: "GIEX 2-zone watering timer",
-        fromZigbee: [tuya.fz.datapoints, fz.ignore_tuya_set_time],
-        toZigbee: [tuya.tz.datapoints],
-        configure: tuya.queryDeviceState,
+        extend: [tuya.modernExtend.tuyaBase({dp: true, queryOnConfigure: true})],
         exposes: [
             exposes.binary("valve_1", ea.STATE_SET, "ON", "OFF").withDescription("State of the valve 1"),
             e.enum("state_1", ea.STATE, ["Manual", "Auto", "Closed"]).withDescription("State of the valve 1"),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20715,80 +20715,69 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_8zizsafo", "_TZE284_iilebqoo"]),
-        model: 'GX03',
-        vendor: 'GIEX',
-        description: 'GIEX 2-zone watering timer',
-        fromZigbee: [{
-            cluster: 'manuSpecificTuya',
-            type: ['commandDataResponse', 'commandDataReport'],
-            convert: (model, msg, publish, options, meta) => {
-                const result = tuya.fz.datapoints.convert(model, msg, publish, options, meta) || {};
-                if (meta.state.timer_1 === undefined && result.timer_1 === undefined) {
-                    result.timer_1 = result.timer_2 = 5;
-                    const endpoint = meta.device.getEndpoint(1);
-                    tuya.sendDataPointValue(endpoint, 13, result.timer_1).catch(() => {});
-                    tuya.sendDataPointValue(endpoint, 14, result.timer_2).catch(() => {});
-                    endpoint.command('manuSpecificTuya', 'dataQuery', {}).catch(() => {});
-                }
-                if ((result.state_1 === 'Closed' || meta.state.state_1 === 'Closed') && meta.state.countdown_1 !== 0) result.countdown_1 = 0;
-                if ((result.state_2 === 'Closed' || meta.state.state_2 === 'Closed') && meta.state.countdown_2 !== 0) result.countdown_2 = 0;
-                return result;
-            }
-        }, fz.ignore_tuya_set_time],
+        model: "GX03",
+        vendor: "GIEX",
+        description: "GIEX 2-zone watering timer",
+        fromZigbee: [
+            {
+                cluster: "manuSpecificTuya",
+                type: ["commandDataResponse", "commandDataReport"],
+                convert: (model, msg, publish, options, meta) => {
+                    const result = tuya.fz.datapoints.convert(model, msg, publish, options, meta) || {};
+                    if (meta.state.timer_1 === undefined && result.timer_1 === undefined) {
+                        result.timer_1 = result.timer_2 = 5;
+                        const endpoint = meta.device.getEndpoint(1);
+                        tuya.sendDataPointValue(endpoint, 13, result.timer_1).catch(() => {});
+                        tuya.sendDataPointValue(endpoint, 14, result.timer_2).catch(() => {});
+                        endpoint.command("manuSpecificTuya", "dataQuery", {}).catch(() => {});
+                    }
+                    if ((result.state_1 === "Closed" || meta.state.state_1 === "Closed") && meta.state.countdown_1 !== 0) result.countdown_1 = 0;
+                    if ((result.state_2 === "Closed" || meta.state.state_2 === "Closed") && meta.state.countdown_2 !== 0) result.countdown_2 = 0;
+                    return result;
+                },
+            },
+            fz.ignore_tuya_set_time,
+        ],
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.configureMagicPacket,
         exposes: [
-            exposes.binary('valve_1', ea.STATE_SET, 'ON', 'OFF')
-                .withDescription('State of the valve 1'),
-            e.enum('state_1', ea.STATE, ['Manual', 'Auto', 'Closed'])
-                .withDescription('State of the valve 1'),
-            e.numeric('timer_1', ea.STATE_SET)
+            exposes.binary("valve_1", ea.STATE_SET, "ON", "OFF").withDescription("State of the valve 1"),
+            e.enum("state_1", ea.STATE, ["Manual", "Auto", "Closed"]).withDescription("State of the valve 1"),
+            e
+                .numeric("timer_1", ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
-                .withUnit('min')
-                .withDescription('Timer for the valve 1 operation'),
-            e.numeric('countdown_1', ea.STATE)
-                .withUnit('min')
-                .withCategory('diagnostic')
-                .withDescription('Time remaining for the open valve 1'),
-            e.numeric('last_duration_1', ea.STATE)
-                .withUnit('s')
-                .withCategory('diagnostic')
-                .withDescription('Last open duration for the valve 1'),
-            e.binary('valve_2', ea.STATE_SET, 'ON', 'OFF')
-                .withDescription('State of the valve 2'),
-            e.enum('state_2', ea.STATE, ['Manual', 'Auto', 'Closed'])
-                .withDescription('State of the valve 2'),
-            e.numeric('timer_2', ea.STATE_SET)
+                .withUnit("min")
+                .withDescription("Timer for the valve 1 operation"),
+            e.numeric("countdown_1", ea.STATE).withUnit("min").withCategory("diagnostic").withDescription("Time remaining for the open valve 1"),
+            e.numeric("last_duration_1", ea.STATE).withUnit("s").withCategory("diagnostic").withDescription("Last open duration for the valve 1"),
+            e.binary("valve_2", ea.STATE_SET, "ON", "OFF").withDescription("State of the valve 2"),
+            e.enum("state_2", ea.STATE, ["Manual", "Auto", "Closed"]).withDescription("State of the valve 2"),
+            e
+                .numeric("timer_2", ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
-                .withUnit('min')
-                .withDescription('Timer for the valve 2 operation'),
-            e.numeric('countdown_2', ea.STATE)
-                .withUnit('min')
-                .withCategory('diagnostic')
-                .withDescription('Time remaining for the open valve 2'),
-            e.numeric('last_duration_2', ea.STATE)
-                .withUnit('s')
-                .withCategory('diagnostic')
-                .withDescription('Last open duration for the valve 2'),
+                .withUnit("min")
+                .withDescription("Timer for the valve 2 operation"),
+            e.numeric("countdown_2", ea.STATE).withUnit("min").withCategory("diagnostic").withDescription("Time remaining for the open valve 2"),
+            e.numeric("last_duration_2", ea.STATE).withUnit("s").withCategory("diagnostic").withDescription("Last open duration for the valve 2"),
             e.battery(),
         ],
         meta: {
             tuyaDatapoints: [
-                [1, 'valve_1', tuya.valueConverter.onOff],
-                [104, 'state_1', tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
-                [13, 'countdown_1', tuya.valueConverter.raw],
-                [13, 'timer_1', { from: () => undefined, to: (value) => value }],
-                [25, 'last_duration_1', tuya.valueConverter.raw],
-                [2, 'valve_2', tuya.valueConverter.onOff],
-                [105, 'state_2', tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
-                [14, 'countdown_2', tuya.valueConverter.raw],
-                [14, 'timer_2', { from: () => undefined, to: (value) => value }],
-                [26, 'last_duration_2', tuya.valueConverter.raw],
-                [59, 'battery', tuya.valueConverter.raw],
+                [1, "valve_1", tuya.valueConverter.onOff],
+                [104, "state_1", tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
+                [13, "countdown_1", tuya.valueConverter.raw],
+                [13, "timer_1", {from: () => undefined, to: (value) => value}],
+                [25, "last_duration_1", tuya.valueConverter.raw],
+                [2, "valve_2", tuya.valueConverter.onOff],
+                [105, "state_2", tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
+                [14, "countdown_2", tuya.valueConverter.raw],
+                [14, "timer_2", {from: () => undefined, to: (value) => value}],
+                [26, "last_duration_2", tuya.valueConverter.raw],
+                [59, "battery", tuya.valueConverter.raw],
             ],
         },
         whiteLabel: [tuya.whitelabel("Nova Digital", "ZVL-DUAL", "Water Valve with 2 zones", ["_TZE284_iilebqoo"])],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20715,52 +20715,80 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_8zizsafo", "_TZE284_iilebqoo"]),
-        model: "GX03",
-        vendor: "GIEX",
-        description: "GIEX 2 zone watering timer",
-        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        model: 'GX03',
+        vendor: 'GIEX',
+        description: 'GIEX 2-zone watering timer',
+        fromZigbee: [{
+            cluster: 'manuSpecificTuya',
+            type: ['commandDataResponse', 'commandDataReport'],
+            convert: (model, msg, publish, options, meta) => {
+                const result = tuya.fz.datapoints.convert(model, msg, publish, options, meta) || {};
+                if (meta.state.timer_1 === undefined && result.timer_1 === undefined) {
+                    result.timer_1 = result.timer_2 = 5;
+                    const endpoint = meta.device.getEndpoint(1);
+                    tuya.sendDataPointValue(endpoint, 13, result.timer_1).catch(() => {});
+                    tuya.sendDataPointValue(endpoint, 14, result.timer_2).catch(() => {});
+                    endpoint.command('manuSpecificTuya', 'dataQuery', {}).catch(() => {});
+                }
+                if ((result.state_1 === 'Closed' || meta.state.state_1 === 'Closed') && meta.state.countdown_1 !== 0) result.countdown_1 = 0;
+                if ((result.state_2 === 'Closed' || meta.state.state_2 === 'Closed') && meta.state.countdown_2 !== 0) result.countdown_2 = 0;
+                return result;
+            }
+        }, fz.ignore_tuya_set_time],
+        toZigbee: [tuya.tz.datapoints],
+        configure: tuya.configureMagicPacket,
         exposes: [
-            e.binary("valve_1", ea.STATE_SET, "ON", "OFF").withDescription("Switch state"),
-            e
-                .numeric("countdown_1", ea.STATE_SET)
+            exposes.binary('valve_1', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('State of the valve 1'),
+            e.enum('state_1', ea.STATE, ['Manual', 'Auto', 'Closed'])
+                .withDescription('State of the valve 1'),
+            e.numeric('timer_1', ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
-                .withUnit("min")
-                .withDescription("Countdown timer for valve operation"),
-            e.binary("valve_2", ea.STATE_SET, "ON", "OFF").withDescription("Switch state"),
-            e
-                .numeric("countdown_2", ea.STATE_SET)
+                .withUnit('min')
+                .withDescription('Timer for the valve 1 operation'),
+            e.numeric('countdown_1', ea.STATE)
+                .withUnit('min')
+                .withCategory('diagnostic')
+                .withDescription('Time remaining for the open valve 1'),
+            e.numeric('last_duration_1', ea.STATE)
+                .withUnit('s')
+                .withCategory('diagnostic')
+                .withDescription('Last open duration for the valve 1'),
+            e.binary('valve_2', ea.STATE_SET, 'ON', 'OFF')
+                .withDescription('State of the valve 2'),
+            e.enum('state_2', ea.STATE, ['Manual', 'Auto', 'Closed'])
+                .withDescription('State of the valve 2'),
+            e.numeric('timer_2', ea.STATE_SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
-                .withUnit("min")
-                .withDescription("Countdown timer for valve operation"),
+                .withUnit('min')
+                .withDescription('Timer for the valve 2 operation'),
+            e.numeric('countdown_2', ea.STATE)
+                .withUnit('min')
+                .withCategory('diagnostic')
+                .withDescription('Time remaining for the open valve 2'),
+            e.numeric('last_duration_2', ea.STATE)
+                .withUnit('s')
+                .withCategory('diagnostic')
+                .withDescription('Last open duration for the valve 2'),
             e.battery(),
         ],
         meta: {
             tuyaDatapoints: [
-                [1, "valve_1", tuya.valueConverter.onOff],
-                [59, "battery", tuya.valueConverter.raw],
-                [
-                    104,
-                    "valve_1",
-                    tuya.valueConverterBasic.lookup({
-                        OFF: tuya.enum(2),
-                        ON: tuya.enum(0),
-                    }),
-                ],
-                [2, "valve_2", tuya.valueConverter.onOff],
-                [
-                    105,
-                    "valve_2",
-                    tuya.valueConverterBasic.lookup({
-                        OFF: tuya.enum(2),
-                        ON: tuya.enum(0),
-                    }),
-                ],
-                [13, "countdown_1", tuya.valueConverter.raw],
-                [14, "countdown_2", tuya.valueConverter.raw],
+                [1, 'valve_1', tuya.valueConverter.onOff],
+                [104, 'state_1', tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
+                [13, 'countdown_1', tuya.valueConverter.raw],
+                [13, 'timer_1', { from: () => undefined, to: (value) => value }],
+                [25, 'last_duration_1', tuya.valueConverter.raw],
+                [2, 'valve_2', tuya.valueConverter.onOff],
+                [105, 'state_2', tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
+                [14, 'countdown_2', tuya.valueConverter.raw],
+                [14, 'timer_2', { from: () => undefined, to: (value) => value }],
+                [26, 'last_duration_2', tuya.valueConverter.raw],
+                [59, 'battery', tuya.valueConverter.raw],
             ],
         },
         whiteLabel: [tuya.whitelabel("Nova Digital", "ZVL-DUAL", "Water Valve with 2 zones", ["_TZE284_iilebqoo"])],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20718,64 +20718,59 @@ export const definitions: DefinitionWithExtend[] = [
         model: "GX03",
         vendor: "GIEX",
         description: "GIEX 2-zone watering timer",
-        fromZigbee: [
-            {
-                cluster: "manuSpecificTuya",
-                type: ["commandDataResponse", "commandDataReport"],
-                convert: (model, msg, publish, options, meta) => {
-                    const result = tuya.fz.datapoints.convert(model, msg, publish, options, meta) || {};
-                    if (meta.state.timer_1 === undefined && result.timer_1 === undefined) {
-                        result.timer_1 = result.timer_2 = 5;
-                        const endpoint = meta.device.getEndpoint(1);
-                        tuya.sendDataPointValue(endpoint, 13, result.timer_1 as number).catch(() => {});
-                        tuya.sendDataPointValue(endpoint, 14, result.timer_2 as number).catch(() => {});
-                        endpoint.command("manuSpecificTuya", "dataQuery", {}).catch(() => {});
-                    }
-                    if ((result.state_1 === "Closed" || meta.state.state_1 === "Closed") && meta.state.countdown_1 !== 0) result.countdown_1 = 0;
-                    if ((result.state_2 === "Closed" || meta.state.state_2 === "Closed") && meta.state.countdown_2 !== 0) result.countdown_2 = 0;
-                    return result;
-                },
-            },
-            fz.ignore_tuya_set_time,
-        ],
+        fromZigbee: [tuya.fz.datapoints, fz.ignore_tuya_set_time],
         toZigbee: [tuya.tz.datapoints],
-        configure: tuya.configureMagicPacket,
+        configure: tuya.queryDeviceState,
         exposes: [
-            exposes.binary("valve_1", ea.STATE_SET, "ON", "OFF").withDescription("State of the valve 1"),
-            e.enum("state_1", ea.STATE, ["Manual", "Auto", "Closed"]).withDescription("State of the valve 1"),
-            e
-                .numeric("timer_1", ea.STATE_SET)
+            exposes.binary("valve_1", ea.STATE_SET, "ON", "OFF")
+                .withDescription("State of the valve 1"),
+            e.enum("state_1", ea.STATE, ["Manual", "Auto", "Closed"])
+                .withDescription("State of the valve 1"),
+            e.numeric("timer_1", ea.SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
                 .withUnit("min")
                 .withDescription("Timer for the valve 1 operation"),
-            e.numeric("countdown_1", ea.STATE).withUnit("min").withCategory("diagnostic").withDescription("Time remaining for the open valve 1"),
-            e.numeric("last_duration_1", ea.STATE).withUnit("s").withCategory("diagnostic").withDescription("Last open duration for the valve 1"),
-            e.binary("valve_2", ea.STATE_SET, "ON", "OFF").withDescription("State of the valve 2"),
-            e.enum("state_2", ea.STATE, ["Manual", "Auto", "Closed"]).withDescription("State of the valve 2"),
-            e
-                .numeric("timer_2", ea.STATE_SET)
+            e.numeric("countdown_1", ea.STATE)
+                .withUnit("min")
+                .withCategory("diagnostic")
+                .withDescription("Time remaining for the open valve 1"),
+            e.numeric("last_duration_1", ea.STATE)
+                .withUnit("s")
+                .withCategory("diagnostic")
+                .withDescription("Last open duration for the valve 1"),
+            e.binary("valve_2", ea.STATE_SET, "ON", "OFF")
+                .withDescription("State of the valve 2"),
+            e.enum("state_2", ea.STATE, ["Manual", "Auto", "Closed"])
+                .withDescription("State of the valve 2"),
+            e.numeric("timer_2", ea.SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
                 .withUnit("min")
                 .withDescription("Timer for the valve 2 operation"),
-            e.numeric("countdown_2", ea.STATE).withUnit("min").withCategory("diagnostic").withDescription("Time remaining for the open valve 2"),
-            e.numeric("last_duration_2", ea.STATE).withUnit("s").withCategory("diagnostic").withDescription("Last open duration for the valve 2"),
+            e.numeric("countdown_2", ea.STATE)
+                .withUnit("min")
+                .withCategory("diagnostic")
+                .withDescription("Time remaining for the open valve 2"),
+            e.numeric("last_duration_2", ea.STATE)
+                .withUnit("s")
+                .withCategory("diagnostic")
+                .withDescription("Last open duration for the valve 2"),
             e.battery(),
         ],
         meta: {
             tuyaDatapoints: [
                 [1, "valve_1", tuya.valueConverter.onOff],
-                [104, "state_1", tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
-                [13, "countdown_1", tuya.valueConverter.raw],
-                [13, "timer_1", {from: () => undefined, to: (value) => value}],
+                [104, "state_1", tuya.giexGx03ValveState(1)],
+                [13, "countdown_1", tuya.valueConverter.countdown],
+                [13, "timer_1", tuya.valueConverter.raw],
                 [25, "last_duration_1", tuya.valueConverter.raw],
                 [2, "valve_2", tuya.valueConverter.onOff],
-                [105, "state_2", tuya.valueConverterBasic.lookup({Manual: tuya.enum(0), Auto: tuya.enum(1), Closed: tuya.enum(2)})],
-                [14, "countdown_2", tuya.valueConverter.raw],
-                [14, "timer_2", {from: () => undefined, to: (value) => value}],
+                [105, "state_2", tuya.giexGx03ValveState(2)],
+                [14, "countdown_2", tuya.valueConverter.countdown],
+                [14, "timer_2", tuya.valueConverter.raw],
                 [26, "last_duration_2", tuya.valueConverter.raw],
                 [59, "battery", tuya.valueConverter.raw],
             ],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20722,42 +20722,28 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [tuya.tz.datapoints],
         configure: tuya.queryDeviceState,
         exposes: [
-            exposes.binary("valve_1", ea.STATE_SET, "ON", "OFF")
-                .withDescription("State of the valve 1"),
-            e.enum("state_1", ea.STATE, ["Manual", "Auto", "Closed"])
-                .withDescription("State of the valve 1"),
-            e.numeric("timer_1", ea.SET)
+            exposes.binary("valve_1", ea.STATE_SET, "ON", "OFF").withDescription("State of the valve 1"),
+            e.enum("state_1", ea.STATE, ["Manual", "Auto", "Closed"]).withDescription("State of the valve 1"),
+            e
+                .numeric("timer_1", ea.SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
                 .withUnit("min")
                 .withDescription("Timer for the valve 1 operation"),
-            e.numeric("countdown_1", ea.STATE)
-                .withUnit("min")
-                .withCategory("diagnostic")
-                .withDescription("Time remaining for the open valve 1"),
-            e.numeric("last_duration_1", ea.STATE)
-                .withUnit("s")
-                .withCategory("diagnostic")
-                .withDescription("Last open duration for the valve 1"),
-            e.binary("valve_2", ea.STATE_SET, "ON", "OFF")
-                .withDescription("State of the valve 2"),
-            e.enum("state_2", ea.STATE, ["Manual", "Auto", "Closed"])
-                .withDescription("State of the valve 2"),
-            e.numeric("timer_2", ea.SET)
+            e.numeric("countdown_1", ea.STATE).withUnit("min").withCategory("diagnostic").withDescription("Time remaining for the open valve 1"),
+            e.numeric("last_duration_1", ea.STATE).withUnit("s").withCategory("diagnostic").withDescription("Last open duration for the valve 1"),
+            e.binary("valve_2", ea.STATE_SET, "ON", "OFF").withDescription("State of the valve 2"),
+            e.enum("state_2", ea.STATE, ["Manual", "Auto", "Closed"]).withDescription("State of the valve 2"),
+            e
+                .numeric("timer_2", ea.SET)
                 .withValueMin(1)
                 .withValueMax(1440)
                 .withValueStep(1)
                 .withUnit("min")
                 .withDescription("Timer for the valve 2 operation"),
-            e.numeric("countdown_2", ea.STATE)
-                .withUnit("min")
-                .withCategory("diagnostic")
-                .withDescription("Time remaining for the open valve 2"),
-            e.numeric("last_duration_2", ea.STATE)
-                .withUnit("s")
-                .withCategory("diagnostic")
-                .withDescription("Last open duration for the valve 2"),
+            e.numeric("countdown_2", ea.STATE).withUnit("min").withCategory("diagnostic").withDescription("Time remaining for the open valve 2"),
+            e.numeric("last_duration_2", ea.STATE).withUnit("s").withCategory("diagnostic").withDescription("Last open duration for the valve 2"),
             e.battery(),
         ],
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20727,8 +20727,8 @@ export const definitions: DefinitionWithExtend[] = [
                     if (meta.state.timer_1 === undefined && result.timer_1 === undefined) {
                         result.timer_1 = result.timer_2 = 5;
                         const endpoint = meta.device.getEndpoint(1);
-                        tuya.sendDataPointValue(endpoint, 13, result.timer_1).catch(() => {});
-                        tuya.sendDataPointValue(endpoint, 14, result.timer_2).catch(() => {});
+                        tuya.sendDataPointValue(endpoint, 13, result.timer_1 as number).catch(() => {});
+                        tuya.sendDataPointValue(endpoint, 14, result.timer_2 as number).catch(() => {});
                         endpoint.command("manuSpecificTuya", "dataQuery", {}).catch(() => {});
                     }
                     if ((result.state_1 === "Closed" || meta.state.state_1 === "Closed") && meta.state.countdown_1 !== 0) result.countdown_1 = 0;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20749,12 +20749,12 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaDatapoints: [
                 [1, "valve_1", tuya.valueConverter.onOff],
-                [104, "state_1", tuya.giexGx03ValveState(1)],
+                [104, "state_1", tuya.valueConverter.GX03ValveState(1)],
                 [13, "countdown_1", tuya.valueConverter.countdown],
                 [13, "timer_1", tuya.valueConverter.raw],
                 [25, "last_duration_1", tuya.valueConverter.raw],
                 [2, "valve_2", tuya.valueConverter.onOff],
-                [105, "state_2", tuya.giexGx03ValveState(2)],
+                [105, "state_2", tuya.valueConverter.GX03ValveState(2)],
                 [14, "countdown_2", tuya.valueConverter.countdown],
                 [14, "timer_2", tuya.valueConverter.raw],
                 [26, "last_duration_2", tuya.valueConverter.raw],

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1094,7 +1094,7 @@ export const giexGx03ValveState = (zoneNum: number) => {
                 publish({[`countdown_${zoneNum}`]: 0});
             }
             const lookup: Record<number, string> = {0: "Manual", 1: "Auto", 2: "Closed"};
-            if (typeof value === 'number' && value in lookup) {
+            if (typeof value === "number" && value in lookup) {
                 return lookup[value];
             }
             return `Unknown (${value})`;

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -2599,7 +2599,7 @@ export const valueConverter = {
                         timer_2: 5,
                     });
                     const endpoint = meta.device.getEndpoint(1);
-                    (async () => {
+                    void (async () => {
                         await sendDataPointValue(endpoint, 13, 5);
                         await sendDataPointValue(endpoint, 14, 5);
                     })();

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1094,7 +1094,7 @@ export const giexGx03ValveState = (zoneNum: number) => {
                 publish({[`countdown_${zoneNum}`]: 0});
             }
             const lookup: KeyValue = {0: "Manual", 1: "Auto", 2: "Closed"};
-            return lookup[value as number] ?? (value as number);
+            return lookup[value as number] ?? `Unknown (${value})`;
         },
     };
 };

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1048,13 +1048,6 @@ export const configureQuery = async (device: Zh.Device, coordinatorEndpoint: Zh.
     await device.getEndpoint(1).command("manuSpecificTuya", "dataQuery", {});
 };
 
-export const queryDeviceState = async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
-    // Request the device to start reporting
-    await configureMagicPacket(device, coordinatorEndpoint);
-    // Request the device to report a value of all attributes
-    await configureQuery(device, coordinatorEndpoint);
-};
-
 export const configureMcuVersionRequest = async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
     await device.getEndpoint(1).command("manuSpecificTuya", "mcuVersionRequest", {seq: 0x0002});
 };

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1083,7 +1083,7 @@ export const giexGx03ValveState = (zoneNum: number) => {
             if (meta.state?.timer_1 === undefined) {
                 publish({
                     timer_1: 5,
-                    timer_2: 5
+                    timer_2: 5,
                 });
                 const endpoint = meta.device.getEndpoint(1);
                 sendDataPointValue(endpoint, 13, 5).catch(() => {});
@@ -1091,11 +1091,11 @@ export const giexGx03ValveState = (zoneNum: number) => {
             }
             // Reset the related countdown on valve closing
             if (value === 2) {
-                publish({ [`countdown_${zoneNum}`]: 0 });
+                publish({[`countdown_${zoneNum}`]: 0});
             }
             const lookup: KeyValue = {0: "Manual", 1: "Auto", 2: "Closed"};
             return lookup[value as number] ?? value;
-        }
+        },
     };
 };
 

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1093,8 +1093,11 @@ export const giexGx03ValveState = (zoneNum: number) => {
             if (value === 2) {
                 publish({[`countdown_${zoneNum}`]: 0});
             }
-            const lookup: KeyValue = {0: "Manual", 1: "Auto", 2: "Closed"};
-            return lookup[value as number] ?? (`Unknown (${value})` as string);
+            const lookup: Record<number, string> = {0: "Manual", 1: "Auto", 2: "Closed"};
+            if (typeof value === 'number' && value in lookup) {
+                return lookup[value];
+            }
+            return `Unknown (${value})`;
         },
     };
 };

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1078,7 +1078,7 @@ export const whitelabel = (vendor: string, model: string, description: string, m
 
 export const giexGx03ValveState = (zoneNum: number) => {
     return {
-        from: (value: unknown, meta: Fz.Meta, options: KeyValue, publish: Publish) => {
+        from: (value: unknown, meta: Fz.Meta, options: KeyValue, publish: Publish): string | number => {
             // Set initial value to both timers
             if (meta.state?.timer_1 === undefined) {
                 publish({
@@ -1094,7 +1094,7 @@ export const giexGx03ValveState = (zoneNum: number) => {
                 publish({[`countdown_${zoneNum}`]: 0});
             }
             const lookup: KeyValue = {0: "Manual", 1: "Auto", 2: "Closed"};
-            return lookup[value as number] ?? value;
+            return lookup[value as number] ?? (value as number);
         },
     };
 };

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -2591,7 +2591,7 @@ export const valueConverter = {
     GX03ValveState: (zoneNum: number) => {
         const lookup: Record<number, string> = {0: "Manual", 1: "Auto", 2: "Closed"};
         return {
-            from: async (value: unknown, meta: Fz.Meta, options: KeyValue, publish: Publish): Promise<string> => {
+            from: (value: unknown, meta: Fz.Meta, options: KeyValue, publish: Publish) => {
                 // Set initial value to both timers to unlock UI
                 if (meta.state?.timer_1 === undefined) {
                     publish({
@@ -2599,8 +2599,10 @@ export const valueConverter = {
                         timer_2: 5,
                     });
                     const endpoint = meta.device.getEndpoint(1);
-                    await sendDataPointValue(endpoint, 13, 5);
-                    await sendDataPointValue(endpoint, 14, 5);
+                    (async () => {
+                        await sendDataPointValue(endpoint, 13, 5);
+                        await sendDataPointValue(endpoint, 14, 5);
+                    })();
                 }
                 // Reset the related countdown on valve closing
                 if (value === 2) {

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1048,6 +1048,13 @@ export const configureQuery = async (device: Zh.Device, coordinatorEndpoint: Zh.
     await device.getEndpoint(1).command("manuSpecificTuya", "dataQuery", {});
 };
 
+export const queryDeviceState = async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
+    // Request the device to start reporting
+    await configureMagicPacket(device, coordinatorEndpoint);
+    // Request the device to report a value of all attributes
+    await configureQuery(device, coordinatorEndpoint);
+};
+
 export const configureMcuVersionRequest = async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
     await device.getEndpoint(1).command("manuSpecificTuya", "mcuVersionRequest", {seq: 0x0002});
 };
@@ -1067,6 +1074,29 @@ export const whitelabel = (vendor: string, model: string, description: string, m
         return {manufacturerName};
     });
     return {vendor, model, description, fingerprint};
+};
+
+export const giexGx03ValveState = (zoneNum: number) => {
+    return {
+        from: (value: unknown, meta: Fz.Meta, options: KeyValue, publish: Publish) => {
+            // Set initial value to both timers
+            if (meta.state?.timer_1 === undefined) {
+                publish({
+                    timer_1: 5,
+                    timer_2: 5
+                });
+                const endpoint = meta.device.getEndpoint(1);
+                sendDataPointValue(endpoint, 13, 5).catch(() => {});
+                sendDataPointValue(endpoint, 14, 5).catch(() => {});
+            }
+            // Reset the related countdown on valve closing
+            if (value === 2) {
+                publish({ [`countdown_${zoneNum}`]: 0 });
+            }
+            const lookup: KeyValue = {0: "Manual", 1: "Auto", 2: "Closed"};
+            return lookup[value as number] ?? value;
+        }
+    };
 };
 
 class Base {

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1076,32 +1076,6 @@ export const whitelabel = (vendor: string, model: string, description: string, m
     return {vendor, model, description, fingerprint};
 };
 
-export const giexGx03ValveState = (zoneNum: number) => {
-    return {
-        from: (value: unknown, meta: Fz.Meta, options: KeyValue, publish: Publish): string | number => {
-            // Set initial value to both timers
-            if (meta.state?.timer_1 === undefined) {
-                publish({
-                    timer_1: 5,
-                    timer_2: 5,
-                });
-                const endpoint = meta.device.getEndpoint(1);
-                sendDataPointValue(endpoint, 13, 5).catch(() => {});
-                sendDataPointValue(endpoint, 14, 5).catch(() => {});
-            }
-            // Reset the related countdown on valve closing
-            if (value === 2) {
-                publish({[`countdown_${zoneNum}`]: 0});
-            }
-            const lookup: Record<number, string> = {0: "Manual", 1: "Auto", 2: "Closed"};
-            if (typeof value === "number" && value in lookup) {
-                return lookup[value];
-            }
-            return `Unknown (${value})`;
-        },
-    };
-};
-
 class Base {
     value: number;
 
@@ -2613,6 +2587,31 @@ export const valueConverter = {
             }
             return schedules;
         },
+    },
+    GX03ValveState: (zoneNum: number) => {
+        const lookup: Record<number, string> = {0: "Manual", 1: "Auto", 2: "Closed"};
+        return {
+            from: async (value: unknown, meta: Fz.Meta, options: KeyValue, publish: Publish): Promise<string> => {
+                // Set initial value to both timers to unlock UI
+                if (meta.state?.timer_1 === undefined) {
+                    publish({
+                        timer_1: 5,
+                        timer_2: 5,
+                    });
+                    const endpoint = meta.device.getEndpoint(1);
+                    await sendDataPointValue(endpoint, 13, 5);
+                    await sendDataPointValue(endpoint, 14, 5);
+                }
+                // Reset the related countdown on valve closing
+                if (value === 2) {
+                    publish({[`countdown_${zoneNum}`]: 0});
+                }
+                if (typeof value === "number" && value in lookup) {
+                    return lookup[value];
+                }
+                return `Unknown (${value})`;
+            },
+        };
     },
 };
 

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1094,7 +1094,7 @@ export const giexGx03ValveState = (zoneNum: number) => {
                 publish({[`countdown_${zoneNum}`]: 0});
             }
             const lookup: KeyValue = {0: "Manual", 1: "Auto", 2: "Closed"};
-            return lookup[value as number] ?? `Unknown (${value})`;
+            return lookup[value as number] ?? (`Unknown (${value})` as string);
         },
     };
 };


### PR DESCRIPTION
Replaced the current rudimentory implementation. Separated timer/countdown to keep timer as a user setting and countdown as a counter, revealed last duration for statistics, reset countdown which was staying non-zero, set initial timer value to unlock this control in HA.