### PR TITLE
Legrand 412170: force device_mode to 'switch' on configure, add missing 'identify' expose

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -116,7 +116,7 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fz.identify, fz.electrical_measurement],
         toZigbee: [tzLegrand.identify, tz.electrical_measurement_power],
-        exposes: [e.power().withAccess(ea.STATE_GET)],
+        exposes: [e.power().withAccess(ea.STATE_GET), eLegrand.identify()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "haElectricalMeasurement"]);

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -1,11 +1,11 @@
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
-import {eLegrand, fzLegrand, legrandExtend, legrandOptions, readInitialBatteryState, tzLegrand} from "../lib/legrand";
+import {eLegrand, fzLegrand, type LegrandDevicesCluster, legrandExtend, legrandOptions, readInitialBatteryState, tzLegrand} from "../lib/legrand";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, Fz, KeyValueAny} from "../lib/types";
+import type {DefinitionWithExtend, Fz} from "../lib/types";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -123,8 +123,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint);
 
-            const payload: KeyValueAny = {deviceMode: 3};
-            await endpoint.write("manuSpecificLegrandDevices", payload, legrandOptions);
+            await endpoint.write<"manuSpecificLegrandDevices", LegrandDevicesCluster>("manuSpecificLegrandDevices", {deviceMode: 3}, legrandOptions);
             await endpoint.read("manuSpecificLegrandDevices", [0x0000], legrandOptions);
         },
     },

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -5,7 +5,7 @@ import {eLegrand, fzLegrand, legrandExtend, legrandOptions, readInitialBatterySt
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, Fz} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValueAny} from "../lib/types";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -129,6 +129,15 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "haElectricalMeasurement"]);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint);
+
+            // Force device_mode to 'switch' (3) on first configure, 'auto'(4) is officially unsupported and erratic on 412170
+            if (!device.meta.deviceModeInitialized) {
+                const payload: KeyValueAny = {deviceMode: 3};
+                await endpoint.write("manuSpecificLegrandDevices", payload, legrandOptions);
+                await endpoint.read("manuSpecificLegrandDevices", [0x0000], legrandOptions);
+                device.meta.deviceModeInitialized = true;
+                device.save();
+            }
         },
     },
     {

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -117,6 +117,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fz.identify, fz.electrical_measurement],
         toZigbee: [tzLegrand.identify, tz.electrical_measurement_power],
         exposes: [e.power().withAccess(ea.STATE_GET), eLegrand.identify()],
+        version: "0.0.1",
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "haElectricalMeasurement"]);

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -114,30 +114,18 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [{vendor: "BTicino", model: "FC80RC"}],
         extend: [legrandExtend.addLegrandDevicesCluster(), m.onOff()],
         ota: true,
-        fromZigbee: [fz.identify, fz.electrical_measurement, fzLegrand.cluster_fc01],
-        toZigbee: [tzLegrand.legrand_device_mode, tzLegrand.identify, tz.electrical_measurement_power],
-        exposes: [
-            e.power().withAccess(ea.STATE_GET),
-            e
-                .enum("device_mode", ea.ALL, ["switch", "auto"])
-                .withDescription(
-                    "Switch: normal on/off mode, momentary push-buttons on C1/C2 toggle the relay cleanly (recommended). auto: produces erratic behavior.",
-                ),
-        ],
+        fromZigbee: [fz.identify, fz.electrical_measurement],
+        toZigbee: [tzLegrand.identify, tz.electrical_measurement_power],
+        exposes: [e.power().withAccess(ea.STATE_GET)],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "haElectricalMeasurement"]);
             await reporting.readEletricalMeasurementMultiplierDivisors(endpoint);
             await reporting.activePower(endpoint);
 
-            // Force device_mode to 'switch' (3) on first configure, 'auto'(4) is officially unsupported and erratic on 412170
-            if (!device.meta.deviceModeInitialized) {
-                const payload: KeyValueAny = {deviceMode: 3};
-                await endpoint.write("manuSpecificLegrandDevices", payload, legrandOptions);
-                await endpoint.read("manuSpecificLegrandDevices", [0x0000], legrandOptions);
-                device.meta.deviceModeInitialized = true;
-                device.save();
-            }
+            const payload: KeyValueAny = {deviceMode: 3};
+            await endpoint.write("manuSpecificLegrandDevices", payload, legrandOptions);
+            await endpoint.read("manuSpecificLegrandDevices", [0x0000], legrandOptions);
         },
     },
     {

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -61,7 +61,7 @@ const getApplicableCalibrationModes = (isNLLVSwitch: boolean): KeyValueString =>
 
 export const legrandOptions = {manufacturerCode: Zcl.ManufacturerCode.LEGRAND_GROUP, disableDefaultResponse: true};
 
-interface LegrandDevicesCluster {
+export interface LegrandDevicesCluster {
     attributes: {
         deviceMode: number;
         ledInDark: number;


### PR DESCRIPTION
Follow-up to #12141 (which clarified the description but left users to set the mode manually).

The 412170's factory default `device_mode` is not switch, which causes erratic behavior with the L to C1 push-button wiring method documented in Legrand's installation sheet.

- This change writes device_mode `switch` (3) on configure.
- It removes the exposed `device_mode`.
- Adds the missing 'identify' exposure.

~~This change writes device_mode `switch` (3) on first configure, setting a flag in `device.meta.deviceModeInitialized` so the write only happens once. User-chosen values are preserved across later re-configures.~~

~~The user-facing device_mode enum remains in exposes/toZigbee, so anyone with an unusual need to set auto can still do so manually. But this is not supported or documented by Legrand for this device (it was a leftover from reusing code from the contactor 412171 implementation).~~

More technical details:

The converter code for the 412170 was reused from an earlier contactor (Legrand 412171) which is a different device with different use-case and wiring method (sustained-state switches instead of momentary push buttons). The officially described use-case for 'auto' mode is to follow On-Peak/Off-Peak electricity rates via wiring of dry contacts from an electricity meter to the 412171, so a water heater will be on during the lower electricity rates. The Zigbee OnOff cluster is disabled when the 412171 is in auto mode, but on the 412170, OnOff keeps working in either mode.

Legrand's Home+Control app exposes an 'auto' mode for the 412171, but does *not* for the 412170 here. Since it's the same firmware on both devices, it accepts the mode 'auto' without complaining on the 412170, but the mode results in erratic behaviour if used with the wiring method L to C1 on the 412170. To make a long story short, the 412170 doesn't have an 'auto' mode. See #12141 for the full details.

Tested with 412170 paired from scratch, write/read confirmed via debug log, flag confirmed in database.db.
