### PR TITLE
feat(add): Moes SYT-ZB01 smart scene button with rotary knob

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12282,24 +12282,13 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Moes",
         description: "Smart scene button with rotary knob",
         exposes: [
-            e.battery(),
-            e.action(["toggle", "off", "brightness_step_up", "brightness_step_down"]),
             e
                 .enum("operation_mode", ea.ALL, ["command", "event"])
                 .withDescription('Operation mode: "command" - for group control, "event" - for clicks'),
         ],
-        fromZigbee: [
-            fz.battery,
-            fz.command_toggle,
-            fz.command_off,
-            fz.command_step,
-            fz.command_move,
-            fz.command_stop,
-            tuya.fz.on_off_action,
-            tuya.fz.operation_mode,
-        ],
+        fromZigbee: [tuya.fz.on_off_action, tuya.fz.operation_mode],
         toZigbee: [tuya.tz.operation_mode],
-        extend: [tuya.modernExtend.tuyaBase({forceTimeUpdates: true})],
+        extend: [m.commandsOnOff(), m.commandsLevelCtrl(), m.battery(), tuya.modernExtend.tuyaBase({forceTimeUpdates: true})],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.write<"genOnOff", tuya.TuyaGenOnOff>("genOnOff", {tuyaOperationMode: 1});
@@ -12309,10 +12298,6 @@ export const definitions: DefinitionWithExtend[] = [
             } catch {
                 /* do nothing */
             }
-            await endpoint.read("genPowerCfg", ["batteryVoltage", "batteryPercentageRemaining"]);
-            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
-            await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
-            await reporting.batteryPercentageRemaining(endpoint);
         },
     },
     {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12277,6 +12277,45 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS004F", ["_TZ3000_1fqpj6qz"]),
+        model: "SYT-ZB01",
+        vendor: "Moes",
+        description: "Smart scene button with rotary knob",
+        exposes: [
+            e.battery(),
+            e.action(["toggle", "off", "brightness_step_up", "brightness_step_down"]),
+            e
+                .enum("operation_mode", ea.ALL, ["command", "event"])
+                .withDescription('Operation mode: "command" - for group control, "event" - for clicks'),
+        ],
+        fromZigbee: [
+            fz.battery,
+            fz.command_toggle,
+            fz.command_off,
+            fz.command_step,
+            fz.command_move,
+            fz.command_stop,
+            tuya.fz.on_off_action,
+            tuya.fz.operation_mode,
+        ],
+        toZigbee: [tuya.tz.operation_mode],
+        extend: [tuya.modernExtend.tuyaBase({forceTimeUpdates: true})],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.write<"genOnOff", tuya.TuyaGenOnOff>("genOnOff", {tuyaOperationMode: 1});
+            await endpoint.read<"genOnOff", tuya.TuyaGenOnOff>("genOnOff", ["tuyaOperationMode"]);
+            try {
+                await endpoint.read(0xe001, [0xd011]);
+            } catch {
+                /* do nothing */
+            }
+            await endpoint.read("genPowerCfg", ["batteryVoltage", "batteryPercentageRemaining"]);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_hkdl5fmv"]),
         model: "TS0601_rcbo",
         vendor: "Tuya",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- If you are adding support for a new device, please also submit a picture for the documentation. -->
<!-- Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation -->
<!-- The line below can be removed if you are NOT adding support for a new device. -->
Link to picture pull request: TODO

## Device

| Field | Value |
|-------|-------|
| Model | SYT-ZB01 |
| Vendor | Moes |
| Description | Smart scene button with rotary knob |
| Fingerprint | `TS004F` / `_TZ3000_1fqpj6qz` |

## Notes

- Based on the same `TS004F` base as the YSR-MINI-Z, sharing its `fromZigbee`, `toZigbee`, `extend`, and `configure` structure
- Exposes `toggle`, `off`, `brightness_step_up`, `brightness_step_down` actions
- No color temperature support (device does not have a color temperature ring)
- Exposes `operation_mode` (`command` / `event`) and `battery`