### PR TITLE
fix(tuya): TS0601_dimmer_1_gang_1 physical knob feedback

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4493,6 +4493,21 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "1 gang smart dimmer",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        // Some variants (notably ION Industries _TZE200_ykgar0ow / _TZE200_4mh6tyyo)
+        // emit standard genOnOff / genLevelCtrl attribute reports for local
+        // knob/rotation events once those clusters are bound to the coordinator
+        // and attribute reporting is configured. Without these, HA never sees
+        // physical-knob state changes (see #10272, #25203). For variants whose
+        // firmware does not support standard reporting, the bind + configReport
+        // requests are harmless no-ops.
+        fromZigbee: [fz.on_off, fz.brightness],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
+            await reporting.onOff(endpoint);
+            await reporting.brightness(endpoint);
+        },
         exposes: (device, options) => {
             const exps: Expose[] = [
                 tuya.exposes.lightBrightnessWithMinMax(),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4496,7 +4496,7 @@ export const definitions: DefinitionWithExtend[] = [
         // Some variants (notably ION Industries _TZE200_ykgar0ow / _TZE200_4mh6tyyo)
         // emit standard genOnOff / genLevelCtrl attribute reports for local
         // knob/rotation events once those clusters are bound to the coordinator
-        // and attribute reporting is configured. Without these, HA never sees
+        // and attribute reporting is configured. Without these there are no
         // physical-knob state changes (see #10272, #25203). For variants whose
         // firmware does not support standard reporting, the bind + configReport
         // requests are harmless no-ops.

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4500,6 +4500,7 @@ export const definitions: DefinitionWithExtend[] = [
         // physical-knob state changes (see #10272, #25203). For variants whose
         // firmware does not support standard reporting, the bind + configReport
         // requests are harmless no-ops.
+        version: "0.0.1",
         fromZigbee: [fz.on_off, fz.brightness],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);


### PR DESCRIPTION
Some variants of this device (notably ION Industries _TZE200_ykgar0ow and _TZE200_4mh6tyyo) transmit standard genOnOff.onOff and genLevelCtrl.currentLevel attribute reports for local knob/rotation events, but only after their standard clusters are bound to the coordinator and attribute reporting is configured. The existing converter relied solely on Tuya DPs for state, which this firmware only emits as echoes of Z2M-initiated commands - never for physical input.

Add fz.on_off and fz.brightness to the fromZigbee list and a configure function that sets up the bindings + reporting at pairing time. Variants whose firmware might not support standard reporting are unaffected: the configure requests should be accepted but never trigger reports, and the added fz handlers just never fire.

Disclaimer: although finding the root cause and implementing the fix was AI-assisted (Claude Opus 4.7), the fix is human-validated end-to-end on a real _TZE200_ykgar0ow dimmer: knob press updates state, rotation updates brightness, Z2M-initiated set commands behave as before.

For those having issues with a `TZE200_ykgar0ow` interested in testing this solution in the shape of an external converter, add this file to your `external_converters` directory and give it a shot. This is what I used for testing the solution before turning it into this PR.

`ion_dimmer.js`
```js
const tuya = require('zigbee-herdsman-converters/lib/tuya');
const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
const reporting = require('zigbee-herdsman-converters/lib/reporting');
const exposes = require('zigbee-herdsman-converters/lib/exposes');
const e = exposes.presets;
const ea = exposes.access;

// Hybrid of Z2M's built-in TS0601_dimmer_1_gang_1 definition for _TZE200_ykgar0ow
// (see src/devices/tuya.ts in zigbee-herdsman-converters) plus the standard
// fz.on_off and fz.brightness converters.
//
// Why: this firmware variant transmits standard genOnOff.onOff and
// genLevelCtrl.currentLevel attribute reports for local knob/rotation events,
// but only after manual binding of those clusters from device endpoint 1 to
// the coordinator and configuring attribute reporting (neither of which the
// built-in does). The built-in only registers Tuya DP fromZigbee handlers, so
// standard cluster reports are dropped with "No converter available". Adding
// fz.on_off and fz.brightness fixes that.
module.exports = {
    fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_ykgar0ow'}],
    model: 'ID200W-ZIGB',
    vendor: 'ION Industries',
    description: 'LED Zigbee Dimmer 200W (with knob feedback)',
    extend: [tuya.modernExtend.tuyaBase({dp: true})],
    fromZigbee: [fz.on_off, fz.brightness],
    exposes: [
        tuya.exposes.lightBrightnessWithMinMax(),
        tuya.exposes.countdown(),
        e.power_on_behavior().withAccess(ea.STATE_SET),
    ],
    meta: {
        tuyaDatapoints: [
            [1, 'state', tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
            [2, 'brightness', tuya.valueConverter.scale0_254to0_1000],
            [3, 'min_brightness', tuya.valueConverter.scale0_254to0_1000],
            [5, 'max_brightness', tuya.valueConverter.scale0_254to0_1000],
            [6, 'countdown', tuya.valueConverter.countdown],
            [14, 'power_on_behavior', tuya.valueConverter.powerOnBehavior],
        ],
    },
    // Auto-setup of bindings + attribute reporting so a fresh pairing gets
    // knob feedback without manual UI clicks. Runs once at pairing and again
    // when the user triggers Reconfigure. tuyaBase's own configure step
    // (magic packet) runs alongside this one --- Z2M merges them.
    configure: async (device, coordinatorEndpoint) => {
        const endpoint = device.getEndpoint(1);
        await reporting.bind(endpoint, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
        await reporting.onOff(endpoint);
        await reporting.brightness(endpoint);
    },
};
```

Refs: #10272, Koenkk/zigbee2mqtt#25203, Koenkk/zigbee2mqtt/discussions/23955