### PR TITLE
Add Eglo 113135 / EGLO_ZM_RGB_W (AwoX firmware)

### DIFF
--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -317,6 +317,14 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        zigbeeModel: ["EGLO_ZM_RGB_W"],
+        model: "EGLO_ZM_RGB_W",
+        vendor: "AwoX",
+        description: "RGB bulb with dedicated 3000 K white LED",
+        extend: [m.light({colorTemp: {range: [333, 333], startup: false}, color: {modes: ["xy", "hs"]}})],
+        whiteLabel: [{vendor: "EGLO", model: "113135"}],
+    },
+    {
         zigbeeModel: ["EPIR_Zm"],
         model: "EPIR_Zm",
         vendor: "AwoX",


### PR DESCRIPTION
## Device

| | |
|---|---|
| **`zigbeeModel`** | `EGLO_ZM_RGB_W` |
| **`manufacturer`** | `AwoX` |
| **Retail SKU** | Eglo 113135 — "Crosslink-Z RGB bulb" (E27, 400 lm, CRI 80) |
| **Firmware** | `2.7.3_1387` |
| **Source** | https://www.eglo.com/de/leuchtmittel-110273.html |

E27 bulb with on/off, brightness (0–254), XY + HS colour, and a **single, fixed** 3000 K white preset implemented as a dedicated white LED (not a tunable CT range).

## Definition

Added to `src/devices/awox.ts` alongside the existing `EGLO_ZM_TW`, following the file convention of `vendor: "AwoX"` + `whiteLabel: [{vendor: "EGLO", model: "<retail SKU>"}]`:

```ts
{
    zigbeeModel: ["EGLO_ZM_RGB_W"],
    model: "EGLO_ZM_RGB_W",
    vendor: "AwoX",
    description: "RGB bulb with dedicated 3000 K white LED",
    extend: [m.light({colorTemp: {range: [333, 333], startup: false}, color: {modes: ["xy", "hs"]}})],
    whiteLabel: [{vendor: "EGLO", model: "113135"}],
},
```

`colorTemp.range` is `[333, 333]` because the bulb only supports the one mired value (3000 K white LED) — verified against the device's interview output. `startup: false` suppresses the start-up CT option since there's nothing to choose between.

## Endpoints (interview output)

```
EP 1   in:  genBasic, genIdentify, genGroups, genScenes, genOnOff, genLevelCtrl,
            lightingColorCtrl, touchlink, manuSpecificAmazonWWAH, genTime
       out: genOnOff
EP 3   manuSpecific 0xFF50 / 0xFF51 + genGroups   (AwoX BLE/scene clusters, not used by Z2M)
EP 242 out: greenPower                            (standard GP endpoint)
```

Only EP 1 is needed for the light surface; the `m.light()` extend handles all of it.

## Tested

Running with the same definition as an external converter on Z2M 2.x for ~weeks:

- on/off via `genOnOff`
- brightness via `genLevelCtrl` (full 0–254 range)
- HS + XY colour picker — both pickers update the bulb correctly and the bulb's reported state matches
- 3000 K white preset via `color_temp: 333` — switches to the dedicated white LED as expected
- `power_on_behavior` and `effect` exposed by `m.light()` work

## Prior art

Closes #10557 and supersedes #10797 (both abandoned / auto-closed by the stale bot). Credit to @ringaction for the awox.ts location and the initial `range: [333, 333]` insight; this PR cleans up the description, adds `startup: false`, and adds the Eglo retail SKU as a `whiteLabel`.

---

No picture PR yet — happy to add one if the maintainers want; the product image is at https://www.eglo.com/de/leuchtmittel-110273.html .