### PR TITLE
added Tuya synonym of PJ1203A

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -17324,7 +17324,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_81yrt3lo", "_TZE284_81yrt3lo"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_81yrt3lo", "_TZE284_81yrt3lo", "_TZE28C1000000_81yrt3lo"]),
         model: "PJ-1203A",
         vendor: "Tuya",
         description: "Bidirectional energy meter with 80A current clamp",


### PR DESCRIPTION
I bought a thing from aliexpress, It says PJ1203A but z2m doesn't recognised it, I added the reporting name _TZE28C1000000_81yrt3lo

I am not a developer but I'm trying to help, hope I have not messed something up.

<img width="976" height="624" alt="Screenshot 2026-05-18 at 18 40 11" src="https://github.com/user-attachments/assets/15aa5fc7-0a7c-4b29-a4ed-f65d4d6a5511" />

<img width="480" height="640" alt="IMG_0485 Medium" src="https://github.com/user-attachments/assets/e58676c0-a224-439d-b8e8-ffac9961a86d" />
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
