### PR TITLE
Add support for Shelly EM Gen4 (S4EM-002CXCEU)

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1338,6 +1338,25 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        fingerprint: [{modelID: "EM", manufacturerName: "Shelly"}],
+        model: "S4EM-002CXCEU",
+        vendor: "Shelly",
+        description: "EM Gen4",
+        extend: [
+            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3}}),
+            m.onOff({powerOnBehavior: false, endpointNames: ["1"]}),
+            m.electricityMeter({
+                endpointNames: ["2", "3"],
+                producedEnergy: true,
+                acFrequency: true,
+            }),
+            m.forcePowerSource({powerSource: "Mains (single phase)"}),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyWiFiSetup(),
+        ],
+    },
+    {
         fingerprint: [
             {
                 type: "Router",


### PR DESCRIPTION
## What

Adds support for the **Shelly EM Gen4** (`S4EM-002CXCEU`), a 2-channel contactless energy meter with a built-in relay (Zigbee `modelID: "EM"`, manufacturer `Shelly`).

Product page: https://www.shelly.com/products/shelly-em-gen4

Without this converter, Z2M flags the device as "Unsupported (generated)" and only auto-exposes a partial set of attributes on endpoint 2, missing the second channel and the relay.

## Device fingerprint (from a live unit)

* `modelID`: `EM`
* `manufacturerName`: `Shelly`
* Firmware ID: `1.8.99-emg4prod0` (date code `20260120`)
* Type: Router (mains-powered)

### Endpoints

| Endpoint | Input clusters | Output clusters | Function |
|---------:|----------------|-----------------|----------|
| 1   | `genBasic`, `genIdentify`, `genGroups`, `genScenes`, `genOnOff` | `genOta` | Built-in relay |
| 2   | `seMetering`, `seMeterIdentification`, `haElectricalMeasurement` | - | Channel 1 (CT clamp) |
| 3   | `seMetering`, `seMeterIdentification`, `haElectricalMeasurement` | - | Channel 2 (CT clamp) |
| 239 | `0xFC01` (64513), `0xFC02` (64514) | - | Shelly manufacturer-specific |
| 242 | - | `greenPower` | Green Power proxy |

## Why this shape

* `deviceEndpoints` exposes the three Zigbee endpoints by name so the multi-endpoint helpers below can target them.
* `onOff({endpointNames: ["1"]})` binds the relay on EP1 only (the metering endpoints have no `genOnOff` cluster).
* `electricityMeter({endpointNames: ["2", "3"], producedEnergy: true, acFrequency: true})` mirrors the EM Mini Gen4 entry and produces `*_2` / `*_3` suffixed exposes per channel.
* `forcePowerSource({powerSource: "Mains (single phase)"})` is needed because the EM Gen4 does not advertise the `genBasic.powerSource` attribute (`0x0007`) during the Zigbee interview, leaving Z2M with an `Unknown` power source. The device is always mains-powered (110-240 V AC, single-phase by design), so we set it explicitly at `configure()` time.
* `shellyPowerFactorInt16Fix`, `shellyCustomClusters` and `shellyWiFiSetup` are the standard Gen4 add-ons (cf. EM Mini, Plug US Gen4, Power Strip 4 Gen4, Dimmer Gen4 all use the same trio).

## Tested on a live unit

Validated end-to-end on a live Shelly EM Gen4 paired with Zigbee2MQTT 2.10.1 (HA add-on `45df7312_zigbee2mqtt`) over a Sonoff Dongle-E coordinator, using the external-converter mechanism (`bridge/request/converter/save`) before opening this PR.

After re-interview, the device transitions from `source: "generated", supported: false` to `source: "external", supported: true`, with 14 properly named exposes:

* **Relay (EP1):** `state_1` (on/off)
* **Channel 1 (EP2):** `power_2`, `voltage_2`, `current_2`, `ac_frequency_2`, `energy_2`, `produced_energy_2`
* **Channel 2 (EP3):** `power_3`, `voltage_3`, `current_3`, `ac_frequency_3`, `energy_3`, `produced_energy_3`
* `linkquality`, `power_source` (now `Mains (single phase)` thanks to `forcePowerSource`)

## Related issues / PRs

* Issue Koenkk/zigbee2mqtt#29147 — EM Mini Gen4 (closely related, single-channel variant)
* PR #10276 — Wi-Fi Setup Cluster for Gen4 devices
* PR #12011 — 2PM Gen4 (multi-endpoint Shelly Gen4 pattern reference)

## Open question

The endpoint naming uses raw numbers (`"1"`, `"2"`, `"3"`). Some users may prefer `"relay"`, `"l1"`, `"l2"` for friendlier exposes. The numeric form matches the existing Shelly Power Strip 4 Gen4 entry — kept identical for consistency. Happy to switch if reviewers prefer the semantic naming.

A separate PR on Koenkk/zigbee2mqtt.io will add the device picture (`public/images/devices/S4EM-002CXCEU.png`).