### PR TITLE
feat(add) static_state to lumi.vibration.agl002

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2482,7 +2482,6 @@ export const definitions: DefinitionWithExtend[] = [
                 percentageAttribute: 0x18,
             }),
             lumi.lumiModernExtend.lumiZigbeeOTA(),
-            lumi.lumiModernExtend.lumiStaticStateAction(),
             m.enumLookup<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "device_mode",
                 cluster: "manuSpecificLumi",
@@ -2587,12 +2586,17 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
+            // Primary actions on closuresDoorLock 0x0055
             m.actionEnumLookup<"closuresDoorLock", undefined>({
                 cluster: "closuresDoorLock",
                 attribute: {ID: 0x0055, type: Zcl.DataType.UINT16},
                 actionLookup: {triple_tap: 0, movement: 1, vibration: 2, orientation: 3, fall: 4},
                 extraActions: ["static"],
             }),
+            // and the static-state edge on manuSpecificLumi 0x01F3, declared as an
+            // extraAction above. Emits true transition only (the device does
+            // report the false transition)
+            lumi.lumiModernExtend.lumiStaticStateAction(),
             m.binary<"genOnOff", undefined>({
                 name: "contact",
                 cluster: "genOnOff",

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2474,8 +2474,19 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DWZTCGQ11LM",
         vendor: "Aqara",
         description: "Multi-state sensor P100",
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x0116], {manufacturerCode: manufacturerCode}); // device_mode
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01eb], {manufacturerCode: manufacturerCode}); // door_window_type
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x010c], {manufacturerCode: manufacturerCode}); // sensitivity
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01ec], {manufacturerCode: manufacturerCode}); // report_interval
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01f0], {manufacturerCode: manufacturerCode}); // orientation_detection
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01ed], {manufacturerCode: manufacturerCode}); // movement_detection
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01d8], {manufacturerCode: manufacturerCode}); // fall_detection
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x0107], {manufacturerCode: manufacturerCode}); // vibration_detection
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01ef], {manufacturerCode: manufacturerCode}); // triple_tap_detection
+        },
         extend: [
-            m.quirkCheckinInterval("1_HOUR"),
             lumi.lumiModernExtend.addManuSpecificLumiCluster(),
             lumi.lumiModernExtend.lumiPreventReset(),
             lumi.lumiModernExtend.lumiBattery({
@@ -2483,30 +2494,32 @@ export const definitions: DefinitionWithExtend[] = [
                 percentageAttribute: 0x18,
             }),
             lumi.lumiModernExtend.lumiZigbeeOTA(),
-            m.enumLookup({
+            lumi.lumiModernExtend.lumiStaticStateAction(),
+            m.enumLookup<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "device_mode",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x0116, type: 0x20},
+                attribute: {ID: 0x0116, type: Zcl.DataType.UINT8},
                 lookup: {door_window: 3, object: 5},
                 description: "Device operating mode",
                 access: "STATE_SET",
                 entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.enumLookup({
+            m.enumLookup<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "door_window_type",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01eb, type: 0x20},
+                attribute: {ID: 0x01eb, type: Zcl.DataType.UINT8},
                 lookup: {casement_window: 1, hopper_window: 2, composite_window: 3, hinged_door: 4},
-                description: "Door/window type (applies when device_mode = door window)",
+                description: "Door/window type (applies when device_mode = door_window)",
                 access: "STATE_SET",
+                label: "Door/window type",
                 entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.numeric({
+            m.numeric<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "sensitivity",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x010c, type: 0x20},
+                attribute: {ID: 0x010c, type: Zcl.DataType.UINT8},
                 valueMin: 1,
                 valueMax: 10,
                 description: "Detection sensitivity (1 = low, 10 = high)",
@@ -2514,90 +2527,85 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.numeric({
+            m.numeric<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "report_interval",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01ec, type: 0x23},
+                attribute: {ID: 0x01ec, type: Zcl.DataType.UINT32},
                 unit: "s",
                 valueMin: 5,
                 valueMax: 300,
-                description: "Reporting interval in seconds",
+                description:
+                    "Reporting interval in seconds. Also drives the device's 802.15.4 poll cadence — lower values are more responsive but reduce battery life.",
                 access: "STATE_SET",
                 entityCategory: "config",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.binary({
+            m.binary<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "orientation_detection",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01f0, type: 0x10},
+                attribute: {ID: 0x01f0, type: Zcl.DataType.BOOLEAN},
                 valueOn: ["ON", 1],
                 valueOff: ["OFF", 0],
-                description: "Enable orientation event detection",
+                description: "Enable orientation event detection (object mode, requires device button press)",
                 access: "STATE_SET",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.binary({
+            m.binary<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "movement_detection",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01ed, type: 0x10},
+                attribute: {ID: 0x01ed, type: Zcl.DataType.BOOLEAN},
                 valueOn: ["ON", 1],
                 valueOff: ["OFF", 0],
-                description: "Enable movement event detection",
+                description: "Enable movement event detection (object mode, requires device button press)",
                 access: "STATE_SET",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.binary({
+            m.binary<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "fall_detection",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01d8, type: 0x10},
+                attribute: {ID: 0x01d8, type: Zcl.DataType.BOOLEAN},
                 valueOn: ["ON", 1],
                 valueOff: ["OFF", 0],
-                description: "Enable fall event detection",
+                description: "Enable fall event detection (object mode, requires device button press)",
                 access: "STATE_SET",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.binary({
+            m.binary<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "vibration_detection",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x0107, type: 0x10},
+                attribute: {ID: 0x0107, type: Zcl.DataType.BOOLEAN},
                 valueOn: ["ON", 1],
                 valueOff: ["OFF", 0],
-                description: "Enable vibration event detection",
+                description: "Enable vibration event detection (object mode, requires device button press)",
                 access: "STATE_SET",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.binary({
+            m.binary<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "triple_tap_detection",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01ef, type: 0x10},
+                attribute: {ID: 0x01ef, type: Zcl.DataType.BOOLEAN},
                 valueOn: ["ON", 1],
                 valueOff: ["OFF", 0],
-                description: "Enable triple-tap event detection",
+                description: "Enable triple-tap event detection (object mode, requires device button press)",
                 access: "STATE_SET",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            m.enumLookup({
+            m.enumLookup<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "orientation",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01f1, type: 0x20},
+                attribute: {ID: 0x01f1, type: Zcl.DataType.UINT8},
                 lookup: {face_up: 1, face_down: 2, vertical: 3, tilt: 4},
                 description: "Last reported orientation (relevant when action = orientation)",
                 access: "STATE",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
-            // 0x01f3 fires true on every detection but never resets — no signal beyond `action`, not exposed.
-            m.actionEnumLookup({
+            m.actionEnumLookup<"closuresDoorLock", undefined>({
                 cluster: "closuresDoorLock",
-                attribute: {ID: 0x0055, type: 0x21},
-                actionLookup: {
-                    triple_tap: 0,
-                    movement: 1,
-                    vibration: 2,
-                    orientation: 3,
-                    fall: 4,
-                },
+                attribute: {ID: 0x0055, type: Zcl.DataType.UINT16},
+                actionLookup: {triple_tap: 0, movement: 1, vibration: 2, orientation: 3, fall: 4},
+                extraActions: ["static"],
             }),
-            m.binary({
+            m.binary<"genOnOff", undefined>({
                 name: "contact",
                 cluster: "genOnOff",
                 attribute: "onOff",
@@ -2606,12 +2614,12 @@ export const definitions: DefinitionWithExtend[] = [
                 description: "Door/window state (door/window mode only)",
                 access: "STATE",
             }),
-            m.enumLookup({
+            m.enumLookup<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "device_posture",
                 cluster: "manuSpecificLumi",
-                attribute: {ID: 0x01ee, type: 0x20},
+                attribute: {ID: 0x01ee, type: Zcl.DataType.UINT8},
                 lookup: {normal: 1, abnormal: 2},
-                description: "Mounting orientation check — 'abnormal' when the sensor is incorrectly installed or needs calibration",
+                description: "Door/window mounting orientation check — 'abnormal' if the sensor is incorrectly installed or needs calibration",
                 access: "STATE",
                 entityCategory: "diagnostic",
                 zigbeeCommandOptions: {manufacturerCode},

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2474,18 +2474,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DWZTCGQ11LM",
         vendor: "Aqara",
         description: "Multi-state sensor P100",
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x0116], {manufacturerCode: manufacturerCode}); // device_mode
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01eb], {manufacturerCode: manufacturerCode}); // door_window_type
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x010c], {manufacturerCode: manufacturerCode}); // sensitivity
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01ec], {manufacturerCode: manufacturerCode}); // report_interval
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01f0], {manufacturerCode: manufacturerCode}); // orientation_detection
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01ed], {manufacturerCode: manufacturerCode}); // movement_detection
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01d8], {manufacturerCode: manufacturerCode}); // fall_detection
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x0107], {manufacturerCode: manufacturerCode}); // vibration_detection
-            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x01ef], {manufacturerCode: manufacturerCode}); // triple_tap_detection
-        },
         extend: [
             lumi.lumiModernExtend.addManuSpecificLumiCluster(),
             lumi.lumiModernExtend.lumiPreventReset(),

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -2428,6 +2428,18 @@ export const lumiModernExtend = {
             attribute: "presentValue",
             ...args,
         }),
+    lumiStaticStateAction: (): ModernExtend => {
+        const converter: Fz.Converter<"manuSpecificLumi", ManuSpecificLumi, ["attributeReport"]> = {
+            cluster: "manuSpecificLumi",
+            type: ["attributeReport"],
+            convert: (model, msg, publish, options, meta) => {
+                if (msg.data["499"] === 1) {
+                    return {action: "static"};
+                }
+            },
+        };
+        return {fromZigbee: [converter], isModernExtend: true};
+    },
     lumiVoc: (args?: Partial<modernExtend.NumericArgs<"genAnalogInput">>) =>
         modernExtend.numeric({
             name: "voc",


### PR DESCRIPTION
`manuSpecificLumi` attribute 0x01F3 (Aqara API name: `static_state`) Fires `true` whenever the device becomes still after a motion event (`movement`, `vibration`, `orientation`, `fall`, or `triple_tap`). The `false` transition is not reliably emitted by the firmware, so only the rising edge is surfaced — add as an additional `action` value named `static`, alongside the primary action codes carried on `closuresDoorLock` attribute 0x0055.

vibration.agl002 does not implement Zigbee Poll Control cluster, there is zero traffic on cluster 0x0020. The device manages its own polling via the `report_interval` setting (manuSpecificLumi 0x01EC) sending 802.15.4 Data Requests to the coordinator at exactly that interval. `quirkCheckinInterval` is a no-op for the P100, therefore removed.

Added more information to settings descriptions
Added `<"manuSpecificLumi", ManuSpecificLumi>` to extends Changed attribute types to Zcl.DataType
Changed attribute types to `Zcl.DataType`

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
