### PR TITLE
Add support for AOne Rotary Slave Dimmer - AU-A1ZB2WDM-Slave

### DIFF
--- a/src/devices/aurora_lighting.ts
+++ b/src/devices/aurora_lighting.ts
@@ -219,15 +219,15 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({configureReporting: true})],
     },
     {
-        zigbeeModel: ['WallDimmerSlave'],
-        model: 'AU-A1ZB2WDM-Slave',
-        vendor: 'Aurora',
-        description: 'AOne Rotary Slave Dimmer',
+        zigbeeModel: ["WallDimmerSlave"],
+        model: "AU-A1ZB2WDM-Slave",
+        vendor: "Aurora",
+        description: "AOne Rotary Slave Dimmer",
         extend: [
-            m.deviceEndpoints({"endpoints": {"default": 2, "backlight": 3}}),
-            m.commandsOnOff({"endpointNames": ["default"]}),
-            m.commandsLevelCtrl({"endpointNames": ["default"]}),
-            m.onOff({"powerOnBehavior": false, "endpointNames": ["backlight"]}),
+            m.deviceEndpoints({endpoints: {default: 2, backlight: 3}}),
+            m.commandsOnOff({endpointNames: ["default"]}),
+            m.commandsLevelCtrl({endpointNames: ["default"]}),
+            m.onOff({powerOnBehavior: false, endpointNames: ["backlight"]}),
         ],
         meta: {
             multiEndpoint: true,

--- a/src/devices/aurora_lighting.ts
+++ b/src/devices/aurora_lighting.ts
@@ -219,6 +219,21 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({configureReporting: true})],
     },
     {
+        zigbeeModel: ['WallDimmerSlave'],
+        model: 'AU-A1ZB2WDM-Slave',
+        vendor: 'Aurora',
+        description: 'AOne Rotary Slave Dimmer',
+        extend: [
+            m.deviceEndpoints({"endpoints": {"default": 2, "backlight": 3}}),
+            m.commandsOnOff({"endpointNames": ["default"]}),
+            m.commandsLevelCtrl({"endpointNames": ["default"]}),
+            m.onOff({"powerOnBehavior": false, "endpointNames": ["backlight"]}),
+        ],
+        meta: {
+            multiEndpoint: true,
+        },
+    },
+    {
         zigbeeModel: ["DoubleSocket50AU"],
         model: "AU-A1ZBDSS",
         vendor: "Aurora Lighting",


### PR DESCRIPTION
Added definition for AU-A1ZB2WDM-Slave, addresses issue: [External Converter]: WallDimmerSlave from Aurora #31695

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [AU-A1ZB2WDM-Slave](https://www.zigbee2mqtt.io/images/devices/AU-A1ZB2WDM.png)
