### PR TITLE
fix: Hue: stop unwanted state reports

### DIFF
--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -612,23 +612,12 @@ const philipsModernExtend = {
                     ),
                 );
             }
-            // Bind manuSpecificPhilips2 and register the Fz converter for all
-            // hueEffect/gradient devices, not just gradient. This enables state
-            // reports for effects, brightness, color, etc. on non-gradient bulbs too.
+            // Register the Fz converter for all devices (if user enables state reports later)
             result.fromZigbee.push(manuSpecificPhilips2Fz);
-            result.configure.push(async (device, coordinatorEndpoint, definition) => {
-                for (const ep of device.endpoints) {
-                    let supported = false;
-                    try {
-                        supported = ep.supportsInputCluster("manuSpecificPhilips2");
-                    } catch {
-                        // Custom cluster not in registry — skip
-                    }
-                    if (supported) {
-                        await ep.bind("manuSpecificPhilips2", coordinatorEndpoint);
-                    }
-                }
-            });
+            // Don't bind or configure reporting automatically - causes unwanted effects
+            // (reports in-between states, conflicting with optimistic states)
+            // https://github.com/Koenkk/zigbee2mqtt/issues/32050#issuecomment-4496461658
+
             // All Hue-specific effects per Bifrost spec
             effects.push("sunset", "sunrise", "sparkle", "opal", "glisten", "underwater", "cosmos", "sunbeam", "enchant");
             effects.push("none", "finish_effect", "stop_effect", "stop_hue_effect");

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -285,7 +285,7 @@ describe("ModernExtend", () => {
 
                 "power_on_behavior",
             ],
-            bind: {1: ["manuSpecificPhilips2"]},
+            bind: {},
             read: {
                 1: [
                     ["lightingColorCtrl", ["colorCapabilities"]],


### PR DESCRIPTION
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/32050#issuecomment-4496461658
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/32053

Removes `manuSpecificPhilips2` bind from Philips hue lights.

Before fw v1.145.2, the bind without reporting has no effect afaict. I don't see why it was added?

After fw v1.145.2, Hue lights may report their state through the bind, even if reporting is not enabled.
The lights report in-between states while transitioning (even without transition specified), which cause conflicts with the optimistic Z2M / HA / etc states.

I wonder if we want an explicit unbind for the already configured lights. Or for all of them, in case the bulb binds itself automatically?