### PR TITLE
Fix system mode and off mode display for Acova Alcantara 2 and Alcantara 3

### DIFF
--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -1,11 +1,31 @@
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
+import * as constants from "../lib/constants";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValueAny} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
+
+const acova = {
+    fz: {
+        thermostat: {
+            ...fz.thermostat,
+            convert: (model, msg, publish, options, meta) => {
+                const result = fz.thermostat.convert(model, msg, publish, options, meta) as KeyValueAny;
+                if (result && msg.data.systemMode !== undefined) {
+                    result.system_mode = utils.getFromLookup(msg.data.systemMode, constants.acovaThermostatSystemModes as Record<string | number, string>,);
+                    if (result.system_mode === "off") {
+                        result.hvac_action = "off";
+                    }
+                }
+                return result;
+            },
+        } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
+    },
+};
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -16,10 +36,10 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ALCANTARA2",
         vendor: "Acova",
         description: "Alcantara 2 heater",
-        fromZigbee: [fz.thermostat, fz.hvac_user_interface],
+        fromZigbee: [acova.fz.thermostat, fz.hvac_user_interface],
         toZigbee: [
             tz.thermostat_local_temperature,
-            tz.thermostat_system_mode,
+            tz.acova_thermostat_system_mode,
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_running_state,
@@ -47,10 +67,10 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ALCANTARA3",
         vendor: "Acova",
         description: "Alcantara 3 heater",
-        fromZigbee: [fz.thermostat, fz.hvac_user_interface, fz.electrical_measurement],
+        fromZigbee: [acova.fz.thermostat, fz.hvac_user_interface, fz.electrical_measurement],
         toZigbee: [
             tz.thermostat_local_temperature,
-            tz.thermostat_system_mode,
+            tz.acova_thermostat_system_mode,
             tz.thermostat_occupied_heating_setpoint,
             tz.thermostat_unoccupied_heating_setpoint,
             tz.thermostat_running_state,

--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -16,7 +16,10 @@ const acova = {
             convert: (model, msg, publish, options, meta) => {
                 const result = fz.thermostat.convert(model, msg, publish, options, meta) as KeyValueAny;
                 if (result && msg.data.systemMode !== undefined) {
-                    result.system_mode = utils.getFromLookup(msg.data.systemMode, constants.acovaThermostatSystemModes as Record<string | number, string>,);
+                    result.system_mode = utils.getFromLookup(
+                        msg.data.systemMode,
+                        constants.acovaThermostatSystemModes as Record<string | number, string>,
+                    );
                     if (result.system_mode === "off") {
                         result.hvac_action = "off";
                     }


### PR DESCRIPTION
This PR permit to fix :

- Switching to Off Mode on a Thermostat card is displayed as Idle in Home Assistant (system_mode: off/hvac_action: idle)
- Switching back to Heat Mode on a Thermostat card the reset the radiator to 7°C (minimum setpoint) instead of restoring the previous BOX/Zigbee managed mode

Tested on :

- Acova Alcantara 2 (I suppose it's exactly the same for Acova Alcantara 3)

Objective :

- Reproduce correct behavior like on ZHA after my migration from ZHA to Zigbee2MQTT