### PR TITLE
feat: add mpcbstudio devices (mpcb-relay, mpcb-temp)

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -209,6 +209,7 @@ import {definitions as mill} from "./mill";
 import {definitions as mindy} from "./mindy";
 import {definitions as modular} from "./modular";
 import {definitions as moes} from "./moes";
+import {definitions as mpcbstudio} from "./mpcbstudio";
 import {definitions as msh} from "./msh";
 import {definitions as mullerLicht} from "./muller_licht";
 import {definitions as multir} from "./multir";
@@ -584,6 +585,7 @@ const definitions: DefinitionWithExtend[] = [
     ...mindy,
     ...modular,
     ...moes,
+    ...mpcbstudio,
     ...msh,
     ...mullerLicht,
     ...multir,

--- a/src/devices/mpcbstudio.ts
+++ b/src/devices/mpcbstudio.ts
@@ -1,0 +1,19 @@
+import * as m from "../lib/modernExtend";
+import type {DefinitionWithExtend} from "../lib/types";
+
+export const definitions: DefinitionWithExtend[] = [
+    {
+        fingerprint: [{modelID: "mpcb-relay", manufacturerName: "mpcbstudio"}],
+        model: "mpcb-relay",
+        vendor: "mpcbstudio",
+        description: "MPCB Smart Relay (ESP32-C6 Zigbee end device)",
+        extend: [m.onOff({powerOnBehavior: false})],
+    },
+    {
+        fingerprint: [{modelID: "mpcb-temp", manufacturerName: "mpcbstudio"}],
+        model: "mpcb-temp",
+        vendor: "mpcbstudio",
+        description: "MPCB Temperature Sensor (ESP32-C6 Zigbee end device)",
+        extend: [m.temperature()],
+    },
+];


### PR DESCRIPTION
## Summary

- Add device definitions for **mpcbstudio** vendor (ESP32-C6 Zigbee end devices)
- `mpcb-relay` — Smart Relay with on/off control (`modelID: mpcb-relay`, `manufacturerName: mpcbstudio`)
- `mpcb-temp` — Temperature Sensor (`modelID: mpcb-temp`, `manufacturerName: mpcbstudio`)

## Devices

### mpcb-relay
ESP32-C6-based smart relay end device. Uses `ZigbeeLight` endpoint with OnOff cluster. Supports basic on/off switching. `powerOnBehavior: false` (device manages its own power-on state via firmware).

### mpcb-temp
ESP32-C6-based temperature sensor end device. Uses `ZigbeeTempSensor` endpoint with Temperature Measurement cluster. Reports temperature in the range -40..85°C.

## Test plan
- [ ] Device `mpcb-relay` pairs as end device, on/off control works
- [ ] Device `mpcb-temp` pairs as end device, temperature reported correctly
- [ ] Both devices identified by fingerprint `{modelID, manufacturerName}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)