### PR TITLE
fix: Philips 9290022169: Fix color temp range

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1411,7 +1411,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "9290022169",
         vendor: "Philips",
         description: "Hue white ambiance E27 with Bluetooth",
-        extend: [philips.m.light({colorTemp: {range: undefined}})],
+        extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ["LTA004"],


### PR DESCRIPTION
Confirmed on `LTA001` latest fw `1.145.2` `20260209`.
With `undefined` it wrongly defaults to `[150,500]`