### PR TITLE
feat(moes): add countdown + battery_state + error_status to ZWV-YC water valve

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1376,7 +1376,22 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZWV-YC",
         vendor: "Moes",
         description: "Water valve",
-        extend: [m.battery(), m.onOff({powerOnBehavior: false, configureReporting: true})],
+        extend: [tuya.modernExtend.tuyaBase({dp: true, forceTimeUpdates: true})],
+        exposes: [
+            tuya.exposes.errorStatus(),
+            tuya.exposes.switch(),
+            tuya.exposes.batteryState(),
+            tuya.exposes.countdown().withValueMin(0).withValueMax(255).withUnit("minutes").withDescription("Max on time in minutes"),
+        ],
+        meta: {
+            tuyaSendCommand: "sendData",
+            tuyaDatapoints: [
+                [26, "error_status", tuya.valueConverter.raw],
+                [101, "state", tuya.valueConverter.onOff],
+                [111, "countdown", tuya.valueConverter.raw],
+                [115, "battery_state", tuya.valueConverter.batteryState],
+            ],
+        },
     },
     {
         fingerprint: tuya.fingerprint("TS0011", ["_TZ3000_hhiodade"]),


### PR DESCRIPTION
## Summary

The Moes ZWV-YC (TS0049) currently exposes only `state` (switch) + `battery_percentage` via `m.onOff()` + `m.battery()`. The same TS0049 hardware family is supported with a full datapoint mapping (countdown / battery_state / error_status) via the generic `TS0049` "Water valve" definition in `src/devices/tuya.ts`. The MOES-specific definition was missing those mappings.

This PR replaces the minimal `extend` with the full `tuya.modernExtend.tuyaBase` + `tuyaDatapoints` configuration from the generic TS0049 definition, exposing:

| Datapoint | Name | Type |
|---|---|---|
| 26 | `error_status` | raw |
| 101 | `state` | onOff |
| 111 | `countdown` (0-255 min) | raw |
| 115 | `battery_state` | batteryState |

## Why this matters

Without the `countdown` datapoint, users can only schedule irrigation via Home Assistant-side `switch.turn_on` → `delay(N)` → `switch.turn_off`. If HA crashes mid-cycle, the valve stays open and floods the planters. The hardware's native countdown auto-off (used by the generic TS0049 definition) is much safer for irrigation automations.

## Verification

Datapoint layout taken verbatim from the existing generic `TS0049` "Water valve" definition in `src/devices/tuya.ts`. Verified working on `_TZ3000_cjfmu5he` in a personal balcony irrigation setup. Other fingerprints (`_TZ3000_mq4wujmp`, `_TZ3000_5af5r192`, `_TZ3000_ogjpfoyn`) are unchanged in the fingerprint list and presumed identical hardware; please flag if anyone reports otherwise.

`npx tsc --noEmit` and `npm run build` (which runs the indexer) both pass locally.