### PR TITLE
fix: Inovelli: parse mmWave target id as int8 per updated docs

### DIFF
--- a/src/lib/inovelli.ts
+++ b/src/lib/inovelli.ts
@@ -2805,8 +2805,8 @@ const fzLocal = {
         cluster: INOVELLI_MMWAVE_CLUSTER_NAME,
         type: ["commandReportTargetInfo"],
         convert: (model, msg, publish, options, meta) => {
-            // Per Inovelli cluster docs: each target is x,y,z,dop,id as int16 (10 bytes), after targetNum.
-            const stride = 10;
+            // Per Inovelli cluster docs: each target is x,y,z,dop (int16) + id (int8) = 9 bytes, after targetNum.
+            const stride = 9;
             const buf = msg.data.targets;
             const targets: Array<{id: number; x: number; y: number; z: number; dop: number}> = [];
             const count = Math.min(msg.data.targetNum, Math.floor(buf.length / stride));
@@ -2816,7 +2816,7 @@ const fzLocal = {
                 const y = buf.readInt16LE(o + 2);
                 const z = buf.readInt16LE(o + 4);
                 const dop = buf.readInt16LE(o + 6);
-                const id = buf.readInt16LE(o + 8);
+                const id = buf.readInt8(o + 8);
                 targets.push({id, x, y, z, dop});
             }
             return {mmwave_targets: targets};

--- a/test/inovelli.test.ts
+++ b/test/inovelli.test.ts
@@ -1842,12 +1842,12 @@ describe("Inovelli fromZigbee converters", () => {
 
         describe("report_target_info", () => {
             it("should parse a single target from buffer", () => {
-                const buf = Buffer.alloc(10);
+                const buf = Buffer.alloc(9);
                 buf.writeInt16LE(100, 0);
                 buf.writeInt16LE(-50, 2);
                 buf.writeInt16LE(200, 4);
                 buf.writeInt16LE(10, 6);
-                buf.writeInt16LE(1, 8);
+                buf.writeInt8(1, 8);
                 const payload = processFromZigbeeMessage(
                     definition,
                     "manuSpecificInovelliMMWave",
@@ -1861,17 +1861,17 @@ describe("Inovelli fromZigbee converters", () => {
             });
 
             it("should parse two targets from buffer", () => {
-                const buf = Buffer.alloc(20);
+                const buf = Buffer.alloc(18);
                 buf.writeInt16LE(100, 0);
                 buf.writeInt16LE(-50, 2);
                 buf.writeInt16LE(200, 4);
                 buf.writeInt16LE(10, 6);
-                buf.writeInt16LE(1, 8);
-                buf.writeInt16LE(-100, 10);
-                buf.writeInt16LE(50, 12);
-                buf.writeInt16LE(-200, 14);
-                buf.writeInt16LE(20, 16);
-                buf.writeInt16LE(2, 18);
+                buf.writeInt8(1, 8);
+                buf.writeInt16LE(-100, 9);
+                buf.writeInt16LE(50, 11);
+                buf.writeInt16LE(-200, 13);
+                buf.writeInt16LE(20, 15);
+                buf.writeInt8(2, 17);
                 const payload = processFromZigbeeMessage(
                     definition,
                     "manuSpecificInovelliMMWave",
@@ -1888,12 +1888,12 @@ describe("Inovelli fromZigbee converters", () => {
             });
 
             it("should limit targets to buffer capacity when targetNum exceeds it", () => {
-                const buf = Buffer.alloc(10);
+                const buf = Buffer.alloc(9);
                 buf.writeInt16LE(50, 0);
                 buf.writeInt16LE(60, 2);
                 buf.writeInt16LE(70, 4);
                 buf.writeInt16LE(80, 6);
-                buf.writeInt16LE(3, 8);
+                buf.writeInt8(3, 8);
                 const payload = processFromZigbeeMessage(
                     definition,
                     "manuSpecificInovelliMMWave",


### PR DESCRIPTION
## Summary

Fixes #12118

### Background

The pre-#11915 parser used a **9-byte** stride (x/y/z/dop as int16, `id` as uint8), which matched real device traffic on VZM32-SN firmware `100863491`.

[#11915](https://github.com/Koenkk/zigbee-herdsman-converters/pull/11915) changed parsing to a **10-byte** stride (`id` as int16) because [Inovelli’s mmWave cluster documentation](https://help.inovelli.com/en/articles/12773613-blue-series-mmwave-presence-dimmer-switch-advanced-mmwave-configuration#h_af22026e99) incorrectly described `id` as int16 at the time. **Inovelli later corrected the docs** — `id` is int8, so each target is 9 bytes — but the converter change remained and regressed parsing: `Math.floor(buf.length / 10)` is 0 for 9-byte buffers, so `mmwave_targets` was always published as `[]`.

This PR aligns the parser with the corrected documentation and observed firmware behavior again.

### Change

- Restore 9-byte stride per target
- Read `id` with `readInt8` (signed int8 per updated docs)

## Test plan

- [x] `npm test -- test/inovelli.test.ts -t "report_target_info"`
- [x] Pre-commit hook (build + full test suite) passed on commit