### PR TITLE
Add AOYAN AY-204Z white label

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -13541,7 +13541,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-204ZL"],
+        zigbeeModel: ["ZG-204ZL", "AY-204Z"],
         fingerprint: tuya.fingerprint("TS0601", [
             "_TZE200_3towulqd",
             "_TZE200_1ibpyhdc",
@@ -13557,24 +13557,48 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "Luminance motion sensor",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
-        exposes: [
-            e.occupancy(),
-            e.illuminance().withUnit("lx"),
-            e.battery(),
-            e
-                .enum("sensitivity", ea.STATE_SET, ["low", "medium", "high"])
-                .withDescription("PIR sensor sensitivity (refresh and update only while active)"),
-            e
-                .enum("keep_time", ea.STATE_SET, ["10", "30", "60", "120"])
-                .withDescription("PIR keep time in seconds (refresh and update only while active)"),
-            e
-                .numeric("illuminance_interval", ea.STATE_SET)
-                .withValueMin(1)
-                .withValueMax(720)
-                .withValueStep(1)
-                .withUnit("minutes")
-                .withDescription("Brightness acquisition interval (refresh and update only while active)"),
+        whiteLabel: [
+            {
+                model: "AY-204Z",
+                vendor: "AOYAN",
+                description: "Luminance motion sensor",
+                fingerprint: [
+                    {modelID: "AY-204Z", manufacturerName: "AOYAN"},
+                    {modelID: "AY-204Z", manufacturerName: "AOYAN "},
+                    {modelID: "AY-204Z", manufacturerName: "AOYAN  "},
+                ],
+            },
         ],
+        exposes: (device) => {
+            const exposes = [
+                e.occupancy(),
+                e.illuminance().withUnit("lx"),
+                e.battery(),
+                e
+                    .enum("sensitivity", ea.STATE_SET, ["low", "medium", "high"])
+                    .withDescription("PIR sensor sensitivity (refresh and update only while active)"),
+                e
+                    .enum("keep_time", ea.STATE_SET, ["10", "30", "60", "120"])
+                    .withDescription("PIR keep time in seconds (refresh and update only while active)"),
+                e
+                    .numeric("illuminance_interval", ea.STATE_SET)
+                    .withValueMin(1)
+                    .withValueMax(720)
+                    .withValueStep(1)
+                    .withUnit("minutes")
+                    .withDescription("Brightness acquisition interval (refresh and update only while active)"),
+            ];
+    
+            if (!isDummyDevice(device) && device.modelID === "AY-204Z") {
+                const illuminance = exposes.findIndex((expose) => expose.name === "illuminance");
+                if (illuminance !== -1) exposes.splice(illuminance, 1);
+    
+                const illuminanceInterval = exposes.findIndex((expose) => expose.name === "illuminance_interval");
+                if (illuminanceInterval !== -1) exposes.splice(illuminanceInterval, 1);
+            }
+    
+            return exposes;
+        },
         meta: {
             tuyaDatapoints: [
                 [1, "occupancy", tuya.valueConverter.trueFalse0],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -13576,12 +13576,12 @@ export const definitions: DefinitionWithExtend[] = [
                     .withUnit("minutes")
                     .withDescription("Brightness acquisition interval (refresh and update only while active)"),
             ];
-    
+
             if (!isDummyDevice(device) && device.modelID === "AY-204Z") {
                 exposes.splice(5, 1);
                 exposes.splice(1, 1);
             }
-    
+
             return exposes;
         },
         meta: {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -13557,18 +13557,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "Luminance motion sensor",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
-        whiteLabel: [
-            {
-                model: "AY-204Z",
-                vendor: "AOYAN",
-                description: "Luminance motion sensor",
-                fingerprint: [
-                    {modelID: "AY-204Z", manufacturerName: "AOYAN"},
-                    {modelID: "AY-204Z", manufacturerName: "AOYAN "},
-                    {modelID: "AY-204Z", manufacturerName: "AOYAN  "},
-                ],
-            },
-        ],
         exposes: (device) => {
             const exposes = [
                 e.occupancy(),
@@ -13590,11 +13578,8 @@ export const definitions: DefinitionWithExtend[] = [
             ];
     
             if (!isDummyDevice(device) && device.modelID === "AY-204Z") {
-                const illuminance = exposes.findIndex((expose) => expose.name === "illuminance");
-                if (illuminance !== -1) exposes.splice(illuminance, 1);
-    
-                const illuminanceInterval = exposes.findIndex((expose) => expose.name === "illuminance_interval");
-                if (illuminanceInterval !== -1) exposes.splice(illuminanceInterval, 1);
+                exposes.splice(5, 1);
+                exposes.splice(1, 1);
             }
     
             return exposes;
@@ -13627,7 +13612,19 @@ export const definitions: DefinitionWithExtend[] = [
                 [102, "illuminance_interval", tuya.valueConverter.raw],
             ],
         },
-        whiteLabel: [tuya.whitelabel("Nedis", "ZBSM20WT", "Nedis motion sensor", ["_TZE200_s6hzw8g2"])],
+        whiteLabel: [
+            tuya.whitelabel("Nedis", "ZBSM20WT", "Nedis motion sensor", ["_TZE200_s6hzw8g2"]),
+            {
+                model: "AY-204Z",
+                vendor: "AOYAN",
+                description: "Luminance motion sensor",
+                fingerprint: [
+                    {modelID: "AY-204Z", manufacturerName: "AOYAN"},
+                    {modelID: "AY-204Z", manufacturerName: "AOYAN "},
+                    {modelID: "AY-204Z", manufacturerName: "AOYAN  "},
+                ],
+            },
+        ],
     },
     {
         fingerprint: [


### PR DESCRIPTION
Tested with an external converter.

Device information:
- Model: AY-204Z
- Vendor: AOYAN
- Zigbee model: AY-204Z
- Manufacturer name: AOYAN
- Description: Luminance motion sensor

Supported features for AY-204Z:
- Occupancy
- Battery
- PIR sensitivity
- PIR keep time

Illuminance and illuminance_interval are hidden for AY-204Z because they are not working correctly on this variant.