### PR TITLE
Add TS130F _TZE20C_xbexmf8h

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5145,11 +5145,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TS130F_xbexmf8h",
         vendor: "Tuya",
         description: "Blind/curtain motor controller",
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             e.cover().withPosition(),
-            e.enum("moving", ea.STATE, ["UP", "STOP", "DOWN"]).withDescription("Moving direction"),
             e
                 .numeric("calibration_time", ea.STATE)
                 .withUnit("s")
@@ -5162,56 +5160,12 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         meta: {
             tuyaDatapoints: [
-                [
-                    1,
-                    "state",
-                    tuya.valueConverterBasic.lookup({
-                        OPEN: tuya.enum(0),
-                        STOP: tuya.enum(1),
-                        CLOSE: tuya.enum(2),
-                    }),
-                ],
-                [
-                    1,
-                    "moving",
-                    tuya.valueConverterBasic.lookup({
-                        UP: tuya.enum(0),
-                        STOP: tuya.enum(1),
-                        DOWN: tuya.enum(2),
-                    }),
-                ],
+                [1, "state", tuya.valueConverterBasic.lookup({OPEN: tuya.enum(0), STOP: tuya.enum(1), CLOSE: tuya.enum(2)})],
                 [2, "position", tuya.valueConverter.coverPosition],
-                [
-                    3,
-                    "calibration",
-                    tuya.valueConverterBasic.lookup({
-                        ON: tuya.enum(0),
-                        OFF: tuya.enum(1),
-                    }),
-                ],
-                [
-                    8,
-                    "motor_reversal",
-                    tuya.valueConverterBasic.lookup({
-                        OFF: tuya.enum(0),
-                        ON: tuya.enum(1),
-                    }),
-                ],
-                [
-                    10,
-                    "calibration_time",
-                    {
-                        from: (v: number) => v / 10,
-                    },
-                ],
-                [
-                    14,
-                    "backlight_mode",
-                    tuya.valueConverterBasic.lookup({
-                        ON: tuya.enum(0),
-                        OFF: tuya.enum(1),
-                    }),
-                ],
+                [3, "calibration", tuya.valueConverter.onOffEnumOn0],
+                [8, "motor_reversal", tuya.valueConverter.onOffEnumOn1],
+                [10, "calibration_time", {from: (v: number) => v / 10}],
+                [14, "backlight_mode", tuya.valueConverter.onOffEnumOn0],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5141,52 +5141,78 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint('TS130F', ['_TZE20C_xbexmf8h']),
-        model: 'TS130F_xbexmf8h',
-        vendor: 'Tuya',
-        description: 'Blind/curtain motor controller',
+        fingerprint: tuya.fingerprint("TS130F", ["_TZE20C_xbexmf8h"]),
+        model: "TS130F_xbexmf8h",
+        vendor: "Tuya",
+        description: "Blind/curtain motor controller",
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
         onEvent: tuya.onEventSetTime,
         exposes: [
             e.cover().withPosition(),
-            e.enum('moving', ea.STATE, ['UP', 'STOP', 'DOWN'])
-                .withDescription('Moving direction'),
-            e.numeric('calibration_time', ea.STATE)
-                .withUnit('s').withValueStep(0.1)
-                .withDescription('Calibration time measured by motor')
-                .withCategory('diagnostic'),
-            e.binary('motor_reversal', ea.ALL, 'ON', 'OFF')
-                .withDescription('Reverse motor direction')
-                .withCategory('config'),
-            e.binary('calibration', ea.ALL, 'ON', 'OFF')
-                .withDescription('Calibration mode')
-                .withCategory('config'),
-            e.binary('backlight_mode', ea.ALL, 'ON', 'OFF')
-                .withDescription('Switch backlight')
-                .withCategory('config'),
+            e.enum("moving", ea.STATE, ["UP", "STOP", "DOWN"]).withDescription("Moving direction"),
+            e
+                .numeric("calibration_time", ea.STATE)
+                .withUnit("s")
+                .withValueStep(0.1)
+                .withDescription("Calibration time measured by motor")
+                .withCategory("diagnostic"),
+            e.binary("motor_reversal", ea.ALL, "ON", "OFF").withDescription("Reverse motor direction").withCategory("config"),
+            e.binary("calibration", ea.ALL, "ON", "OFF").withDescription("Calibration mode").withCategory("config"),
+            e.binary("backlight_mode", ea.ALL, "ON", "OFF").withDescription("Switch backlight").withCategory("config"),
         ],
         meta: {
             tuyaDatapoints: [
-                [1, 'state', tuya.valueConverterBasic.lookup({
-                    'OPEN': tuya.enum(0), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(2),
-                })],
-                [1, 'moving', tuya.valueConverterBasic.lookup({
-                    'UP': tuya.enum(0), 'STOP': tuya.enum(1), 'DOWN': tuya.enum(2),
-                })],
-                [2, 'position', tuya.valueConverter.coverPosition],
-                [3, 'calibration', tuya.valueConverterBasic.lookup({
-                    'ON': tuya.enum(0), 'OFF': tuya.enum(1),
-                })],
-                [8, 'motor_reversal', tuya.valueConverterBasic.lookup({
-                    'OFF': tuya.enum(0), 'ON': tuya.enum(1),
-                })],
-                [10, 'calibration_time', {
-                    from: (v: number) => v / 10,
-                }],
-                [14, 'backlight_mode', tuya.valueConverterBasic.lookup({
-                    'ON': tuya.enum(0), 'OFF': tuya.enum(1),
-                })],
+                [
+                    1,
+                    "state",
+                    tuya.valueConverterBasic.lookup({
+                        OPEN: tuya.enum(0),
+                        STOP: tuya.enum(1),
+                        CLOSE: tuya.enum(2),
+                    }),
+                ],
+                [
+                    1,
+                    "moving",
+                    tuya.valueConverterBasic.lookup({
+                        UP: tuya.enum(0),
+                        STOP: tuya.enum(1),
+                        DOWN: tuya.enum(2),
+                    }),
+                ],
+                [2, "position", tuya.valueConverter.coverPosition],
+                [
+                    3,
+                    "calibration",
+                    tuya.valueConverterBasic.lookup({
+                        ON: tuya.enum(0),
+                        OFF: tuya.enum(1),
+                    }),
+                ],
+                [
+                    8,
+                    "motor_reversal",
+                    tuya.valueConverterBasic.lookup({
+                        OFF: tuya.enum(0),
+                        ON: tuya.enum(1),
+                    }),
+                ],
+                [
+                    10,
+                    "calibration_time",
+                    {
+                        from: (v: number) => v / 10,
+                    },
+                ],
+                [
+                    14,
+                    "backlight_mode",
+                    tuya.valueConverterBasic.lookup({
+                        ON: tuya.enum(0),
+                        OFF: tuya.enum(1),
+                    }),
+                ],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5141,6 +5141,56 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        fingerprint: tuya.fingerprint('TS130F', ['_TZE20C_xbexmf8h']),
+        model: 'TS130F_xbexmf8h',
+        vendor: 'Tuya',
+        description: 'Blind/curtain motor controller',
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        onEvent: tuya.onEventSetTime,
+        exposes: [
+            e.cover().withPosition(),
+            e.enum('moving', ea.STATE, ['UP', 'STOP', 'DOWN'])
+                .withDescription('Moving direction'),
+            e.numeric('calibration_time', ea.STATE)
+                .withUnit('s').withValueStep(0.1)
+                .withDescription('Calibration time measured by motor')
+                .withCategory('diagnostic'),
+            e.binary('motor_reversal', ea.ALL, 'ON', 'OFF')
+                .withDescription('Reverse motor direction')
+                .withCategory('config'),
+            e.binary('calibration', ea.ALL, 'ON', 'OFF')
+                .withDescription('Calibration mode')
+                .withCategory('config'),
+            e.binary('backlight_mode', ea.ALL, 'ON', 'OFF')
+                .withDescription('Switch backlight')
+                .withCategory('config'),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, 'state', tuya.valueConverterBasic.lookup({
+                    'OPEN': tuya.enum(0), 'STOP': tuya.enum(1), 'CLOSE': tuya.enum(2),
+                })],
+                [1, 'moving', tuya.valueConverterBasic.lookup({
+                    'UP': tuya.enum(0), 'STOP': tuya.enum(1), 'DOWN': tuya.enum(2),
+                })],
+                [2, 'position', tuya.valueConverter.coverPosition],
+                [3, 'calibration', tuya.valueConverterBasic.lookup({
+                    'ON': tuya.enum(0), 'OFF': tuya.enum(1),
+                })],
+                [8, 'motor_reversal', tuya.valueConverterBasic.lookup({
+                    'OFF': tuya.enum(0), 'ON': tuya.enum(1),
+                })],
+                [10, 'calibration_time', {
+                    from: (v: number) => v / 10,
+                }],
+                [14, 'backlight_mode', tuya.valueConverterBasic.lookup({
+                    'ON': tuya.enum(0), 'OFF': tuya.enum(1),
+                })],
+            ],
+        },
+    },
+    {
         zigbeeModel: ["qnazj70", "kjintbl"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_oisqyl4o", "_TZ3000_uim07oem", "_TZE200_js3mgbjb", "_TZE200_7deq70b8", "_TZE204_ptaqh9tk"]),
         model: "TS0601_switch",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5147,7 +5147,6 @@ export const definitions: DefinitionWithExtend[] = [
         description: 'Blind/curtain motor controller',
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
-        onEvent: tuya.onEventSetTime,
         exposes: [
             e.cover().withPosition(),
             e.enum('moving', ea.STATE, ['UP', 'STOP', 'DOWN'])

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1189,6 +1189,8 @@ export const valueConverter = {
     trueFalseEnum0: valueConverterBasic.trueFalse(new Enum(0)),
     trueFalseEnum1: valueConverterBasic.trueFalse(new Enum(1)),
     onOff: valueConverterBasic.lookup({ON: true, OFF: false}),
+    onOffEnumOn1: valueConverterBasic.lookup({ON: new Enum(1), OFF: new Enum(0)}),
+    onOffEnumOn0: valueConverterBasic.lookup({ON: new Enum(0), OFF: new Enum(1)}),
     powerOnBehavior: valueConverterBasic.lookup({off: 0, on: 1, previous: 2}),
     powerOnBehaviorEnum: valueConverterBasic.lookup({off: new Enum(0), on: new Enum(1), previous: new Enum(2)}),
     switchType: valueConverterBasic.lookup({momentary: new Enum(0), toggle: new Enum(1), state: new Enum(2)}),


### PR DESCRIPTION
## Add support for Tuya TS130F `_TZE20C_xbexmf8h` blind/curtain motor controller

### Description
Adds support for a new TS130F subtype with manufacturer name `_TZE20C_xbexmf8h`, a Tuya-based blind/curtain motor controller.

This device uses the `manuSpecificTuya` cluster with the following data points:

| DP | Feature | Type | Values |
|----|---------|------|--------|
| 1 | state / moving | enum | 0=OPEN/UP, 1=STOP, 2=CLOSE/DOWN |
| 2 | position | value | 0–100 |
| 3 | calibration | enum | 0=ON, 1=OFF |
| 8 | motor_reversal | enum | 0=OFF, 1=ON |
| 10 | calibration_time | value | tenths of a second |
| 14 | backlight_mode | enum | 0=ON, 1=OFF |

### Features
**Controls**
- Open / Stop / Close
- Set position by percentage
- Real-time state and position feedback (reports via `commandActiveStatusReport` and `commandActiveStatusReportAlt`)

**Configuration**
- `backlight_mode` — controls the physical switch LED backlight (DP 14)
- `motor_reversal` — reverses the motor direction (DP 8)
- `calibration` — starts/ends the calibration process (DP 3)

**Diagnostics**
- `calibration_time` — travel time measured by the motor during the last calibration, in seconds (DP 10, unit: tenths of a second)

### Testing
Tested on hardware with zigbee2mqtt 2.x. All features verified working including physical button feedback, position reporting, calibration, motor reversal and backlight control.