### PR TITLE
Refactor device specific converters

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2306,30 +2306,6 @@ export const U02I007C01_water_leak: Fz.Converter<"ssIasZone", undefined, "comman
         };
     },
 };
-export const scenes_recall_scene_65024: Fz.Converter<65024, undefined, ["raw"]> = {
-    cluster: 65024,
-    type: ["raw"],
-    convert: (model, msg, publish, options, meta) => {
-        return {action: `scene_${msg.data[msg.data.length - 2] - 9}`};
-    },
-};
-export const adeo_button_65024: Fz.Converter<65024, undefined, ["raw"]> = {
-    cluster: 65024,
-    type: ["raw"],
-    convert: (model, msg, publish, options, meta) => {
-        const clickMapping: KeyValueNumberString = {1: "single", 2: "double", 3: "hold"};
-        return {action: `${clickMapping[msg.data[6]]}`};
-    },
-};
-export const color_stop_raw: Fz.Converter<"lightingColorCtrl", undefined, ["raw"]> = {
-    cluster: "lightingColorCtrl",
-    type: ["raw"],
-    convert: (model, msg, publish, options, meta) => {
-        const payload = {action: postfixWithEndpointName("color_stop", msg, model, meta)};
-        addActionGroup(payload, msg, model);
-        return payload;
-    },
-};
 export const almond_click: Fz.Converter<"ssIasAce", undefined, ["commandArm"]> = {
     cluster: "ssIasAce",
     type: ["commandArm"],

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2458,24 +2458,6 @@ export const ZMCSW032D_cover_position: Fz.Converter<"closuresWindowCovering", un
     },
 };
 // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const STS_PRS_251_presence: Fz.Converter<"genBinaryInput", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genBinaryInput",
-    type: ["attributeReport", "readResponse"],
-    options: [exposes.options.presence_timeout()],
-    convert: (model, msg, publish, options, meta) => {
-        const useOptionsTimeout = options?.presence_timeout != null;
-        const timeout = useOptionsTimeout ? Number(options.presence_timeout) : 100; // 100 seconds by default
-
-        // Stop existing timer because motion is detected and set a new one.
-        clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
-
-        const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
-        globalStore.putValue(msg.endpoint, "timer", timer);
-
-        return {presence: true};
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
 export const CC2530ROUTER_led: Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "genOnOff",
     type: ["attributeReport", "readResponse"],

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2433,24 +2433,6 @@ export const ZMCSW032D_cover_position: Fz.Converter<"closuresWindowCovering", un
         return result;
     },
 };
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const KAMI_contact: Fz.Converter<"ssIasZone", undefined, ["raw"]> = {
-    cluster: "ssIasZone",
-    type: ["raw"],
-    convert: (model, msg, publish, options, meta) => {
-        return {contact: msg.data[7] === 0};
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const KAMI_occupancy: Fz.Converter<"msOccupancySensing", undefined, ["raw"]> = {
-    cluster: "msOccupancySensing",
-    type: ["raw"],
-    convert: (model, msg, publish, options, meta) => {
-        if (msg.data[7] === 1) {
-            return {action: "motion"};
-        }
-    },
-};
 export const tuya_relay_din_led_indicator: Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "genOnOff",
     type: ["attributeReport", "readResponse"],

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -2434,27 +2434,6 @@ export const ZMCSW032D_cover_position: Fz.Converter<"closuresWindowCovering", un
     },
 };
 // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const CC2530ROUTER_led: Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genOnOff",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        return {led: msg.data.onOff === 1};
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const CC2530ROUTER_meta: Fz.Converter<"genBinaryValue", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genBinaryValue",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const data = msg.data;
-        return {
-            description: data.description,
-            type: data.inactiveText,
-            rssi: data.presentValue,
-        };
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
 export const KAMI_contact: Fz.Converter<"ssIasZone", undefined, ["raw"]> = {
     cluster: "ssIasZone",
     type: ["raw"],
@@ -2470,15 +2449,6 @@ export const KAMI_occupancy: Fz.Converter<"msOccupancySensing", undefined, ["raw
         if (msg.data[7] === 1) {
             return {action: "motion"};
         }
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const DNCKAT_S00X_buttons: Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genOnOff",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const action = msg.data.onOff === 1 ? "release" : "hold";
-        return {action: postfixWithEndpointName(action, msg, model, meta)};
     },
 };
 export const tuya_relay_din_led_indicator: Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]> = {

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -2239,13 +2239,6 @@ export const humidity: Tz.Converter = {
 // #endregion
 
 // #region Non-generic converters
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const STS_PRS_251_beep: Tz.Converter = {
-    key: ["beep"],
-    convertSet: async (entity, key, value, meta) => {
-        await entity.command("genIdentify", "identify", {identifytime: value as number}, utils.getOptions(meta.mapped, entity));
-    },
-};
 export const tuya_relay_din_led_indicator: Tz.Converter = {
     key: ["indicator_mode"],
     convertSet: async (entity, key, value, meta) => {

--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -4,7 +4,8 @@ import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import {nodonPilotWire} from "../lib/nodon";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz, Tz} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValueNumberString, Tz} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -23,6 +24,30 @@ const fzLocal = {
             };
         },
     } satisfies Fz.Converter<"ssIasZone", undefined, "commandStatusChangeNotification">,
+    scenes_recall_scene_65024: {
+        cluster: 65024,
+        type: ["raw"],
+        convert: (model, msg, publish, options, meta) => {
+            return {action: `scene_${msg.data[msg.data.length - 2] - 9}`};
+        },
+    } satisfies Fz.Converter<65024, undefined, ["raw"]>,
+    adeo_button_65024: {
+        cluster: 65024,
+        type: ["raw"],
+        convert: (model, msg, publish, options, meta) => {
+            const clickMapping: KeyValueNumberString = {1: "single", 2: "double", 3: "hold"};
+            return {action: `${clickMapping[msg.data[6]]}`};
+        },
+    } satisfies Fz.Converter<65024, undefined, ["raw"]>,
+    color_stop_raw: {
+        cluster: "lightingColorCtrl",
+        type: ["raw"],
+        convert: (model, msg, publish, options, meta) => {
+            const payload = {action: utils.postfixWithEndpointName("color_stop", msg, model, meta)};
+            utils.addActionGroup(payload, msg, model);
+            return payload;
+        },
+    } satisfies Fz.Converter<"lightingColorCtrl", undefined, ["raw"]>,
 };
 
 const tzLocal = {
@@ -272,8 +297,8 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_step_color_temperature,
             fz.command_step_hue,
             fz.command_step_saturation,
-            fz.color_stop_raw,
-            fz.scenes_recall_scene_65024,
+            fzLocal.color_stop_raw,
+            fzLocal.scenes_recall_scene_65024,
         ],
         toZigbee: [],
         exposes: [
@@ -442,7 +467,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "83633204",
         vendor: "ADEO",
         description: "1-key remote control",
-        fromZigbee: [fz.adeo_button_65024, fz.battery],
+        fromZigbee: [fzLocal.adeo_button_65024, fz.battery],
         exposes: [e.action(["single", "double", "hold"]), e.battery()],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/custom_devices_diy.ts
+++ b/src/devices/custom_devices_diy.ts
@@ -256,6 +256,36 @@ const fzLocal = {
             };
         },
     } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    CC2530ROUTER_led: {
+        cluster: "genOnOff",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            return {led: msg.data.onOff === 1};
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    CC2530ROUTER_meta: {
+        cluster: "genBinaryValue",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const data = msg.data;
+            return {
+                description: data.description,
+                type: data.inactiveText,
+                rssi: data.presentValue,
+            };
+        },
+    } satisfies Fz.Converter<"genBinaryValue", undefined, ["attributeReport", "readResponse"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    DNCKAT_S00X_buttons: {
+        cluster: "genOnOff",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const action = msg.data.onOff === 1 ? "release" : "hold";
+            return {action: postfixWithEndpointName(action, msg, model, meta)};
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
 };
 
 function ptvoGetMetaOption(device: Zh.Device | DummyDevice, key: string, defaultValue: unknown) {
@@ -424,7 +454,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "CC2530.ROUTER",
         vendor: "Custom devices (DiY)",
         description: "CC2530 router",
-        fromZigbee: [fz.CC2530ROUTER_led, fz.CC2530ROUTER_meta],
+        fromZigbee: [fzLocal.CC2530ROUTER_led, fzLocal.CC2530ROUTER_meta],
         toZigbee: [tz.ptvo_switch_trigger],
         exposes: [e.binary("led", ea.STATE, true, false)],
     },
@@ -769,7 +799,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DNCKATSW002",
         vendor: "Custom devices (DiY)",
         description: "DNCKAT double key wired wall light switch",
-        fromZigbee: [fz.DNCKAT_S00X_buttons],
+        fromZigbee: [fzLocal.DNCKAT_S00X_buttons],
         extend: [m.deviceEndpoints({endpoints: {left: 1, right: 2}}), m.onOff({endpointNames: ["left", "right"]})],
         exposes: [e.action(["release_left", "hold_left", "release_right", "hold_right"])],
     },
@@ -778,7 +808,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DNCKATSW003",
         vendor: "Custom devices (DiY)",
         description: "DNCKAT triple key wired wall light switch",
-        fromZigbee: [fz.DNCKAT_S00X_buttons],
+        fromZigbee: [fzLocal.DNCKAT_S00X_buttons],
         extend: [m.deviceEndpoints({endpoints: {left: 1, center: 2, right: 3}}), m.onOff({endpointNames: ["left", "center", "right"]})],
         exposes: [e.action(["release_left", "hold_left", "release_right", "hold_right", "release_center", "hold_center"])],
     },
@@ -787,7 +817,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DNCKATSW004",
         vendor: "Custom devices (DiY)",
         description: "DNCKAT quadruple key wired wall light switch",
-        fromZigbee: [fz.DNCKAT_S00X_buttons],
+        fromZigbee: [fzLocal.DNCKAT_S00X_buttons],
         extend: [
             m.deviceEndpoints({endpoints: {bottom_left: 1, bottom_right: 2, top_left: 3, top_right: 4}}),
             m.onOff({endpointNames: ["bottom_left", "bottom_right", "top_left", "top_right"]}),

--- a/src/devices/kami.ts
+++ b/src/devices/kami.ts
@@ -1,8 +1,28 @@
-import * as fz from "../converters/fromZigbee";
 import * as exposes from "../lib/exposes";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, Fz} from "../lib/types";
 
 const e = exposes.presets;
+
+const fzLocal = {
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    KAMI_contact: {
+        cluster: "ssIasZone",
+        type: ["raw"],
+        convert: (model, msg, publish, options, meta) => {
+            return {contact: msg.data[7] === 0};
+        },
+    } satisfies Fz.Converter<"ssIasZone", undefined, ["raw"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    KAMI_occupancy: {
+        cluster: "msOccupancySensing",
+        type: ["raw"],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.data[7] === 1) {
+                return {action: "motion"};
+            }
+        },
+    } satisfies Fz.Converter<"msOccupancySensing", undefined, ["raw"]>,
+};
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -10,7 +30,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "N20",
         vendor: "KAMI",
         description: "Contact sensor or motion sensor",
-        fromZigbee: [fz.KAMI_contact, fz.KAMI_occupancy],
+        fromZigbee: [fzLocal.KAMI_contact, fzLocal.KAMI_occupancy],
         toZigbee: [],
         exposes: [e.contact(), e.action(["motion"])],
     },

--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -6,7 +6,8 @@ import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as globalStore from "../lib/store";
-import type {DefinitionWithExtend, Fz, KeyValue} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValue, Tz} from "../lib/types";
+import * as utils from "../lib/utils";
 import {centraliteExtend, fzLocal as fzCentralite, type ManuSpecificCentraliteHumidity} from "./centralite";
 
 const e = exposes.presets;
@@ -63,6 +64,16 @@ export const smartthingsExtend = {
         }),
 };
 
+const tzLocal = {
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    STS_PRS_251_beep: {
+        key: ["beep"],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.command("genIdentify", "identify", {identifytime: value as number}, utils.getOptions(meta.mapped, entity));
+        },
+    } satisfies Tz.Converter,
+};
+
 export const fzLocal = {
     acceleration: {
         cluster: "manuSpecificSamsungAccelerometer",
@@ -102,6 +113,21 @@ export const fzLocal = {
             return {presence: true};
         },
     } satisfies Fz.Converter<"manuSpecificSmartThingsArrivalSensor", SmartThingsArrivalSensor, "commandArrivalSensorNotify">,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    STS_PRS_251_presence: {
+        cluster: "genBinaryInput",
+        type: ["attributeReport", "readResponse"],
+        options: [exposes.options.presence_timeout()],
+        convert: (model, msg, publish, options, meta) => {
+            const useOptionsTimeout = options?.presence_timeout != null;
+            const timeout = useOptionsTimeout ? Number(options.presence_timeout) : 100; // 100 seconds by default
+            // Stop existing timer because motion is detected and set a new one.
+            clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
+            const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
+            globalStore.putValue(msg.endpoint, "timer", timer);
+            return {presence: true};
+        },
+    } satisfies Fz.Converter<"genBinaryInput", undefined, ["attributeReport", "readResponse"]>,
 };
 
 export const definitions: DefinitionWithExtend[] = [
@@ -128,14 +154,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "STS-PRS-251",
         vendor: "SmartThings",
         description: "Arrival sensor",
-        fromZigbee: [fz.STS_PRS_251_presence, fz.battery, fz.identify],
+        fromZigbee: [fzLocal.STS_PRS_251_presence, fz.battery, fz.identify],
         exposes: [
             e.battery(),
             e.presence(),
             e.action(["identify"]),
             e.enum("beep", ea.SET, ["2", "5", "10", "15", "30"]).withDescription("Trigger beep for x seconds"),
         ],
-        toZigbee: [tz.STS_PRS_251_beep],
+        toZigbee: [tzLocal.STS_PRS_251_beep],
         meta: {battery: {voltageToPercentage: {min: 2500, max: 3000}}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Move devicce specific converters to local files.
Smartthings, Adeo, Kami and CustomDevicesDIY.
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

