### PR TITLE
Move Tuya specific converters from fromZigbee.ts and toZigbee.ts

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -3,7 +3,7 @@ import * as constants from "../lib/constants";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as globalStore from "../lib/store";
-import type {Fz, KeyValue, KeyValueAny, KeyValueNumberString} from "../lib/types";
+import type {Fz, KeyValue, KeyValueAny} from "../lib/types";
 import * as utils from "../lib/utils";
 import {
     addActionGroup,
@@ -1982,41 +1982,6 @@ export const hw_version: Fz.Converter<"genBasic", undefined, ["attributeReport",
 // #endregion
 
 // #region Non-generic converters
-export const tuya_doorbell_button: Fz.Converter<"ssIasZone", undefined, "commandStatusChangeNotification"> = {
-    cluster: "ssIasZone",
-    type: "commandStatusChangeNotification",
-    convert: (model, msg, publish, options, meta) => {
-        if (hasAlreadyProcessedMessage(msg, model)) return;
-        const lookup: KeyValueAny = {1: "pressed"};
-        const zoneStatus = msg.data.zonestatus;
-        return {
-            action: lookup[zoneStatus & 1],
-            tamper: (zoneStatus & (1 << 2)) > 0,
-            battery_low: (zoneStatus & (1 << 3)) > 0,
-        };
-    },
-};
-export const ts0216_siren: Fz.Converter<"ssIasWd", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "ssIasWd",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const result: KeyValueAny = {};
-        if (msg.data.maxDuration !== undefined) result.duration = msg.data.maxDuration;
-        if (msg.data["2"] !== undefined) {
-            result.volume = mapNumberRange(msg.data["2"] as number, 100, 10, 0, 100);
-        }
-
-        if (["_TYZB01_sbpc1zrb"].includes(meta.device.manufacturerName) && typeof msg.data["2"] === "number") {
-            const volData = msg.data["2"];
-            result.volume = volData === 0 ? 0 : mapNumberRange(volData, 100, 33, 1, 100);
-        }
-
-        if (msg.data["61440"] !== undefined) {
-            result.alarm = msg.data["61440"] !== 0;
-        }
-        return result;
-    },
-};
 export const ptvo_switch_uart: Fz.Converter<"genMultistateValue", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "genMultistateValue",
     type: ["attributeReport", "readResponse"],
@@ -2433,22 +2398,6 @@ export const ZMCSW032D_cover_position: Fz.Converter<"closuresWindowCovering", un
         return result;
     },
 };
-export const tuya_relay_din_led_indicator: Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genOnOff",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const property = 0x8001;
-
-        if (msg.data[property] !== undefined) {
-            const dict: KeyValueNumberString = {0: "off", 1: "on_off", 2: "off_on"};
-            const value = msg.data[property] as number;
-
-            if (dict[value] !== undefined) {
-                return {[postfixWithEndpointName("indicator_mode", msg, model, meta)]: dict[value]};
-            }
-        }
-    },
-};
 export const ias_keypad: Fz.Converter<"ssIasZone", undefined, "commandStatusChangeNotification"> = {
     cluster: "ssIasZone",
     type: "commandStatusChangeNotification",
@@ -2552,20 +2501,6 @@ export const sunricher_switch2801K4: Fz.Converter<"greenPower", undefined, ["com
         } else {
             return {action: SUNRICHER_SWITCH2801K4_LOOKUP[commandID]};
         }
-    },
-};
-export const command_stop_move_raw: Fz.Converter<"lightingColorCtrl", undefined, "raw"> = {
-    cluster: "lightingColorCtrl",
-    type: "raw",
-    convert: (model, msg, publish, options, meta) => {
-        // commandStopMove without params
-        if (msg.data[2] !== 71) return;
-        if (hasAlreadyProcessedMessage(msg, model)) return;
-        const movestop = "stop";
-        const action = postfixWithEndpointName(`hue_${movestop}`, msg, model, meta);
-        const payload = {action};
-        addActionGroup(payload, msg, model);
-        return payload;
     },
 };
 // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
@@ -2825,72 +2760,5 @@ export const ias_ace_occupancy_with_timeout: Fz.Converter<"ssIasAce", undefined,
     convert: (model, msg, publish, options, meta) => {
         const newMsg = {...msg, type: "attributeReport" as const, data: {occupancy: 1}};
         return occupancy_with_timeout.convert(model, newMsg, publish, options, meta);
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const ZM35HQ_attr: Fz.Converter<"ssIasZone", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "ssIasZone",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        let result: KeyValueAny = {};
-        const data = msg.data;
-        if (data && data.zoneStatus !== undefined) {
-            const result1 = ias_occupancy_alarm_1_report.convert(model, msg, publish, options, meta);
-            result = {...result1};
-        }
-        if (data && data.currentZoneSensitivityLevel !== undefined) {
-            const senslookup: Record<number, string> = {0: "low", 1: "medium", 2: "high"};
-            result.sensitivity = senslookup[data.currentZoneSensitivityLevel];
-        }
-        if (data && data["61441"] !== undefined) {
-            const keeptimelookup: Record<number, number> = {0: 30, 1: 60, 2: 120};
-            result.keep_time = keeptimelookup[data["61441"] as number];
-        }
-        return result;
-    },
-};
-export const TS110E: Fz.Converter<"genLevelCtrl", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genLevelCtrl",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const result: KeyValue = {};
-        if (msg.data["64515"] !== undefined) {
-            result.min_brightness = utils.mapNumberRange(msg.data["64515"] as number, 0, 1000, 1, 255);
-        }
-        if (msg.data["64516"] !== undefined) {
-            result.max_brightness = utils.mapNumberRange(msg.data["64516"] as number, 0, 1000, 1, 255);
-        }
-        if (msg.data["61440"] !== undefined) {
-            const propertyName = utils.postfixWithEndpointName("brightness", msg, model, meta);
-            result[propertyName] = utils.mapNumberRange(msg.data["61440"] as number, 0, 1000, 0, 255);
-        }
-        return result;
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const TS110E_light_type: Fz.Converter<"genLevelCtrl", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genLevelCtrl",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const result: KeyValue = {};
-        if (msg.data["64514"] !== undefined) {
-            const lookup: Record<number, string> = {0: "led", 1: "incandescent", 2: "halogen"};
-            result.light_type = lookup[msg.data["64514"] as number];
-        }
-        return result;
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const TS110E_switch_type: Fz.Converter<"genLevelCtrl", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "genLevelCtrl",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const result: KeyValue = {};
-        if (msg.data["64514"] !== undefined) {
-            const lookup: Record<number, string> = {0: "momentary", 1: "toggle", 2: "state"};
-            const propertyName = utils.postfixWithEndpointName("switch_type", msg, model, meta);
-            result[propertyName] = lookup[msg.data["64514"] as number];
-        }
-        return result;
     },
 };

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -2239,17 +2239,6 @@ export const humidity: Tz.Converter = {
 // #endregion
 
 // #region Non-generic converters
-export const tuya_relay_din_led_indicator: Tz.Converter = {
-    key: ["indicator_mode"],
-    convertSet: async (entity, key, value, meta) => {
-        utils.assertString(value, key);
-        value = value.toLowerCase();
-        const lookup = {off: 0x00, on_off: 0x01, off_on: 0x02};
-        const payload = utils.getFromLookup(value, lookup);
-        await entity.write("genOnOff", {32769: {value: payload, type: 0x30}});
-        return {state: {indicator_mode: value}};
-    },
-};
 // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
 export const ZMCSW032D_cover_position: Tz.Converter = {
     key: ["position", "tilt"],
@@ -2291,52 +2280,6 @@ export const ZMCSW032D_cover_position: Tz.Converter = {
     convertGet: async (entity, key, meta) => {
         const isPosition = key === "position";
         await entity.read("closuresWindowCovering", [isPosition ? "currentPositionLiftPercentage" : "currentPositionTiltPercentage"]);
-    },
-};
-export const tuya_led_controller: Tz.Converter = {
-    key: ["state", "color"],
-    convertSet: async (entity, key, value, meta) => {
-        if (key === "state") {
-            utils.assertString(value, key);
-            if (value.toLowerCase() === "off") {
-                await entity.command("genOnOff", "offWithEffect", {effectid: 0x01, effectvariant: 0x01}, utils.getOptions(meta.mapped, entity));
-            } else {
-                await entity.command(
-                    "genLevelCtrl",
-                    "moveToLevelWithOnOff",
-                    {level: 255, transtime: 0, optionsMask: 0, optionsOverride: 0},
-                    utils.getOptions(meta.mapped, entity),
-                );
-            }
-            return {state: {state: value.toUpperCase()}};
-        }
-        if (key === "color") {
-            utils.assertObject(value);
-            const hue = utils.mapNumberRange(value.h, 0, 360, 0, 254);
-            const saturation = utils.mapNumberRange(value.s, 0, 100, 0, 254);
-            const transtime = 0;
-            const direction = 0;
-
-            await entity.command(
-                "lightingColorCtrl",
-                "moveToHue",
-                {hue, transtime, direction, optionsMask: 0, optionsOverride: 0},
-                utils.getOptions(meta.mapped, entity),
-            );
-            await entity.command(
-                "lightingColorCtrl",
-                "moveToSaturation",
-                {saturation, transtime, optionsMask: 0, optionsOverride: 0},
-                utils.getOptions(meta.mapped, entity),
-            );
-        }
-    },
-    convertGet: async (entity, key, meta) => {
-        if (key === "state") {
-            await entity.read("genOnOff", ["onOff"]);
-        } else if (key === "color") {
-            await entity.read("lightingColorCtrl", ["currentHue", "currentSaturation"]);
-        }
     },
 };
 export const ptvo_switch_trigger: Tz.Converter = {
@@ -2815,75 +2758,6 @@ export const TS0003_curtain_switch: Tz.Converter = {
         await entity.read("genOnOff", ["onOff"]);
     },
 };
-export const ts0216_duration: Tz.Converter = {
-    key: ["duration"],
-    convertSet: async (entity, key, value, meta) => {
-        await entity.write("ssIasWd", {maxDuration: value as number});
-    },
-    convertGet: async (entity, key, meta) => {
-        await entity.read("ssIasWd", ["maxDuration"]);
-    },
-};
-export const ts0216_volume: Tz.Converter = {
-    key: ["volume"],
-    convertSet: async (entity, key, value, meta) => {
-        utils.assertNumber(value);
-
-        if (["_TYZB01_sbpc1zrb"].includes(meta.device.manufacturerName)) {
-            const volume = value === 0 ? 0 : utils.mapNumberRange(value, 1, 100, 100, 33);
-            await entity.write("ssIasWd", {2: {value: volume, type: 0x20}});
-            return;
-        }
-
-        await entity.write("ssIasWd", {2: {value: utils.mapNumberRange(value, 0, 100, 100, 10), type: 0x20}});
-    },
-    convertGet: async (entity, key, meta) => {
-        await entity.read("ssIasWd", [0x0002]);
-    },
-};
-export const ts0216_alarm: Tz.Converter = {
-    key: ["alarm"],
-    convertSet: async (entity, key, value, meta) => {
-        const info = value ? (2 << 4) + (1 << 2) + 0 : 0;
-
-        await entity.command(
-            "ssIasWd",
-            "startWarning",
-            {startwarninginfo: info, warningduration: 0, strobedutycycle: 0, strobelevel: 3},
-            utils.getOptions(meta.mapped, entity),
-        );
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const ZM35HQ_attr: Tz.Converter = {
-    key: ["sensitivity", "keep_time"],
-    convertSet: async (entity, key, value, meta) => {
-        switch (key) {
-            case "sensitivity":
-                await entity.write("ssIasZone", {currentZoneSensitivityLevel: utils.getFromLookup(value, {low: 0, medium: 1, high: 2})});
-                break;
-            case "keep_time":
-                await entity.write("ssIasZone", {61441: {value: utils.getFromLookup(value, {30: 0, 60: 1, 120: 2}), type: 0x20}});
-                break;
-            default: // Unknown key
-                throw new Error(`Unhandled key ${key}`);
-        }
-    },
-    convertGet: async (entity, key, meta) => {
-        // Apparently, reading values may interfere with a commandStatusChangeNotification for changed occupancy.
-        // Therefore, read "zoneStatus" as well.
-        await entity.read("ssIasZone", ["currentZoneSensitivityLevel", 61441, "zoneStatus"]);
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const TS0210_sensitivity: Tz.Converter = {
-    key: ["sensitivity"],
-    convertSet: async (entity, key, value, meta) => {
-        value = utils.toNumber(value, "sensitivity");
-        await entity.write("ssIasZone", {currentZoneSensitivityLevel: value as number});
-        return {state: {sensitivity: value}};
-    },
-};
 export const dawondns_only_off: Tz.Converter = {
     key: ["state"],
     convertSet: async (entity, key, value, meta) => {
@@ -2976,42 +2850,5 @@ export const ptvo_switch_light_brightness: Tz.Converter = {
             return await light_onoff_brightness.convertGet(entity, key, meta);
         }
         throw new Error("LevelControl not supported on this endpoint.");
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const TS110E_options: Tz.Converter = {
-    key: ["min_brightness", "max_brightness", "light_type", "switch_type"],
-    convertSet: async (entity, key, value, meta) => {
-        let payload = null;
-        if (key === "min_brightness" || key === "max_brightness") {
-            const id = key === "min_brightness" ? 64515 : 64516;
-            payload = {[id]: {value: utils.mapNumberRange(utils.toNumber(value, key), 1, 255, 0, 1000), type: 0x21}};
-        } else if (key === "light_type" || key === "switch_type") {
-            utils.assertString(value, "light_type/switch_type");
-            const lookup: KeyValue = key === "light_type" ? {led: 0, incandescent: 1, halogen: 2} : {momentary: 0, toggle: 1, state: 2};
-            payload = {64514: {value: lookup[value], type: 0x20}};
-        }
-        await entity.write("genLevelCtrl", payload, utils.getOptions(meta.mapped, entity));
-        return {state: {[key]: value}};
-    },
-    convertGet: async (entity, key, meta) => {
-        let id = null;
-        if (key === "min_brightness") id = 64515;
-        if (key === "max_brightness") id = 64516;
-        if (key === "light_type" || key === "switch_type") id = 64514;
-        await entity.read("genLevelCtrl", [id]);
-    },
-};
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-export const TS110E_light_onoff_brightness: Tz.Converter = {
-    ...light_onoff_brightness,
-    convertSet: async (entity, key, value, meta) => {
-        const {message} = meta;
-        if (message.state === "ON" || (typeof message.brightness === "number" && message.brightness > 1)) {
-            // Does not turn off with physical press when turned on with just moveToLevelWithOnOff, required on before.
-            // https://github.com/Koenkk/zigbee2mqtt/issues/15902#issuecomment-1382848150
-            await entity.command("genOnOff", "on", {}, utils.getOptions(meta.mapped, entity));
-        }
-        return await light_onoff_brightness.convertSet(entity, key, value, meta);
     },
 };

--- a/src/devices/cleverio.ts
+++ b/src/devices/cleverio.ts
@@ -14,8 +14,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SA100",
         vendor: "Cleverio",
         description: "Smart siren",
-        fromZigbee: [fz.ts0216_siren, fz.ias_alarm_only_alarm_1, fz.power_source],
-        toZigbee: [tz.warning, tz.ts0216_volume],
+        fromZigbee: [tuya.fz.ts0216_siren, fz.ias_alarm_only_alarm_1, fz.power_source],
+        toZigbee: [tz.warning, tuya.tz.ts0216_volume],
         exposes: [
             e.warning(),
             e.binary("alarm", ea.STATE, true, false),

--- a/src/devices/lidl.ts
+++ b/src/devices/lidl.ts
@@ -6,7 +6,7 @@ import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as globalStore from "../lib/store";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, Fz, KeyValue, Publish, Tz} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValue, KeyValueAny, Publish, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
@@ -21,6 +21,21 @@ const fzLocal = {
             return {action: "on"};
         },
     } satisfies Fz.Converter<"genOnOff", tuya.TuyaGenOnOff, "commandTuyaAction">,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    HG06668_doorbell_button: {
+        cluster: "ssIasZone",
+        type: "commandStatusChangeNotification",
+        convert: (model, msg, publish, options, meta) => {
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            const lookup: KeyValueAny = {1: "pressed"};
+            const zoneStatus = msg.data.zonestatus;
+            return {
+                action: lookup[zoneStatus & 1],
+                tamper: (zoneStatus & (1 << 2)) > 0,
+                battery_low: (zoneStatus & (1 << 3)) > 0,
+            };
+        },
+    } satisfies Fz.Converter<"ssIasZone", undefined, "commandStatusChangeNotification">,
 };
 
 const valueConverterLocal = {
@@ -284,7 +299,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "HG06668",
         vendor: "Lidl",
         description: "Silvercrest smart wireless door bell button",
-        fromZigbee: [fz.battery, fz.tuya_doorbell_button],
+        fromZigbee: [fz.battery, fzLocal.HG06668_doorbell_button],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/qa.ts
+++ b/src/devices/qa.ts
@@ -1,5 +1,4 @@
 import * as fz from "../converters/fromZigbee";
-import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as legacy from "../lib/legacy";
 import * as m from "../lib/modernExtend";
@@ -284,8 +283,8 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "QA",
         description: "Dimmer 1 channel",
         extend: [m.light({powerOnBehavior: false, configureReporting: true, effect: false}), tuya.modernExtend.tuyaMagicPacket()],
-        fromZigbee: [tuya.fz.power_on_behavior_1, fz.TS110E_switch_type, fz.TS110E, fz.on_off],
-        toZigbee: [tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tz.TS110E_options],
+        fromZigbee: [tuya.fz.power_on_behavior_1, tuya.fz.TS110E_switch_type, tuya.fz.TS110E, fz.on_off],
+        toZigbee: [tuya.tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tuya.tz.TS110E_options],
         exposes: [e.power_on_behavior(), tuya.exposes.switchType()],
     },
     {
@@ -299,8 +298,8 @@ export const definitions: DefinitionWithExtend[] = [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
             m.light({endpointNames: ["l1", "l2"], powerOnBehavior: false, configureReporting: true, effect: false}),
         ],
-        fromZigbee: [tuya.fz.power_on_behavior_1, fz.TS110E_switch_type, fz.TS110E, fz.on_off],
-        toZigbee: [tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tz.TS110E_options],
+        fromZigbee: [tuya.fz.power_on_behavior_1, tuya.fz.TS110E_switch_type, tuya.fz.TS110E, fz.on_off],
+        toZigbee: [tuya.tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tuya.tz.TS110E_options],
         exposes: [e.power_on_behavior(), tuya.exposes.switchType()],
     },
     {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1050,6 +1050,36 @@ const tzLocal = {
             }
         },
     } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    ZM35HQ_attr: {
+        key: ["sensitivity", "keep_time"],
+        convertSet: async (entity, key, value, meta) => {
+            switch (key) {
+                case "sensitivity":
+                    await entity.write("ssIasZone", {currentZoneSensitivityLevel: utils.getFromLookup(value, {low: 0, medium: 1, high: 2})});
+                    break;
+                case "keep_time":
+                    await entity.write("ssIasZone", {61441: {value: utils.getFromLookup(value, {30: 0, 60: 1, 120: 2}), type: 0x20}});
+                    break;
+                default: // Unknown key
+                    throw new Error(`Unhandled key ${key}`);
+            }
+        },
+        convertGet: async (entity, key, meta) => {
+            // Apparently, reading values may interfere with a commandStatusChangeNotification for changed occupancy.
+            // Therefore, read "zoneStatus" as well.
+            await entity.read("ssIasZone", ["currentZoneSensitivityLevel", 61441, "zoneStatus"]);
+        },
+    } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS0210_sensitivity: {
+        key: ["sensitivity"],
+        convertSet: async (entity, key, value, meta) => {
+            value = utils.toNumber(value, "sensitivity");
+            await entity.write("ssIasZone", {currentZoneSensitivityLevel: value as number});
+            return {state: {sensitivity: value}};
+        },
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -1646,6 +1676,42 @@ const fzLocal = {
             }
         },
     } satisfies Fz.Converter<"manuSpecificTuya", undefined, ["commandDataReport", "commandDataResponse"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    ZM35HQ_attr: {
+        cluster: "ssIasZone",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            let result: KeyValueAny = {};
+            const data = msg.data;
+            if (data && data.zoneStatus !== undefined) {
+                const result1 = fz.ias_occupancy_alarm_1_report.convert(model, msg, publish, options, meta);
+                result = {...result1};
+            }
+            if (data && data.currentZoneSensitivityLevel !== undefined) {
+                const senslookup: Record<number, string> = {0: "low", 1: "medium", 2: "high"};
+                result.sensitivity = senslookup[data.currentZoneSensitivityLevel];
+            }
+            if (data && data["61441"] !== undefined) {
+                const keeptimelookup: Record<number, number> = {0: 30, 1: 60, 2: 120};
+                result.keep_time = keeptimelookup[data["61441"] as number];
+            }
+            return result;
+        },
+    } satisfies Fz.Converter<"ssIasZone", undefined, ["attributeReport", "readResponse"]>,
+    command_stop_move_raw: {
+        cluster: "lightingColorCtrl",
+        type: "raw",
+        convert: (model, msg, publish, options, meta) => {
+            // commandStopMove without params
+            if (msg.data[2] !== 71) return;
+            if (hasAlreadyProcessedMessage(msg, model)) return;
+            const movestop = "stop";
+            const action = postfixWithEndpointName(`hue_${movestop}`, msg, model, meta);
+            const payload = {action};
+            addActionGroup(payload, msg, model);
+            return payload;
+        },
+    } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
 };
 
 export const definitions: DefinitionWithExtend[] = [
@@ -3856,8 +3922,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZM-35H-Q",
         vendor: "Tuya",
         description: "Motion sensor",
-        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, fz.ZM35HQ_attr, legacy.fromZigbee.ZM35HQ_battery],
-        toZigbee: [tz.ZM35HQ_attr],
+        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery, fzLocal.ZM35HQ_attr, legacy.fromZigbee.ZM35HQ_battery],
+        toZigbee: [tzLocal.ZM35HQ_attr],
         extend: [m.quirkCheckinInterval(15000)],
         exposes: [
             e.occupancy(),
@@ -3875,8 +3941,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "IH012-RT01",
         vendor: "Tuya",
         description: "Motion sensor",
-        fromZigbee: [fz.ZM35HQ_attr, fz.battery],
-        toZigbee: [tz.ZM35HQ_attr],
+        fromZigbee: [fzLocal.ZM35HQ_attr, fz.battery],
+        toZigbee: [tzLocal.ZM35HQ_attr],
         extend: [
             m.quirkCheckinInterval(15000),
             // Occupancy reporting interval is 60s, so allow for one dropped update plus a small safety margin of 5s
@@ -3914,8 +3980,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "IH012-RT02",
         vendor: "Tuya",
         description: "Motion sensor",
-        fromZigbee: [fz.ias_occupancy_alarm_1, fz.ZM35HQ_attr, fz.battery],
-        toZigbee: [tz.ZM35HQ_attr],
+        fromZigbee: [fz.ias_occupancy_alarm_1, fzLocal.ZM35HQ_attr, fz.battery],
+        toZigbee: [tzLocal.ZM35HQ_attr],
         extend: [m.quirkCheckinInterval(15000)],
         exposes: [
             e.occupancy(),
@@ -5688,7 +5754,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Led strip controller HSB",
         extend: [tuyaLight()],
         fromZigbee: [fz.on_off, tuya.fz.led_controller],
-        toZigbee: [tz.tuya_led_controller, tz.ignore_transition, tz.ignore_rate],
+        toZigbee: [tuya.tz.led_controller, tz.ignore_transition, tz.ignore_rate],
     },
     {
         zigbeeModel: ["TS0502A"],
@@ -11203,14 +11269,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TS0216",
         vendor: "Tuya",
         description: "Sound and flash siren",
-        fromZigbee: [fz.ts0216_siren, fz.battery],
+        fromZigbee: [tuya.fz.ts0216_siren, fz.battery],
         exposes: [
             e.battery(),
             e.binary("alarm", ea.STATE_SET, true, false),
             e.numeric("volume", ea.ALL).withValueMin(0).withValueMax(100).withDescription("Volume of siren"),
         ],
         whiteLabel: [tuya.whitelabel("Hejhome", "GKZ-SA141", "Sound and flash siren", ["_TYZB01_sbpc1zrb"])],
-        toZigbee: [tz.ts0216_alarm, tz.ts0216_duration, tz.ts0216_volume],
+        toZigbee: [tuya.tz.ts0216_alarm, tuya.tz.ts0216_duration, tuya.tz.ts0216_volume],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
@@ -11859,7 +11925,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("ONENUO", "TS0210_5oy7cysk", "Vibration sensor", ["'_TZ32101000000_5oy7cysk'"]),
         ],
         fromZigbee: [fz.battery, fz.ias_vibration_alarm_1_with_timeout],
-        toZigbee: [tz.TS0210_sensitivity],
+        toZigbee: [tzLocal.TS0210_sensitivity],
         exposes: [
             e.battery(),
             e.battery_voltage(),
@@ -11880,8 +11946,8 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Din smart relay (with power monitoring)",
         vendor: "Tuya",
         extend: [tuyaBase()],
-        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, tuya.fz.power_outage_memory, fz.tuya_relay_din_led_indicator],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tz.tuya_relay_din_led_indicator],
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, tuya.fz.power_outage_memory, tuya.fz.relay_din_led_indicator],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tuya.tz.relay_din_led_indicator],
         whiteLabel: [{vendor: "MatSee Plus", model: "ATMS1602Z"}],
         ota: true,
         configure: async (device, coordinatorEndpoint) => {
@@ -11916,8 +11982,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TS011F_din_smart_relay_polling",
         description: "Din smart relay (with power monitoring via polling)",
         vendor: "Tuya",
-        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, tuya.fz.power_outage_memory, fz.tuya_relay_din_led_indicator],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tz.tuya_relay_din_led_indicator],
+        fromZigbee: [fz.on_off, fz.electrical_measurement, fz.metering, tuya.fz.power_outage_memory, tuya.fz.relay_din_led_indicator],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tuya.tz.relay_din_led_indicator],
         whiteLabel: [
             tuya.whitelabel("Tongou", "TO-Q-SY1-JZT", "Din smart relay (with power monitoring via polling)", ["_TZ3000_qeuvnohg"]),
             tuya.whitelabel("TOMZN", "TOB9Z-63M", "Din smart relay (with power monitoring via polling)", ["_TZ3000_6l1pjfqe"]),
@@ -11958,8 +12024,8 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Din smart relay (without power monitoring)",
         vendor: "Tuya",
         extend: [tuyaBase()],
-        fromZigbee: [fz.on_off, tuya.fz.power_outage_memory, fz.tuya_relay_din_led_indicator],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tz.tuya_relay_din_led_indicator],
+        fromZigbee: [fz.on_off, tuya.fz.power_outage_memory, tuya.fz.relay_din_led_indicator],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_1, tuya.tz.relay_din_led_indicator],
         whiteLabel: [tuya.whitelabel("Tongou", "TO-Q-SY1-ZT", "Din smart relay (without power monitoring)", ["_TZ3000_gzvniqjb"])],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
@@ -12514,7 +12580,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_toggle,
             fz.command_move_hue,
             fz.command_step_color_temperature,
-            fz.command_stop_move_raw,
+            fzLocal.command_stop_move_raw,
             tuya.fz.multi_action,
             tuya.fz.operation_mode,
             fz.battery,
@@ -13963,8 +14029,8 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "1 channel dimmer",
         extend: [tuyaBase(), m.light({powerOnBehavior: false, configureReporting: true, effect: false}), tuya.modernExtend.tuyaMagicPacket()],
-        fromZigbee: [tuya.fz.power_on_behavior_1, fz.TS110E_switch_type, fz.TS110E, fz.on_off],
-        toZigbee: [tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tz.TS110E_options],
+        fromZigbee: [tuya.fz.power_on_behavior_1, tuya.fz.TS110E_switch_type, tuya.fz.TS110E, fz.on_off],
+        toZigbee: [tuya.tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tuya.tz.TS110E_options],
         exposes: [e.power_on_behavior(), tuya.exposes.switchType(), e.min_brightness(), e.max_brightness()],
         configure: tuya.configureMagicPacket,
     },
@@ -13978,10 +14044,10 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Lonsonho", "QS-Zigbee-D02-TRIAC-LN_1", "1 channel dimmer", ["_TZ3210_ngqk6jia"]),
         ],
         ota: true,
-        fromZigbee: [fz.TS110E, fz.TS110E_light_type, tuya.fz.power_on_behavior_1, fz.on_off],
+        fromZigbee: [tuya.fz.TS110E, tuya.fz.TS110E_light_type, tuya.fz.power_on_behavior_1, fz.on_off],
         toZigbee: [
             tuya.tz.TS110E_onoff_brightness,
-            tz.TS110E_options,
+            tuya.tz.TS110E_options,
             tuya.tz.power_on_behavior_1,
             tz.light_brightness_move,
             tzLocal.ts110eCountdown,
@@ -14011,8 +14077,8 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Ekaza",
         description: "1 channel dimmer",
         extend: [tuyaBase()],
-        fromZigbee: [fz.TS110E, tuya.fz.power_on_behavior_1, fz.on_off],
-        toZigbee: [tuya.tz.TS110E_onoff_brightness, tz.TS110E_options, tuya.tz.power_on_behavior_1, tz.light_brightness_move],
+        fromZigbee: [tuya.fz.TS110E, tuya.fz.power_on_behavior_1, fz.on_off],
+        toZigbee: [tuya.tz.TS110E_onoff_brightness, tuya.tz.TS110E_options, tuya.tz.power_on_behavior_1, tz.light_brightness_move],
         exposes: [e.light_brightness().withMinBrightness().withMaxBrightness(), e.power_on_behavior().withAccess(ea.ALL)],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
@@ -14051,8 +14117,8 @@ export const definitions: DefinitionWithExtend[] = [
                 configureReporting: true,
             }),
         ],
-        fromZigbee: [tuya.fz.power_on_behavior_1, fz.TS110E_switch_type, fz.TS110E],
-        toZigbee: [tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tz.TS110E_options],
+        fromZigbee: [tuya.fz.power_on_behavior_1, tuya.fz.TS110E_switch_type, tuya.fz.TS110E],
+        toZigbee: [tuya.tz.TS110E_light_onoff_brightness, tuya.tz.power_on_behavior_1, tuya.tz.TS110E_options],
         configure: tuya.configureMagicPacket,
         exposes: [
             e.min_brightness().withEndpoint("l1"),
@@ -14071,8 +14137,8 @@ export const definitions: DefinitionWithExtend[] = [
         description: "2 channel dimmer",
         whiteLabel: [tuya.whitelabel("Nedis", "ZBWD20RD", "SmartLife Triac Dimmer", ["_TZ3210_mt5xjoy6"])],
         extend: [tuyaBase()],
-        fromZigbee: [fz.TS110E, fz.TS110E_switch_type, tuya.fz.power_on_behavior_1, fz.on_off],
-        toZigbee: [tuya.tz.TS110E_onoff_brightness, tz.TS110E_options, tuya.tz.power_on_behavior_1, tz.light_brightness_move],
+        fromZigbee: [tuya.fz.TS110E, tuya.fz.TS110E_switch_type, tuya.fz.power_on_behavior_1, fz.on_off],
+        toZigbee: [tuya.tz.TS110E_onoff_brightness, tuya.tz.TS110E_options, tuya.tz.power_on_behavior_1, tz.light_brightness_move],
         meta: {multiEndpoint: true},
         exposes: [
             e.power_on_behavior(),
@@ -18785,9 +18851,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "QS-Zigbee-D04",
         vendor: "LEDRON",
         description: "0-10v dimmer",
-        fromZigbee: [fz.TS110E, fz.on_off],
+        fromZigbee: [tuya.fz.TS110E, fz.on_off],
         extend: [tuyaBase()],
-        toZigbee: [tuya.tz.TS110E_onoff_brightness, tz.TS110E_options, tz.light_brightness_move],
+        toZigbee: [tuya.tz.TS110E_onoff_brightness, tuya.tz.TS110E_options, tz.light_brightness_move],
         whiteLabel: [tuya.whitelabel("Ledron", "QS-Zigbee-D06-DC", "Dimmer 12-36v", ["_TZ3210_hquixjeg"])],
         exposes: [e.light_brightness().withMinBrightness().withMaxBrightness()],
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/woox.ts
+++ b/src/devices/woox.ts
@@ -71,8 +71,8 @@ export const definitions: DefinitionWithExtend[] = [
         model: "R7051",
         vendor: "Woox",
         description: "Smart siren",
-        fromZigbee: [fz.battery, fz.ts0216_siren, fz.ias_alarm_only_alarm_1, fz.power_source],
-        toZigbee: [tz.warning, tz.ts0216_volume, tz.ts0216_duration],
+        fromZigbee: [fz.battery, tuya.fz.ts0216_siren, fz.ias_alarm_only_alarm_1, fz.power_source],
+        toZigbee: [tz.warning, tuya.tz.ts0216_volume, tuya.tz.ts0216_duration],
         exposes: [
             e.battery(),
             e.battery_voltage(),

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -3027,6 +3027,43 @@ const tuyaTz = {
             if (key === "brightness") await entity.read("genLevelCtrl", [61440]);
         },
     } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS110E_options: {
+        key: ["min_brightness", "max_brightness", "light_type", "switch_type"],
+        convertSet: async (entity, key, value, meta) => {
+            let payload = null;
+            if (key === "min_brightness" || key === "max_brightness") {
+                const id = key === "min_brightness" ? 64515 : 64516;
+                payload = {[id]: {value: utils.mapNumberRange(utils.toNumber(value, key), 1, 255, 0, 1000), type: 0x21}};
+            } else if (key === "light_type" || key === "switch_type") {
+                utils.assertString(value, "light_type/switch_type");
+                const lookup: KeyValue = key === "light_type" ? {led: 0, incandescent: 1, halogen: 2} : {momentary: 0, toggle: 1, state: 2};
+                payload = {64514: {value: lookup[value], type: 0x20}};
+            }
+            await entity.write("genLevelCtrl", payload, utils.getOptions(meta.mapped, entity));
+            return {state: {[key]: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            let id = null;
+            if (key === "min_brightness") id = 64515;
+            if (key === "max_brightness") id = 64516;
+            if (key === "light_type" || key === "switch_type") id = 64514;
+            await entity.read("genLevelCtrl", [id]);
+        },
+    } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS110E_light_onoff_brightness: {
+        ...tz.light_onoff_brightness,
+        convertSet: async (entity, key, value, meta) => {
+            const {message} = meta;
+            if (message.state === "ON" || (typeof message.brightness === "number" && message.brightness > 1)) {
+                // Does not turn off with physical press when turned on with just moveToLevelWithOnOff, required on before.
+                // https://github.com/Koenkk/zigbee2mqtt/issues/15902#issuecomment-1382848150
+                await entity.command("genOnOff", "on", {}, utils.getOptions(meta.mapped, entity));
+            }
+            return await tz.light_onoff_brightness.convertSet(entity, key, value, meta);
+        },
+    } satisfies Tz.Converter,
     cover_reversal: {
         key: ["motor_reversal"],
         convertSet: async (entity, key, value, meta) => {
@@ -3218,6 +3255,102 @@ const tuyaTz = {
                 "tuyaRgbMode",
                 "colorTemperature",
             ]);
+        },
+    } satisfies Tz.Converter,
+    relay_din_led_indicator: {
+        key: ["indicator_mode"],
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertString(value, key);
+            value = value.toLowerCase();
+            const lookup = {off: 0x00, on_off: 0x01, off_on: 0x02};
+            const payload = utils.getFromLookup(value, lookup);
+            await entity.write("genOnOff", {32769: {value: payload, type: 0x30}});
+            return {state: {indicator_mode: value}};
+        },
+    } satisfies Tz.Converter,
+    led_controller: {
+        key: ["state", "color"],
+        convertSet: async (entity, key, value, meta) => {
+            if (key === "state") {
+                utils.assertString(value, key);
+                if (value.toLowerCase() === "off") {
+                    await entity.command("genOnOff", "offWithEffect", {effectid: 0x01, effectvariant: 0x01}, utils.getOptions(meta.mapped, entity));
+                } else {
+                    await entity.command(
+                        "genLevelCtrl",
+                        "moveToLevelWithOnOff",
+                        {level: 255, transtime: 0, optionsMask: 0, optionsOverride: 0},
+                        utils.getOptions(meta.mapped, entity),
+                    );
+                }
+                return {state: {state: value.toUpperCase()}};
+            }
+            if (key === "color") {
+                utils.assertObject(value);
+                const hue = utils.mapNumberRange(value.h, 0, 360, 0, 254);
+                const saturation = utils.mapNumberRange(value.s, 0, 100, 0, 254);
+                const transtime = 0;
+                const direction = 0;
+
+                await entity.command(
+                    "lightingColorCtrl",
+                    "moveToHue",
+                    {hue, transtime, direction, optionsMask: 0, optionsOverride: 0},
+                    utils.getOptions(meta.mapped, entity),
+                );
+                await entity.command(
+                    "lightingColorCtrl",
+                    "moveToSaturation",
+                    {saturation, transtime, optionsMask: 0, optionsOverride: 0},
+                    utils.getOptions(meta.mapped, entity),
+                );
+            }
+        },
+        convertGet: async (entity, key, meta) => {
+            if (key === "state") {
+                await entity.read("genOnOff", ["onOff"]);
+            } else if (key === "color") {
+                await entity.read("lightingColorCtrl", ["currentHue", "currentSaturation"]);
+            }
+        },
+    } satisfies Tz.Converter,
+    ts0216_duration: {
+        key: ["duration"],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write("ssIasWd", {maxDuration: value as number});
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read("ssIasWd", ["maxDuration"]);
+        },
+    } satisfies Tz.Converter,
+    ts0216_volume: {
+        key: ["volume"],
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertNumber(value);
+
+            if (["_TYZB01_sbpc1zrb"].includes(meta.device.manufacturerName)) {
+                const volume = value === 0 ? 0 : utils.mapNumberRange(value, 1, 100, 100, 33);
+                await entity.write("ssIasWd", {2: {value: volume, type: 0x20}});
+                return;
+            }
+
+            await entity.write("ssIasWd", {2: {value: utils.mapNumberRange(value, 0, 100, 100, 10), type: 0x20}});
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read("ssIasWd", [0x0002]);
+        },
+    } satisfies Tz.Converter,
+    ts0216_alarm: {
+        key: ["alarm"],
+        convertSet: async (entity, key, value, meta) => {
+            const info = value ? (2 << 4) + (1 << 2) + 0 : 0;
+
+            await entity.command(
+                "ssIasWd",
+                "startWarning",
+                {startwarninginfo: info, warningduration: 0, strobedutycycle: 0, strobelevel: 3},
+                utils.getOptions(meta.mapped, entity),
+            );
         },
     } satisfies Tz.Converter,
 };
@@ -3628,6 +3761,88 @@ const tuyaFz = {
             return Object.assign(result, libColor.syncColorState(result, meta.state, msg.endpoint, options, epPostfix));
         },
     } satisfies Fz.Converter<"lightingColorCtrl", TuyaLightingColorCtrl, ["attributeReport", "readResponse"]>,
+    relay_din_led_indicator: {
+        cluster: "genOnOff",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const property = 0x8001;
+
+            if (msg.data[property] !== undefined) {
+                const dict: KeyValueNumberString = {0: "off", 1: "on_off", 2: "off_on"};
+                const value = msg.data[property] as number;
+
+                if (dict[value] !== undefined) {
+                    return {[utils.postfixWithEndpointName("indicator_mode", msg, model, meta)]: dict[value]};
+                }
+            }
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
+    TS110E: {
+        cluster: "genLevelCtrl",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValue = {};
+            if (msg.data["64515"] !== undefined) {
+                result.min_brightness = utils.mapNumberRange(msg.data["64515"] as number, 0, 1000, 1, 255);
+            }
+            if (msg.data["64516"] !== undefined) {
+                result.max_brightness = utils.mapNumberRange(msg.data["64516"] as number, 0, 1000, 1, 255);
+            }
+            if (msg.data["61440"] !== undefined) {
+                const propertyName = utils.postfixWithEndpointName("brightness", msg, model, meta);
+                result[propertyName] = utils.mapNumberRange(msg.data["61440"] as number, 0, 1000, 0, 255);
+            }
+            return result;
+        },
+    } satisfies Fz.Converter<"genLevelCtrl", undefined, ["attributeReport", "readResponse"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS110E_light_type: {
+        cluster: "genLevelCtrl",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValue = {};
+            if (msg.data["64514"] !== undefined) {
+                const lookup: Record<number, string> = {0: "led", 1: "incandescent", 2: "halogen"};
+                result.light_type = lookup[msg.data["64514"] as number];
+            }
+            return result;
+        },
+    } satisfies Fz.Converter<"genLevelCtrl", undefined, ["attributeReport", "readResponse"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS110E_switch_type: {
+        cluster: "genLevelCtrl",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValue = {};
+            if (msg.data["64514"] !== undefined) {
+                const lookup: Record<number, string> = {0: "momentary", 1: "toggle", 2: "state"};
+                const propertyName = utils.postfixWithEndpointName("switch_type", msg, model, meta);
+                result[propertyName] = lookup[msg.data["64514"] as number];
+            }
+            return result;
+        },
+    } satisfies Fz.Converter<"genLevelCtrl", undefined, ["attributeReport", "readResponse"]>,
+    ts0216_siren: {
+        cluster: "ssIasWd",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const result: KeyValueAny = {};
+            if (msg.data.maxDuration !== undefined) result.duration = msg.data.maxDuration;
+            if (msg.data["2"] !== undefined) {
+                result.volume = utils.mapNumberRange(msg.data["2"] as number, 100, 10, 0, 100);
+            }
+
+            if (["_TYZB01_sbpc1zrb"].includes(meta.device.manufacturerName) && typeof msg.data["2"] === "number") {
+                const volData = msg.data["2"];
+                result.volume = volData === 0 ? 0 : utils.mapNumberRange(volData, 100, 33, 1, 100);
+            }
+
+            if (msg.data["61440"] !== undefined) {
+                result.alarm = msg.data["61440"] !== 0;
+            }
+            return result;
+        },
+    } satisfies Fz.Converter<"ssIasWd", undefined, ["attributeReport", "readResponse"]>,
 };
 
 export {tuyaFz as fz};


### PR DESCRIPTION
Moved Tuya-related converters from the generic `fromZigbee.ts` and `toZigbee.ts` files into the Tuya-specific library `(lib/tuya.ts`) and device file (`devices/tuya.ts`).
`fz.tuya_doorbell_button` renamed to `HG06668_doorbell_button` and moved to `devices/lidl.ts`.
Devices updated with new references for converters.
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

