### PR TITLE
Add FrankEver FK-BV05 device support

### DIFF
--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -1,6 +1,7 @@
 import * as exposes from "../lib/exposes";
 import * as legacy from "../lib/legacy";
 import * as tuya from "../lib/tuya";
+import {onEvent as tuyaOnEvent} from "../lib/tuya";
 import type {DefinitionWithExtend} from "../lib/types";
 
 const e = exposes.presets;
@@ -37,27 +38,16 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee smart water valve with flow meter and temperature sensor",
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
-        onEvent: tuya.onEvent,
+        onEvent: tuyaOnEvent,
         configure: tuya.configureMagicPacket,
         exposes: [
             // --- Valve Controls ---
             e.switch().setAccess("state", ea.STATE_SET),
-            e
-                .numeric("threshold", ea.STATE_SET)
-                .withUnit("%")
-                .withValueMin(0)
-                .withValueMax(100)
-                .withValueStep(10)
-                .withDescription("Target valve opening percentage"),
+            e.numeric("threshold", ea.STATE_SET).withUnit("%").withValueMin(0).withValueMax(100).withValueStep(10).withDescription("Target valve opening percentage"),
             e.numeric("position", ea.STATE).withUnit("%").withDescription("Current valve position"),
             e.enum("power_off_state", ea.STATE_SET, ["off", "on", "maintain"]).withDescription("Power-off status behavior"),
             e.enum("weather_delay", ea.STATE_SET, ["cancel", "24h", "48h", "72h"]).withDescription("Weather delay"),
-            e
-                .numeric("countdown", ea.STATE_SET)
-                .withUnit("s")
-                .withValueMin(0)
-                .withValueMax(86400)
-                .withDescription("Irrigation Duration (countdown in seconds)"),
+            e.numeric("countdown", ea.STATE_SET).withUnit("s").withValueMin(0).withValueMax(86400).withDescription("Irrigation Duration (countdown in seconds)"),
 
             // --- Sensors ---
             e.numeric("water_temperature", ea.STATE).withUnit("°C").withDescription("Water temperature"),
@@ -67,46 +57,19 @@ export const definitions: DefinitionWithExtend[] = [
 
             // --- Irrigation Volume Limits ---
             e.binary("single_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable single irrigation volume limit"),
-            e
-                .numeric("single_irrigation_set", ea.STATE_SET)
-                .withUnit("L")
-                .withValueMin(0)
-                .withValueMax(1000)
-                .withDescription("Single irrigation water volume setting"),
+            e.numeric("single_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Single irrigation water volume setting"),
             e.binary("day_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable daily irrigation volume limit"),
-            e
-                .numeric("day_irrigation_set", ea.STATE_SET)
-                .withUnit("L")
-                .withValueMin(0)
-                .withValueMax(1000)
-                .withDescription("Daily irrigation water volume setting"),
+            e.numeric("day_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Daily irrigation water volume setting"),
 
             // --- Alarms and Thresholds ---
             e.binary("water_volume_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water volume alarm switch"),
-            e
-                .numeric("water_volume_alarm_set", ea.STATE_SET)
-                .withUnit("L")
-                .withValueMin(0)
-                .withValueMax(1000)
-                .withDescription("Alarm water volume setting value"),
+            e.numeric("water_volume_alarm_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Alarm water volume setting value"),
             e.binary("water_temp_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water temperature alarm switch"),
-            e
-                .numeric("water_temp_alarm_max", ea.STATE_SET)
-                .withUnit("°C")
-                .withValueMin(0)
-                .withValueMax(120)
-                .withDescription("Alarm water temperature maximum setting"),
-            e
-                .numeric("water_temp_alarm_min", ea.STATE_SET)
-                .withUnit("°C")
-                .withValueMin(0)
-                .withValueMax(120)
-                .withDescription("Alarm water temperature minimum setting"),
-
+            e.numeric("water_temp_alarm_max", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature maximum setting"),
+            e.numeric("water_temp_alarm_min", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature minimum setting"),
+            
             // --- Maintenance ---
-            e
-                .binary("creep_switch", ea.STATE_SET, "ON", "OFF")
-                .withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
+            e.binary("creep_switch", ea.STATE_SET, "ON", "OFF").withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
         ],
         meta: {
             tuyaDatapoints: [
@@ -115,10 +78,10 @@ export const definitions: DefinitionWithExtend[] = [
                 [3, "position", tuya.valueConverter.raw],
                 [5, "water_consumed_last", tuya.valueConverter.raw],
                 [6, "water_consumed_total", tuya.valueConverter.raw],
-                [10, "weather_delay", tuya.valueConverterBasic.lookup({cancel: 0, "24h": 1, "48h": 2, "72h": 3})],
+                [10, "weather_delay", tuya.valueConverterBasic.lookup({"cancel": 0, "24h": 1, "48h": 2, "72h": 3})],
                 [11, "countdown", tuya.valueConverter.raw],
                 [22, "water_temperature", tuya.valueConverter.raw],
-                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({water_leakage_yes: 0, water_leakage_no: 1})],
+                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({"water_leakage_yes": 0, "water_leakage_no": 1})], 
                 [102, "single_irrigation_switch", tuya.valueConverter.onOff],
                 [103, "single_irrigation_set", tuya.valueConverter.raw],
                 [104, "day_irrigation_switch", tuya.valueConverter.onOff],
@@ -127,7 +90,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [107, "water_volume_alarm_set", tuya.valueConverter.raw],
                 [108, "water_temp_alarm_switch", tuya.valueConverter.onOff],
                 [109, "water_temp_alarm_max", tuya.valueConverter.raw],
-                [110, "power_off_state", tuya.valueConverterBasic.lookup({off: 0, on: 1, maintain: 2})],
+                [110, "power_off_state", tuya.valueConverterBasic.lookup({"off": 0, "on": 1, "maintain": 2})],
                 [112, "creep_switch", tuya.valueConverter.onOff],
                 [113, "water_temp_alarm_min", tuya.valueConverter.raw],
             ],

--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -43,11 +43,22 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             // --- Valve Controls ---
             e.switch().setAccess("state", ea.STATE_SET),
-            e.numeric("threshold", ea.STATE_SET).withUnit("%").withValueMin(0).withValueMax(100).withValueStep(10).withDescription("Target valve opening percentage"),
+            e
+                .numeric("threshold", ea.STATE_SET)
+                .withUnit("%")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(10)
+                .withDescription("Target valve opening percentage"),
             e.numeric("position", ea.STATE).withUnit("%").withDescription("Current valve position"),
             e.enum("power_off_state", ea.STATE_SET, ["off", "on", "maintain"]).withDescription("Power-off status behavior"),
             e.enum("weather_delay", ea.STATE_SET, ["cancel", "24h", "48h", "72h"]).withDescription("Weather delay"),
-            e.numeric("countdown", ea.STATE_SET).withUnit("s").withValueMin(0).withValueMax(86400).withDescription("Irrigation Duration (countdown in seconds)"),
+            e
+                .numeric("countdown", ea.STATE_SET)
+                .withUnit("s")
+                .withValueMin(0)
+                .withValueMax(86400)
+                .withDescription("Irrigation Duration (countdown in seconds)"),
 
             // --- Sensors ---
             e.numeric("water_temperature", ea.STATE).withUnit("°C").withDescription("Water temperature"),
@@ -57,19 +68,46 @@ export const definitions: DefinitionWithExtend[] = [
 
             // --- Irrigation Volume Limits ---
             e.binary("single_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable single irrigation volume limit"),
-            e.numeric("single_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Single irrigation water volume setting"),
+            e
+                .numeric("single_irrigation_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Single irrigation water volume setting"),
             e.binary("day_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable daily irrigation volume limit"),
-            e.numeric("day_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Daily irrigation water volume setting"),
+            e
+                .numeric("day_irrigation_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Daily irrigation water volume setting"),
 
             // --- Alarms and Thresholds ---
             e.binary("water_volume_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water volume alarm switch"),
-            e.numeric("water_volume_alarm_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Alarm water volume setting value"),
+            e
+                .numeric("water_volume_alarm_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Alarm water volume setting value"),
             e.binary("water_temp_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water temperature alarm switch"),
-            e.numeric("water_temp_alarm_max", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature maximum setting"),
-            e.numeric("water_temp_alarm_min", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature minimum setting"),
-            
+            e
+                .numeric("water_temp_alarm_max", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(0)
+                .withValueMax(120)
+                .withDescription("Alarm water temperature maximum setting"),
+            e
+                .numeric("water_temp_alarm_min", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(0)
+                .withValueMax(120)
+                .withDescription("Alarm water temperature minimum setting"),
+
             // --- Maintenance ---
-            e.binary("creep_switch", ea.STATE_SET, "ON", "OFF").withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
+            e
+                .binary("creep_switch", ea.STATE_SET, "ON", "OFF")
+                .withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
         ],
         meta: {
             tuyaDatapoints: [
@@ -78,10 +116,10 @@ export const definitions: DefinitionWithExtend[] = [
                 [3, "position", tuya.valueConverter.raw],
                 [5, "water_consumed_last", tuya.valueConverter.raw],
                 [6, "water_consumed_total", tuya.valueConverter.raw],
-                [10, "weather_delay", tuya.valueConverterBasic.lookup({"cancel": 0, "24h": 1, "48h": 2, "72h": 3})],
+                [10, "weather_delay", tuya.valueConverterBasic.lookup({cancel: 0, "24h": 1, "48h": 2, "72h": 3})],
                 [11, "countdown", tuya.valueConverter.raw],
                 [22, "water_temperature", tuya.valueConverter.raw],
-                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({"water_leakage_yes": 0, "water_leakage_no": 1})], 
+                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({water_leakage_yes: 0, water_leakage_no: 1})],
                 [102, "single_irrigation_switch", tuya.valueConverter.onOff],
                 [103, "single_irrigation_set", tuya.valueConverter.raw],
                 [104, "day_irrigation_switch", tuya.valueConverter.onOff],
@@ -90,7 +128,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [107, "water_volume_alarm_set", tuya.valueConverter.raw],
                 [108, "water_temp_alarm_switch", tuya.valueConverter.onOff],
                 [109, "water_temp_alarm_max", tuya.valueConverter.raw],
-                [110, "power_off_state", tuya.valueConverterBasic.lookup({"off": 0, "on": 1, "maintain": 2})],
+                [110, "power_off_state", tuya.valueConverterBasic.lookup({off: 0, on: 1, maintain: 2})],
                 [112, "creep_switch", tuya.valueConverter.onOff],
                 [113, "water_temp_alarm_min", tuya.valueConverter.raw],
             ],

--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -41,11 +41,22 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             // --- Valve Controls ---
             e.switch().setAccess("state", ea.STATE_SET),
-            e.numeric("threshold", ea.STATE_SET).withUnit("%").withValueMin(0).withValueMax(100).withValueStep(10).withDescription("Target valve opening percentage"),
+            e
+                .numeric("threshold", ea.STATE_SET)
+                .withUnit("%")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(10)
+                .withDescription("Target valve opening percentage"),
             e.numeric("position", ea.STATE).withUnit("%").withDescription("Current valve position"),
             e.enum("power_off_state", ea.STATE_SET, ["off", "on", "maintain"]).withDescription("Power-off status behavior"),
             e.enum("weather_delay", ea.STATE_SET, ["cancel", "24h", "48h", "72h"]).withDescription("Weather delay"),
-            e.numeric("countdown", ea.STATE_SET).withUnit("s").withValueMin(0).withValueMax(86400).withDescription("Irrigation Duration (countdown in seconds)"),
+            e
+                .numeric("countdown", ea.STATE_SET)
+                .withUnit("s")
+                .withValueMin(0)
+                .withValueMax(86400)
+                .withDescription("Irrigation Duration (countdown in seconds)"),
 
             // --- Sensors ---
             e.numeric("water_temperature", ea.STATE).withUnit("°C").withDescription("Water temperature"),
@@ -55,19 +66,46 @@ export const definitions: DefinitionWithExtend[] = [
 
             // --- Irrigation Volume Limits ---
             e.binary("single_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable single irrigation volume limit"),
-            e.numeric("single_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Single irrigation water volume setting"),
+            e
+                .numeric("single_irrigation_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Single irrigation water volume setting"),
             e.binary("day_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable daily irrigation volume limit"),
-            e.numeric("day_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Daily irrigation water volume setting"),
+            e
+                .numeric("day_irrigation_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Daily irrigation water volume setting"),
 
             // --- Alarms and Thresholds ---
             e.binary("water_volume_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water volume alarm switch"),
-            e.numeric("water_volume_alarm_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Alarm water volume setting value"),
+            e
+                .numeric("water_volume_alarm_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Alarm water volume setting value"),
             e.binary("water_temp_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water temperature alarm switch"),
-            e.numeric("water_temp_alarm_max", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature maximum setting"),
-            e.numeric("water_temp_alarm_min", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature minimum setting"),
-            
+            e
+                .numeric("water_temp_alarm_max", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(0)
+                .withValueMax(120)
+                .withDescription("Alarm water temperature maximum setting"),
+            e
+                .numeric("water_temp_alarm_min", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(0)
+                .withValueMax(120)
+                .withDescription("Alarm water temperature minimum setting"),
+
             // --- Maintenance ---
-            e.binary("creep_switch", ea.STATE_SET, "ON", "OFF").withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
+            e
+                .binary("creep_switch", ea.STATE_SET, "ON", "OFF")
+                .withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
         ],
         meta: {
             tuyaDatapoints: [
@@ -76,10 +114,10 @@ export const definitions: DefinitionWithExtend[] = [
                 [3, "position", tuya.valueConverter.raw],
                 [5, "water_consumed_last", tuya.valueConverter.raw],
                 [6, "water_consumed_total", tuya.valueConverter.raw],
-                [10, "weather_delay", tuya.valueConverterBasic.lookup({"cancel": 0, "24h": 1, "48h": 2, "72h": 3})],
+                [10, "weather_delay", tuya.valueConverterBasic.lookup({cancel: 0, "24h": 1, "48h": 2, "72h": 3})],
                 [11, "countdown", tuya.valueConverter.raw],
                 [22, "water_temperature", tuya.valueConverter.raw],
-                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({"water_leakage_yes": 0, "water_leakage_no": 1})], 
+                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({water_leakage_yes: 0, water_leakage_no: 1})],
                 [102, "single_irrigation_switch", tuya.valueConverter.onOff],
                 [103, "single_irrigation_set", tuya.valueConverter.raw],
                 [104, "day_irrigation_switch", tuya.valueConverter.onOff],
@@ -88,7 +126,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [107, "water_volume_alarm_set", tuya.valueConverter.raw],
                 [108, "water_temp_alarm_switch", tuya.valueConverter.onOff],
                 [109, "water_temp_alarm_max", tuya.valueConverter.raw],
-                [110, "power_off_state", tuya.valueConverterBasic.lookup({"off": 0, "on": 1, "maintain": 2})],
+                [110, "power_off_state", tuya.valueConverterBasic.lookup({off: 0, on: 1, maintain: 2})],
                 [112, "creep_switch", tuya.valueConverter.onOff],
                 [113, "water_temp_alarm_min", tuya.valueConverter.raw],
             ],

--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -37,7 +37,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee smart water valve with flow meter and temperature sensor",
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
-        onEvent: tuya.onEventSetLocalTime,
+        onEvent: tuya.onEvent,
         configure: tuya.configureMagicPacket,
         exposes: [
             // --- Valve Controls ---

--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -1,7 +1,6 @@
 import * as exposes from "../lib/exposes";
 import * as legacy from "../lib/legacy";
 import * as tuya from "../lib/tuya";
-import {onEvent as tuyaOnEvent} from "../lib/tuya";
 import type {DefinitionWithExtend} from "../lib/types";
 
 const e = exposes.presets;
@@ -38,27 +37,15 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee smart water valve with flow meter and temperature sensor",
         fromZigbee: [tuya.fz.datapoints],
         toZigbee: [tuya.tz.datapoints],
-        onEvent: tuyaOnEvent,
         configure: tuya.configureMagicPacket,
         exposes: [
             // --- Valve Controls ---
             e.switch().setAccess("state", ea.STATE_SET),
-            e
-                .numeric("threshold", ea.STATE_SET)
-                .withUnit("%")
-                .withValueMin(0)
-                .withValueMax(100)
-                .withValueStep(10)
-                .withDescription("Target valve opening percentage"),
+            e.numeric("threshold", ea.STATE_SET).withUnit("%").withValueMin(0).withValueMax(100).withValueStep(10).withDescription("Target valve opening percentage"),
             e.numeric("position", ea.STATE).withUnit("%").withDescription("Current valve position"),
             e.enum("power_off_state", ea.STATE_SET, ["off", "on", "maintain"]).withDescription("Power-off status behavior"),
             e.enum("weather_delay", ea.STATE_SET, ["cancel", "24h", "48h", "72h"]).withDescription("Weather delay"),
-            e
-                .numeric("countdown", ea.STATE_SET)
-                .withUnit("s")
-                .withValueMin(0)
-                .withValueMax(86400)
-                .withDescription("Irrigation Duration (countdown in seconds)"),
+            e.numeric("countdown", ea.STATE_SET).withUnit("s").withValueMin(0).withValueMax(86400).withDescription("Irrigation Duration (countdown in seconds)"),
 
             // --- Sensors ---
             e.numeric("water_temperature", ea.STATE).withUnit("°C").withDescription("Water temperature"),
@@ -68,46 +55,19 @@ export const definitions: DefinitionWithExtend[] = [
 
             // --- Irrigation Volume Limits ---
             e.binary("single_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable single irrigation volume limit"),
-            e
-                .numeric("single_irrigation_set", ea.STATE_SET)
-                .withUnit("L")
-                .withValueMin(0)
-                .withValueMax(1000)
-                .withDescription("Single irrigation water volume setting"),
+            e.numeric("single_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Single irrigation water volume setting"),
             e.binary("day_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable daily irrigation volume limit"),
-            e
-                .numeric("day_irrigation_set", ea.STATE_SET)
-                .withUnit("L")
-                .withValueMin(0)
-                .withValueMax(1000)
-                .withDescription("Daily irrigation water volume setting"),
+            e.numeric("day_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Daily irrigation water volume setting"),
 
             // --- Alarms and Thresholds ---
             e.binary("water_volume_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water volume alarm switch"),
-            e
-                .numeric("water_volume_alarm_set", ea.STATE_SET)
-                .withUnit("L")
-                .withValueMin(0)
-                .withValueMax(1000)
-                .withDescription("Alarm water volume setting value"),
+            e.numeric("water_volume_alarm_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Alarm water volume setting value"),
             e.binary("water_temp_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water temperature alarm switch"),
-            e
-                .numeric("water_temp_alarm_max", ea.STATE_SET)
-                .withUnit("°C")
-                .withValueMin(0)
-                .withValueMax(120)
-                .withDescription("Alarm water temperature maximum setting"),
-            e
-                .numeric("water_temp_alarm_min", ea.STATE_SET)
-                .withUnit("°C")
-                .withValueMin(0)
-                .withValueMax(120)
-                .withDescription("Alarm water temperature minimum setting"),
-
+            e.numeric("water_temp_alarm_max", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature maximum setting"),
+            e.numeric("water_temp_alarm_min", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature minimum setting"),
+            
             // --- Maintenance ---
-            e
-                .binary("creep_switch", ea.STATE_SET, "ON", "OFF")
-                .withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
+            e.binary("creep_switch", ea.STATE_SET, "ON", "OFF").withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
         ],
         meta: {
             tuyaDatapoints: [
@@ -116,10 +76,10 @@ export const definitions: DefinitionWithExtend[] = [
                 [3, "position", tuya.valueConverter.raw],
                 [5, "water_consumed_last", tuya.valueConverter.raw],
                 [6, "water_consumed_total", tuya.valueConverter.raw],
-                [10, "weather_delay", tuya.valueConverterBasic.lookup({cancel: 0, "24h": 1, "48h": 2, "72h": 3})],
+                [10, "weather_delay", tuya.valueConverterBasic.lookup({"cancel": 0, "24h": 1, "48h": 2, "72h": 3})],
                 [11, "countdown", tuya.valueConverter.raw],
                 [22, "water_temperature", tuya.valueConverter.raw],
-                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({water_leakage_yes: 0, water_leakage_no: 1})],
+                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({"water_leakage_yes": 0, "water_leakage_no": 1})], 
                 [102, "single_irrigation_switch", tuya.valueConverter.onOff],
                 [103, "single_irrigation_set", tuya.valueConverter.raw],
                 [104, "day_irrigation_switch", tuya.valueConverter.onOff],
@@ -128,7 +88,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [107, "water_volume_alarm_set", tuya.valueConverter.raw],
                 [108, "water_temp_alarm_switch", tuya.valueConverter.onOff],
                 [109, "water_temp_alarm_max", tuya.valueConverter.raw],
-                [110, "power_off_state", tuya.valueConverterBasic.lookup({off: 0, on: 1, maintain: 2})],
+                [110, "power_off_state", tuya.valueConverterBasic.lookup({"off": 0, "on": 1, "maintain": 2})],
                 [112, "creep_switch", tuya.valueConverter.onOff],
                 [113, "water_temp_alarm_min", tuya.valueConverter.raw],
             ],

--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -35,9 +35,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "FK-BV05",
         vendor: "FrankEver",
         description: "Zigbee smart water valve with flow meter and temperature sensor",
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [tuya.tz.datapoints],
-        configure: tuya.configureMagicPacket,
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             // --- Valve Controls ---
             e.switch().setAccess("state", ea.STATE_SET),

--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -42,11 +42,22 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             // --- Valve Controls ---
             e.switch().setAccess("state", ea.STATE_SET),
-            e.numeric("threshold", ea.STATE_SET).withUnit("%").withValueMin(0).withValueMax(100).withValueStep(10).withDescription("Target valve opening percentage"),
+            e
+                .numeric("threshold", ea.STATE_SET)
+                .withUnit("%")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(10)
+                .withDescription("Target valve opening percentage"),
             e.numeric("position", ea.STATE).withUnit("%").withDescription("Current valve position"),
             e.enum("power_off_state", ea.STATE_SET, ["off", "on", "maintain"]).withDescription("Power-off status behavior"),
             e.enum("weather_delay", ea.STATE_SET, ["cancel", "24h", "48h", "72h"]).withDescription("Weather delay"),
-            e.numeric("countdown", ea.STATE_SET).withUnit("s").withValueMin(0).withValueMax(86400).withDescription("Irrigation Duration (countdown in seconds)"),
+            e
+                .numeric("countdown", ea.STATE_SET)
+                .withUnit("s")
+                .withValueMin(0)
+                .withValueMax(86400)
+                .withDescription("Irrigation Duration (countdown in seconds)"),
 
             // --- Sensors ---
             e.numeric("water_temperature", ea.STATE).withUnit("°C").withDescription("Water temperature"),
@@ -56,19 +67,46 @@ export const definitions: DefinitionWithExtend[] = [
 
             // --- Irrigation Volume Limits ---
             e.binary("single_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable single irrigation volume limit"),
-            e.numeric("single_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Single irrigation water volume setting"),
+            e
+                .numeric("single_irrigation_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Single irrigation water volume setting"),
             e.binary("day_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable daily irrigation volume limit"),
-            e.numeric("day_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Daily irrigation water volume setting"),
+            e
+                .numeric("day_irrigation_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Daily irrigation water volume setting"),
 
             // --- Alarms and Thresholds ---
             e.binary("water_volume_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water volume alarm switch"),
-            e.numeric("water_volume_alarm_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Alarm water volume setting value"),
+            e
+                .numeric("water_volume_alarm_set", ea.STATE_SET)
+                .withUnit("L")
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withDescription("Alarm water volume setting value"),
             e.binary("water_temp_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water temperature alarm switch"),
-            e.numeric("water_temp_alarm_max", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature maximum setting"),
-            e.numeric("water_temp_alarm_min", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature minimum setting"),
-            
+            e
+                .numeric("water_temp_alarm_max", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(0)
+                .withValueMax(120)
+                .withDescription("Alarm water temperature maximum setting"),
+            e
+                .numeric("water_temp_alarm_min", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(0)
+                .withValueMax(120)
+                .withDescription("Alarm water temperature minimum setting"),
+
             // --- Maintenance ---
-            e.binary("creep_switch", ea.STATE_SET, "ON", "OFF").withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
+            e
+                .binary("creep_switch", ea.STATE_SET, "ON", "OFF")
+                .withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
         ],
         meta: {
             tuyaDatapoints: [
@@ -77,10 +115,10 @@ export const definitions: DefinitionWithExtend[] = [
                 [3, "position", tuya.valueConverter.raw],
                 [5, "water_consumed_last", tuya.valueConverter.raw],
                 [6, "water_consumed_total", tuya.valueConverter.raw],
-                [10, "weather_delay", tuya.valueConverterBasic.lookup({"cancel": 0, "24h": 1, "48h": 2, "72h": 3})],
+                [10, "weather_delay", tuya.valueConverterBasic.lookup({cancel: 0, "24h": 1, "48h": 2, "72h": 3})],
                 [11, "countdown", tuya.valueConverter.raw],
                 [22, "water_temperature", tuya.valueConverter.raw],
-                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({"water_leakage_yes": 0, "water_leakage_no": 1})], 
+                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({water_leakage_yes: 0, water_leakage_no: 1})],
                 [102, "single_irrigation_switch", tuya.valueConverter.onOff],
                 [103, "single_irrigation_set", tuya.valueConverter.raw],
                 [104, "day_irrigation_switch", tuya.valueConverter.onOff],
@@ -89,7 +127,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [107, "water_volume_alarm_set", tuya.valueConverter.raw],
                 [108, "water_temp_alarm_switch", tuya.valueConverter.onOff],
                 [109, "water_temp_alarm_max", tuya.valueConverter.raw],
-                [110, "power_off_state", tuya.valueConverterBasic.lookup({"off": 0, "on": 1, "maintain": 2})],
+                [110, "power_off_state", tuya.valueConverterBasic.lookup({off: 0, on: 1, maintain: 2})],
                 [112, "creep_switch", tuya.valueConverter.onOff],
                 [113, "water_temp_alarm_min", tuya.valueConverter.raw],
             ],

--- a/src/devices/frankever.ts
+++ b/src/devices/frankever.ts
@@ -30,4 +30,69 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Countdown timer in minutes"),
         ],
     },
+    {
+        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE200_nbqnmkee"}],
+        model: "FK-BV05",
+        vendor: "FrankEver",
+        description: "Zigbee smart water valve with flow meter and temperature sensor",
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [tuya.tz.datapoints],
+        onEvent: tuya.onEventSetLocalTime,
+        configure: tuya.configureMagicPacket,
+        exposes: [
+            // --- Valve Controls ---
+            e.switch().setAccess("state", ea.STATE_SET),
+            e.numeric("threshold", ea.STATE_SET).withUnit("%").withValueMin(0).withValueMax(100).withValueStep(10).withDescription("Target valve opening percentage"),
+            e.numeric("position", ea.STATE).withUnit("%").withDescription("Current valve position"),
+            e.enum("power_off_state", ea.STATE_SET, ["off", "on", "maintain"]).withDescription("Power-off status behavior"),
+            e.enum("weather_delay", ea.STATE_SET, ["cancel", "24h", "48h", "72h"]).withDescription("Weather delay"),
+            e.numeric("countdown", ea.STATE_SET).withUnit("s").withValueMin(0).withValueMax(86400).withDescription("Irrigation Duration (countdown in seconds)"),
+
+            // --- Sensors ---
+            e.numeric("water_temperature", ea.STATE).withUnit("°C").withDescription("Water temperature"),
+            e.numeric("water_consumed_last", ea.STATE).withUnit("L").withDescription("Single water consumption (Last irrigation)"),
+            e.numeric("water_consumed_total", ea.STATE).withUnit("L").withDescription("Daily water consumption total"),
+            e.enum("water_leakage_state", ea.STATE, ["water_leakage_yes", "water_leakage_no"]).withDescription("Leak detection status"),
+
+            // --- Irrigation Volume Limits ---
+            e.binary("single_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable single irrigation volume limit"),
+            e.numeric("single_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Single irrigation water volume setting"),
+            e.binary("day_irrigation_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable daily irrigation volume limit"),
+            e.numeric("day_irrigation_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Daily irrigation water volume setting"),
+
+            // --- Alarms and Thresholds ---
+            e.binary("water_volume_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water volume alarm switch"),
+            e.numeric("water_volume_alarm_set", ea.STATE_SET).withUnit("L").withValueMin(0).withValueMax(1000).withDescription("Alarm water volume setting value"),
+            e.binary("water_temp_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Water temperature alarm switch"),
+            e.numeric("water_temp_alarm_max", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature maximum setting"),
+            e.numeric("water_temp_alarm_min", ea.STATE_SET).withUnit("°C").withValueMin(0).withValueMax(120).withDescription("Alarm water temperature minimum setting"),
+            
+            // --- Maintenance ---
+            e.binary("creep_switch", ea.STATE_SET, "ON", "OFF").withDescription("Peristaltic function switch (Auto cycle anti-calc) - KEEP OFF for normal use"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tuya.valueConverter.onOff],
+                [2, "threshold", tuya.valueConverter.raw],
+                [3, "position", tuya.valueConverter.raw],
+                [5, "water_consumed_last", tuya.valueConverter.raw],
+                [6, "water_consumed_total", tuya.valueConverter.raw],
+                [10, "weather_delay", tuya.valueConverterBasic.lookup({"cancel": 0, "24h": 1, "48h": 2, "72h": 3})],
+                [11, "countdown", tuya.valueConverter.raw],
+                [22, "water_temperature", tuya.valueConverter.raw],
+                [101, "water_leakage_state", tuya.valueConverterBasic.lookup({"water_leakage_yes": 0, "water_leakage_no": 1})], 
+                [102, "single_irrigation_switch", tuya.valueConverter.onOff],
+                [103, "single_irrigation_set", tuya.valueConverter.raw],
+                [104, "day_irrigation_switch", tuya.valueConverter.onOff],
+                [105, "day_irrigation_set", tuya.valueConverter.raw],
+                [106, "water_volume_alarm_switch", tuya.valueConverter.onOff],
+                [107, "water_volume_alarm_set", tuya.valueConverter.raw],
+                [108, "water_temp_alarm_switch", tuya.valueConverter.onOff],
+                [109, "water_temp_alarm_max", tuya.valueConverter.raw],
+                [110, "power_off_state", tuya.valueConverterBasic.lookup({"off": 0, "on": 1, "maintain": 2})],
+                [112, "creep_switch", tuya.valueConverter.onOff],
+                [113, "water_temp_alarm_min", tuya.valueConverter.raw],
+            ],
+        },
+    },
 ];


### PR DESCRIPTION
Added support for the FrankEver FK-BV05 Zigbee smart water valve, including various controls and sensor data.

<img width="512" height="512" alt="_TZE200_nbqnmkee" src="https://github.com/user-attachments/assets/57e043cf-c68b-4f8d-b361-fe3bb0ee0bbc" />
