### PR TITLE
samotech: update SM323_v2 description

### DIFF
--- a/src/devices/samotech.ts
+++ b/src/devices/samotech.ts
@@ -61,7 +61,7 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: [{modelID: "HK_DIM_A", manufacturerName: "Samotech"}],
         model: "SM323_v2",
         vendor: "Samotech",
-        description: "Zigbee retrofit dimmer 250W",
+        description: "Zigbee dimmer switch SM323",
         extend: [m.light({configureReporting: true}), m.electricityMeter(), sunricher.extend.externalSwitchType()],
     },
     {


### PR DESCRIPTION
Updates the `SM323_v2` device description.

Changed from "Zigbee retrofit dimmer 250W" to "Zigbee dimmer switch SM323" to better reflect the product's current positioning. Submitted as the device manufacturer (Samotech). The legacy `SM323` entry is intentionally left unchanged.