### PR TITLE
fix(develco): restore KEYZB-110 buzzer after firmware v2.0.6

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -313,9 +313,20 @@ export const arm_mode: Tz.Converter = {
             delayUntil = performance.now() + value.delay * 1000;
         }
 
+        let audibleNotif = 0;
+        if (value.audiblenotif != null) {
+            utils.assertNumber(value.audiblenotif, "audiblenotif");
+            if (!utils.isInRange(0, 255, value.audiblenotif)) {
+                throw new Error(`Invalid audiblenotif value: ${value.audiblenotif} (expected ${0} to ${255})`);
+            }
+
+            audibleNotif = Math.round(value.audiblenotif);
+        }
+
         globalStore.putValue(entity, "panelStatus", panelStatus);
         globalStore.putValue(entity, "delayUntil", delayUntil);
-        const payload = {panelstatus: panelStatus, secondsremain: secondsRemain, audiblenotif: 0, alarmstatus: 0};
+        globalStore.putValue(entity, "audibleNotif", audibleNotif);
+        const payload = {panelstatus: panelStatus, secondsremain: secondsRemain, audiblenotif: audibleNotif, alarmstatus: 0};
         await entity.commandResponse("ssIasAce", "panelStatusChanged", payload);
     },
 };

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -249,6 +249,13 @@ const develco = {
                 await entity.read<"ssIasZone", DevelcoIasZone>("ssIasZone", ["develcoAlarmOffDelay"], manufacturerOptions);
             },
         } satisfies Tz.Converter,
+        arm_mode: {
+            key: ["arm_mode"],
+            convertSet: async (entity, key, value, meta) => {
+                utils.assertObject(value, key);
+                await tz.arm_mode.convertSet?.(entity, key, {...value, audiblenotif: value.audiblenotif ?? 1}, meta);
+            },
+        } satisfies Tz.Converter,
     },
 };
 
@@ -1017,7 +1024,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.ignore_iaszone_attreport,
             fz.ignore_iasace_commandgetpanelstatus,
         ],
-        toZigbee: [tz.arm_mode],
+        toZigbee: [develco.tz.arm_mode],
         exposes: [
             e.battery_low(),
             e.tamper(),
@@ -1038,7 +1045,7 @@ export const definitions: DefinitionWithExtend[] = [
                 voltageReporting: true,
                 percentageReporting: false,
             }),
-            m.iasGetPanelStatusResponse(),
+            m.iasGetPanelStatusResponse({audiblenotif: 1}),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(44);

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -726,7 +726,8 @@ export function iasArmCommandDefaultResponse(): ModernExtend {
     return {fromZigbee: [converter], isModernExtend: true};
 }
 
-export function iasGetPanelStatusResponse(): ModernExtend {
+export function iasGetPanelStatusResponse(options?: {audiblenotif?: number}): ModernExtend {
+    const defaultAudibleNotif = options?.audiblenotif ?? 0;
     const converter: Fz.Converter<"ssIasAce", undefined, ["commandGetPanelStatus"]> = {
         cluster: "ssIasAce",
         type: ["commandGetPanelStatus"],
@@ -737,7 +738,7 @@ export function iasGetPanelStatusResponse(): ModernExtend {
                 const payload = {
                     panelstatus: globalStore.getValue(msg.endpoint, "panelStatus"),
                     secondsremain: Math.min(secondsRemain, constants.iasMaxSecondsRemain),
-                    audiblenotif: 0x00,
+                    audiblenotif: globalStore.getValue(msg.endpoint, "audibleNotif", defaultAudibleNotif),
                     alarmstatus: 0x00,
                 };
                 assertNumber(msg.meta.zclTransactionSequenceNumber);


### PR DESCRIPTION
## Summary

Fixes missing buzzer feedback on the Develco/Frient Intelligent Keypad (KEYZB-110 / KEPZB-110) after firmware v2.0.6 by sending `audiblenotif: 1` in IAS ACE panel status responses instead of always using `0`.

Potentially fixes [Koenkk/zigbee2mqtt#31761](https://github.com/Koenkk/zigbee2mqtt/issues/31761).

## Problem

After updating the Frient Keypad (KEPZB-110) to firmware **131078 (v2.0.6)**, users reported that the keypad no longer beeps during arm/disarm delays, while key presses still produce audible feedback. Downgrading to v2.0.5 restores the previous behavior.

As analyzed in [zigbee2mqtt#31761](https://github.com/Koenkk/zigbee2mqtt/issues/31761), Zigbee2MQTT sends `ssIasAce.panelStatusChanged` with `audiblenotif: 0`, which per the Zigbee specification means *mute audible notification*. Firmware v2.0.6 appears to honor this field correctly, whereas older firmware may have ignored it.

Example log from the issue:

```
panelStatusChanged({"panelstatus":4,"secondsremain":180,"audiblenotif":0,"alarmstatus":0})
```

Per [this comment](https://github.com/Koenkk/zigbee2mqtt/issues/31761#issuecomment-4321673661), `audiblenotif` should be made configurable in `arm_mode` so integrations can control audible feedback as intended.

## Solution

1. **`arm_mode` converter** (`src/converters/toZigbee.ts`)
   - Add optional `audiblenotif` to the `arm_mode` payload (validated as `0–255`, default `0` for backward compatibility).
   - Persist the value in `globalStore` so `getPanelStatusRsp` stays consistent with `panelStatusChanged`.

2. **`iasGetPanelStatusResponse` extend** (`src/lib/modernExtend.ts`)
   - Accept an optional `{ audiblenotif }` default for devices that need a non-zero fallback when no value is stored yet.

3. **KEYZB-110 device definition** (`src/devices/develco.ts`)
   - Use a device-specific `develco.tz.arm_mode` wrapper that defaults `audiblenotif` to `1` when not explicitly set.
   - Configure `m.iasGetPanelStatusResponse({ audiblenotif: 1 })` for consistent responses to `commandGetPanelStatus`.

Other IAS ACE keypads using `tz.arm_mode` are unchanged and keep `audiblenotif: 0` unless explicitly overridden via MQTT.

## Example

```json
{
  "arm_mode": {
    "mode": "exit_delay",
    "delay": 180,
    "audiblenotif": 1
  }
}
```

For KEYZB-110, `audiblenotif` defaults to `1` even when omitted.

## Test plan

- [ ] KEYZB-110 / KEPZB-110 on firmware **v2.0.6**: arm/disarm with entry/exit delay — keypad should beep again
- [ ] Verify Z2M debug log shows `audiblenotif: 1` in `panelStatusChanged` and `getPanelStatusRsp`
- [ ] Confirm other IAS ACE keypads (e.g. Centralite, Hive, UEI) still behave as before
- [ ] Optional: set `"audiblenotif": 0` on KEYZB-110 to confirm audible feedback can be disabled
- [ ] `pnpm run build && pnpm run check && pnpm test`

## Related

- [Koenkk/zigbee2mqtt#31761](https://github.com/Koenkk/zigbee2mqtt/issues/31761) — Frient Keypad latest update removes buzzer
- [Koenkk/zigbee-OTA#1153](https://github.com/Koenkk/zigbee-OTA/issues/1153) — Develco KEYZB-110 not beeping after firmware update
