### PR TITLE
Update nodon.ts: Add  power apparent exposed by 'SEM-4-1-00'

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -309,6 +309,7 @@ export const definitions: DefinitionWithExtend[] = [
                 producedEnergy: true,
             }),
         ],
+        exposes: [e.power_apparent()],
         ota: true,
     },
     {


### PR DESCRIPTION
Add apparent power measurement for the Nodon ‘SEM-4-1-00’ device,  which is not currently exposed by Zigbee2MQTT.

Tested with 2  'SEM-4-1-00' devices running with firmware version 003.00.09
