### PR TITLE
Deactivate unneeded local temperature exposed property for Acova Alcantara 2 and Alcantara 3

### DIFF
--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -24,6 +24,7 @@ const acova = {
                         result.hvac_action = "off";
                     }
                 }
+                result.local_temperature = null;
                 return result;
             },
         } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,


### PR DESCRIPTION
This PR permit to fix :

- Deactivate the false Local temperature (local_temperature) exposed property (same as Occupied heating setpoint) because the radiator cannot return mesured current temperature
- Remove the current_temperature state attribute from Home Assistant and the "Current temperature" information displayed on Thermostat card

Tested on :

- Acova Alcantara 2 (I suppose it's exactly the same for Acova Alcantara 3)

Objective :

- Reproduce correct behavior like on ZHA after my migration from ZHA to Zigbee2MQTT