### PR TITLE
Support SMARTERCURRY TZE284_aaeasoll illuminance sensor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -27406,37 +27406,38 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_aaeasoll']),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_aaeasoll"]),
 
-        model: 'TZE284_aaeasoll',
-        vendor: 'SMARTERCURRY',
-        description: 'Illuminance sensor',
+        model: "TZE284_aaeasoll",
+        vendor: "SMARTERCURRY",
+        description: "Illuminance sensor",
 
-        extend: [
-            tuya.modernExtend.tuyaBase({ dp: true }),
-        ],
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
 
         exposes: [
             e.illuminance().withAccess(ea.STATE),
             e.battery().withAccess(ea.STATE),
 
-            e.enum('report_interval', ea.STATE_SET, ['5m', '10m', '15m', '20m', '30m', '1h'])
-                .withDescription('Data reporting interval'),
+            e.enum("report_interval", ea.STATE_SET, ["5m", "10m", "15m", "20m", "30m", "1h"]).withDescription("Data reporting interval"),
         ],
 
         meta: {
             tuyaDatapoints: [
-                [2, 'illuminance', tuya.valueConverter.raw],
-                [4, 'battery', tuya.valueConverter.raw],
+                [2, "illuminance", tuya.valueConverter.raw],
+                [4, "battery", tuya.valueConverter.raw],
 
-                [101, 'report_interval', tuya.valueConverterBasic.lookup({
-                    '5m':  0,
-                    '10m': 1,
-                    '15m': 2,
-                    '20m': 3,
-                    '30m': 4,
-                    '1h':  5,
-                })],
+                [
+                    101,
+                    "report_interval",
+                    tuya.valueConverterBasic.lookup({
+                        "5m": 0,
+                        "10m": 1,
+                        "15m": 2,
+                        "20m": 3,
+                        "30m": 4,
+                        "1h": 5,
+                    }),
+                ],
             ],
         },
 

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -27407,42 +27407,21 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_aaeasoll"]),
-
         model: "TZE284_aaeasoll",
         vendor: "SMARTERCURRY",
         description: "Illuminance sensor",
-
-        extend: [
-            tuya.modernExtend.tuyaBase({
-                dp: true,
-                timeStart: "1970",
-            }),
-        ],
-
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"})],
         exposes: [
             e.illuminance().withAccess(ea.STATE),
             e.battery().withAccess(ea.STATE),
 
             e.enum("report_interval", ea.STATE_SET, ["5m", "10m", "15m", "20m", "30m", "1h"]).withDescription("Data reporting interval"),
         ],
-
         meta: {
             tuyaDatapoints: [
                 [2, "illuminance", tuya.valueConverter.raw],
                 [4, "battery", tuya.valueConverter.raw],
-
-                [
-                    101,
-                    "report_interval",
-                    tuya.valueConverterBasic.lookup({
-                        "5m": 0,
-                        "10m": 1,
-                        "15m": 2,
-                        "20m": 3,
-                        "30m": 4,
-                        "1h": 5,
-                    }),
-                ],
+                [101, "report_interval", tuya.valueConverterBasic.lookup({"5m": 0, "10m": 1, "15m": 2, "20m": 3, "30m": 4, "1h": 5})],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -27405,43 +27405,42 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
-    {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_aaeasoll"]),
+        {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_aaeasoll']),
 
-        model: "TZE284_aaeasoll",
-        vendor: "SMARTERCURRY",
-        description: "Illuminance sensor",
+        model: 'TZE284_aaeasoll',
+        vendor: 'SMARTERCURRY',
+        description: 'Illuminance sensor',
 
-        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        extend: [
+            tuya.modernExtend.tuyaBase({ 
+                dp: true,
+                timeStart: '1970',
+            }),
+        ],
 
         exposes: [
             e.illuminance().withAccess(ea.STATE),
             e.battery().withAccess(ea.STATE),
 
-            e.enum("report_interval", ea.STATE_SET, ["5m", "10m", "15m", "20m", "30m", "1h"]).withDescription("Data reporting interval"),
+            e.enum('report_interval', ea.STATE_SET, ['5m', '10m', '15m', '20m', '30m', '1h'])
+                .withDescription('Data reporting interval'),
         ],
 
         meta: {
             tuyaDatapoints: [
-                [2, "illuminance", tuya.valueConverter.raw],
-                [4, "battery", tuya.valueConverter.raw],
+                [2, 'illuminance', tuya.valueConverter.raw],
+                [4, 'battery', tuya.valueConverter.raw],
 
-                [
-                    101,
-                    "report_interval",
-                    tuya.valueConverterBasic.lookup({
-                        "5m": 0,
-                        "10m": 1,
-                        "15m": 2,
-                        "20m": 3,
-                        "30m": 4,
-                        "1h": 5,
-                    }),
-                ],
+                [101, 'report_interval', tuya.valueConverterBasic.lookup({
+                    '5m':  0,
+                    '10m': 1,
+                    '15m': 2,
+                    '20m': 3,
+                    '30m': 4,
+                    '1h':  5,
+                })],
             ],
         },
-
-        onEvent: tuya.onEventSetTime,
-        configure: tuya.configureMagicPacket,
     },
 ];

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -27405,17 +27405,17 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
-        {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_aaeasoll']),
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_aaeasoll"]),
 
-        model: 'TZE284_aaeasoll',
-        vendor: 'SMARTERCURRY',
-        description: 'Illuminance sensor',
+        model: "TZE284_aaeasoll",
+        vendor: "SMARTERCURRY",
+        description: "Illuminance sensor",
 
         extend: [
-            tuya.modernExtend.tuyaBase({ 
+            tuya.modernExtend.tuyaBase({
                 dp: true,
-                timeStart: '1970',
+                timeStart: "1970",
             }),
         ],
 
@@ -27423,23 +27423,26 @@ export const definitions: DefinitionWithExtend[] = [
             e.illuminance().withAccess(ea.STATE),
             e.battery().withAccess(ea.STATE),
 
-            e.enum('report_interval', ea.STATE_SET, ['5m', '10m', '15m', '20m', '30m', '1h'])
-                .withDescription('Data reporting interval'),
+            e.enum("report_interval", ea.STATE_SET, ["5m", "10m", "15m", "20m", "30m", "1h"]).withDescription("Data reporting interval"),
         ],
 
         meta: {
             tuyaDatapoints: [
-                [2, 'illuminance', tuya.valueConverter.raw],
-                [4, 'battery', tuya.valueConverter.raw],
+                [2, "illuminance", tuya.valueConverter.raw],
+                [4, "battery", tuya.valueConverter.raw],
 
-                [101, 'report_interval', tuya.valueConverterBasic.lookup({
-                    '5m':  0,
-                    '10m': 1,
-                    '15m': 2,
-                    '20m': 3,
-                    '30m': 4,
-                    '1h':  5,
-                })],
+                [
+                    101,
+                    "report_interval",
+                    tuya.valueConverterBasic.lookup({
+                        "5m": 0,
+                        "10m": 1,
+                        "15m": 2,
+                        "20m": 3,
+                        "30m": 4,
+                        "1h": 5,
+                    }),
+                ],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -27405,4 +27405,42 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
+    {
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE284_aaeasoll']),
+
+        model: 'TZE284_aaeasoll',
+        vendor: 'SMARTERCURRY',
+        description: 'Illuminance sensor',
+
+        extend: [
+            tuya.modernExtend.tuyaBase({ dp: true }),
+        ],
+
+        exposes: [
+            e.illuminance().withAccess(ea.STATE),
+            e.battery().withAccess(ea.STATE),
+
+            e.enum('report_interval', ea.STATE_SET, ['5m', '10m', '15m', '20m', '30m', '1h'])
+                .withDescription('Data reporting interval'),
+        ],
+
+        meta: {
+            tuyaDatapoints: [
+                [2, 'illuminance', tuya.valueConverter.raw],
+                [4, 'battery', tuya.valueConverter.raw],
+
+                [101, 'report_interval', tuya.valueConverterBasic.lookup({
+                    '5m':  0,
+                    '10m': 1,
+                    '15m': 2,
+                    '20m': 3,
+                    '30m': 4,
+                    '1h':  5,
+                })],
+            ],
+        },
+
+        onEvent: tuya.onEventSetTime,
+        configure: tuya.configureMagicPacket,
+    },
 ];


### PR DESCRIPTION

<img width="512" height="512" alt="41EaMxQIFLL _SL1000_" src="https://github.com/user-attachments/assets/8a3b9265-6afb-44c0-bf9e-8c0fec96bbf8" />
Added support for TZE284_aaeasoll illuminance sensor with configuration options. I already used external converter tested the illuminance, battery fetaures. They all work as expected.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
