### PR TITLE
Add Tuya _TZE200_xixlazkg fan coil unit (FCU) thermostat

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6326,6 +6326,50 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_xixlazkg"]),
+        model: "TS0601_thermostat_fancoil",
+        vendor: "Tuya",
+        description: "Fan coil unit (FCU) thermostat",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [
+            e.child_lock(),
+            e
+                .climate()
+                .withSetpoint("current_heating_setpoint", 10, 35, 1, ea.STATE_SET)
+                .withLocalTemperature(ea.STATE)
+                .withSystemMode(["heat", "cool", "dry", "fan_only", "emergency_heating", "auto"], ea.STATE_SET)
+                .withFanMode(["low", "medium", "high", "auto"], ea.STATE_SET)
+                .withPreset(["off", "on"])
+                .withLocalTemperatureCalibration(-9.9, 9.9, 0.1, ea.STATE_SET),
+            e.binary("battery_low", ea.STATE, true, false).withDescription("Indicates if the battery of this device is almost empty"),
+            e.numeric("error", ea.STATE).withCategory("diagnostic").withDescription("Device error code reported by the thermostat"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "preset", tuya.valueConverterBasic.lookup({off: false, on: true})],
+                [
+                    2,
+                    "system_mode",
+                    tuya.valueConverterBasic.lookup({
+                        fan_only: tuya.enum(0),
+                        cool: tuya.enum(1),
+                        dry: tuya.enum(2),
+                        heat: tuya.enum(3),
+                        auto: tuya.enum(4),
+                        emergency_heating: tuya.enum(5),
+                    }),
+                ],
+                [16, "current_heating_setpoint", tuya.valueConverter.raw],
+                [24, "local_temperature", tuya.valueConverter.divideBy10],
+                [28, "fan_mode", tuya.valueConverterBasic.lookup({low: tuya.enum(0), medium: tuya.enum(1), high: tuya.enum(2), auto: tuya.enum(3)})],
+                [35, "battery_low", tuya.valueConverter.trueFalse0],
+                [40, "child_lock", tuya.valueConverter.lockUnlock],
+                [44, "local_temperature_calibration", tuya.valueConverter.localTemperatureCalibration],
+                [45, "error", tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_dzuqwsyg", "_TZE204_dzuqwsyg"]),
         model: "BAC-002-ALZB",
         vendor: "Tuya",


### PR DESCRIPTION
Adds support for the **Tuya TS0601 / `_TZE200_xixlazkg`** fan coil unit (FCU) air-conditioning thermostat, which is currently *Not supported*.

### Device
A wall thermostat for fan coil units: cooling/heating/dry/fan modes with low/medium/high/auto fan speed, local temperature, setpoint, child lock and temperature calibration.

### Datapoints
Validated against **43 units running in production** (previously via an external converter with the identical datapoint map):

| DP | Property |
|----|----------|
| 1 | `preset` (on/off) |
| 2 | `system_mode` (fan_only=0, cool=1, dry=2, heat=3, auto=4, emergency_heating=5) |
| 16 | `current_heating_setpoint` (raw, °C) |
| 24 | `local_temperature` (÷10) |
| 28 | `fan_mode` (low/medium/high/auto) |
| 35 | `battery_low` |
| 40 | `child_lock` |
| 44 | `local_temperature_calibration` |
| 45 | `error` (diagnostic) |

### Notes
- Uses the modern `tuya.modernExtend.tuyaBase({dp: true})` extend.
- `model` is descriptive (`TS0601_thermostat_fancoil`); the exact retail model/brand is unknown — happy to update if a reviewer can identify it.
- `pnpm check` (biome), `pnpm build` (tsc) and `pnpm test` (all 561 tests) pass locally.