### PR TITLE
Add Tuya _TZE200_2jwrgrro curtain motor to TS0601_cover_1

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7344,6 +7344,7 @@ export const definitions: DefinitionWithExtend[] = [
                 "_TZE200_m6lwazh9", // incomplete, see https://github.com/Koenkk/zigbee2mqtt/issues/31774
                 "_TZE204_zuq5xxib",
                 "_TZE200_swlgvdlh",
+                "_TZE200_2jwrgrro",
             ]),
             ...tuya.fingerprint("zo2pocs\u0000", ["_TYST11_fzo2pocs"]),
             ...tuya.fingerprint("dank5zs\u0000", ["_TYST11_udank5zs"]),


### PR DESCRIPTION
Adds the **Tuya TS0601 / `_TZE200_2jwrgrro`** curtain/roller-blind motor, currently *Not supported*.

It is a standard Tuya curtain motor using the usual `state` (open/stop/close) + `position` datapoints, so it is added to the existing generic **`TS0601_cover_1`** definition (alongside `_TZE200_swlgvdlh` etc.).

- Validated on **9 units running in production** (previously via an external converter with the same state/position datapoints).
- If position runs inverted on a given unit, the existing `cover_position_percent_fix` option handles it.
- `pnpm check` (biome), `pnpm build` (tsc) and `pnpm test` (561 tests) pass locally.