### PR TITLE
samotech: update SM323_v1 description

### DIFF
--- a/src/devices/samotech.ts
+++ b/src/devices/samotech.ts
@@ -53,7 +53,7 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: [{manufacturerName: "Samotech", modelID: "Dimmer-Switch-ZB3.0"}],
         model: "SM323_v1",
         vendor: "Samotech",
-        description: "Zigbee retrofit dimmer 250W",
+        description: "Zigbee dimmer switch",
         extend: [m.light({configureReporting: true})],
     },
     {


### PR DESCRIPTION
Updates the `SM323_v1` device description.

Changed from "Zigbee retrofit dimmer 250W" to "Zigbee dimmer switch" – the new wording matches the device's own reported modelID (`Dimmer-Switch-ZB3.0`) and better reflects the product's current positioning.

Submitted as the device manufacturer (Samotech). Companion PR for SM323_v2 (#12326) was merged previously.