### PR TITLE
Fix Shelly 2PM Gen4 (Cover mode) fingerprint for firmware 2.0.0-beta1

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1450,9 +1450,9 @@ export const definitions: DefinitionWithExtend[] = [
                 modelID: "2PM",
                 endpoints: [
                     {ID: 1, profileID: 260, deviceID: 514, inputClusters: [0, 3, 4, 5, 258], outputClusters: [25]},
+                    {ID: 2, inputClusters: [7], outputClusters: [3, 4, 5, 6]},
                     {ID: 3, inputClusters: [7], outputClusters: [3, 4, 5, 6]},
-                    {ID: 4, inputClusters: [7], outputClusters: [3, 4, 5, 6]},
-                    {ID: 5, inputClusters: [], outputClusters: [3, 4, 6, 8, 258]},
+                    {ID: 4, inputClusters: [], outputClusters: [3, 4, 6, 8, 258]},
                     {ID: 239, profileID: 49153, deviceID: 8193, inputClusters: [64513, 64514], outputClusters: []},
                     {ID: 242, profileID: 41440, deviceID: 97, inputClusters: [], outputClusters: [33]},
                 ],
@@ -1470,14 +1470,14 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw2"),
         ],
         extend: [
-            m.deviceEndpoints({endpoints: {sw1: 3, sw2: 4}}),
+            m.deviceEndpoints({endpoints: {sw1: 2, sw2: 3}}),
             m.windowCovering({controls: ["lift", "tilt"]}),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["2PMInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
         configure: async (device, coordinatorEndpoint) => {
-            for (const epID of [3, 4]) {
+            for (const epID of [2, 3]) {
                 const ep = device.getEndpoint(epID);
                 if (ep) {
                     await ep.bind("genOnOff", coordinatorEndpoint);


### PR DESCRIPTION
PR #12011 added support for the Shelly 2PM Gen4 with firmware 2.0.0-beta1. However, in cover mode fingerprint and configuration don't match the correct clusters.
This caused the device to show as "unsupported" and the `configure` step to fail with `UNSUPPORTED_CLUSTER` when trying to read `genOnOffSwitchCfg` on EP 4 (which has no input clusters in cover mode).
This PR fixes the fingerprint for cover mode which has the clusters shifted by `-1` (same as the 1PM #12059).