### PR TITLE
Fix state datapoint for _TZE284_waa352qv

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15020,10 +15020,19 @@ export const definitions: DefinitionWithExtend[] = [
                 [
                     1,
                     "state",
-                    tuya.valueConverterBasic.lookup({
-                        OPEN: tuya.enum(0),
-                        STOP: tuya.enum(1),
-                        CLOSE: tuya.enum(2),
+                    tuya.valueConverterBasic.lookup((_, device) => {
+                        if (device.manufacturerName === "_TZE284_waa352qv") {
+                            return {
+                                STOP: tuya.enum(0),
+                                CLOSE: tuya.enum(1),
+                                OPEN: tuya.enum(2),
+                            };
+                        }
+                        return {
+                            OPEN: tuya.enum(0),
+                            STOP: tuya.enum(1),
+                            CLOSE: tuya.enum(2),
+                        };
                     }),
                 ],
                 [2, "position", tuya.valueConverter.coverPosition],


### PR DESCRIPTION
Fix state datapoint for _TZE284_waa352qv [Issue TS0601_cover_5 _TZE284_waa352qv: wrong state-codes?
 #32142](https://github.com/Koenkk/zigbee2mqtt/issues/32142).