### PR TITLE
fix(tuya): add _TZE284_sdvbnmj5 to Novato ZPV-01

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -19350,7 +19350,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_dsagrkvg", "_TZE284_zm8zpwas"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_dsagrkvg", "_TZE284_zm8zpwas", "_TZE284_sdvbnmj5"]),
         model: "ZPV-01",
         vendor: "Novato",
         description: "Battery powered smart valve",


### PR DESCRIPTION
Adds the new Tuya manufacturer name `_TZE284_sdvbnmj5` to the existing Novato ZPV-01 (battery powered smart valve) definition.

Newer production batches of the ZPV-01 ship with a new Tuya chip that reports `TS0601` / `_TZE284_sdvbnmj5` and is currently detected as unsupported. The device uses the same datapoints as the existing `_TZE204_dsagrkvg` / `_TZE284_zm8zpwas` variants (DP1 state, DP8 valve_state, DP101 battery), so only the fingerprint is added.

Not a new device, so no picture PR is needed.