### PR TITLE
[SNZB-04PR2] Fix batteryVoltage reporting

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -6095,6 +6095,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SNZB-04PR2",
         vendor: "SONOFF",
         description: "Contact sensor",
+        version: "0.0.1",
         extend: [
             m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1", "battery_low"]}),
             m.binary({

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -6107,7 +6107,11 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.SHENZHEN_COOLKIT_TECHNOLOGY_CO_LTD},
                 access: "STATE_GET",
             }),
-            ewelinkBattery(),
+            m.battery({
+                percentageReporting: true,
+                voltageReporting: true,
+                voltageReportingConfig: false,
+            }),
         ],
         ota: true,
     },

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -6108,7 +6108,8 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
             m.battery({
-                percentageReporting: true,
+                percentageReportingConfig: {min: 3600, max: 7200, change: 2},
+                voltage: true,
                 voltageReporting: true,
                 voltageReportingConfig: false,
             }),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

## Description
Fixes a recurring `UNSUPPORTED_ATTRIBUTE` error on the **SONOFF SNZB-04PR2** (SenseGuard DW Gen2) door contact sensor.

## Motivation
The SONOFF SNZB-04PR2 should natively support and report battery voltage, but it seems it rejects active writing of reporting intervals for `batteryVoltage`. 

Currently it results in those errors:
`[2026-06-04 19:06:14] error: 	z2m: Failed to configure 'Türkontakt Haustür', attempt 1 (Error: ZCL command 0xa4c13811cb60ffff/1 genPowerCfg.configReport([{"minimumReportInterval":3600,"maximumReportInterval":7200,"reportableChange":100,"attribute":"batteryVoltage"}], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (Status 'UNSUPPORTED_ATTRIBUTE')`

By setting `voltageReportingConfig: false` within `m.battery()`, we explicitly prevent Zigbee2MQTT from sending the unsupported `configReport` command while preserving the voltage data point layout and the passive reading/reporting of battery values.

## Checklist
- [x] The change fixes the recurring background configuration timeout / attribute error.
- [x] Battery percentage and millivolt data points are still correctly displayed.
- [x] Tested locally using an external converter with identical parameters.

### Result
Tested with a partially drained battery and the voltage dropped from 3200 to 3000, so it works as expected 😄 
<img width="511" height="681" alt="image" src="https://github.com/user-attachments/assets/9e4d3dc0-02ce-4726-bd6c-c0319e8f8202" />
