### PR TITLE
Update moes.ts to fix curtain switch _TZE204_srmahpwl position readings

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1553,8 +1553,8 @@ export const definitions: DefinitionWithExtend[] = [
                         },
                         to: (v, meta) => {
                             return tuya.valueConverter.coverPosition.to(v, meta);
-                        }
-                    }
+                        },
+                    },
                 ],
                 [
                     3,

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1538,7 +1538,24 @@ export const definitions: DefinitionWithExtend[] = [
                         CLOSE: tuya.enum(2),
                     }),
                 ],
-                [2, "position", tuya.valueConverter.coverPosition],
+                [
+                    2,
+                    "position",
+                    {
+                        // Workaround: Fix overflow / underdlow in position readings when limits are reached for some seconds:
+                        // - When the curtain is fully opened it coninues with 101, 102, ...
+                        // - When the curtain is fully closed it coninues with 255, 254, ...
+                        from: (v) => {
+                            if (v > 100) {
+                                return v > 150 ? 0 : 100;
+                            }
+                            return v;
+                        },
+                        to: (v, meta) => {
+                            return tuya.valueConverter.coverPosition.to(v, meta);
+                        }
+                    }
+                ],
                 [
                     3,
                     "calibration",


### PR DESCRIPTION
The curtain switch device `_TZE204_srmahpwl` reports position values outside the valid cover range when reaching its fully open or fully closed limits. The device continues reporting updates for approximately 3 seconds after reaching the end stops in order to synchronize its state, during which it may emit invalid position values.

This PR clamps the reported position value to the range 0-100 before publishing it. This prevents invalid position states from being exposed to Zigbee2MQTT and downstream consumers such as Home Assistant.

**Example**

_Before:_

- OPEN action →  Device starts reporting position: 98, 99, 100, 102, 102, .., 100
- CLOSE action →  Device starts reporting position: 2, 1, 0, 255, 254, .., 0

_After:_

- OPEN action →  Device starts reporting position: 98, 99, 100, .., 100
- CLOSE action →  Device starts reporting position: 2, 1, 0, .., 0

**Notes**
- No behavior change for devices reporting valid position values.
- Only affects out-of-range values received from the device.
- Improves robustness against firmware quirks observed when a cover reaches its end stops.
- Workaround added only in position reading but not setting.