### PR TITLE
add: Eglo 901463

### DIFF
--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -291,7 +291,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "AwoX",
         description: "LED with adjustable color temp on main ring; extra RGB strip for full colors.",
         extend: [m.light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"]}}), m.commandsOnOff()],
-        whiteLabel: [{vendor: "EGLO", model: "900566"}],
+        whiteLabel: [
+            {vendor: "EGLO", model: "900566"},
+            {vendor: "EGLO", model: "901463"},
+        ],
     },
     {
         zigbeeModel: ["EGLO_ZM_TW"],


### PR DESCRIPTION
Any tip, how define, that Eglo 901463 is another model, but is detect as 900566?

- https://github.com/Koenkk/zigbee2mqtt.io/pull/5218

Eglo 901463:
<img width="512" height="512" alt="901463" src="https://github.com/user-attachments/assets/437dc8e0-51aa-4ee2-b18d-02ce7c882d6d" />

Eglo 900566:
<img width="512" height="512" alt="900566" src="https://github.com/user-attachments/assets/f4bab7e9-e835-405b-94da-042fd480c3e9" />
