### PR TITLE
fix: IKEA VINDSTYRKA: Allow reading VOC index

### DIFF
--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -1308,7 +1308,6 @@ export const presets = {
     vibration: () => new Binary("vibration", access.STATE, true, false).withDescription("Indicates whether the device detected vibration"),
     tilt: () => new Binary("tilt", access.STATE, true, false).withDescription("Indicates whether the device detected tilt"),
     voc: () => new Numeric("voc", access.STATE).withLabel("VOC").withUnit("µg/m³").withDescription("Measured VOC value"),
-    voc_index: () => new Numeric("voc_index", access.STATE).withLabel("VOC index").withDescription("VOC index"),
     voltage: () => new Numeric("voltage", access.STATE).withUnit("V").withDescription("Measured electrical potential value"),
     voltage_phase_b: () =>
         new Numeric("voltage_phase_b", access.STATE)

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -506,7 +506,7 @@ export function ikeaVoc(args?: Partial<m.NumericArgs<"manuSpecificIkeaVocIndexMe
         attribute: "measuredValue",
         reporting: {min: "1_MINUTE", max: "2_MINUTES", change: 1},
         description: "Sensirion VOC index: 100 = average, <100 = less tVOC, >100 = more tVOC",
-        access: "STATE",
+        access: "STATE_GET",
         ...args,
     });
 }


### PR DESCRIPTION
- Reading the attribute works on both 1.0.010 and 1.0.11 firmware -> STATE_GET

- The `voc_index` in `exposes.ts` seems unused