### PR TITLE
fix: use coord address when `gppNwkAddr` not present in GP frame for `tempMaster`

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1,5 +1,6 @@
 import {Zcl} from "zigbee-herdsman";
 import type {PartialClusterOrRawAttributes} from "zigbee-herdsman/dist/controller/tstype";
+import {COORDINATOR_ADDRESS} from "zigbee-herdsman/dist/zspec";
 import type {GpdManufAttributeReport} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
@@ -1476,7 +1477,7 @@ const fzLocal = {
                     "response",
                     {
                         options: 0b000,
-                        tempMaster: msg.data.gppNwkAddr,
+                        tempMaster: msg.data.gppNwkAddr ?? COORDINATOR_ADDRESS,
                         tempMasterTx: networkParameters.channel - 11,
                         srcID: msg.data.srcID,
                         gpdCmd: 0xfe,


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/32211 https://github.com/Koenkk/zigbee2mqtt/issues/32234

Same logic as ZH, always fallback to coordinator when proxy not present.