### PR TITLE
fix(moes): restore genOnOff on/off for ZWV-YC water valve (reverts #12283)

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1376,22 +1376,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZWV-YC",
         vendor: "Moes",
         description: "Water valve",
-        extend: [tuya.modernExtend.tuyaBase({dp: true, forceTimeUpdates: true})],
-        exposes: [
-            tuya.exposes.errorStatus(),
-            tuya.exposes.switch(),
-            tuya.exposes.batteryState(),
-            tuya.exposes.countdown().withValueMin(0).withValueMax(255).withUnit("minutes").withDescription("Max on time in minutes"),
-        ],
-        meta: {
-            tuyaSendCommand: "sendData",
-            tuyaDatapoints: [
-                [26, "error_status", tuya.valueConverter.raw],
-                [101, "state", tuya.valueConverter.onOff],
-                [111, "countdown", tuya.valueConverter.raw],
-                [115, "battery_state", tuya.valueConverter.batteryState],
-            ],
-        },
+        extend: [m.battery(), m.onOff({powerOnBehavior: false, configureReporting: true})],
     },
     {
         fingerprint: tuya.fingerprint("TS0011", ["_TZ3000_hhiodade"]),


### PR DESCRIPTION
## Summary

Reverts the Moes ZWV-YC (TS0049) on/off path from Tuya datapoint 101 back to the
genOnOff cluster, fixing a regression introduced by #12283 in which the valve stopped
switching after Z2M 2.11.0.

## Root cause

#12283 replaced `m.onOff()` (genOnOff, cluster 6) with a Tuya datapoint mapping where
`state` is driven by DP 101. On the `_TZ3000_*` firmware variants of this hardware the
Tuya DP layer is **decoupled from the switching relay**:

- DP 101 is ACKed and echoed back via `commandActiveStatusReportAlt`, so the frontend
  shows the new state (optimistic), but
- the relay only actuates on **genOnOff (cluster 6)**.

After 2.11.0, on/off silently stopped working while the UI still reported success. This
optimistic echo is also what made the original #12283 verification look fine — nothing
physically switched.

## Reproduction / evidence

- Reported on `_TZ3000_cjfmu5he` in Koenkk/zigbee2mqtt#32235.
- Independently reproduced on `_TZ3000_ogjpfoyn`: factory reset (battery out 30 s +
  button held 10 s) followed by external converters using DP 1 and DP 101 — neither
  actuated the relay; only genOnOff did.

## Why not a hybrid converter

The countdown auto-off that motivated #12283 (hardware-side flood protection) is
unreachable on this hardware for the same reason — DP 111 (`countdown`) is soft
bookkeeping and does not arm a hardware timer. A hybrid (genOnOff for switching + DP
exposes for countdown / battery_state / error_status) would therefore not deliver the
safety benefit, and only risks genOnOff and Tuya reporting fighting each other. A clean
revert is the correct fix.

## Change

Restores the pre-#12283 `extend` for all four fingerprints (`_TZ3000_cjfmu5he`,
`_TZ3000_mq4wujmp`, `_TZ3000_5af5r192`, `_TZ3000_ogjpfoyn`):

```ts
extend: [m.battery(), m.onOff({powerOnBehavior: false, configureReporting: true})],
```

The resulting blob is byte-identical to the definition that shipped before #12283.

Fixes Koenkk/zigbee2mqtt#32235
