### PR TITLE
fix: IOTPerfect PF-PM02D-TYZ: expose fault

### DIFF
--- a/src/devices/iotperfect.ts
+++ b/src/devices/iotperfect.ts
@@ -1,10 +1,8 @@
-import * as exposes from "../lib/exposes";
-import * as legacy from "../lib/legacy";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend} from "../lib/types";
 
-const e = exposes.presets;
-const ea = exposes.access;
+const te = tuya.exposes;
+const tvc = tuya.valueConverter;
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -19,8 +17,13 @@ export const definitions: DefinitionWithExtend[] = [
         model: "PF-PM02D-TYZ",
         vendor: "IOTPerfect",
         description: "Smart water/gas valve",
-        exposes: [e.switch().setAccess("state", ea.STATE_SET)],
-        fromZigbee: [legacy.fz.tuya_switch],
-        toZigbee: [legacy.tz.tuya_switch_state],
+        extend: [tuya.modernExtend.tuyaBase({dp: true, queryOnConfigure: true})],
+        exposes: [te.switch(), te.fault()],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tvc.onOff],
+                [26, "fault", tvc.fault],
+            ],
+        },
     },
 ];


### PR DESCRIPTION
The valves report bitmap faults, but I didn't make much sense of them. 

So I left it as true/false.

```
_TZE200_d0ypnbvn
"label": [
    "0x01"
]
```

```
_TZE284_v5xjyphj
"label": [
    "ov_cr",
    "ov_vol",
    "ov_pwr",
    "ls_cr",
    "ls_vol",
    "ls_pow"
]
```