### PR TITLE
Possible fix for issue #32238

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1981,6 +1981,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Schneider Electric",
         description: "Push button dimmer",
         extend: [
+            schneiderElectricExtend.addSchneiderLightSwitchConfigurationCluster(),
             m.light({
                 effect: false,
                 powerOnBehavior: true,
@@ -1990,7 +1991,6 @@ export const definitions: DefinitionWithExtend[] = [
             m.lightingBallast(),
             m.identify(),
             schneiderElectricExtend.dimmingMode(),
-            schneiderElectricExtend.addSchneiderLightSwitchConfigurationCluster(),
             indicatorMode(),
         ],
         meta: {omitOptionalLevelParams: true},


### PR DESCRIPTION
See https://github.com/Koenkk/zigbee2mqtt/issues/32238#issuecomment-4651507127
From the log:
```
[08/06/2026 16:12:55] zh:controller:endpoint: Ignoring unknown attribute wiserControlMode in cluster lightingBallastCfg
[08/06/2026 16:12:57] z2m: Failed to configure '0x14b457fffe9b52e1', attempt 1 (RangeError: ZCL command 0x14b457fffe9b52e1/3 lightingBallastCfg.read(["wiserControlMode"],

```
The `wiserControlMode` attribute is unknown according to the log.  This update ensures that the attribute is defined before  it is accessed, which should (could?) prevent the error. 


<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
