### PR TITLE
feat: Plugwise 170-01: OpenTherm controls, battery type, product variant

### DIFF
--- a/src/devices/plugwise.ts
+++ b/src/devices/plugwise.ts
@@ -2,13 +2,16 @@ import {Zcl} from "zigbee-herdsman";
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
+import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz, KeyValue, Tz} from "../lib/types";
+import type {Configure, DefinitionWithExtend, Fz, KeyValue, ModernExtend, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
+
+const NS = "zhc:plugwise";
 
 const _manufacturerOptions = {manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V};
 
@@ -44,6 +47,14 @@ interface PlugwiseHvacThermostat {
     commands: {
         plugwiseCalibrateValve: Record<string, never>;
     };
+    commandResponses: never;
+}
+
+interface PlugwiseGenPowerCfg {
+    attributes: {
+        plugwiseBatteryType: number;
+    };
+    commands: never;
     commandResponses: never;
 }
 
@@ -123,6 +134,33 @@ const plugwiseExtend = {
             },
             commandsResponse: {},
         }),
+    plugwiseGenPowerCfgCluster: () =>
+        m.deviceAddCustomCluster("genPowerCfg", {
+            name: "genPowerCfg",
+            ID: Zcl.Clusters.genPowerCfg.ID,
+            attributes: {
+                plugwiseBatteryType: {
+                    name: "plugwiseBatteryType",
+                    ID: 0x007f,
+                    type: Zcl.DataType.ENUM8,
+                    manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V,
+                    write: true,
+                },
+            },
+            commands: {},
+            commandsResponse: {},
+        }),
+    batteryType: (args?: Partial<m.EnumLookupArgs<"genPowerCfg", PlugwiseGenPowerCfg>>) =>
+        m.enumLookup<"genPowerCfg", PlugwiseGenPowerCfg>({
+            name: "battery_type",
+            cluster: "genPowerCfg",
+            attribute: "plugwiseBatteryType",
+            lookup: {alkaline: 0x00, nimh: 0x01},
+            description: "Installed battery chemistry. Set this to match the batteries fitted: alkaline (non-rechargeable) or NiMH (rechargeable).",
+            zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V},
+            access: "ALL",
+            entityCategory: "config",
+        }),
     boilerWaterTemperature: (args?: Partial<m.NumericArgs<"hvacThermostat", PlugwiseHvacThermostat>>) =>
         m.numeric<"hvacThermostat", PlugwiseHvacThermostat>({
             name: "boiler_water_temperature",
@@ -157,6 +195,72 @@ const plugwiseExtend = {
             access: "STATE",
             unit: "°C",
             scale: 100,
+            ...args,
+        }),
+    externalHeatDemand: (args?: Partial<m.NumericArgs<"hvacThermostat", PlugwiseHvacThermostat>>) =>
+        m.numeric<"hvacThermostat", PlugwiseHvacThermostat>({
+            name: "external_heat_demand",
+            cluster: "hvacThermostat",
+            attribute: "plugwiseExternalHeatDemand",
+            description:
+                "OpenTherm boiler control setpoint override. Set to 0 to disable the override and return control to the thermostat. Requires External Control to be unlocked on the device (see https://www.plugwise.com/emma-external-control).",
+            zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V},
+            access: "ALL",
+            unit: "°C",
+            scale: 100,
+            valueMin: 0,
+            valueMax: 90,
+            valueStep: 0.01,
+            ...args,
+        }),
+    externalHeatDemandTimeout: (args?: Partial<m.NumericArgs<"hvacThermostat", PlugwiseHvacThermostat>>) =>
+        m.numeric<"hvacThermostat", PlugwiseHvacThermostat>({
+            name: "external_heat_demand_timeout",
+            cluster: "hvacThermostat",
+            attribute: "plugwiseExternalHeatDemandTimeout",
+            description:
+                "Watchdog timeout for the external heat demand override before it is automatically cancelled. Requires External Control to be unlocked on the device (see https://www.plugwise.com/emma-external-control).",
+            zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V},
+            access: "ALL",
+            unit: "s",
+            valueMin: 300,
+            valueMax: 3600,
+            valueStep: 1,
+            entityCategory: "config",
+            ...args,
+        }),
+    maxDhwSetpoint: (args?: Partial<m.NumericArgs<"hvacThermostat", PlugwiseHvacThermostat>>) =>
+        m.numeric<"hvacThermostat", PlugwiseHvacThermostat>({
+            name: "max_dhw_setpoint",
+            cluster: "hvacThermostat",
+            attribute: "plugwiseMaxDhwSetpoint",
+            description:
+                "Maximum domestic hot water (DHW) setpoint exchanged with the boiler over OpenTherm. Requires External Control to be unlocked on the device (see https://www.plugwise.com/emma-external-control).",
+            zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V},
+            access: "ALL",
+            unit: "°C",
+            scale: 100,
+            valueMin: 0,
+            valueMax: 100,
+            valueStep: 0.01,
+            entityCategory: "config",
+            ...args,
+        }),
+    maxBoilerSetpoint: (args?: Partial<m.NumericArgs<"hvacThermostat", PlugwiseHvacThermostat>>) =>
+        m.numeric<"hvacThermostat", PlugwiseHvacThermostat>({
+            name: "max_boiler_setpoint",
+            cluster: "hvacThermostat",
+            attribute: "plugwiseMaxBoilerSetpoint",
+            description:
+                "Maximum central heating (CH) water setpoint exchanged with the boiler over OpenTherm. Requires External Control to be unlocked on the device (see https://www.plugwise.com/emma-external-control).",
+            zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V},
+            access: "ALL",
+            unit: "°C",
+            scale: 100,
+            valueMin: 0,
+            valueMax: 100,
+            valueStep: 0.01,
+            entityCategory: "config",
             ...args,
         }),
     applicationFaultCode: (args?: Partial<m.NumericArgs<"hvacThermostat", PlugwiseHvacThermostat>>) =>
@@ -212,6 +316,62 @@ const plugwiseExtend = {
             reporting: false,
             ...args,
         }),
+    /**
+     * Read-only `product_variant` exposed from the standard genBasic `productCode` (0x000A, CHAR_STR).
+     * Tolerates devices that do not implement the attribute (e.g. current Emma firmware): the configure
+     * read is wrapped in try/catch so `UNSUPPORTED_ATTRIBUTE` does not fail the interview. Once the
+     * firmware ships 0x000A, the value will populate automatically.
+     */
+    productVariant: (): ModernExtend => {
+        const expose = e
+            .text("product_variant", ea.STATE_GET)
+            .withDescription(
+                "Product variant reported by the device, based on the detected backplate. For example: 'OpenTherm', 'OnOff', 'OpenTherm/OnOff', or 'Wireless'.",
+            )
+            .withCategory("diagnostic");
+
+        const fromZigbee = [
+            {
+                cluster: "genBasic",
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg, publish, options, meta) => {
+                    if (msg.data.productCode !== undefined) {
+                        // productCode is an OCTET_STR; zigbee-herdsman delivers it as a Buffer or string.
+                        const raw = msg.data.productCode;
+                        const value = Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw);
+                        return {product_variant: value};
+                    }
+                },
+            } satisfies Fz.Converter<"genBasic", undefined, ["attributeReport", "readResponse"]>,
+        ];
+
+        const toZigbee: Tz.Converter[] = [
+            {
+                key: ["product_variant"],
+                convertGet: async (entity, key, meta) => {
+                    await entity.read("genBasic", ["productCode"]);
+                },
+            },
+        ];
+
+        const configure: Configure[] = [
+            async (device, coordinatorEndpoint, definition) => {
+                const endpoint = device.getEndpoint(1);
+                if (!endpoint) return;
+                try {
+                    await endpoint.read("genBasic", ["productCode"]);
+                } catch (error) {
+                    if ((error as Error).message.includes("UNSUPPORTED_ATTRIBUTE")) {
+                        // ignore: firmware does not implement productCode yet (forward-compat).
+                    } else {
+                        logger.warning(`Failed to read genBasic productCode: ${error}`, NS);
+                    }
+                }
+            },
+        ];
+
+        return {exposes: [expose], fromZigbee, toZigbee, configure, isModernExtend: true};
+    },
 };
 
 const fzLocal = {
@@ -387,11 +547,13 @@ export const definitions: DefinitionWithExtend[] = [
         model: "170-01",
         vendor: "Plugwise",
         description: "Emma Wired Pro / Emma Wireless",
-        version: "0.0.3",
+        version: "0.0.4",
         extend: [
             plugwiseExtend.plugwiseHvacThermostatCluster(),
+            plugwiseExtend.plugwiseGenPowerCfgCluster(),
             plugwiseExtend.applicationFaultCodeStatus(),
             plugwiseExtend.oemFaultCode(),
+            plugwiseExtend.productVariant(),
             m.temperature({
                 reporting: {min: "1_SECOND", max: 870, change: 10},
             }),
@@ -490,6 +652,10 @@ export const definitions: DefinitionWithExtend[] = [
             plugwiseExtend.boilerWaterTemperature({
                 reporting: {min: "1_MINUTE", max: 870, change: 0.1},
             }),
+            plugwiseExtend.externalHeatDemand(),
+            plugwiseExtend.externalHeatDemandTimeout(),
+            plugwiseExtend.maxDhwSetpoint(),
+            plugwiseExtend.maxBoilerSetpoint(),
             m.numeric({
                 name: "boiler_setpoint",
                 cluster: "hvacThermostat",
@@ -500,13 +666,14 @@ export const definitions: DefinitionWithExtend[] = [
                 reporting: {min: "1_SECOND", max: 870, change: 1},
             }),
             m.battery(),
+            plugwiseExtend.batteryType(),
             m.enumLookup({
                 name: "keypad_lockout",
                 cluster: "hvacUserInterfaceCfg",
                 attribute: "keypadLockout",
                 lookup: {no_lockout: 0x00, level_1: 0x01, level_2: 0x02},
                 description:
-                    "Keaypad lockout. No lockout — all buttons active. Level 1 — normal operation, menu blocked; setpoint change via slider still allowed. Level 2 — all buttons and slider blocked; only the hardware unlock sequence is accepted.",
+                    "Keypad lockout. No lockout — all buttons active. Level 1 — normal operation, menu blocked; setpoint change via slider still allowed. Level 2 — all buttons and slider blocked; only the hardware unlock sequence is accepted.",
                 reporting: {min: "1_SECOND", max: 870, change: null},
                 entityCategory: "config",
             }),

--- a/test/plugwise.test.ts
+++ b/test/plugwise.test.ts
@@ -1,0 +1,154 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import type {Models as ZHModels} from "zigbee-herdsman";
+import {Zcl} from "zigbee-herdsman";
+import {findByDevice} from "../src/index";
+import type {Definition, Tz} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+const PLUGWISE_MFG = {manufacturerCode: Zcl.ManufacturerCode.PLUGWISE_B_V};
+
+describe("Plugwise 170-01 (Emma)", () => {
+    let emma: Definition;
+
+    beforeEach(async () => {
+        const device = mockDevice({modelID: "170-01", endpoints: []});
+        emma = await findByDevice(device);
+    });
+
+    describe("manufacturer-specific OpenTherm attributes", () => {
+        let meta: Tz.Meta;
+        let endpoint: ZHModels.Endpoint;
+        let writeFn: ReturnType<typeof vi.fn>;
+        let readFn: ReturnType<typeof vi.fn>;
+
+        // Each writable mfg attribute: the exposed property, the underlying cluster
+        // attribute, the user-facing set value, and the scaled value written on the wire.
+        const cases = [
+            {property: "external_heat_demand", attribute: "plugwiseExternalHeatDemand", input: 60, raw: 6000},
+            {property: "external_heat_demand_timeout", attribute: "plugwiseExternalHeatDemandTimeout", input: 600, raw: 600},
+            {property: "max_dhw_setpoint", attribute: "plugwiseMaxDhwSetpoint", input: 65, raw: 6500},
+            {property: "max_boiler_setpoint", attribute: "plugwiseMaxBoilerSetpoint", input: 75, raw: 7500},
+        ];
+
+        beforeEach(() => {
+            writeFn = vi.fn();
+            readFn = vi.fn();
+            // endpoint_name (!= undefined) makes determineEndpoint return this entity directly.
+            endpoint = {write: writeFn, read: readFn} as unknown as ZHModels.Endpoint;
+            meta = {endpoint_name: null} as unknown as Tz.Meta;
+        });
+
+        it.each(cases)("$property convertSet writes the scaled value with the Plugwise manufacturer code", async ({
+            property,
+            attribute,
+            input,
+            raw,
+        }) => {
+            // Arrange
+            const converter = emma.toZigbee?.find((c) => c.key.includes(property));
+            if (!converter?.convertSet) throw new Error(`No toZigbee convertSet for '${property}'`);
+
+            // Act
+            const result = await converter.convertSet(endpoint, property, input, meta);
+
+            // Assert
+            expect(writeFn).toHaveBeenCalledTimes(1);
+            expect(writeFn).toHaveBeenCalledWith("hvacThermostat", {[attribute]: raw}, PLUGWISE_MFG);
+            expect(result).toStrictEqual({state: {[property]: input}});
+        });
+
+        it.each(cases)("$property convertGet reads the attribute with the Plugwise manufacturer code", async ({property, attribute}) => {
+            // Arrange
+            const converter = emma.toZigbee?.find((c) => c.key.includes(property));
+            if (!converter?.convertGet) throw new Error(`No toZigbee convertGet for '${property}'`);
+
+            // Act
+            await converter.convertGet(endpoint, property, meta);
+
+            // Assert
+            expect(readFn).toHaveBeenCalledTimes(1);
+            expect(readFn).toHaveBeenCalledWith("hvacThermostat", [attribute], PLUGWISE_MFG);
+        });
+
+        describe("battery_type (Plugwise genPowerCfg mfg attribute)", () => {
+            it.each([
+                ["alkaline", 0x00],
+                ["nimh", 0x01],
+            ])("convertSet '%s' writes value %i to genPowerCfg with the Plugwise manufacturer code", async (value, raw) => {
+                // Arrange
+                const converter = emma.toZigbee?.find((c) => c.key.includes("battery_type"));
+                if (!converter?.convertSet) throw new Error("No toZigbee convertSet for 'battery_type'");
+
+                // Act
+                await converter.convertSet(endpoint, "battery_type", value, meta);
+
+                // Assert
+                expect(writeFn).toHaveBeenCalledTimes(1);
+                expect(writeFn).toHaveBeenCalledWith("genPowerCfg", {plugwiseBatteryType: raw}, PLUGWISE_MFG);
+            });
+
+            it("convertGet reads battery_type with the Plugwise manufacturer code", async () => {
+                // Arrange
+                const converter = emma.toZigbee?.find((c) => c.key.includes("battery_type"));
+                if (!converter?.convertGet) throw new Error("No toZigbee convertGet for 'battery_type'");
+
+                // Act
+                await converter.convertGet(endpoint, "battery_type", meta);
+
+                // Assert
+                expect(readFn).toHaveBeenCalledTimes(1);
+                expect(readFn).toHaveBeenCalledWith("genPowerCfg", ["plugwiseBatteryType"], PLUGWISE_MFG);
+            });
+        });
+    });
+
+    describe("product_variant (genBasic productCode 0x000A)", () => {
+        const findGenBasicConverter = () => emma.fromZigbee?.find((c) => c.cluster === "genBasic" && c.type.includes("readResponse"));
+
+        it("registers a genBasic fromZigbee converter for product_variant", () => {
+            expect(findGenBasicConverter()).toBeDefined();
+        });
+
+        it.each([
+            ["Buffer", Buffer.from("OpenTherm", "utf8"), "OpenTherm"],
+            ["string", "Wireless", "Wireless"],
+        ])("fromZigbee converts a %s productCode into product_variant", (_label, raw, expected) => {
+            // Arrange
+            const converter = findGenBasicConverter();
+            if (!converter?.convert) throw new Error("No genBasic fromZigbee convert for product_variant");
+
+            // Act
+            const result = converter.convert(emma, {data: {productCode: raw}} as never, () => {}, {}, {} as never);
+
+            // Assert
+            expect(result).toStrictEqual({product_variant: expected});
+        });
+
+        it("fromZigbee ignores messages without a productCode attribute", () => {
+            // Arrange
+            const converter = findGenBasicConverter();
+            if (!converter?.convert) throw new Error("No genBasic fromZigbee convert for product_variant");
+
+            // Act
+            const result = converter.convert(emma, {data: {}} as never, () => {}, {}, {} as never);
+
+            // Assert
+            expect(result).toBeUndefined();
+        });
+
+        it("convertGet (read button) reads genBasic productCode", async () => {
+            // Arrange
+            const readFn = vi.fn();
+            const endpoint = {read: readFn} as unknown as ZHModels.Endpoint;
+            const converter = emma.toZigbee?.find((c) => c.key.includes("product_variant"));
+            if (!converter?.convertGet) throw new Error("No toZigbee convertGet for 'product_variant'");
+
+            // Act
+            await converter.convertGet(endpoint, "product_variant", {} as unknown as Tz.Meta);
+
+            // Assert
+            expect(readFn).toHaveBeenCalledTimes(1);
+            expect(readFn).toHaveBeenCalledWith("genBasic", ["productCode"]);
+        });
+    });
+});


### PR DESCRIPTION
Extends the existing Plugwise Emma (`170-01`) definition with manufacturer-specific OpenTherm controls and a few related features. No new device — this is an update to an existing one (so no device-picture PR is needed).

## Changes

- **OpenTherm controls** (writable manufacturer-specific `hvacThermostat` attributes): `external_heat_demand`, `external_heat_demand_timeout`, `max_dhw_setpoint`, `max_boiler_setpoint`. Their descriptions note that the device requires *External Control* to be unlocked before these writes are accepted, with a link to the Plugwise External Control page.
- **`battery_type`** — config enum (`alkaline` / `nimh`) backed by a Plugwise `genPowerCfg` manufacturer attribute (`0x007F`).
- **`product_variant`** — read-only diagnostic, read from the standard `genBasic` `productCode` (`0x000A`). The configure read is wrapped so that `UNSUPPORTED_ATTRIBUTE` (current firmware does not implement it yet) does not fail the interview; it also exposes a read button and populates automatically once firmware ships the attribute. Reflects the detected backplate (e.g. `OpenTherm`, `OnOff`, `OpenTherm/OnOff`, `Wireless`).
- Fix a typo in the `keypad_lockout` description (`Keaypad` → `Keypad`).
- Bump the `170-01` definition `version` `0.0.3` → `0.0.4`.

## Test plan

Adds `test/plugwise.test.ts` (vitest) covering:
- scaled writes/reads for each OpenTherm attribute, asserting the value and the Plugwise manufacturer code on the wire;
- `battery_type` set/get;
- `product_variant` parsing (Buffer + string) and the read.

Local run of the full CI gates passes: `pnpm build`, `pnpm check`, `pnpm test` (577 passed), `pnpm bench`.
