### PR TITLE
feat(add): Zemismart KES-606US-LH1 (1-gang) and KES-606US-L2 (2-gang) with scene mode support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11051,7 +11051,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3",]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3"]),
         model: "TS0726_2_gang",
         vendor: "Tuya",
         description: "2 gang switch with neutral wire",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11037,33 +11037,45 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_l8bfzlcd"]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_l8bfzlcd", "_TZ3000_ovbvmhiq"]),
         model: "TS0726_1_gang",
         vendor: "Tuya",
         description: "1 gang switch with neutral wire",
         extend: [tuya.modernExtend.tuyaBase()],
         fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
         toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode],
-        exposes: [e.switch(), e.power_on_behavior(), e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]), e.action(["scene_1"])],
+        exposes: (device) => {
+            const exposes = [e.switch(), e.power_on_behavior(), e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]), e.action(["scene_1"])];
+            if (utils.isDummyDevice(device) || device.manufacturerName === "_TZ3000_ovbvmhiq") {
+                exposes.push(e.enum("indicator_mode", ea.ALL, ["none", "relay", "pos"]));
+            }
+            return exposes;
+        },
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3"]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3", "_TZ3000_icoxotza"]),
         model: "TS0726_2_gang",
         vendor: "Tuya",
         description: "2 gang switch with neutral wire",
         extend: [tuya.modernExtend.tuyaBase()],
         fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
         toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode],
-        exposes: [
-            ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
-            ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
-            ...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)),
-            e.action(["scene_1", "scene_2"]),
-        ],
+        exposes: (device) => {
+            const exposes = [
+                ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
+                ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
+                ...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)),
+                e.action(["scene_1", "scene_2"]),
+            ];
+            if (utils.isDummyDevice(device) || device.manufacturerName === "_TZ3000_icoxotza") {
+                exposes.push(e.enum("indicator_mode", ea.ALL, ["none", "relay", "pos"]));
+            }
+            return exposes;
+        },
         endpoint: (device) => {
             return {l1: 1, l2: 2};
         },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11051,24 +11051,19 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3", "_TZ3000_icoxotza"]),
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3002_1s0vfmtv", "_TZ3002_gdwja9a7", "_TZ3002_u7d3nes3",]),
         model: "TS0726_2_gang",
         vendor: "Tuya",
         description: "2 gang switch with neutral wire",
         extend: [tuya.modernExtend.tuyaBase()],
         fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
         toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode],
-        exposes: (device) => {
-            const exposes = [
-                ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
-                ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
-            ];
-            if (utils.isDummyDevice(device) || device.manufacturerName !== "_TZ3000_icoxotza") {
-                exposes.push(...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)));
-                exposes.push(e.action(["scene_1", "scene_2"]));
-            }
-            return exposes;
-        },
+        exposes: [
+            ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
+            ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
+            ...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)),
+            e.action(["scene_1", "scene_2"]),
+        ],
         endpoint: (device) => {
             return {l1: 1, l2: 2};
         },

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -130,11 +130,9 @@ const tzLocal = {
             await entity.read("closuresWindowCovering", [isPosition ? "currentPositionLiftPercentage" : "currentPositionTiltPercentage"]);
         },
     } satisfies Tz.Converter,
-   
 };
 
 const fzLocal = {
-
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     ZMCSW032D_cover_position: {
         cluster: "closuresWindowCovering",
@@ -1175,5 +1173,5 @@ export const definitions: DefinitionWithExtend[] = [
                 [13, "battery", tuya.valueConverter.raw],
             ],
         },
-   
+    },
 ];

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -148,7 +148,7 @@ const tzLocal = {
         convertSet: async (entity, key, value, meta) => {
             const ep = meta.device.getEndpoint(1);
             await ep.write("genOnOff", {
-                0x8001: {value: utils.getFromLookup(value, {none: 0, relay: 1, pos: 2}), type: 0x30},
+                32769: {value: utils.getFromLookup(value, {none: 0, relay: 1, pos: 2}), type: 0x30},
             });
             return {state: {indicator_mode: value as string}};
         },
@@ -1209,7 +1209,8 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ovbvmhiq"]),
         model: "KES-606US-LH1",
         vendor: "Zemismart",
-        description: "Smart light switch - 1 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
+        description:
+            "Smart light switch - 1 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
         extend: [tuya.modernExtend.tuyaBase()],
         fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
         toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode, tzLocal.indicator_mode_none_relay_pos],
@@ -1229,7 +1230,8 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_icoxotza"]),
         model: "KES-606US-L2",
         vendor: "Zemismart",
-        description: "Smart light switch - 2 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
+        description:
+            "Smart light switch - 2 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
         extend: [tuya.modernExtend.tuyaBase()],
         fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
         toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode, tzLocal.indicator_mode_none_relay_pos],

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -161,8 +161,10 @@ const fzLocal = {
     TS0726_action: {
         cluster: "genOnOff" as const,
         type: ["commandTuyaAction"] as const,
-        convert: (model: unknown, msg: {endpoint: {id: number}}, publish: unknown, options: unknown, meta: unknown) => {
-            return {action: `scene_${(msg as {endpoint: {id: number}}).endpoint.id}`};
+        // biome-ignore lint/style/useNamingConvention: Zigbee endpoint uses ID not id
+        convert: (model: unknown, msg: {endpoint: {ID: number}}, publish: unknown, options: unknown, meta: unknown) => {
+            // biome-ignore lint/style/useNamingConvention: Zigbee endpoint uses ID not id
+            return {action: `scene_${(msg as {endpoint: {ID: number}}).endpoint.ID}`};
         },
     },
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -157,6 +157,14 @@ const tzLocal = {
 
 const fzLocal = {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS0726_action: {
+        cluster: "genOnOff",
+        type: ["commandTuyaAction"],
+        convert: (model, msg, publish, options, meta) => {
+            return {action: `scene_${msg.endpoint.ID}`};
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["commandTuyaAction"]>,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     ZMCSW032D_cover_position: {
         cluster: "closuresWindowCovering",
         type: ["attributeReport", "readResponse"],
@@ -1197,7 +1205,7 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
-{
+    {
         fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ovbvmhiq"]),
         model: "KES-606US-LH1",
         vendor: "Zemismart",

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -161,8 +161,8 @@ const fzLocal = {
     TS0726_action: {
         cluster: "genOnOff" as const,
         type: ["commandTuyaAction"] as const,
-        convert: (model: unknown, msg: {endpoint: {ID: number}}, publish: unknown, options: unknown, meta: unknown) => {
-            return {action: `scene_${(msg as {endpoint: {ID: number}}).endpoint.ID}`};
+        convert: (model: unknown, msg: {endpoint: {id: number}}, publish: unknown, options: unknown, meta: unknown) => {
+            return {action: `scene_${(msg as {endpoint: {id: number}}).endpoint.id}`};
         },
     },
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -130,6 +130,29 @@ const tzLocal = {
             await entity.read("closuresWindowCovering", [isPosition ? "currentPositionLiftPercentage" : "currentPositionTiltPercentage"]);
         },
     } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS0726_switch_mode: {
+        key: ["switch_mode"],
+        convertSet: async (entity, key, value, meta) => {
+            await entity.write(0xe001, {
+                53280: {
+                    value: utils.getFromLookup(value, {switch: 0, scene: 1}),
+                    type: 0x30,
+                },
+            });
+            return {state: {switch_mode: value}};
+        },
+    } satisfies Tz.Converter,
+    indicator_mode_none_relay_pos: {
+        key: ["indicator_mode"],
+        convertSet: async (entity, key, value, meta) => {
+            const ep = meta.device.getEndpoint(1);
+            await ep.write("genOnOff", {
+                0x8001: {value: utils.getFromLookup(value, {none: 0, relay: 1, pos: 2}), type: 0x30},
+            });
+            return {state: {indicator_mode: value as string}};
+        },
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -1172,6 +1195,50 @@ export const definitions: DefinitionWithExtend[] = [
                 ],
                 [13, "battery", tuya.valueConverter.raw],
             ],
+        },
+    },
+{
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ovbvmhiq"]),
+        model: "KES-606US-LH1",
+        vendor: "Zemismart",
+        description: "Smart light switch - 1 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
+        extend: [tuya.modernExtend.tuyaBase()],
+        fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode, tzLocal.indicator_mode_none_relay_pos],
+        exposes: [
+            e.switch(),
+            e.power_on_behavior(),
+            e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]),
+            tuya.exposes.indicatorModeNoneRelayPos(),
+            e.action(["scene_1"]),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_icoxotza"]),
+        model: "KES-606US-L2",
+        vendor: "Zemismart",
+        description: "Smart light switch - 2 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
+        extend: [tuya.modernExtend.tuyaBase()],
+        fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
+        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode, tzLocal.indicator_mode_none_relay_pos],
+        exposes: [
+            ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
+            ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
+            ...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)),
+            tuya.exposes.indicatorModeNoneRelayPos(),
+            e.action(["scene_1", "scene_2"]),
+        ],
+        endpoint: (device) => ({l1: 1, l2: 2}),
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            for (const ep of [1, 2]) {
+                await reporting.bind(device.getEndpoint(ep), coordinatorEndpoint, ["genOnOff"]);
+            }
         },
     },
 ];

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -157,7 +157,7 @@ const tzLocal = {
 };
 
 const fzLocal = {
-// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     TS0726_action: {
         cluster: "genOnOff" as const,
         type: ["commandTuyaAction"] as const,

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -1,4 +1,3 @@
-import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as legacy from "../lib/legacy";
@@ -131,42 +130,11 @@ const tzLocal = {
             await entity.read("closuresWindowCovering", [isPosition ? "currentPositionLiftPercentage" : "currentPositionTiltPercentage"]);
         },
     } satisfies Tz.Converter,
-    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-    TS0726_switch_mode: {
-        key: ["switch_mode"],
-        convertSet: async (entity, key, value, meta) => {
-            await entity.write(0xe001, {
-                53280: {
-                    value: utils.getFromLookup(value, {switch: 0, scene: 1}),
-                    type: 0x30,
-                },
-            });
-            return {state: {switch_mode: value}};
-        },
-    } satisfies Tz.Converter,
-    indicator_mode_none_relay_pos: {
-        key: ["indicator_mode"],
-        convertSet: async (entity, key, value, meta) => {
-            const ep = meta.device.getEndpoint(1);
-            await ep.write("genOnOff", {
-                32769: {value: utils.getFromLookup(value, {none: 0, relay: 1, pos: 2}), type: 0x30},
-            });
-            return {state: {indicator_mode: value as string}};
-        },
-    } satisfies Tz.Converter,
+   
 };
 
 const fzLocal = {
-    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-    TS0726_action: {
-        cluster: "genOnOff" as const,
-        type: ["commandTuyaAction"] as const,
-        // biome-ignore lint/style/useNamingConvention: Zigbee endpoint uses ID not id
-        convert: (model: unknown, msg: {endpoint: {ID: number}}, publish: unknown, options: unknown, meta: unknown) => {
-            // biome-ignore lint/style/useNamingConvention: Zigbee endpoint uses ID not id
-            return {action: `scene_${(msg as {endpoint: {ID: number}}).endpoint.ID}`};
-        },
-    },
+
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     ZMCSW032D_cover_position: {
         cluster: "closuresWindowCovering",
@@ -1207,51 +1175,5 @@ export const definitions: DefinitionWithExtend[] = [
                 [13, "battery", tuya.valueConverter.raw],
             ],
         },
-    },
-    {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_ovbvmhiq"]),
-        model: "KES-606US-LH1",
-        vendor: "Zemismart",
-        description:
-            "Smart light switch - 1 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
-        extend: [tuya.modernExtend.tuyaBase()],
-        fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode, tzLocal.indicator_mode_none_relay_pos],
-        exposes: [
-            e.switch(),
-            e.power_on_behavior(),
-            e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]),
-            tuya.exposes.indicatorModeNoneRelayPos(),
-            e.action(["scene_1"]),
-        ],
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
-        },
-    },
-    {
-        fingerprint: tuya.fingerprint("TS0726", ["_TZ3000_icoxotza"]),
-        model: "KES-606US-L2",
-        vendor: "Zemismart",
-        description:
-            "Smart light switch - 2 gang with neutral wire and scene mode (US). NOTE: scene mode requires one-time initialization via Tuya Smart Life app before pairing to Z2M. Steps: 1) pair to Smart Life, 2) set key to scene mode in Smart Life device settings, 3) remove from Smart Life, 4) reset and re-pair to Z2M.",
-        extend: [tuya.modernExtend.tuyaBase()],
-        fromZigbee: [fz.on_off, tuya.fz.power_on_behavior_2, fzLocal.TS0726_action],
-        toZigbee: [tz.on_off, tuya.tz.power_on_behavior_2, tzLocal.TS0726_switch_mode, tzLocal.indicator_mode_none_relay_pos],
-        exposes: [
-            ...[1, 2].map((ep) => e.switch().withEndpoint(`l${ep}`)),
-            ...[1, 2].map((ep) => e.power_on_behavior().withEndpoint(`l${ep}`)),
-            ...[1, 2].map((ep) => e.enum("switch_mode", ea.STATE_SET, ["switch", "scene"]).withEndpoint(`l${ep}`)),
-            tuya.exposes.indicatorModeNoneRelayPos(),
-            e.action(["scene_1", "scene_2"]),
-        ],
-        endpoint: (device) => ({l1: 1, l2: 2}),
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            for (const ep of [1, 2]) {
-                await reporting.bind(device.getEndpoint(ep), coordinatorEndpoint, ["genOnOff"]);
-            }
-        },
-    },
+   
 ];

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -157,14 +157,14 @@ const tzLocal = {
 };
 
 const fzLocal = {
-    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+// biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     TS0726_action: {
-        cluster: "genOnOff",
-        type: ["commandTuyaAction"],
-        convert: (model, msg, publish, options, meta) => {
-            return {action: `scene_${msg.endpoint.ID}`};
+        cluster: "genOnOff" as const,
+        type: ["commandTuyaAction"] as const,
+        convert: (model: unknown, msg: {endpoint: {ID: number}}, publish: unknown, options: unknown, meta: unknown) => {
+            return {action: `scene_${(msg as {endpoint: {ID: number}}).endpoint.ID}`};
         },
-    } satisfies Fz.Converter,
+    },
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     ZMCSW032D_cover_position: {
         cluster: "closuresWindowCovering",

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -1,3 +1,4 @@
+import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as legacy from "../lib/legacy";
@@ -163,7 +164,7 @@ const fzLocal = {
         convert: (model, msg, publish, options, meta) => {
             return {action: `scene_${msg.endpoint.ID}`};
         },
-    } satisfies Fz.Converter<"genOnOff", undefined, ["commandTuyaAction"]>,
+    } satisfies Fz.Converter,
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     ZMCSW032D_cover_position: {
         cluster: "closuresWindowCovering",


### PR DESCRIPTION
## Devices added

| Model | `manufacturerName` | Gangs | Scene Mode |
|---|---|---|---|
| Zemismart KES-606US-LH1 | `_TZ3000_ovbvmhiq` | 1 | ✅ |
| Zemismart KES-606US-L2  | `_TZ3000_icoxotza` | 2 | ✅ |

## Key finding: Scene mode requires Smart Life pre-initialization

Scene mode **does work**, but requires a one-time initialization via the Tuya Smart Life app before pairing to Z2M:

1. Pair the switch to Smart Life
2. Set the desired keys to **Scene Mode** in Smart Life device settings
3. Remove the device from Smart Life
4. Reset the switch and re-pair to Z2M

Without this pre-initialization, setting `switch_mode` to `scene` will not trigger action events.

## Features supported

- `switch_mode`: `switch` / `scene` (per endpoint)
- `action`: `scene_1` / `scene_2`
- `power_on_behavior`
- `indicator_mode`: `none` / `relay` / `pos` (via `genOnOff` attribute `0x8001`)
- `configureMagicPacket` required for independent per-gang control

Tested on Z2M Edge v2.7.2-1.