### PR TITLE
add: Aqara Spotlight T2 Pro (SSWQD22LM)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3388,6 +3388,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [lumi.modernExtend.addManuSpecificLumiCluster(), lumiZigbeeOTA(), lumiLight({colorTemp: true, powerOutageMemory: "switch"})],
     },
     {
+        zigbeeModel: ["lumi.light.acn040"],
+        model: "SSWQD22LM",
+        vendor: "Aqara",
+        description: "Spotlight T2 Pro",
+        extend: [lumi.modernExtend.addManuSpecificLumiCluster(), lumiZigbeeOTA(), lumiLight({colorTemp: true, colorTempRange: [166, 370]})],
+    },
+    {
         zigbeeModel: ["lumi.switch.n0agl1"],
         model: "SSM-U01",
         vendor: "Aqara",


### PR DESCRIPTION
Adds the Aqara Spotlight T2 Pro (`SSWQD22LM`, zigbeeModel `lumi.light.acn040`), successor to the Spotlight T2 (`SSWQD03LM`). Reuses `lumiLight` with the T2 Pro's color temperature range of 166-370 mired, which matches the product spec of 2700K-6000K (https://www.aqara.com/en/product/spotlight-t2-pro/).

Verified on real hardware (6 units, Zigbee2MQTT 2.12.0):
- `state` / `brightness` / `color_temp` (166-370 mired, both extremes confirmed visually), `device_temperature` and `power_outage_count` all work.
- **No `power_outage_memory`** (unlike SSWQD03LM): the device rejects the write both ways — `"switch"` -> `Not supported`, `"light"` -> `UNSUPPORTED_ATTRIBUTE` (genBasic `0xF299`).
- **No power/energy metering**: the `haElectricalMeasurement` / `seMetering` / `genAnalogInput`(ep21) clusters are present but read back `0` or `UNSUPPORTED_ATTRIBUTE` even at full brightness, i.e. dummy clusters. (This is why the auto-generated definition's electricity-meter / analog_input entities were always 0/null - cf. #29621.)
- `color_temp_startup` (startUpColorTemperature) does work on the device, but is intentionally omitted to match the `lumiLight` convention shared by the other lumi lights.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5224