### PR TITLE
Update description in legrand.ts: 067755 is not batteryless

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -45,7 +45,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         model: "067755",
         vendor: "Legrand",
-        description: "Wireless and batteryless 4 scenes control",
+        description: "Wireless 4 scenes control",
         ota: true,
         meta: {battery: {voltageToPercentage: {min: 2500, max: 3000}}, publishDuplicateTransaction: true},
         fromZigbee: [fz.identify, fz.battery, fzLocal.command_recall_by_groupid],


### PR DESCRIPTION
There is another Green Power device 067755L without battery, that's probably where the name came from:  https://www.legrand.fr/pro/catalogue/commande-sans-fils-sans-pile-self-e-celiane-with-netatmo-4-scenarios-enjoliveur-blanc

It seems these devices without battery are implemented in z2m as ZLGP:
https://www.zigbee2mqtt.io/devices/ZLGP14_ZLGP15_ZLGP16.html

