### PR TITLE
Update philips.ts (Hue Xamento White and Color Ambiance GU10 (white))

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4351,7 +4351,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "929004611301",
         vendor: "Philips",
         description: "Hue Xamento White and Color Ambiance GU10 (white)",
-        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["929003074701"],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4347,6 +4347,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, turnsOffAtBrightness1: true})],
     },
     {
+        zigbeeModel: ["929004611301_01", "929004611301_02", "929004611301_03"],
+        model: "929004611301",
+        vendor: "Philips",
+        description: "Hue Xamento White and Color Ambiance GU10 (white)",
+        extend: [philipsLight({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+    },
+    {
         zigbeeModel: ["929003074701"],
         model: "929003074701",
         vendor: "Philips",

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4351,7 +4351,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "929004611301",
         vendor: "Philips",
         description: "Hue Xamento White and Color Ambiance GU10 (white)",
-        extend: [philipsLight({"colorTemp":{"range":[153,500]},"color":{"modes":["xy","hs"],"enhancedHue":true}})],
+        extend: [philipsLight({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["929003074701"],


### PR DESCRIPTION
"Hue Xamento White and Color Ambiance GU10 (white)" added

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5228
