### PR TITLE
Add Heimgard Entry Lock HT-SLM-3 support

### DIFF
--- a/src/devices/heimgard_technologies.ts
+++ b/src/devices/heimgard_technologies.ts
@@ -60,6 +60,39 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.lock(), e.pincode(), e.battery(), e.sound_volume()],
     },
     {
+        zigbeeModel: ['HT-SLM-3'],
+        model: 'HT-SLM-3',
+        vendor: 'Heimgard Technologies',
+        description: 'Heimgard Entry Lock',
+        ota: true,
+        meta: {pinCodeCount: 40},
+        fromZigbee: [
+            fz.lock,
+            fz.battery,
+            fz.lock_operation_event,
+            fz.lock_programming_event,
+            fz.lock_pin_code_response,
+            fz.lock_user_status_response,
+        ],
+        toZigbee: [tz.identify, tz.lock, tz.lock_sound_volume, tz.pincode_lock, tz.lock_userstatus],
+        exposes: [
+            e.lock(),
+            e.battery(),
+            e.pincode(),
+            e.lock_action(),
+            e.lock_action_source_name(),
+            e.lock_action_user(),
+            e.sound_volume(),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await reporting.lockState(endpoint);
+            await reporting.batteryPercentageRemaining(endpoint);
+            await endpoint.read('closuresDoorLock', ['lockState', 'soundVolume']);
+        },
+    },
+    {
         zigbeeModel: ["HC-IWDIM-1"],
         model: "HC-IWDIM-1",
         vendor: "Heimgard Technologies",

--- a/src/devices/heimgard_technologies.ts
+++ b/src/devices/heimgard_technologies.ts
@@ -60,10 +60,10 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.lock(), e.pincode(), e.battery(), e.sound_volume()],
     },
     {
-        zigbeeModel: ['HT-SLM-3'],
-        model: 'HT-SLM-3',
-        vendor: 'Heimgard Technologies',
-        description: 'Heimgard Entry Lock',
+        zigbeeModel: ["HT-SLM-3"],
+        model: "HT-SLM-3",
+        vendor: "Heimgard Technologies",
+        description: "Heimgard Entry Lock",
         ota: true,
         meta: {pinCodeCount: 40},
         fromZigbee: [
@@ -75,21 +75,13 @@ export const definitions: DefinitionWithExtend[] = [
             fz.lock_user_status_response,
         ],
         toZigbee: [tz.identify, tz.lock, tz.lock_sound_volume, tz.pincode_lock, tz.lock_userstatus],
-        exposes: [
-            e.lock(),
-            e.battery(),
-            e.pincode(),
-            e.lock_action(),
-            e.lock_action_source_name(),
-            e.lock_action_user(),
-            e.sound_volume(),
-        ],
+        exposes: [e.lock(), e.battery(), e.pincode(), e.lock_action(), e.lock_action_source_name(), e.lock_action_user(), e.sound_volume()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['closuresDoorLock', 'genPowerCfg']);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["closuresDoorLock", "genPowerCfg"]);
             await reporting.lockState(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
-            await endpoint.read('closuresDoorLock', ['lockState', 'soundVolume']);
+            await endpoint.read("closuresDoorLock", ["lockState", "soundVolume"]);
         },
     },
     {


### PR DESCRIPTION
Added support for Heimgard Entry Lock with various features.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5230
