### PR TITLE
fix(tuya): TS0601_dimmer_1_gang_1 suppress stale periodic state report

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4666,14 +4666,22 @@ export const definitions: DefinitionWithExtend[] = [
         // physical-knob state changes (see #10272, #25203). For variants whose
         // firmware does not support standard reporting, the bind + configReport
         // requests are harmless no-ops.
-        version: "0.0.1",
+        //
+        // maximumReportInterval is set to 0 (change-only reporting, no periodic
+        // heartbeat). The library default of 3600s causes this firmware to send
+        // a stale hourly report --- genOnOff.onOff always 1 and a frozen
+        // genLevelCtrl.currentLevel regardless of actual state --- which
+        // overwrites the correct state in the consumer once an hour. The
+        // event-driven on-change reports remain accurate, so suppressing the
+        // periodic path is sufficient and lossless.
+        version: "0.0.2",
         fromZigbee: [fz.on_off, fz.brightness],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
-            await reporting.onOff(endpoint);
-            await reporting.brightness(endpoint);
+            await reporting.onOff(endpoint, {max: 0});
+            await reporting.brightness(endpoint, {max: 0});
         },
         exposes: (device, options) => {
             const exps: Expose[] = [


### PR DESCRIPTION
Follow-up to #12235. That PR bound genOnOff/genLevelCtrl and configured reporting with the library defaults (maximumReportInterval 3600s). On the ION Industries firmware variant (_TZE200_ykgar0ow) the periodic/timer-driven report reads a stale attribute cache: it always sends genOnOff.onOff = 1 and a frozen genLevelCtrl.currentLevel regardless of the device's real state. The result is that the correct state is overwritten with a spurious "on" once per hour.

The event-driven on-change reports are accurate (that is what #12235 unlocked), so only the periodic path is at fault. Set maximumReportInterval to 0 (change-only reporting, no heartbeat) for both attributes. This is lossless for state tracking: the periodic report was never a liveness mechanism (that is handled separately by Z2M's availability feature via active pinging of mains-powered devices), so suppressing it costs nothing.

Verified on a real _TZE200_ykgar0ow dimmer: after reconfigure, no spurious hourly reports over an overnight window with the lamp off, while knob press and rotation still report immediately.