### PR TITLE
Rollback remove unwanted local_temperature exposed property for Acova Alcantara 3

### DIFF
--- a/src/devices/acova.ts
+++ b/src/devices/acova.ts
@@ -21,11 +21,10 @@ const acova = {
                         msg.data.systemMode,
                         constants.acovaThermostatSystemModes as Record<string | number, string>,
                     );
-                    if (result.system_mode === "off") {
-                        result.hvac_action = "off";
-                    }
                 }
-                result.local_temperature = null;
+                if (model.model === "ALCANTARA2") {
+                    result.local_temperature = null;
+                }
                 return result;
             },
         } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,


### PR DESCRIPTION
This PR permit to fix :

- Rollback https://github.com/Koenkk/zigbee-herdsman-converters/pull/12331 for Acova Alcantara 3 radiators that have temperature measured on device. Deactivating local_temperature exposed property only applies to Acova Alcantara 2 radiators