### PR TITLE
Add support for Shelly Dimmer 0/1-10V PM Gen4 (S4DM-0010WW)

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1729,6 +1729,23 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        fingerprint: [{modelID: "Dimmer 0-1/10", manufacturerName: "Shelly"}],
+        model: "S4DM-0010WW",
+        vendor: "Shelly",
+        description: "Dimmer 0/1-10V PM Gen4",
+        extend: [
+            m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4, "239": 239}}),
+            m.light(),
+            m.electricityMeter(),
+            m.commandsOnOff({endpointNames: ["2", "3", "4"]}),
+            m.commandsWindowCovering({endpointNames: ["4"]}),
+            m.commandsLevelCtrl({endpointNames: ["4"]}),
+            shellyModernExtend.shellyPowerFactorInt16Fix(),
+            ...shellyModernExtend.shellyCustomClusters(),
+            shellyModernExtend.shellyWiFiSetup(),
+        ],
+    },
+    {
         fingerprint: [{modelID: "BLU H&T ZB", manufacturerName: "Shelly"}],
         model: "SBHT-203C",
         vendor: "Shelly",


### PR DESCRIPTION
Adds support for the Shelly Dimmer 0/1-10V PM Gen4.

- Zigbee model: `Dimmer 0-1/10`
- Model: `S4DM-0010WW`
- Vendor: `Shelly`

Based on the external definition generated by Zigbee2MQTT with endpoints for light, electricity meter, on/off, window covering, and level control. Includes the usual Shelly Gen4 extensions (power factor fix, custom clusters, WiFi setup).

Product info: https://kb.shelly.cloud/knowledge-base/shelly-dimmer-0-1-10v-pm-gen4
Docs PR: https://github.com/Koenkk/zigbee2mqtt.io/pull/5232