### PR TITLE
fix: add new bticino hardwareRevision for bticino K4027C

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -238,7 +238,7 @@ export const definitions: DefinitionWithExtend[] = [
                 model: "K4027C/L4027C/N4027C/NT4027C",
                 vendor: "BTicino",
                 description: "Shutter SW with level control",
-                fingerprint: [{hardwareVersion: 9}, {hardwareVersion: 13}],
+                fingerprint: [{hardwareVersion: 9}, {hardwareVersion: 13}, {hardwareVersion: 16}],
             },
         ],
         ota: true,


### PR DESCRIPTION
I recently purchased a [BTicino K4027C from Amazon](https://www.amazon.it/-/en/BTicino-K4027C-Connected-Shutter-Control/dp/B07DS4MKH6/ref=sr_1_4).

The device is currently being incorrectly identified as a Legrand device.

After investigating, I found that the issue is related to the hardware revision. These devices report `hardwareRevision` 16, whereas the other shutter modules I already own report `hardwareRevision` 9.

This PR adds support for `hardwareRevision` 16 so that the device is correctly identified as a BTicino K4027C.

This is my first PR...
I hope I did everything correctly :D

<img width="687" height="656" alt="Screenshot 2026-06-14 at 15 37 00" src="https://github.com/user-attachments/assets/7d2a798e-5553-40d6-bcd7-c292247e3353" />

<img width="1268" height="862" alt="Screenshot 2026-06-14 at 15 33 26" src="https://github.com/user-attachments/assets/34ddfa36-e621-4848-b637-33a69536b003" />



