### PR TITLE
Add Philips Hue Xamento GU10 (Black) device support

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4353,6 +4353,13 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Hue Xamento White and Color Ambiance GU10 (white)",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
+     {
+        zigbeeModel: ["929003812701_01", "929003812701_02", "929003812701_03"],
+        model: "929004611301",
+        vendor: "Philips",
+        description: "Hue Xamento White and Color Ambiance GU10 (Black)",
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+    },
     {
         zigbeeModel: ["929003074701"],
         model: "929003074701",

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4353,7 +4353,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Hue Xamento White and Color Ambiance GU10 (white)",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
-     {
+    {
         zigbeeModel: ["929003812701_01", "929003812701_02", "929003812701_03"],
         model: "929004611301",
         vendor: "Philips",

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4355,7 +4355,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         zigbeeModel: ["929003812701_01", "929003812701_02", "929003812701_03"],
-        model: "929004611301",
+        model: "929003812701",
         vendor: "Philips",
         description: "Hue Xamento White and Color Ambiance GU10 (Black)",
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],


### PR DESCRIPTION
I bought a Hue 3-pack Xamento spot. I see that it is supported by Zigbee2MQTT but it gives a not supported status.
On the support page I found this: https://www.zigbee2mqtt.io/devices/929003812601.html.

I think my model number is different? Can you add this?
