### PR TITLE
wyze: fix WLCKG1 lock state reporting via cluster 64512 raw frames

### DIFF
--- a/src/devices/wyze.ts
+++ b/src/devices/wyze.ts
@@ -2,9 +2,25 @@ import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, Fz} from "../lib/types";
 
 const e = exposes.presets;
+
+// The Wyze Lock v1 reports lock state via manufacturer-specific cluster 64512 (0xFC00)
+// raw frames rather than standard ZCL lock operation events. Byte 80 of these frames
+// encodes the current state: low two bits 0b11 = locked, 0b00 = unlocked.
+const fzLocal = {
+    wyzeLockRaw: {
+        cluster: 64512,
+        type: ["raw"],
+        convert: (model, msg) => {
+            if (!msg.data || msg.data.length <= 80) return undefined;
+            const stateBit = msg.data[80] & 3;
+            if (stateBit === 3) return {state: "LOCK", lock_state: "locked"};
+            if (stateBit === 0) return {state: "UNLOCK", lock_state: "unlocked"};
+        },
+    } satisfies Fz.Converter<64512, undefined, ["raw"]>,
+};
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -12,7 +28,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "WLCKG1",
         vendor: "Wyze",
         description: "Lock",
-        fromZigbee: [fz.lock, fz.lock_operation_event, fz.battery],
+        fromZigbee: [fz.lock, fz.battery, fzLocal.wyzeLockRaw],
         toZigbee: [tz.lock],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.endpoints[0];

--- a/src/devices/wyze.ts
+++ b/src/devices/wyze.ts
@@ -17,7 +17,7 @@ const fzLocal = {
         cluster: 64512,
         type: ["raw"],
         convert: (model, msg) => {
-            if (!msg.data || msg.data.length !== 85) return undefined;
+            if (msg.data?.length !== 85) return undefined;
             const stateBit = msg.data[80] & 3;
             if (stateBit === 3) return {state: "LOCK", lock_state: "locked"};
             if (stateBit === 0) return {state: "UNLOCK", lock_state: "unlocked"};

--- a/src/devices/wyze.ts
+++ b/src/devices/wyze.ts
@@ -7,14 +7,17 @@ import type {DefinitionWithExtend, Fz} from "../lib/types";
 const e = exposes.presets;
 
 // The Wyze Lock v1 reports lock state via manufacturer-specific cluster 64512 (0xFC00)
-// raw frames rather than standard ZCL lock operation events. Byte 80 of these frames
-// encodes the current state: low two bits 0b11 = locked, 0b00 = unlocked.
+// raw frames rather than standard ZCL lock operation events.
+// Only len=85 frames reliably encode physical lock state at byte 80:
+//   low two bits 0b11 = locked, 0b00 = unlocked.
+// Heartbeat/rejoin frames (len=123) always have byte 80 = 0 regardless of actual state
+// and must be skipped to avoid corrupting HA state on Z2M restart.
 const fzLocal = {
     wyzeLockRaw: {
         cluster: 64512,
         type: ["raw"],
         convert: (model, msg) => {
-            if (!msg.data || msg.data.length <= 80) return undefined;
+            if (!msg.data || msg.data.length !== 85) return undefined;
             const stateBit = msg.data[80] & 3;
             if (stateBit === 3) return {state: "LOCK", lock_state: "locked"};
             if (stateBit === 0) return {state: "UNLOCK", lock_state: "unlocked"};


### PR DESCRIPTION
## Summary

The Wyze Lock v1 (`WLCKG1`, zigbeeModel `Ford`) does not emit standard ZCL lock operation events, so the existing `fz.lock_operation_event` converter never fires and lock state is never reported after pairing.

The lock reports its state via manufacturer-specific cluster 64512 (`0xFC00`) raw frames. Byte 80 of these frames encodes the current lock state in the low two bits: `0b11` (3) = locked, `0b00` (0) = unlocked.

### Changes

- Add `fzLocal.wyzeLockRaw` converter that decodes lock state from byte 80 of cluster 64512 raw frames
- Remove `fz.lock_operation_event` which has no effect on this device
- Keep `fz.lock` for ZCL command responses (lock/unlock via HA)

### Testing

Tested across three Wyze Lock v1 units. The b80 bitmask behaviour is consistent across units and firmware versions. Lock and unlock state are now correctly reported both from remote commands and physical operation of the lock.