### PR TITLE
 fix(detect): Detect _TZ3210_qlmnxmac as Tuya TS0002_power 

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6781,7 +6781,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS0002", ["_TZ3000_aaifmpuq", "_TZ3000_irrmjcgi", "_TZ3000_huvxrx4i", "_TZ3000_pxfjrzyj","_TZ3210_qlmnxmac"]),
+        fingerprint: tuya.fingerprint("TS0002", ["_TZ3000_aaifmpuq", "_TZ3000_irrmjcgi", "_TZ3000_huvxrx4i", "_TZ3000_pxfjrzyj", "_TZ3210_qlmnxmac"]),
         model: "TS0002_power",
         vendor: "Tuya",
         description: "2 gang switch with power monitoring",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6781,7 +6781,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS0002", ["_TZ3000_aaifmpuq", "_TZ3000_irrmjcgi", "_TZ3000_huvxrx4i", "_TZ3000_pxfjrzyj"]),
+        fingerprint: tuya.fingerprint("TS0002", ["_TZ3000_aaifmpuq", "_TZ3000_irrmjcgi", "_TZ3000_huvxrx4i", "_TZ3000_pxfjrzyj","_TZ3210_qlmnxmac"]),
         model: "TS0002_power",
         vendor: "Tuya",
         description: "2 gang switch with power monitoring",


### PR DESCRIPTION
Hey i received this device  _TZ3210_qlmnxmac it came in as a 1 outlout power switch but it is actually a 2

<img width="846" height="579" alt="image" src="https://github.com/user-attachments/assets/60b6e4d7-5792-4908-aa58-91b2264da3fc" />

 https://melery.com/products/melery-zigbee-smart-wall-socket-au-electrical-plug-outlet-power-monitoring-touch-sensor-switch-wireless-remote-alexa-google-home

i think this is the correct spot to add support