### PR TITLE
Immediately clear Inovelli notificationComplete events

### DIFF
--- a/src/lib/inovelli.ts
+++ b/src/lib/inovelli.ts
@@ -2801,7 +2801,10 @@ const fzLocal = {
             // notificationComplete is a transient event vs a stateful change
             // treat it similar to an action by publishing "" to clear it on the next tick
             clearTimeout(globalStore.getValue(msg.endpoint, "notification_complete_clear"));
-            const timer = setTimeout(() => publish({notificationComplete: ""}), 0);
+            const timer = setTimeout(() => {
+                publish({notificationComplete: ""});
+                globalStore.clearValue(msg.endpoint, "notification_complete_clear");
+            }, 0);
             globalStore.putValue(msg.endpoint, "notification_complete_clear", timer);
 
             return {notificationComplete: value};

--- a/src/lib/inovelli.ts
+++ b/src/lib/inovelli.ts
@@ -7,6 +7,7 @@ import * as tz from "../converters/toZigbee";
 import * as exposes from "./exposes";
 import * as m from "./modernExtend";
 import * as reporting from "./reporting";
+import * as globalStore from "./store";
 import type {Configure, DummyDevice, Expose, Fz, KeyValue, KeyValueAny, ModernExtend, Tz, Zh} from "./types";
 import * as utils from "./utils";
 
@@ -2795,10 +2796,15 @@ const fzLocal = {
         cluster: INOVELLI_CLUSTER_NAME,
         type: ["commandLedEffectComplete"],
         convert: (model, msg, publish, options, meta) => {
-            if (msg.data.notificationType in LED_NOTIFICATION_TYPES) {
-                return {notificationComplete: LED_NOTIFICATION_TYPES[msg.data.notificationType]};
-            }
-            return {notificationComplete: "Unknown"};
+            const value = msg.data.notificationType in LED_NOTIFICATION_TYPES ? LED_NOTIFICATION_TYPES[msg.data.notificationType] : "Unknown";
+
+            // notificationComplete is a transient event vs a stateful change
+            // treat it similar to an action by publishing "" to clear it on the next tick
+            clearTimeout(globalStore.getValue(msg.endpoint, "notification_complete_clear"));
+            const timer = setTimeout(() => publish({notificationComplete: ""}), 0);
+            globalStore.putValue(msg.endpoint, "notification_complete_clear", timer);
+
+            return {notificationComplete: value};
         },
     } satisfies Fz.Converter<typeof INOVELLI_CLUSTER_NAME, Inovelli, ["commandLedEffectComplete"]>,
     report_target_info: {

--- a/test/inovelli.test.ts
+++ b/test/inovelli.test.ts
@@ -1,7 +1,7 @@
 import {beforeAll, describe, expect, it, vi} from "vitest";
 import {definitions as inovelliDeviceDefinitions} from "../src/devices/inovelli";
 import {findByDevice} from "../src/index";
-import type {Definition, Expose, Fz, KeyValue, KeyValueAny, Tz} from "../src/lib/types";
+import type {Definition, Expose, Fz, KeyValue, KeyValueAny, Tz, Zh} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 /** EP2 raw scene buffer: `data[4]` must be `0x00` for scene parsing; `data[5]` / `data[6]` index `buttonLookup` / `clickLookup` in `src/lib/inovelli.ts`. */
@@ -9,19 +9,29 @@ function rawInovelliEp2Scene(data4: number, buttonLookupKey: number, clickLookup
     return [0, 0, 0, 0, data4, buttonLookupKey, clickLookupKey];
 }
 
-function processFromZigbeeMessage(definition: Definition, cluster: string, type: string, data: KeyValue | number[], endpointID: number) {
+function processFromZigbeeMessage(
+    definition: Definition,
+    cluster: string,
+    type: string,
+    data: KeyValue | number[],
+    endpointID: number,
+    // Required for converters that touch globalStore; the store discriminates entities by constructor name and rejects plain mocks.
+    device?: Zh.Device,
+) {
     const converters = definition.fromZigbee.filter((c) => {
         const typeMatch = Array.isArray(c.type) ? c.type.includes(type) : c.type === type;
         return c.cluster === cluster && typeMatch;
     });
+
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const endpoint = device ? device.getEndpoint(endpointID) : ({ID: endpointID} as any);
 
     let payload: KeyValue = {};
     for (const converter of converters) {
         // biome-ignore lint/suspicious/noExplicitAny: test mock
         const msg: Fz.Message<any, any, any> = {
             data,
-            // biome-ignore lint/suspicious/noExplicitAny: test mock
-            endpoint: {ID: endpointID} as any,
+            endpoint,
             device: null,
             meta: null,
             groupID: 0,
@@ -1626,9 +1636,10 @@ describe("Inovelli OTA", () => {
 describe("Inovelli fromZigbee converters", () => {
     describe("VZM31-SN", () => {
         let definition: Definition;
+        let device: Zh.Device;
 
         beforeAll(async () => {
-            ({definition} = await setupVZM31());
+            ({device, definition} = await setupVZM31());
             expect(definition.model).toBe("VZM31-SN");
         });
 
@@ -1700,8 +1711,33 @@ describe("Inovelli fromZigbee converters", () => {
                 {notificationType: -1, expected: "CONFIG_BUTTON_DOUBLE_PRESS"},
                 {notificationType: 99, expected: "Unknown"},
             ])("maps notificationType=$notificationType to $expected", ({notificationType, expected}) => {
-                const payload = processFromZigbeeMessage(definition, "manuSpecificInovelli", "commandLedEffectComplete", {notificationType}, 1);
+                const payload = processFromZigbeeMessage(
+                    definition,
+                    "manuSpecificInovelli",
+                    "commandLedEffectComplete",
+                    {notificationType},
+                    1,
+                    device,
+                );
                 expect(payload).toStrictEqual({notificationComplete: expected});
+            });
+
+            it("schedules a follow-up notificationComplete:'' publish", async () => {
+                const converter = definition.fromZigbee.find(
+                    // biome-ignore lint/suspicious/noExplicitAny: test mock
+                    (c) => c.cluster === "manuSpecificInovelli" && (c.type as any).includes("commandLedEffectComplete"),
+                ) as Fz.Converter;
+                const published: KeyValue[] = [];
+                converter.convert(
+                    definition,
+                    // biome-ignore lint/suspicious/noExplicitAny: test mock
+                    {data: {notificationType: 16}, endpoint: device.getEndpoint(1)} as any,
+                    (p) => published.push(p),
+                    {},
+                    {state: {}, device: null, deviceExposesChanged: () => {}},
+                );
+                await new Promise((resolve) => setTimeout(resolve, 0));
+                expect(published).toEqual([{notificationComplete: ""}]);
             });
         });
 

--- a/test/inovelli.test.ts
+++ b/test/inovelli.test.ts
@@ -1723,10 +1723,10 @@ describe("Inovelli fromZigbee converters", () => {
             });
 
             it("schedules a follow-up notificationComplete:'' publish", async () => {
-                const converter = definition.fromZigbee.find(
-                    // biome-ignore lint/suspicious/noExplicitAny: test mock
-                    (c) => c.cluster === "manuSpecificInovelli" && (c.type as any).includes("commandLedEffectComplete"),
-                ) as Fz.Converter;
+                const converter = definition.fromZigbee.find((c) => {
+                    const typeMatch = Array.isArray(c.type) ? c.type.includes("commandLedEffectComplete") : c.type === "commandLedEffectComplete";
+                    return c.cluster === "manuSpecificInovelli" && typeMatch;
+                }) as Fz.Converter;
                 const published: KeyValue[] = [];
                 converter.convert(
                     definition,


### PR DESCRIPTION
This is an alternative proposal to address the issues raised in Koenkk/zigbee2mqtt#31686 (via wbyoung/lampie#2)

This effectively vendors the behavior to immediately clear the `notificationComplete` event here. Rationale is this is vendor-specific behavior and probably belongs here vs in Z2M via the HA extension.

Chose `0` on the timeout just so it fires next tick.

Made with my buddy Claude

cc @rohankapoorcom @wbyoung
