### PR TITLE
Add new vendor "_TZE2841000000_nhgdf6qr" for TS0601_soil_3

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4282,6 +4282,7 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0601", [
             "_TZE284_aao3yzhs",
             "_TZE284_nhgdf6qr",
+            "_TZE2841000000_nhgdf6qr",
             "_TZE284_ap9owrsa",
             "_TZE284_33bwcga2",
             "_TZE284_wckqztdq",


### PR DESCRIPTION
The sensor I got from aliexpress had a vendor ID not matching with the existing ones. I have tested it with an external converter on my Z2M install with the device, everything seems to works without issues
