### PR TITLE
Add eWeLink human presence radar support

### DIFF
--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -455,4 +455,37 @@ export const definitions: DefinitionWithExtend[] = [
         },
         ota: true,
     },
+    {
+        zigbeeModel: ["CK-BL702-MWS-01(7016)"],
+        model: "MG3-5RZ",
+        vendor: "eWeLink",
+        description: "Zigbee human presence radar (5.8 GHz)",
+        extend: [
+            m.occupancy({reporting: false}),
+            m.numeric({
+                name: "occupied_to_unoccupied_delay",
+                cluster: 0x0406,
+                attribute: {ID: 0x0020, type: 0x21},
+                description: "Ultrasonic occupied → unoccupied delay (seconds)",
+                valueMin: 60,
+                valueMax: 65535,
+            }),
+            m.numeric({
+                name: "unoccupied_to_occupied_delay",
+                cluster: 0x0406,
+                attribute: {ID: 0x0021, type: 0x21},
+                description: "Ultrasonic unoccupied → occupied delay (seconds)",
+                valueMin: 0,
+                valueMax: 65535,
+            }),
+            m.enumLookup({
+                name: "occupancy_sensitivity",
+                lookup: {low: 1, medium: 2, high: 3},
+                cluster: 0x0406,
+                attribute: {ID: 0x0022, type: 0x20},
+                description: "Sensitivity of human presence detection",
+            }),
+        ],
+        ota: false,
+    },
 ];


### PR DESCRIPTION
Added support for eWeLink Zigbee human presence radar with configuration options for delays and sensitivity.

The device identifies itself as:

zigbeeModel: CK-BL702-MWS-01(7016)

The functionality matches the existing SONOFF MG1_5RZ device:

- occupancy
- occupied_to_unoccupied_delay
- unoccupied_to_occupied_delay
- occupancy_sensitivity

The converter was adapted from the existing MG1_5RZ implementation and tested successfully.