### PR TITLE
feat(tuya): add applicationVersion 67 to TS011F_plug_3 fingerprint (EARU ATMS1603ZG)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10029,7 +10029,7 @@ export const definitions: DefinitionWithExtend[] = [
             {modelID: "TS011F", applicationVersion: 100, priority: -1},
             {modelID: "TS011F", applicationVersion: 69, priority: -1},
             {modelID: "TS011F", applicationVersion: 68, priority: -1},
-            {modelID: "TS011F", applicationVersion: 67, priority: -1},
+            {modelID: "TS011F", applicationVersion: 67, manufacturerName: "_TZ3000_9ni6xxld", priority: -1},
             {modelID: "TS011F", applicationVersion: 65, priority: -1},
             {modelID: "TS011F", applicationVersion: 64, priority: -1},
             {modelID: "TS011F", softwareBuildID: "1.0.5\u0000", manufacturerName: "_TZ3000_cehuw1lw", priority: -1},

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10029,6 +10029,7 @@ export const definitions: DefinitionWithExtend[] = [
             {modelID: "TS011F", applicationVersion: 100, priority: -1},
             {modelID: "TS011F", applicationVersion: 69, priority: -1},
             {modelID: "TS011F", applicationVersion: 68, priority: -1},
+            {modelID: "TS011F", applicationVersion: 67, priority: -1},
             {modelID: "TS011F", applicationVersion: 65, priority: -1},
             {modelID: "TS011F", applicationVersion: 64, priority: -1},
             {modelID: "TS011F", softwareBuildID: "1.0.5\u0000", manufacturerName: "_TZ3000_cehuw1lw", priority: -1},


### PR DESCRIPTION
## What
Add `applicationVersion: 67` to the `TS011F_plug_3` fingerprint array.

## Why
The **EARU ATMS1603ZG** DIN rail Zigbee power meter (TS011F, `_TZ3000_9ni6xxld`, applicationVersion 67) currently matches `TS011F_plug_1` because its applicationVersion is not in the plug_3 fingerprint list.

When matched to plug_1, the `haElectricalMeasurement` bind and configureReporting commands **crash the BL0937 measurement IC**, causing power, current, and voltage readings to permanently freeze at 0 until the device is power-cycled.

With plug_3 (`electricityMeasurementPoll`), the device works reliably — polling at 10-second intervals returns correct readings without any IC crash.

## Testing
- Tested on real hardware: EARU ATMS1603ZG
- IEEE: `0xa49e69fffe013e03`
- Stack: 0.0 build 67
- manufacturerName: `_TZ3000_9ni6xxld`
- Confirmed stable operation for 24+ hours with plug_3 polling mode
- Confirmed crash is reproducible within seconds when bind/configureReporting is sent (plug_1 mode)

## Notes
- The existing applicationVersions in plug_3 are: 64, 65, 68, 69, 100, 160, 192
- Version 67 fits the same pattern of BL0937-based devices that cannot handle active reporting
- Version 66 is already covered elsewhere (plug_2)