### PR TITLE
Add _TZE2841000000_tgrzpqf4 to TS0601_soil_3 (Tuya soil sensor / SGS01)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4287,6 +4287,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_wckqztdq",
             "_TZE284_3urschql",
             "_TZE284_tgrzpqf4",
+            "_TZE2841000000_tgrzpqf4",
         ]),
         model: "TS0601_soil_3",
         vendor: "Tuya",


### PR DESCRIPTION
This adds the manufacturerName `_TZE2841000000_tgrzpqf4` to the existing
`TS0601_soil_3` definition.

It is the same Tuya soil moisture/temperature sensor (SGS01) already
supported in this definition — the fingerprint list already contains the
clean-format twin `_TZE284_tgrzpqf4`. This particular unit ships with a
malformed manufacturerName that injects `1000000` into the string, so it
falls through to the auto-generated definition and is reported as
unsupported.

No changes to `meta`/`exposes` are needed: the existing datapoints already
match this unit, including `divideBy10` on DP 5 (temperature). All DPs were
verified on live hardware:

- DP 3 soil_moisture (raw): 55 in hand → 0 released ✓
- DP 5 temperature (divideBy10): raw 284 → 28.4 °C, consistent with ambient ✓
- DP 9 temperature_unit: reports `celsius` ✓
- DP 14 battery_state (batteryState enum): `high` at full charge ✓
- DP 15 battery (raw): 100 ✓

Interview evidence (manufacturerName is stable across interview and all
subsequent reports):

{"definition":{... "model":"TS0601", ... "vendor":"_TZE2841000000_tgrzpqf4", ...},
 "ieee_address":"0xa4c1389c6d4d9cc0","status":"successful","supported":false}

Tested on Zigbee2MQTT 2.12.0.

https://es.aliexpress.com/item/1005007443398328.html?spm=a2g0o.order_list.order_list_main.5.12a3194dYd8RXK&gatewayAdapt=glo2esp