### PR TITLE
fix(wyze): exclude fz.lock to prevent hourly false locked state

### DIFF
--- a/src/devices/wyze.ts
+++ b/src/devices/wyze.ts
@@ -12,6 +12,9 @@ const e = exposes.presets;
 //   low two bits 0b11 = locked, 0b00 = unlocked.
 // Heartbeat/rejoin frames (len=123) always have byte 80 = 0 regardless of actual state
 // and must be skipped to avoid corrupting HA state on Z2M restart.
+// fz.lock is intentionally excluded: the device sends a ZCL lockState attribute report
+// (cluster 0x0101) approximately every hour that always contains lockState=1 (locked)
+// regardless of the actual physical state, causing false "locked" updates in HA.
 const fzLocal = {
     wyzeLockRaw: {
         cluster: 64512,
@@ -31,12 +34,11 @@ export const definitions: DefinitionWithExtend[] = [
         model: "WLCKG1",
         vendor: "Wyze",
         description: "Lock",
-        fromZigbee: [fz.lock, fz.battery, fzLocal.wyzeLockRaw],
+        fromZigbee: [fz.battery, fzLocal.wyzeLockRaw],
         toZigbee: [tz.lock],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.endpoints[0];
             await reporting.bind(endpoint, coordinatorEndpoint, ["closuresDoorLock", "genPowerCfg"]);
-            await reporting.lockState(endpoint);
             await reporting.batteryPercentageRemaining(endpoint);
         },
         exposes: [e.lock(), e.battery()],


### PR DESCRIPTION
## Summary

Follow-up to #12438.

After deploying the merged converter, I observed the Wyze Lock v1 reporting `locked` in Home Assistant approximately once per hour even when the lock was physically unlocked. Investigation of the Zigbee2MQTT logs identified the cause:

The device sends a standard ZCL `lockState` attribute report on cluster `0x0101` (closuresDoorLock) roughly every hour that **always contains `lockState=1` (locked)** regardless of actual physical state. The `fz.lock` converter faithfully processes these and publishes a `locked` state update, corrupting HA's view of the lock.

**Example from logs** — two reports 10 minutes apart with the lock physically unlocked the whole time:
- `17:02:48` — ZCL reports `lockState=0` (correct)
- `17:12:45` — ZCL reports `lockState=1` (incorrect, hourly report)

## Changes

- Remove `fz.lock` from `fromZigbee` — the ZCL lockState attribute is unreliable on this device
- Remove `reporting.lockState()` from `configure()` — no longer consumed
- Expand the block comment to document why `fz.lock` is excluded

Physical lock state continues to be tracked exclusively via the manufacturer-specific cluster 64512 len=85 frames (byte 80 bitmask), which are accurate.