### PR TITLE
Feat/Sonoff snzb 02dr2 external display

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -107,6 +107,9 @@ interface SonoffSnzb02dr2 {
         temperatureUnits: number;
         temperatureCalibration: number;
         humidityCalibration: number;
+        temperatureSensorSelect: number;
+        externalTemperature: number;
+        externalHumidity: number;
     };
     commands: never;
     commandResponses: never;
@@ -5755,6 +5758,9 @@ export const definitions: DefinitionWithExtend[] = [
                     temperatureUnits: {name: "temperatureUnits", ID: 0x0007, type: Zcl.DataType.UINT16, write: true, max: 0xffff},
                     temperatureCalibration: {name: "temperatureCalibration", ID: 0x2003, type: Zcl.DataType.INT16, write: true, min: -32768},
                     humidityCalibration: {name: "humidityCalibration", ID: 0x2004, type: Zcl.DataType.INT16, write: true, min: -32768},
+                    temperatureSensorSelect: {name: "temperatureSensorSelect", ID: 0x600e, type: Zcl.DataType.UINT8, write: true, max: 0xff},
+                    externalTemperature: {name: "externalTemperature", ID: 0x600d, type: Zcl.DataType.INT16, write: true, min: -32768},
+                    externalHumidity: {name: "externalHumidity", ID: 0x6018, type: Zcl.DataType.UINT16, write: true, max: 0xffff},
                 },
                 commands: {},
                 commandsResponse: {},
@@ -5763,6 +5769,41 @@ export const definitions: DefinitionWithExtend[] = [
             m.temperature(),
             m.humidity(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
+            m.enumLookup<"customSonoffSnzb02dr2", SonoffSnzb02dr2>({
+                name: "temperature_sensor_select",
+                lookup: {internal: 0, external: 1},
+                cluster: "customSonoffSnzb02dr2",
+                attribute: "temperatureSensorSelect",
+                entityCategory: "config",
+                description:
+                    "Data source shown on the display. Set to 'external' to enable the external display and show the values written to external_temperature and external_humidity; set to 'internal' to show the built-in sensor again.",
+            }),
+            m.numeric<"customSonoffSnzb02dr2", SonoffSnzb02dr2>({
+                name: "external_temperature",
+                cluster: "customSonoffSnzb02dr2",
+                attribute: "externalTemperature",
+                description:
+                    "Temperature value to display when temperature_sensor_select is set to 'external'. Push readings here from another sensor (e.g. via an automation).",
+                access: "STATE_SET",
+                valueMin: -50,
+                valueMax: 125,
+                scale: 100,
+                valueStep: 0.1,
+                unit: "°C",
+            }),
+            m.numeric<"customSonoffSnzb02dr2", SonoffSnzb02dr2>({
+                name: "external_humidity",
+                cluster: "customSonoffSnzb02dr2",
+                attribute: "externalHumidity",
+                description:
+                    "Relative humidity value to display when temperature_sensor_select is set to 'external'. Push readings here from another sensor. Requires device firmware 1.0.4 or later.",
+                access: "STATE_SET",
+                valueMin: 0,
+                valueMax: 100,
+                scale: 100,
+                valueStep: 0.1,
+                unit: "%",
+            }),
             m.numeric<"customSonoffSnzb02dr2", SonoffSnzb02dr2>({
                 name: "comfort_temperature_min",
                 cluster: "customSonoffSnzb02dr2",

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -548,3 +548,60 @@ describe("Sonoff TRVZB", () => {
         });
     });
 });
+
+describe("Sonoff SNZB-02DR2", () => {
+    let device: Definition;
+    let endpoint: ZHModels.Endpoint;
+    let writeFn: Mock;
+    let meta: Tz.Meta;
+
+    beforeEach(async () => {
+        device = await findByDevice(mockDevice({modelID: "SNZB-02DR2", endpoints: [{ID: 1}]}));
+
+        writeFn = vi.fn();
+        endpoint = {write: writeFn} as unknown as ZHModels.Endpoint;
+        meta = {
+            state: {},
+            device: null,
+            message: null,
+            mapped: null,
+            options: null,
+            publish: null,
+            endpoint_name: null,
+        };
+    });
+
+    describe("toZigbee", () => {
+        it("enables the external display via temperature_sensor_select", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("temperature_sensor_select"));
+
+            await tzConverter.convertSet(endpoint, "temperature_sensor_select", "external", meta);
+
+            expect(writeFn).toHaveBeenCalledWith("customSonoffSnzb02dr2", {temperatureSensorSelect: 1}, undefined);
+        });
+
+        it("disables the external display via temperature_sensor_select", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("temperature_sensor_select"));
+
+            await tzConverter.convertSet(endpoint, "temperature_sensor_select", "internal", meta);
+
+            expect(writeFn).toHaveBeenCalledWith("customSonoffSnzb02dr2", {temperatureSensorSelect: 0}, undefined);
+        });
+
+        it("writes external temperature scaled x100 (signed)", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("external_temperature"));
+
+            await tzConverter.convertSet(endpoint, "external_temperature", -10.07, meta);
+
+            expect(writeFn).toHaveBeenCalledWith("customSonoffSnzb02dr2", {externalTemperature: -1007}, undefined);
+        });
+
+        it("writes external humidity scaled x100", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("external_humidity"));
+
+            await tzConverter.convertSet(endpoint, "external_humidity", 88, meta);
+
+            expect(writeFn).toHaveBeenCalledWith("customSonoffSnzb02dr2", {externalHumidity: 8800}, undefined);
+        });
+    });
+});


### PR DESCRIPTION
This is an update for an existing device.

Sonoff SNZB 02DR2 supports displaying temperature and humidity from external source. The solution is based on a discussion: 
https://github.com/Koenkk/zigbee2mqtt/discussions/31115

Documentation is also updated:
https://github.com/Koenkk/zigbee2mqtt.io/pull/5243