### PR TITLE
fix(TO-Q-SYS-JZT): map DP 108 to control_mode

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18970,6 +18970,7 @@ export const definitions: DefinitionWithExtend[] = [
                     "timing_switch_off",
                 ])
                 .withDescription("Last event of the device"),
+            e.enum("control_mode", ea.STATE, ["local_lock", "local_mode", "remote_mode", "full_control"]).withDescription("Device control mode"),
             e.enum("over_current_setting", ea.STATE_SET, ["Ignore", "Alarm", "Trip"]).withDescription("Over current setting"),
             e
                 .numeric("over_current_threshold", ea.STATE_SET)
@@ -19064,11 +19065,12 @@ export const definitions: DefinitionWithExtend[] = [
                 ],
                 [
                     108,
-                    "leakage_setting",
+                    "control_mode",
                     tuya.valueConverterBasic.lookup({
-                        Ignore: tuya.enum(0),
-                        Alarm: tuya.enum(1),
-                        Trip: tuya.enum(2),
+                        local_lock: tuya.enum(0),
+                        local_mode: tuya.enum(1),
+                        remote_mode: tuya.enum(2),
+                        full_control: tuya.enum(3),
                     }),
                 ],
                 [


### PR DESCRIPTION
DP 108 on _TZE284_6ocnqlhn was mislabeled as leakage_setting with a 3-value
lookup (Ignore/Alarm/Trip). The device reports value 3, which threw
"Value '3' is not allowed, expected one of 0,1,2". Per Tuya app inspection
(issue #32310), DP 108 is the device control mode: 0=local_lock, 1=local_mode,
2=remote_mode, 3=full_control. Relabel it and expose control_mode.
Closes Koenkk/zigbee2mqtt#32310