### PR TITLE
Add _TZE284_xpq2rzhq to Moes ZSS-QY-HP

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -13078,6 +13078,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE200_sgpeacqp",
             "_TZE204_fwondbzy",
             "_TZE284_fwondbzy",
+            "_TZE284_xpq2rzhq",
         ]),
         model: "TS0601_smart_human_presence_sensor_1",
         vendor: "Tuya",
@@ -13086,7 +13087,7 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [legacy.tz.tuya_smart_human_presense_sensor],
         whiteLabel: [
             tuya.whitelabel("Tuya", "ZY-M100-L", "Ceiling human breathe sensor", ["_TZE204_ztc6ggyl"]),
-            tuya.whitelabel("Moes", "ZSS-QY-HP", "Human presence sensor", ["_TZE204_fwondbzy", "_TZE284_fwondbzy"]),
+            tuya.whitelabel("Moes", "ZSS-QY-HP", "Human presence sensor", ["_TZE204_fwondbzy", "_TZE284_fwondbzy", "_TZE284_xpq2rzhq"]),
         ],
         exposes: [
             e.illuminance(),


### PR DESCRIPTION
Adds fingerprint _TZE284_xpq2rzhq to the existing Moes ZSS-QY-HP
(TS0601_smart_human_presence_sensor_1).

Same hardware as the already-supported _TZE204_fwondbzy / _TZE284_fwondbzy
variant — just a newer manufacturer name from a different production batch.
The base xpq2rzhq is already supported on the _TZE200_ and _TZE204_ prefixes;
only the _TZE284_ prefix was missing.

Tested via external converter on Zigbee2MQTT 2.12.0 (z-h-c 26.63.0):
device pairs and exposes presence, target_distance, illuminance,
radar_sensitivity, min/max range, detection_delay, fading_time and self_test
identically to the 230V unit.
