### PR TITLE
fix(tuya): move _TZ3000_ky0fq4ho to TS011F_din_smart_relay_polling

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12266,7 +12266,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_8bxrzyxz", "_TZ3000_ky0fq4ho", "_TZ3210_vbfp8eyv"]),
+        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_8bxrzyxz", "_TZ3210_vbfp8eyv"]),
         model: "TS011F_din_smart_relay",
         description: "Din smart relay (with power monitoring)",
         vendor: "Tuya",
@@ -12303,7 +12303,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_qeuvnohg", "_TZ3000_6l1pjfqe", "_TZ3000_2iiimqs9", "_TZ3000_viqwamhn"]),
+        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_qeuvnohg", "_TZ3000_6l1pjfqe", "_TZ3000_2iiimqs9", "_TZ3000_viqwamhn", "_TZ3000_ky0fq4ho"]),
         model: "TS011F_din_smart_relay_polling",
         description: "Din smart relay (with power monitoring via polling)",
         vendor: "Tuya",


### PR DESCRIPTION
## Problem

`_TZ3000_ky0fq4ho` (Tuya TS011F DIN rail relay) is currently matched to `TS011F_din_smart_relay` (push-based reporting). On this device, `reporting.bind()` fails with `INVALID_EP` because the coordinator endpoint 0 (ZDO) cannot be used as a binding source:

```
Failed to configure 'kitchen_sockets', attempt 1
(Error: Bind 0xa4c138f47386fab2/1 genOnOff from '0x00124b0022ab7170/0'
failed (Status 'INVALID_EP'))
```

Since the exception is thrown **before** `saveClusterAttributeKeyValue`, the cluster attribute divisors are never saved and `activePower` is always reported as `0` — even when the device is under load.

## Root cause

The push-based `configure()` in `TS011F_din_smart_relay` calls `reporting.bind()` without error handling. When bind fails, `device.save()` is never reached and the `haElectricalMeasurement` / `seMetering` divisors stay at their defaults, causing incorrect (zero) power readings.

## Fix

Move `_TZ3000_ky0fq4ho` to `TS011F_din_smart_relay_polling`, which uses `electricityMeasurementPoll()` instead of relying on push reporting. The polling variant already handles this correctly for similar devices (`_TZ3000_qeuvnohg`, `_TZ3000_6l1pjfqe`, `_TZ3000_2iiimqs9`, `_TZ3000_viqwamhn`).

## Evidence

**Before** (matched to push variant — `configure` fails every restart, `power` always `0`):

```
model: TS011F_din_smart_relay
error: Failed to configure 'kitchen_sockets', attempt 1
       (INVALID_EP on reporting.bind)
{"current":3972,"power":0,"voltage":230,"energy":2192.59}
```

**After** (matched to polling variant — interview succeeds, energy reads correctly):

```
model: TS011F_din_smart_relay_polling
info: Successfully interviewed 'kitchen_sockets'
{"current":0.48,"power":0,"voltage":230,"energy":2192.76}
```

> `power: 0` in the after-log is expected — only a refrigerator in standby was connected at that moment. `energy` advancing from `2192.59` → `2192.76 kWh` confirms the metering cluster is read correctly after the fix. Under actual load (kitchen appliances) `power` reports correctly via the poll.

## Device info

- **Model:** Tuya TS011F DIN rail smart relay with power monitoring
- **Manufacturer:** `_TZ3000_ky0fq4ho`
- **Zigbee2MQTT version tested:** 2.12.0 / zigbee-herdsman-converters 26.63.0
- **Coordinator:** ZStack3x0