### PR TITLE
fix: Tongou TO-Q-SYS-JZT: allow changing control_mode

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18972,7 +18972,7 @@ export const definitions: DefinitionWithExtend[] = [
                     "timing_switch_off",
                 ])
                 .withDescription("Last event of the device"),
-            e.enum("control_mode", ea.STATE, ["local_lock", "local_mode", "remote_mode", "full_control"]).withDescription("Device control mode"),
+            e.enum("control_mode", ea.STATE_SET, ["local_lock", "local_mode", "remote_mode", "full_control"]).withDescription("Device control mode"),
             e.enum("over_current_setting", ea.STATE_SET, ["Ignore", "Alarm", "Trip"]).withDescription("Over current setting"),
             e
                 .numeric("over_current_threshold", ea.STATE_SET)


### PR DESCRIPTION
@Romulas-12 forgot to mention: I believe you can select the mode.
If you figure out what it does, please update the description

- fixes https://github.com/Koenkk/zigbee-herdsman-converters/pull/12466