### PR TITLE
fix(tuya): correct localTempCalibration1 decode for offsets above 5.5 °C

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1947,7 +1947,7 @@ export const valueConverter = {
     lockUnlock: valueConverterBasic.lookup({LOCK: true, UNLOCK: false}),
     localTempCalibration1: {
         from: (v: number) => {
-            if (v > 55) v -= 0x100000000;
+            if (v > 0x7fffffff) v -= 0x100000000;
             return v / 10;
         },
         to: (v: number) => {

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -56,4 +56,28 @@ describe("lib/tuya", () => {
             expect(result).toStrictEqual(data.from);
         });
     });
+
+    describe("valueConverter.localTempCalibration1", () => {
+        const conv = tuya.valueConverter.localTempCalibration1;
+
+        // Regression for the `if (v > 55)` threshold bug: positive offsets above
+        // 5.5 °C (raw > 55) were wrongly treated as 2's-complement negatives and
+        // had 0x100000000 subtracted, e.g. from(60) === -429496723.6 instead of 6.
+        it("from() decodes positive calibration above 5.5 °C", () => {
+            expect(conv.from(60)).toBe(6); // was -429496723.6
+            expect(conv.from(90)).toBe(9); // max range, was -429496720.6
+        });
+
+        it("from() still decodes values up to 5.5 °C and negatives", () => {
+            expect(conv.from(0)).toBe(0);
+            expect(conv.from(55)).toBe(5.5);
+            expect(conv.from(0x100000000 - 90)).toBe(-9); // encoded -9
+        });
+
+        it("to()/from() round-trips the full range", () => {
+            for (const c of [-9, -5.5, -0.5, 0, 0.5, 5.5, 6, 9]) {
+                expect(conv.from(conv.to(c))).toBe(c);
+            }
+        });
+    });
 });


### PR DESCRIPTION
fix(tuya): correct localTempCalibration1 decode for offsets above 5.5 °C

### Problem

`valueConverter.localTempCalibration1.from()` used `if (v > 55)`, treating any
positive calibration above 5.5 °C (raw > 55) as a 2's-complement negative and
subtracting `0x100000000`. An offset of `+6 °C` read back as `-429496723.6`,
which is outside the `-9..9` range and breaks the entity. Negative offsets were
unaffected (they are encoded as `>= 0x100000000 - 90`).

Reproduced on a TECH VNTH-T2_v2; affects every device using this converter
(TECH, Essentials, AVATTO, MOES).

### Fix

Use `v > 0x7fffffff`, matching the sibling converters
`localTempCalibration{3,4,5}` which already handle this correctly. The threshold
sits safely between the max positive raw (`9 °C → 90`) and the smallest
encoded-negative raw (`-0.5 °C → 0x100000000 - 5`).

### Test

Added a regression test in `test/tuya.test.ts` covering `from()` for positive
offsets above 5.5 °C, values up to 5.5 °C, negatives, and a full-range
`to()`/`from()` round-trip. It fails on master (`from(60) === -429496723.6`) and
passes with the fix. Full suite: 587 passed.
