### PR TITLE
Add _TZE284_kv1nvirl fingerprint to Tongou TOQCB2-80

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -19737,6 +19737,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_mrffaamu",
             "_TZE284_tzreobvu",
             "_TZE284_9xstqowh",
+            "_TZE284_kv1nvirl"
         ]),
         model: "TOQCB2-80",
         vendor: "Tongou",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -19737,7 +19737,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_mrffaamu",
             "_TZE284_tzreobvu",
             "_TZE284_9xstqowh",
-            "_TZE284_kv1nvirl"
+            "_TZE284_kv1nvirl",
         ]),
         model: "TOQCB2-80",
         vendor: "Tongou",


### PR DESCRIPTION
Adds the `_TZE284_kv1nvirl` manufacturer fingerprint to the existing Tongou TOQCB2-80 definition.

Device model ID: TS0601
Manufacturer name: _TZE284_kv1nvirl

Tested successfully using an external converter based on the existing TOQCB2-80 definition. Switching, electrical measurements and protection settings work correctly.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
