### PR TITLE
fix(NodOn): add missing endpoint for FPS-4-1-00 and SIN-4-FP-20

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -235,6 +235,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Electrical heating actuator",
         extend: [m.onOff({powerOnBehavior: true}), m.electricityMeter({cluster: "metering"}), m.temperature(), m.humidity(), ...nodonPilotWire(true)],
         ota: true,
+        endpoint: (device) => ({default: 1}),
     },
     {
         zigbeeModel: ["IRB-4-1-00"],
@@ -404,6 +405,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Pilot wire heating module",
         extend: [m.onOff({powerOnBehavior: true}), m.electricityMeter({cluster: "metering"}), ...nodonPilotWire(true)],
         ota: true,
+        endpoint: (device) => ({default: 1}),
     },
     {
         zigbeeModel: ["SIN-4-FP-21"],


### PR DESCRIPTION
## Problem

`FPS-4-1-00` and `SIN-4-FP-20` expose two Zigbee endpoints:
- **Endpoint 1** — the actual actuator (`genOnOff`, metering, temperature…)
- **Endpoint 242** — Green Power proxy (`greenPower` output only)

Without an explicit `endpoint` mapping, Z2M resolves commands dynamically. On device join, the device broadcasts a `device_announce` from endpoint 242 (Green Power proxy). Z2M temporarily associates endpoint 242 as the primary endpoint for commands. All subsequent `set state ON/OFF` commands are routed there and time out after 10 s — the device never switches.

```
error: Publish 'set' 'state' to '0x6cfd22fffe81adaf' failed:
  ZCL command 0x6cfd22fffe81adaf/242 genOnOff.on({}) timed out after 10000ms
```

**Known workaround (before this fix):** restart Z2M. On restart, no `device_announce` is received; Z2M reads endpoint 1 from its device database (populated during interview) and commands work — until the next device rejoin.

## Root cause

`SIN-4-FP-21` already has the fix (`endpoint: (device) => ({default: 1})`), but `FPS-4-1-00` and `SIN-4-FP-20`, which have the same hardware profile (EFR32MG21 + Green Power proxy on endpoint 242), are missing it.

## Fix

```diff
  {
      zigbeeModel: ['FPS-4-1-00'],
      ...
      ota: true,
+     endpoint: (device) => ({default: 1}),
  },
  {
      zigbeeModel: ['SIN-4-FP-20'],
      ...
      ota: true,
+     endpoint: (device) => ({default: 1}),
  },
```

## Tested

- **FPS-4-1-00** — validated on physical device: 6× ON/OFF commands at 3 s intervals, all acknowledged by device with no timeout. Tested with Z2M 2.12.0, zigbee-herdsman-converters 26.63.0, SONOFF Zigbee 3.0 USB Dongle Plus-E (EFR32MG21, firmware 7.4.4 [GA]).
- **SIN-4-FP-20** — same hardware profile and identical definition as FPS-4-1-00, fix applied by analogy with SIN-4-FP-21.