### PR TITLE
feat(device): add Nyce NCZ-3014-HA

### DIFF
--- a/src/devices/nyce.ts
+++ b/src/devices/nyce.ts
@@ -21,6 +21,20 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.contact(), e.battery_low(), e.battery()],
     },
     {
+        zigbeeModel: ["3014"],
+        model: "NCZ-3014-HA",
+        vendor: "Nyce",
+        description: "Garage door tilt sensor",
+        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
+        toZigbee: [],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
+        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
+    },
+    {
         zigbeeModel: ["3011"],
         model: "NCZ-3011-HA",
         vendor: "Nyce",

--- a/src/devices/nyce.ts
+++ b/src/devices/nyce.ts
@@ -21,10 +21,10 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.contact(), e.battery_low(), e.battery()],
     },
     {
-        zigbeeModel: ["3014"],
-        model: "NCZ-3014-HA",
+        zigbeeModel: ["3011"],
+        model: "NCZ-3011-HA",
         vendor: "Nyce",
-        description: "Garage door tilt sensor",
+        description: "Door/window sensor",
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {
@@ -35,10 +35,10 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
-        zigbeeModel: ["3011"],
-        model: "NCZ-3011-HA",
+        zigbeeModel: ["3014"],
+        model: "NCZ-3014-HA",
         vendor: "Nyce",
-        description: "Door/window sensor",
+        description: "Garage door tilt sensor",
         fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {

--- a/src/devices/nyce.ts
+++ b/src/devices/nyce.ts
@@ -1,5 +1,6 @@
 import * as fz from "../converters/fromZigbee";
 import * as exposes from "../lib/exposes";
+import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend} from "../lib/types";
 
@@ -39,14 +40,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "NCZ-3014-HA",
         vendor: "Nyce",
         description: "Garage door tilt sensor",
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
-        toZigbee: [],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
-            await reporting.batteryPercentageRemaining(endpoint);
-        },
-        exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
+        extend: [m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1", "tamper", "battery_low"]}), m.battery()],
     },
     {
         zigbeeModel: ["3043"],


### PR DESCRIPTION
Adds support for Nyce NCZ-3014-HA garage door tilt sensor.

Tested with:
- Zigbee model: 3014
- Model: NCZ-3014-HA
- Reports open/closed via IAS contact
- Exposes: contact, battery_low, tamper, battery

Notes:
- Based on the existing NCZ-3011-HA definition.
- configure() is replicated from models 3010 and 3011, even though all those devices (and the 3014) I have time out when binding genPowerCfg during reconfigure.
- External converter tested locally in Zigbee2MQTT before upstreaming.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5247
