### PR TITLE
fix: unref timers

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -596,8 +596,7 @@ export const occupancy_with_timeout: Fz.Converter<"msOccupancySensing", undefine
         if (timeout !== 0) {
             const timer = setTimeout(() => {
                 publish({occupancy: false});
-            }, timeout * 1000);
-            timer.unref();
+            }, timeout * 1000).unref();
 
             globalStore.putValue(msg.endpoint, "occupancy_timer", timer);
         }
@@ -1100,8 +1099,7 @@ export const ias_vibration_alarm_1_with_timeout: Fz.Converter<"ssIasZone", undef
         if (timeout !== 0) {
             const timer = setTimeout(() => {
                 publish({vibration: false});
-            }, timeout * 1000);
-            timer.unref();
+            }, timeout * 1000).unref();
 
             globalStore.getValue(msg.endpoint, "timers").push(timer);
         }
@@ -1295,8 +1293,7 @@ export const ias_occupancy_alarm_1_with_timeout: Fz.Converter<"ssIasZone", undef
         clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
 
         if (timeout !== 0) {
-            const timer = setTimeout(() => publish({occupancy: false}), timeout * 1000);
-            timer.unref();
+            const timer = setTimeout(() => publish({occupancy: false}), timeout * 1000).unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
         }
 
@@ -1473,8 +1470,7 @@ export const command_move: Fz.Converter<"genLevelCtrl", undefined, ["commandMove
                     const property = postfixWithEndpointName("brightness", msg, model, meta);
                     const deltaProperty = postfixWithEndpointName("action_brightness_delta", msg, model, meta);
                     publish({[property]: brightness, [deltaProperty]: delta});
-                }, intervalOpts);
-                timer.unref();
+                }, intervalOpts).unref();
 
                 globalStore.putValue(msg.endpoint, "simulated_brightness_timer", timer);
             }
@@ -1915,8 +1911,7 @@ export const checkin_presence: Fz.Converter<"genPollCtrl", undefined, ["commandC
         // Stop existing timer because presence is detected and set a new one.
         clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
 
-        const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
-        timer.unref();
+        const timer = setTimeout(() => publish({presence: false}), timeout * 1000).unref();
         globalStore.putValue(msg.endpoint, "timer", timer);
 
         return {presence: true};

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -597,6 +597,7 @@ export const occupancy_with_timeout: Fz.Converter<"msOccupancySensing", undefine
             const timer = setTimeout(() => {
                 publish({occupancy: false});
             }, timeout * 1000);
+            timer.unref();
 
             globalStore.putValue(msg.endpoint, "occupancy_timer", timer);
         }
@@ -1100,6 +1101,7 @@ export const ias_vibration_alarm_1_with_timeout: Fz.Converter<"ssIasZone", undef
             const timer = setTimeout(() => {
                 publish({vibration: false});
             }, timeout * 1000);
+            timer.unref();
 
             globalStore.getValue(msg.endpoint, "timers").push(timer);
         }
@@ -1294,6 +1296,7 @@ export const ias_occupancy_alarm_1_with_timeout: Fz.Converter<"ssIasZone", undef
 
         if (timeout !== 0) {
             const timer = setTimeout(() => publish({occupancy: false}), timeout * 1000);
+            timer.unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
         }
 
@@ -1471,6 +1474,7 @@ export const command_move: Fz.Converter<"genLevelCtrl", undefined, ["commandMove
                     const deltaProperty = postfixWithEndpointName("action_brightness_delta", msg, model, meta);
                     publish({[property]: brightness, [deltaProperty]: delta});
                 }, intervalOpts);
+                timer.unref();
 
                 globalStore.putValue(msg.endpoint, "simulated_brightness_timer", timer);
             }
@@ -1912,6 +1916,7 @@ export const checkin_presence: Fz.Converter<"genPollCtrl", undefined, ["commandC
         clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
 
         const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
+        timer.unref();
         globalStore.putValue(msg.endpoint, "timer", timer);
 
         return {presence: true};

--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -134,8 +134,7 @@ const fzLocal = {
                     }
                 }
                 globalStore.putValue(endpoint, "button_click_count", 0);
-            }, timeout);
-            timer.unref();
+            }, timeout).unref();
             globalStore.putValue(endpoint, "timer", timer);
         },
     } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,

--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -135,6 +135,7 @@ const fzLocal = {
                 }
                 globalStore.putValue(endpoint, "button_click_count", 0);
             }, timeout);
+            timer.unref();
             globalStore.putValue(endpoint, "timer", timer);
         },
     } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,

--- a/src/devices/echostar.ts
+++ b/src/devices/echostar.ts
@@ -19,6 +19,7 @@ const fzLocal = {
 
             const lookup: KeyValueAny = {commandOn: "bell1", commandOff: "bell2"};
             const timer = setTimeout(() => globalStore.getValue(msg.endpoint, "action").pop(), timeout * 1000);
+            timer.unref();
 
             const list = globalStore.getValue(msg.endpoint, "action");
             if (list.length === 0 || list.length > 4) {

--- a/src/devices/echostar.ts
+++ b/src/devices/echostar.ts
@@ -18,8 +18,7 @@ const fzLocal = {
             }
 
             const lookup: KeyValueAny = {commandOn: "bell1", commandOff: "bell2"};
-            const timer = setTimeout(() => globalStore.getValue(msg.endpoint, "action").pop(), timeout * 1000);
-            timer.unref();
+            const timer = setTimeout(() => globalStore.getValue(msg.endpoint, "action").pop(), timeout * 1000).unref();
 
             const list = globalStore.getValue(msg.endpoint, "action");
             if (list.length === 0 || list.length > 4) {

--- a/src/devices/fireangel.ts
+++ b/src/devices/fireangel.ts
@@ -18,8 +18,7 @@ const fzLocal = {
             if (lastTestTimeout) clearTimeout(lastTestTimeout);
 
             if (testActive) {
-                const timeout = setTimeout(() => publish({test: false}), 8000);
-                timeout.unref();
+                const timeout = setTimeout(() => publish({test: false}), 8000).unref();
                 globalStore.putValue(msg.endpoint, "lastTestTimeout", timeout);
             }
 

--- a/src/devices/fireangel.ts
+++ b/src/devices/fireangel.ts
@@ -19,6 +19,7 @@ const fzLocal = {
 
             if (testActive) {
                 const timeout = setTimeout(() => publish({test: false}), 8000);
+                timeout.unref();
                 globalStore.putValue(msg.endpoint, "lastTestTimeout", timeout);
             }
 

--- a/src/devices/javis.ts
+++ b/src/devices/javis.ts
@@ -36,6 +36,7 @@ const fzLocal = {
 
             clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
             const timer = setTimeout(() => publish({action: "lock", state: "LOCK"}), 2 * 1000);
+            timer.unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
 
             return {

--- a/src/devices/javis.ts
+++ b/src/devices/javis.ts
@@ -35,8 +35,7 @@ const fzLocal = {
             const data = utf8FromStr(msg.data["16896"] as string);
 
             clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
-            const timer = setTimeout(() => publish({action: "lock", state: "LOCK"}), 2 * 1000);
-            timer.unref();
+            const timer = setTimeout(() => publish({action: "lock", state: "LOCK"}), 2 * 1000).unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
 
             return {

--- a/src/devices/kmpcil.ts
+++ b/src/devices/kmpcil.ts
@@ -46,6 +46,7 @@ function handleKmpcilPresence(
     // Stop existing timer because motion is detected and set a new one.
     clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
     const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
+    timer.unref();
     globalStore.putValue(msg.endpoint, "timer", timer);
 
     return {presence: true};

--- a/src/devices/kmpcil.ts
+++ b/src/devices/kmpcil.ts
@@ -45,8 +45,7 @@ function handleKmpcilPresence(
     const timeout = Number(mode ? timeoutDc : timeoutBattery);
     // Stop existing timer because motion is detected and set a new one.
     clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
-    const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
-    timer.unref();
+    const timer = setTimeout(() => publish({presence: false}), timeout * 1000).unref();
     globalStore.putValue(msg.endpoint, "timer", timer);
 
     return {presence: true};

--- a/src/devices/lidl.ts
+++ b/src/devices/lidl.ts
@@ -110,7 +110,7 @@ const valueConverterLocal = {
                     ts.iteration_start_timestamp = Date.now();
                     if (ts.timer > 1) {
                         // report every minute
-                        const interval = setInterval(() => {
+                        ts.iteration_inverval = setInterval(() => {
                             const now = Date.now();
                             const wateringEndTime = ts.iteration_start_timestamp + ts.timer * 60 * 1000;
                             const timeLeftInMinutes = Math.round((wateringEndTime - now) / 1000 / 60);
@@ -122,9 +122,7 @@ const valueConverterLocal = {
                                     time_left: timeLeftInMinutes,
                                 });
                             }
-                        }, 60 * 1000);
-                        ts.iteration_inverval = interval;
-                        interval.unref();
+                        }, 60 * 1000).unref();
                     }
                     // initial reporting
                     result.time_left = ts.timer;

--- a/src/devices/lidl.ts
+++ b/src/devices/lidl.ts
@@ -110,7 +110,7 @@ const valueConverterLocal = {
                     ts.iteration_start_timestamp = Date.now();
                     if (ts.timer > 1) {
                         // report every minute
-                        ts.iteration_inverval = setInterval(() => {
+                        const interval = setInterval(() => {
                             const now = Date.now();
                             const wateringEndTime = ts.iteration_start_timestamp + ts.timer * 60 * 1000;
                             const timeLeftInMinutes = Math.round((wateringEndTime - now) / 1000 / 60);
@@ -123,6 +123,8 @@ const valueConverterLocal = {
                                 });
                             }
                         }, 60 * 1000);
+                        ts.iteration_inverval = interval;
+                        interval.unref();
                     }
                     // initial reporting
                     result.time_left = ts.timer;

--- a/src/devices/mindy.ts
+++ b/src/devices/mindy.ts
@@ -66,7 +66,8 @@ const tzLocal = {
                     } catch {
                         /* Do nothing */
                     }
-                    setTimeout(() => retryRead(attempts - 1), 10000);
+                    const timer = setTimeout(() => retryRead(attempts - 1), 10000);
+                    timer.unref();
                 }
             };
 

--- a/src/devices/mindy.ts
+++ b/src/devices/mindy.ts
@@ -66,8 +66,7 @@ const tzLocal = {
                     } catch {
                         /* Do nothing */
                     }
-                    const timer = setTimeout(() => retryRead(attempts - 1), 10000);
-                    timer.unref();
+                    setTimeout(() => retryRead(attempts - 1), 10000).unref();
                 }
             };
 

--- a/src/devices/nous.ts
+++ b/src/devices/nous.ts
@@ -51,9 +51,10 @@ export const definitions: DefinitionWithExtend[] = [
                         from: (v: boolean, meta, options, publish) => {
                             if (!v) return false;
 
-                            setTimeout(() => {
+                            const timer = setTimeout(() => {
                                 publish({warming_up: false});
                             }, 120 * 1000);
+                            timer.unref();
                             return true;
                         },
                     },

--- a/src/devices/nous.ts
+++ b/src/devices/nous.ts
@@ -51,10 +51,9 @@ export const definitions: DefinitionWithExtend[] = [
                         from: (v: boolean, meta, options, publish) => {
                             if (!v) return false;
 
-                            const timer = setTimeout(() => {
+                            setTimeout(() => {
                                 publish({warming_up: false});
-                            }, 120 * 1000);
-                            timer.unref();
+                            }, 120 * 1000).unref();
                             return true;
                         },
                     },

--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -108,8 +108,7 @@ export const fzLocal = {
             // Stop existing timer because motion is detected and set a new one.
             clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
 
-            const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
-            timer.unref();
+            const timer = setTimeout(() => publish({presence: false}), timeout * 1000).unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
             return {presence: true};
         },
@@ -124,8 +123,7 @@ export const fzLocal = {
             const timeout = useOptionsTimeout ? Number(options.presence_timeout) : 100; // 100 seconds by default
             // Stop existing timer because motion is detected and set a new one.
             clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
-            const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
-            timer.unref();
+            const timer = setTimeout(() => publish({presence: false}), timeout * 1000).unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
             return {presence: true};
         },

--- a/src/devices/smartthings.ts
+++ b/src/devices/smartthings.ts
@@ -109,6 +109,7 @@ export const fzLocal = {
             clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
 
             const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
+            timer.unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
             return {presence: true};
         },
@@ -124,6 +125,7 @@ export const fzLocal = {
             // Stop existing timer because motion is detected and set a new one.
             clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
             const timer = setTimeout(() => publish({presence: false}), timeout * 1000);
+            timer.unref();
             globalStore.putValue(msg.endpoint, "timer", timer);
             return {presence: true};
         },

--- a/src/devices/sunricher.ts
+++ b/src/devices/sunricher.ts
@@ -1194,7 +1194,7 @@ export const definitions: DefinitionWithExtend[] = [
                         throw error;
                     }
 
-                    await new Promise((resolve) => setTimeout(resolve, 2000 * retryCount));
+                    await utils.sleep(2000 * retryCount);
                 }
             }
         },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -916,15 +916,14 @@ const tzLocal = {
             // allowing user apps to turn it on again if needed.
             // This could probably be improved by actually turning it on again if necessary.
             if (transitionSeconds !== 0) {
-                const timer = setTimeout(
+                setTimeout(
                     () => {
                         tz.on_off.convertGet(entity, "state", meta).catch((error) => {
                             logger.warning(`Error getting state of TS0505B_1 after transition: ${error.message}`, NS);
                         });
                     },
                     transitionSeconds * 1000 + 100,
-                );
-                timer.unref();
+                ).unref();
             }
 
             return ret;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -522,7 +522,7 @@ const tzLocal = {
 
             // AE-720K requires ON twice (similar to pressing ON twice on device)
             await tuya.sendDataPointBool(entity, 1, true);
-            await new Promise((r) => setTimeout(r, 220));
+            await utils.sleep(220);
             await tuya.sendDataPointBool(entity, 1, true);
 
             return {state: {state: "ON"}};
@@ -916,7 +916,7 @@ const tzLocal = {
             // allowing user apps to turn it on again if needed.
             // This could probably be improved by actually turning it on again if necessary.
             if (transitionSeconds !== 0) {
-                setTimeout(
+                const timer = setTimeout(
                     () => {
                         tz.on_off.convertGet(entity, "state", meta).catch((error) => {
                             logger.warning(`Error getting state of TS0505B_1 after transition: ${error.message}`, NS);
@@ -924,6 +924,7 @@ const tzLocal = {
                     },
                     transitionSeconds * 1000 + 100,
                 );
+                timer.unref();
             }
 
             return ret;
@@ -987,7 +988,9 @@ const tzLocal = {
 
             for (let slot = 1; slot <= 4; slot++) {
                 await bindSlotTS0601SmartSceneKnob(entity, slot, mode);
-                if (slot < 4) await new Promise((resolve) => setTimeout(resolve, 500));
+                if (slot < 4) {
+                    await utils.sleep(500);
+                }
             }
 
             // Scene mode doesn't use Group ID
@@ -1102,7 +1105,7 @@ const fzLocal = {
                     const be4 = (n: number) => [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff];
                     const payload = [...be4(utcTime), ...be4(localTime)];
                     await ep.command("manuSpecificTuya", "mcuSyncTime", {payloadSize: 8, payload}, {disableDefaultResponse: true});
-                    await new Promise((r) => setTimeout(r, 500));
+                    await utils.sleep(500);
                     try {
                         await tuya.sendDataPointBool(ep, 17, false);
                     } catch {
@@ -6566,7 +6569,7 @@ export const definitions: DefinitionWithExtend[] = [
                             if (v === "off") {
                                 if (meta.options.wake_before_power_transition === true) {
                                     await tuya.sendDataPointBool(ep, 1, true, "dataRequest", 1);
-                                    await new Promise((r) => setTimeout(r, 120));
+                                    await utils.sleep(120);
                                 }
 
                                 await tuya.sendDataPointBool(ep, 1, false, "dataRequest", 1);
@@ -6576,7 +6579,7 @@ export const definitions: DefinitionWithExtend[] = [
                             if (meta.options.wake_before_power_transition === true) {
                                 if (meta.state.system_mode === "off") {
                                     await tuya.sendDataPointBool(ep, 1, true, "dataRequest", 1);
-                                    await new Promise((r) => setTimeout(r, 120));
+                                    await utils.sleep(120);
                                 }
                             }
 

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -111,19 +111,16 @@ const ubisys = {
                 const log = (message: string) => {
                     logger.warning(`ubisys: ${message}`, NS);
                 };
-                const sleepSeconds = async (s: number) => {
-                    return await new Promise((resolve) => setTimeout(resolve, s * 1000));
-                };
                 const waitUntilStopped = async () => {
                     let operationalStatus = 0;
                     do {
-                        await sleepSeconds(2);
+                        await utils.sleep(2000);
                         const response = await entity.read<"closuresWindowCovering", UbisysClosuresWindowCovering>("closuresWindowCovering", [
                             "operationalStatus",
                         ]);
                         operationalStatus = response.operationalStatus;
                     } while (operationalStatus !== 0);
-                    await sleepSeconds(2);
+                    await utils.sleep(2000);
                 };
                 const writeAttrFromJson = async (
                     attr: string,
@@ -147,7 +144,7 @@ const ubisys = {
                             manufacturerOptions.ubisys,
                         );
                         if (delaySecondsAfter) {
-                            await sleepSeconds(delaySecondsAfter);
+                            await utils.sleep(delaySecondsAfter * 1000);
                         }
                     }
                 };
@@ -160,7 +157,7 @@ const ubisys = {
                     await entity.write("closuresWindowCovering", {
                         windowCoveringMode: mode & ~modeCalibrationBitMask,
                     });
-                    await sleepSeconds(2);
+                    await utils.sleep(2000);
                 }
                 // delay a bit if reconfiguring basic configuration attributes
                 await writeAttrFromJson("ubisysWindowCoveringType", undefined, undefined, 2);
@@ -192,17 +189,17 @@ const ubisys = {
                         manufacturerOptions.ubisys,
                     );
                     // enable calibration mode
-                    await sleepSeconds(2);
+                    await utils.sleep(2000);
                     await entity.write("closuresWindowCovering", {
                         windowCoveringMode: mode | modeCalibrationBitMask,
                     });
-                    await sleepSeconds(2);
+                    await utils.sleep(2000);
                     // move down a bit and back up to detect upper limit
                     log("  Moving cover down a bit...");
                     await entity.command("closuresWindowCovering", "downClose", {});
-                    await sleepSeconds(5);
+                    await utils.sleep(5000);
                     await entity.command("closuresWindowCovering", "stop", {});
-                    await sleepSeconds(2);
+                    await utils.sleep(2000);
                     log("  Moving up again to detect upper limit...");
                     await entity.command("closuresWindowCovering", "upOpen", {});
                     await waitUntilStopped();
@@ -242,11 +239,11 @@ const ubisys = {
                 if (hasCalibrate) {
                     log("  Finalizing calibration...");
                     // disable calibration mode again
-                    await sleepSeconds(2);
+                    await utils.sleep(2000);
                     await entity.write("closuresWindowCovering", {
                         windowCoveringMode: mode & ~modeCalibrationBitMask,
                     });
-                    await sleepSeconds(2);
+                    await utils.sleep(2000);
                     // re-read and dump all relevant attributes
                     log("  Done - will now read back the results.");
                     await ubisys.tz.configure_j1.convertGet(entity, key, meta);

--- a/src/devices/vsmart.ts
+++ b/src/devices/vsmart.ts
@@ -2,6 +2,7 @@ import {Zcl} from "zigbee-herdsman";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import type {DefinitionWithExtend, ModernExtend, Tz} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const ea = exposes.access;
 
@@ -423,7 +424,7 @@ const mLocal = {
                         );
 
                         if (i < commands.length - 1) {
-                            await new Promise((resolve) => setTimeout(resolve, COMMAND_DELAY_MS));
+                            await utils.sleep(COMMAND_DELAY_MS);
                         }
                     }
 

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -93,10 +93,6 @@ const tzLocal = {
         convertSet: async (entity, key, value, meta) => {
             utils.assertNumber(value, key);
             if (meta.options.time_close != null && meta.options.time_open != null) {
-                const sleepSeconds = async (s: number) => {
-                    return await new Promise((resolve) => setTimeout(resolve, s * 1000));
-                };
-
                 const oldPosition = meta.state.position;
                 if (value === 100) {
                     await entity.command("closuresWindowCovering", "upOpen", {}, utils.getOptions(meta.mapped, entity));
@@ -106,18 +102,16 @@ const tzLocal = {
                     if (utils.isNumber(oldPosition) && oldPosition > value) {
                         const delta = oldPosition - value;
                         utils.assertNumber(meta.options.time_open);
-                        const mutiplicateur = meta.options.time_open / 100;
-                        const timeBeforeStop = delta * mutiplicateur;
+                        const timeBeforeStop = delta * (meta.options.time_open / 100) * 1000;
                         await entity.command("closuresWindowCovering", "downClose", {}, utils.getOptions(meta.mapped, entity));
-                        await sleepSeconds(timeBeforeStop);
+                        await utils.sleep(timeBeforeStop);
                         await entity.command("closuresWindowCovering", "stop", {}, utils.getOptions(meta.mapped, entity));
                     } else if (utils.isNumber(oldPosition) && oldPosition < value) {
                         const delta = value - oldPosition;
                         utils.assertNumber(meta.options.time_close);
-                        const mutiplicateur = meta.options.time_close / 100;
-                        const timeBeforeStop = delta * mutiplicateur;
+                        const timeBeforeStop = delta * (meta.options.time_close / 100) * 1000;
                         await entity.command("closuresWindowCovering", "upOpen", {}, utils.getOptions(meta.mapped, entity));
-                        await sleepSeconds(timeBeforeStop);
+                        await utils.sleep(timeBeforeStop);
                         await entity.command("closuresWindowCovering", "stop", {}, utils.getOptions(meta.mapped, entity));
                     }
                 }

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -2475,7 +2475,8 @@ export const boschBsenExtend = {
                             // only known to Bosch. Therefore, we have to manually defer the turn-off by
                             // 4 seconds + 3 minutes to avoid any confusion.
                             const timeoutDelay = 184 * 1000;
-                            setTimeout(() => publish({occupancy: false}), timeoutDelay);
+                            const timer = setTimeout(() => publish({occupancy: false}), timeoutDelay);
+                            timer.unref();
                             meta.device.meta.occupancyLockTimeout = Date.now() + timeoutDelay;
                         }
                     }
@@ -2504,11 +2505,12 @@ export const boschBsenExtend = {
 
                 if (occupancyLockTimeout > currentTime) {
                     const timeoutDelay = occupancyLockTimeout - currentTime;
-                    setTimeout(() => {
+                    const timer = setTimeout(() => {
                         endpoint.read("ssIasZone", ["zoneStatus"]).catch((exception) => {
                             logger.warning(`Error during reading the zoneStatus on device '${event.data.device.ieeeAddr}': ${exception}`, NS);
                         });
                     }, timeoutDelay);
+                    timer.unref();
                 } else {
                     await endpoint.read("ssIasZone", ["zoneStatus"]);
                 }
@@ -3032,6 +3034,7 @@ export const boschSmokeAlarmExtend = {
                                 async () => await sendAlarmControlMessage(entity, broadcastAlarm, alarmMode, timeoutInSeconds),
                                 (timeoutInSeconds - 60) * 1000,
                             );
+                            alarmTimer.unref();
                             globalStore.putValue("boschSmokeAlarm", "alarmTimer", alarmTimer);
                         }
                     }

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -2475,8 +2475,7 @@ export const boschBsenExtend = {
                             // only known to Bosch. Therefore, we have to manually defer the turn-off by
                             // 4 seconds + 3 minutes to avoid any confusion.
                             const timeoutDelay = 184 * 1000;
-                            const timer = setTimeout(() => publish({occupancy: false}), timeoutDelay);
-                            timer.unref();
+                            setTimeout(() => publish({occupancy: false}), timeoutDelay).unref();
                             meta.device.meta.occupancyLockTimeout = Date.now() + timeoutDelay;
                         }
                     }
@@ -2505,12 +2504,11 @@ export const boschBsenExtend = {
 
                 if (occupancyLockTimeout > currentTime) {
                     const timeoutDelay = occupancyLockTimeout - currentTime;
-                    const timer = setTimeout(() => {
+                    setTimeout(() => {
                         endpoint.read("ssIasZone", ["zoneStatus"]).catch((exception) => {
                             logger.warning(`Error during reading the zoneStatus on device '${event.data.device.ieeeAddr}': ${exception}`, NS);
                         });
-                    }, timeoutDelay);
-                    timer.unref();
+                    }, timeoutDelay).unref();
                 } else {
                     await endpoint.read("ssIasZone", ["zoneStatus"]);
                 }
@@ -3033,8 +3031,7 @@ export const boschSmokeAlarmExtend = {
                             const alarmTimer = setTimeout(
                                 async () => await sendAlarmControlMessage(entity, broadcastAlarm, alarmMode, timeoutInSeconds),
                                 (timeoutInSeconds - 60) * 1000,
-                            );
-                            alarmTimer.unref();
+                            ).unref();
                             globalStore.putValue("boschSmokeAlarm", "alarmTimer", alarmTimer);
                         }
                     }

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -559,6 +559,7 @@ export function tradfriOccupancy(): ModernExtend {
                         publish({occupancy: false});
                         globalStore.clearValue(msg.endpoint, "timer");
                     }, timeout * 1000);
+                    timer.unref();
                     globalStore.putValue(msg.endpoint, "timer", timer);
                 }
 

--- a/src/lib/ikea.ts
+++ b/src/lib/ikea.ts
@@ -558,8 +558,7 @@ export function tradfriOccupancy(): ModernExtend {
                     const timer = setTimeout(() => {
                         publish({occupancy: false});
                         globalStore.clearValue(msg.endpoint, "timer");
-                    }, timeout * 1000);
-                    timer.unref();
+                    }, timeout * 1000).unref();
                     globalStore.putValue(msg.endpoint, "timer", timer);
                 }
 

--- a/src/lib/inovelli.ts
+++ b/src/lib/inovelli.ts
@@ -2805,6 +2805,7 @@ const fzLocal = {
                 publish({notificationComplete: ""});
                 globalStore.clearValue(msg.endpoint, "notification_complete_clear");
             }, 0);
+            timer.unref();
             globalStore.putValue(msg.endpoint, "notification_complete_clear", timer);
 
             return {notificationComplete: value};

--- a/src/lib/inovelli.ts
+++ b/src/lib/inovelli.ts
@@ -2804,8 +2804,7 @@ const fzLocal = {
             const timer = setTimeout(() => {
                 publish({notificationComplete: ""});
                 globalStore.clearValue(msg.endpoint, "notification_complete_clear");
-            }, 0);
-            timer.unref();
+            }, 0).unref();
             globalStore.putValue(msg.endpoint, "notification_complete_clear", timer);
 
             return {notificationComplete: value};

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -1607,8 +1607,7 @@ const fromZigbee = {
                 case dataPoints.x5hFactoryReset: {
                     if (value) {
                         clearTimeout(globalStore.getValue(msg.endpoint, "factoryResetTimer"));
-                        const timer = setTimeout(() => publish({factory_reset: "OFF"}), 60 * 1000);
-                        timer.unref();
+                        const timer = setTimeout(() => publish({factory_reset: "OFF"}), 60 * 1000).unref();
                         globalStore.putValue(msg.endpoint, "factoryResetTimer", timer);
                         logger.info("The thermostat is resetting now. It will be available in 1 minute.", "zhc:legacy:fz:x5h_thermostat");
                     }
@@ -3556,8 +3555,7 @@ const fromZigbee = {
                             // for a few seconds
                             clearTimeout(globalStore.getValue(msg.endpoint, "running_timer"));
                             if (running) {
-                                const timer = setTimeout(() => publish({running: false}), 3 * 1000);
-                                timer.unref();
+                                const timer = setTimeout(() => publish({running: false}), 3 * 1000).unref();
                                 globalStore.putValue(msg.endpoint, "running_timer", timer);
                             }
 

--- a/src/lib/legacy.ts
+++ b/src/lib/legacy.ts
@@ -1608,6 +1608,7 @@ const fromZigbee = {
                     if (value) {
                         clearTimeout(globalStore.getValue(msg.endpoint, "factoryResetTimer"));
                         const timer = setTimeout(() => publish({factory_reset: "OFF"}), 60 * 1000);
+                        timer.unref();
                         globalStore.putValue(msg.endpoint, "factoryResetTimer", timer);
                         logger.info("The thermostat is resetting now. It will be available in 1 minute.", "zhc:legacy:fz:x5h_thermostat");
                     }
@@ -3556,6 +3557,7 @@ const fromZigbee = {
                             clearTimeout(globalStore.getValue(msg.endpoint, "running_timer"));
                             if (running) {
                                 const timer = setTimeout(() => publish({running: false}), 3 * 1000);
+                                timer.unref();
                                 globalStore.putValue(msg.endpoint, "running_timer", timer);
                             }
 
@@ -4325,7 +4327,7 @@ const toZigbee2 = {
                         await sendDataPointValue(entity, dataPoints.x5hSetTempCeiling, value);
                         const setpoint = globalStore.getValue(entity, "currentHeatingSetpoint", 20);
                         const setpointRaw = Math.round(setpoint * 10);
-                        await new Promise((r) => setTimeout(r, 500));
+                        await utils.sleep(500);
                         await sendDataPointValue(entity, dataPoints.x5hSetTemp, setpointRaw);
                     } else {
                         throw new Error("Supported values are in range [35, 95]");

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -4825,8 +4825,7 @@ function armW600WeeklyScheduleUploadTimeout(deviceOrEntity: string | Zh.Device |
 
         failW600WeeklyScheduleUpload(storeKey, "Timed out waiting for the device to finish the weekly schedule OTA transfer", publish);
     }, W600_WEEKLY_SCHEDULE_OTA_STAGE_TTL_MS);
-
-    timeout.unref?.();
+    timeout.unref();
     W600_WEEKLY_SCHEDULE_UPLOAD_TIMEOUTS.set(storeKey, timeout);
 }
 
@@ -6265,6 +6264,7 @@ export const fromZigbee = {
                     // Aqara Opple does not generate a release event when pressed for more than 5 seconds
                     // After 5 seconds of not releasing we assume release.
                     const timer = setTimeout(() => publish({action: `button_${button}_release`}), 5000);
+                    timer.unref();
                     globalStore.putValue(msg.endpoint, "timer", timer);
                 }
                 return {action: `button_${button}_${action}`};
@@ -6628,6 +6628,7 @@ export const fromZigbee = {
                     const timer = setTimeout(() => {
                         publish({occupancy: false});
                     }, timeout * 1000);
+                    timer.unref();
 
                     globalStore.putValue(msg.endpoint, "occupancy_timer", timer);
                 }
@@ -6802,6 +6803,7 @@ export const fromZigbee = {
                         const timer = setTimeout(() => {
                             publish({vibration: false});
                         }, timeout * 1000);
+                        timer.unref();
 
                         globalStore.putValue(msg.endpoint, "vibration_timer", timer);
                     }
@@ -6895,6 +6897,7 @@ export const fromZigbee = {
                 const timer = setTimeout(() => {
                     publish({occupancy: false});
                 }, timeout * 1000);
+                timer.unref();
 
                 globalStore.putValue(msg.endpoint, "occupancy_timer", timer);
             }
@@ -7250,9 +7253,11 @@ export const fromZigbee = {
                     const holdTimer = setTimeout(() => {
                         globalStore.putValue(msg.endpoint, "hold", false);
                     }, options.hold_timeout_expire || 4000);
+                    holdTimer.unref();
                     globalStore.putValue(msg.endpoint, "hold_timer", holdTimer);
                     // After 4000 milliseconds of not receiving release we assume it will not happen.
                 }, options.hold_timeout || 1000); // After 1000 milliseconds of not releasing we assume hold.
+                timer.unref();
                 globalStore.putValue(msg.endpoint, "timer", timer);
             } else if (state === 1) {
                 if (globalStore.getValue(msg.endpoint, "hold")) {
@@ -9022,12 +9027,15 @@ export const toZigbee = {
                                 if (result2 && desiredStates.includes(result2[0x0421] as number)) {
                                     resolve();
                                 } else {
-                                    setTimeout(checkDesiredState, 500);
+                                    const timer = setTimeout(checkDesiredState, 500);
+                                    timer.unref();
                                 }
                             };
-                            setTimeout(checkDesiredState, 500);
+                            const timer = setTimeout(checkDesiredState, 500);
+                            timer.unref();
                         } else {
-                            setTimeout(checkState, 500);
+                            const timer = setTimeout(checkState, 500);
+                            timer.unref();
                         }
                     };
                     void checkState();

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -4824,8 +4824,7 @@ function armW600WeeklyScheduleUploadTimeout(deviceOrEntity: string | Zh.Device |
         }
 
         failW600WeeklyScheduleUpload(storeKey, "Timed out waiting for the device to finish the weekly schedule OTA transfer", publish);
-    }, W600_WEEKLY_SCHEDULE_OTA_STAGE_TTL_MS);
-    timeout.unref();
+    }, W600_WEEKLY_SCHEDULE_OTA_STAGE_TTL_MS).unref();
     W600_WEEKLY_SCHEDULE_UPLOAD_TIMEOUTS.set(storeKey, timeout);
 }
 
@@ -6263,8 +6262,7 @@ export const fromZigbee = {
                 if (msg.data.presentValue === 0) {
                     // Aqara Opple does not generate a release event when pressed for more than 5 seconds
                     // After 5 seconds of not releasing we assume release.
-                    const timer = setTimeout(() => publish({action: `button_${button}_release`}), 5000);
-                    timer.unref();
+                    const timer = setTimeout(() => publish({action: `button_${button}_release`}), 5000).unref();
                     globalStore.putValue(msg.endpoint, "timer", timer);
                 }
                 return {action: `button_${button}_${action}`};
@@ -6627,8 +6625,7 @@ export const fromZigbee = {
                 if (timeout !== 0) {
                     const timer = setTimeout(() => {
                         publish({occupancy: false});
-                    }, timeout * 1000);
-                    timer.unref();
+                    }, timeout * 1000).unref();
 
                     globalStore.putValue(msg.endpoint, "occupancy_timer", timer);
                 }
@@ -6802,8 +6799,7 @@ export const fromZigbee = {
                     if (timeout !== 0) {
                         const timer = setTimeout(() => {
                             publish({vibration: false});
-                        }, timeout * 1000);
-                        timer.unref();
+                        }, timeout * 1000).unref();
 
                         globalStore.putValue(msg.endpoint, "vibration_timer", timer);
                     }
@@ -6896,8 +6892,7 @@ export const fromZigbee = {
             if (timeout !== 0) {
                 const timer = setTimeout(() => {
                     publish({occupancy: false});
-                }, timeout * 1000);
-                timer.unref();
+                }, timeout * 1000).unref();
 
                 globalStore.putValue(msg.endpoint, "occupancy_timer", timer);
             }
@@ -7252,12 +7247,10 @@ export const fromZigbee = {
                     globalStore.putValue(msg.endpoint, "hold", Date.now());
                     const holdTimer = setTimeout(() => {
                         globalStore.putValue(msg.endpoint, "hold", false);
-                    }, options.hold_timeout_expire || 4000);
-                    holdTimer.unref();
+                    }, options.hold_timeout_expire || 4000).unref();
                     globalStore.putValue(msg.endpoint, "hold_timer", holdTimer);
                     // After 4000 milliseconds of not receiving release we assume it will not happen.
-                }, options.hold_timeout || 1000); // After 1000 milliseconds of not releasing we assume hold.
-                timer.unref();
+                }, options.hold_timeout || 1000).unref(); // After 1000 milliseconds of not releasing we assume hold.
                 globalStore.putValue(msg.endpoint, "timer", timer);
             } else if (state === 1) {
                 if (globalStore.getValue(msg.endpoint, "hold")) {
@@ -9027,15 +9020,12 @@ export const toZigbee = {
                                 if (result2 && desiredStates.includes(result2[0x0421] as number)) {
                                     resolve();
                                 } else {
-                                    const timer = setTimeout(checkDesiredState, 500);
-                                    timer.unref();
+                                    setTimeout(checkDesiredState, 500).unref();
                                 }
                             };
-                            const timer = setTimeout(checkDesiredState, 500);
-                            timer.unref();
+                            setTimeout(checkDesiredState, 500).unref();
                         } else {
-                            const timer = setTimeout(checkState, 500);
-                            timer.unref();
+                            setTimeout(checkState, 500).unref();
                         }
                     };
                     void checkState();

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -682,6 +682,7 @@ export function poll(args: {
                                 setTimer();
                             }
                         }, seconds * 1000);
+                        timer.unref();
                         globalStore.putValue(event.data.device.ieeeAddr, args.key, timer);
                     };
                     setTimer();
@@ -1736,6 +1737,7 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
                     clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
                     if (timeout !== 0) {
                         const timer = setTimeout(() => publish({[alarm1Name]: false, [alarm2Name]: false}), timeout * 1000);
+                        timer.unref();
                         globalStore.putValue(msg.endpoint, "timer", timer);
                     }
                 }
@@ -1795,6 +1797,7 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
                         if (addTimeout) {
                             // At least one zone active
                             const timer = setTimeout(() => publish({[alarm1Name]: false, [alarm2Name]: false}), keepAliveTimeout * 1000);
+                            timer.unref();
                             globalStore.putValue(msg.endpoint, "timeout", timer);
                         } else {
                             globalStore.clearValue(msg.endpoint, "timeout");

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -681,8 +681,7 @@ export function poll(args: {
                             if (globalStore.getValue(event.data.device.ieeeAddr, args.key) === timer) {
                                 setTimer();
                             }
-                        }, seconds * 1000);
-                        timer.unref();
+                        }, seconds * 1000).unref();
                         globalStore.putValue(event.data.device.ieeeAddr, args.key, timer);
                     };
                     setTimer();
@@ -1736,8 +1735,7 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
                     const timeout = options?.[timeoutProperty] != null ? Number(options[timeoutProperty]) : 90;
                     clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
                     if (timeout !== 0) {
-                        const timer = setTimeout(() => publish({[alarm1Name]: false, [alarm2Name]: false}), timeout * 1000);
-                        timer.unref();
+                        const timer = setTimeout(() => publish({[alarm1Name]: false, [alarm2Name]: false}), timeout * 1000).unref();
                         globalStore.putValue(msg.endpoint, "timer", timer);
                     }
                 }
@@ -1796,8 +1794,7 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
                         clearTimeout(globalStore.getValue(msg.endpoint, "timeout"));
                         if (addTimeout) {
                             // At least one zone active
-                            const timer = setTimeout(() => publish({[alarm1Name]: false, [alarm2Name]: false}), keepAliveTimeout * 1000);
-                            timer.unref();
+                            const timer = setTimeout(() => publish({[alarm1Name]: false, [alarm2Name]: false}), keepAliveTimeout * 1000).unref();
                             globalStore.putValue(msg.endpoint, "timeout", timer);
                         } else {
                             globalStore.clearValue(msg.endpoint, "timeout");

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -585,13 +585,14 @@ const philipsModernExtend = {
                     // When an effect is active or being set, read state after a delay
                     // to sync brightness (effects modulate it internally).
                     if (data.effectType !== undefined) {
-                        setTimeout(async () => {
+                        const timer = setTimeout(async () => {
                             try {
                                 await entity.read<"manuSpecificPhilips2", ManuSpecificPhilips2>("manuSpecificPhilips2", ["state"]);
                             } catch (_e) {
                                 // Best-effort sync
                             }
                         }, 1000);
+                        timer.unref();
                     }
 
                     // Merge syncColorState results into newState. syncColorState
@@ -1003,13 +1004,14 @@ const philipsTz = {
                 // Effects modulate brightness internally (e.g. candle dims to 30-60%).
                 // Read state after a short delay so the Fz converter picks up the
                 // actual brightness the device settled on.
-                setTimeout(async () => {
+                const timer = setTimeout(async () => {
                     try {
                         await entity.read<"manuSpecificPhilips2", ManuSpecificPhilips2>("manuSpecificPhilips2", ["state"]);
                     } catch (_e) {
                         // Ignore read failures — best-effort sync
                     }
                 }, 1000);
+                timer.unref();
 
                 return {state};
             }

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -585,14 +585,13 @@ const philipsModernExtend = {
                     // When an effect is active or being set, read state after a delay
                     // to sync brightness (effects modulate it internally).
                     if (data.effectType !== undefined) {
-                        const timer = setTimeout(async () => {
+                        setTimeout(async () => {
                             try {
                                 await entity.read<"manuSpecificPhilips2", ManuSpecificPhilips2>("manuSpecificPhilips2", ["state"]);
                             } catch (_e) {
                                 // Best-effort sync
                             }
-                        }, 1000);
-                        timer.unref();
+                        }, 1000).unref();
                     }
 
                     // Merge syncColorState results into newState. syncColorState
@@ -1004,14 +1003,13 @@ const philipsTz = {
                 // Effects modulate brightness internally (e.g. candle dims to 30-60%).
                 // Read state after a short delay so the Fz converter picks up the
                 // actual brightness the device settled on.
-                const timer = setTimeout(async () => {
+                setTimeout(async () => {
                     try {
                         await entity.read<"manuSpecificPhilips2", ManuSpecificPhilips2>("manuSpecificPhilips2", ["state"]);
                     } catch (_e) {
                         // Ignore read failures — best-effort sync
                     }
-                }, 1000);
-                timer.unref();
+                }, 1000).unref();
 
                 return {state};
             }

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -3913,8 +3913,7 @@ const tuyaFz = {
                                     payload.power = 0;
                                 }
                                 publish(payload);
-                            }, time * 1000);
-                            timer.unref();
+                            }, time * 1000).unref();
                             globalStore.putValue(msg.endpoint, key, timer);
                             delete result[key];
                         }
@@ -4504,8 +4503,7 @@ const tuyaModernExtend = {
                                     if (globalStore.getValue(event.data.device.ieeeAddr, "query_interval") === timer) {
                                         setTimer();
                                     }
-                                }, queryIntervalSeconds * 1000);
-                                timer.unref();
+                                }, queryIntervalSeconds * 1000).unref();
                                 globalStore.putValue(event.data.device.ieeeAddr, "query_interval", timer);
                             };
                             setTimer();

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -3905,19 +3905,17 @@ const tuyaFz = {
                                 (c) => c.cluster.name === "haElectricalMeasurement" && c.attribute.name === lookup[key],
                             );
                             const time = (configuredReporting ? configuredReporting.minimumReportInterval : 5) * 2 + 1;
-                            globalStore.putValue(
-                                msg.endpoint,
-                                key,
-                                setTimeout(() => {
-                                    const payload = {[key]: value};
-                                    // Device takes a lot of time to report power 0 in some cases. When current == 0 we can assume power == 0
-                                    // https://github.com/Koenkk/zigbee2mqtt/discussions/19680#discussioncomment-7868445
-                                    if (key === "current") {
-                                        payload.power = 0;
-                                    }
-                                    publish(payload);
-                                }, time * 1000),
-                            );
+                            const timer = setTimeout(() => {
+                                const payload = {[key]: value};
+                                // Device takes a lot of time to report power 0 in some cases. When current == 0 we can assume power == 0
+                                // https://github.com/Koenkk/zigbee2mqtt/discussions/19680#discussioncomment-7868445
+                                if (key === "current") {
+                                    payload.power = 0;
+                                }
+                                publish(payload);
+                            }, time * 1000);
+                            timer.unref();
+                            globalStore.putValue(msg.endpoint, key, timer);
                             delete result[key];
                         }
                     }
@@ -4507,6 +4505,7 @@ const tuyaModernExtend = {
                                         setTimer();
                                     }
                                 }, queryIntervalSeconds * 1000);
+                                timer.unref();
                                 globalStore.putValue(event.data.device.ieeeAddr, "query_interval", timer);
                             };
                             setTimer();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -349,9 +349,8 @@ export function filterObject<T>(obj: T, keys: string[]): Partial<T> {
 }
 
 export async function sleep(ms: number) {
-    return await new Promise((resolve) => {
-        const timer = setTimeout(resolve, ms);
-        timer.unref();
+    return await new Promise<void>((resolve) => {
+        setTimeout(resolve, ms).unref();
     });
 }
 
@@ -543,8 +542,7 @@ export function noOccupancySince(endpoint: Zh.Endpoint, options: KeyValueAny, pu
             options.no_occupancy_since.forEach((since: number) => {
                 const timer = setTimeout(() => {
                     publish({no_occupancy_since: since});
-                }, since * 1000);
-                timer.unref();
+                }, since * 1000).unref();
                 globalStore.getValue(endpoint, "no_occupancy_since_timers").push(timer);
             });
         } else if (action === "stop") {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -349,7 +349,10 @@ export function filterObject<T>(obj: T, keys: string[]): Partial<T> {
 }
 
 export async function sleep(ms: number) {
-    return await new Promise((resolve) => setTimeout(resolve, ms));
+    return await new Promise((resolve) => {
+        const timer = setTimeout(resolve, ms);
+        timer.unref();
+    });
 }
 
 export function toSnakeCase(value: string | KeyValueAny) {
@@ -532,7 +535,7 @@ export function normalizeCelsiusVersionOfFahrenheit(value: number) {
 export function noOccupancySince(endpoint: Zh.Endpoint, options: KeyValueAny, publish: Publish, action: "start" | "stop") {
     if (options?.no_occupancy_since) {
         if (action === "start") {
-            globalStore.getValue(endpoint, "no_occupancy_since_timers", []).forEach((t: ReturnType<typeof setInterval>) => {
+            globalStore.getValue(endpoint, "no_occupancy_since_timers", []).forEach((t: NodeJS.Timeout) => {
                 clearTimeout(t);
             });
             globalStore.putValue(endpoint, "no_occupancy_since_timers", []);
@@ -541,10 +544,11 @@ export function noOccupancySince(endpoint: Zh.Endpoint, options: KeyValueAny, pu
                 const timer = setTimeout(() => {
                     publish({no_occupancy_since: since});
                 }, since * 1000);
+                timer.unref();
                 globalStore.getValue(endpoint, "no_occupancy_since_timers").push(timer);
             });
         } else if (action === "stop") {
-            globalStore.getValue(endpoint, "no_occupancy_since_timers", []).forEach((t: ReturnType<typeof setInterval>) => {
+            globalStore.getValue(endpoint, "no_occupancy_since_timers", []).forEach((t: NodeJS.Timeout) => {
                 clearTimeout(t);
             });
             globalStore.putValue(endpoint, "no_occupancy_since_timers", []);


### PR DESCRIPTION
Avoid holding the event loop with timers.
All of these are background ops, with low impact, so, shouldn't be a problem.
Might end up solving a few "weird" shutdown-related issues.

Also switched some "sleep" usage to the dedicated util.

Note: a further refactor could be improving the store and specifically properly cleaning up timers (currently buried in random objects) with a ZHC shutdown sequence.