### PR TITLE
Add support for EGLO Connect.Z GU10 (110308)

### DIFF
--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -393,6 +393,14 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [{vendor: "EGLO", model: "900116"}],
     },
     {
+        zigbeeModel: ["ESMLzm_TW_GU10"],
+        model: "110308",
+        vendor: "AwoX",
+        description: "Connect.Z GU10 tunable white",
+        extend: [m.light({colorTemp: {range: [153, 370]}})],
+        whiteLabel: [{vendor: "EGLO", model: "110308"}],
+    },
+    {
         fingerprint: [
             {
                 type: "Router",

--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -398,7 +398,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "AwoX",
         description: "Connect.Z GU10 tunable white",
         extend: [m.light({colorTemp: {range: [153, 370]}})],
-        whiteLabel: [{vendor: "EGLO", model: "110308"}],
     },
     {
         fingerprint: [


### PR DESCRIPTION
Adds support for the EGLO Connect.Z GU10 (110308).

Device information:

* Zigbee model: ESMLzm_TW_GU10
* Manufacturer: AwoX
* Firmware: 3.0.1_1593

Tested:

* On/off
* Brightness control
* Color temperature control

The device was previously detected as unsupported and used an automatically generated definition. All tested functionality works correctly.

Closes #12481
