### PR TITLE
Fix Sylvania 74388 battery percentage

### DIFF
--- a/src/devices/sylvania.ts
+++ b/src/devices/sylvania.ts
@@ -14,7 +14,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Smart+ contact and temperature sensor",
         fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: "3V_2100"}},
+        meta: {battery: {voltageToPercentage: {min: 2500, max: 2800}}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["msTemperatureMeasurement", "genPowerCfg"]);


### PR DESCRIPTION
## Summary
- adjust Sylvania 74388 battery voltage-to-percentage mapping to treat 2800 mV as full

## Root cause
The 74388 currently uses the shared `3V_2100` conversion curve, which maps a reported 2800 mV to 27%. These sensors appear to cap their Zigbee-reported `batteryVoltage` at 28 / 2800 mV even when brand new CR2 batteries measure above 3 V with a voltmeter.

Fixes #12487
