### PR TITLE
use reported multiplier/divisor for lupus 12050 power reporting

### DIFF
--- a/src/devices/lupus.ts
+++ b/src/devices/lupus.ts
@@ -39,8 +39,8 @@ export const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "seMetering"]);
+            await reporting.readMeteringMultiplierDivisor(endpoint);
             await reporting.instantaneousDemand(endpoint);
-            endpoint.saveClusterAttributeKeyValue("seMetering", {divisor: 10, multiplier: 1});
         },
     },
     {

--- a/src/devices/lupus.ts
+++ b/src/devices/lupus.ts
@@ -32,6 +32,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["PSMP5_00.00.03.11TC", "PSMP5_00.00.05.12TC", "PSMP5_00.00.03.05TC"],
         model: "12050",
         vendor: "Lupus",
+        version: "0.0.1",
         description: "LUPUSEC mains socket with power meter",
         fromZigbee: [fz.on_off, fz.metering],
         exposes: [e.switch(), e.power()],


### PR DESCRIPTION
This fixes a bug with Lupus 12050 smart plugs: The converter previously hardcoded the divisor and multiplier, even though the device actually reports which values should be used.  
On my own devices of this type, this meant that the reported power was off by a factor of 10.

I first tested this with a custom converter, and it works reliably & correctly.  
Hopefully this change is useful to other lupus 12050 users.