### PR TITLE
Add Philips Hue Essential lightstrip (5m) 929004294901

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -5087,6 +5087,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
+        zigbeeModel: ["929004294901"],
+        model: "929004294901",
+        vendor: "Philips",
+        description: "Hue Essential lightstrip (5m)",
+        extend: [philips.m.light({colorTemp: {range: [153, 447]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+    },
+    {
         zigbeeModel: ["929004611002", "929004611102"],
         model: "929004611002",
         vendor: "Philips",


### PR DESCRIPTION
Adds the 5 m variant of the Hue Essential lightstrip. It's the same product as the already-supported `929004294903` (16ft) with an identical extend, so I placed `929004294901` right next to it.

Tested on the device: on/off, brightness, colour temperature (153–447 mired), full colour via xy/hs, and the Hue light effects all work. OTA comes for free through `philips.m.light`.

Fixes #32353