### PR TITLE
Allow partial SONOFF water valve composite settings

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -3192,10 +3192,13 @@ const sonoffExtend = {
                 key: ["seasonal_watering_adjustment"],
                 convertSet: async (entity, key, value, meta) => {
                     utils.assertObject(value, key);
+                    const stateValue = meta.state[key];
+                    const current = utils.isObject(stateValue) ? stateValue : {};
+                    const nextValue = {...current, ...value};
 
                     const array = new Uint8Array(12);
                     for (let i = 0; i < 12; i++) {
-                        const rawMonthValue = Number(value[months[i]]);
+                        const rawMonthValue = Number(nextValue[months[i]]);
                         const monthValue = Number.isFinite(rawMonthValue) ? rawMonthValue : 1;
                         const boundedMonthValue = Math.min(2, Math.max(0.1, monthValue));
                         array[i] = Math.round(boundedMonthValue * 10);
@@ -3217,7 +3220,7 @@ const sonoffExtend = {
 
                     return {
                         state: {
-                            [key]: value,
+                            [key]: nextValue,
                         },
                     };
                 },
@@ -3466,12 +3469,15 @@ const sonoffExtend = {
                 key: ["valve_alarm_settings"],
                 convertSet: async (entity, key, value, meta) => {
                     utils.assertObject(value, key);
+                    const stateValue = meta.state[key];
+                    const current = utils.isObject(stateValue) ? stateValue : {};
+                    const nextValue = {...current, ...value};
                     const state = {
-                        enable_alarm_water_shortage: !!value.enable_alarm_water_shortage,
-                        enable_alarm_water_leak: !!value.enable_alarm_water_leak,
-                        enable_water_shortage_auto_close: !!value.enable_water_shortage_auto_close,
-                        alarm_water_shortage_duration: Number(value.alarm_water_shortage_duration) || 0,
-                        alarm_water_leak_duration: Number(value.alarm_water_leak_duration) || 0,
+                        enable_alarm_water_shortage: !!nextValue.enable_alarm_water_shortage,
+                        enable_alarm_water_leak: !!nextValue.enable_alarm_water_leak,
+                        enable_water_shortage_auto_close: !!nextValue.enable_water_shortage_auto_close,
+                        alarm_water_shortage_duration: Number(nextValue.alarm_water_shortage_duration) || 0,
+                        alarm_water_leak_duration: Number(nextValue.alarm_water_leak_duration) || 0,
                     };
 
                     let enableBits = 0;
@@ -4277,8 +4283,13 @@ const sonoffExtend = {
                 endpoints: endpointNames,
                 convertSet: async (entity, key, value, meta) => {
                     utils.assertObject(value, key);
+                    const stateValue = meta.state[key];
+                    const reportKey = meta.endpoint_name ? `irrigation_plan_report_${meta.endpoint_name}` : "irrigation_plan_report";
+                    const reportValue = meta.state[reportKey];
+                    const current = utils.isObject(stateValue) ? stateValue : utils.isObject(reportValue) ? reportValue : {};
+                    const nextValue = {...current, ...value};
                     const parseIntWithDefault = (fieldName: string, defaultValue: number, min: number, max: number): number | undefined => {
-                        const raw = value[fieldName];
+                        const raw = nextValue[fieldName];
                         const parsed = raw === undefined || raw === null ? defaultValue : Number(raw);
                         if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
                             logger.error(`irrigation_plan_settings invalid ${fieldName}, expected integer in range [${min}, ${max}].`, NS);
@@ -4297,12 +4308,12 @@ const sonoffExtend = {
                     }
                     payloadValue[i++] = planIndex & 0xff;
                     // Whether schedule is enabled
-                    payloadValue[i++] = value.enable_state ? 0x01 : 0x00;
+                    payloadValue[i++] = nextValue.enable_state ? 0x01 : 0x00;
 
                     // Loop type
                     const loopTypeModeKey =
-                        typeof value.loop_type_mode === "string" && value.loop_type_mode in loopTypeModeMappingReverse
-                            ? (value.loop_type_mode as keyof typeof loopTypeModeMappingReverse)
+                        typeof nextValue.loop_type_mode === "string" && nextValue.loop_type_mode in loopTypeModeMappingReverse
+                            ? (nextValue.loop_type_mode as keyof typeof loopTypeModeMappingReverse)
                             : "odd_days";
                     const loopTypeMode = loopTypeModeMappingReverse[loopTypeModeKey];
                     let loopTypeValueCode = 0;
@@ -4313,7 +4324,7 @@ const sonoffExtend = {
                         }
                         loopTypeValueCode = loopTypeIntervalDays;
                     } else if (loopTypeMode === loopTypeModeMappingReverse.weekdays) {
-                        const weekDays = value.loop_type_week_days;
+                        const weekDays = nextValue.loop_type_week_days;
                         if (utils.isObject(weekDays)) {
                             for (const dayName of loopTypeWeekDayNames) {
                                 if (weekDays[dayName] === true) {
@@ -4327,7 +4338,7 @@ const sonoffExtend = {
                     payloadValue[i++] = loopTypeWord & 0xff;
 
                     // Enable date: start of local day -> device local-2000 seconds
-                    const enableDateValue = value.enable_date;
+                    const enableDateValue = nextValue.enable_date;
                     if (!utils.isString(enableDateValue)) {
                         logger.error("irrigation_plan_settings invalid enable_date, expected local date in YYYY-MM-DD format.", NS);
                         return;
@@ -4364,18 +4375,18 @@ const sonoffExtend = {
                     let irrigationModeCode = irrigationModeMappingReverse.duration;
                     if (hasFlowMeter) {
                         const irrigationModeKey =
-                            typeof value.irrigation_mode === "string"
-                                ? (value.irrigation_mode as keyof typeof irrigationModeMappingReverse)
+                            typeof nextValue.irrigation_mode === "string"
+                                ? (nextValue.irrigation_mode as keyof typeof irrigationModeMappingReverse)
                                 : "duration";
                         irrigationModeCode = irrigationModeMappingReverse[irrigationModeKey] ?? irrigationModeMappingReverse.duration;
                     } else {
-                        const irrigationModeKey = value.irrigation_mode === "duration_with_interval" ? "duration_with_interval" : "duration";
+                        const irrigationModeKey = nextValue.irrigation_mode === "duration_with_interval" ? "duration_with_interval" : "duration";
                         irrigationModeCode = irrigationModeMappingReverse[irrigationModeKey];
                     }
                     payloadValue[i++] = irrigationModeCode & 0xff;
 
                     // Start time offset from start of local day.
-                    const startTimeValue = value.start_time;
+                    const startTimeValue = nextValue.start_time;
                     if (!utils.isString(startTimeValue)) {
                         logger.error("irrigation_plan_settings invalid start_time, expected HH:mm.", NS);
                         return;
@@ -4417,8 +4428,8 @@ const sonoffExtend = {
 
                     // Irrigation amount unit
                     const irrigationAmountUnitKey = hasFlowMeter
-                        ? typeof value.irrigation_amount_unit === "string"
-                            ? (value.irrigation_amount_unit as keyof typeof irrigationAmountUnitMappingReverse)
+                        ? typeof nextValue.irrigation_amount_unit === "string"
+                            ? (nextValue.irrigation_amount_unit as keyof typeof irrigationAmountUnitMappingReverse)
                             : "US gallon"
                         : "liter";
                     const irrigationAmountUnitCode =
@@ -4443,14 +4454,14 @@ const sonoffExtend = {
                     payloadValue[i++] = failSafe & 0xff;
 
                     // Create datetime: Unix UTC seconds.
-                    if (!utils.isString(value.create_datetime)) {
+                    if (!utils.isString(nextValue.create_datetime)) {
                         logger.error(
                             "irrigation_plan_settings invalid create_datetime, expected ISO 8601 datetime with timezone offset (Z or ±HH:mm).",
                             NS,
                         );
                         return;
                     }
-                    const createDatetimeUTC = parseIsoWithOffsetToUtcSeconds(value.create_datetime);
+                    const createDatetimeUTC = parseIsoWithOffsetToUtcSeconds(nextValue.create_datetime);
                     if (createDatetimeUTC === undefined) {
                         logger.error(
                             "irrigation_plan_settings invalid create_datetime, expected ISO 8601 datetime with timezone offset (Z or ±HH:mm).",
@@ -4476,7 +4487,7 @@ const sonoffExtend = {
                             defaultResponseOptions,
                         );
 
-                    return {state: {[key]: value}};
+                    return {state: {[key]: nextValue}};
                 },
             },
         ];
@@ -7939,6 +7950,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "SONOFF",
         whiteLabel: [{model: "SWV-ZFU", vendor: "SONOFF", fingerprint: [{modelID: "SWV-ZFU"}]}],
         description: "Zigbee smart water valve",
+        meta: {homeassistant: {switchType: "valve"}},
         extend: [
             m.deviceAddCustomCluster("customClusterEwelink", {
                 name: "customClusterEwelink",
@@ -8064,6 +8076,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SWV-ZF2",
         vendor: "SONOFF",
         description: "Zigbee dual-channel smart water valve",
+        meta: {homeassistant: {switchType: "valve"}},
         extend: [
             m.deviceEndpoints({endpoints: {"1": 1, "2": 2}}),
             m.deviceAddCustomCluster("customClusterEwelink", {
@@ -8211,6 +8224,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "SONOFF",
         whiteLabel: [{model: "SWV-ZNU", vendor: "SONOFF", fingerprint: [{modelID: "SWV-ZNU"}]}],
         description: "Zigbee smart water valve",
+        meta: {homeassistant: {switchType: "valve"}},
         extend: [
             m.deviceAddCustomCluster("customClusterEwelink", {
                 name: "customClusterEwelink",

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -3069,18 +3069,21 @@ const sonoffExtend = {
                 key: ["manual_default_settings"],
                 convertSet: async (entity, key, value, meta) => {
                     utils.assertObject(value, key);
+                    const stateValue = meta.state[key];
+                    const current = utils.isObject(stateValue) ? stateValue : {};
+                    const nextValue = {...current, ...value};
 
-                    if (hasFlowMeter && (typeof value.irrigation_mode !== "string" || modeMap[value.irrigation_mode] === undefined)) {
+                    if (hasFlowMeter && (typeof nextValue.irrigation_mode !== "string" || modeMap[nextValue.irrigation_mode] === undefined)) {
                         logger.error("manual_default_settings invalid irrigation_mode, expected one of: duration, capacity.", NS);
                         return;
                     }
-                    if (hasFlowMeter && value.irrigation_amount_unit !== "US gallon" && value.irrigation_amount_unit !== "liter") {
+                    if (hasFlowMeter && nextValue.irrigation_amount_unit !== "US gallon" && nextValue.irrigation_amount_unit !== "liter") {
                         logger.error("manual_default_settings invalid irrigation_amount_unit, expected one of: US gallon, liter.", NS);
                         return;
                     }
 
                     const parseRequiredInt = (fieldName: string): number | undefined => {
-                        const parsed = Number(value[fieldName]);
+                        const parsed = Number(nextValue[fieldName]);
                         if (!Number.isInteger(parsed)) {
                             logger.error(`manual_default_settings invalid ${fieldName}, expected integer.`, NS);
                             return;
@@ -3096,8 +3099,8 @@ const sonoffExtend = {
                         return;
                     }
 
-                    const mode = hasFlowMeter ? modeMap[value.irrigation_mode] : modeMap.duration;
-                    const capacityUnit = hasFlowMeter ? (value.irrigation_amount_unit === "US gallon" ? 0 : 1) : 1;
+                    const mode = hasFlowMeter ? modeMap[nextValue.irrigation_mode] : modeMap.duration;
+                    const capacityUnit = hasFlowMeter ? (nextValue.irrigation_amount_unit === "US gallon" ? 0 : 1) : 1;
 
                     const array = new Uint8Array(12);
                     array[0] = mode;
@@ -3129,7 +3132,7 @@ const sonoffExtend = {
 
                     return {
                         state: {
-                            [key]: value,
+                            [key]: nextValue,
                         },
                     };
                 },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -224,6 +224,15 @@ export interface DefinitionMeta {
      */
     overrideHaDiscoveryPayload?(payload: KeyValueAny): void;
     /**
+     * Home Assistant discovery hints for bridge integrations.
+     */
+    homeassistant?: {
+        /**
+         * Discover switch exposes as a more specific Home Assistant entity type.
+         */
+        switchType?: "valve";
+    };
+    /**
      * Never use a transition when transitioning to off (even when specified)
      */
     noOffTransitionWhenOff?: boolean | ((entity: Zh.Endpoint) => boolean);

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -610,13 +610,15 @@ describe("Sonoff SWV-ZFE", () => {
     let device: Definition;
     let endpoint: ZHModels.Endpoint;
     let writeFn: Mock;
+    let commandFn: Mock;
     let meta: Tz.Meta;
 
     beforeEach(async () => {
         device = await findByDevice(mockDevice({modelID: "SWV-ZFE", endpoints: [{ID: 1}]}));
 
         writeFn = vi.fn();
-        endpoint = {write: writeFn} as unknown as ZHModels.Endpoint;
+        commandFn = vi.fn();
+        endpoint = {write: writeFn, command: commandFn} as unknown as ZHModels.Endpoint;
         meta = {
             state: {
                 manual_default_settings: {
@@ -626,6 +628,52 @@ describe("Sonoff SWV-ZFE", () => {
                     irrigation_amount: 42,
                     fail_safe: 60,
                 },
+                seasonal_watering_adjustment: {
+                    january: 1.1,
+                    february: 1.2,
+                    march: 1.3,
+                    april: 1.4,
+                    may: 1.5,
+                    june: 1.6,
+                    july: 1.7,
+                    august: 1.8,
+                    september: 1.9,
+                    october: 2,
+                    november: 0.9,
+                    december: 0.8,
+                },
+                valve_alarm_settings: {
+                    enable_alarm_water_shortage: true,
+                    enable_alarm_water_leak: false,
+                    enable_water_shortage_auto_close: true,
+                    alarm_water_shortage_duration: 5,
+                    alarm_water_leak_duration: 1,
+                },
+                irrigation_plan_report: {
+                    plan_index: 2,
+                    enable_state: true,
+                    loop_type_mode: "weekdays",
+                    loop_type_interval_days: 1,
+                    loop_type_week_days: {
+                        sunday: true,
+                        monday: false,
+                        tuesday: true,
+                        wednesday: false,
+                        thursday: true,
+                        friday: false,
+                        saturday: false,
+                    },
+                    enable_date: "2026-06-21",
+                    start_time: "06:30",
+                    irrigation_mode: "capacity",
+                    irrigation_total_duration: 20,
+                    irrigation_duration: 4,
+                    interval_duration: 3,
+                    irrigation_amount_unit: "liter",
+                    irrigation_amount: 50,
+                    fail_safe: 30,
+                    create_datetime: "2026-06-21T04:30:00Z",
+                },
             },
             device: null,
             message: null,
@@ -634,6 +682,10 @@ describe("Sonoff SWV-ZFE", () => {
             publish: null,
             endpoint_name: null,
         };
+    });
+
+    it("marks the switch expose for Home Assistant valve discovery", () => {
+        expect(device.meta?.homeassistant?.switchType).toStrictEqual("valve");
     });
 
     describe("toZigbee", () => {
@@ -663,6 +715,150 @@ describe("Sonoff SWV-ZFE", () => {
                         irrigation_amount_unit: "liter",
                         irrigation_amount: 42,
                         fail_safe: 60,
+                    },
+                },
+            });
+        });
+
+        it("merges partial seasonal watering adjustment settings with current state", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("seasonal_watering_adjustment"));
+
+            const result = await tzConverter.convertSet(endpoint, "seasonal_watering_adjustment", {june: 0.7}, meta);
+
+            expect(writeFn).toHaveBeenCalledWith(
+                "customClusterEwelink",
+                {
+                    20510: {
+                        value: {
+                            elementType: 0x20,
+                            elements: new Uint8Array([11, 12, 13, 14, 15, 7, 17, 18, 19, 20, 9, 8]),
+                        },
+                        type: 0x48,
+                    },
+                },
+                {},
+            );
+            expect(result).toEqual({
+                state: {
+                    seasonal_watering_adjustment: {
+                        january: 1.1,
+                        february: 1.2,
+                        march: 1.3,
+                        april: 1.4,
+                        may: 1.5,
+                        june: 0.7,
+                        july: 1.7,
+                        august: 1.8,
+                        september: 1.9,
+                        october: 2,
+                        november: 0.9,
+                        december: 0.8,
+                    },
+                },
+            });
+        });
+
+        it("merges partial valve alarm settings with current state", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("valve_alarm_settings"));
+
+            const result = await tzConverter.convertSet(endpoint, "valve_alarm_settings", {alarm_water_leak_duration: 3}, meta);
+
+            expect(writeFn).toHaveBeenCalledWith(
+                "customClusterEwelink",
+                {
+                    20512: {
+                        value: {
+                            elementType: 0x20,
+                            elements: new Uint8Array([0b01001, 5, 3, 0]),
+                        },
+                        type: 0x48,
+                    },
+                },
+                {},
+            );
+            expect(result).toEqual({
+                state: {
+                    valve_alarm_settings: {
+                        enable_alarm_water_shortage: true,
+                        enable_alarm_water_leak: false,
+                        enable_water_shortage_auto_close: true,
+                        alarm_water_shortage_duration: 5,
+                        alarm_water_leak_duration: 3,
+                    },
+                },
+            });
+        });
+
+        it("merges partial irrigation plan settings with the last report", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("irrigation_plan_settings"));
+            const year2000InUtc = 946684800;
+            const enableDate = Date.UTC(2026, 5, 21, 0, 0, 0) / 1000 - year2000InUtc;
+            const createDatetime = Date.parse("2026-06-21T04:30:00Z") / 1000;
+            const expectedPayload = [
+                2,
+                1,
+                3,
+                0b00010101,
+                (enableDate >> 24) & 0xff,
+                (enableDate >> 16) & 0xff,
+                (enableDate >> 8) & 0xff,
+                enableDate & 0xff,
+                1,
+                0,
+                0,
+                91,
+                104,
+                0,
+                20,
+                0,
+                9,
+                0,
+                3,
+                1,
+                0,
+                50,
+                0,
+                30,
+                (createDatetime >> 24) & 0xff,
+                (createDatetime >> 16) & 0xff,
+                (createDatetime >> 8) & 0xff,
+                createDatetime & 0xff,
+            ];
+
+            const result = await tzConverter.convertSet(endpoint, "irrigation_plan_settings", {irrigation_duration: 9}, meta);
+
+            expect(commandFn).toHaveBeenCalledWith(
+                "customClusterEwelink",
+                "irrigationPlanSettings",
+                {data: expectedPayload},
+                {disableDefaultResponse: false},
+            );
+            expect(result).toEqual({
+                state: {
+                    irrigation_plan_settings: {
+                        plan_index: 2,
+                        enable_state: true,
+                        loop_type_mode: "weekdays",
+                        loop_type_interval_days: 1,
+                        loop_type_week_days: {
+                            sunday: true,
+                            monday: false,
+                            tuesday: true,
+                            wednesday: false,
+                            thursday: true,
+                            friday: false,
+                            saturday: false,
+                        },
+                        enable_date: "2026-06-21",
+                        start_time: "06:30",
+                        irrigation_mode: "capacity",
+                        irrigation_total_duration: 20,
+                        irrigation_duration: 9,
+                        interval_duration: 3,
+                        irrigation_amount_unit: "liter",
+                        irrigation_amount: 50,
+                        fail_safe: 30,
+                        create_datetime: "2026-06-21T04:30:00Z",
                     },
                 },
             });

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -605,3 +605,67 @@ describe("Sonoff SNZB-02DR2", () => {
         });
     });
 });
+
+describe("Sonoff SWV-ZFE", () => {
+    let device: Definition;
+    let endpoint: ZHModels.Endpoint;
+    let writeFn: Mock;
+    let meta: Tz.Meta;
+
+    beforeEach(async () => {
+        device = await findByDevice(mockDevice({modelID: "SWV-ZFE", endpoints: [{ID: 1}]}));
+
+        writeFn = vi.fn();
+        endpoint = {write: writeFn} as unknown as ZHModels.Endpoint;
+        meta = {
+            state: {
+                manual_default_settings: {
+                    irrigation_duration: 15,
+                    irrigation_mode: "capacity",
+                    irrigation_amount_unit: "liter",
+                    irrigation_amount: 42,
+                    fail_safe: 60,
+                },
+            },
+            device: null,
+            message: null,
+            mapped: null,
+            options: null,
+            publish: null,
+            endpoint_name: null,
+        };
+    });
+
+    describe("toZigbee", () => {
+        it("merges partial manual default settings with current state", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("manual_default_settings"));
+
+            const result = await tzConverter.convertSet(endpoint, "manual_default_settings", {irrigation_duration: 30}, meta);
+
+            expect(writeFn).toHaveBeenCalledWith(
+                "customClusterEwelink",
+                {
+                    20509: {
+                        value: {
+                            elementType: 0x20,
+                            elements: new Uint8Array([1, 0, 30, 0, 30, 0, 10, 1, 0, 42, 0, 60]),
+                        },
+                        type: 0x48,
+                    },
+                },
+                {},
+            );
+            expect(result).toEqual({
+                state: {
+                    manual_default_settings: {
+                        irrigation_duration: 30,
+                        irrigation_mode: "capacity",
+                        irrigation_amount_unit: "liter",
+                        irrigation_amount: 42,
+                        fail_safe: 60,
+                    },
+                },
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- merge partial writes for SONOFF SWV-ZFE seasonal watering adjustment settings
- merge partial writes for valve alarm settings
- merge irrigation plan updates with the current settings or latest plan report before encoding the payload
- expand tests to cover manual defaults, seasonal adjustment, valve alarm, and irrigation plan partial updates

## Testing
- `npx pnpm@10.12.1 run check`
- `npx pnpm@10.12.1 vitest run test/sonoff.test.ts --config ./test/vitest.config.mts`
- `npx pnpm@10.12.1 vitest run test/shelly.test.ts test/sonoff.test.ts --config ./test/vitest.config.mts`