### PR TITLE
Fix GIEX irrigation time exposes

### DIFF
--- a/src/devices/giex.ts
+++ b/src/devices/giex.ts
@@ -26,9 +26,9 @@ const exportTemplates = {
                 .withValueMin(0)
                 .withValueMax(100)
                 .withDescription("Number of cycle irrigation times, set to 0 for single cycle"),
-            e.numeric(legacy.giexWaterValve.irrigationStartTime, ea.STATE).withDescription("Last irrigation start time"),
-            e.numeric(legacy.giexWaterValve.irrigationEndTime, ea.STATE).withDescription("Last irrigation end time"),
-            e.numeric(legacy.giexWaterValve.lastIrrigationDuration, ea.STATE).withDescription("Last irrigation duration"),
+            e.text(legacy.giexWaterValve.irrigationStartTime, ea.STATE).withDescription("Last irrigation start time"),
+            e.text(legacy.giexWaterValve.irrigationEndTime, ea.STATE).withDescription("Last irrigation end time"),
+            e.text(legacy.giexWaterValve.lastIrrigationDuration, ea.STATE).withDescription("Last irrigation duration"),
             e.numeric(legacy.giexWaterValve.waterConsumed, ea.STATE).withUnit("L").withDescription("Last irrigation water consumption"),
         ],
     },


### PR DESCRIPTION
The GIEX valve reports irrigation_start_time, irrigation_end_time and last_irrigation_duration as strings.

Examples:
- 21:52:37
- 21:40:49
- 00:03:40

These values are currently exposed as numeric, which causes them to be truncated.

Changing the exposes from numeric to text fixes the issue.

Tested on QT06_2 (_TZE200_a7sghmms).