### PR TITLE
Make Shelly 2PM cover tilt configurable

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -19,6 +19,14 @@ const NS = "zhc:shelly";
 const HA_ELECTRICAL_MEASUREMENT_CLUSTER_ID = 0x0b04;
 const HA_ELECTRICAL_MEASUREMENT_POWER_FACTOR_ATTR_ID = 0x0510;
 
+const checkOption = (device: Zh.Device | DummyDevice, options: KeyValue, key: string, defaultValue = false): boolean => {
+    if (options?.[key] === "true") return true;
+    if (options?.[key] === "false") return false;
+    if (!utils.isDummyDevice(device) && device.meta[key] !== undefined) return !!device.meta[key];
+
+    return defaultValue;
+};
+
 const shellyPresenceEndpointNames = (device: Zh.Device | DummyDevice): string[] => {
     const count =
         !utils.isDummyDevice(device) && typeof device.meta.presence_zone_count === "number"
@@ -381,6 +389,25 @@ const shellyModernExtend = {
             }),
         ];
     },
+    shellyWindowCovering(): ModernExtend {
+        const result = m.windowCovering({controls: ["lift", "tilt"]});
+        const tiltOption = e
+            .enum("cover_tilt_enabled", ea.SET, ["auto", "true", "false"])
+            .withDescription("Expose tilt/slat controls for covers with Shelly slat control enabled");
+        const exposesFn: DefinitionExposesFunction = (device, options) => {
+            const cover = e.cover().withPosition();
+            if (checkOption(device, options, "cover_tilt_enabled")) {
+                cover.withTilt();
+            }
+
+            return [cover];
+        };
+
+        result.exposes = [exposesFn];
+        result.options = [...(result.options ?? []), tiltOption];
+
+        return result;
+    },
     shellyPresenceOccupancy(): ModernExtend {
         const exposesFn: DefinitionExposesFunction = (device) => {
             return shellyPresenceEndpointNames(device).map((endpointName) => e.occupancy().withAccess(ea.STATE_GET).withEndpoint(endpointName));
@@ -421,6 +448,7 @@ const shellyModernExtend = {
         const featurePowerstripPowerOnBehavior = features.includes("PowerstripPowerOnBehavior");
         const featureTwoPMInputMode = features.includes("2PMInputMode");
         const featureOnePMInputMode = features.includes("1PMInputMode");
+        const featureCoverTiltAuto = features.includes("CoverTiltAuto");
         const featurePresenceZonesAuto = features.includes("PresenceZonesAuto");
 
         // Generic helper functions
@@ -822,6 +850,27 @@ const shellyModernExtend = {
                     await rpcReceive(ep, "rpc_rxctl");
                 } catch (e) {
                     logger.warning(`Failed to read switch_mode during configure, use get to retry: ${e}`, NS);
+                }
+            });
+        }
+        if (featureCoverTiltAuto) {
+            configure.push(async (device) => {
+                const ep = device.getEndpoint(SHELLY_ENDPOINT_ID);
+                if (!ep) return;
+                try {
+                    const response = await rpcRequest(ep, "Cover.GetConfig", {id: 0});
+                    const result = response?.result ?? response?.params ?? response;
+                    if (!result) return;
+                    assertObject<KeyValue>(result);
+                    if (!result.slat) return;
+                    assertObject<KeyValue>(result.slat);
+                    const enabled = result.slat.enable;
+                    if (typeof enabled === "boolean" && device.meta.cover_tilt_enabled !== enabled) {
+                        device.meta.cover_tilt_enabled = enabled;
+                        device.save();
+                    }
+                } catch (e) {
+                    logger.warning(`Failed to read cover_tilt_enabled during configure, use manual option to override: ${e}`, NS);
                 }
             });
         }
@@ -1592,9 +1641,9 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         extend: [
             m.deviceEndpoints({endpoints: {sw1: 2, sw2: 3}}),
-            m.windowCovering({controls: ["lift", "tilt"]}),
+            shellyModernExtend.shellyWindowCovering(),
             ...shellyModernExtend.shellyCustomClusters(),
-            shellyModernExtend.shellyRPCSetup(["2PMInputMode"]),
+            shellyModernExtend.shellyRPCSetup(["2PMInputMode", "CoverTiltAuto"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
         configure: async (device, coordinatorEndpoint) => {

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -1,7 +1,129 @@
+import assert from "node:assert";
 import {describe, expect, it, vi} from "vitest";
 import {findByDevice} from "../src/index";
-import type {DefinitionExposesFunction} from "../src/lib/types";
+import type {DefinitionExposesFunction, Expose} from "../src/lib/types";
 import {mockDevice} from "./utils";
+
+const getFeatureNames = (expose: Expose): string[] => {
+    return "features" in expose ? expose.features.map((feature) => feature.name) : [];
+};
+
+describe("Shelly 2PM Gen4 cover mode", () => {
+    const mockShelly2PMCover = (read?: ReturnType<typeof vi.fn>) =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 514, inputClusterIDs: [0, 3, 4, 5, 258], outputClusterIDs: []},
+                {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: [], read},
+                {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
+            ],
+        });
+
+    it("exposes lift-only covers by default and opt-in tilt controls", async () => {
+        const device = mockShelly2PMCover();
+        const definition = await findByDevice(device);
+        expect(definition.model).toBe("S4SW-002P16EU-COVER");
+        expect(typeof definition.exposes).toBe("function");
+        const exposes = definition.exposes as DefinitionExposesFunction;
+
+        const defaultCover = exposes(device, {}).find((expose) => expose.type === "cover");
+        const tiltCover = exposes(device, {cover_tilt_enabled: "true"}).find((expose) => expose.type === "cover");
+        device.meta.cover_tilt_enabled = true;
+        const autoDetectedTiltCover = exposes(device, {cover_tilt_enabled: "auto"}).find((expose) => expose.type === "cover");
+        assert(defaultCover);
+        assert(tiltCover);
+        assert(autoDetectedTiltCover);
+
+        expect(getFeatureNames(defaultCover)).toContain("position");
+        expect(getFeatureNames(defaultCover)).not.toContain("tilt");
+        expect(getFeatureNames(tiltCover)).toContain("position");
+        expect(getFeatureNames(tiltCover)).toContain("tilt");
+        expect(getFeatureNames(autoDetectedTiltCover)).toContain("tilt");
+        expect(definition.options?.some((option) => option.name === "cover_tilt_enabled")).toBe(true);
+    });
+
+    it("persists Shelly slat control from Cover.GetConfig during configure", async () => {
+        const response = JSON.stringify({id: 1, result: {id: 0, slat: {enable: true}}});
+        const read = vi
+            .fn()
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: response.length})
+            .mockResolvedValueOnce({data: response});
+        const device = mockShelly2PMCover(read);
+        const save = vi.spyOn(device, "save").mockImplementation(() => {});
+        const definition = await findByDevice(device);
+
+        await definition.configure?.(device, mockShelly2PMCover().getEndpoint(1), definition);
+
+        expect(device.meta.cover_tilt_enabled).toBe(true);
+        expect(save).toHaveBeenCalledTimes(1);
+        expect(read).toHaveBeenCalledWith("shellyRPCCluster", ["rxCtl"], expect.any(Object));
+        expect(read).toHaveBeenCalledWith("shellyRPCCluster", ["data"], expect.any(Object));
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
+            "shellyRPCCluster",
+            {data: expect.stringContaining("Cover.GetConfig")},
+            expect.any(Object),
+        );
+    });
+
+    it("persists Shelly slat control from Cover.GetConfig params during configure", async () => {
+        const response = JSON.stringify({id: 1, params: {id: 0, slat: {enable: true}}});
+        const read = vi
+            .fn()
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: response.length})
+            .mockResolvedValueOnce({data: response});
+        const device = mockShelly2PMCover(read);
+        const save = vi.spyOn(device, "save").mockImplementation(() => {});
+        const definition = await findByDevice(device);
+
+        await definition.configure?.(device, mockShelly2PMCover().getEndpoint(1), definition);
+
+        expect(device.meta.cover_tilt_enabled).toBe(true);
+        expect(save).toHaveBeenCalledTimes(1);
+    });
+
+    it("overwrites stale persisted slat control from Cover.GetConfig during configure", async () => {
+        const response = JSON.stringify({id: 1, result: {id: 0, slat: {enable: false}}});
+        const read = vi
+            .fn()
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: response.length})
+            .mockResolvedValueOnce({data: response});
+        const device = mockShelly2PMCover(read);
+        device.meta.cover_tilt_enabled = true;
+        const save = vi.spyOn(device, "save").mockImplementation(() => {});
+        const definition = await findByDevice(device);
+
+        await definition.configure?.(device, mockShelly2PMCover().getEndpoint(1), definition);
+
+        expect(device.meta.cover_tilt_enabled).toBe(false);
+        expect(save).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves persisted slat control unchanged when Cover.GetConfig has no boolean slat flag", async () => {
+        const response = JSON.stringify({id: 1, result: {id: 0}});
+        const read = vi
+            .fn()
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: 0})
+            .mockResolvedValueOnce({rxCtl: response.length})
+            .mockResolvedValueOnce({data: response});
+        const device = mockShelly2PMCover(read);
+        device.meta.cover_tilt_enabled = true;
+        const save = vi.spyOn(device, "save").mockImplementation(() => {});
+        const definition = await findByDevice(device);
+
+        await definition.configure?.(device, mockShelly2PMCover().getEndpoint(1), definition);
+
+        expect(device.meta.cover_tilt_enabled).toBe(true);
+        expect(save).not.toHaveBeenCalled();
+    });
+});
 
 describe("Shelly Presence Gen4", () => {
     const mockShellyPresence = (read?: ReturnType<typeof vi.fn>) =>


### PR DESCRIPTION
## Summary
- Make Shelly 2PM Gen4 cover tilt/slat exposure dynamic instead of always exposing tilt.
- Read `Cover.GetConfig` over the Shelly RPC cluster during configure and persist `slat.enable` into device metadata.
- Keep a `cover_tilt_enabled` device option with `auto`, `true`, and `false` for manual override when RPC config cannot be read.
- Handle `Cover.GetConfig` responses wrapped in `result`, wrapped in `params`, or returned directly.

## Scope
This PR is intentionally cover-only. The related behavior from the original combined branch was split into separate PRs:
- Wi-Fi readback/fallback fix: #12524
- Switch input endpoint cleanup: #12525

## Review feedback addressed
- `auto` is no longer equivalent to `false`: after configure it follows the device-reported `slat.enable` value, while `true` and `false` remain explicit overrides.
- Overwrites stale persisted tilt metadata when the device reports `slat.enable: false`.
- Keeps tilt controls hidden for Shelly 2PM cover variants without slat control, while still allowing a manual override when RPC config cannot be read.

## Validation
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.18.3 exec vitest run test/shelly.test.ts --config ./test/vitest.config.mts` (`8` tests)
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.18.3 exec biome check --error-on-warnings src/devices/shelly.ts test/shelly.test.ts`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.18.3 run build`
- `git diff --check`

## Live validation
- Verified on my Home Assistant instance that the Shelly 2PM Gen4 cover devices expose the `cover_tilt_enabled` option.
- Verified on my Home Assistant instance that cover tilt/slat controls remain hidden when Shelly slat control is disabled.
- Verified on my Home Assistant instance with a combined local override before this split; this PR now contains only the cover part of that validated behavior.