### PR TITLE
Make Bosch RM230Z HA climate modes configurable

### DIFF
--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -757,28 +757,36 @@ export const definitions: DefinitionWithExtend[] = [
         model: "BTH-RM230Z",
         vendor: "Bosch",
         description: "Room thermostat II 230V",
+        options: [exposes.options.homeassistant_climate_modes()],
         meta: {
-            overrideHaDiscoveryPayload: (payload) => {
+            overrideHaDiscoveryPayload: (payload, options) => {
                 if (payload.mode_command_topic?.endsWith("/system_mode")) {
+                    const climateModes = options?.homeassistant_climate_modes;
+                    const activeModes = climateModes === "cool" ? ["cool"] : climateModes === "heat_cool" ? ["heat", "cool"] : ["heat"];
+                    const fallbackMode = activeModes[0];
+                    const activeModesTemplate = `[${activeModes.map((mode) => `'${mode}'`).join(",")}]`;
+
                     payload.mode_command_topic = payload.mode_command_topic.substring(0, payload.mode_command_topic.lastIndexOf("/system_mode"));
                     payload.mode_command_template =
-                        "{% set values = " +
-                        `{ 'auto':'schedule','heat':'manual','cool':'manual','off':'pause'} %}` +
-                        `{% if value == "heat" or value == "cool" %}` +
+                        `{% set active_modes = ${activeModesTemplate} %}` +
+                        `{% set values = {'auto':'schedule','off':'pause'} %}` +
+                        "{% if value in active_modes %}" +
                         `{"operating_mode": "manual", "system_mode": "{{ value }}"}` +
                         "{% else %}" +
                         `{"operating_mode": "{{ values[value] if value in values.keys() else 'pause' }}"}` +
                         "{% endif %}";
                     payload.mode_state_template =
-                        "{% set values = " +
-                        `{'schedule':'auto','manual':'heat','pause':'off'} %}` +
+                        `{% set active_modes = ${activeModesTemplate} %}` +
+                        `{% set fallback_mode = '${fallbackMode}' %}` +
+                        "{% set values = {'schedule':'auto','pause':'off'} %}" +
                         "{% set value = value_json.operating_mode %}" +
-                        `{% if value == "manual" %}` +
-                        "{{ value_json.system_mode }}" +
+                        "{% set mode = value_json.system_mode %}" +
+                        "{% if value == 'manual' %}" +
+                        "{{ mode if mode in active_modes else fallback_mode }}" +
                         "{% else %}" +
                         `{{ values[value] if value in values.keys() else 'off' }}` +
                         "{% endif %}";
-                    payload.modes = ["off", "heat", "cool", "auto"];
+                    payload.modes = ["off", ...activeModes, "auto"];
                 }
             },
         },

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -850,6 +850,10 @@ export const options = {
         new Enum("thermostat_unit", access.SET, ["celsius", "fahrenheit"]).withDescription(
             "Controls the temperature unit of the thermostat (default celsius).",
         ),
+    homeassistant_climate_modes: () =>
+        new Enum("homeassistant_climate_modes", access.SET, ["heat", "cool", "heat_cool"])
+            .withLabel("Home Assistant climate modes")
+            .withDescription("Controls which modes are exposed in Home Assistant climate discovery (default heat)."),
     expose_pin: () =>
         new Binary("expose_pin", access.SET, true, false)
             .withLabel("Expose PIN")

--- a/test/bosch.test.ts
+++ b/test/bosch.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, it, vi} from "vitest";
 import {findByDevice} from "../src/index";
 import {boschThermostatExtend} from "../src/lib/bosch";
 import {repInterval} from "../src/lib/constants";
-import type {DefinitionExposesFunction} from "../src/lib/types";
+import type {DefinitionExposesFunction, KeyValueAny} from "../src/lib/types";
 import {mockDevice, reportingItem} from "./utils";
 
 describe("Bosch thermostats", () => {
@@ -74,5 +74,54 @@ describe("Bosch thermostat relayState extension", () => {
         expect(relayStateExposes(device)).toStrictEqual([]);
         expect(device.getEndpoint(1).bind).not.toHaveBeenCalled();
         expect(device.getEndpoint(1).configureReporting).not.toHaveBeenCalled();
+    });
+});
+
+describe("Bosch Room thermostat II 230V Home Assistant climate modes", () => {
+    const getDefinition = () =>
+        findByDevice(
+            mockDevice({
+                modelID: "RBSH-RTH0-ZB-EU",
+                manufacturerName: "BOSCH",
+                endpoints: [{ID: 1, inputClusters: ["hvacThermostat"]}],
+            }),
+        );
+
+    const buildPayload = async (options = {}) => {
+        const definition = await getDefinition();
+        const payload: KeyValueAny = {
+            mode_command_topic: "zigbee2mqtt/bad_thermostat/set/system_mode",
+        };
+
+        definition.meta?.overrideHaDiscoveryPayload?.(payload, options);
+
+        return {definition, payload};
+    };
+
+    it("defaults to heat-only Home Assistant climate discovery", async () => {
+        const {definition, payload} = await buildPayload();
+        const option = definition.options?.find((option) => option.name === "homeassistant_climate_modes");
+
+        expect(option?.label).toBe("Home Assistant climate modes");
+        expect(payload.mode_command_topic).toBe("zigbee2mqtt/bad_thermostat/set");
+        expect(payload.mode_command_template).toContain("{% set active_modes = ['heat'] %}");
+        expect(payload.mode_state_template).toContain("{% set fallback_mode = 'heat' %}");
+        expect(payload.modes).toStrictEqual(["off", "heat", "auto"]);
+    });
+
+    it("can expose cool-only Home Assistant climate discovery", async () => {
+        const {payload} = await buildPayload({homeassistant_climate_modes: "cool"});
+
+        expect(payload.mode_command_template).toContain("{% set active_modes = ['cool'] %}");
+        expect(payload.mode_state_template).toContain("{% set fallback_mode = 'cool' %}");
+        expect(payload.modes).toStrictEqual(["off", "cool", "auto"]);
+    });
+
+    it("can expose heat and cool Home Assistant climate discovery", async () => {
+        const {payload} = await buildPayload({homeassistant_climate_modes: "heat_cool"});
+
+        expect(payload.mode_command_template).toContain("{% set active_modes = ['heat','cool'] %}");
+        expect(payload.mode_state_template).toContain("{% set fallback_mode = 'heat' %}");
+        expect(payload.modes).toStrictEqual(["off", "heat", "cool", "auto"]);
     });
 });


### PR DESCRIPTION
## Summary
- Add a `homeassistant_climate_modes` device option for Bosch Room thermostat II 230V.
- Default Home Assistant climate discovery to heating-only modes (`off`, `heat`, `auto`) for normal RM230Z radiator/floor-heating installs.
- Allow explicit `cool` or `heat_cool` discovery only when the installation really supports cooling, e.g. a heat-pump setup.
- Use the readable option label `Home Assistant climate modes` in Zigbee2MQTT settings.

## Dependency

- Depends on Koenkk/zigbee-herdsman-converters#12526 for the optional HA discovery override `options` type.
- Depends on Koenkk/zigbee2mqtt#32379 for Zigbee2MQTT to pass the device options into the converter hook.
- This PR no longer carries the generic hook type change itself; it only consumes the optional second argument in the Bosch override.
- Documentation is tracked separately in Koenkk/zigbee2mqtt.io#5264.

## Review feedback addressed
- Cooling is no longer exposed unconditionally.
- The default is now heating-only, while the optional override covers installations where this thermostat is paired with equipment that can cool.
- The option is generic for HA discovery only; it does not change the actual Zigbee thermostat system mode support.
- The shared hook typing was split into Koenkk/zigbee-herdsman-converters#12526 instead of being bundled into this device-specific PR.

## Validation
- `pnpm run build`
- `pnpm run check`
- `pnpm test` (`19` files, `615` tests)
- `pnpm test test/bosch.test.ts`
- `git diff --check`

## Live validation on my Home Assistant instance
- Deployed the built `dist/devices/bosch.js` and `dist/lib/exposes.js` to the Zigbee2MQTT add-on and restarted the add-on.
- Verified all five live Bosch RM230Z devices now advertise the `homeassistant_climate_modes` option under `definition.options` in `zigbee2mqtt/bridge/devices`: Bad Thermostat, Schlafzimmer Thermostat, Arbeitszimmer Thermostat, Wohnzimmer Thermostat Flur, Wohnzimmer Thermostat Küche.
- Verified Home Assistant exposes all five live climate entities with `hvac_modes: ["off", "heat", "auto"]` by default.
- Revalidated `Arbeitszimmer Thermostat` through `zigbee2mqtt/bridge/request/device/options`:
  - `homeassistant_climate_modes: cool` -> retained HA discovery `modes: ["off", "cool", "auto"]`.
  - `homeassistant_climate_modes: heat_cool` -> retained HA discovery `modes: ["off", "heat", "cool", "auto"]`.
  - Reverted to `heat` -> retained HA discovery `modes: ["off", "heat", "auto"]` and the bridge device payload returned to no custom persisted options.
