### PR TITLE
fix: Excellux ZG-104PLV: expose presence as binary occupancy

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26142,7 +26142,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         description: "PIR motion sensor, vibration sensor, and light sensor",
         exposes: [
-            e.enum("presence", ea.STATE, ["true", "false"]).withDescription("Presence state, true: motion detected, false: no motion"),
+            e.occupancy().withDescription("Presence state, true: motion detected, false: no motion"),
             e.binary("vibration", ea.STATE, true, false).withDescription("Vibration state, true: vibration detected, false: no vibration"),
             e.enum("illuminance_warning", ea.STATE, ["none", "low", "high"]).withDescription("Illuminance warning level"),
             e.battery(),
@@ -26192,7 +26192,7 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaDatapoints: [
                 [4, "battery", tuya.valueConverter.raw],
-                [1, "presence", tuya.valueConverterBasic.lookup({true: tuya.enum(1), false: tuya.enum(0)})],
+                [1, "occupancy", tuya.valueConverter.trueFalse1],
                 [3, "vibration", tuya.valueConverter.raw],
                 [6, "vibration_sensitivity", tuya.valueConverter.raw],
                 [20, "illuminance", tuya.valueConverter.raw],


### PR DESCRIPTION
## What

Changes the `ZG-104PLV` (Excellux PIR / vibration / light sensor) `presence` from a string `enum` (`"true"`/`"false"`) to a binary `occupancy` expose.

## Why

The motion signal is currently exposed as an enum, so consumers that expect a boolean presence/motion signal don't see it as one:

- In Home Assistant it discovers as a `sensor` holding the string `"true"`/`"false"`, **not** a `binary_sensor`. That breaks anything that filters on binary sensors — e.g. the Magic Areas integration ignores it entirely for occupancy tracking, and it can't carry a `occupancy`/`motion` device class.
- It's inconsistent with the rest of the file. This is the only `enum("presence")` in `tuya.ts`; the other ~22 Tuya PIR/presence sensors using the same DP1 enum pattern all use `e.occupancy()`.
- The underlying datapoint (DP1, enum `0`/`1`) maps cleanly to a boolean, so there's no device-side reason for the enum — it's a historical artifact of the original add (#11290), and the later cosmetic cleanup (#11451) explicitly left converter logic untouched.

## Breaking change

Yes. The property/entity renames `presence` → `occupancy` (and the value type changes from the string `"true"`/`"false"` to a boolean / HA `on`/`off`). Users with automations referencing `presence` will need to update them.

Note there is precedent: #11451 already shipped a breaking rename on this same device (`presence_state` → `presence`).

## Tested

Validated on real hardware (1 unit) via an external converter before submitting: the device now discovers as `binary_sensor` `occupancy` (device_class occupancy), toggles `ON` on motion / `OFF` when clear, and all other exposes (vibration, illuminance, battery, sampling_interval, etc.) are unaffected.
