### PR TITLE
Expose Bosch RM230Z weekly schedule

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -1567,6 +1567,7 @@ export const thermostat_weekly_schedule: Tz.Converter = {
 
         let daysofweek = value.dayofweek;
         const transitions = value.transitions;
+        const convertedTransitions: TClusterCommandPayload<"hvacThermostat", "setWeeklySchedule">["transitions"] = [];
         let numoftrans = 0;
         const modes: string[] = [];
 
@@ -1590,47 +1591,61 @@ export const thermostat_weekly_schedule: Tz.Converter = {
 
             // transform transition payload values if needed
             for (const elem of transitions) {
+                const heatSetpoint = elem.heatSetpoint ?? elem.heat_setpoint;
+                const coolSetpoint = elem.coolSetpoint ?? elem.cool_setpoint;
+                let transitionTime = elem.transitionTime ?? elem.transition_time ?? elem.time;
+                const convertedTransition: Partial<TClusterCommandPayload<"hvacThermostat", "setWeeklySchedule">["transitions"][number]> = {};
+
                 // update mode if needed
-                if (elem.heatSetpoint != null && !modes.includes("heat")) {
+                if (heatSetpoint != null && !modes.includes("heat")) {
                     modes.push("heat");
                 }
-                if (elem.coolSetpoint != null && !modes.includes("cool")) {
+                if (coolSetpoint != null && !modes.includes("cool")) {
                     modes.push("cool");
                 }
 
                 // transform setpoint values if numeric
-                if (typeof elem.heatSetpoint === "number") {
-                    elem.heatSetpoint = Math.round(elem.heatSetpoint * 100);
+                if (typeof heatSetpoint === "number") {
+                    convertedTransition.heatSetpoint = Math.round(heatSetpoint * 100);
+                } else if (heatSetpoint != null) {
+                    convertedTransition.heatSetpoint = heatSetpoint;
                 }
-                if (typeof elem.coolSetpoint === "number") {
-                    elem.coolSetpoint = Math.round(elem.coolSetpoint * 100);
+                if (typeof coolSetpoint === "number") {
+                    convertedTransition.coolSetpoint = Math.round(coolSetpoint * 100);
+                } else if (coolSetpoint != null) {
+                    convertedTransition.coolSetpoint = coolSetpoint;
                 }
 
                 // accept 24h time notation (e.g. 19:30)
-                if (typeof elem.transitionTime === "string") {
-                    const time = elem.transitionTime.split(":");
+                if (typeof transitionTime === "string") {
+                    const time = transitionTime.split(":");
                     const timeHour = Number.parseInt(time[0], 10) * 60;
                     const timeMinute = Number.parseInt(time[1], 10);
 
                     if (time.length !== 2 || Number.isNaN(timeHour) || Number.isNaN(timeMinute)) {
-                        logger.warning(`weekly_schedule: expected 24h time notation (e.g. 19:30) but got '${elem.transitionTime}'!`, NS);
+                        logger.warning(`weekly_schedule: expected 24h time notation (e.g. 19:30) but got '${transitionTime}'!`, NS);
                     } else {
-                        elem.transitionTime = timeHour + timeMinute;
+                        transitionTime = timeHour + timeMinute;
                     }
-                } else if (typeof elem.transitionTime === "object") {
-                    if (elem.transitionTime.hour == null || elem.transitionTime.minute == null) {
+                } else if (typeof transitionTime === "object") {
+                    if (transitionTime.hour == null || transitionTime.minute == null) {
                         throw new Error(
-                            `weekly_schedule: expected 24h time object (e.g. {"hour": 19, "minute": 30}), but got '${JSON.stringify(elem.transitionTime)}'!`,
+                            `weekly_schedule: expected 24h time object (e.g. {"hour": 19, "minute": 30}), but got '${JSON.stringify(transitionTime)}'!`,
                         );
                     }
-                    if (Number.isNaN(elem.transitionTime.hour)) {
-                        throw new Error(`weekly_schedule: expected time.hour to be a number, but got '${elem.transitionTime.hour}'!`);
+                    if (Number.isNaN(transitionTime.hour)) {
+                        throw new Error(`weekly_schedule: expected time.hour to be a number, but got '${transitionTime.hour}'!`);
                     }
-                    if (Number.isNaN(elem.transitionTime.minute)) {
-                        throw new Error(`weekly_schedule: expected time.minute to be a number, but got '${elem.transitionTime.minute}'!`);
+                    if (Number.isNaN(transitionTime.minute)) {
+                        throw new Error(`weekly_schedule: expected time.minute to be a number, but got '${transitionTime.minute}'!`);
                     }
-                    elem.transitionTime = Number.parseInt(elem.transitionTime.hour, 10) * 60 + Number.parseInt(elem.transitionTime.minute, 10);
+                    transitionTime = Number.parseInt(transitionTime.hour, 10) * 60 + Number.parseInt(transitionTime.minute, 10);
                 }
+
+                convertedTransition.transitionTime = transitionTime;
+                convertedTransitions.push(
+                    convertedTransition as TClusterCommandPayload<"hvacThermostat", "setWeeklySchedule">["transitions"][number],
+                );
             }
         } else {
             logger.error("weekly_schedule: transitions is not an array!", NS);
@@ -1669,7 +1684,7 @@ export const thermostat_weekly_schedule: Tz.Converter = {
         await entity.command(
             "hvacThermostat",
             "setWeeklySchedule",
-            {dayofweek, numoftrans, transitions, mode},
+            {dayofweek, numoftrans, transitions: convertedTransitions, mode},
             utils.getOptions(meta.mapped, entity),
         );
     },

--- a/src/devices/bosch.ts
+++ b/src/devices/bosch.ts
@@ -788,7 +788,7 @@ export const definitions: DefinitionWithExtend[] = [
             boschThermostatExtend.customUserInterfaceCfgCluster(),
             boschThermostatExtend.relayState(),
             boschThermostatExtend.operatingMode({enableReporting: true}),
-            boschThermostatExtend.rmThermostat(),
+            boschThermostatExtend.rmThermostat({weeklySchedule: true}),
             boschThermostatExtend.setpointChangeSource({enableReporting: true}),
             boschThermostatExtend.humidity(),
             boschThermostatExtend.heaterType(),

--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -19,6 +19,30 @@ const ea = exposes.access;
 
 const NS = "zhc:bosch";
 
+function addWeeklyScheduleExpose(climate: exposes.Climate) {
+    const featureDayOfWeek = new exposes.List(
+        "dayofweek",
+        ea.SET,
+        new exposes.Composite("day", "dayofweek", ea.SET).withFeature(
+            new exposes.Enum("day", ea.SET, ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday", "away_or_vacation"]),
+        ),
+    )
+        .withLabel("Day of week")
+        .withLengthMin(1)
+        .withLengthMax(8)
+        .withDescription("Days on which the schedule will be active.");
+    const featureTransitionTime = new exposes.Composite("time", "transition_time", ea.SET)
+        .withFeature(new exposes.Numeric("hour", ea.SET))
+        .withFeature(new exposes.Numeric("minute", ea.SET))
+        .withDescription("Trigger transition X minutes after 00:00.");
+    const featureTransition = new exposes.Composite("transition", "transition", ea.SET)
+        .withFeature(featureTransitionTime)
+        .withFeature(new exposes.Numeric("heat_setpoint", ea.SET).withLabel("Heat setpoint").withDescription("Target heat setpoint"));
+    const featureTransitions = new exposes.List("transitions", ea.SET, featureTransition).withLengthMin(1).withLengthMax(10);
+
+    climate.addFeature(new exposes.Composite("schedule", "weekly_schedule", ea.ALL).withFeature(featureDayOfWeek).withFeature(featureTransitions));
+}
+
 export const manufacturerOptions = {
     manufacturerCode: Zcl.ManufacturerCode.ROBERT_BOSCH_GMBH,
     sendPolicy: <SendPolicy>"immediate",
@@ -3696,7 +3720,7 @@ export const boschThermostatExtend = {
             lowStatus: true,
             lowStatusReportingConfig: {min: "MIN", max: "MAX", change: null},
         }),
-    rmThermostat: (): ModernExtend => {
+    rmThermostat: (args?: {weeklySchedule?: boolean}): ModernExtend => {
         const thermostat = m.thermostat({
             localTemperature: {
                 configure: {reporting: {min: "1_MINUTE", max: "1_HOUR", change: 10}},
@@ -3724,9 +3748,16 @@ export const boschThermostatExtend = {
                 values: ["cooling_only", "heating_only"],
                 configure: {reporting: {min: "MIN", max: "MAX", change: null}},
             },
+            weeklySchedule: args?.weeklySchedule ? {values: ["heat"]} : undefined,
         });
 
         const exposes: (Expose | DefinitionExposesFunction)[] = thermostat.exposes;
+
+        if (args?.weeklySchedule) {
+            const climate = exposes[0] as exposes.Climate;
+            climate.features = climate.features.filter((feature) => feature.property !== "weekly_schedule");
+            addWeeklyScheduleExpose(climate);
+        }
 
         return {
             exposes: exposes,

--- a/test/bosch.test.ts
+++ b/test/bosch.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from "vitest";
+import {findByDevice} from "../src/index";
+import {mockDevice} from "./utils";
+
+describe("Bosch thermostats", () => {
+    it("exposes standard weekly schedule controls for BTH-RM230Z", async () => {
+        const device = mockDevice({
+            modelID: "RBSH-RTH0-ZB-EU",
+            manufacturerName: "BOSCH",
+            endpoints: [{ID: 1, inputClusters: ["genOnOff", "hvacThermostat", "hvacUserInterfaceCfg", "msRelativeHumidity"]}],
+        });
+        const definition = await findByDevice(device);
+
+        expect(definition.toZigbee.some((converter) => converter.key.includes("weekly_schedule"))).toBe(true);
+        expect(definition.toZigbee.some((converter) => converter.key.includes("clear_weekly_schedule"))).toBe(true);
+        expect(definition.fromZigbee.some((converter) => converter.cluster === "hvacThermostat")).toBe(true);
+        expect(JSON.stringify(definition.exposes)).toContain("weekly_schedule");
+
+        const coordinator = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).getEndpoint(1);
+        const endpoint = device.getEndpoint(1);
+        await definition.configure?.(device, coordinator, definition);
+
+        expect(endpoint.read).toHaveBeenCalledWith("hvacThermostat", ["numberOfWeeklyTrans", "numberOfDailyTrans", "startOfWeek"]);
+    });
+
+    it("does not expose weekly schedule controls for BTH-RM", async () => {
+        const device = mockDevice({
+            modelID: "RBSH-RTH0-BAT-ZB-EU",
+            manufacturerName: "BOSCH",
+            endpoints: [{ID: 1, inputClusters: ["hvacThermostat", "hvacUserInterfaceCfg"]}],
+        });
+        const definition = await findByDevice(device);
+
+        expect(definition.toZigbee.some((converter) => converter.key.includes("weekly_schedule"))).toBe(false);
+        expect(JSON.stringify(definition.exposes)).not.toContain("weekly_schedule");
+    });
+});


### PR DESCRIPTION
## Summary
- expose standard Zigbee thermostat weekly schedule controls for Bosch BTH-RM230Z (Room thermostat II 230V)
- keep the shared Bosch RM thermostat helper opt-in so the battery RM model remains unchanged
- use a Bosch-specific snake_case weekly schedule expose while keeping the toZigbee converter compatible with existing camelCase payloads
- add regression coverage for RM230Z schedule exposure and configure-time schedule capability reads

## Context
The Bosch RM230Z manual describes automatic room control through a schedule. The existing converter already exposes the Bosch private `operating_mode` value `schedule`, but did not expose the standard ZCL weekly schedule payloads needed to inspect or write the actual schedule.

Related prior work in #9662 covered other private Bosch thermostat attributes; I did not find schedule support implemented there.

The generic thermostat weekly schedule expose currently uses camelCase properties that fail the repository expose naming check, so this PR leaves the shared helper untouched and adds an opt-in Bosch expose using `transition_time` and `heat_setpoint`. The converter accepts both the new snake_case keys and the existing camelCase keys for compatibility.

## Validation
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 exec vitest run test/checks.test.ts test/bosch.test.ts test/toZigbee.test.ts --config ./test/vitest.config.mts`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 run check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 run build`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 test`

## Combined live validation on my Home Assistant instance
- Built a combined ZHC override containing this PR together with #12497, #12498, #12509, and #12510, then deployed the compiled files to the Zigbee2MQTT add-on.
- Verified all five live Bosch Room Thermostat II 230V devices expose `weekly_schedule` via `zigbee2mqtt/bridge/devices`: Bad Thermostat, Schlafzimmer Thermostat, Arbeitszimmer Thermostat, Wohnzimmer Thermostat Flur, Wohnzimmer Thermostat Küche.
- Verified the retained Home Assistant discovery payloads for all five Bosch climate entities still publish heat-only default modes: `["off", "heat", "auto"]`.
- Verified the schedule support composes with #12498's `homeassistant_climate_modes` option on the same live devices.
