### PR TITLE
Handle named custom raw attribute responses

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -148,6 +148,39 @@ function convertReportingConfigTime(time: ReportingConfigTime): number {
     return time;
 }
 
+function getAttributeValue<Cl extends string | number, Custom extends TCustomCluster | undefined = undefined>(
+    msg: Fz.Message<Cl, Custom, ["attributeReport", "readResponse"]>,
+    cluster: Cl,
+    attribute: ClusterWithAttribute<Cl, Custom>["attribute"],
+    manufacturerCode: number | undefined,
+    device: Zh.Device | undefined,
+): unknown {
+    const attributeKey = isString(attribute) ? attribute : attribute.ID;
+    if (attributeKey in msg.data) {
+        return msg.data[attributeKey as keyof typeof msg.data];
+    }
+
+    if (isString(attribute)) {
+        return undefined;
+    }
+
+    const attributeID = attribute.ID;
+    if (typeof attributeID !== "number") {
+        return undefined;
+    }
+
+    try {
+        const clusterDefinition = Zcl.Utils.getCluster(cluster, manufacturerCode, device?.customClusters);
+        const clusterAttribute = Zcl.Utils.getClusterAttribute(clusterDefinition, attributeID, manufacturerCode);
+
+        if (clusterAttribute?.name && clusterAttribute.name in msg.data) {
+            return msg.data[clusterAttribute.name as keyof typeof msg.data];
+        }
+    } catch {
+        // Some vendor-specific raw attributes are intentionally not present in a cluster definition.
+    }
+}
+
 export async function setupAttributes<Cl extends string | number, Custom extends TCustomCluster | undefined = undefined>(
     entity: Zh.Device | Zh.Endpoint,
     coordinatorEndpoint: Zh.Endpoint,
@@ -2621,9 +2654,10 @@ export function enumLookup<Cl extends string | number, Custom extends TCustomClu
             convert:
                 fzConvert ??
                 ((model, msg, publish, options, meta) => {
-                    if (attributeKey in msg.data && (!endpointName || getEndpointName(msg, model, meta) === endpointName)) {
+                    const value = getAttributeValue(msg, cluster, attribute, zigbeeCommandOptions?.manufacturerCode, meta.device);
+                    if (value !== undefined && (!endpointName || getEndpointName(msg, model, meta) === endpointName)) {
                         // skip undefined value
-                        if (msg.data[attributeKey] !== undefined) return {[expose.property]: getFromLookupByValue(msg.data[attributeKey], lookup)};
+                        return {[expose.property]: getFromLookupByValue(value, lookup)};
                     }
                 }),
             // biome-ignore lint/suspicious/noExplicitAny: generic
@@ -2745,13 +2779,14 @@ export function numeric<Cl extends string | number, Custom extends TCustomCluste
             convert:
                 fzConvert ??
                 ((model, msg, publish, options, meta) => {
-                    if (attributeKey in msg.data) {
+                    const attributeValue = getAttributeValue(msg, cluster, attribute, zigbeeCommandOptions?.manufacturerCode, meta.device);
+                    if (attributeValue !== undefined) {
                         const endpoint = endpoints?.find((e) => getEndpointName(msg, model, meta) === e);
                         if (endpoints && !endpoint) {
                             return;
                         }
 
-                        let value = msg.data[attributeKey];
+                        let value = attributeValue;
                         assertNumber(value);
 
                         if (scale !== undefined) {
@@ -2842,8 +2877,9 @@ export function binary<Cl extends string | number, Custom extends TCustomCluster
             cluster: cluster.toString(),
             type: ["attributeReport", "readResponse"],
             convert: (model, msg, publish, options, meta) => {
-                if (attributeKey in msg.data && (!endpointName || getEndpointName(msg, model, meta) === endpointName)) {
-                    return {[expose.property]: msg.data[attributeKey] === valueOn[1] ? valueOn[0] : valueOff[0]};
+                const value = getAttributeValue(msg, cluster, attribute, zigbeeCommandOptions?.manufacturerCode, meta.device);
+                if (value !== undefined && (!endpointName || getEndpointName(msg, model, meta) === endpointName)) {
+                    return {[expose.property]: value === valueOn[1] ? valueOn[0] : valueOff[0]};
                 }
             },
             // biome-ignore lint/suspicious/noExplicitAny: generic
@@ -2914,8 +2950,9 @@ export function text<Cl extends string | number, Custom extends TCustomCluster |
             cluster: cluster.toString(),
             type: ["attributeReport", "readResponse"],
             convert: (model, msg, publish, options, meta) => {
-                if (attributeKey in msg.data && (!endpointName || getEndpointName(msg, model, meta) === endpointName)) {
-                    return {[expose.property]: msg.data[attributeKey]};
+                const value = getAttributeValue(msg, cluster, attribute, zigbeeCommandOptions?.manufacturerCode, meta.device);
+                if (value !== undefined && (!endpointName || getEndpointName(msg, model, meta) === endpointName)) {
+                    return {[expose.property]: value};
                 }
             },
             // biome-ignore lint/suspicious/noExplicitAny: generic

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -443,7 +443,7 @@ export namespace Tz {
         options?: Option[] | ((definition: Definition) => Option[]);
         endpoints?: string[];
         convertSet?: (entity: Zh.Endpoint | Zh.Group, key: string, value: unknown, meta: Tz.Meta) => Promise<ConvertSetResult> | ConvertSetResult;
-        convertGet?: (entity: Zh.Endpoint | Zh.Group, key: string, meta: Tz.Meta) => Promise<void>;
+        convertGet?: (entity: Zh.Endpoint | Zh.Group, key: string, meta: Tz.Meta) => Promise<ConvertSetResult>;
     }
 }
 

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -1,5 +1,6 @@
-import {describe, expect, test} from "vitest";
+import {describe, expect, test, vi} from "vitest";
 import * as fz from "../src/converters/fromZigbee";
+import {findByDevice} from "../src/index";
 import {repInterval} from "../src/lib/constants";
 import {fromZigbee as lumiFz} from "../src/lib/lumi";
 import {setupAttributes} from "../src/lib/modernExtend";
@@ -489,5 +490,42 @@ describe("ModernExtend", () => {
             "acCurrentMultiplier",
         ]);
         expect(deviceEp.read).toHaveBeenNthCalledWith(2, "haElectricalMeasurement", ["acCurrentOverload", "acFrequency"]);
+    });
+
+    test("raw attribute modern extends consume named custom-cluster read responses", async () => {
+        const device = mockDevice({
+            modelID: "TRETAKT Smart plug",
+            manufacturerName: "IKEA of Sweden",
+            endpoints: [{ID: 1, inputClusters: ["genOnOff"], inputClusterIDs: [0xfc85]}],
+        });
+        vi.spyOn(device, "save").mockImplementation(() => {});
+        const coordinator = mockDevice({modelID: "", endpoints: [{}]});
+        const definition = await findByDevice(device);
+
+        await definition.configure?.(device, coordinator.endpoints[0], definition);
+
+        expect(device.endpoints[0].read).toHaveBeenCalledWith("manuSpecificIkeaSmartPlug", [0]);
+        expect(device.endpoints[0].read).toHaveBeenCalledWith("manuSpecificIkeaSmartPlug", [1]);
+
+        const converters = definition.fromZigbee.filter((converter) => converter.cluster === "manuSpecificIkeaSmartPlug");
+        expect(converters).toHaveLength(2);
+
+        const childLock = converters.flatMap((converter) => {
+            const result = converter.convert(definition, {data: {childLock: 0}, endpoint: device.endpoints[0]} as never, () => {}, {}, {
+                device,
+                state: {},
+            } as never);
+            return result === undefined ? [] : [result];
+        });
+        const ledEnable = converters.flatMap((converter) => {
+            const result = converter.convert(definition, {data: {ledEnable: 1}, endpoint: device.endpoints[0]} as never, () => {}, {}, {
+                device,
+                state: {},
+            } as never);
+            return result === undefined ? [] : [result];
+        });
+
+        expect(childLock).toStrictEqual([{child_lock: "UNLOCK"}]);
+        expect(ledEnable).toStrictEqual([{led_enable: "TRUE"}]);
     });
 });


### PR DESCRIPTION
## Summary
- allow modern extends that use raw `{ID, type}` attributes to consume both numeric and named read/attribute response payload keys
- apply the fallback to enum, numeric, binary, and text modern extends
- widen `convertGet` typing so RPC-style getters can return immediate state when they receive it synchronously

## Why
Some custom clusters are read by numeric attribute ID, but zigbee-herdsman decodes the response using the custom cluster attribute name. This left values at `unknown`/`null` even though the device replied successfully.

Observed with IKEA INSPELNING smart plug controls:
- read request: `manuSpecificIkeaSmartPlug.read([0])`
- response: `{childLock: 0}`
- read request: `manuSpecificIkeaSmartPlug.read([1])`
- response: `{ledEnable: 1}`

Before this change, the generic binary modern extend only looked for keys `0` and `1`, so `child_lock` and `led_enable` stayed unset. With this change, it also resolves the custom cluster attribute name from the registered device custom clusters.

## Review feedback addressed
- The custom cluster name lookup is now explicitly limited to raw numeric attribute IDs; string attributes stay on the direct payload-key path.

## Validation
- `./node_modules/.bin/biome check --error-on-warnings src/lib/modernExtend.ts src/lib/types.ts test/modernExtend.test.ts`
- `./node_modules/.bin/tsc`
- `node dist/indexer.js`
- `./node_modules/.bin/vitest run --config ./test/vitest.config.mts test/modernExtend.test.ts`
- post-rebase: `pnpm exec biome check --error-on-warnings src/lib/modernExtend.ts test/modernExtend.test.ts`
- post-rebase: `pnpm exec vitest run --config ./test/vitest.config.mts test/modernExtend.test.ts`

Live validated on my Home Assistant instance with an IKEA INSPELNING smart plug:
- manual get published `child_lock: "UNLOCK"` and `led_enable: "TRUE"`
- single `device/configure` read both attributes during setup and finished with `status: ok`
