### PR TITLE
Expose SONOFF valve settings as scalar controls

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -4623,22 +4623,23 @@ const sonoffExtend = {
 
         const baseExposes = [
             e
-                .composite("irrigation_plan_remove", "irrigation_plan_remove", ea.SET)
-                .withDescription("Remove irrigation plan")
-                .withFeature(
-                    e.numeric("plan_index", ea.SET).withValueMin(0).withValueMax(5).withDescription("The index of the irrigation plan to remove"),
-                )
+                .numeric("irrigation_plan_remove_plan_index", ea.SET)
+                .withValueMin(0)
+                .withValueMax(5)
+                .withDescription("Index of the irrigation plan to remove")
                 .withCategory("config"),
         ];
-        const exposes = baseExposes.flatMap((expose) => exposeCompositeEndpoints(expose, endpointNames));
+        const exposes = baseExposes.flatMap((expose) => utils.exposeEndpoints(expose, endpointNames));
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ["irrigation_plan_remove"],
+                key: ["irrigation_plan_remove", "irrigation_plan_remove_plan_index"],
                 endpoints: endpointNames,
                 convertSet: async (entity, key, value, meta) => {
-                    utils.assertObject(value, key);
-                    const planIndex = Number(value.plan_index);
+                    if (key === "irrigation_plan_remove") {
+                        utils.assertObject(value, key);
+                    }
+                    const planIndex = key === "irrigation_plan_remove" ? Number((value as KeyValue).plan_index) : Number(value);
                     const data = Buffer.alloc(1);
                     data.writeUInt8(planIndex & 0xff, 0);
 
@@ -4657,7 +4658,8 @@ const sonoffExtend = {
 
                     return {
                         state: {
-                            [key]: {plan_index: planIndex},
+                            irrigation_plan_remove: {plan_index: planIndex},
+                            irrigation_plan_remove_plan_index: planIndex,
                             [settingsProperty]: null,
                         },
                     };

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2911,7 +2911,7 @@ const sonoffExtend = {
         };
     },
     rainDelayEndDatetime: (): ModernExtend => {
-        const exposes = [e.text("rain_delay_end_datetime", ea.STATE).withDescription("User triggered delay end time.")];
+        const exposes = [e.text("rain_delay_end_datetime", ea.STATE).withDescription("User triggered delay end time.").withCategory("diagnostic")];
 
         const toZigbee: Tz.Converter[] = [];
 
@@ -3002,20 +3002,39 @@ const sonoffExtend = {
         };
     },
     manualDefaultSettings: (hasFlowMeter: boolean): ModernExtend => {
-        const exposes = e
-            .composite("manual_default_settings", "manual_default_settings", ea.ALL)
-            .withDescription("Single irrigation settings")
-            .withFeature(
-                e.numeric("irrigation_duration", ea.ALL).withValueMin(1).withValueMax(719).withUnit("min").withDescription("Irrigation duration"),
-            );
+        const exposes: Expose[] = [
+            e
+                .numeric("manual_irrigation_duration", ea.ALL)
+                .withValueMin(1)
+                .withValueMax(719)
+                .withUnit("min")
+                .withDescription("Default duration for manual irrigation")
+                .withCategory("config"),
+        ];
         if (hasFlowMeter) {
-            exposes
-                .withFeature(e.enum("irrigation_mode", ea.ALL, ["duration", "capacity"]).withDescription("Irrigation mode: duration or capacity"))
-                .withFeature(e.enum("irrigation_amount_unit", ea.ALL, ["US gallon", "liter"]).withDescription("Capacity unit"))
-                .withFeature(e.numeric("irrigation_amount", ea.ALL).withValueMin(0).withValueMax(10000).withDescription("Irrigation volume"))
-                .withFeature(
-                    e.numeric("fail_safe", ea.ALL).withValueMin(0).withValueMax(719).withUnit("min").withDescription("Safety protection timeout"),
-                );
+            exposes.push(
+                e
+                    .enum("manual_irrigation_mode", ea.ALL, ["duration", "capacity"])
+                    .withDescription("Default mode for manual irrigation")
+                    .withCategory("config"),
+                e
+                    .enum("manual_irrigation_amount_unit", ea.ALL, ["US gallon", "liter"])
+                    .withDescription("Default manual irrigation unit")
+                    .withCategory("config"),
+                e
+                    .numeric("manual_irrigation_amount", ea.ALL)
+                    .withValueMin(0)
+                    .withValueMax(10000)
+                    .withDescription("Default manual irrigation amount")
+                    .withCategory("config"),
+                e
+                    .numeric("manual_fail_safe", ea.ALL)
+                    .withValueMin(0)
+                    .withValueMax(719)
+                    .withUnit("min")
+                    .withDescription("Manual irrigation safety timeout")
+                    .withCategory("config"),
+            );
         }
 
         const modeMap: {[key: string]: number} = {
@@ -3026,6 +3045,25 @@ const sonoffExtend = {
             0: "duration",
             1: "capacity",
         };
+        const scalarToCompositeKey: {[key: string]: string} = {
+            manual_irrigation_duration: "irrigation_duration",
+            manual_irrigation_mode: "irrigation_mode",
+            manual_irrigation_amount_unit: "irrigation_amount_unit",
+            manual_irrigation_amount: "irrigation_amount",
+            manual_fail_safe: "fail_safe",
+        };
+        const publishManualSettings = (manualDefaultSettings: KeyValue): KeyValue => ({
+            manual_default_settings: manualDefaultSettings,
+            manual_irrigation_duration: manualDefaultSettings.irrigation_duration,
+            ...(hasFlowMeter
+                ? {
+                      manual_irrigation_mode: manualDefaultSettings.irrigation_mode,
+                      manual_irrigation_amount_unit: manualDefaultSettings.irrigation_amount_unit,
+                      manual_irrigation_amount: manualDefaultSettings.irrigation_amount,
+                      manual_fail_safe: manualDefaultSettings.fail_safe,
+                  }
+                : {}),
+        });
 
         const fromZigbee: Fz.Converter<"customClusterEwelink", SonoffSwvzn, ["attributeReport", "readResponse"]>[] = [
             {
@@ -3057,21 +3095,26 @@ const sonoffExtend = {
                         manualDefaultSettings.fail_safe = safetyTimeoutLimit;
                     }
 
-                    return {
-                        manual_default_settings: manualDefaultSettings,
-                    };
+                    return publishManualSettings(manualDefaultSettings);
                 },
             },
         ];
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ["manual_default_settings"],
+                key: ["manual_default_settings", ...Object.keys(scalarToCompositeKey)],
                 convertSet: async (entity, key, value, meta) => {
-                    utils.assertObject(value, key);
-                    const stateValue = meta.state[key];
+                    const partialValue: KeyValue = {};
+                    if (key === "manual_default_settings") {
+                        utils.assertObject(value, key);
+                        Object.assign(partialValue, value);
+                    } else {
+                        partialValue[scalarToCompositeKey[key]] = value;
+                    }
+
+                    const stateValue = meta.state.manual_default_settings;
                     const current = utils.isObject(stateValue) ? stateValue : {};
-                    const nextValue = {...current, ...value};
+                    const nextValue = {...current, ...partialValue};
 
                     if (hasFlowMeter && (typeof nextValue.irrigation_mode !== "string" || modeMap[nextValue.irrigation_mode] === undefined)) {
                         logger.error("manual_default_settings invalid irrigation_mode, expected one of: duration, capacity.", NS);
@@ -3131,9 +3174,7 @@ const sonoffExtend = {
                     );
 
                     return {
-                        state: {
-                            [key]: nextValue,
-                        },
+                        state: publishManualSettings(nextValue),
                     };
                 },
                 convertGet: async (entity, key, meta) => {
@@ -3143,7 +3184,7 @@ const sonoffExtend = {
         ];
 
         return {
-            exposes: [exposes],
+            exposes,
             fromZigbee,
             toZigbee,
             isModernExtend: true,
@@ -3152,15 +3193,20 @@ const sonoffExtend = {
     seasonalWateringAdjustment: (): ModernExtend => {
         const months = ["january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december"];
 
-        let exposesComposite = e
-            .composite("seasonal_watering_adjustment", "seasonal_watering_adjustment", ea.ALL)
-            .withDescription("Monthly watering adjustment multiplier (1.0 = 100%, 2.0 = 200%)");
-
-        for (const month of months) {
-            exposesComposite = exposesComposite.withFeature(
-                e.numeric(month, ea.ALL).withValueMin(0.1).withValueMax(2).withValueStep(0.1).withDescription(`Adjustment multiplier for ${month}`),
-            );
-        }
+        const exposes = months.map((month) =>
+            e
+                .numeric(`seasonal_watering_adjustment_${month}`, ea.ALL)
+                .withValueMin(0.1)
+                .withValueMax(2)
+                .withValueStep(0.1)
+                .withDescription(`Watering adjustment multiplier for ${month} (1.0 = 100%, 2.0 = 200%)`)
+                .withCategory("config"),
+        );
+        const scalarToCompositeKey = Object.fromEntries(months.map((month) => [`seasonal_watering_adjustment_${month}`, month]));
+        const publishSeasonalWateringAdjustment = (values: KeyValue): KeyValue => ({
+            seasonal_watering_adjustment: values,
+            ...Object.fromEntries(months.map((month) => [`seasonal_watering_adjustment_${month}`, values[month]])),
+        });
 
         const fromZigbee: Fz.Converter<"customClusterEwelink", SonoffSwvzn, ["attributeReport", "readResponse"]>[] = [
             {
@@ -3180,21 +3226,26 @@ const sonoffExtend = {
                         result[months[i]] = array[i] / 10;
                     }
 
-                    return {
-                        seasonal_watering_adjustment: result,
-                    };
+                    return publishSeasonalWateringAdjustment(result);
                 },
             },
         ];
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ["seasonal_watering_adjustment"],
+                key: ["seasonal_watering_adjustment", ...Object.keys(scalarToCompositeKey)],
                 convertSet: async (entity, key, value, meta) => {
-                    utils.assertObject(value, key);
-                    const stateValue = meta.state[key];
+                    const partialValue: KeyValue = {};
+                    if (key === "seasonal_watering_adjustment") {
+                        utils.assertObject(value, key);
+                        Object.assign(partialValue, value);
+                    } else {
+                        partialValue[scalarToCompositeKey[key]] = value;
+                    }
+
+                    const stateValue = meta.state.seasonal_watering_adjustment;
                     const current = utils.isObject(stateValue) ? stateValue : {};
-                    const nextValue = {...current, ...value};
+                    const nextValue = {...current, ...partialValue};
 
                     const array = new Uint8Array(12);
                     for (let i = 0; i < 12; i++) {
@@ -3219,9 +3270,7 @@ const sonoffExtend = {
                     );
 
                     return {
-                        state: {
-                            [key]: nextValue,
-                        },
+                        state: publishSeasonalWateringAdjustment(nextValue),
                     };
                 },
                 convertGet: async (entity, key, meta) => {
@@ -3231,7 +3280,7 @@ const sonoffExtend = {
         ];
 
         return {
-            exposes: [exposesComposite],
+            exposes,
             fromZigbee,
             toZigbee,
             isModernExtend: true,
@@ -3414,28 +3463,32 @@ const sonoffExtend = {
         };
     },
     valveAlarmSettings: (): ModernExtend => {
-        const exposes = e
-            .composite("valve_alarm_settings", "valve_alarm_settings", ea.ALL)
-            .withDescription("Valve alarm settings")
-            .withFeature(e.binary("enable_alarm_water_shortage", ea.ALL, true, false).withDescription("Water shortage alarm"))
-            .withFeature(e.binary("enable_alarm_water_leak", ea.ALL, true, false).withDescription("Water leak alarm"))
-            .withFeature(e.binary("enable_water_shortage_auto_close", ea.ALL, true, false).withDescription("Auto close valve on water shortage"))
-            .withFeature(
-                e
-                    .numeric("alarm_water_shortage_duration", ea.ALL)
-                    .withValueMin(1)
-                    .withValueMax(10)
-                    .withUnit("min")
-                    .withDescription("Water shortage trigger alarm duration"),
-            )
-            .withFeature(
-                e
-                    .numeric("alarm_water_leak_duration", ea.ALL)
-                    .withValueMin(1)
-                    .withValueMax(3)
-                    .withUnit("min")
-                    .withDescription("Water leak trigger alarm duration"),
-            );
+        const exposes = [
+            e.binary("enable_alarm_water_shortage", ea.ALL, true, false).withDescription("Water shortage alarm").withCategory("config"),
+            e.binary("enable_alarm_water_leak", ea.ALL, true, false).withDescription("Water leak alarm").withCategory("config"),
+            e
+                .binary("enable_water_shortage_auto_close", ea.ALL, true, false)
+                .withDescription("Auto close valve on water shortage")
+                .withCategory("config"),
+            e
+                .numeric("alarm_water_shortage_duration", ea.ALL)
+                .withValueMin(1)
+                .withValueMax(10)
+                .withUnit("min")
+                .withDescription("Water shortage trigger alarm duration")
+                .withCategory("config"),
+            e
+                .numeric("alarm_water_leak_duration", ea.ALL)
+                .withValueMin(1)
+                .withValueMax(3)
+                .withUnit("min")
+                .withDescription("Water leak trigger alarm duration")
+                .withCategory("config"),
+        ];
+        const publishValveAlarmSettings = (valveAlarmSettings: KeyValue): KeyValue => ({
+            valve_alarm_settings: valveAlarmSettings,
+            ...valveAlarmSettings,
+        });
 
         const fromZigbee: Fz.Converter<"customClusterEwelink", SonoffSwvzn, ["attributeReport", "readResponse"]>[] = [
             {
@@ -3451,27 +3504,39 @@ const sonoffExtend = {
                     }
                     const enableBits = array[0];
 
-                    return {
-                        valve_alarm_settings: {
-                            enable_alarm_water_shortage: !!(enableBits & 0b00001),
-                            enable_alarm_water_leak: !!(enableBits & 0b00010),
-                            enable_water_shortage_auto_close: !!(enableBits & 0b01000),
-                            alarm_water_shortage_duration: array[1],
-                            alarm_water_leak_duration: array[2],
-                        },
-                    };
+                    return publishValveAlarmSettings({
+                        enable_alarm_water_shortage: !!(enableBits & 0b00001),
+                        enable_alarm_water_leak: !!(enableBits & 0b00010),
+                        enable_water_shortage_auto_close: !!(enableBits & 0b01000),
+                        alarm_water_shortage_duration: array[1],
+                        alarm_water_leak_duration: array[2],
+                    });
                 },
             },
         ];
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ["valve_alarm_settings"],
+                key: [
+                    "valve_alarm_settings",
+                    "enable_alarm_water_shortage",
+                    "enable_alarm_water_leak",
+                    "enable_water_shortage_auto_close",
+                    "alarm_water_shortage_duration",
+                    "alarm_water_leak_duration",
+                ],
                 convertSet: async (entity, key, value, meta) => {
-                    utils.assertObject(value, key);
-                    const stateValue = meta.state[key];
+                    const partialValue: KeyValue = {};
+                    if (key === "valve_alarm_settings") {
+                        utils.assertObject(value, key);
+                        Object.assign(partialValue, value);
+                    } else {
+                        partialValue[key] = value;
+                    }
+
+                    const stateValue = meta.state.valve_alarm_settings;
                     const current = utils.isObject(stateValue) ? stateValue : {};
-                    const nextValue = {...current, ...value};
+                    const nextValue = {...current, ...partialValue};
                     const state = {
                         enable_alarm_water_shortage: !!nextValue.enable_alarm_water_shortage,
                         enable_alarm_water_leak: !!nextValue.enable_alarm_water_leak,
@@ -3506,9 +3571,7 @@ const sonoffExtend = {
                     );
 
                     return {
-                        state: {
-                            [key]: state,
-                        },
+                        state: publishValveAlarmSettings(state),
                     };
                 },
                 convertGet: async (entity, key, meta) => {
@@ -3518,7 +3581,7 @@ const sonoffExtend = {
         ];
 
         return {
-            exposes: [exposes],
+            exposes,
             fromZigbee,
             toZigbee,
             isModernExtend: true,
@@ -3542,7 +3605,8 @@ const sonoffExtend = {
                 .withFeature(e.enum("type", ea.SET, ["24_hours", "30_days", "6_months"]).withDescription("Reading type"))
                 .withFeature(e.text("time_start", ea.SET).withDescription("Start time in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"))
                 .withFeature(e.text("time_end", ea.SET).withDescription("End time in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"))
-                .withLabel("Read irrigation history"),
+                .withLabel("Read irrigation history")
+                .withCategory("config"),
         ];
 
         const normalizeUtcEpochSeconds = (input: unknown, label: string): number | undefined => {
@@ -4055,96 +4119,136 @@ const sonoffExtend = {
             saturday: (mask & loopTypeWeekDayBitMapping.saturday) > 0,
         });
 
-        const irrigationPlanSettings = e
-            .composite("irrigation_plan_settings", "irrigation_plan_settings", ea.STATE_SET)
-            .withDescription("Set irrigation plan")
-            .withFeature(e.numeric("plan_index", ea.SET).withValueMin(0).withValueMax(5).withDescription("Plan index"))
-            .withFeature(e.binary("enable_state", ea.SET, true, false))
-            .withFeature(e.enum("loop_type_mode", ea.SET, ["odd_days", "even_days", "day_interval", "weekdays"]))
-            .withFeature(
+        const irrigationPlanSettingExposes: Expose[] = [
+            e
+                .numeric("irrigation_plan_index", ea.ALL)
+                .withValueMin(0)
+                .withValueMax(5)
+                .withDescription("Irrigation plan index")
+                .withCategory("config"),
+            e.binary("irrigation_plan_enabled", ea.ALL, true, false).withDescription("Enable the selected irrigation plan").withCategory("config"),
+            e
+                .enum("irrigation_plan_loop_type", ea.ALL, ["odd_days", "even_days", "day_interval", "weekdays"])
+                .withDescription("Repeat mode for the selected irrigation plan")
+                .withCategory("config"),
+            e
+                .numeric("irrigation_plan_interval_days", ea.ALL)
+                .withValueMin(0)
+                .withValueMax(30)
+                .withDescription("Repeat interval in days when loop type is day_interval")
+                .withCategory("config"),
+            ...loopTypeWeekDayNames.map((day) =>
                 e
-                    .numeric("loop_type_interval_days", ea.SET)
-                    .withValueMin(1)
-                    .withValueMax(30)
-                    .withDescription("Only effective when loop_type_mode is day_interval"),
-            )
-            .withFeature(
-                e
-                    .composite("loop_type_week_days", "loop_type_week_days", ea.SET)
-                    .withDescription("Only effective when loop_type_mode is weekdays")
-                    .withFeature(e.binary("sunday", ea.SET, true, false))
-                    .withFeature(e.binary("monday", ea.SET, true, false))
-                    .withFeature(e.binary("tuesday", ea.SET, true, false))
-                    .withFeature(e.binary("wednesday", ea.SET, true, false))
-                    .withFeature(e.binary("thursday", ea.SET, true, false))
-                    .withFeature(e.binary("friday", ea.SET, true, false))
-                    .withFeature(e.binary("saturday", ea.SET, true, false)),
-            )
-            .withFeature(e.text("enable_date", ea.SET).withDescription("Enable date in local YYYY-MM-DD format."))
-            .withFeature(e.text("start_time", ea.SET).withDescription("Start time in local HH:mm format (24-hour, zero-padded)."))
-            .withFeature(
-                e.enum(
-                    "irrigation_mode",
-                    ea.SET,
+                    .binary(`irrigation_plan_${day}`, ea.ALL, true, false)
+                    .withDescription(`Run the selected irrigation plan on ${day}`)
+                    .withCategory("config"),
+            ),
+            e.text("irrigation_plan_enable_date", ea.ALL).withDescription("Enable date in local YYYY-MM-DD format").withCategory("config"),
+            e.text("irrigation_plan_start_time", ea.ALL).withDescription("Start time in local HH:mm format").withCategory("config"),
+            e
+                .enum(
+                    "irrigation_plan_mode",
+                    ea.ALL,
                     hasFlowMeter ? ["duration", "capacity", "duration_with_interval"] : ["duration", "duration_with_interval"],
-                ),
-            )
-            .withFeature(e.numeric("irrigation_total_duration", ea.SET).withValueMin(0).withValueMax(719).withUnit("min"))
-            .withFeature(e.numeric("irrigation_duration", ea.SET).withValueMin(1).withValueMax(60).withUnit("min"))
-            .withFeature(e.numeric("interval_duration", ea.SET).withValueMin(1).withValueMax(60).withUnit("min"));
+                )
+                .withDescription("Irrigation mode for the selected plan")
+                .withCategory("config"),
+            e
+                .numeric("irrigation_plan_total_duration", ea.ALL)
+                .withValueMin(0)
+                .withValueMax(719)
+                .withUnit("min")
+                .withDescription("Total duration for the selected irrigation plan")
+                .withCategory("config"),
+            e
+                .numeric("irrigation_plan_duration", ea.ALL)
+                .withValueMin(1)
+                .withValueMax(60)
+                .withUnit("min")
+                .withDescription("Irrigation duration for the selected plan")
+                .withCategory("config"),
+            e
+                .numeric("irrigation_plan_interval_duration", ea.ALL)
+                .withValueMin(1)
+                .withValueMax(60)
+                .withUnit("min")
+                .withDescription("Pause duration between irrigation cycles")
+                .withCategory("config"),
+        ];
         if (hasFlowMeter) {
-            irrigationPlanSettings
-                .withFeature(e.enum("irrigation_amount_unit", ea.SET, ["US gallon", "liter"]))
-                .withFeature(e.numeric("irrigation_amount", ea.SET).withValueMin(1).withValueMax(10000))
-                .withFeature(e.numeric("fail_safe", ea.SET).withValueMin(0).withValueMax(719).withUnit("min"));
+            irrigationPlanSettingExposes.push(
+                e
+                    .enum("irrigation_plan_amount_unit", ea.ALL, ["US gallon", "liter"])
+                    .withDescription("Water amount unit for the selected irrigation plan")
+                    .withCategory("config"),
+                e
+                    .numeric("irrigation_plan_amount", ea.ALL)
+                    .withValueMin(0)
+                    .withValueMax(10000)
+                    .withDescription("Water amount for the selected irrigation plan")
+                    .withCategory("config"),
+                e
+                    .numeric("irrigation_plan_fail_safe", ea.ALL)
+                    .withValueMin(0)
+                    .withValueMax(719)
+                    .withUnit("min")
+                    .withDescription("Safety timeout for the selected irrigation plan")
+                    .withCategory("config"),
+            );
         }
-        irrigationPlanSettings.withFeature(
-            e.text("create_datetime", ea.SET).withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
+        irrigationPlanSettingExposes.push(
+            e
+                .text("irrigation_plan_create_datetime", ea.ALL)
+                .withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)")
+                .withCategory("config"),
         );
 
-        const irrigationPlanReport = e
-            .composite("irrigation_plan_report", "irrigation_plan_report", ea.STATE)
-            .withDescription("Irrigation plan report")
-            .withFeature(e.numeric("plan_index", ea.STATE))
-            .withFeature(e.binary("enable_state", ea.STATE, true, false))
-            .withFeature(e.enum("loop_type_mode", ea.STATE, ["odd_days", "even_days", "day_interval", "weekdays"]))
-            .withFeature(e.numeric("loop_type_interval_days", ea.STATE).withDescription("Effective when loop_type_mode is day_interval"))
-            .withFeature(
-                e
-                    .composite("loop_type_week_days", "loop_type_week_days", ea.STATE)
-                    .withDescription("Effective when loop_type_mode is weekdays")
-                    .withFeature(e.binary("sunday", ea.STATE, true, false))
-                    .withFeature(e.binary("monday", ea.STATE, true, false))
-                    .withFeature(e.binary("tuesday", ea.STATE, true, false))
-                    .withFeature(e.binary("wednesday", ea.STATE, true, false))
-                    .withFeature(e.binary("thursday", ea.STATE, true, false))
-                    .withFeature(e.binary("friday", ea.STATE, true, false))
-                    .withFeature(e.binary("saturday", ea.STATE, true, false)),
-            )
-            .withFeature(e.text("enable_date", ea.STATE).withDescription("Enable date in local YYYY-MM-DD format (local day start)"))
-            .withFeature(e.text("start_time", ea.STATE).withDescription("Start time in local HH:mm format (24-hour)"))
-            .withFeature(
-                e.enum(
-                    "irrigation_mode",
-                    ea.STATE,
-                    hasFlowMeter ? ["duration", "capacity", "duration_with_interval"] : ["duration", "duration_with_interval"],
-                ),
-            )
-            .withFeature(e.numeric("irrigation_total_duration", ea.STATE))
-            .withFeature(e.numeric("irrigation_duration", ea.STATE))
-            .withFeature(e.numeric("interval_duration", ea.STATE));
-        if (hasFlowMeter) {
-            irrigationPlanReport
-                .withFeature(e.enum("irrigation_amount_unit", ea.STATE, ["US gallon", "liter"]))
-                .withFeature(e.numeric("irrigation_amount", ea.STATE))
-                .withFeature(e.numeric("fail_safe", ea.STATE));
-        }
-        irrigationPlanReport.withFeature(
-            e.text("create_datetime", ea.STATE).withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
-        );
+        const scalarToCompositeKey: {[key: string]: string} = {
+            irrigation_plan_index: "plan_index",
+            irrigation_plan_enabled: "enable_state",
+            irrigation_plan_loop_type: "loop_type_mode",
+            irrigation_plan_interval_days: "loop_type_interval_days",
+            irrigation_plan_enable_date: "enable_date",
+            irrigation_plan_start_time: "start_time",
+            irrigation_plan_mode: "irrigation_mode",
+            irrigation_plan_total_duration: "irrigation_total_duration",
+            irrigation_plan_duration: "irrigation_duration",
+            irrigation_plan_interval_duration: "interval_duration",
+            irrigation_plan_amount_unit: "irrigation_amount_unit",
+            irrigation_plan_amount: "irrigation_amount",
+            irrigation_plan_fail_safe: "fail_safe",
+            irrigation_plan_create_datetime: "create_datetime",
+        };
+        const weekdayScalarToCompositeKey = Object.fromEntries(loopTypeWeekDayNames.map((day) => [`irrigation_plan_${day}`, day])) as Record<
+            string,
+            LoopTypeWeekDay
+        >;
+        const publishIrrigationPlan = (property: string, value: KeyValue): KeyValue => ({
+            [property]: value,
+            irrigation_plan_index: value.plan_index,
+            irrigation_plan_enabled: value.enable_state,
+            irrigation_plan_loop_type: value.loop_type_mode,
+            irrigation_plan_interval_days: value.loop_type_interval_days,
+            ...Object.fromEntries(
+                loopTypeWeekDayNames.map((day) => [`irrigation_plan_${day}`, (value.loop_type_week_days as KeyValue | undefined)?.[day]]),
+            ),
+            irrigation_plan_enable_date: value.enable_date,
+            irrigation_plan_start_time: value.start_time,
+            irrigation_plan_mode: value.irrigation_mode,
+            irrigation_plan_total_duration: value.irrigation_total_duration,
+            irrigation_plan_duration: value.irrigation_duration,
+            irrigation_plan_interval_duration: value.interval_duration,
+            ...(hasFlowMeter
+                ? {
+                      irrigation_plan_amount_unit: value.irrigation_amount_unit,
+                      irrigation_plan_amount: value.irrigation_amount,
+                      irrigation_plan_fail_safe: value.fail_safe,
+                  }
+                : {}),
+            irrigation_plan_create_datetime: value.create_datetime,
+        });
 
-        const baseExposes = [irrigationPlanSettings, irrigationPlanReport];
-        const allExposes = baseExposes.flatMap((expose) => exposeCompositeEndpoints(expose, endpointNames));
+        const allExposes = irrigationPlanSettingExposes.flatMap((expose) => utils.exposeEndpoints(expose, endpointNames));
 
         const fromZigbee: Fz.Converter<"customClusterEwelink", SonoffSwvzn, ["raw"]>[] = [
             {
@@ -4242,36 +4346,34 @@ const sonoffExtend = {
                         const createDatetimeDevice = payload.readUInt32BE(offset);
                         const createDatetimeISO = formatUtcSecondsToIsoWithOffset(createDatetimeDevice, offsetSeconds);
 
-                        return {
-                            [property]: {
-                                plan_index: planIndex,
-                                enable_state: enableState === 1,
-                                loop_type_mode: loopTypeModeMapping[loopTypeMode],
-                                loop_type_interval_days: loopTypeMode === loopTypeModeMappingReverse.day_interval ? loopTypeValue : 0,
-                                loop_type_week_days:
-                                    loopTypeMode === loopTypeModeMappingReverse.weekdays
-                                        ? decodeLoopTypeWeekDays(loopTypeValue)
-                                        : decodeLoopTypeWeekDays(0),
-                                enable_date: enableDate,
-                                start_time: startTime,
-                                irrigation_mode: hasFlowMeter
-                                    ? (irrigationModeMapping[irrigationMode] ?? "duration")
-                                    : irrigationModeMapping[irrigationMode] === "duration_with_interval"
-                                      ? "duration_with_interval"
-                                      : "duration",
-                                irrigation_total_duration: irrigationTotalDuration,
-                                irrigation_duration: irrigationDuration,
-                                interval_duration: intervalDuration,
-                                ...(hasFlowMeter
-                                    ? {
-                                          irrigation_amount_unit: irrigationAmountUnitMapping[irrigationAmountUnit],
-                                          irrigation_amount: irrigationAmount,
-                                          fail_safe: failSafe,
-                                      }
-                                    : {}),
-                                create_datetime: createDatetimeISO,
-                            },
-                        };
+                        return publishIrrigationPlan(property, {
+                            plan_index: planIndex,
+                            enable_state: enableState === 1,
+                            loop_type_mode: loopTypeModeMapping[loopTypeMode],
+                            loop_type_interval_days: loopTypeMode === loopTypeModeMappingReverse.day_interval ? loopTypeValue : 0,
+                            loop_type_week_days:
+                                loopTypeMode === loopTypeModeMappingReverse.weekdays
+                                    ? decodeLoopTypeWeekDays(loopTypeValue)
+                                    : decodeLoopTypeWeekDays(0),
+                            enable_date: enableDate,
+                            start_time: startTime,
+                            irrigation_mode: hasFlowMeter
+                                ? (irrigationModeMapping[irrigationMode] ?? "duration")
+                                : irrigationModeMapping[irrigationMode] === "duration_with_interval"
+                                  ? "duration_with_interval"
+                                  : "duration",
+                            irrigation_total_duration: irrigationTotalDuration,
+                            irrigation_duration: irrigationDuration,
+                            interval_duration: intervalDuration,
+                            ...(hasFlowMeter
+                                ? {
+                                      irrigation_amount_unit: irrigationAmountUnitMapping[irrigationAmountUnit],
+                                      irrigation_amount: irrigationAmount,
+                                      fail_safe: failSafe,
+                                  }
+                                : {}),
+                            create_datetime: createDatetimeISO,
+                        });
                     }
                 },
             },
@@ -4279,15 +4381,32 @@ const sonoffExtend = {
 
         const toZigbee: Tz.Converter[] = [
             {
-                key: ["irrigation_plan_settings"],
+                key: ["irrigation_plan_settings", ...Object.keys(scalarToCompositeKey), ...Object.keys(weekdayScalarToCompositeKey)],
                 endpoints: endpointNames,
                 convertSet: async (entity, key, value, meta) => {
-                    utils.assertObject(value, key);
-                    const stateValue = meta.state[key];
+                    const partialValue: KeyValue = {};
+                    if (key === "irrigation_plan_settings") {
+                        utils.assertObject(value, key);
+                        Object.assign(partialValue, value);
+                    } else if (key in weekdayScalarToCompositeKey) {
+                        const reportState = meta.state.irrigation_plan_report;
+                        const settingsState = meta.state.irrigation_plan_settings;
+                        const reportWeekDays = utils.isObject(reportState) ? reportState.loop_type_week_days : undefined;
+                        const settingsWeekDays = utils.isObject(settingsState) ? settingsState.loop_type_week_days : undefined;
+                        partialValue.loop_type_week_days = {
+                            ...(utils.isObject(reportWeekDays) ? reportWeekDays : {}),
+                            ...(utils.isObject(settingsWeekDays) ? settingsWeekDays : {}),
+                            [weekdayScalarToCompositeKey[key]]: value,
+                        };
+                    } else {
+                        partialValue[scalarToCompositeKey[key]] = value;
+                    }
+
+                    const stateValue = meta.state.irrigation_plan_settings;
                     const reportKey = meta.endpoint_name ? `irrigation_plan_report_${meta.endpoint_name}` : "irrigation_plan_report";
                     const reportValue = meta.state[reportKey];
                     const current = utils.isObject(stateValue) ? stateValue : utils.isObject(reportValue) ? reportValue : {};
-                    const nextValue = {...current, ...value};
+                    const nextValue = {...current, ...partialValue};
                     const parseIntWithDefault = (fieldName: string, defaultValue: number, min: number, max: number): number | undefined => {
                         const raw = nextValue[fieldName];
                         const parsed = raw === undefined || raw === null ? defaultValue : Number(raw);
@@ -4437,7 +4556,7 @@ const sonoffExtend = {
                     payloadValue[i++] = irrigationAmountUnitCode & 0xff;
 
                     // Irrigation amount
-                    const irrigationAmountValue = hasFlowMeter ? parseIntWithDefault("irrigation_amount", 30, 1, 10000) : 10;
+                    const irrigationAmountValue = hasFlowMeter ? parseIntWithDefault("irrigation_amount", 30, 0, 10000) : 10;
                     if (irrigationAmountValue === undefined) {
                         return;
                     }
@@ -4487,7 +4606,7 @@ const sonoffExtend = {
                             defaultResponseOptions,
                         );
 
-                    return {state: {[key]: nextValue}};
+                    return {state: publishIrrigationPlan("irrigation_plan_settings", nextValue)};
                 },
             },
         ];
@@ -4508,7 +4627,8 @@ const sonoffExtend = {
                 .withDescription("Remove irrigation plan")
                 .withFeature(
                     e.numeric("plan_index", ea.SET).withValueMin(0).withValueMax(5).withDescription("The index of the irrigation plan to remove"),
-                ),
+                )
+                .withCategory("config"),
         ];
         const exposes = baseExposes.flatMap((expose) => exposeCompositeEndpoints(expose, endpointNames));
 
@@ -4613,7 +4733,8 @@ const sonoffExtend = {
         const exposes = [
             e
                 .text("rain_delay", ea.SET)
-                .withDescription('Schedule delay end time in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00), or "0" to disable'),
+                .withDescription('Schedule delay end time in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00), or "0" to disable')
+                .withCategory("config"),
         ];
 
         const toZigbee: Tz.Converter[] = [

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -8076,7 +8076,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "SONOFF",
         whiteLabel: [{model: "SWV-ZFU", vendor: "SONOFF", fingerprint: [{modelID: "SWV-ZFU"}]}],
         description: "Zigbee smart water valve",
-        meta: {homeassistant: {switchType: "valve"}},
         extend: [
             m.deviceAddCustomCluster("customClusterEwelink", {
                 name: "customClusterEwelink",
@@ -8122,6 +8121,7 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior: false,
                 skipDuplicateTransaction: true,
                 configureReporting: false,
+                homeassistant: {type: "valve"},
             }),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             sonoffExtend.swvznGenTimeCompatResponse(),
@@ -8202,7 +8202,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SWV-ZF2",
         vendor: "SONOFF",
         description: "Zigbee dual-channel smart water valve",
-        meta: {homeassistant: {switchType: "valve"}},
         extend: [
             m.deviceEndpoints({endpoints: {"1": 1, "2": 2}}),
             m.deviceAddCustomCluster("customClusterEwelink", {
@@ -8256,6 +8255,7 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior: false,
                 skipDuplicateTransaction: true,
                 configureReporting: false,
+                homeassistant: {type: "valve"},
             }),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             sonoffExtend.swvznGenTimeCompatResponse(),
@@ -8350,7 +8350,6 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "SONOFF",
         whiteLabel: [{model: "SWV-ZNU", vendor: "SONOFF", fingerprint: [{modelID: "SWV-ZNU"}]}],
         description: "Zigbee smart water valve",
-        meta: {homeassistant: {switchType: "valve"}},
         extend: [
             m.deviceAddCustomCluster("customClusterEwelink", {
                 name: "customClusterEwelink",
@@ -8392,6 +8391,7 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior: false,
                 skipDuplicateTransaction: true,
                 configureReporting: false,
+                homeassistant: {type: "valve"},
             }),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             sonoffExtend.swvznGenTimeCompatResponse(),

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2967,7 +2967,9 @@ const sonoffExtend = {
             }
         }
 
-        const exposes = [e.enum("valve_abnormal_state", ea.STATE, allCombinations).withDescription("Valve abnormal state")];
+        const exposes = [
+            e.enum("valve_abnormal_state", ea.STATE, allCombinations).withDescription("Valve abnormal state").withCategory("diagnostic"),
+        ];
 
         const fromZigbee: Fz.Converter<"customClusterEwelink", SonoffSwvzn, ["attributeReport", "readResponse"]>[] = [
             {
@@ -3304,7 +3306,8 @@ const sonoffExtend = {
             )
             .withFeature(e.text("start_time", ea.STATE).withDescription("Schedule start time"))
             .withFeature(e.text("expected_end_time", ea.STATE).withDescription("Expected end time"))
-            .withFeature(e.text("actual_end_time", ea.STATE).withDescription("Actual end time"));
+            .withFeature(e.text("actual_end_time", ea.STATE).withDescription("Actual end time"))
+            .withCategory("diagnostic");
         if (hasFlowMeter) {
             baseExposes
                 .withFeature(e.enum("irrigation_amount_unit", ea.STATE, ["US gallon", "liter"]).withDescription("Irrigation amount unit"))
@@ -3592,9 +3595,9 @@ const sonoffExtend = {
         const clusterName = "customClusterEwelink";
         const commandName = "readRecord";
         const exposes = [
-            e.text("24_hours_records", ea.STATE),
-            e.text("30_days_records", ea.STATE),
-            e.text("180_days_records", ea.STATE),
+            e.text("24_hours_records", ea.STATE).withCategory("diagnostic"),
+            e.text("30_days_records", ea.STATE).withCategory("diagnostic"),
+            e.text("180_days_records", ea.STATE).withCategory("diagnostic"),
             e
                 .composite("read_swvzf_records", "read_swvzf_records", ea.STATE_SET)
                 .withDescription(

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -14,6 +14,9 @@ import type {Access, LevelConfigFeatures, Range} from "./types";
 import {getLabelFromName} from "./utils";
 
 export type Feature = Numeric | Binary | Enum | Composite | List | Text;
+export interface HomeAssistant {
+    type?: "valve";
+}
 
 export class Base {
     name: string;
@@ -25,6 +28,7 @@ export class Base {
     description?: string;
     features?: Feature[];
     category?: "config" | "diagnostic";
+    homeassistant?: HomeAssistant;
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -70,6 +74,11 @@ export class Base {
     withCategory(category: "config" | "diagnostic") {
         this.category = category;
         this.validateCategory();
+        return this;
+    }
+
+    withHomeAssistant(homeassistant: HomeAssistant) {
+        this.homeassistant = homeassistant;
         return this;
     }
 
@@ -121,6 +130,7 @@ export class Base {
             target.features = this.features.map((f) => f.clone());
         }
         target.category = this.category;
+        target.homeassistant = this.homeassistant ? {...this.homeassistant} : undefined;
     }
 }
 

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -553,6 +553,7 @@ export interface OnOffArgs {
     endpointNames?: string[];
     configureReporting?: boolean;
     description?: string;
+    homeassistant?: exposes.HomeAssistant;
 }
 export function onOff(args: OnOffArgs = {}): ModernExtend {
     const {
@@ -561,10 +562,13 @@ export function onOff(args: OnOffArgs = {}): ModernExtend {
         configureReporting = true,
         endpointNames = undefined,
         description = undefined,
+        homeassistant = undefined,
         ota = false,
     } = args;
 
-    const exposes: Expose[] = description ? exposeEndpoints(e.switch(description), endpointNames) : exposeEndpoints(e.switch(), endpointNames);
+    const switchExpose = description ? e.switch(description) : e.switch();
+    if (homeassistant) switchExpose.withHomeAssistant(homeassistant);
+    const exposes: Expose[] = exposeEndpoints(switchExpose, endpointNames);
 
     const fromZigbee = [skipDuplicateTransaction ? fz.on_off_skip_duplicate_transaction : fz.on_off];
     const toZigbee: Tz.Converter[] = [endpointNames ? {...tz.on_off, endpoints: endpointNames} : tz.on_off];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -224,15 +224,6 @@ export interface DefinitionMeta {
      */
     overrideHaDiscoveryPayload?(payload: KeyValueAny): void;
     /**
-     * Home Assistant discovery hints for bridge integrations.
-     */
-    homeassistant?: {
-        /**
-         * Discover switch exposes as a more specific Home Assistant entity type.
-         */
-        switchType?: "valve";
-    };
-    /**
      * Never use a transition when transitioning to off (even when specified)
      */
     noOffTransitionWhenOff?: boolean | ((entity: Zh.Endpoint) => boolean);

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -688,6 +688,23 @@ describe("Sonoff SWV-ZFE", () => {
         expect(device.meta?.homeassistant?.switchType).toStrictEqual("valve");
     });
 
+    it("exposes irrigation controls as Home Assistant friendly scalar entities", () => {
+        const exposeNames = device.exposes.map((expose) => expose.name);
+
+        expect(exposeNames).toContain("manual_irrigation_duration");
+        expect(exposeNames).toContain("seasonal_watering_adjustment_june");
+        expect(exposeNames).toContain("enable_alarm_water_shortage");
+        expect(exposeNames).toContain("irrigation_plan_duration");
+        expect(exposeNames).not.toContain("manual_default_settings");
+        expect(exposeNames).not.toContain("seasonal_watering_adjustment");
+        expect(exposeNames).not.toContain("valve_alarm_settings");
+        expect(exposeNames).not.toContain("irrigation_plan_settings");
+        expect(exposeNames).not.toContain("irrigation_plan_report");
+
+        expect(device.exposes.find((expose) => expose.name === "irrigation_plan_interval_days")).toMatchObject({value_min: 0});
+        expect(device.exposes.find((expose) => expose.name === "irrigation_plan_amount")).toMatchObject({value_min: 0});
+    });
+
     describe("toZigbee", () => {
         it("merges partial manual default settings with current state", async () => {
             const tzConverter = device.toZigbee.find((c) => c.key.includes("manual_default_settings"));
@@ -707,7 +724,7 @@ describe("Sonoff SWV-ZFE", () => {
                 },
                 {},
             );
-            expect(result).toEqual({
+            expect(result).toMatchObject({
                 state: {
                     manual_default_settings: {
                         irrigation_duration: 30,
@@ -716,6 +733,11 @@ describe("Sonoff SWV-ZFE", () => {
                         irrigation_amount: 42,
                         fail_safe: 60,
                     },
+                    manual_irrigation_duration: 30,
+                    manual_irrigation_mode: "capacity",
+                    manual_irrigation_amount_unit: "liter",
+                    manual_irrigation_amount: 42,
+                    manual_fail_safe: 60,
                 },
             });
         });
@@ -738,7 +760,7 @@ describe("Sonoff SWV-ZFE", () => {
                 },
                 {},
             );
-            expect(result).toEqual({
+            expect(result).toMatchObject({
                 state: {
                     seasonal_watering_adjustment: {
                         january: 1.1,
@@ -754,6 +776,9 @@ describe("Sonoff SWV-ZFE", () => {
                         november: 0.9,
                         december: 0.8,
                     },
+                    seasonal_watering_adjustment_january: 1.1,
+                    seasonal_watering_adjustment_june: 0.7,
+                    seasonal_watering_adjustment_december: 0.8,
                 },
             });
         });
@@ -776,7 +801,7 @@ describe("Sonoff SWV-ZFE", () => {
                 },
                 {},
             );
-            expect(result).toEqual({
+            expect(result).toMatchObject({
                 state: {
                     valve_alarm_settings: {
                         enable_alarm_water_shortage: true,
@@ -785,6 +810,11 @@ describe("Sonoff SWV-ZFE", () => {
                         alarm_water_shortage_duration: 5,
                         alarm_water_leak_duration: 3,
                     },
+                    enable_alarm_water_shortage: true,
+                    enable_alarm_water_leak: false,
+                    enable_water_shortage_auto_close: true,
+                    alarm_water_shortage_duration: 5,
+                    alarm_water_leak_duration: 3,
                 },
             });
         });
@@ -833,7 +863,7 @@ describe("Sonoff SWV-ZFE", () => {
                 {data: expectedPayload},
                 {disableDefaultResponse: false},
             );
-            expect(result).toEqual({
+            expect(result).toMatchObject({
                 state: {
                     irrigation_plan_settings: {
                         plan_index: 2,
@@ -860,6 +890,48 @@ describe("Sonoff SWV-ZFE", () => {
                         fail_safe: 30,
                         create_datetime: "2026-06-21T04:30:00Z",
                     },
+                    irrigation_plan_index: 2,
+                    irrigation_plan_enabled: true,
+                    irrigation_plan_loop_type: "weekdays",
+                    irrigation_plan_sunday: true,
+                    irrigation_plan_tuesday: true,
+                    irrigation_plan_duration: 9,
+                    irrigation_plan_amount_unit: "liter",
+                    irrigation_plan_amount: 50,
+                    irrigation_plan_fail_safe: 30,
+                },
+            });
+        });
+
+        it("allows scalar plan edits when inactive amount and interval fields are reported as zero", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("irrigation_plan_duration"));
+            meta.state.irrigation_plan_report = {
+                ...meta.state.irrigation_plan_report,
+                loop_type_mode: "weekdays",
+                loop_type_interval_days: 0,
+                irrigation_mode: "duration",
+                irrigation_amount: 0,
+                irrigation_amount_unit: "US gallon",
+            };
+
+            const result = await tzConverter.convertSet(endpoint, "irrigation_plan_duration", 5, meta);
+
+            expect(commandFn).toHaveBeenCalledWith(
+                "customClusterEwelink",
+                "irrigationPlanSettings",
+                {data: expect.arrayContaining([0, 5, 0, 3, 0, 0])},
+                {disableDefaultResponse: false},
+            );
+            expect(result).toMatchObject({
+                state: {
+                    irrigation_plan_settings: {
+                        loop_type_interval_days: 0,
+                        irrigation_duration: 5,
+                        irrigation_amount: 0,
+                    },
+                    irrigation_plan_interval_days: 0,
+                    irrigation_plan_duration: 5,
+                    irrigation_plan_amount: 0,
                 },
             });
         });

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -707,6 +707,16 @@ describe("Sonoff SWV-ZFE", () => {
         expect(device.exposes.find((expose) => expose.name === "irrigation_plan_amount")).toMatchObject({value_min: 0});
     });
 
+    it("marks read-only valve status and history exposes as diagnostics", () => {
+        expect(device.exposes.find((expose) => expose.name === "manual_irrigation_duration")).toMatchObject({category: "config"});
+        expect(device.exposes.find((expose) => expose.name === "irrigation_plan_duration")).toMatchObject({category: "config"});
+        expect(device.exposes.find((expose) => expose.name === "valve_abnormal_state")).toMatchObject({category: "diagnostic"});
+        expect(device.exposes.find((expose) => expose.name === "irrigation_schedule_status")).toMatchObject({category: "diagnostic"});
+        expect(device.exposes.find((expose) => expose.name === "24_hours_records")).toMatchObject({category: "diagnostic"});
+        expect(device.exposes.find((expose) => expose.name === "30_days_records")).toMatchObject({category: "diagnostic"});
+        expect(device.exposes.find((expose) => expose.name === "180_days_records")).toMatchObject({category: "diagnostic"});
+    });
+
     describe("toZigbee", () => {
         it("merges partial manual default settings with current state", async () => {
             const tzConverter = device.toZigbee.find((c) => c.key.includes("manual_default_settings"));

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -695,11 +695,13 @@ describe("Sonoff SWV-ZFE", () => {
         expect(exposeNames).toContain("seasonal_watering_adjustment_june");
         expect(exposeNames).toContain("enable_alarm_water_shortage");
         expect(exposeNames).toContain("irrigation_plan_duration");
+        expect(exposeNames).toContain("irrigation_plan_remove_plan_index");
         expect(exposeNames).not.toContain("manual_default_settings");
         expect(exposeNames).not.toContain("seasonal_watering_adjustment");
         expect(exposeNames).not.toContain("valve_alarm_settings");
         expect(exposeNames).not.toContain("irrigation_plan_settings");
         expect(exposeNames).not.toContain("irrigation_plan_report");
+        expect(exposeNames).not.toContain("irrigation_plan_remove");
 
         expect(device.exposes.find((expose) => expose.name === "irrigation_plan_interval_days")).toMatchObject({value_min: 0});
         expect(device.exposes.find((expose) => expose.name === "irrigation_plan_amount")).toMatchObject({value_min: 0});
@@ -932,6 +934,36 @@ describe("Sonoff SWV-ZFE", () => {
                     irrigation_plan_interval_days: 0,
                     irrigation_plan_duration: 5,
                     irrigation_plan_amount: 0,
+                },
+            });
+        });
+
+        it("removes an irrigation plan through the scalar plan index", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("irrigation_plan_remove_plan_index"));
+
+            const result = await tzConverter.convertSet(endpoint, "irrigation_plan_remove_plan_index", 3, meta);
+
+            expect(commandFn).toHaveBeenCalledWith("customClusterEwelink", "irrigationPlanRemove", {data: [3]}, {disableDefaultResponse: true});
+            expect(result).toMatchObject({
+                state: {
+                    irrigation_plan_remove: {plan_index: 3},
+                    irrigation_plan_remove_plan_index: 3,
+                    irrigation_plan_settings_3: null,
+                },
+            });
+        });
+
+        it("keeps the legacy composite irrigation plan remove command", async () => {
+            const tzConverter = device.toZigbee.find((c) => c.key.includes("irrigation_plan_remove"));
+
+            const result = await tzConverter.convertSet(endpoint, "irrigation_plan_remove", {plan_index: 4}, meta);
+
+            expect(commandFn).toHaveBeenCalledWith("customClusterEwelink", "irrigationPlanRemove", {data: [4]}, {disableDefaultResponse: true});
+            expect(result).toMatchObject({
+                state: {
+                    irrigation_plan_remove: {plan_index: 4},
+                    irrigation_plan_remove_plan_index: 4,
+                    irrigation_plan_settings_4: null,
                 },
             });
         });

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -685,7 +685,8 @@ describe("Sonoff SWV-ZFE", () => {
     });
 
     it("marks the switch expose for Home Assistant valve discovery", () => {
-        expect(device.meta?.homeassistant?.switchType).toStrictEqual("valve");
+        expect(device.meta?.homeassistant).toBeUndefined();
+        expect(device.exposes.find((expose) => expose.type === "switch")).toMatchObject({homeassistant: {type: "valve"}});
     });
 
     it("exposes irrigation controls as Home Assistant friendly scalar entities", () => {


### PR DESCRIPTION
## Summary
- Rework SONOFF SWV-ZFE/ZFU/SWV-ZF2 irrigation settings from broad public composites into scalar controls that Home Assistant can render as normal number/select/text/switch entities.
- Keep legacy composite MQTT payloads accepted by the converter and keep publishing legacy composite state for compatibility.
- Allow zero for inactive plan amount/interval fields so duration-mode plans do not appear as `unknown` in Home Assistant.
- Expose irrigation plan removal as scalar config `irrigation_plan_remove_plan_index` instead of a one-field composite, while still accepting the old `irrigation_plan_remove` composite command.
- Mark read-only valve fault, irrigation schedule status, and irrigation record-history exposes as diagnostics so Home Assistant does not show them as primary controls.
- Add generic expose-level Home Assistant metadata and mark the generated SONOFF valve switch exposes as `homeassistant: {type: "valve"}` for the paired Zigbee2MQTT discovery change.

## Why
Home Assistant does not provide a useful native editor for the previous large nested composites. This follows the PR #32362/#32363 discussion: use composites only for fields that really have to be written atomically, and model independent plan/default/alarm values as independent exposes.

Read-only schedule/status/history values are useful for debugging and dashboards, but they are not actions or settings. Categorizing them as diagnostics keeps the main device controls focused on the valve, manual watering defaults, alarm configuration, and plan configuration.

The Home Assistant valve discovery hint belongs to the expose that represents the actor, not to device-level metadata. That keeps the mechanism generic and lets Zigbee2MQTT consume expose metadata without knowing about SONOFF-specific model details.

## Live validation on my Home Assistant instance
Validated with a real SONOFF Zigbee smart water valve:
- `zigbee2mqtt/bridge/devices` no longer exposes `manual_default_settings`, `seasonal_watering_adjustment`, `valve_alarm_settings`, `irrigation_plan_settings`, `irrigation_plan_report`, or `irrigation_plan_remove` as public setting composites.
- Home Assistant creates scalar entities such as `manual_irrigation_duration`, `manual_irrigation_mode`, `manual_irrigation_amount`, `irrigation_plan_enabled`, `irrigation_plan_start_time`, `seasonal_watering_adjustment_january`, `irrigation_plan_remove_plan_index`, and alarm controls.
- Previously-unknown inactive fields report valid zero states: `irrigation_plan_interval_days = 0`, `irrigation_plan_amount = 0`.
- Read-only valve status/history entities are categorized as diagnostics after rediscovery, while manual and irrigation-plan input entities remain config controls.

## Current rebase
- Rebased onto current upstream `master` (`v26.71.0`).
- Dropped the already-upstream partial-update commits from this PR branch; this PR now carries only the scalar-control delta plus diagnostic metadata for read-only status/history exposes and the generic expose-level Home Assistant hint.

## Validation
- `./node_modules/.bin/vitest run test/sonoff.test.ts --config ./test/vitest.config.mts -t "Home Assistant valve discovery|SWV-ZFE"`
- `./node_modules/.bin/biome check --error-on-warnings src/lib/exposes.ts src/lib/modernExtend.ts src/lib/types.ts src/devices/sonoff.ts test/sonoff.test.ts`
- `./node_modules/.bin/tsc --noEmit`

## Dependencies
Before merging, the paired Home Assistant discovery work and docs should be aligned:

- Koenkk/zigbee2mqtt#32367 for consuming the expose-level Home Assistant `valve` hint.
- Koenkk/zigbee2mqtt#32363 only for any remaining scalar composite fallback/metadata cases that cannot be represented as first-class scalar exposes here.
- Koenkk/zigbee2mqtt.io#5262 for the user-facing migration notes.

Compatibility intent: legacy composite MQTT `/set` payloads remain accepted, and legacy composite state is still published for existing MQTT consumers. The generated `/bridge/devices` expose tree changes to prefer independent scalar controls where fields do not need to be written atomically.
