### PR TITLE
Fix Third Reality soil moisture fallback

### DIFF
--- a/src/devices/third_reality.ts
+++ b/src/devices/third_reality.ts
@@ -21,6 +21,7 @@ import type {
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
+const ea = exposes.access;
 
 function conditionalPressure(): ModernExtend {
     const base = m.pressure();
@@ -191,6 +192,73 @@ interface Third24gRadar {
     };
     commands: never;
     commandResponses: never;
+}
+
+function thirdRealitySoilMoisture(): ModernExtend {
+    const expose = e.soil_moisture().withAccess(ea.STATE_GET);
+
+    const supportsNativeSoilMoisture = (device: Zh.Device | DummyDevice): boolean => {
+        if (utils.isDummyDevice(device)) return true;
+        return device.endpoints.some((endpoint) => endpoint.supportsInputCluster("msSoilMoisture"));
+    };
+
+    const getMeasurementEndpoint = (device: Zh.Device): Zh.Endpoint => {
+        return (
+            device.endpoints.find((endpoint) => endpoint.supportsInputCluster("msSoilMoisture")) ??
+            device.endpoints.find((endpoint) => endpoint.supportsInputCluster("msRelativeHumidity")) ??
+            device.endpoints[0]
+        );
+    };
+
+    const hasMeasuredValue = (data: KeyValue): data is KeyValue & {measuredValue: number} => {
+        if (!("measuredValue" in data)) return false;
+        utils.assertNumber(data.measuredValue);
+        return true;
+    };
+
+    return {
+        exposes: [() => [expose]],
+        fromZigbee: [
+            {
+                cluster: "msSoilMoisture",
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg) => {
+                    if (hasMeasuredValue(msg.data)) return {soil_moisture: msg.data.measuredValue / 100};
+                },
+            },
+            {
+                cluster: "msRelativeHumidity",
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg) => {
+                    if (!supportsNativeSoilMoisture(msg.device) && hasMeasuredValue(msg.data)) {
+                        return {soil_moisture: msg.data.measuredValue / 100};
+                    }
+                },
+            },
+        ],
+        toZigbee: [
+            {
+                key: ["soil_moisture"],
+                convertGet: async (entity, key, meta) => {
+                    const endpoint = getMeasurementEndpoint(meta.device);
+                    await endpoint.read(supportsNativeSoilMoisture(meta.device) ? "msSoilMoisture" : "msRelativeHumidity", ["measuredValue"]);
+                },
+            },
+        ],
+        configure: [
+            async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
+                const endpoint = getMeasurementEndpoint(device);
+                if (supportsNativeSoilMoisture(device)) {
+                    await reporting.bind(endpoint, coordinatorEndpoint, ["msSoilMoisture"]);
+                    await reporting.soil_moisture(endpoint);
+                } else {
+                    await reporting.bind(endpoint, coordinatorEndpoint, ["msRelativeHumidity"]);
+                    await reporting.humidity(endpoint);
+                }
+            },
+        ],
+        isModernExtend: true,
+    };
 }
 
 export const fzLocal = {
@@ -890,7 +958,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Smart Soil Moisture Sensor",
         extend: [
             m.temperature(),
-            m.soilMoisture(),
+            thirdRealitySoilMoisture(),
             m.battery(),
             m.deviceAddCustomCluster("3rSoilSpecialCluster", {
                 name: "3rSoilSpecialCluster",

--- a/test/third_reality.test.ts
+++ b/test/third_reality.test.ts
@@ -1,0 +1,96 @@
+import {describe, expect, test, vi} from "vitest";
+import {findByDevice} from "../src";
+import type {Definition, Expose, Zh} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+function getDeviceExposes(definition: Definition, device: Zh.Device): Expose[] {
+    return typeof definition.exposes === "function" ? definition.exposes(device, {}) : (definition.exposes ?? []);
+}
+
+function getConverter(definition: Definition, cluster: string) {
+    const converter = definition.fromZigbee?.find((item) => item.cluster === cluster);
+    expect(converter).toBeDefined();
+    return converter;
+}
+
+function getSoilGetConverter(definition: Definition) {
+    const converter = definition.toZigbee?.find((item) => item.key.includes("soil_moisture"));
+    expect(converter?.convertGet).toBeDefined();
+    return converter;
+}
+
+describe("Third Reality soil moisture sensors", () => {
+    test("3RSM0147Z falls back to relative humidity cluster for soil moisture on older hardware", async () => {
+        const device = mockDevice(
+            {
+                modelID: "3RSM0147Z",
+                manufacturerName: "Third Reality, Inc",
+                endpoints: [
+                    {ID: 1, inputClusters: ["genBasic", "genPowerCfg", "msTemperatureMeasurement", "msRelativeHumidity"], inputClusterIDs: [0xff01]},
+                ],
+            },
+            "EndDevice",
+        );
+        const definition = await findByDevice(device);
+        const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).endpoints[0];
+
+        await definition.configure?.(device, coordinatorEndpoint, definition);
+
+        const bindClusters = vi.mocked(device.endpoints[0].bind).mock.calls.map((call) => call[0]);
+        const reportingClusters = vi.mocked(device.endpoints[0].configureReporting).mock.calls.map((call) => call[0]);
+        expect(bindClusters).toContain("msRelativeHumidity");
+        expect(bindClusters).not.toContain("msSoilMoisture");
+        expect(reportingClusters).toContain("msRelativeHumidity");
+        expect(reportingClusters).not.toContain("msSoilMoisture");
+
+        const exposes = getDeviceExposes(definition, device).map((expose) => expose.property);
+        expect(exposes).toContain("soil_moisture");
+        expect(exposes).not.toContain("humidity");
+
+        const converter = getConverter(definition, "msRelativeHumidity");
+        const result = converter?.convert(definition, {data: {measuredValue: 6615}, device} as never, vi.fn(), {}, {device} as never);
+        expect(result).toStrictEqual({soil_moisture: 66.15});
+
+        vi.mocked(device.endpoints[0].read).mockClear();
+        await getSoilGetConverter(definition)?.convertGet?.(device.endpoints[0], "soil_moisture", {device} as never);
+        expect(device.endpoints[0].read).toHaveBeenCalledWith("msRelativeHumidity", ["measuredValue"]);
+    });
+
+    test("3RSM0147Z uses native soil moisture cluster when present", async () => {
+        const device = mockDevice(
+            {
+                modelID: "3RSM0147Z",
+                manufacturerName: "Third Reality, Inc",
+                endpoints: [
+                    {
+                        ID: 1,
+                        inputClusters: ["genBasic", "genPowerCfg", "msTemperatureMeasurement", "msRelativeHumidity", "msSoilMoisture"],
+                        inputClusterIDs: [0xff01],
+                    },
+                ],
+            },
+            "EndDevice",
+        );
+        const definition = await findByDevice(device);
+        const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).endpoints[0];
+
+        await definition.configure?.(device, coordinatorEndpoint, definition);
+
+        const bindClusters = vi.mocked(device.endpoints[0].bind).mock.calls.map((call) => call[0]);
+        const reportingClusters = vi.mocked(device.endpoints[0].configureReporting).mock.calls.map((call) => call[0]);
+        expect(bindClusters).toContain("msSoilMoisture");
+        expect(reportingClusters).toContain("msSoilMoisture");
+
+        const nativeConverter = getConverter(definition, "msSoilMoisture");
+        const nativeResult = nativeConverter?.convert(definition, {data: {measuredValue: 5519}, device} as never, vi.fn(), {}, {device} as never);
+        expect(nativeResult).toStrictEqual({soil_moisture: 55.19});
+
+        const fallbackConverter = getConverter(definition, "msRelativeHumidity");
+        const fallbackResult = fallbackConverter?.convert(definition, {data: {measuredValue: 1234}, device} as never, vi.fn(), {}, {device} as never);
+        expect(fallbackResult).toBeUndefined();
+
+        vi.mocked(device.endpoints[0].read).mockClear();
+        await getSoilGetConverter(definition)?.convertGet?.(device.endpoints[0], "soil_moisture", {device} as never);
+        expect(device.endpoints[0].read).toHaveBeenCalledWith("msSoilMoisture", ["measuredValue"]);
+    });
+});


### PR DESCRIPTION
## Summary

- make `3RSM0147Z` soil moisture handling depend on the interviewed endpoint clusters
- keep native `msSoilMoisture` reporting/readback for units that expose it
- fall back to `msRelativeHumidity` as `soil_moisture` for older units that report the probe value there and do not expose the native soil moisture input cluster
- keep exposing `soil_moisture` instead of a normal humidity sensor for this model

## Why

My local Home Assistant/Zigbee2MQTT install has two `3RSM0147Z` variants:

- `Pflanzensensor 1`: hardware v1/application v51, endpoint exposes `msSoilMoisture`
- `Pflanzensensor 2`: hardware v0/application v38, endpoint does not expose `msSoilMoisture`, but reports the probe value through `msRelativeHumidity`

The old definition always configured `msSoilMoisture`, so the older unit repeatedly failed configure with:

```text
Device 0xffffb40e06020107 has no input cluster msSoilMoisture
```

Related public reports also describe early `3RSM0147Z` units exposing/reporting the probe moisture as humidity rather than native soil moisture:

- https://github.com/Koenkk/zigbee2mqtt/issues/26917
- https://github.com/Koenkk/zigbee2mqtt/issues/27950
- https://github.com/Koenkk/zigbee2mqtt/discussions/27484

## Validation

Local:

- `./node_modules/.bin/biome check --write src/devices/third_reality.ts test/third_reality.test.ts`
- `./node_modules/.bin/vitest run test/third_reality.test.ts --config ./test/vitest.config.mts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc && node dist/indexer.js`
- `git diff --check`

Live validation on my Home Assistant instance:

- deployed only `dist/devices/third_reality.js` into the Zigbee2MQTT add-on
- reconfigured `Pflanzensensor 2` through `zigbee2mqtt/bridge/request/device/configure`
- confirmed response: `{"data":{"id":"Pflanzensensor 2"},"status":"ok"}`
- confirmed `/get {"soil_moisture":""}` reads `msRelativeHumidity` and publishes `soil_moisture: 66.15`
- confirmed current HA discovery for this device includes `soil_moisture` and no humidity entity

