### PR TITLE
fix(bosch): make RM230Z relay support optional

### DIFF
--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -3533,7 +3533,27 @@ export const boschThermostatExtend = {
             commands: {},
             commandsResponse: {},
         }),
-    relayState: () => m.onOff({description: "The state of the relay controlling the connected heating/cooling device", powerOnBehavior: false}),
+    relayState: (): ModernExtend => {
+        const description = "The state of the relay controlling the connected heating/cooling device";
+        const relay = m.onOff({description, powerOnBehavior: false, configureReporting: false});
+        const relayExposes = (relay.exposes ?? []).filter((relayExpose): relayExpose is Expose => typeof relayExpose !== "function");
+        const relayEndpoint = (device: Zh.Device) => device.endpoints.find((endpoint) => endpoint.supportsInputCluster("genOnOff"));
+        const expose: DefinitionExposesFunction = (device) => {
+            return utils.isDummyDevice(device) || relayEndpoint(device) ? relayExposes : [];
+        };
+        const configure: Configure = async (device, coordinatorEndpoint) => {
+            const endpoint = relayEndpoint(device);
+            if (!endpoint) {
+                logger.debug(`Skipping Bosch thermostat relay reporting for ${device.ieeeAddr}: no genOnOff input cluster`, NS);
+                return;
+            }
+
+            await endpoint.bind("genOnOff", coordinatorEndpoint);
+            await endpoint.configureReporting("genOnOff", payload<"genOnOff">("onOff", 0, repInterval.MAX, 1));
+        };
+
+        return {...relay, exposes: [expose], configure: [configure]};
+    },
     cableSensorMode: () =>
         m.enumLookup<"hvacThermostat", BoschThermostatCluster>({
             name: "cable_sensor_mode",

--- a/test/bosch.test.ts
+++ b/test/bosch.test.ts
@@ -1,6 +1,9 @@
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
 import {findByDevice} from "../src/index";
-import {mockDevice} from "./utils";
+import {boschThermostatExtend} from "../src/lib/bosch";
+import {repInterval} from "../src/lib/constants";
+import type {DefinitionExposesFunction} from "../src/lib/types";
+import {mockDevice, reportingItem} from "./utils";
 
 describe("Bosch thermostats", () => {
     it("exposes standard weekly schedule controls for BTH-RM230Z", async () => {
@@ -9,12 +12,14 @@ describe("Bosch thermostats", () => {
             manufacturerName: "BOSCH",
             endpoints: [{ID: 1, inputClusters: ["genOnOff", "hvacThermostat", "hvacUserInterfaceCfg", "msRelativeHumidity"]}],
         });
+        vi.spyOn(device, "save").mockImplementation(() => {});
         const definition = await findByDevice(device);
 
         expect(definition.toZigbee.some((converter) => converter.key.includes("weekly_schedule"))).toBe(true);
         expect(definition.toZigbee.some((converter) => converter.key.includes("clear_weekly_schedule"))).toBe(true);
         expect(definition.fromZigbee.some((converter) => converter.cluster === "hvacThermostat")).toBe(true);
-        expect(JSON.stringify(definition.exposes)).toContain("weekly_schedule");
+        const exposes = typeof definition.exposes === "function" ? definition.exposes(device, {}) : definition.exposes;
+        expect(JSON.stringify(exposes)).toContain("weekly_schedule");
 
         const coordinator = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).getEndpoint(1);
         const endpoint = device.getEndpoint(1);
@@ -33,5 +38,41 @@ describe("Bosch thermostats", () => {
 
         expect(definition.toZigbee.some((converter) => converter.key.includes("weekly_schedule"))).toBe(false);
         expect(JSON.stringify(definition.exposes)).not.toContain("weekly_schedule");
+    });
+});
+
+describe("Bosch thermostat relayState extension", () => {
+    const relayStateExposes = (device: ReturnType<typeof mockDevice>) => {
+        const relayState = boschThermostatExtend.relayState();
+        expect(relayState.exposes).toHaveLength(1);
+
+        const expose = relayState.exposes?.[0] as DefinitionExposesFunction;
+        return expose(device, {});
+    };
+
+    it("exposes and configures the relay when the device supports genOnOff", async () => {
+        const relayState = boschThermostatExtend.relayState();
+        const device = mockDevice({modelID: "RBSH-RTH0-ZB-EU", endpoints: [{ID: 1, inputClusters: ["genOnOff"]}]});
+        const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).getEndpoint(1);
+
+        await relayState.configure?.[0](device, coordinatorEndpoint, {} as never);
+
+        const exposes = relayStateExposes(device);
+        expect(exposes.map((expose) => expose.type)).toStrictEqual(["switch"]);
+        expect(exposes[0].features?.map((feature) => feature.property)).toStrictEqual(["state"]);
+        expect(device.getEndpoint(1).bind).toHaveBeenCalledWith("genOnOff", coordinatorEndpoint);
+        expect(device.getEndpoint(1).configureReporting).toHaveBeenCalledWith("genOnOff", [reportingItem("onOff", 0, repInterval.MAX, 1)]);
+    });
+
+    it("does not expose or configure the relay when the device does not support genOnOff", async () => {
+        const relayState = boschThermostatExtend.relayState();
+        const device = mockDevice({modelID: "RBSH-RTH0-ZB-EU", endpoints: [{ID: 1, inputClusters: ["hvacThermostat"]}]});
+        const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).getEndpoint(1);
+
+        await relayState.configure?.[0](device, coordinatorEndpoint, {} as never);
+
+        expect(relayStateExposes(device)).toStrictEqual([]);
+        expect(device.getEndpoint(1).bind).not.toHaveBeenCalled();
+        expect(device.getEndpoint(1).configureReporting).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary

Some Bosch Room Thermostat II 230V (`BTH-RM230Z`) installations do not expose the `genOnOff` input cluster. The converter currently adds `relayState()` unconditionally, so configure tries to bind/configure `genOnOff` and fails on those devices.

This makes the relay support conditional on the interviewed endpoint data:

- keep the relay switch expose and reporting setup when an endpoint supports `genOnOff`
- hide the relay switch expose when no endpoint supports `genOnOff`
- skip relay reporting setup in that case instead of failing device configure

## Validation

- `node --run check`
- `node --run build`
- `./node_modules/.bin/vitest run test/bosch.test.ts --config ./test/vitest.config.mts`
- `node --run test`

## Live validation

Validated with a local Zigbee2MQTT override on my local install with five `BTH-RM230Z` devices:

- `Arbeitszimmer Thermostat`, `Wohnzimmer Thermostat Flur`, and `Wohnzimmer Thermostat Küche` do not expose `genOnOff`; manual configure now logs `Skipping Bosch thermostat relay reporting ... no genOnOff input cluster` and completes successfully.
- `Schlafzimmer Thermostat` and `Bad Thermostat` still configure successfully without taking the skip path, preserving relay-capable behavior.

Before this change, the no-relay devices failed manual configure with `Device ... has no input cluster genOnOff`.
