### PR TITLE
Mark battery state exposes as diagnostic

### DIFF
--- a/src/devices/alecto.ts
+++ b/src/devices/alecto.ts
@@ -45,7 +45,7 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {},
         exposes: [
             e.enum("smoke_state", ea.STATE, ["alarm", "normal"]),
-            e.enum("battery_state", ea.STATE, ["low", "middle", "high"]),
+            e.enum("battery_state", ea.STATE, ["low", "middle", "high"]).withCategory("diagnostic"),
             e.enum("checking_result", ea.STATE, ["checking", "check_success", "check_failure", "others"]),
             e.numeric("smoke_value", ea.STATE),
             e.numeric("battery", ea.STATE),

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -2461,7 +2461,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.voc(),
             e.aqi(),
             e.pm10(),
-            e.enum("battery_state", ea.STATE, ["not_charging", "charging", "charged"]),
+            e.enum("battery_state", ea.STATE, ["not_charging", "charging", "charged"]).withCategory("diagnostic"),
         ],
     },
     {

--- a/src/devices/lincukoo.ts
+++ b/src/devices/lincukoo.ts
@@ -380,7 +380,12 @@ export const definitions: DefinitionWithExtend[] = [
             ];
 
             if (["_TZE284_iunyuzwe"].includes(device.manufacturerName)) {
-                exps.push(e.enum("battery_state", ea.STATE, ["low", "middle", "high"]).withDescription("battery state of the sensor"));
+                exps.push(
+                    e
+                        .enum("battery_state", ea.STATE, ["low", "middle", "high"])
+                        .withDescription("battery state of the sensor")
+                        .withCategory("diagnostic"),
+                );
             } else {
                 exps.push(e.enum("alarm_ringtone", ea.STATE_SET, ["ring1", "ring2", "ring3"]).withDescription("Ringtone of the alarm"));
                 exps.push(e.battery());
@@ -461,7 +466,10 @@ export const definitions: DefinitionWithExtend[] = [
                 .withUnit("m")
                 .withDescription("Maximum range"),
             e.numeric("radar_sensitivity", ea.STATE_SET).withValueMin(0).withValueMax(4).withValueStep(1).withDescription("Sensitivity of the radar"),
-            e.enum("battery_state", ea.STATE, ["low", "middle", "high", "usb"]).withDescription("battery state of the sensor"),
+            e
+                .enum("battery_state", ea.STATE, ["low", "middle", "high", "usb"])
+                .withDescription("battery state of the sensor")
+                .withCategory("diagnostic"),
         ],
         meta: {
             tuyaDatapoints: [
@@ -804,7 +812,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withValueStep(1.5)
                 .withUnit("m")
                 .withDescription("Detection distance"),
-            e.enum("battery_state", ea.STATE, ["low", "middle", "high", "USB"]).withDescription("Battery status"),
+            e.enum("battery_state", ea.STATE, ["low", "middle", "high", "USB"]).withDescription("Battery status").withCategory("diagnostic"),
             e.binary("switch_night_light", ea.STATE_SET, "ON", "OFF").withDescription("Night light switch"),
         ],
         meta: {

--- a/src/devices/pushok.ts
+++ b/src/devices/pushok.ts
@@ -548,6 +548,7 @@ export const definitions: DefinitionWithExtend[] = [
                 zigbeeCommandOptions: {},
                 description: "Battery state",
                 access: "STATE_GET",
+                entityCategory: "diagnostic",
                 reporting: null,
             }),
             m.iasZoneAlarm({

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10308,7 +10308,10 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Soil moisture sensor",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
-            e.enum("battery_state", ea.STATE, ["low", "middle", "high"]).withDescription("low: 1-25%, middle: 26-50%, high: 51-100%"),
+            e
+                .enum("battery_state", ea.STATE, ["low", "middle", "high"])
+                .withDescription("low: 1-25%, middle: 26-50%, high: 51-100%")
+                .withCategory("diagnostic"),
             e.temperature(),
             e.soil_moisture(),
             e.humidity(),
@@ -14651,7 +14654,10 @@ export const definitions: DefinitionWithExtend[] = [
             e.numeric("error_status", ea.STATE).withDescription("Device error code"),
             e.enum("rain_sensor_status", ea.STATE, ["rain", "no_rain"]).withDescription("Rain sensor state"),
             e.binary("rain_sensor_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable/disable rain sensor"),
-            e.enum("battery_state", ea.STATE, ["no_charge", "charging", "charged"]).withDescription("Battery charging state"),
+            e
+                .enum("battery_state", ea.STATE, ["no_charge", "charging", "charged"])
+                .withDescription("Battery charging state")
+                .withCategory("diagnostic"),
         ],
         meta: {
             tuyaSendCommand: "sendData",
@@ -24076,7 +24082,10 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         exposes: [
             e.enum("water_warning", ea.STATE, ["none", "alarm"]).withDescription("Water shortage warning"),
-            e.enum("battery_state", ea.STATE, ["low", "middle", "high"]).withDescription("low: 16.67%, middle:16.68-83.33%, high: 83.34-100%"),
+            e
+                .enum("battery_state", ea.STATE, ["low", "middle", "high"])
+                .withDescription("low: 16.67%, middle:16.68-83.33%, high: 83.34-100%")
+                .withCategory("diagnostic"),
             e.soil_moisture(),
             e.temperature(),
             e.humidity(),

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -821,7 +821,8 @@ const tuyaExposes = {
         e.enum("indicator_mode", ea.ALL, ["none", "relay", "pos"]).withDescription("Mode of the indicator light").withCategory("config"),
     powerOutageMemory: () =>
         e.enum("power_outage_memory", ea.ALL, ["on", "off", "restore"]).withDescription("Recover state after power outage").withCategory("config"),
-    batteryState: () => e.enum("battery_state", ea.STATE, ["low", "medium", "high"]).withDescription("State of the battery"),
+    batteryState: () =>
+        e.enum("battery_state", ea.STATE, ["low", "medium", "high"]).withDescription("State of the battery").withCategory("diagnostic"),
     doNotDisturb: () =>
         e
             .binary("do_not_disturb", ea.STATE_SET, true, false)

--- a/test/batteryState.test.ts
+++ b/test/batteryState.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest";
+import {findByDevice} from "../src/index";
+import * as tuya from "../src/lib/tuya";
+import type {Definition, DefinitionExposesFunction, Expose} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+function resolveExposes(definition: Definition, device: ReturnType<typeof mockDevice>): Expose[] {
+    return typeof definition.exposes === "function" ? (definition.exposes as DefinitionExposesFunction)(device, {}) : definition.exposes;
+}
+
+function batteryStateExpose(exposes: Expose[]): Expose | undefined {
+    return exposes.find((expose) => expose.name === "battery_state");
+}
+
+describe("battery_state exposes", () => {
+    it("marks the shared Tuya battery_state expose as diagnostic", () => {
+        expect(tuya.exposes.batteryState().category).toBe("diagnostic");
+    });
+
+    it("marks direct Tuya battery_state exposes as diagnostic", async () => {
+        const device = mockDevice({modelID: "TS0601", manufacturerName: "_TZE284_o9ofysmo", endpoints: [{ID: 1}]});
+        const definition = await findByDevice(device);
+
+        expect(definition.model).toBe("ZS-301Z");
+        expect(batteryStateExpose(resolveExposes(definition, device))?.category).toBe("diagnostic");
+    });
+
+    it("marks modern enumLookup battery_state exposes as diagnostic", async () => {
+        const device = mockDevice({modelID: "POK012", endpoints: [{ID: 1}]});
+        const definition = await findByDevice(device);
+
+        expect(definition.model).toBe("POK012");
+        expect(batteryStateExpose(resolveExposes(definition, device))?.category).toBe("diagnostic");
+    });
+});


### PR DESCRIPTION
## Summary

- Mark `battery_state` exposes as diagnostic metadata where they are emitted directly by device definitions.
- Mark the shared Tuya `batteryState()` helper as diagnostic so Tuya datapoint devices inherit the same Home Assistant category.
- Mark the PushOk `POK012` `m.enumLookup` battery-state expose as diagnostic via the existing `entityCategory` option.
- Add regression coverage for the shared Tuya helper, a Tuya soil sensor definition, and the modern `enumLookup` path.

## Why

Home Assistant already treats `battery`, `battery_low`, and `voltage` as diagnostic-style device health entities. `battery_state` has the same operational meaning, but some devices still exposed it as a primary sensor.

## Validation

- `node --run check`
- `node --run build`
- `node --run test` (`19` files, `615` tests)
- `git diff --check`

## Live validation

Tested on a Home Assistant / Zigbee2MQTT override with two Tuya soil sensors:

- `sensor.pflanzensensor_3_battery_state`
- `sensor.pflanzensensor_4_battery_state`

After deploying the converter override, retained MQTT discovery for both sensors published `entity_category: diagnostic`. After removing the two stale Home Assistant MQTT entity-registry rows and restarting Zigbee2MQTT, Home Assistant recreated both entities with `entity_category: diagnostic`.
