### PR TITLE
Add LGT016 as AU regional variant of Hue Play wall washer (046677590161)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4804,7 +4804,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
-        zigbeeModel: ["LGT009", "LGT010", "LGT012", "046677590161", "046677590130"],
+        zigbeeModel: ["LGT009", "LGT010", "LGT012", "LGT016", "046677590161", "046677590130"],
         model: "046677590161",
         vendor: "Philips",
         description: "Hue Play wall washer",


### PR DESCRIPTION
## Summary

\`LGT016\` is the Zigbee model ID reported by the Philips Hue Play wall washer sold in Australia (catalog number 046677590161). It is not currently in the supported model list, causing the device to show as \"Not supported\" in Zigbee2MQTT.

This PR adds \`LGT016\` to the existing \`zigbeeModel\` array alongside \`LGT009\`, \`LGT010\`, and \`LGT012\`.

## Verification

Verified via external converter that \`LGT016\` behaves identically to the other model IDs in this definition — full color (xy/hs), color temperature (153–500 mireds), and gradient with extended effects (sparkle, opal, glisten, underwater, cosmos, sunbeam, enchant) all work correctly.

## Device info

| Field | Value |
|-------|-------|
| Zigbee model | \`LGT016\` |
| OUI | Philips Lighting BV (\`0x001788\`) |
| Manufacturer string | \`Signify Netherlands B.V.\` |
| Firmware | \`1.122.2 / 20240902\` |
| Region | Australia |
| Catalog number | \`046677590161\` |