### PR TITLE
Add AOYAN AY-204ZX

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24068,7 +24068,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-204ZK"],
+        zigbeeModel: ["ZG-204ZK", "AY-204ZX"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_ka8l86iu", "_TZE200_zbfmvj13"]),
         model: "ZG-204ZK",
         vendor: "HOBEIAN",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24106,6 +24106,14 @@ export const definitions: DefinitionWithExtend[] = [
             e.binary("indicator", ea.STATE_SET, "ON", "OFF").withDescription("LED indicator mode"),
             e.binary("anti_interference", ea.STATE_SET, "ON", "OFF").withDescription("Anti interference function"),
         ],
+        whiteLabel: [
+            {
+                model: "AY-204ZX",
+                vendor: "AOYAN",
+                description: "24Ghz millimeter wave and T&H sensor",
+                fingerprint: [{modelID: "AY-204ZX", manufacturerName: "AOYAN"}],
+            },
+        ],
         meta: {
             tuyaDatapoints: [
                 [1, "presence", tuya.valueConverter.trueFalse1],


### PR DESCRIPTION
Adds AOYAN AY-204ZX as a white label for the existing ZG-204ZX definition.

Image PR: Koenkk/zigbee2mqtt.io#5256
Image branch: `zyjsmile857/zigbee2mqtt.io:add-aoyan-ay-204zx-image`