### PR TITLE
Add AOYAN AY205Z

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -14247,6 +14247,14 @@ export const definitions: DefinitionWithExtend[] = [
                 [123, "motion_detection_sensitivity", tuya.valueConverter.raw],
             ],
         },
+        whiteLabel: [
+            {
+                model: "AY205Z",
+                vendor: "AOYAN",
+                description: "PIR 24Ghz human presence sensor",
+                fingerprint: [{modelID: "AY205Z", manufacturerName: "AOYAN"}],
+            },
+        ],
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_bw4ayyeh"]),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -14169,7 +14169,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-204ZM"],
+        zigbeeModel: ["ZG-204ZM", "AY205Z"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_2aaelwxk", "_TZE200_kb5noeto", "_TZE200_tyffvoij", "_TZE200_yflzeeqj"]),
         model: "ZG-204ZM",
         vendor: "Tuya",


### PR DESCRIPTION
Adds AOYAN AY205Z as a white label for the existing ZG-204ZM definition.

Image PR: Koenkk/zigbee2mqtt.io#5257
Image branch: `zyjsmile857/zigbee2mqtt.io:add-aoyan-ay205z-image`