### PR TITLE
Add AOYAN AY02SZ

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22700,7 +22700,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-102ZM"],
+        zigbeeModel: ["ZG-102ZM", "AY02SZ"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_wzk0x7fq", "_TZE200_jfw0a4aa"]),
         model: "ZG-102ZM",
         vendor: "HOBEIAN",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -22705,6 +22705,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZG-102ZM",
         vendor: "HOBEIAN",
         description: "Vibration sensor",
+        whiteLabel: [
+            {
+                model: "AY02SZ",
+                vendor: "AOYAN",
+                description: "Vibration sensor",
+                fingerprint: [{modelID: "AY02SZ", manufacturerName: "AOYAN"}],
+            },
+        ],
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             e.vibration(),


### PR DESCRIPTION
Adds AOYAN AY02SZ as a white label for the existing ZG-102ZM vibration sensor definition.

Image PR: Koenkk/zigbee2mqtt.io#5259
Image branch: `zyjsmile857/zigbee2mqtt.io:add-aoyan-ay02sz-image`