### PR TITLE
Add AOYAN switch modules

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11102,6 +11102,119 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        zigbeeModel: ["AY-601ZL"],
+        model: "AY-601ZL",
+        vendor: "AOYAN",
+        description: "1 gang switch module - without neutral wire",
+        whiteLabel: [
+            {
+                vendor: "AOYAN",
+                model: "AY-801ZL",
+                description: "1 gang switch module - without neutral wire",
+                fingerprint: [{modelID: "AY-801ZL"}],
+            },
+        ],
+        extend: [
+            tuya.modernExtend.tuyaBase(),
+            tuya.modernExtend.tuyaOnOff({
+                backlightModeOffNormalInverted: true,
+                onOffCountdown: true,
+            }),
+            m.forcePowerSource({powerSource: "Mains (single phase)"}),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            try {
+                const endpoint = device.getEndpoint(1);
+                await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
+            } catch {
+                // Some Tuya devices fail binding
+            }
+            device.powerSource = "Mains (single phase)";
+            device.save();
+        },
+    },
+    {
+        zigbeeModel: ["AY-602ZL"],
+        model: "AY-602ZL",
+        vendor: "AOYAN",
+        description: "2 gang switch module - without neutral wire",
+        whiteLabel: [
+            {
+                vendor: "AOYAN",
+                model: "AY-802ZL",
+                description: "2 gang switch module - without neutral wire",
+                fingerprint: [{modelID: "AY-802ZL"}],
+            },
+        ],
+        extend: [
+            tuya.modernExtend.tuyaBase(),
+            tuya.modernExtend.tuyaOnOff({
+                backlightModeOffNormalInverted: true,
+                onOffCountdown: true,
+                endpoints: ["left", "right"],
+            }),
+            m.forcePowerSource({powerSource: "Mains (single phase)"}),
+        ],
+        endpoint: (device) => {
+            return {left: 1, right: 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            try {
+                for (const ID of [1, 2]) {
+                    const endpoint = device.getEndpoint(ID);
+                    await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
+                }
+            } catch {
+                // Some Tuya devices fail binding
+            }
+            device.powerSource = "Mains (single phase)";
+            device.save();
+        },
+    },
+    {
+        zigbeeModel: ["AY-603ZL"],
+        model: "AY-603ZL",
+        vendor: "AOYAN",
+        description: "3 gang switch module - without neutral wire",
+        whiteLabel: [
+            {
+                vendor: "AOYAN",
+                model: "AY-803ZL",
+                description: "3 gang switch module - without neutral wire",
+                fingerprint: [{modelID: "AY-803ZL"}],
+            },
+        ],
+        extend: [
+            tuya.modernExtend.tuyaBase(),
+            tuya.modernExtend.tuyaOnOff({
+                backlightModeOffNormalInverted: true,
+                onOffCountdown: true,
+                endpoints: ["left", "center", "right"],
+            }),
+            m.forcePowerSource({powerSource: "Mains (single phase)"}),
+        ],
+        endpoint: (device) => {
+            return {left: 1, center: 2, right: 3};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            try {
+                for (const ID of [1, 2, 3]) {
+                    const endpoint = device.getEndpoint(ID);
+                    await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
+                }
+            } catch {
+                // Some Tuya devices fail binding
+            }
+            device.powerSource = "Mains (single phase)";
+            device.save();
+        },
+    },
+    {
         zigbeeModel: ["TS0014"],
         model: "TS0014",
         vendor: "Tuya",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11122,17 +11122,6 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
         ],
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            try {
-                const endpoint = device.getEndpoint(1);
-                await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
-            } catch {
-                // Some Tuya devices fail binding
-            }
-            device.powerSource = "Mains (single phase)";
-            device.save();
-        },
     },
     {
         zigbeeModel: ["AY-602ZL"],
@@ -11156,23 +11145,6 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
         ],
-        endpoint: (device) => {
-            return {left: 1, right: 2};
-        },
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            try {
-                for (const ID of [1, 2]) {
-                    const endpoint = device.getEndpoint(ID);
-                    await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
-                }
-            } catch {
-                // Some Tuya devices fail binding
-            }
-            device.powerSource = "Mains (single phase)";
-            device.save();
-        },
     },
     {
         zigbeeModel: ["AY-603ZL"],
@@ -11196,23 +11168,6 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
         ],
-        endpoint: (device) => {
-            return {left: 1, center: 2, right: 3};
-        },
-        meta: {multiEndpoint: true},
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-            try {
-                for (const ID of [1, 2, 3]) {
-                    const endpoint = device.getEndpoint(ID);
-                    await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
-                }
-            } catch {
-                // Some Tuya devices fail binding
-            }
-            device.powerSource = "Mains (single phase)";
-            device.save();
-        },
     },
     {
         zigbeeModel: ["TS0014"],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11102,7 +11102,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["AY-601ZL"],
+        zigbeeModel: ["AY-601ZL", "AY-801ZL"],
         model: "AY-601ZL",
         vendor: "AOYAN",
         description: "1 gang switch module - without neutral wire",
@@ -11124,7 +11124,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["AY-602ZL"],
+        zigbeeModel: ["AY-602ZL", "AY-802ZL"],
         model: "AY-602ZL",
         vendor: "AOYAN",
         description: "2 gang switch module - without neutral wire",
@@ -11147,7 +11147,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["AY-603ZL"],
+        zigbeeModel: ["AY-603ZL", "AY-803ZL"],
         model: "AY-603ZL",
         vendor: "AOYAN",
         description: "3 gang switch module - without neutral wire",


### PR DESCRIPTION
Adds AOYAN 1, 2 and 3 gang switch modules without neutral wire.

Models added:
- AY-601ZL / AY-801ZL
- AY-602ZL / AY-802ZL
- AY-603ZL / AY-803ZL

Image PR: Koenkk/zigbee2mqtt.io#5260
Image branch: `zyjsmile857/zigbee2mqtt.io:add-aoyan-switch-module-images`