### PR TITLE
feat(NodOn): modernize SDO-4-1-00 and add configureReporting for ssIasZone/zoneStatus

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -291,10 +291,20 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SDO-4-1-00",
         vendor: "NodOn",
         description: "Door & window opening sensor",
-        fromZigbee: [fz.battery, fz.ias_contact_alarm_1],
-        toZigbee: [],
-        exposes: [e.contact()],
-        extend: [m.battery({voltageReporting: true})],
+        extend: [
+            m.battery({voltageReporting: true}),
+            m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1"]}),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            // No bind needed: coordinator is already enrolled as IAS CIE during pairing.
+            await endpoint.configureReporting("ssIasZone", [{
+                attribute: "zoneStatus",
+                minimumReportInterval: 0,
+                maximumReportInterval: constants.repInterval.HOUR,
+                reportableChange: 1,
+            }]);
+        },
         ota: true,
     },
     {

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -291,19 +291,10 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SDO-4-1-00",
         vendor: "NodOn",
         description: "Door & window opening sensor",
-        extend: [m.battery({voltageReporting: true}), m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1"]})],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            // No bind needed: coordinator is already enrolled as IAS CIE during pairing.
-            await endpoint.configureReporting("ssIasZone", [
-                {
-                    attribute: "zoneStatus",
-                    minimumReportInterval: 0,
-                    maximumReportInterval: constants.repInterval.HOUR,
-                    reportableChange: 1,
-                },
-            ]);
-        },
+        extend: [
+            m.battery({voltageReporting: true}),
+            m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1"], zoneStatusReporting: {max: constants.repInterval.HOUR}}),
+        ],
         ota: true,
     },
     {

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -291,19 +291,18 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SDO-4-1-00",
         vendor: "NodOn",
         description: "Door & window opening sensor",
-        extend: [
-            m.battery({voltageReporting: true}),
-            m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1"]}),
-        ],
+        extend: [m.battery({voltageReporting: true}), m.iasZoneAlarm({zoneType: "contact", zoneAttributes: ["alarm_1"]})],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             // No bind needed: coordinator is already enrolled as IAS CIE during pairing.
-            await endpoint.configureReporting("ssIasZone", [{
-                attribute: "zoneStatus",
-                minimumReportInterval: 0,
-                maximumReportInterval: constants.repInterval.HOUR,
-                reportableChange: 1,
-            }]);
+            await endpoint.configureReporting("ssIasZone", [
+                {
+                    attribute: "zoneStatus",
+                    minimumReportInterval: 0,
+                    maximumReportInterval: constants.repInterval.HOUR,
+                    reportableChange: 1,
+                },
+            ]);
         },
         ota: true,
     },

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1663,7 +1663,7 @@ export interface IasArgs {
     zoneAttributes: IasZoneAttribute[];
     alarmTimeout?: boolean;
     keepAliveTimeout?: (device: Device) => number;
-    zoneStatusReporting?: boolean;
+    zoneStatusReporting?: boolean | Partial<ReportingConfigWithoutAttribute>;
     description?: string;
     invertAlarm?: true;
     manufacturerZoneAttributes?: ManufacturerZoneAttribute[];
@@ -1814,9 +1814,12 @@ export function iasZoneAlarm(args: IasArgs): ModernExtend {
 
     let configure: Configure[];
     if (args.zoneStatusReporting) {
+        const zoneStatusReportingConfig = isObject(args.zoneStatusReporting) ? args.zoneStatusReporting : {};
         configure = [
             async (device, coordinatorEndpoint) => {
-                await setupAttributes(device, coordinatorEndpoint, "ssIasZone", [{attribute: "zoneStatus", min: "MIN", max: "MAX", change: 0}]);
+                await setupAttributes(device, coordinatorEndpoint, "ssIasZone", [
+                    {attribute: "zoneStatus", min: "MIN", max: "MAX", change: 0, ...zoneStatusReportingConfig},
+                ]);
             },
         ];
     }


### PR DESCRIPTION
### Problem

The current `SDO-4-1-00` definition has two issues:

**1. Incomplete modernExtend migration**

The entry mixes legacy converters with `modernExtend`:

```typescript
fromZigbee: [fz.battery, fz.ias_contact_alarm_1],  // legacy
toZigbee: [],
exposes: [e.contact()],                              // legacy
extend: [m.battery({voltageReporting: true})],       // modernExtend
```

`fz.battery` is already covered by `m.battery`. `fz.ias_contact_alarm_1` and `e.contact()` are covered by `m.iasZoneAlarm`.

**2. No `configureReporting` for `ssIasZone/zoneStatus`**

Without it, the periodic heartbeat interval is never configured. The attribute does not appear in Z2M's Reporting tab and stays at whatever the device factory default is.

---

### Fix

```diff
  {
      zigbeeModel: ['SDO-4-1-00'],
      model: 'SDO-4-1-00',
      vendor: 'NodOn',
      description: 'Door & window opening sensor',
-     fromZigbee: [fz.battery, fz.ias_contact_alarm_1],
-     toZigbee: [],
-     exposes: [e.contact()],
      extend: [
          m.battery({voltageReporting: true}),
+         m.iasZoneAlarm({zoneType: 'contact', zoneAttributes: ['alarm_1']}),
      ],
+     configure: async (device, coordinatorEndpoint) => {
+         const endpoint = device.getEndpoint(1);
+         await endpoint.configureReporting('ssIasZone', [{
+             attribute: 'zoneStatus',
+             minimumReportInterval: 0,
+             maximumReportInterval: constants.repInterval.HOUR,
+             reportableChange: 1,
+         }]);
+     },
      ota: true,
  },
```

---

### Tested

- Device: **SDO-4-1-00** firmware V4.3.0
- Platform: Z2M 2.12.0 / zigbee-herdsman-converters 26.72.0
- Coordinator: SONOFF Zigbee 3.0 USB Dongle Plus-E (EFR32MG21, firmware 7.4.4 GA)
- `configureReporting` confirmed applied: `cluster ssIasZone (0x0500), attr zoneStatus (0x0002), min: 0s, max: 3600s, change: 1`
- Hourly heartbeats received consistently over 24h of monitoring
- Immediate open/close notifications confirmed on each door event

