### PR TITLE
Fix Shelly switch input endpoint discovery

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -27,6 +27,23 @@ const checkOption = (device: Zh.Device | DummyDevice, options: KeyValue, key: st
     return defaultValue;
 };
 
+const shellySwitchInputEndpoints = (device: Zh.Device | DummyDevice, endpoints: Record<string, number>): Record<string, number> => {
+    if (utils.isDummyDevice(device)) return endpoints;
+
+    return Object.fromEntries(Object.entries(endpoints).filter(([, endpoint]) => device.getEndpoint(endpoint) !== undefined));
+};
+
+const shellySwitchInputExposes = (device: Zh.Device | DummyDevice, endpoints: Record<string, number>): Expose[] =>
+    Object.keys(shellySwitchInputEndpoints(device, endpoints)).map((endpoint) =>
+        e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint(endpoint),
+    );
+
+const shellyDeviceEndpoints = (endpoints: Record<string, number>): ModernExtend => ({
+    meta: {multiEndpoint: true},
+    endpoint: (device) => shellySwitchInputEndpoints(device, endpoints),
+    isModernExtend: true,
+});
+
 const shellyPresenceEndpointNames = (device: Zh.Device | DummyDevice): string[] => {
     const count =
         !utils.isDummyDevice(device) && typeof device.meta.presence_zone_count === "number"
@@ -533,6 +550,26 @@ const shellyModernExtend = {
             }
         };
 
+        const getRPCEndpoint = (entity: Zh.Endpoint | Zh.Group): Zh.Endpoint | Zh.Group => {
+            utils.assertEndpoint(entity);
+            const endpoint = entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
+            if (!endpoint) throw new Error(`Shelly RPC endpoint ${SHELLY_ENDPOINT_ID} not found`);
+            return endpoint;
+        };
+
+        const getShellySwitchConfig = async (endpoint: Zh.Endpoint | Zh.Group, id: number): Promise<KeyValue | undefined> => {
+            const response = await rpcRequest(endpoint, "Switch.GetConfig", {id});
+            const result = response?.result ?? response?.params ?? response;
+            if (!result) return undefined;
+            assertObject<KeyValue>(result);
+            return result;
+        };
+
+        const getShellySwitchMode = async (endpoint: Zh.Endpoint | Zh.Group, id: number): Promise<string | undefined> => {
+            const config = await getShellySwitchConfig(endpoint, id);
+            return typeof config?.in_mode === "string" ? config.in_mode : undefined;
+        };
+
         // Features for exposes
         const featurePercentage = (name: string, label: string) => {
             return e.numeric(name, ea.STATE_SET).withValueMin(0).withValueMax(100).withValueStep(1).withLabel(label).withUnit("%");
@@ -790,24 +827,25 @@ const shellyModernExtend = {
             const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
             exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
                 if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
-                return [
-                    e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint("sw1"),
-                    e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint("sw2"),
-                ];
+                return Object.keys(shellySwitchInputEndpoints(device, {sw1: 2, sw2: 3})).map((endpoint) =>
+                    e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint(endpoint),
+                );
             });
             toZigbee.push({
                 key: ["switch_mode"],
                 convertSet: async (entity, key, value, meta) => {
                     const switchId = meta.endpoint_name === "sw1" ? 0 : 1;
-                    const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
+                    const ep = getRPCEndpoint(entity);
                     await rpcSend(ep, "Switch.SetConfig", {id: switchId, config: {in_mode: value}});
                     return {state: {switch_mode: value}};
                 },
                 convertGet: async (entity, key, meta) => {
                     const switchId = meta.endpoint_name === "sw1" ? 0 : 1;
-                    const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
-                    await rpcSend(ep, "Switch.GetConfig", {id: switchId});
-                    await rpcReceive(ep, "rpc_rxctl");
+                    const ep = getRPCEndpoint(entity);
+                    const mode = await getShellySwitchMode(ep, switchId);
+                    if (mode) {
+                        meta.publish({[meta.endpoint_name ? `switch_mode_${meta.endpoint_name}` : "switch_mode"]: mode});
+                    }
                 },
             });
             configure.push(async (device) => {
@@ -815,8 +853,7 @@ const shellyModernExtend = {
                 if (!ep) return;
                 try {
                     for (const id of [0, 1]) {
-                        await rpcSend(ep, "Switch.GetConfig", {id});
-                        await rpcReceive(ep, "rpc_rxctl");
+                        await getShellySwitchConfig(ep, id);
                     }
                 } catch (e) {
                     logger.warning(`Failed to read switch_mode during configure, use get to retry: ${e}`, NS);
@@ -827,27 +864,30 @@ const shellyModernExtend = {
             const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
             exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
                 if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
-                return [e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint("sw1")];
+                return Object.keys(shellySwitchInputEndpoints(device, {sw1: 2})).map((endpoint) =>
+                    e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint(endpoint),
+                );
             });
             toZigbee.push({
                 key: ["switch_mode"],
                 convertSet: async (entity, key, value, meta) => {
-                    const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
+                    const ep = getRPCEndpoint(entity);
                     await rpcSend(ep, "Switch.SetConfig", {id: 0, config: {in_mode: value}});
                     return {state: {switch_mode: value}};
                 },
                 convertGet: async (entity, key, meta) => {
-                    const ep = determineEndpoint(entity, meta, "shellyRPCCluster");
-                    await rpcSend(ep, "Switch.GetConfig", {id: 0});
-                    await rpcReceive(ep, "rpc_rxctl");
+                    const ep = getRPCEndpoint(entity);
+                    const mode = await getShellySwitchMode(ep, 0);
+                    if (mode) {
+                        meta.publish({[meta.endpoint_name ? `switch_mode_${meta.endpoint_name}` : "switch_mode"]: mode});
+                    }
                 },
             });
             configure.push(async (device) => {
                 const ep = device.getEndpoint(SHELLY_ENDPOINT_ID);
                 if (!ep) return;
                 try {
-                    await rpcSend(ep, "Switch.GetConfig", {id: 0});
-                    await rpcReceive(ep, "rpc_rxctl");
+                    await getShellySwitchConfig(ep, 0);
                 } catch (e) {
                     logger.warning(`Failed to read switch_mode during configure, use get to retry: ${e}`, NS);
                 }
@@ -1388,9 +1428,8 @@ const fzLocal = {
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
             if (!Object.hasOwn(msg.data, "switchType")) return {};
-            const epName = utils.getFromLookup(msg.endpoint.ID, {2: "sw1", 3: "sw1", 4: "sw2"});
-            if (!epName) return {};
-            return {[`switch_type_${epName}`]: utils.getFromLookup(msg.data.switchType as number, {0: "toggle", 1: "momentary"})};
+            const property = utils.postfixWithEndpointName("switch_type", msg, model, meta);
+            return {[property]: utils.getFromLookup(msg.data.switchType as number, {0: "toggle", 1: "momentary"})};
         },
     } satisfies Fz.Converter<"genOnOffSwitchCfg", undefined, ["attributeReport", "readResponse"]>,
 
@@ -1619,7 +1658,7 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fzLocal.two_switch_inputs_events, fzLocal.two_switch_inputs_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
-        exposes: [
+        exposes: (device) => [
             e.action([
                 "input_1_on",
                 "input_1_off",
@@ -1636,11 +1675,10 @@ export const definitions: DefinitionWithExtend[] = [
                 "input_2_triple",
                 "input_2_hold",
             ]),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw2"),
+            ...shellySwitchInputExposes(device, {sw1: 2, sw2: 3}),
         ],
         extend: [
-            m.deviceEndpoints({endpoints: {sw1: 2, sw2: 3}}),
+            shellyDeviceEndpoints({sw1: 2, sw2: 3}),
             shellyModernExtend.shellyWindowCovering(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["2PMInputMode", "CoverTiltAuto"]),
@@ -1691,7 +1729,7 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fzLocal.two_switch_inputs_events, fzLocal.two_switch_inputs_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
-        exposes: [
+        exposes: (device) => [
             e.action([
                 "input_1_on",
                 "input_1_off",
@@ -1708,11 +1746,10 @@ export const definitions: DefinitionWithExtend[] = [
                 "input_2_triple",
                 "input_2_hold",
             ]),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw2"),
+            ...shellySwitchInputExposes(device, {sw1: 3, sw2: 4}),
         ],
         extend: [
-            m.deviceEndpoints({endpoints: {l1: 1, l2: 2, sw1: 3, sw2: 4}}),
+            shellyDeviceEndpoints({l1: 1, l2: 2, sw1: 3, sw2: 4}),
             m.onOff({powerOnBehavior: false, endpointNames: ["l1", "l2"]}),
             m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert";
 import {describe, expect, it, vi} from "vitest";
 import {findByDevice} from "../src/index";
-import type {DefinitionExposesFunction, Expose} from "../src/lib/types";
+import type {DefinitionExposesFunction, Expose, Fz, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 const getFeatureNames = (expose: Expose): string[] => {
-    return "features" in expose ? expose.features.map((feature) => feature.name) : [];
+    return "features" in expose && expose.features ? expose.features.map((feature) => feature.name) : [];
 };
 
 describe("Shelly 2PM Gen4 cover mode", () => {
@@ -19,6 +19,105 @@ describe("Shelly 2PM Gen4 cover mode", () => {
                 {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
             ],
         });
+
+    const mockShelly2PMCoverWithInputs = (read?: ReturnType<typeof vi.fn>) =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 514, inputClusterIDs: [0, 3, 4, 5, 258], outputClusterIDs: [25]},
+                {ID: 2, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 3, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 4, inputClusterIDs: [], outputClusterIDs: [3, 4, 6, 8, 258]},
+                {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: [], read},
+                {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
+            ],
+        });
+
+    const mockShelly2PMSwitchWithInputs = (read?: ReturnType<typeof vi.fn>) =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: [25]},
+                {ID: 2, profileID: 260, deviceID: 266, inputClusterIDs: [4, 5, 6, 2820, 1794], outputClusterIDs: []},
+                {ID: 3, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 4, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 5, inputClusterIDs: [], outputClusterIDs: [3, 4, 6, 8, 258]},
+                {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: [], read},
+                {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
+            ],
+        });
+
+    it("does not expose switch input controls when the device has no switch input endpoints", async () => {
+        const device = mockShelly2PMCover();
+        const definition = await findByDevice(device);
+        expect(definition.model).toBe("S4SW-002P16EU-COVER");
+        expect(definition.endpoint?.(device)).toStrictEqual({});
+        expect(typeof definition.exposes).toBe("function");
+
+        const exposes = definition.exposes as DefinitionExposesFunction;
+        const featureNames = exposes(device, {}).flatMap((expose) => [expose.name, ...getFeatureNames(expose)]);
+
+        expect(featureNames).not.toContain("switch_type");
+        expect(featureNames).not.toContain("switch_mode");
+    });
+
+    it("maps the second cover switch input type to sw2", async () => {
+        const device = mockShelly2PMCoverWithInputs();
+        const definition = await findByDevice(device);
+        const converter = definition.fromZigbee.find((converter) => converter.cluster === "genOnOffSwitchCfg") as Fz.Converter;
+
+        const state = converter.convert(
+            definition,
+            {data: {switchType: 1}, endpoint: device.getEndpoint(3), device, type: "attributeReport"} as never,
+            vi.fn(),
+            {},
+            {device, state: {}} as never,
+        );
+
+        expect(definition.endpoint?.(device)).toStrictEqual({sw1: 2, sw2: 3});
+        expect(state).toStrictEqual({switch_type_sw2: "momentary"});
+    });
+
+    it("maps switch-mode endpoint 3 input type to sw1", async () => {
+        const device = mockShelly2PMSwitchWithInputs();
+        const definition = await findByDevice(device);
+        const converter = definition.fromZigbee.find((converter) => converter.cluster === "genOnOffSwitchCfg") as Fz.Converter;
+
+        const state = converter.convert(
+            definition,
+            {data: {switchType: 0}, endpoint: device.getEndpoint(3), device, type: "attributeReport"} as never,
+            vi.fn(),
+            {},
+            {device, state: {}} as never,
+        );
+
+        expect(definition.endpoint?.(device)).toStrictEqual({l1: 1, l2: 2, sw1: 3, sw2: 4});
+        expect(state).toStrictEqual({switch_type_sw1: "toggle"});
+    });
+
+    it("reads two-channel switch mode through the Shelly RPC endpoint", async () => {
+        const response = JSON.stringify({id: 1, result: {id: 1, in_mode: "detached"}});
+        const read = vi.fn().mockResolvedValueOnce({rxCtl: response.length}).mockResolvedValueOnce({data: response});
+        const device = mockShelly2PMCoverWithInputs(read);
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((converter) => converter.key.includes("switch_mode")) as Tz.Converter;
+        const publish = vi.fn();
+
+        await converter.convertGet?.(device.getEndpoint(3), "switch_mode", {endpoint_name: "sw2", message: {}, publish} as never);
+
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
+            "shellyRPCCluster",
+            {data: expect.stringContaining("Switch.GetConfig")},
+            expect.any(Object),
+        );
+        expect(read).toHaveBeenCalledWith("shellyRPCCluster", ["rxCtl"], expect.any(Object));
+        expect(read).toHaveBeenCalledWith("shellyRPCCluster", ["data"], expect.any(Object));
+        expect(device.getEndpoint(3).write).not.toHaveBeenCalled();
+        expect(device.getEndpoint(3).read).not.toHaveBeenCalled();
+        expect(publish).toHaveBeenCalledWith({switch_mode_sw2: "detached"});
+    });
 
     it("exposes lift-only covers by default and opt-in tilt controls", async () => {
         const device = mockShelly2PMCover();


### PR DESCRIPTION
## Summary
- Resolve Shelly switch input endpoints from the interviewed device instead of always exposing hardcoded `sw1` / `sw2` controls.
- Hide `switch_type` and `switch_mode` controls for Shelly 2PM cover-mode variants that do not expose switch input endpoints.
- Read and write switch mode through the dedicated Shelly RPC endpoint instead of the per-channel switch endpoint.
- Fix `switch_type` reporting so endpoint 3 maps to `sw2` for two-input devices.

## Scope
This is the switch input endpoint cleanup split out from #12497. It intentionally does not change cover tilt exposure or Wi-Fi readback/fallback behavior.

## Validation
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.18.3 exec vitest run test/shelly.test.ts --config ./test/vitest.config.mts` (`6` tests)
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.18.3 exec biome check --error-on-warnings src/devices/shelly.ts test/shelly.test.ts`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.18.3 run build`
- `git diff --check`

## Live validation
- Verified on my Home Assistant instance that a Shelly 2PM Gen4 cover-mode device without switch input endpoints no longer exposes stale switch type/mode controls.
- Verified on my Home Assistant instance that the stale switch input Home Assistant discovery entities can be cleaned up by the corrected endpoint-aware discovery.