### PR TITLE
Type HA discovery override options

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -222,7 +222,7 @@ export interface DefinitionMeta {
     /**
      * Override the Home Assistant discovery payload using a custom function.
      */
-    overrideHaDiscoveryPayload?(payload: KeyValueAny): void;
+    overrideHaDiscoveryPayload?(payload: KeyValueAny, options?: KeyValueAny): void;
     /**
      * Home Assistant discovery hints for bridge integrations.
      */


### PR DESCRIPTION
## Summary
- allow `definition.meta.overrideHaDiscoveryPayload` to receive optional device options
- keep the hook backward-compatible for existing overrides that only use the discovery payload

## Why

Zigbee2MQTT can pass per-device options into the Home Assistant discovery override hook without locally redeclaring converter types. This keeps the hook signature owned by zigbee-herdsman-converters and lets device-specific HA discovery behavior remain configurable.

This was split out of Koenkk/zigbee2mqtt#32379 after review feedback that Zigbee2MQTT should not override or redeclare converter types locally.

## Validation
- `pnpm run build`
- `pnpm run check`
- `pnpm test` (`19` files, `615` tests)
- `pnpm exec biome check src/lib/types.ts --error-on-warnings`
- `git diff --check`
