### PR TITLE
Add support for Nova Digital QZ-4x4-6 W/B

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5668,6 +5668,44 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Ekaza", "EKAT-T3074-6WZ", "6 gang switch", ["_TZE284_g1enhdsi"]),
         ],
     },
+
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_hyssaqjk"]),
+        model: "QZ-4x4-6 W/B",
+        vendor: "Nova Digital",
+        description: "Quartzo 6 gang switch",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+        },
+        exposes: [
+            tuya.exposes.switch().withEndpoint("l1"),
+            tuya.exposes.switch().withEndpoint("l2"),
+            tuya.exposes.switch().withEndpoint("l3"),
+            tuya.exposes.switch().withEndpoint("l4"),
+            tuya.exposes.switch().withEndpoint("l5"),
+            tuya.exposes.switch().withEndpoint("l6"),
+            e.binary("backlight_switch", ea.STATE_SET, "ON", "OFF").withDescription("Turns the backlight on or off"),
+            e.power_on_behavior(["off", "on", "previous"]).withAccess(ea.STATE_SET),
+        ],
+        endpoint: (device) => {
+            return {l1: 1, l2: 1, l3: 1, l4: 1, l5: 1, l6: 1};
+        },
+        meta: {
+            multiEndpoint: true,
+            tuyaDatapoints: [
+                [1, "state_l1", tuya.valueConverter.onOff],
+                [2, "state_l2", tuya.valueConverter.onOff],
+                [3, "state_l3", tuya.valueConverter.onOff],
+                [4, "state_l4", tuya.valueConverter.onOff],
+                [5, "state_l5", tuya.valueConverter.onOff],
+                [6, "state_l6", tuya.valueConverter.onOff],
+                [14, "power_on_behavior", tuya.valueConverter.powerOnBehaviorEnum],
+                [16, "backlight_switch", tuya.valueConverter.onOff],
+            ],
+        },
+    },
+
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_raz9qavg"]),
         model: "KRC-103",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5668,16 +5668,12 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Ekaza", "EKAT-T3074-6WZ", "6 gang switch", ["_TZE284_g1enhdsi"]),
         ],
     },
-
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_hyssaqjk"]),
         model: "QZ-4x4-6 W/B",
         vendor: "Nova Digital",
         description: "Quartzo 6 gang switch",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
-        configure: async (device, coordinatorEndpoint) => {
-            await tuya.configureMagicPacket(device, coordinatorEndpoint);
-        },
         exposes: [
             tuya.exposes.switch().withEndpoint("l1"),
             tuya.exposes.switch().withEndpoint("l2"),
@@ -5705,7 +5701,6 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
-
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_raz9qavg"]),
         model: "KRC-103",


### PR DESCRIPTION
Adds support for the Nova Digital QZ-4x4-6 W/B, a Quartzo 6 gang Zigbee wall switch.

Device information:

* Vendor: Nova Digital
* Model: QZ-4x4-6 W/B
* Zigbee modelID: TS0601
* Manufacturer name: _TZE284_hyssaqjk

Validated features:

* state_l1
* state_l2
* state_l3
* state_l4
* state_l5
* state_l6
* power_on_behavior
* backlight_switch

Validated datapoints:

* DP 1: state_l1
* DP 2: state_l2
* DP 3: state_l3
* DP 4: state_l4
* DP 5: state_l5
* DP 6: state_l6
* DP 14: power_on_behavior
* DP 16: backlight_switch

Notes:

* tuya.configureMagicPacket is required for physical button state synchronization.
* indicator_mode and countdown were tested but are not available in the Tuya/Nova Digital app for this firmware, so they are intentionally not exposed.
* After mains power restore, the device applies power_on_behavior physically, but may not immediately report state_l1–state_l6 back to Zigbee2MQTT until a physical or remote toggle occurs.

Tested:

* Device pairing
* Control from Zigbee2MQTT to device
* Physical button synchronization from device to Zigbee2MQTT
* Backlight switch
* Power-on behavior
* Re-pairing

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5268
