### PR TITLE
Mark meter voltage telemetry diagnostic for HA

### DIFF
--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -16,6 +16,10 @@ import {getLabelFromName} from "./utils";
 export type Feature = Numeric | Binary | Enum | Composite | List | Text;
 export interface HomeAssistant {
     type?: "valve";
+    entityCategory?: "config" | "diagnostic";
+    deviceClass?: string;
+    enabledByDefault?: boolean;
+    icon?: string;
 }
 
 export class Base {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1896,6 +1896,7 @@ export function iasWarning(args: IasWarningArgs = {}): ModernExtend {
 // Uses Electrical Measurement and/or Gas Metering, but for simplicity was put here.
 type MultiplierDivisor = {multiplier?: number; divisor?: number};
 type MeterType = "electricity" | "gas"; // water, etc
+const diagnosticHomeAssistant = {entityCategory: "diagnostic"} as const satisfies exposes.HomeAssistant;
 interface MeterArgs {
     type?: MeterType;
     cluster?: "both" | "metering" | "electrical";
@@ -2206,8 +2207,8 @@ function genericMeter(args: MeterArgs = {}) {
 
     if (args.cluster === "both") {
         if (args.power !== false) exposes.push(e.power().withAccess(ea.STATE_GET));
-        if (args.voltage !== false) exposes.push(e.voltage().withAccess(ea.STATE_GET));
-        if (args.acFrequency !== false) exposes.push(e.ac_frequency().withAccess(ea.STATE_GET));
+        if (args.voltage !== false) exposes.push(e.voltage().withAccess(ea.STATE_GET).withHomeAssistant(diagnosticHomeAssistant));
+        if (args.acFrequency !== false) exposes.push(e.ac_frequency().withAccess(ea.STATE_GET).withHomeAssistant(diagnosticHomeAssistant));
         if (args.powerFactor !== false) exposes.push(e.power_factor().withAccess(ea.STATE_GET));
         if (args.current !== false) exposes.push(e.current().withAccess(ea.STATE_GET));
         if (args.energy !== false) exposes.push(e.energy().withAccess(ea.STATE_GET));
@@ -2288,9 +2289,9 @@ function genericMeter(args: MeterArgs = {}) {
         delete configureLookup.haElectricalMeasurement;
     } else if (args.cluster === "electrical") {
         if (args.power !== false) exposes.push(e.power().withAccess(ea.STATE_GET));
-        if (args.voltage !== false) exposes.push(e.voltage().withAccess(ea.STATE_GET));
+        if (args.voltage !== false) exposes.push(e.voltage().withAccess(ea.STATE_GET).withHomeAssistant(diagnosticHomeAssistant));
         if (args.current !== false) exposes.push(e.current().withAccess(ea.STATE_GET));
-        if (args.acFrequency !== false) exposes.push(e.ac_frequency().withAccess(ea.STATE_GET));
+        if (args.acFrequency !== false) exposes.push(e.ac_frequency().withAccess(ea.STATE_GET).withHomeAssistant(diagnosticHomeAssistant));
         if (args.powerFactor !== false) exposes.push(e.power_factor().withAccess(ea.STATE_GET));
         fromZigbee = [args.fzElectricalMeasurement ?? fz.electrical_measurement];
 
@@ -2308,7 +2309,10 @@ function genericMeter(args: MeterArgs = {}) {
             toZigbee.push(tz.electrical_measurement_power_phase_b, tz.electrical_measurement_power_phase_c);
         }
         if (args.voltage !== false) {
-            exposes.push(e.voltage_phase_b().withAccess(ea.STATE_GET), e.voltage_phase_c().withAccess(ea.STATE_GET));
+            exposes.push(
+                e.voltage_phase_b().withAccess(ea.STATE_GET).withHomeAssistant(diagnosticHomeAssistant),
+                e.voltage_phase_c().withAccess(ea.STATE_GET).withHomeAssistant(diagnosticHomeAssistant),
+            );
             toZigbee.push(tz.acvoltage_phase_b, tz.acvoltage_phase_c);
         }
         if (args.current !== false) {

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, test} from "vitest";
 import * as fz from "../src/converters/fromZigbee";
 import {repInterval} from "../src/lib/constants";
 import {fromZigbee as lumiFz} from "../src/lib/lumi";
-import {setupAttributes} from "../src/lib/modernExtend";
+import {electricityMeter, setupAttributes} from "../src/lib/modernExtend";
 import * as philips from "../src/lib/philips";
 import {assertDefinition, mockDevice, reportingItem} from "./utils";
 
@@ -221,6 +221,17 @@ describe("ModernExtend", () => {
                 ],
             },
         });
+    });
+
+    test("electricityMeter marks secondary electrical telemetry diagnostic for Home Assistant", () => {
+        const exposes = electricityMeter({acFrequency: true, threePhase: true}).exposes ?? [];
+        const byProperty = (property: string) => exposes.find((expose) => "property" in expose && expose.property === property);
+
+        expect(byProperty("power")?.homeassistant).toBeUndefined();
+        expect(byProperty("voltage")).toMatchObject({homeassistant: {entityCategory: "diagnostic"}});
+        expect(byProperty("ac_frequency")).toMatchObject({homeassistant: {entityCategory: "diagnostic"}});
+        expect(byProperty("voltage_phase_b")).toMatchObject({homeassistant: {entityCategory: "diagnostic"}});
+        expect(byProperty("voltage_phase_c")).toMatchObject({homeassistant: {entityCategory: "diagnostic"}});
     });
 
     test(`philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ["sparkle", "opal", "glisten"]}})`, async () => {


### PR DESCRIPTION
## Summary

Add generic expose-level Home Assistant discovery metadata fields and use them in `m.electricityMeter()` for secondary electrical telemetry:

- `entityCategory`
- `deviceClass`
- `enabledByDefault`
- `icon`

The meter extension now marks voltage, phase voltage, and AC frequency exposes as Home Assistant diagnostics while leaving primary power/energy/current exposes unchanged.

## Why

This moves the electrical telemetry categorization to ZHC, where the expose intent is defined, instead of hardcoding secondary electrical heuristics in Zigbee2MQTT. Zigbee2MQTT can then consume the expose metadata generically.

## Validation

Local validation:

- `pnpm install --frozen-lockfile`
- `pnpm exec biome check --error-on-warnings src/lib/exposes.ts src/lib/modernExtend.ts test/modernExtend.test.ts`
- `pnpm vitest run test/modernExtend.test.ts --config ./test/vitest.config.mts -t "electricityMeter marks secondary electrical telemetry diagnostic"`
- `pnpm run build`
- `pnpm vitest run test/modernExtend.test.ts --config ./test/vitest.config.mts`
- commit hook full validation: `pnpm run build`, `pnpm run check`, `pnpm test` -> 21 test files / 630 tests passed

## Paired work

- Koenkk/zigbee2mqtt#32380 consumes expose-level Home Assistant metadata and maps it to MQTT discovery payload fields.
- Koenkk/zigbee2mqtt.io#5271 documents the Home Assistant behavior.
