### PR TITLE
fix: set disableDefaultResponse for several Tuya switch modules

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7036,7 +7036,7 @@ export const definitions: DefinitionWithExtend[] = [
         endpoint: (device) => {
             return {l1: 1, l2: 2};
         },
-        meta: {multiEndpoint: true},
+        meta: {multiEndpoint: true, disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
 
@@ -7286,7 +7286,7 @@ export const definitions: DefinitionWithExtend[] = [
         endpoint: (device) => {
             return {l1: 1, l2: 2, l3: 3};
         },
-        meta: {multiEndpoint: true},
+        meta: {multiEndpoint: true, disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
@@ -7436,6 +7436,7 @@ export const definitions: DefinitionWithExtend[] = [
                 inchingSwitch: (m) => m === "_TZ3000_afgzktgb",
             }),
         ],
+        meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
@@ -11010,6 +11011,7 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "Mercator Ikuü", model: "SSW01"},
             tuya.whitelabel("Nous", "LZ3", "Smart water/gas valve", ["_TZ3000_abjodzas"]),
         ],
+        meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
@@ -11267,6 +11269,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Nova Digital", "SA-4", "Safira smart light switch - 4 gang", ["_TZ3000_iymfxdis"]),
             tuya.whitelabel("AVATTO", "ZBTS60-04", "4 gang switch module with backlight", ["_TZ3000_r9e2w7dn"]),
         ],
+        meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);


### PR DESCRIPTION
These Tuya switch modules — `TS0001_switch_module`, `TS0002_basic`, `TS0003_switch_module_2`, `TS0004`, `TS0011` — frequently do **not** send a ZCL Default Response to on/off commands. With the default response expected, zigbee-herdsman waits the full 10 s command timeout for every command. Because commands to a device are serialized, this stacks badly when several gangs/lights are toggled in quick succession (a scene, or a multi-button scene switch): the lights appear to "hang" for many seconds even though the switch physically actuates.

Setting `meta.disableDefaultResponse` makes on/off fire-and-forget; the new state is still confirmed by the device's own attribute reports. This matches the existing `TS0003` `_TZ3000_ouwfc1qj` variant, which already sets `meta.disableDefaultResponse`.

Verified on real `_TZ3000_*` / `_TZ3210_*` devices: the outgoing `genOnOff` command frame changes from `disableDefaultResponse:false` to `true`, the 10 s timeouts disappear, and attribute-report based state stays correct.

For the multi-endpoint definitions `multiEndpoint` is unchanged (`TS0004` keeps it via `deviceEndpoints`).

Trade-off worth noting for reviewers: for any units of these models that *do* answer reliably, z2m will no longer surface a per-command failure (it relies on the attribute report instead). Given these modules are well-known unreliable responders, fire-and-forget is the better default — happy to scope this to specific manufacturerNames if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
