### PR TITLE
fix: Prevent stale Wyze lock raw frames

### DIFF
--- a/src/devices/wyze.ts
+++ b/src/devices/wyze.ts
@@ -6,12 +6,28 @@ import type {DefinitionWithExtend, Fz} from "../lib/types";
 
 const e = exposes.presets;
 
+const wyzeLockRawSeq = new Map<string, number>();
+
+const isStaleWyzeLockRawFrame = (msg: Fz.Message<64512, undefined, "raw">): boolean => {
+    if (msg.data.length <= 3) return false;
+    const seq = msg.data[3];
+    const key = `${msg.device.ieeeAddr}:${msg.endpoint.ID}`;
+    const lastSeq = wyzeLockRawSeq.get(key);
+
+    if (lastSeq !== undefined && seq <= lastSeq && lastSeq - seq < 50) return true;
+
+    wyzeLockRawSeq.set(key, seq);
+    return false;
+};
+
 // The Wyze Lock v1 reports lock state via manufacturer-specific cluster 64512 (0xFC00)
 // raw frames rather than standard ZCL lock operation events.
 // Only len=85 frames reliably encode physical lock state at byte 80:
 //   low two bits 0b11 = locked, 0b00 = unlocked.
 // Heartbeat/rejoin frames (len=123) always have byte 80 = 0 regardless of actual state
 // and must be skipped to avoid corrupting HA state on Z2M restart.
+// Raw frames can also arrive out of order; byte 3 is a per-device sequence byte and
+// stale frames must be skipped to avoid publishing an old lock state after a newer one.
 // fz.lock is intentionally excluded: the device sends a ZCL lockState attribute report
 // (cluster 0x0101) approximately every hour that always contains lockState=1 (locked)
 // regardless of the actual physical state, causing false "locked" updates in HA.
@@ -20,7 +36,8 @@ const fzLocal = {
         cluster: 64512,
         type: ["raw"],
         convert: (model, msg) => {
-            if (msg.data?.length !== 85) return undefined;
+            if (isStaleWyzeLockRawFrame(msg)) return undefined;
+            if (msg.data.length !== 85) return undefined;
             const stateBit = msg.data[80] & 3;
             if (stateBit === 3) return {state: "LOCK", lock_state: "locked"};
             if (stateBit === 0) return {state: "UNLOCK", lock_state: "unlocked"};


### PR DESCRIPTION
Follow-up to #12438 and #12462.

After running those fixes on multiple WLCKG1 locks at home for about a week, I noticed one remaining edge case: the lock can deliver manufacturer-specific raw frames out of order. In one observed sequence, an older `len=85` unlock frame arrived after newer lock frames, causing Zigbee2MQTT to publish a stale unlocked state.

This PR keeps the previous `len=85` / `b80 & 3` decoder intact and only adds sequence suppression before decoding. Byte `3` appears to act as a per-lock raw-frame sequence byte, matching the same general approach used by the ZHA community quirks to ignore duplicate/out-of-order Wyze raw frames.

Observed bad sequence:

```text
b3=89 -> UNLOCK
b3=90 -> LOCK
b3=91 -> short frame
b3=92 -> LOCK
b3=87 -> stale UNLOCK, arrived last
```

Validation:
- Running in my home for about a week without issues across multiple WLCKG1 locks.
- pnpm exec biome check --error-on-warnings src/devices/wyze.ts
- pnpm build
- pre-commit hook: pnpm check, pnpm build, pnpm test (629 tests passed)