### PR TITLE
fix: Tuya TS011F_plug_1 `_TZ3008_reatplte`: report correct voltage/power

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10037,6 +10037,15 @@ export const definitions: DefinitionWithExtend[] = [
                 acCurrentDivisor,
                 acCurrentMultiplier: 1,
             });
+            // _TZ3008_reatplte reports voltage and power scaled by 10 (e.g. rmsVoltage=2350 means 235.0V).
+            // The device exposes the correct divisors via the haElectricalMeasurement cluster, but
+            // TS011F_plug_1's configure does not read them, so the cache defaults to 1 and values appear 10x too large.
+            // Reading the acCurrent* attributes fails on this device with UNSUPPORTED_ATTRIBUTE (like other
+            // Tuya TS011F plugs, see comment about _TZ3000_0zfrhq4i above), so only the voltage and power
+            // divisors are read from the device here; current uses the hardcoded value saved above.
+            if (device.manufacturerName === "_TZ3008_reatplte") {
+                await endpoint.read("haElectricalMeasurement", ["acVoltageMultiplier", "acVoltageDivisor", "acPowerMultiplier", "acPowerDivisor"]);
+            }
             endpoint.saveClusterAttributeKeyValue("seMetering", {
                 divisor: 100,
                 multiplier: 1,

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -10037,14 +10037,24 @@ export const definitions: DefinitionWithExtend[] = [
                 acCurrentDivisor,
                 acCurrentMultiplier: 1,
             });
-            // _TZ3008_reatplte reports voltage and power scaled by 10 (e.g. rmsVoltage=2350 means 235.0V).
-            // The device exposes the correct divisors via the haElectricalMeasurement cluster, but
-            // TS011F_plug_1's configure does not read them, so the cache defaults to 1 and values appear 10x too large.
-            // Reading the acCurrent* attributes fails on this device with UNSUPPORTED_ATTRIBUTE (like other
-            // Tuya TS011F plugs, see comment about _TZ3000_0zfrhq4i above), so only the voltage and power
-            // divisors are read from the device here; current uses the hardcoded value saved above.
-            if (device.manufacturerName === "_TZ3008_reatplte") {
-                await endpoint.read("haElectricalMeasurement", ["acVoltageMultiplier", "acVoltageDivisor", "acPowerMultiplier", "acPowerDivisor"]);
+            // Some TS011F plugs (e.g. _TZ3008_reatplte) report voltage/power/current scaled by a non-default
+            // factor and expose the correct multipliers/divisors via the haElectricalMeasurement cluster.
+            // Try to read each attribute individually because some devices return UNSUPPORTED_ATTRIBUTE for a
+            // subset, and reading them in bulk would cause one failure to abort the rest. Successful reads are
+            // cached by zigbee-herdsman and override the hardcoded values saved above.
+            for (const attr of [
+                "acVoltageMultiplier",
+                "acVoltageDivisor",
+                "acPowerMultiplier",
+                "acPowerDivisor",
+                "acCurrentMultiplier",
+                "acCurrentDivisor",
+            ] as const) {
+                try {
+                    await endpoint.read("haElectricalMeasurement", [attr]);
+                } catch {
+                    /* Not all Tuya plugs expose all multiplier/divisor attributes; fall back to defaults. */
+                }
             }
             endpoint.saveClusterAttributeKeyValue("seMetering", {
                 divisor: 100,


### PR DESCRIPTION
This device reports rmsVoltage and activePower scaled by 10 (e.g. rmsVoltage=2350 means 235.0V, activePower=1039 means 103.9W) and exposes the correct acVoltageDivisor=10 and acPowerDivisor=10 when those attributes are read. The TS011F_plug_1 configure step only saves acCurrentDivisor in the haElectricalMeasurement attribute cache, so these divisors default to 1 and fz.electrical_measurement publishes values ~10x too large.

Read the voltage and power multipliers/divisors from the device during configure for `_TZ3008_reatplte` so the correct factors end up in the attribute cache. The current attributes (acCurrent*) are intentionally not read because this device returns UNSUPPORTED_ATTRIBUTE for them, like other Tuya TS011F plugs; the existing hardcoded acCurrentDivisor handling is unchanged.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/32404

