### PR TITLE
fix(NodOn): fix SDC-4-1-00 dry contact sensor (inverted logic, wrong attribute, add reporting)

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -79,15 +79,6 @@ const nodonModernExtend = {
             zigbeeCommandOptions: {manufacturerCode: 0x128b},
             ...args,
         }),
-    dryContact: (args?: Partial<m.EnumLookupArgs<"genBinaryInput">>) =>
-        m.enumLookup({
-            name: "dry_contact",
-            lookup: {contact_closed: 0x00, contact_open: 0x01},
-            cluster: "genBinaryInput",
-            attribute: {ID: 0x055, type: Zcl.DataType.ENUM8},
-            description: "State of the contact, closed or open.",
-            ...args,
-        }),
     impulseMode: (args?: Partial<m.NumericArgs<"genOnOff">>) => {
         const resultName = "impulse_mode_configuration";
         const resultUnit = "ms";
@@ -284,7 +275,19 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SDC-4-1-00",
         vendor: "NodOn",
         description: "Dry contact sensor",
-        extend: [m.battery({voltageReporting: true}), nodonModernExtend.dryContact()],
+        extend: [
+            m.battery({voltageReporting: true}),
+            m.binary({
+                name: "dry_contact",
+                cluster: "genBinaryInput",
+                attribute: "presentValue",
+                reporting: {attribute: "presentValue", min: 0, max: constants.repInterval.HOUR, change: 1},
+                valueOn: ["contact_closed", 1],
+                valueOff: ["contact_open", 0],
+                description: "State of the dry contact, closed or open.",
+                access: "STATE_GET",
+            }),
+        ],
         ota: true,
     },
     {

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -281,7 +281,7 @@ export const definitions: DefinitionWithExtend[] = [
                 name: "dry_contact",
                 cluster: "genBinaryInput",
                 attribute: "presentValue",
-                reporting: {attribute: "presentValue", min: 0, max: constants.repInterval.HOUR, change: 1},
+                reporting: {min: 0, max: constants.repInterval.HOUR, change: 1},
                 valueOn: ["contact_closed", 1],
                 valueOff: ["contact_open", 0],
                 description: "State of the dry contact, closed or open.",


### PR DESCRIPTION
### Problem

The current `SDC-4-1-00` definition uses `nodonModernExtend.dryContact()`, which has three bugs:

**1. Inverted contact logic**

```typescript
lookup: {contact_closed: 0x00, contact_open: 0x01}
```

The device reports `presentValue = 1` when the contact is **closed**. The current mapping is inverted.

**2. Wrong attribute key**

```typescript
attribute: {ID: 0x055, type: Zcl.DataType.ENUM8}
```

`presentValue` (0x0055) is a named attribute in the cluster definition. Using a numeric ID causes zigbee-herdsman to look for key `85` (number) in `msg.data`, while it stores it as `"presentValue"` (string). The contact state never updates.

**3. No `configureReporting`**

Without it, no heartbeat is configured and the attribute does not appear in Z2M's Reporting tab.

---

### Fix

Replace `nodonModernExtend.dryContact()` with `m.binary` inline and remove the now-unused helper.

---

### Tested

- Device: **SDC-4-1-00** firmware V4.3.0
- Platform: Z2M 2.12.0 / zigbee-herdsman-converters 26.72.0
- Coordinator: SONOFF Zigbee 3.0 USB Dongle Plus-E (EFR32MG21, firmware 7.4.4 GA)
- `contact_closed` / `contact_open` transitions confirmed on multiple open/close cycles
