### PR TITLE
feat(NodOn): add SEM-4-1-00 energy reset, configureReporting and apparent power

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -329,7 +329,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withCategory('config'),
             e.power_apparent(),
         ],
-        configure: async (device, coordinatorEndpoint, logger) => {
+        configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
 
             // Explicit bind — not done by m.electricityMeter because configureReporting: false
@@ -345,37 +345,22 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.read('seMetering', ['multiplier', 'divisor']);
 
             // Split into batches of ≤5 to stay within the ~85-byte ZCL frame limit
-            try {
-                await endpoint.configureReporting('haElectricalMeasurement', [
-                    {attribute: 'acFrequency',   minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 500},  // 5 Hz
-                    {attribute: 'rmsVoltage',    minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 2300}, // 23 V
-                    {attribute: 'rmsCurrent',    minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 100},  // 1 A
-                    {attribute: 'activePower',   minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 W
-                    {attribute: 'apparentPower', minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 VA
-                ]);
-            } catch (error) {
-                logger.debug(`SEM-4-1-00: haElectricalMeasurement batch 1 configureReporting failed: ${(error as Error).message}`);
-            }
-            try {
-                await endpoint.configureReporting('haElectricalMeasurement', [
-                    {attribute: 'powerFactor', minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 20}, // 0.20
-                ]);
-            } catch (error) {
-                logger.debug(`SEM-4-1-00: haElectricalMeasurement batch 2 configureReporting failed: ${(error as Error).message}`);
-            }
-
-            const seAttrs = [
+            await endpoint.configureReporting('haElectricalMeasurement', [
+                {attribute: 'acFrequency',   minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 500},  // 5 Hz
+                {attribute: 'rmsVoltage',    minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 2300}, // 23 V
+                {attribute: 'rmsCurrent',    minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 100},  // 1 A
+                {attribute: 'activePower',   minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 W
+                {attribute: 'apparentPower', minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 VA
+            ]);
+            await endpoint.configureReporting('haElectricalMeasurement', [
+                {attribute: 'powerFactor', minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 20}, // 0.20
+            ]);
+            await endpoint.configureReporting('seMetering', [
                 {attribute: 'currentSummDelivered', minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
-                {attribute: 'currentSummReceived',  minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
-            ];
-
-            for (const attr of seAttrs) {
-                try {
-                    await endpoint.configureReporting('seMetering', [attr]);
-                } catch (error) {
-                    logger.debug(`SEM-4-1-00: seMetering/${attr.attribute} configureReporting failed: ${(error as Error).message}`);
-                }
-            }
+            ]);
+            await endpoint.configureReporting('seMetering', [
+                {attribute: 'currentSummReceived', minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
+            ]);
         },
         ota: true,
     },

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -299,18 +299,84 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
     },
     {
-        zigbeeModel: ["SEM-4-1-00"],
-        model: "SEM-4-1-00",
-        vendor: "NodOn",
-        description: "Energy monitoring sensor",
+        zigbeeModel: ['SEM-4-1-00'],
+        model: 'SEM-4-1-00',
+        vendor: 'NodOn',
+        description: 'Energy monitoring sensor',
         extend: [
+            m.identify(),
             m.electricityMeter({
                 acFrequency: true,
                 powerFactor: true,
                 producedEnergy: true,
+                configureReporting: false,
             }),
         ],
-        exposes: [e.power_apparent()],
+        toZigbee: [
+            {
+                key: ['energy_reset'],
+                convertSet: async (entity, _key, _value, _meta) => {
+                    // genBasic/resetFactDefault resets all cluster attributes to factory defaults.
+                    // Network membership, bindings and configureReporting are not affected (ZCL spec).
+                    await entity.command('genBasic', 'resetFactDefault', {});
+                    return {state: {}};
+                },
+            },
+        ],
+        exposes: [
+            e.enum('energy_reset', ea.SET, ['reset'])
+                .withDescription('Reset all energy counters to 0')
+                .withCategory('config'),
+            e.power_apparent(),
+        ],
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+
+            // Explicit bind — not done by m.electricityMeter because configureReporting: false
+            await endpoint.bind('haElectricalMeasurement', coordinatorEndpoint);
+            await endpoint.bind('seMetering', coordinatorEndpoint);
+
+            await endpoint.read('haElectricalMeasurement', [
+                'acVoltageMultiplier', 'acVoltageDivisor',
+                'acCurrentMultiplier', 'acCurrentDivisor',
+                'acPowerMultiplier', 'acPowerDivisor',
+                'acFrequencyMultiplier', 'acFrequencyDivisor',
+            ]);
+            await endpoint.read('seMetering', ['multiplier', 'divisor']);
+
+            // Split into batches of ≤5 to stay within the ~85-byte ZCL frame limit
+            try {
+                await endpoint.configureReporting('haElectricalMeasurement', [
+                    {attribute: 'acFrequency',   minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 500},  // 5 Hz
+                    {attribute: 'rmsVoltage',    minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 2300}, // 23 V
+                    {attribute: 'rmsCurrent',    minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 100},  // 1 A
+                    {attribute: 'activePower',   minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 W
+                    {attribute: 'apparentPower', minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 VA
+                ]);
+            } catch (error) {
+                logger.debug(`SEM-4-1-00: haElectricalMeasurement batch 1 configureReporting failed: ${(error as Error).message}`);
+            }
+            try {
+                await endpoint.configureReporting('haElectricalMeasurement', [
+                    {attribute: 'powerFactor', minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 20}, // 0.20
+                ]);
+            } catch (error) {
+                logger.debug(`SEM-4-1-00: haElectricalMeasurement batch 2 configureReporting failed: ${(error as Error).message}`);
+            }
+
+            const seAttrs = [
+                {attribute: 'currentSummDelivered', minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
+                {attribute: 'currentSummReceived',  minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
+            ];
+
+            for (const attr of seAttrs) {
+                try {
+                    await endpoint.configureReporting('seMetering', [attr]);
+                } catch (error) {
+                    logger.debug(`SEM-4-1-00: seMetering/${attr.attribute} configureReporting failed: ${(error as Error).message}`);
+                }
+            }
+        },
         ota: true,
     },
     {

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -299,10 +299,10 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
     },
     {
-        zigbeeModel: ['SEM-4-1-00'],
-        model: 'SEM-4-1-00',
-        vendor: 'NodOn',
-        description: 'Energy monitoring sensor',
+        zigbeeModel: ["SEM-4-1-00"],
+        model: "SEM-4-1-00",
+        vendor: "NodOn",
+        description: "Energy monitoring sensor",
         extend: [
             m.identify(),
             m.electricityMeter({
@@ -314,52 +314,54 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         toZigbee: [
             {
-                key: ['energy_reset'],
+                key: ["energy_reset"],
                 convertSet: async (entity, _key, _value, _meta) => {
                     // genBasic/resetFactDefault resets all cluster attributes to factory defaults.
                     // Network membership, bindings and configureReporting are not affected (ZCL spec).
-                    await entity.command('genBasic', 'resetFactDefault', {});
+                    await entity.command("genBasic", "resetFactDefault", {});
                     return {state: {}};
                 },
             },
         ],
         exposes: [
-            e.enum('energy_reset', ea.SET, ['reset'])
-                .withDescription('Reset all energy counters to 0')
-                .withCategory('config'),
+            e.enum("energy_reset", ea.SET, ["reset"]).withDescription("Reset all energy counters to 0").withCategory("config"),
             e.power_apparent(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
 
             // Explicit bind — not done by m.electricityMeter because configureReporting: false
-            await endpoint.bind('haElectricalMeasurement', coordinatorEndpoint);
-            await endpoint.bind('seMetering', coordinatorEndpoint);
+            await endpoint.bind("haElectricalMeasurement", coordinatorEndpoint);
+            await endpoint.bind("seMetering", coordinatorEndpoint);
 
-            await endpoint.read('haElectricalMeasurement', [
-                'acVoltageMultiplier', 'acVoltageDivisor',
-                'acCurrentMultiplier', 'acCurrentDivisor',
-                'acPowerMultiplier', 'acPowerDivisor',
-                'acFrequencyMultiplier', 'acFrequencyDivisor',
+            await endpoint.read("haElectricalMeasurement", [
+                "acVoltageMultiplier",
+                "acVoltageDivisor",
+                "acCurrentMultiplier",
+                "acCurrentDivisor",
+                "acPowerMultiplier",
+                "acPowerDivisor",
+                "acFrequencyMultiplier",
+                "acFrequencyDivisor",
             ]);
-            await endpoint.read('seMetering', ['multiplier', 'divisor']);
+            await endpoint.read("seMetering", ["multiplier", "divisor"]);
 
             // Split into batches of ≤5 to stay within the ~85-byte ZCL frame limit
-            await endpoint.configureReporting('haElectricalMeasurement', [
-                {attribute: 'acFrequency',   minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 500},  // 5 Hz
-                {attribute: 'rmsVoltage',    minimumReportInterval: 30,  maximumReportInterval: 3600, reportableChange: 2300}, // 23 V
-                {attribute: 'rmsCurrent',    minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 100},  // 1 A
-                {attribute: 'activePower',   minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 W
-                {attribute: 'apparentPower', minimumReportInterval: 10,  maximumReportInterval: 3600, reportableChange: 250},  // 250 VA
+            await endpoint.configureReporting("haElectricalMeasurement", [
+                {attribute: "acFrequency", minimumReportInterval: 30, maximumReportInterval: 3600, reportableChange: 500}, // 5 Hz
+                {attribute: "rmsVoltage", minimumReportInterval: 30, maximumReportInterval: 3600, reportableChange: 2300}, // 23 V
+                {attribute: "rmsCurrent", minimumReportInterval: 10, maximumReportInterval: 3600, reportableChange: 100}, // 1 A
+                {attribute: "activePower", minimumReportInterval: 10, maximumReportInterval: 3600, reportableChange: 250}, // 250 W
+                {attribute: "apparentPower", minimumReportInterval: 10, maximumReportInterval: 3600, reportableChange: 250}, // 250 VA
             ]);
-            await endpoint.configureReporting('haElectricalMeasurement', [
-                {attribute: 'powerFactor', minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 20}, // 0.20
+            await endpoint.configureReporting("haElectricalMeasurement", [
+                {attribute: "powerFactor", minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 20}, // 0.20
             ]);
-            await endpoint.configureReporting('seMetering', [
-                {attribute: 'currentSummDelivered', minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
+            await endpoint.configureReporting("seMetering", [
+                {attribute: "currentSummDelivered", minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
             ]);
-            await endpoint.configureReporting('seMetering', [
-                {attribute: 'currentSummReceived', minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
+            await endpoint.configureReporting("seMetering", [
+                {attribute: "currentSummReceived", minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
             ]);
         },
         ota: true,

--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -306,10 +306,18 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.identify(),
             m.electricityMeter({
-                acFrequency: true,
+                // A forced object's `change` is not auto-scaled by the multiplier/divisor (unlike
+                // the default change) — values below are already raw ZCL units. Factors measured
+                // on physical devices: acPowerMultiplier/Divisor=1/1, acCurrentMultiplier/Divisor=1/100,
+                // acVoltageMultiplier/Divisor=1/100, acFrequencyMultiplier/Divisor=1/100.
+                voltage: {min: 30, max: 3600, change: 2300}, // 23 V
+                current: {min: 10, max: 3600, change: 100}, // 1 A
+                power: {min: 10, max: 3600, change: 250}, // 250 W
+                acFrequency: {min: 30, max: 3600, change: 500}, // 5 Hz
+                producedEnergy: {min: 300, max: 3600, change: 10}, // 0.1 kWh
+                energy: {min: 300, max: 3600, change: 10}, // 0.1 kWh
+                apparentPower: {min: 10, max: 3600, change: 250}, // 250 VA, shares activePower's factor
                 powerFactor: true,
-                producedEnergy: true,
-                configureReporting: false,
             }),
         ],
         toZigbee: [
@@ -323,47 +331,7 @@ export const definitions: DefinitionWithExtend[] = [
                 },
             },
         ],
-        exposes: [
-            e.enum("energy_reset", ea.SET, ["reset"]).withDescription("Reset all energy counters to 0").withCategory("config"),
-            e.power_apparent(),
-        ],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-
-            // Explicit bind — not done by m.electricityMeter because configureReporting: false
-            await endpoint.bind("haElectricalMeasurement", coordinatorEndpoint);
-            await endpoint.bind("seMetering", coordinatorEndpoint);
-
-            await endpoint.read("haElectricalMeasurement", [
-                "acVoltageMultiplier",
-                "acVoltageDivisor",
-                "acCurrentMultiplier",
-                "acCurrentDivisor",
-                "acPowerMultiplier",
-                "acPowerDivisor",
-                "acFrequencyMultiplier",
-                "acFrequencyDivisor",
-            ]);
-            await endpoint.read("seMetering", ["multiplier", "divisor"]);
-
-            // Split into batches of ≤5 to stay within the ~85-byte ZCL frame limit
-            await endpoint.configureReporting("haElectricalMeasurement", [
-                {attribute: "acFrequency", minimumReportInterval: 30, maximumReportInterval: 3600, reportableChange: 500}, // 5 Hz
-                {attribute: "rmsVoltage", minimumReportInterval: 30, maximumReportInterval: 3600, reportableChange: 2300}, // 23 V
-                {attribute: "rmsCurrent", minimumReportInterval: 10, maximumReportInterval: 3600, reportableChange: 100}, // 1 A
-                {attribute: "activePower", minimumReportInterval: 10, maximumReportInterval: 3600, reportableChange: 250}, // 250 W
-                {attribute: "apparentPower", minimumReportInterval: 10, maximumReportInterval: 3600, reportableChange: 250}, // 250 VA
-            ]);
-            await endpoint.configureReporting("haElectricalMeasurement", [
-                {attribute: "powerFactor", minimumReportInterval: 60, maximumReportInterval: 3600, reportableChange: 20}, // 0.20
-            ]);
-            await endpoint.configureReporting("seMetering", [
-                {attribute: "currentSummDelivered", minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
-            ]);
-            await endpoint.configureReporting("seMetering", [
-                {attribute: "currentSummReceived", minimumReportInterval: 300, maximumReportInterval: 3600, reportableChange: 100}, // 0.1 kWh
-            ]);
-        },
+        exposes: [e.enum("energy_reset", ea.SET, ["reset"]).withDescription("Reset all energy counters to 0").withCategory("config")],
         ota: true,
     },
     {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1914,7 +1914,8 @@ interface MeterArgs {
     threePhase?: boolean;
     producedEnergy?: false | true | (MultiplierDivisor & Partial<ReportingConfigWithoutAttribute>);
     acFrequency?: false | true | (MultiplierDivisor & Partial<ReportingConfigWithoutAttribute>);
-    powerFactor?: boolean;
+    apparentPower?: false | true | (MultiplierDivisor & Partial<ReportingConfigWithoutAttribute>);
+    powerFactor?: false | true | Partial<ReportingConfigWithoutAttribute>;
     tariffs?: boolean;
     // biome-ignore lint/suspicious/noExplicitAny: generic
     fzElectricalMeasurement?: Fz.Converter<"haElectricalMeasurement", any, any>;
@@ -2019,7 +2020,16 @@ function genericMeter(args: MeterArgs = {}) {
             },
             power_factor: {
                 attribute: "powerFactor" as const,
+                forced: isObject(args.powerFactor) ? args.powerFactor : (false as const),
                 change: 10,
+            },
+            // Report change with every 5VA change
+            apparent_power: {
+                attribute: "apparentPower" as const,
+                divisor: "acPowerDivisor",
+                multiplier: "acPowerMultiplier",
+                forced: isObject(args.apparentPower) ? args.apparentPower : (false as const),
+                change: 5,
             },
             // Report change with every 5V change
             voltage: {
@@ -2162,6 +2172,9 @@ function genericMeter(args: MeterArgs = {}) {
     if (args.acFrequency === false) {
         delete configureLookup.haElectricalMeasurement.ac_frequency;
     }
+    if (args.apparentPower === false) {
+        delete configureLookup.haElectricalMeasurement.apparent_power;
+    }
     if (args.threePhase === false) {
         delete configureLookup.haElectricalMeasurement.power_phase_b;
         delete configureLookup.haElectricalMeasurement.power_phase_c;
@@ -2177,6 +2190,7 @@ function genericMeter(args: MeterArgs = {}) {
         delete configureLookup.haElectricalMeasurement.current;
         delete configureLookup.haElectricalMeasurement.power_factor;
         delete configureLookup.haElectricalMeasurement.ac_frequency;
+        delete configureLookup.haElectricalMeasurement.apparent_power;
         delete configureLookup.haElectricalMeasurement.power_phase_b;
         delete configureLookup.haElectricalMeasurement.power_phase_c;
         delete configureLookup.haElectricalMeasurement.current_phase_b;
@@ -2209,6 +2223,7 @@ function genericMeter(args: MeterArgs = {}) {
         if (args.voltage !== false) exposes.push(e.voltage().withAccess(ea.STATE_GET));
         if (args.acFrequency !== false) exposes.push(e.ac_frequency().withAccess(ea.STATE_GET));
         if (args.powerFactor !== false) exposes.push(e.power_factor().withAccess(ea.STATE_GET));
+        if (args.apparentPower !== false) exposes.push(e.power_apparent());
         if (args.current !== false) exposes.push(e.current().withAccess(ea.STATE_GET));
         if (args.energy !== false) exposes.push(e.energy().withAccess(ea.STATE_GET));
         if (args.producedEnergy !== false) exposes.push(e.produced_energy().withAccess(ea.STATE_GET));
@@ -2292,6 +2307,7 @@ function genericMeter(args: MeterArgs = {}) {
         if (args.current !== false) exposes.push(e.current().withAccess(ea.STATE_GET));
         if (args.acFrequency !== false) exposes.push(e.ac_frequency().withAccess(ea.STATE_GET));
         if (args.powerFactor !== false) exposes.push(e.power_factor().withAccess(ea.STATE_GET));
+        if (args.apparentPower !== false) exposes.push(e.power_apparent());
         fromZigbee = [args.fzElectricalMeasurement ?? fz.electrical_measurement];
 
         toZigbee = [tz.electrical_measurement_power, tz.acvoltage, tz.accurrent, tz.frequency, tz.powerfactor];
@@ -2392,6 +2408,7 @@ export function electricityMeter(args: ElectricityMeterArgs = {}): ModernExtend 
         producedEnergy: false,
         acFrequency: false,
         powerFactor: false,
+        apparentPower: false,
         status: false,
         extendedStatus: false,
         ...args,


### PR DESCRIPTION
### Problem

The existing entry uses `m.electricityMeter()` without a `configure` function.
As a result:
- The device falls back to firmware-default continuous reporting (~5 s interval regardless of
  load). A future firmware update will implement threshold-based reporting natively, using the
  same thresholds as defined in this PR.
- No `energy_reset` capability
- `apparentPower` and `acFrequency` missing from `configureReporting`

### Fix

- Add explicit `configure` with manual bind, multiplier reads, and batched `configureReporting`
- Add `energy_reset` via `genBasic/resetFactDefault`
- Add `m.identify()`

#### Why `configureReporting: false` + explicit configure

Without `configure`, the device uses factory-default reporting (~5 s for all attributes).
With threshold-based reporting, ×63 fewer messages were observed on a stable circuit.

Manual bind is required because `m.electricityMeter({ configureReporting: false })` skips its
own bind/configure step entirely.

Multiplier attributes (`acVoltageMultiplier`/`Divisor`, `acCurrentMultiplier`/`Divisor`,
`acPowerMultiplier`/`Divisor`, `acFrequencyMultiplier`/`Divisor`) are read before
`configureReporting` so ZHC has them in cluster cache to scale the first received reports.

`haElectricalMeasurement configureReporting` is split into batches of ≤5 attributes: a single
call with 6 attributes exceeds the ~85-byte ZCL frame limit and returns `status=FAIL`.

#### Why `energy_reset` via `genBasic/resetFactDefault`

This is the only counter-reset mechanism available in the current firmware. `resetFactDefault`
resets all cluster attributes to factory defaults — it does not affect Zigbee network membership,
bindings, or `configureReporting` (ZCL spec).

### Tested

- Device: SEM-4-1-00
- Platform: Z2M 2.12.0 / zigbee-herdsman-converters 26.72.0
- `voltage`, `current`, `power`, `power_apparent`, `ac_frequency`, `power_factor`, `energy`,
  `produced_energy` confirmed working
- `energy_reset` confirmed working
- `identify` confirmed working