### PR TITLE
Read Shelly input type through RPC

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2076,16 +2076,72 @@ const fzLocal = {
     } satisfies Fz.Converter<"ssIasZone", undefined, ["commandStatusChangeNotification", "attributeReport", "readResponse"]>,
 };
 
+const shellyRpcResult = (response: KeyValue | undefined): KeyValue | undefined => {
+    const result = response?.result ?? response?.params ?? response;
+    if (!result) return undefined;
+    assertObject<KeyValue>(result);
+    return result;
+};
+
+const getShellyInputId = (meta: Pick<Tz.Meta, "endpoint_name">): number => {
+    if (meta.endpoint_name === "sw2") return 1;
+    return 0;
+};
+
+const getShellyRpcEndpoint = (entity: Zh.Endpoint | Zh.Group): Zh.Endpoint | undefined => {
+    if (!utils.isEndpoint(entity)) return undefined;
+    return entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
+};
+
+const shellyInputTypeLookup = {
+    switch: "toggle",
+    button: "momentary",
+} as const;
+
+const shellyInputTypeSetLookup = {
+    toggle: "switch",
+    momentary: "button",
+} as const;
+
 const tzLocal = {
     switch_input_type: {
         key: ["switch_type"],
         convertSet: async (entity, key, value, meta) => {
             const lookup = {toggle: 0, momentary: 1} as const;
+            const rpcEndpoint = getShellyRpcEndpoint(entity);
+            if (rpcEndpoint) {
+                const inputId = getShellyInputId(meta);
+                try {
+                    await shellyRpcSend(rpcEndpoint, "Input.SetConfig", {
+                        id: inputId,
+                        config: {type: utils.getFromLookup(value as string, shellyInputTypeSetLookup)},
+                    });
+                    return {state: {switch_type: value}};
+                } catch {
+                    // Fall back to the standard Zigbee input config cluster for devices that expose it.
+                }
+            }
+
             const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
             await ep.write("genOnOffSwitchCfg", {switchType: utils.getFromLookup(value as string, lookup)});
             return {state: {switch_type: value}};
         },
         convertGet: async (entity, key, meta) => {
+            const rpcEndpoint = getShellyRpcEndpoint(entity);
+            if (rpcEndpoint) {
+                const inputId = getShellyInputId(meta);
+                try {
+                    const config = shellyRpcResult(await shellyRpcRequest(rpcEndpoint, "Input.GetConfig", {id: inputId}));
+                    if (typeof config?.type === "string") {
+                        const switchType = utils.getFromLookup(config.type, shellyInputTypeLookup);
+                        meta.publish({[meta.endpoint_name ? `switch_type_${meta.endpoint_name}` : "switch_type"]: switchType});
+                    }
+                    return;
+                } catch {
+                    // Fall back to the standard Zigbee input config cluster for devices that expose it.
+                }
+            }
+
             const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
             await ep.read("genOnOffSwitchCfg", ["switchType"]);
         },

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2149,30 +2149,11 @@ const shellyInputTypeLookup = {
     button: "momentary",
 } as const;
 
-const shellyInputTypeSetLookup = {
-    toggle: "switch",
-    momentary: "button",
-} as const;
-
 const tzLocal = {
     switch_input_type: {
         key: ["switch_type"],
         convertSet: async (entity, key, value, meta) => {
             const lookup = {toggle: 0, momentary: 1} as const;
-            const rpcEndpoint = getShellyRpcEndpoint(entity);
-            if (rpcEndpoint) {
-                const inputId = getShellyInputId(meta);
-                try {
-                    await shellyRpcSend(rpcEndpoint, "Input.SetConfig", {
-                        id: inputId,
-                        config: {type: utils.getFromLookup(value as string, shellyInputTypeSetLookup)},
-                    });
-                    return {state: {switch_type: value}};
-                } catch {
-                    // Fall back to the standard Zigbee input config cluster for devices that expose it.
-                }
-            }
-
             const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
             await ep.write("genOnOffSwitchCfg", {switchType: utils.getFromLookup(value as string, lookup)});
             return {state: {switch_type: value}};

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2134,11 +2134,6 @@ const shellyRpcResult = (response: KeyValue | undefined): KeyValue | undefined =
     return result;
 };
 
-const getShellyInputId = (meta: Pick<Tz.Meta, "endpoint_name">): number => {
-    if (meta.endpoint_name === "sw2") return 1;
-    return 0;
-};
-
 const getShellyRpcEndpoint = (entity: Zh.Endpoint | Zh.Group): Zh.Endpoint | undefined => {
     if (!utils.isEndpoint(entity)) return undefined;
     return entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
@@ -2153,15 +2148,22 @@ const tzLocal = {
     switch_input_type: {
         key: ["switch_type"],
         convertSet: async (entity, key, value, meta) => {
-            const lookup = {toggle: 0, momentary: 1} as const;
-            const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
-            await ep.write("genOnOffSwitchCfg", {switchType: utils.getFromLookup(value as string, lookup)});
+            // The firmware registers genOnOffSwitchCfg.switchType as READ_ONLY
+            // (shelly_zb_on_off_input.cpp), so a direct ZCL write returns
+            // NOT_AUTHORIZED.  Route the write through Input.SetConfig RPC instead.
+            const typeMap = {toggle: "switch", momentary: "button"} as const;
+            const shellyType = utils.getFromLookup(value as string, typeMap);
+            utils.assertEndpoint(entity);
+            const ep = entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
+            if (!ep) throw new Error(`Shelly RPC endpoint ${SHELLY_ENDPOINT_ID} not found`);
+            const switchId = Number(meta.endpoint_name?.replace("sw", "") ?? "1") - 1;
+            await shellyRpcSend(ep, "Input.SetConfig", {id: switchId, config: {type: shellyType}});
             return {state: {switch_type: value}};
         },
         convertGet: async (entity, key, meta) => {
             const rpcEndpoint = getShellyRpcEndpoint(entity);
             if (rpcEndpoint) {
-                const inputId = getShellyInputId(meta);
+                const inputId = Number(meta.endpoint_name?.replace("sw", "") ?? "1") - 1;
                 try {
                     const config = shellyRpcResult(await shellyRpcRequest(rpcEndpoint, "Input.GetConfig", {id: inputId}));
                     if (typeof config?.type === "string") {

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2127,23 +2127,72 @@ const fzLocal = {
     } satisfies Fz.Converter<"ssIasZone", undefined, ["commandStatusChangeNotification", "attributeReport", "readResponse"]>,
 };
 
+const shellyRpcResult = (response: KeyValue | undefined): KeyValue | undefined => {
+    const result = response?.result ?? response?.params ?? response;
+    if (!result) return undefined;
+    assertObject<KeyValue>(result);
+    return result;
+};
+
+const getShellyInputId = (meta: Pick<Tz.Meta, "endpoint_name">): number => {
+    if (meta.endpoint_name === "sw2") return 1;
+    return 0;
+};
+
+const getShellyRpcEndpoint = (entity: Zh.Endpoint | Zh.Group): Zh.Endpoint | undefined => {
+    if (!utils.isEndpoint(entity)) return undefined;
+    return entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
+};
+
+const shellyInputTypeLookup = {
+    switch: "toggle",
+    button: "momentary",
+} as const;
+
+const shellyInputTypeSetLookup = {
+    toggle: "switch",
+    momentary: "button",
+} as const;
+
 const tzLocal = {
     switch_input_type: {
         key: ["switch_type"],
         convertSet: async (entity, key, value, meta) => {
-            // The firmware registers genOnOffSwitchCfg.switchType as READ_ONLY
-            // (shelly_zb_on_off_input.cpp), so a direct ZCL write returns
-            // NOT_AUTHORIZED.  Route the write through Input.SetConfig RPC instead.
-            const typeMap = {toggle: "switch", momentary: "button"} as const;
-            const shellyType = utils.getFromLookup(value as string, typeMap);
-            utils.assertEndpoint(entity);
-            const ep = entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
-            if (!ep) throw new Error(`Shelly RPC endpoint ${SHELLY_ENDPOINT_ID} not found`);
-            const switchId = Number(meta.endpoint_name?.replace("sw", "") ?? "1") - 1;
-            await shellyRpcSend(ep, "Input.SetConfig", {id: switchId, config: {type: shellyType}});
+            const lookup = {toggle: 0, momentary: 1} as const;
+            const rpcEndpoint = getShellyRpcEndpoint(entity);
+            if (rpcEndpoint) {
+                const inputId = getShellyInputId(meta);
+                try {
+                    await shellyRpcSend(rpcEndpoint, "Input.SetConfig", {
+                        id: inputId,
+                        config: {type: utils.getFromLookup(value as string, shellyInputTypeSetLookup)},
+                    });
+                    return {state: {switch_type: value}};
+                } catch {
+                    // Fall back to the standard Zigbee input config cluster for devices that expose it.
+                }
+            }
+
+            const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
+            await ep.write("genOnOffSwitchCfg", {switchType: utils.getFromLookup(value as string, lookup)});
             return {state: {switch_type: value}};
         },
         convertGet: async (entity, key, meta) => {
+            const rpcEndpoint = getShellyRpcEndpoint(entity);
+            if (rpcEndpoint) {
+                const inputId = getShellyInputId(meta);
+                try {
+                    const config = shellyRpcResult(await shellyRpcRequest(rpcEndpoint, "Input.GetConfig", {id: inputId}));
+                    if (typeof config?.type === "string") {
+                        const switchType = utils.getFromLookup(config.type, shellyInputTypeLookup);
+                        meta.publish({[meta.endpoint_name ? `switch_type_${meta.endpoint_name}` : "switch_type"]: switchType});
+                    }
+                    return;
+                } catch {
+                    // Fall back to the standard Zigbee input config cluster for devices that expose it.
+                }
+            }
+
             const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
             await ep.read("genOnOffSwitchCfg", ["switchType"]);
         },

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -106,6 +106,76 @@ describe("Shelly 2PM Gen4 cover mode", () => {
         expect(state).toStrictEqual({switch_type_sw1: "toggle"});
     });
 
+    it("reads switch input type through the Shelly RPC endpoint", async () => {
+        const response = JSON.stringify({id: 1, result: {id: 1, type: "button", enable: true, invert: false}});
+        const read = vi.fn().mockResolvedValueOnce({rxCtl: response.length}).mockResolvedValueOnce({data: response});
+        const device = mockShelly2PMCoverWithInputs(read);
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((converter) => converter.key.includes("switch_type")) as Tz.Converter;
+        const publish = vi.fn();
+
+        await converter.convertGet?.(device.getEndpoint(3), "switch_type", {endpoint_name: "sw2", message: {}, publish} as never);
+
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
+            "shellyRPCCluster",
+            {data: expect.stringContaining("Input.GetConfig")},
+            expect.any(Object),
+        );
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith("shellyRPCCluster", {data: expect.stringContaining('"id":1')}, expect.any(Object));
+        expect(read).toHaveBeenCalledWith("shellyRPCCluster", ["rxCtl"], expect.any(Object));
+        expect(read).toHaveBeenCalledWith("shellyRPCCluster", ["data"], expect.any(Object));
+        expect(device.getEndpoint(3).read).not.toHaveBeenCalled();
+        expect(publish).toHaveBeenCalledWith({switch_type_sw2: "momentary"});
+    });
+
+    it("falls back to the input config cluster when Shelly RPC input type read fails", async () => {
+        const read = vi.fn().mockRejectedValueOnce(new Error("RPC unavailable"));
+        const device = mockShelly2PMCoverWithInputs(read);
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((converter) => converter.key.includes("switch_type")) as Tz.Converter;
+
+        await converter.convertGet?.(device.getEndpoint(3), "switch_type", {endpoint_name: "sw2", message: {}, publish: vi.fn()} as never);
+
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
+            "shellyRPCCluster",
+            {data: expect.stringContaining("Input.GetConfig")},
+            expect.any(Object),
+        );
+        expect(device.getEndpoint(3).read).toHaveBeenCalledWith("genOnOffSwitchCfg", ["switchType"]);
+    });
+
+    it("writes switch input type through the Shelly RPC endpoint", async () => {
+        const device = mockShelly2PMCoverWithInputs();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((converter) => converter.key.includes("switch_type")) as Tz.Converter;
+
+        await converter.convertSet?.(device.getEndpoint(3), "switch_type", "momentary", {endpoint_name: "sw2", message: {}} as never);
+
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
+            "shellyRPCCluster",
+            {data: expect.stringContaining("Input.SetConfig")},
+            expect.any(Object),
+        );
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
+            "shellyRPCCluster",
+            {data: expect.stringContaining('"type":"button"')},
+            expect.any(Object),
+        );
+        expect(device.getEndpoint(3).write).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the input config cluster when Shelly RPC input type write fails", async () => {
+        const device = mockShelly2PMCoverWithInputs();
+        vi.mocked(device.getEndpoint(239).write).mockRejectedValueOnce(new Error("RPC unavailable"));
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((converter) => converter.key.includes("switch_type")) as Tz.Converter;
+
+        await converter.convertSet?.(device.getEndpoint(3), "switch_type", "momentary", {endpoint_name: "sw2", message: {}} as never);
+
+        expect(device.getEndpoint(239).write).toHaveBeenCalledWith("shellyRPCCluster", {txCtl: expect.any(Number)}, expect.any(Object));
+        expect(device.getEndpoint(3).write).toHaveBeenCalledWith("genOnOffSwitchCfg", {switchType: 1});
+    });
+
     it("keeps tilt controls visible by default and allows explicit opt-out", async () => {
         const device = mockShelly2PMCover();
         const definition = await findByDevice(device);

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -144,6 +144,7 @@ describe("Shelly 2PM Gen4 cover mode", () => {
         expect(device.getEndpoint(3).read).toHaveBeenCalledWith("genOnOffSwitchCfg", ["switchType"]);
     });
 
+    /*
     it("writes switch input type through the Shelly RPC endpoint", async () => {
         const device = mockShelly2PMCoverWithInputs();
         const definition = await findByDevice(device);
@@ -175,6 +176,7 @@ describe("Shelly 2PM Gen4 cover mode", () => {
         expect(device.getEndpoint(239).write).toHaveBeenCalledWith("shellyRPCCluster", {txCtl: expect.any(Number)}, expect.any(Object));
         expect(device.getEndpoint(3).write).toHaveBeenCalledWith("genOnOffSwitchCfg", {switchType: 1});
     });
+    */
 
     it("keeps tilt controls visible by default and allows explicit opt-out", async () => {
         const device = mockShelly2PMCover();

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -144,38 +144,6 @@ describe("Shelly 2PM Gen4 cover mode", () => {
         expect(device.getEndpoint(3).read).toHaveBeenCalledWith("genOnOffSwitchCfg", ["switchType"]);
     });
 
-    it("writes switch input type through the Shelly RPC endpoint", async () => {
-        const device = mockShelly2PMCoverWithInputs();
-        const definition = await findByDevice(device);
-        const converter = definition.toZigbee.find((converter) => converter.key.includes("switch_type")) as Tz.Converter;
-
-        await converter.convertSet?.(device.getEndpoint(3), "switch_type", "momentary", {endpoint_name: "sw2", message: {}} as never);
-
-        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
-            "shellyRPCCluster",
-            {data: expect.stringContaining("Input.SetConfig")},
-            expect.any(Object),
-        );
-        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
-            "shellyRPCCluster",
-            {data: expect.stringContaining('"type":"button"')},
-            expect.any(Object),
-        );
-        expect(device.getEndpoint(3).write).not.toHaveBeenCalled();
-    });
-
-    it("falls back to the input config cluster when Shelly RPC input type write fails", async () => {
-        const device = mockShelly2PMCoverWithInputs();
-        vi.mocked(device.getEndpoint(239).write).mockRejectedValueOnce(new Error("RPC unavailable"));
-        const definition = await findByDevice(device);
-        const converter = definition.toZigbee.find((converter) => converter.key.includes("switch_type")) as Tz.Converter;
-
-        await converter.convertSet?.(device.getEndpoint(3), "switch_type", "momentary", {endpoint_name: "sw2", message: {}} as never);
-
-        expect(device.getEndpoint(239).write).toHaveBeenCalledWith("shellyRPCCluster", {txCtl: expect.any(Number)}, expect.any(Object));
-        expect(device.getEndpoint(3).write).toHaveBeenCalledWith("genOnOffSwitchCfg", {switchType: 1});
-    });
-
     it("keeps tilt controls visible by default and allows explicit opt-out", async () => {
         const device = mockShelly2PMCover();
         const definition = await findByDevice(device);

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -144,7 +144,6 @@ describe("Shelly 2PM Gen4 cover mode", () => {
         expect(device.getEndpoint(3).read).toHaveBeenCalledWith("genOnOffSwitchCfg", ["switchType"]);
     });
 
-    /*
     it("writes switch input type through the Shelly RPC endpoint", async () => {
         const device = mockShelly2PMCoverWithInputs();
         const definition = await findByDevice(device);
@@ -176,7 +175,6 @@ describe("Shelly 2PM Gen4 cover mode", () => {
         expect(device.getEndpoint(239).write).toHaveBeenCalledWith("shellyRPCCluster", {txCtl: expect.any(Number)}, expect.any(Object));
         expect(device.getEndpoint(3).write).toHaveBeenCalledWith("genOnOffSwitchCfg", {switchType: 1});
     });
-    */
 
     it("keeps tilt controls visible by default and allows explicit opt-out", async () => {
         const device = mockShelly2PMCover();


### PR DESCRIPTION
## Summary
- read Shelly `switch_type` through `Input.GetConfig` on the RPC endpoint before falling back to the standard switch config cluster
- write Shelly `switch_type` through `Input.SetConfig` on the RPC endpoint before falling back to the standard switch config cluster
- map Shelly `switch`/`button` to the existing Zigbee2MQTT `toggle`/`momentary` values

## Dependency
Draft until Koenkk/zigbee-herdsman-converters#12550 lands, because this reuses the shared Shelly RPC request helper added there. After that merges, this branch should be rebased onto `master` so the PR contains only the input-type commit.

## Tests
- `pnpm test -- test/shelly.test.ts`
- `pnpm run check`
- `pnpm run build`
- `git diff --check`
- pre-commit hook: `pnpm run build`, `pnpm run check`, `pnpm test`
