### PR TITLE
Add flash_on_click attribute to Schneider device

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -187,6 +187,7 @@ function indicatorMode(endpoint?: string) {
             consistent_with_load: 0,
             always_off: 3,
             always_on: 1,
+            flash_on_click: 4,
         },
         cluster: "manuSpecificSchneiderLightSwitchConfiguration",
         attribute: "ledIndication",


### PR DESCRIPTION
The default mode from the factory is `4`. In this mode, it'll turn the LED white for a short while after clicking it.