### PR TITLE
fix(detect): Detect MLI switch01 as Müller Licht 404021

### DIFF
--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -243,7 +243,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["tint Smart Switch"],
+        zigbeeModel: ["tint Smart Switch", "switch01", "switch01\u0000"],
         model: "404021",
         description: "Tint smart switch",
         vendor: "Müller Licht",

--- a/src/devices/muller_licht.ts
+++ b/src/devices/muller_licht.ts
@@ -243,7 +243,10 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["tint Smart Switch", "switch01", "switch01\u0000"],
+        fingerprint: [
+            {manufacturerName: "MLI", modelID: "tint Smart Switch"},
+            {manufacturerName: "MLI", modelID: "switch01"},
+        ],
         model: "404021",
         description: "Tint smart switch",
         vendor: "Müller Licht",


### PR DESCRIPTION
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/32408

What do you prefer for the trailing character? Z2M automatically strips it? Add it in definitions or not?