### PR TITLE
fix: Tuya TS0601_smart_scene_knob: Allow brightness 255

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1475,12 +1475,7 @@ const fzLocal = {
 
             const baseGroupId = meta.state?.base_group_id as number | undefined;
             const status = (meta.state?.assignment_status as string) || statusUnassigned;
-            // Device sends 0xFF at max brightness, which zigbee-herdsman parses as NaN
-            // Clamp to 254 (max valid ZCL level per Zigbee spec)
-            let level = msg.data.level as number;
-            if (Number.isNaN(level)) {
-                level = 254;
-            }
+            const level = msg.data.level as number;
 
             const prevBrightness = meta.state?.brightness as number | undefined;
             const prevDirection = meta.state?.brightness_direction as string | undefined;
@@ -23508,7 +23503,7 @@ export const definitions: DefinitionWithExtend[] = [
                     "curtain_4_position_close",
                 ])
                 .withDescription("Triggered action from scene button, light knob, or curtain control"),
-            e.numeric("brightness", ea.STATE).withValueMin(1).withValueMax(254).withDescription("Brightness level from light mode (1-254)"),
+            e.numeric("brightness", ea.STATE).withValueMin(1).withValueMax(255).withDescription("Brightness level from light mode (1-255)"),
             e.numeric("color_temp", ea.STATE).withValueMin(153).withValueMax(523).withDescription("Color temperature from light mode (mired)"),
             e
                 .numeric("curtain_position", ea.STATE)


### PR DESCRIPTION
This workaround is not needed anymore cc @Bjk8kds 
- https://github.com/Koenkk/zigbee-herdsman-converters/pull/11103

255 brightness is actually valid for the "generic" Level control cluster.
It's only invalid in the "derived" Level control for lighting. (whatever that means)

I fixed it in ZH here:
- https://github.com/Koenkk/zigbee-herdsman/pull/1752