### PR TITLE
fix:fix alarm duration not applied on first automation trigger

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -777,40 +777,21 @@ const tzLocal = {
         },
     } satisfies Tz.Converter,
     snzb_09p_alert: {
-        key: ["start_manual_alarm", "cancel_alarm", "start_scene_alarm", "siren_on"],
+        key: ["siren_on"],
         convertSet: async (entity, key, value, meta) => {
             const state = meta.state || {};
             const device = meta.device;
+            const message = meta.message;
             if (!device) return;
             const endpoint = device.getEndpoint(1);
             if (!endpoint) return;
 
             let payload: Buffer;
-            switch (key) {
-                case "cancel_alarm":
-                    payload = Buffer.from([1]);
-                    break;
-                case "siren_on": {
-                    if (value === "OFF" || value === false) {
-                        payload = Buffer.from([1]);
-                        break;
-                    }
 
-                    const voice = state.alarm_sound_enable === "ON" || state.alarm_sound_enable === true ? 0x01 : 0x00;
-                    const light = state.alarm_light_enable === "ON" || state.alarm_light_enable === true ? 0x01 : 0x00;
-                    const alertSoundRaw = meta.message?.alarm_sound_type ?? state.alarm_sound_type ?? 0;
-                    const alertSoundParsed =
-                        typeof alertSoundRaw === "string" ? Number.parseInt(alertSoundRaw.replace(/^sound\s+/i, ""), 10) : Number(alertSoundRaw);
-                    const alertSound = Number.isFinite(alertSoundParsed) ? Math.min(9, Math.max(0, alertSoundParsed)) : 0;
-                    const volMap = {low: 0, medium: 1, high: 2, highest: 3} as const;
-                    const volumeLevel = String(state.alarm_volume_level ?? "high").toLowerCase();
-                    const volume = volMap[volumeLevel as keyof typeof volMap] ?? 2;
-                    const duration = Math.min(900, Math.max(1, Number(state.alarm_duration ?? 10)));
-                    payload = Buffer.from([0x02, 0x00, voice, light, alertSound, volume, duration & 0xff, (duration >> 8) & 0xff, 0x00]);
-                    break;
-                }
-                default:
-                    throw new Error(`Unsupported SNZB-09P alert command key '${key}'`);
+            if (message.siren_on === "ON") {
+                payload = Buffer.from([0]);
+            } else {
+                payload = Buffer.from([1]);
             }
 
             await endpoint.command<"customClusterEwelink", "alertCommand", SonoffSnzb09p>(

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -779,7 +779,6 @@ const tzLocal = {
     snzb_09p_alert: {
         key: ["siren_on"],
         convertSet: async (entity, key, value, meta) => {
-            const state = meta.state || {};
             const device = meta.device;
             const message = meta.message;
             if (!device) return;


### PR DESCRIPTION
## Summary

* Improve support for SONOFF SNZB-09P.
* The change is aligned with the latest firmware behavior.
* Fix alarm duration handling for automation-triggered alarms.

## Changes

* Fix the issue where the configured automation alarm duration was not applied on the first trigger.
* Ensure the configured alarm duration takes effect immediately when an automation scene is triggered.
* Keep the alarm duration consistent across consecutive automation triggers.

## Testing

Tested with Zigbee2MQTT on SONOFF ZBDongle-P.

* Verified pairing/interview.
* Verified automation-triggered alarms.
* Verified that the configured alarm duration is applied correctly on both the first and subsequent triggers.
* Verified that manual alarm behavior remains unchanged.
