### PR TITLE
feat(add): Somfy Situo 1 Zigbee 1800194

### DIFF
--- a/src/devices/somfy.ts
+++ b/src/devices/somfy.ts
@@ -145,6 +145,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.onOff(), m.electricityMeter()],
     },
     {
+        zigbeeModel: ["Situo 1 Zigbee"],
+        model: "1800194",
+        vendor: "SOMFY",
+        description: "Situo 1 channel blinds remote",
+        extend: [m.battery(), m.commandsOnOff(), m.commandsWindowCovering()],
+    },
+    {
         zigbeeModel: ["Situo 4 Zigbee"],
         model: "1800195",
         vendor: "SOMFY",


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5284.

Following the documentation at
https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html for adding support for the Somfy Situo 1 Zigbee blinds remote.

This is the single-channel version of the remote added in https://github.com/Koenkk/zigbee-herdsman-converters/pull/12234.