### PR TITLE
Add additional fingerprint for additional TS0301_dual_rail device

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5651,7 +5651,10 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0301", ["_TZE210_inpjmc0h"]),
+        fingerprint: tuya.fingerprint("TS0301", [
+            "_TZE210_inpjmc0h",
+            "_TZE210_yqwse3h5",
+        ]),
         model: "TS0301_dual_rail",
         vendor: "Tuya",
         description: "Top-down bottom-up dual motor shade",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5651,10 +5651,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0301", [
-            "_TZE210_inpjmc0h",
-            "_TZE210_yqwse3h5",
-        ]),
+        fingerprint: tuya.fingerprint("TS0301", ["_TZE210_inpjmc0h", "_TZE210_yqwse3h5"]),
         model: "TS0301_dual_rail",
         vendor: "Tuya",
         description: "Top-down bottom-up dual motor shade",


### PR DESCRIPTION
Add _TZE210_yqwse3h5 as a fingerprint for the TS0301_dual_rail definition. This adds support for some Yoolax Top-Down Bottom-Up shades. (Apparently, they ship different motor models or changed recently as I have different fingerprints for some of my shades).

Verified functionality works as expected.