### PR TITLE
feat(sonoff): enable OTA support for SNZB-02LD

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -5955,6 +5955,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SNZB-02LD",
         vendor: "SONOFF",
         description: "Waterproof (IP65) sensor with screen and probe temperature detection",
+        ota: true,
         extend: [
             m.deviceAddCustomCluster("customSonoffSnzb02ld", {
                 name: "customSonoffSnzb02ld",


### PR DESCRIPTION
Enable OTA support for SONOFF SNZB-02LD.

The device definition already exists, but it was missing `ota: true`.

Tested with Zigbee2MQTT 2.12.0 and a real SNZB-02LD device.

Before this change:
- SNZB-02LD did not appear on the Zigbee2MQTT OTA page.

After adding `ota: true`:
- SNZB-02LD appears on the OTA page.
- Firmware information is read successfully:
  - Firmware ID: 1.1.0
  - Firmware version: 20250421.

Validation:
- `pnpm run check`
- 21 test files passed
- 645 tests passed