### PR TITLE
Add fingerprint to detect _TZE28C1000000_y4jqpry8 as Zemismart ZMS-206US-4

### DIFF
--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -813,6 +813,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE204_xibaabmu",
             "_TZE284_xibaabmu",
             "_TZE204_08qc13ct",
+            "_TZE28C1000000_y4jqpry8",
         ]),
         model: "ZMS-206US-4",
         vendor: "Zemismart",


### PR DESCRIPTION
Hello.

This PR is a follow-up of https://github.com/Koenkk/zigbee2mqtt/issues/32091

It seems that we have a new fingerprint for the Zemismart touch switch ZMS-206US-4, the datapoints remain the same so i've updated the zemismart code to add the new string

This is the switch

https://aliexpress.com/item/1005010390685707.html
https://www.zemismart.com/products/zms-206us-1c?VariantsId=17920