### PR TITLE
fix(lumi.sensor_occupy.agl8): Adjust min/step values for absence delay timer

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5913,9 +5913,9 @@ export const definitions: DefinitionWithExtend[] = [
 
             m.numeric<"manuSpecificLumi", ManuSpecificLumi>({
                 name: "absence_delay_timer",
-                valueMin: 10,
+                valueMin: 1,
                 valueMax: 300,
-                valueStep: 5,
+                valueStep: 1,
                 scale: 1,
                 unit: "sec",
                 cluster: "manuSpecificLumi",


### PR DESCRIPTION
Modified devices/lumi.ts

- Latest firmware for lumi.sensor_occupy.agl8 allows absence delay timer value to go down to 1 second.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
