### PR TITLE
Schneider Electric 41EPBDWCLMZ/354PBDMBTZ: expose level_config (on_level, current_level_startup)

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -2017,9 +2017,9 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Schneider Electric",
         description: "Wiser 40/300-Series Module Dimmer",
         fromZigbee: [fz.on_off, fz.brightness, fz.level_config, fz.lighting_ballast_configuration],
-        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config],
+        toZigbee: [tz.light_onoff_brightness, tz.level_config, tz.ballast_config, tz.ignore_transition],
         exposes: [
-            e.light_brightness(),
+            e.light_brightness().withLevelConfig(["on_level", "current_level_startup"]),
             e
                 .numeric("ballast_minimum_level", ea.ALL)
                 .withValueMin(1)


### PR DESCRIPTION
### What this does

Exposes `level_config` (with `on_level` and `current_level_startup`) on the
Schneider Electric / Clipsal Wiser **41EPBDWCLMZ/354PBDMBTZ** "40/300-Series
Module Dimmer" (`CH/DIMMER/1`), bringing it to parity with the sibling Wiser
dimmers that already expose level config (`WDE002386` NHPB/DIMMER/1,
`WDE002334` NHROTARY/DIMMER/1).

The read/write plumbing was already present — `fz.level_config` was in
`fromZigbee` and `tz.level_config` in `toZigbee` — but the expose was never
attached, so the genLevelCtrl level-config attributes were reachable over MQTT
yet invisible in the frontend/HA. This adds `.withLevelConfig(["on_level",
"current_level_startup"])` to surface them, scoped to the two features this
hardware actually implements (matching `WDE002386`).

Also adds `tz.ignore_transition` to the device's `toZigbee`. This old-style
definition lists its converters by hand and was missing it, so the device logged
`No converter available for 'transition'` whenever Home Assistant sent a lone
`transition` value. The modern `m.light()` siblings include `ignore_transition`
automatically; this brings the hand-rolled list in line.

### Why

`on_level` lets the dimmer come up at a fixed brightness on switch-on (including
from the physical push-button), instead of only restoring its previous level.

### Testing

Verified on hardware (firmware 002.003.007 R, App 0.2 build 3, Zigbee2MQTT with
zigbee-herdsman-converters 26.74.0):

- `level_config` now appears in the frontend Exposes tab with `on_level` and
  `current_level_startup`.
- Setting `{"level_config":{"on_level":254}}` makes a physical off→on at the
  wall switch come up at full brightness, with no restore-to-previous dip.
- Setting `{"level_config":{"on_level":"previous"}}` restores the original
  restore-last-brightness behaviour.
- `tz.ignore_transition` removes the recurring `No converter available for
  'transition'` errors.
- `pnpm run check`, `pnpm run build`, and `pnpm test` all pass.