### PR TITLE
Update awox.ts

### DIFF
--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -400,6 +400,14 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: [153, 370]}})],
     },
     {
+        zigbeeModel: ['EZMB-RGB-W-I2C'],
+        model: 'EZMB-RGB-W-I2C',
+        vendor: 'AwoX',
+        description: 'Awox / Eglo Smart lamp E27 Globe G95 Mat RGB 3000K 7W',
+        extend: [m.deviceEndpoints({"endpoints":{"1":1,"3":3}}), m.light({"colorTemp":{"range":[333,333]},"color":{"modes":["xy","hs"],"enhancedHue":true}}), m.commandsOnOff(), m.commandsLevelCtrl(), m.commandsColorCtrl()],
+    };
+
+    {
         fingerprint: [
             {
                 type: "Router",


### PR DESCRIPTION
added new Awox / Eglo light bulb: 
Awox / Eglo Smart lamp E27 | Globe G95 | Mat | RGB + 3000K | Zigbee | 7W

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
