### PR TITLE
Add support for MG-GPO02Z / Sparkelec SGPO2TZ

### DIFF
--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -4,7 +4,7 @@ import * as e from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, Fz, KeyValueAny, Tz} from "../lib/types";
+import type {DefinitionWithExtend, KeyValueAny, Tz} from "../lib/types";
 
 const ea = e.access;
 
@@ -87,7 +87,7 @@ const backlightColorToZigbee: Tz.Converter = {
         writeSocket(cfg.socket1 ?? {}, 1);
         writeSocket(cfg.socket2 ?? {}, 11);
 
-        await tuya.sendDataPointRaw(entity, 107, [...buf]);
+        await tuya.sendDataPointRaw(entity, 107, [buf]);
         return {state: {backlight_color: cfg}};
     },
 };

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -90,7 +90,7 @@ const backlightColorToZigbee: Tz.Converter = {
         await tuya.sendDataPointRaw(entity, 107, [buf]);
         return {state: {backlight_color: cfg}};
     },
-};
+} satisfies Tz.Converter;
 
 // --- Definitions ---
 

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -1,9 +1,98 @@
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
+import * as e from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValueAny, Tz} from "../lib/types";
+
+const ea = e.access;
+
+// --- MG-GPO02Z / SGPO2TZ helpers ---
+
+const powerOnBehaviorConverter = tuya.valueConverterBasic.lookup({
+    power_off: tuya.enum(0),
+    power_on: tuya.enum(1),
+    last: tuya.enum(2),
+});
+
+const childLockConverter = tuya.valueConverterBasic.lookup({LOCK: true, UNLOCK: false});
+
+const countdownConverter = {
+    from: (value: unknown) => (value == null || value === false ? 0 : Number(value)),
+    to: (value: unknown) => Number(value),
+};
+
+const energyConverter = {
+    from: (value: unknown, meta: {state?: {energy?: number}}) => {
+        if (value == null) return 0;
+        const newEnergy = tuya.valueConverter.divideBy1000.from(value as number);
+        const lastEnergy = meta.state?.energy ?? 0;
+        if (newEnergy > 0) return Number((lastEnergy + newEnergy).toFixed(3));
+        return lastEnergy;
+    },
+    to: (value: unknown) => value,
+};
+
+const backlightColorConverter = {
+    from(value: unknown) {
+        if (!value) return null;
+        const buf = Buffer.isBuffer(value) ? value : Buffer.from(value as string);
+        if (buf.length !== 21) return null;
+        const parseSocket = (o: number) => ({
+            onBrightness: buf[o],
+            onHue: buf.readUInt16BE(o + 1),
+            onSaturation: buf.readUInt16BE(o + 3),
+            offBrightness: buf[o + 5],
+            offHue: buf.readUInt16BE(o + 6),
+            offSaturation: buf.readUInt16BE(o + 8),
+        });
+        return {
+            mode: buf[0] === 1 ? "multi" : "single",
+            socket1: parseSocket(1),
+            socket2: parseSocket(11),
+        };
+    },
+    to(value: unknown) {
+        return value;
+    },
+};
+
+const backlightColorToZigbee: Tz.Converter = {
+    key: ["backlight_color"],
+    convertSet: async (entity, key, value, meta) => {
+        let cfg = value as KeyValueAny;
+        if (typeof value === "string") {
+            try {
+                cfg = JSON.parse(value);
+            } catch {
+                throw new Error("backlight_color must be valid JSON");
+            }
+        }
+
+        const buf = Buffer.alloc(21);
+        buf[0] = cfg.mode === "multi" ? 1 : 0;
+
+        const clamp = (v: unknown, min: number, max: number) => Math.max(min, Math.min(max, Number(v) || 0));
+
+        const writeSocket = (s: KeyValueAny, o: number) => {
+            buf[o] = clamp(s.onBrightness ?? 100, 0, 100);
+            buf.writeUInt16BE(clamp(s.onHue ?? 0, 0, 360), o + 1);
+            buf.writeUInt16BE(clamp(s.onSaturation ?? 1000, 0, 1000), o + 3);
+            buf[o + 5] = clamp(s.offBrightness ?? 10, 0, 100);
+            buf.writeUInt16BE(clamp(s.offHue ?? 240, 0, 360), o + 6);
+            buf.writeUInt16BE(clamp(s.offSaturation ?? 1000, 0, 1000), o + 8);
+        };
+
+        writeSocket(cfg.socket1 ?? {}, 1);
+        writeSocket(cfg.socket2 ?? {}, 11);
+
+        await tuya.sendDataPointRaw(entity, 107, [...buf]);
+        return {state: {backlight_color: cfg}};
+    },
+};
+
+// --- Definitions ---
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -82,6 +171,158 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             multiEndpoint: true,
             multiEndpointSkip: ["power", "current", "voltage", "energy"],
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_lq0ffndf"]),
+        model: "MG-GPO02Z",
+        vendor: "MakeGood",
+        description: "Dual GPO with energy monitoring and RGB backlights",
+        whiteLabel: [tuya.whitelabel("Sparkelec", "_TZE200_lq0ffndf", "Dual GPO with energy monitoring and RGB backlights", ["_TZE200_lq0ffndf"])],
+        configure: tuya.configureMagicPacket,
+        fromZigbee: [tuya.fz.datapoints],
+        toZigbee: [backlightColorToZigbee, tuya.tz.datapoints],
+        endpoint: () => ({l1: 1, l2: 1}),
+        exposes: [
+            tuya.exposes.switch().withEndpoint("l1"),
+            tuya.exposes.switch().withEndpoint("l2"),
+
+            e.numeric("countdown_l1", ea.STATE_SET)
+                .withUnit("s")
+                .withValueMin(0)
+                .withValueMax(43200)
+                .withDescription("Auto-off/on countdown timer for socket 1"),
+            e.numeric("countdown_l2", ea.STATE_SET)
+                .withUnit("s")
+                .withValueMin(0)
+                .withValueMax(43200)
+                .withDescription("Auto-off/on countdown timer for socket 2"),
+
+            e.enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
+                .withEndpoint("l1")
+                .withDescription("Behavior when power is restored — socket 1"),
+            e.enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
+                .withEndpoint("l2")
+                .withDescription("Behavior when power is restored — socket 2"),
+
+            e.binary("all_on_off", ea.STATE_SET, "ON", "OFF").withDescription("Master switch — all sockets simultaneously"),
+
+            e.numeric("power", ea.STATE).withUnit("W").withDescription("Instantaneous power"),
+            e.numeric("current", ea.STATE).withUnit("A").withDescription("Instantaneous current"),
+            e.numeric("voltage", ea.STATE).withUnit("V").withDescription("Instantaneous voltage"),
+            e.numeric("energy", ea.STATE).withUnit("kWh").withDescription("Cumulative energy consumption"),
+
+            tuya.exposes.backlightModeOffOn(),
+
+            e.composite("backlight_color", "backlight_color", ea.STATE_SET)
+                .withDescription("Backlight color config is only meaningful when backlight mode is ON")
+                .withFeature(
+                    e.enum("mode", ea.STATE_SET, ["single", "multi"]).withDescription(
+                        "single: one color per socket; multi: separate on/off colors per socket",
+                    ),
+                )
+                .withFeature(
+                    e
+                        .composite("socket1", "socket1", ea.STATE_SET)
+                        .withDescription("Socket 1 LED")
+                        .withFeature(
+                            e.numeric("onBrightness", ea.STATE_SET).withValueMin(0).withValueMax(100).withUnit("%").withDescription("Brightness when socket is ON"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("onHue", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(360)
+                                .withDescription("Hue (0=red, 60=yellow, 120=green, 180=cyan, 240=blue, 300=magenta, 360=purple)"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("onSaturation", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(1000)
+                                .withDescription("Saturation when ON (0=white, 1000=full color)"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("offBrightness", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(100)
+                                .withUnit("%")
+                                .withDescription("Brightness when socket is OFF — backlight mode ON only"),
+                        )
+                        .withFeature(
+                            e.numeric("offHue", ea.STATE_SET).withValueMin(0).withValueMax(360).withDescription("Hue when OFF — multi-color mode only"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("offSaturation", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(1000)
+                                .withDescription("Saturation when OFF — multi-color mode only"),
+                        ),
+                )
+                .withFeature(
+                    e
+                        .composite("socket2", "socket2", ea.STATE_SET)
+                        .withDescription("Socket 2 LED")
+                        .withFeature(
+                            e.numeric("onBrightness", ea.STATE_SET).withValueMin(0).withValueMax(100).withUnit("%").withDescription("Brightness when socket is ON"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("onHue", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(360)
+                                .withDescription("Hue (0=red, 60=yellow, 120=green, 180=cyan, 240=blue, 300=magenta, 360=purple)"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("onSaturation", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(1000)
+                                .withDescription("Saturation when ON (0=white, 1000=full color)"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("offBrightness", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(100)
+                                .withUnit("%")
+                                .withDescription("Brightness when socket is OFF — backlight mode ON only"),
+                        )
+                        .withFeature(
+                            e.numeric("offHue", ea.STATE_SET).withValueMin(0).withValueMax(360).withDescription("Hue when OFF — multi-color mode only"),
+                        )
+                        .withFeature(
+                            e
+                                .numeric("offSaturation", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(1000)
+                                .withDescription("Saturation when OFF — multi-color mode only"),
+                        ),
+                ),
+
+            e.binary("child_lock", ea.STATE_SET, "LOCK", "UNLOCK").withDescription("Prevent physical control of the sockets"),
+        ],
+        meta: {
+            multiEndpoint: true,
+            multiEndpointSkip: ["power", "current", "voltage", "energy", "all_on_off"],
+            tuyaDatapoints: [
+                [1, "state_l1", tuya.valueConverter.onOff],
+                [2, "state_l2", tuya.valueConverter.onOff],
+                [7, "countdown_l1", countdownConverter],
+                [8, "countdown_l2", countdownConverter],
+                [16, "backlight_mode", tuya.valueConverter.onOff],
+                [20, "energy", energyConverter],
+                [21, "current", tuya.valueConverter.divideBy1000],
+                [22, "power", tuya.valueConverter.divideBy10],
+                [23, "voltage", tuya.valueConverter.divideBy10],
+                [29, "power_on_behavior_l1", powerOnBehaviorConverter],
+                [30, "power_on_behavior_l2", powerOnBehaviorConverter],
+                [101, "child_lock", childLockConverter],
+                [107, "backlight_color", backlightColorConverter],
+                [136, "all_on_off", tuya.valueConverter.onOff],
+            ],
         },
     },
 ];

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -187,21 +187,25 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.exposes.switch().withEndpoint("l1"),
             tuya.exposes.switch().withEndpoint("l2"),
 
-            e.numeric("countdown_l1", ea.STATE_SET)
+            e
+                .numeric("countdown_l1", ea.STATE_SET)
                 .withUnit("s")
                 .withValueMin(0)
                 .withValueMax(43200)
                 .withDescription("Auto-off/on countdown timer for socket 1"),
-            e.numeric("countdown_l2", ea.STATE_SET)
+            e
+                .numeric("countdown_l2", ea.STATE_SET)
                 .withUnit("s")
                 .withValueMin(0)
                 .withValueMax(43200)
                 .withDescription("Auto-off/on countdown timer for socket 2"),
 
-            e.enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
+            e
+                .enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
                 .withEndpoint("l1")
                 .withDescription("Behavior when power is restored — socket 1"),
-            e.enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
+            e
+                .enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
                 .withEndpoint("l2")
                 .withDescription("Behavior when power is restored — socket 2"),
 
@@ -214,19 +218,25 @@ export const definitions: DefinitionWithExtend[] = [
 
             tuya.exposes.backlightModeOffOn(),
 
-            e.composite("backlight_color", "backlight_color", ea.STATE_SET)
+            e
+                .composite("backlight_color", "backlight_color", ea.STATE_SET)
                 .withDescription("Backlight color config is only meaningful when backlight mode is ON")
                 .withFeature(
-                    e.enum("mode", ea.STATE_SET, ["single", "multi"]).withDescription(
-                        "single: one color per socket; multi: separate on/off colors per socket",
-                    ),
+                    e
+                        .enum("mode", ea.STATE_SET, ["single", "multi"])
+                        .withDescription("single: one color per socket; multi: separate on/off colors per socket"),
                 )
                 .withFeature(
                     e
                         .composite("socket1", "socket1", ea.STATE_SET)
                         .withDescription("Socket 1 LED")
                         .withFeature(
-                            e.numeric("onBrightness", ea.STATE_SET).withValueMin(0).withValueMax(100).withUnit("%").withDescription("Brightness when socket is ON"),
+                            e
+                                .numeric("onBrightness", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(100)
+                                .withUnit("%")
+                                .withDescription("Brightness when socket is ON"),
                         )
                         .withFeature(
                             e
@@ -251,7 +261,11 @@ export const definitions: DefinitionWithExtend[] = [
                                 .withDescription("Brightness when socket is OFF — backlight mode ON only"),
                         )
                         .withFeature(
-                            e.numeric("offHue", ea.STATE_SET).withValueMin(0).withValueMax(360).withDescription("Hue when OFF — multi-color mode only"),
+                            e
+                                .numeric("offHue", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(360)
+                                .withDescription("Hue when OFF — multi-color mode only"),
                         )
                         .withFeature(
                             e
@@ -266,7 +280,12 @@ export const definitions: DefinitionWithExtend[] = [
                         .composite("socket2", "socket2", ea.STATE_SET)
                         .withDescription("Socket 2 LED")
                         .withFeature(
-                            e.numeric("onBrightness", ea.STATE_SET).withValueMin(0).withValueMax(100).withUnit("%").withDescription("Brightness when socket is ON"),
+                            e
+                                .numeric("onBrightness", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(100)
+                                .withUnit("%")
+                                .withDescription("Brightness when socket is ON"),
                         )
                         .withFeature(
                             e
@@ -291,7 +310,11 @@ export const definitions: DefinitionWithExtend[] = [
                                 .withDescription("Brightness when socket is OFF — backlight mode ON only"),
                         )
                         .withFeature(
-                            e.numeric("offHue", ea.STATE_SET).withValueMin(0).withValueMax(360).withDescription("Hue when OFF — multi-color mode only"),
+                            e
+                                .numeric("offHue", ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(360)
+                                .withDescription("Hue when OFF — multi-color mode only"),
                         )
                         .withFeature(
                             e

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -87,7 +87,7 @@ const backlightColorToZigbee: Tz.Converter = {
         writeSocket(cfg.socket1 ?? {}, 1);
         writeSocket(cfg.socket2 ?? {}, 11);
 
-        await tuya.sendDataPointRaw(entity, 107, [buf]);
+        await tuya.sendDataPointRaw(entity, 107, buf);
         return {state: {backlight_color: cfg}};
     },
 } satisfies Tz.Converter;

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -40,12 +40,12 @@ const backlightColorConverter = {
         const buf = Buffer.isBuffer(value) ? value : Buffer.from(value as string);
         if (buf.length !== 21) return null;
         const parseSocket = (o: number) => ({
-            onBrightness: buf[o],
-            onHue: buf.readUInt16BE(o + 1),
-            onSaturation: buf.readUInt16BE(o + 3),
-            offBrightness: buf[o + 5],
-            offHue: buf.readUInt16BE(o + 6),
-            offSaturation: buf.readUInt16BE(o + 8),
+            on_brightness: buf[o],
+            on_hue: buf.readUInt16BE(o + 1),
+            on_saturation: buf.readUInt16BE(o + 3),
+            off_brightness: buf[o + 5],
+            off_hue: buf.readUInt16BE(o + 6),
+            off_saturation: buf.readUInt16BE(o + 8),
         });
         return {
             mode: buf[0] === 1 ? "multi" : "single",
@@ -76,12 +76,12 @@ const backlightColorToZigbee: Tz.Converter = {
         const clamp = (v: unknown, min: number, max: number) => Math.max(min, Math.min(max, Number(v) || 0));
 
         const writeSocket = (s: KeyValueAny, o: number) => {
-            buf[o] = clamp(s.onBrightness ?? 100, 0, 100);
-            buf.writeUInt16BE(clamp(s.onHue ?? 0, 0, 360), o + 1);
-            buf.writeUInt16BE(clamp(s.onSaturation ?? 1000, 0, 1000), o + 3);
-            buf[o + 5] = clamp(s.offBrightness ?? 10, 0, 100);
-            buf.writeUInt16BE(clamp(s.offHue ?? 240, 0, 360), o + 6);
-            buf.writeUInt16BE(clamp(s.offSaturation ?? 1000, 0, 1000), o + 8);
+            buf[o] = clamp(s.on_brightness ?? 100, 0, 100);
+            buf.writeUInt16BE(clamp(s.on_hue ?? 0, 0, 360), o + 1);
+            buf.writeUInt16BE(clamp(s.on_saturation ?? 1000, 0, 1000), o + 3);
+            buf[o + 5] = clamp(s.off_brightness ?? 10, 0, 100);
+            buf.writeUInt16BE(clamp(s.off_hue ?? 240, 0, 360), o + 6);
+            buf.writeUInt16BE(clamp(s.off_saturation ?? 1000, 0, 1000), o + 8);
         };
 
         writeSocket(cfg.socket1 ?? {}, 1);
@@ -232,7 +232,7 @@ export const definitions: DefinitionWithExtend[] = [
                         .withDescription("Socket 1 LED")
                         .withFeature(
                             e
-                                .numeric("onBrightness", ea.STATE_SET)
+                                .numeric("on_brightness", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(100)
                                 .withUnit("%")
@@ -240,21 +240,21 @@ export const definitions: DefinitionWithExtend[] = [
                         )
                         .withFeature(
                             e
-                                .numeric("onHue", ea.STATE_SET)
+                                .numeric("on_hue", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(360)
                                 .withDescription("Hue (0=red, 60=yellow, 120=green, 180=cyan, 240=blue, 300=magenta, 360=purple)"),
                         )
                         .withFeature(
                             e
-                                .numeric("onSaturation", ea.STATE_SET)
+                                .numeric("on_saturation", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(1000)
                                 .withDescription("Saturation when ON (0=white, 1000=full color)"),
                         )
                         .withFeature(
                             e
-                                .numeric("offBrightness", ea.STATE_SET)
+                                .numeric("off_brightness", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(100)
                                 .withUnit("%")
@@ -262,14 +262,14 @@ export const definitions: DefinitionWithExtend[] = [
                         )
                         .withFeature(
                             e
-                                .numeric("offHue", ea.STATE_SET)
+                                .numeric("off_hue", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(360)
                                 .withDescription("Hue when OFF — multi-color mode only"),
                         )
                         .withFeature(
                             e
-                                .numeric("offSaturation", ea.STATE_SET)
+                                .numeric("off_saturation", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(1000)
                                 .withDescription("Saturation when OFF — multi-color mode only"),
@@ -281,7 +281,7 @@ export const definitions: DefinitionWithExtend[] = [
                         .withDescription("Socket 2 LED")
                         .withFeature(
                             e
-                                .numeric("onBrightness", ea.STATE_SET)
+                                .numeric("on_brightness", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(100)
                                 .withUnit("%")
@@ -289,21 +289,21 @@ export const definitions: DefinitionWithExtend[] = [
                         )
                         .withFeature(
                             e
-                                .numeric("onHue", ea.STATE_SET)
+                                .numeric("on_hue", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(360)
                                 .withDescription("Hue (0=red, 60=yellow, 120=green, 180=cyan, 240=blue, 300=magenta, 360=purple)"),
                         )
                         .withFeature(
                             e
-                                .numeric("onSaturation", ea.STATE_SET)
+                                .numeric("on_saturation", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(1000)
                                 .withDescription("Saturation when ON (0=white, 1000=full color)"),
                         )
                         .withFeature(
                             e
-                                .numeric("offBrightness", ea.STATE_SET)
+                                .numeric("off_brightness", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(100)
                                 .withUnit("%")
@@ -311,14 +311,14 @@ export const definitions: DefinitionWithExtend[] = [
                         )
                         .withFeature(
                             e
-                                .numeric("offHue", ea.STATE_SET)
+                                .numeric("off_hue", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(360)
                                 .withDescription("Hue when OFF — multi-color mode only"),
                         )
                         .withFeature(
                             e
-                                .numeric("offSaturation", ea.STATE_SET)
+                                .numeric("off_saturation", ea.STATE_SET)
                                 .withValueMin(0)
                                 .withValueMax(1000)
                                 .withDescription("Saturation when OFF — multi-color mode only"),

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -1,12 +1,13 @@
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
-import * as e from "../lib/exposes";
+import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend, KeyValueAny, Tz} from "../lib/types";
 
-const ea = e.access;
+const e = exposes.presets;
+const ea = exposes.access;
 
 // Structural alias for one meta.tuyaDatapoints entry — derived from
 // DefinitionWithExtend itself so it always matches the real tuple shape
@@ -207,38 +208,20 @@ const backlightColorExpose = (labels: string[]) => {
     return composite.withCategory("config");
 };
 
-const countdownExpose = (endpoint: string) =>
-    e
-        .numeric("countdown", ea.STATE_SET)
-        .withEndpoint(endpoint)
-        .withUnit("s")
-        .withValueMin(0)
-        .withValueMax(43200)
-        .withValueStep(1)
-        .withDescription("Auto-off/on countdown timer")
-        .withCategory("config");
-
 // Datapoints and exposes shared by every device in this range. `channels` is
 // the list of endpoint keys, in datapoint order.
-const powerOnBehaviorExpose = (channel: string) =>
-    e
-        .enum("power_on_behavior", ea.STATE_SET, ["off", "on", "previous"])
-        .withEndpoint(channel)
-        .withDescription("Behavior when power is restored")
-        .withCategory("config");
-
 const commonExposes = (channels: string[], labels: string[]) => [
     ...channels.map((channel) => tuya.exposes.switch().withEndpoint(channel)),
-    ...channels.map((channel) => countdownExpose(channel)),
-    ...channels.map((channel) => powerOnBehaviorExpose(channel)),
+    ...channels.map((channel) => tuya.exposes.countdown().withEndpoint(channel)),
+    ...channels.map((channel) => e.power_on_behavior().withAccess(ea.STATE_SET).withEndpoint(channel).withCategory("config")),
     e.binary("all_on_off", ea.STATE_SET, "ON", "OFF").withDescription("Turn all channels on or off simultaneously"),
-    e.numeric("power", ea.STATE).withUnit("W").withDescription("Instantaneous power"),
-    e.numeric("current", ea.STATE).withUnit("A").withDescription("Instantaneous current"),
-    e.numeric("voltage", ea.STATE).withUnit("V").withDescription("Instantaneous voltage"),
-    e.numeric("energy", ea.STATE).withUnit("kWh").withDescription("Cumulative energy consumption"),
+    e.power(),
+    e.current(),
+    e.voltage(),
+    e.energy(),
     tuya.exposes.backlightModeOffOn().withAccess(ea.STATE_SET),
     backlightColorExpose(labels),
-    e.binary("child_lock", ea.STATE_SET, "LOCK", "UNLOCK").withDescription("Prevent physical control of the sockets").withCategory("config"),
+    e.child_lock().withCategory("config"),
 ];
 
 const commonMeta = (channels: string[]): DefinitionWithExtend["meta"] => ({

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -108,7 +108,7 @@ const backlightColorConverter = (channelCount: number) => {
 
             // Merge over current state so a partial update does not reset the
             // features (or the channels) it did not mention.
-            const current = meta?.state?.backlight_color ?? {};
+            const current: KeyValueAny = (meta?.state?.backlight_color as KeyValueAny) ?? {};
             const mergeChannel = (name: string) => ({
                 ...backlightDefaults,
                 ...(current[name] ?? {}),

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -4,7 +4,7 @@ import * as e from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, KeyValueAny} from "../lib/types";
+import type {DefinitionWithExtend, KeyValueAny, Tz} from "../lib/types";
 
 const ea = e.access;
 
@@ -91,7 +91,7 @@ const backlightColorConverter = (channelCount: number) => {
             return result;
         },
 
-        to(value: unknown, meta: {state?: {"backlight_color"?: KeyValueAny}}) {
+        to(value: unknown, meta: Tz.Meta) {
             let config: KeyValueAny = value;
 
             if (typeof value === "string") {
@@ -179,12 +179,7 @@ const channelBacklightFeature = (property: string, label: string) =>
                 .withDescription("Brightness while off — backlight mode ON only"),
         )
         .withFeature(
-            e
-                .numeric("off_hue", ea.STATE_SET)
-                .withValueMin(0)
-                .withValueMax(359)
-                .withValueStep(1)
-                .withDescription("Hue while off — multi mode only"),
+            e.numeric("off_hue", ea.STATE_SET).withValueMin(0).withValueMax(359).withValueStep(1).withDescription("Hue while off — multi mode only"),
         )
         .withFeature(
             e

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -4,93 +4,264 @@ import * as e from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend, KeyValueAny, Tz} from "../lib/types";
+import type {DefinitionWithExtend} from "../lib/types";
 
 const ea = e.access;
 
-// --- MG-GPO02Z / SGPO2TZ helpers ---
+// --- MakeGood / Sparkelec TS0601 RGB-backlight range helpers ---
+//
+//   _TZE200_lq0ffndf  MG-GPO02Z  (Sparkelec SGPO2TZ)   2 channels
+//   _TZE200_4jvmbiph  MG-AU03    (Sparkelec SGPO2XTZ)  3 channels
+//
+// DP 107 is a raw blob of 1 + (10 * channel count) bytes, so a single
+// converter parameterised by channel count serves both devices.
 
-const powerOnBehaviorConverter = tuya.valueConverterBasic.lookup({
-    power_off: tuya.enum(0),
-    power_on: tuya.enum(1),
-    last: tuya.enum(2),
-});
-
-const childLockConverter = tuya.valueConverterBasic.lookup({LOCK: true, UNLOCK: false});
-
+// The device reports `false` rather than 0 when a countdown is idle.
 const countdownConverter = {
     from: (value: unknown) => (value == null || value === false ? 0 : Number(value)),
     to: (value: unknown) => Number(value),
 };
 
+// DP 20 reports an energy increment since the last report rather than a
+// running total, so the cumulative figure is accumulated here. Note this
+// means the total lives in Zigbee2MQTT state — clearing device state resets
+// the displayed total even though the device keeps counting.
 const energyConverter = {
     from: (value: unknown, meta: {state?: {energy?: number}}) => {
-        if (value == null) return 0;
-        const newEnergy = tuya.valueConverter.divideBy1000.from(value as number);
-        const lastEnergy = meta.state?.energy ?? 0;
-        if (newEnergy > 0) return Number((lastEnergy + newEnergy).toFixed(3));
-        return lastEnergy;
+        const previous = Number(meta?.state?.energy) || 0;
+        if (value == null) return previous;
+
+        const increment = tuya.valueConverter.divideBy1000.from(value as number);
+
+        // Only add positive deltas; ignore zero reports and any reset/rollover.
+        if (increment > 0) return Number((previous + increment).toFixed(3));
+        return previous;
     },
     to: (value: unknown) => value,
 };
 
-const backlightColorConverter = {
-    from(value: unknown) {
-        if (!value) return null;
-        const buf = Buffer.isBuffer(value) ? value : Buffer.from(value as string);
-        if (buf.length !== 21) return null;
-        const parseSocket = (o: number) => ({
-            on_brightness: buf[o],
-            on_hue: buf.readUInt16BE(o + 1),
-            on_saturation: buf.readUInt16BE(o + 3),
-            off_brightness: buf[o + 5],
-            off_hue: buf.readUInt16BE(o + 6),
-            off_saturation: buf.readUInt16BE(o + 8),
-        });
-        return {
-            mode: buf[0] === 1 ? "multi" : "single",
-            socket1: parseSocket(1),
-            socket2: parseSocket(11),
-        };
-    },
-    to(value: unknown) {
-        return value;
-    },
+const BACKLIGHT_CHANNEL_SIZE = 10;
+
+const backlightDefaults = {
+    on_brightness: 100,
+    on_hue: 0,
+    on_saturation: 1000,
+    off_brightness: 10,
+    off_hue: 240,
+    off_saturation: 1000,
 };
 
-const backlightColorToZigbee: Tz.Converter = {
-    key: ["backlight_color"],
-    convertSet: async (entity, key, value, meta) => {
-        let cfg = value as KeyValueAny;
-        if (typeof value === "string") {
-            try {
-                cfg = JSON.parse(value);
-            } catch {
-                throw new Error("backlight_color must be valid JSON");
+const clampBacklight = (value: unknown, min: number, max: number) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return min;
+    return Math.max(min, Math.min(max, Math.round(numeric)));
+};
+
+const backlightColorConverter = (channelCount: number) => {
+    const length = 1 + channelCount * BACKLIGHT_CHANNEL_SIZE;
+    const offsetOf = (index: number) => 1 + index * BACKLIGHT_CHANNEL_SIZE;
+    const channelNames = Array.from({length: channelCount}, (_v, i) => `socket${i + 1}`);
+
+    return {
+        from(value: unknown) {
+            if (!value) return null;
+
+            const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value as string);
+            if (buffer.length !== length) return null;
+
+            const parseChannel = (o: number) => ({
+                on_brightness: buffer[o],
+                on_hue: buffer.readUInt16BE(o + 1),
+                on_saturation: buffer.readUInt16BE(o + 3),
+                off_brightness: buffer[o + 5],
+                off_hue: buffer.readUInt16BE(o + 6),
+                off_saturation: buffer.readUInt16BE(o + 8),
+            });
+
+            const result: Record<string, unknown> = {mode: buffer[0] === 1 ? "multi" : "single"};
+            for (const [index, name] of channelNames.entries()) {
+                result[name] = parseChannel(offsetOf(index));
             }
-        }
+            return result;
+        },
 
-        const buf = Buffer.alloc(21);
-        buf[0] = cfg.mode === "multi" ? 1 : 0;
+        to(value: unknown, meta: {state?: {backlight_color?: Record<string, any>}}) {
+            let config: any = value;
 
-        const clamp = (v: unknown, min: number, max: number) => Math.max(min, Math.min(max, Number(v) || 0));
+            if (typeof value === "string") {
+                try {
+                    config = JSON.parse(value);
+                } catch {
+                    throw new Error("backlight_color must contain valid JSON");
+                }
+            }
 
-        const writeSocket = (s: KeyValueAny, o: number) => {
-            buf[o] = clamp(s.on_brightness ?? 100, 0, 100);
-            buf.writeUInt16BE(clamp(s.on_hue ?? 0, 0, 360), o + 1);
-            buf.writeUInt16BE(clamp(s.on_saturation ?? 1000, 0, 1000), o + 3);
-            buf[o + 5] = clamp(s.off_brightness ?? 10, 0, 100);
-            buf.writeUInt16BE(clamp(s.off_hue ?? 240, 0, 360), o + 6);
-            buf.writeUInt16BE(clamp(s.off_saturation ?? 1000, 0, 1000), o + 8);
-        };
+            if (!config || typeof config !== "object") {
+                throw new Error("backlight_color must be an object");
+            }
 
-        writeSocket(cfg.socket1 ?? {}, 1);
-        writeSocket(cfg.socket2 ?? {}, 11);
+            // Merge over current state so a partial update does not reset the
+            // features (or the channels) it did not mention.
+            const current = meta?.state?.backlight_color ?? {};
+            const mergeChannel = (name: string) => ({
+                ...backlightDefaults,
+                ...(current[name] ?? {}),
+                ...(config[name] ?? {}),
+            });
 
-        await tuya.sendDataPointRaw(entity, 107, buf);
-        return {state: {backlight_color: cfg}};
-    },
-} satisfies Tz.Converter;
+            const buffer = Buffer.alloc(length);
+            buffer[0] = (config.mode ?? current.mode ?? "single") === "multi" ? 1 : 0;
+
+            for (const [index, name] of channelNames.entries()) {
+                const channel = mergeChannel(name);
+                const o = offsetOf(index);
+
+                buffer[o] = clampBacklight(channel.on_brightness, 0, 100);
+                buffer.writeUInt16BE(clampBacklight(channel.on_hue, 0, 359), o + 1);
+                buffer.writeUInt16BE(clampBacklight(channel.on_saturation, 0, 1000), o + 3);
+
+                buffer[o + 5] = clampBacklight(channel.off_brightness, 0, 100);
+                buffer.writeUInt16BE(clampBacklight(channel.off_hue, 0, 359), o + 6);
+                buffer.writeUInt16BE(clampBacklight(channel.off_saturation, 0, 1000), o + 8);
+            }
+
+            // tuya.tz.datapoints dispatches on Array.isArray() and wraps the
+            // result with Buffer.from() before sendDataPointRaw, so return an
+            // array rather than the Buffer itself.
+            return [...buffer];
+        },
+    };
+};
+
+const channelBacklightFeature = (property: string, label: string) =>
+    e
+        .composite(property, property, ea.STATE_SET)
+        .withLabel(label)
+        .withDescription(`${label} backlight settings`)
+        .withFeature(
+            e
+                .numeric("on_brightness", ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(1)
+                .withUnit("%")
+                .withDescription("Brightness while on"),
+        )
+        .withFeature(
+            e
+                .numeric("on_hue", ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(359)
+                .withValueStep(1)
+                .withDescription("Hue while on: 0 red, 60 yellow, 120 green, 180 cyan, 240 blue, 270 purple, 300 magenta"),
+        )
+        .withFeature(
+            e
+                .numeric("on_saturation", ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withValueStep(1)
+                .withDescription("Saturation while on: 0 white, 1000 full colour"),
+        )
+        .withFeature(
+            e
+                .numeric("off_brightness", ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(1)
+                .withUnit("%")
+                .withDescription("Brightness while off — backlight mode ON only"),
+        )
+        .withFeature(
+            e
+                .numeric("off_hue", ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(359)
+                .withValueStep(1)
+                .withDescription("Hue while off — multi mode only"),
+        )
+        .withFeature(
+            e
+                .numeric("off_saturation", ea.STATE_SET)
+                .withValueMin(0)
+                .withValueMax(1000)
+                .withValueStep(1)
+                .withDescription("Saturation while off — multi mode only"),
+        );
+
+const backlightColorExpose = (labels: string[]) => {
+    let composite = e
+        .composite("backlight_color", "backlight_color", ea.STATE_SET)
+        .withDescription("Backlight colour configuration, only meaningful when backlight mode is ON")
+        .withFeature(
+            e
+                .enum("mode", ea.STATE_SET, ["single", "multi"])
+                .withDescription("single: one colour per channel; multi: separate on and off colours per channel"),
+        );
+
+    labels.forEach((label, index) => {
+        composite = composite.withFeature(channelBacklightFeature(`socket${index + 1}`, label));
+    });
+
+    return composite.withCategory("config");
+};
+
+const countdownExpose = (endpoint: string) =>
+    e
+        .numeric("countdown", ea.STATE_SET)
+        .withEndpoint(endpoint)
+        .withUnit("s")
+        .withValueMin(0)
+        .withValueMax(43200)
+        .withValueStep(1)
+        .withDescription("Auto-off/on countdown timer")
+        .withCategory("config");
+
+// Datapoints and exposes shared by every device in this range. `channels` is
+// the list of endpoint keys, in datapoint order.
+const commonExposes = (channels: string[], labels: string[]) => [
+    ...channels.map((channel) => tuya.exposes.switch().withEndpoint(channel)),
+    ...channels.map((channel) => countdownExpose(channel)),
+    ...channels.map((channel) => e.power_on_behavior().withAccess(ea.STATE_SET).withEndpoint(channel).withCategory("config")),
+    e.binary("all_on_off", ea.STATE_SET, "ON", "OFF").withDescription("Turn all channels on or off simultaneously"),
+    e.power(),
+    e.current(),
+    e.voltage(),
+    e.energy(),
+    tuya.exposes.backlightModeOffOn().withAccess(ea.STATE_SET),
+    backlightColorExpose(labels),
+    e.child_lock().withCategory("config"),
+];
+
+const commonMeta = (channels: string[]) => ({
+    multiEndpoint: true,
+    multiEndpointSkip: ["power", "current", "voltage", "energy", "all_on_off", "backlight_mode", "backlight_color", "child_lock"],
+    tuyaDatapoints: [
+        // Relays: DP 1..n
+        ...channels.map((channel, i): [number, string, unknown] => [i + 1, `state_${channel}`, tuya.valueConverter.onOff]),
+
+        // Countdown timers: DP 7..
+        ...channels.map((channel, i): [number, string, unknown] => [i + 7, `countdown_${channel}`, countdownConverter]),
+
+        // Backlight enable
+        [16, "backlight_mode", tuya.valueConverter.onOff],
+
+        // Electrical measurements
+        [20, "energy", energyConverter],
+        [21, "current", tuya.valueConverter.divideBy1000],
+        [22, "power", tuya.valueConverter.divideBy10],
+        [23, "voltage", tuya.valueConverter.divideBy10],
+        // DP 24 is reported by the device but its meaning is unconfirmed, so it is not exposed.
+
+        // Power-on behaviour: DP 29..
+        ...channels.map((channel, i): [number, string, unknown] => [i + 29, `power_on_behavior_${channel}`, tuya.valueConverter.powerOnBehaviorEnum]),
+
+        [101, "child_lock", tuya.valueConverter.lockUnlock],
+        [107, "backlight_color", backlightColorConverter(channels.length)],
+        [136, "all_on_off", tuya.valueConverter.onOff],
+        // DP 165 is reported by the device but its meaning is unconfirmed, so it is not exposed.
+    ],
+});
 
 // --- Definitions ---
 
@@ -177,175 +348,27 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_lq0ffndf"]),
         model: "MG-GPO02Z",
         vendor: "MakeGood",
-        description: "Dual GPO with energy monitoring and RGB backlights",
-        whiteLabel: [tuya.whitelabel("Sparkelec", "_TZE200_lq0ffndf", "Dual GPO with energy monitoring and RGB backlights", ["_TZE200_lq0ffndf"])],
-        configure: tuya.configureMagicPacket,
-        fromZigbee: [tuya.fz.datapoints],
-        toZigbee: [backlightColorToZigbee, tuya.tz.datapoints],
+        description: "Double GPO with energy monitoring and RGB backlights",
+        whiteLabel: [tuya.whitelabel("Sparkelec", "SGPO2TZ", "Double GPO with energy monitoring and RGB backlights", ["_TZE200_lq0ffndf"])],
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"})],
+        // Both sockets are on endpoint 1; the l1/l2 split is by datapoint. This
+        // mapping exists only so withEndpoint() postfixes the property names.
         endpoint: () => ({l1: 1, l2: 1}),
-        exposes: [
-            tuya.exposes.switch().withEndpoint("l1"),
-            tuya.exposes.switch().withEndpoint("l2"),
-
-            e
-                .numeric("countdown_l1", ea.STATE_SET)
-                .withUnit("s")
-                .withValueMin(0)
-                .withValueMax(43200)
-                .withDescription("Auto-off/on countdown timer for socket 1"),
-            e
-                .numeric("countdown_l2", ea.STATE_SET)
-                .withUnit("s")
-                .withValueMin(0)
-                .withValueMax(43200)
-                .withDescription("Auto-off/on countdown timer for socket 2"),
-
-            e
-                .enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
-                .withEndpoint("l1")
-                .withDescription("Behavior when power is restored — socket 1"),
-            e
-                .enum("power_on_behavior", ea.STATE_SET, ["power_off", "power_on", "last"])
-                .withEndpoint("l2")
-                .withDescription("Behavior when power is restored — socket 2"),
-
-            e.binary("all_on_off", ea.STATE_SET, "ON", "OFF").withDescription("Master switch — all sockets simultaneously"),
-
-            e.numeric("power", ea.STATE).withUnit("W").withDescription("Instantaneous power"),
-            e.numeric("current", ea.STATE).withUnit("A").withDescription("Instantaneous current"),
-            e.numeric("voltage", ea.STATE).withUnit("V").withDescription("Instantaneous voltage"),
-            e.numeric("energy", ea.STATE).withUnit("kWh").withDescription("Cumulative energy consumption"),
-
-            tuya.exposes.backlightModeOffOn(),
-
-            e
-                .composite("backlight_color", "backlight_color", ea.STATE_SET)
-                .withDescription("Backlight color config is only meaningful when backlight mode is ON")
-                .withFeature(
-                    e
-                        .enum("mode", ea.STATE_SET, ["single", "multi"])
-                        .withDescription("single: one color per socket; multi: separate on/off colors per socket"),
-                )
-                .withFeature(
-                    e
-                        .composite("socket1", "socket1", ea.STATE_SET)
-                        .withDescription("Socket 1 LED")
-                        .withFeature(
-                            e
-                                .numeric("on_brightness", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(100)
-                                .withUnit("%")
-                                .withDescription("Brightness when socket is ON"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("on_hue", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(360)
-                                .withDescription("Hue (0=red, 60=yellow, 120=green, 180=cyan, 240=blue, 300=magenta, 360=purple)"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("on_saturation", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(1000)
-                                .withDescription("Saturation when ON (0=white, 1000=full color)"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("off_brightness", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(100)
-                                .withUnit("%")
-                                .withDescription("Brightness when socket is OFF — backlight mode ON only"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("off_hue", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(360)
-                                .withDescription("Hue when OFF — multi-color mode only"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("off_saturation", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(1000)
-                                .withDescription("Saturation when OFF — multi-color mode only"),
-                        ),
-                )
-                .withFeature(
-                    e
-                        .composite("socket2", "socket2", ea.STATE_SET)
-                        .withDescription("Socket 2 LED")
-                        .withFeature(
-                            e
-                                .numeric("on_brightness", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(100)
-                                .withUnit("%")
-                                .withDescription("Brightness when socket is ON"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("on_hue", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(360)
-                                .withDescription("Hue (0=red, 60=yellow, 120=green, 180=cyan, 240=blue, 300=magenta, 360=purple)"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("on_saturation", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(1000)
-                                .withDescription("Saturation when ON (0=white, 1000=full color)"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("off_brightness", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(100)
-                                .withUnit("%")
-                                .withDescription("Brightness when socket is OFF — backlight mode ON only"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("off_hue", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(360)
-                                .withDescription("Hue when OFF — multi-color mode only"),
-                        )
-                        .withFeature(
-                            e
-                                .numeric("off_saturation", ea.STATE_SET)
-                                .withValueMin(0)
-                                .withValueMax(1000)
-                                .withDescription("Saturation when OFF — multi-color mode only"),
-                        ),
-                ),
-
-            e.binary("child_lock", ea.STATE_SET, "LOCK", "UNLOCK").withDescription("Prevent physical control of the sockets"),
+        exposes: commonExposes(["l1", "l2"], ["Socket 1", "Socket 2"]),
+        meta: commonMeta(["l1", "l2"]),
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_4jvmbiph"]),
+        model: "MG-AU03",
+        vendor: "MakeGood",
+        description: "Double GPO with light switch, energy monitoring and RGB backlights",
+        whiteLabel: [
+            tuya.whitelabel("Sparkelec", "SGPO2XTZ", "Double GPO with light switch, energy monitoring and RGB backlights", ["_TZE200_4jvmbiph"]),
         ],
-        meta: {
-            multiEndpoint: true,
-            multiEndpointSkip: ["power", "current", "voltage", "energy", "all_on_off"],
-            tuyaDatapoints: [
-                [1, "state_l1", tuya.valueConverter.onOff],
-                [2, "state_l2", tuya.valueConverter.onOff],
-                [7, "countdown_l1", countdownConverter],
-                [8, "countdown_l2", countdownConverter],
-                [16, "backlight_mode", tuya.valueConverter.onOff],
-                [20, "energy", energyConverter],
-                [21, "current", tuya.valueConverter.divideBy1000],
-                [22, "power", tuya.valueConverter.divideBy10],
-                [23, "voltage", tuya.valueConverter.divideBy10],
-                [29, "power_on_behavior_l1", powerOnBehaviorConverter],
-                [30, "power_on_behavior_l2", powerOnBehaviorConverter],
-                [101, "child_lock", childLockConverter],
-                [107, "backlight_color", backlightColorConverter],
-                [136, "all_on_off", tuya.valueConverter.onOff],
-            ],
-        },
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"})],
+        endpoint: () => ({l1: 1, l2: 1, l3: 1}),
+        // Labels assume block order matches datapoint order (l1, l2, l3) — still to confirm.
+        exposes: commonExposes(["l1", "l2", "l3"], ["Socket 1", "Socket 2", "Socket 3"]),
+        meta: commonMeta(["l1", "l2", "l3"]),
     },
 ];

--- a/src/devices/makegood.ts
+++ b/src/devices/makegood.ts
@@ -4,9 +4,15 @@ import * as e from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, KeyValueAny} from "../lib/types";
 
 const ea = e.access;
+
+// Structural alias for one meta.tuyaDatapoints entry — derived from
+// DefinitionWithExtend itself so it always matches the real tuple shape
+// (number/string/converter, plus an optional per-entry meta object) without
+// having to name the library's internal type.
+type TuyaDpEntry = NonNullable<NonNullable<DefinitionWithExtend["meta"]>["tuyaDatapoints"]>[number];
 
 // --- MakeGood / Sparkelec TS0601 RGB-backlight range helpers ---
 //
@@ -85,8 +91,8 @@ const backlightColorConverter = (channelCount: number) => {
             return result;
         },
 
-        to(value: unknown, meta: {state?: {backlight_color?: Record<string, any>}}) {
-            let config: any = value;
+        to(value: unknown, meta: {state?: {"backlight_color"?: KeyValueAny}}) {
+            let config: KeyValueAny = value;
 
             if (typeof value === "string") {
                 try {
@@ -219,29 +225,36 @@ const countdownExpose = (endpoint: string) =>
 
 // Datapoints and exposes shared by every device in this range. `channels` is
 // the list of endpoint keys, in datapoint order.
+const powerOnBehaviorExpose = (channel: string) =>
+    e
+        .enum("power_on_behavior", ea.STATE_SET, ["off", "on", "previous"])
+        .withEndpoint(channel)
+        .withDescription("Behavior when power is restored")
+        .withCategory("config");
+
 const commonExposes = (channels: string[], labels: string[]) => [
     ...channels.map((channel) => tuya.exposes.switch().withEndpoint(channel)),
     ...channels.map((channel) => countdownExpose(channel)),
-    ...channels.map((channel) => e.power_on_behavior().withAccess(ea.STATE_SET).withEndpoint(channel).withCategory("config")),
+    ...channels.map((channel) => powerOnBehaviorExpose(channel)),
     e.binary("all_on_off", ea.STATE_SET, "ON", "OFF").withDescription("Turn all channels on or off simultaneously"),
-    e.power(),
-    e.current(),
-    e.voltage(),
-    e.energy(),
+    e.numeric("power", ea.STATE).withUnit("W").withDescription("Instantaneous power"),
+    e.numeric("current", ea.STATE).withUnit("A").withDescription("Instantaneous current"),
+    e.numeric("voltage", ea.STATE).withUnit("V").withDescription("Instantaneous voltage"),
+    e.numeric("energy", ea.STATE).withUnit("kWh").withDescription("Cumulative energy consumption"),
     tuya.exposes.backlightModeOffOn().withAccess(ea.STATE_SET),
     backlightColorExpose(labels),
-    e.child_lock().withCategory("config"),
+    e.binary("child_lock", ea.STATE_SET, "LOCK", "UNLOCK").withDescription("Prevent physical control of the sockets").withCategory("config"),
 ];
 
-const commonMeta = (channels: string[]) => ({
+const commonMeta = (channels: string[]): DefinitionWithExtend["meta"] => ({
     multiEndpoint: true,
     multiEndpointSkip: ["power", "current", "voltage", "energy", "all_on_off", "backlight_mode", "backlight_color", "child_lock"],
     tuyaDatapoints: [
         // Relays: DP 1..n
-        ...channels.map((channel, i): [number, string, unknown] => [i + 1, `state_${channel}`, tuya.valueConverter.onOff]),
+        ...channels.map((channel, i): TuyaDpEntry => [i + 1, `state_${channel}`, tuya.valueConverter.onOff]),
 
         // Countdown timers: DP 7..
-        ...channels.map((channel, i): [number, string, unknown] => [i + 7, `countdown_${channel}`, countdownConverter]),
+        ...channels.map((channel, i): TuyaDpEntry => [i + 7, `countdown_${channel}`, countdownConverter]),
 
         // Backlight enable
         [16, "backlight_mode", tuya.valueConverter.onOff],
@@ -254,7 +267,7 @@ const commonMeta = (channels: string[]) => ({
         // DP 24 is reported by the device but its meaning is unconfirmed, so it is not exposed.
 
         // Power-on behaviour: DP 29..
-        ...channels.map((channel, i): [number, string, unknown] => [i + 29, `power_on_behavior_${channel}`, tuya.valueConverter.powerOnBehaviorEnum]),
+        ...channels.map((channel, i): TuyaDpEntry => [i + 29, `power_on_behavior_${channel}`, tuya.valueConverter.powerOnBehaviorEnum]),
 
         [101, "child_lock", tuya.valueConverter.lockUnlock],
         [107, "backlight_color", backlightColorConverter(channels.length)],


### PR DESCRIPTION
# Add support for MakeGood MG-GPO02Z / Sparkelec SGPO2TZ

Original external converter was 100% vibe-coded on my end, with a bunch of additional support and testing from @bdnstn in the original thread: https://github.com/Koenkk/zigbee2mqtt/issues/31952

This PR adds support for the MakeGood MG-GPO02Z dual GPO with energy monitoring and RGB backlights,
also sold in Australia under the Sparkelec SGPO2TZ brand.

The Sparkelec appears to be a slightly different/newer version (marketed as V2) but testing shows the internals are the same.

---

## Added fingerprints

Added fingerprint:

```
_TZE200_lq0ffndf
```

White label added:

```
Sparkelec SGPO2TZ
```

---

## Device investigation

The implementation was based on datapoint information obtained from the Tuya IoT Platform device
model definitions, cross-referenced with live device behaviour reported in the linked issue.

The device uses `TS0601` with the `_TZE200_lq0ffndf` manufacturer name. All datapoints are
communicated on Zigbee endpoint 1. Both sockets are mapped to endpoint 1 (i.e. `{l1: 1, l2: 1}`),
with socket identity carried in the DP number rather than the Zigbee endpoint.

### Confirmed datapoints

| DP  | Tuya name          | Type    | Notes                                          |
| --- | ------------------ | ------- | ---------------------------------------------- |
| 1   | `switch_1`         | Boolean | Socket 1 on/off                                |
| 2   | `switch_2`         | Boolean | Socket 2 on/off                                |
| 7   | `countdown_1`      | Integer | Socket 1 auto-off countdown (s, 0–43200)       |
| 8   | `countdown_2`      | Integer | Socket 2 auto-off countdown (s, 0–43200)       |
| 16  | `switch_backlight` | Boolean | Backlight LED on/off                           |
| 20  | `add_ele`          | Integer | Cumulative energy (kWh, scale 3 → ÷1000)       |
| 21  | `cur_current`      | Integer | Current (mA, scale 0 → ÷1000 for A)           |
| 22  | `cur_power`        | Integer | Power (W, scale 1 → ÷10)                      |
| 23  | `cur_voltage`      | Integer | Voltage (V, scale 1 → ÷10)                    |
| 29  | `relay_status_1`   | Enum    | Socket 1 power-on behavior (power_off/power_on/last) |
| 30  | `relay_status_2`   | Enum    | Socket 2 power-on behavior (power_off/power_on/last) |
| 101 | `child_lock`       | Boolean | Prevent physical button operation              |
| 107 | `backlight_color`  | Raw     | Per-socket RGB color config — see notes below  |
| 136 | `all_on_off`       | Boolean | Master switch — both sockets simultaneously    |

---

## Added functionality

### DP 1 / 2 — switch_1 / switch_2

Mapped to `state_l1` / `state_l2` using `tuya.valueConverter.onOff`.

### DP 7 / 8 — countdown_1 / countdown_2

Mapped to `countdown_l1` / `countdown_l2`. The Tuya platform defines these as `scale: 0`,
so values are passed as raw integers (seconds). A custom converter normalises `null` and
`false` to `0` to avoid unexpected state values on first poll.

### DP 16 — switch_backlight

Mapped to `backlight_mode` using `tuya.exposes.backlightModeOffOn()`.

### DP 20 — add_ele (energy)

Mapped to `energy` (kWh). The Tuya platform defines this as `scale: 3`, so the raw integer
is divided by 1000. The device reports incremental energy values rather than a running total;
a custom accumulating converter adds each reported delta to the previous state value and
ignores zero or negative jumps to prevent spurious resets.

### DP 21 — cur_current

Mapped to `current` (A) using `tuya.valueConverter.divideBy1000`. Tuya reports in mA with
`scale: 0`.

### DP 22 — cur_power

Mapped to `power` (W) using `tuya.valueConverter.divideBy10`. Tuya reports with `scale: 1`.

### DP 23 — cur_voltage

Mapped to `voltage` (V) using `tuya.valueConverter.divideBy10`. Tuya reports with `scale: 1`.

### DP 29 / 30 — relay_status_1 / relay_status_2

Mapped to `power_on_behavior_l1` / `power_on_behavior_l2` using a lookup converter with
Tuya enum values `0 = power_off`, `1 = power_on`, `2 = last`.

### DP 101 — child_lock

Mapped to `child_lock` using a boolean lookup (`LOCK` / `UNLOCK`).

### DP 107 — backlight_color

The Tuya platform exposes a 21-byte raw payload encoding per-socket LED color for both on and
off states. The structure is:

```
byte  0:      mode (0 = single, 1 = multi)
bytes  1–10:  socket 1 (on_brightness, on_hue×2, on_saturation×2, off_brightness, off_hue×2, off_saturation×2)
bytes 11–20:  socket 2 (same layout)
```

Hue is 0–360, saturation is 0–1000, brightness is 0–100. A custom `toZigbee` converter
(`backlightColorToZigbee`) serialises a JSON object into this buffer and sends it via
`tuya.sendDataPointRaw`. The converter is only meaningful when `backlight_mode` is `ON`;
this is noted in the expose description.

> **Note:** DP 107 is only broadcast by the device at power-on. There is no confirmed
> read-back mechanism via z2m. The state is written optimistically and held in z2m state.
> This behaviour was identified during investigation in the linked issue, where the initial
> external converter omitted DP 107 entirely due to the difficulty of mapping it as a
> standard Tuya enum.

### DP 136 — all_on_off

Mapped to `all_on_off` using `tuya.valueConverter.onOff`. Listed in `multiEndpointSkip`
so it is not duplicated per endpoint.

---

## Notes

- Energy monitoring (DPs 20–23) is shared across both sockets; there is no per-socket
  breakdown. These are listed in `multiEndpointSkip` accordingly.
- The device does not use separate Zigbee endpoints per socket — both sockets share
  endpoint 1. The `endpoint` function returns `{l1: 1, l2: 1}`.
- No existing fingerprints or datapoint mappings were modified; this PR only adds the
  new `MG-GPO02Z` definition to `makegood.ts`.
- The Sparkelec SGPO2TZ and MakeGood MG-GPO02Z are the same hardware sold under different
  brands in the Australian market.

Link to Sparkelec product page: https://agmelectrical.com.au/home-automation-wifi-intercoms-smart-switches-and-power-points/sparkelec-touch-zigbee-wifi-switches-and-power-points/double-power-point-10a-smart-zigbee-touch-glass-wall-switch-off-white-sparkelec-sgpo2tz-white.html

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5290