### PR TITLE
Add SISWD11-ZB dimmer switch support

### DIFF
--- a/src/devices/mercator.ts
+++ b/src/devices/mercator.ts
@@ -189,6 +189,20 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_jowqowye"]),
+        model: "SISWD11-ZB",
+        vendor: "Mercator Ikuü",
+        description: "Inline module dimmer switch",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [tuya.exposes.lightBrightness()],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tuya.valueConverter.onOff],
+                [2, "brightness", tuya.valueConverter.scale0_254to0_1000],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS011F", ["_TZ3210_pfbzs1an"]),
         model: "SPPUSB02",
         vendor: "Mercator Ikuü",


### PR DESCRIPTION
Added support for SISWD11-ZB inline module dimmer switch with relevant metadata and datapoints.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5293
