### PR TITLE
fix: tuya weather crash due to missing await

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -5252,7 +5252,11 @@ const tuyaModernExtend = {
 
                     const pld = _prepareTuyaWeatherSyncPayload(meta, number_of_forecast_days, include_current_weather);
 
-                    msg.endpoint.command("manuSpecificTuya", "tuyaWeatherSync", {payload: pld});
+                    msg.endpoint
+                        .command("manuSpecificTuya", "tuyaWeatherSync", {payload: pld})
+                        .catch((error) =>
+                            logger.warning(() => `Failed to sync '${msg.device.ieeeAddr}:${msg.endpoint.ID}' on weather request (${error})`, NS),
+                        );
                 }
             },
         };
@@ -5264,7 +5268,12 @@ const tuyaModernExtend = {
 
                 const pld = _prepareTuyaWeatherSyncPayload(meta, numberOfForecastDays, includeCurrentWeather);
 
-                entity.command("manuSpecificTuya", "tuyaWeatherSync", {payload: pld});
+                entity
+                    .command("manuSpecificTuya", "tuyaWeatherSync", {payload: pld})
+                    .catch(
+                        (error) => () =>
+                            logger.warning(`Failed to sync weather for '${utils.isGroup(entity) ? entity.groupID : entity.ID}' (${error})`, NS),
+                    );
 
                 return {state: {[key]: value}};
             },


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/32435

@Koenkk I went with `warning` log..? Appears they fail rather a lot (based on above logs)...
Also went with `catch` instead of `await`, appears to be the consensus for this kind of tuya stuff.