### PR TITLE
fix(soma): remove tilt control from SmartShades3

### DIFF
--- a/src/devices/soma.ts
+++ b/src/devices/soma.ts
@@ -7,6 +7,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SmartShades3",
         vendor: "SOMA",
         description: "Smart shades 3",
-        extend: [m.battery(), m.windowCovering({controls: ["lift", "tilt"]})],
+        extend: [m.battery(), m.windowCovering({controls: ["lift"]})],
     },
 ];


### PR DESCRIPTION
## Problem

SmartShades3 is a roller shade motor with no physical tilt mechanism. The current definition declares `controls: ["lift", "tilt"]`, which causes `configure()` to attempt reporting setup for `currentPositionTiltPercentage` on every Z2M restart. These devices reject it with `UNSUPPORTED_ATTRIBUTE`, leaving the device stuck in a failed configure state.

Error seen on every restart:
```
Failed to configure 'Front Door Shade Right', attempt 1 (Error: ZCL command closuresWindowCovering.configReport([{"attribute":"currentPositionTiltPercentage",...}]) failed (Status 'UNSUPPORTED_ATTRIBUTE'))
```

## Root Cause

SmartShades3 is SOMA's roller shade product. SOMA's **Tilt 2** is a separate product for venetian/zebra blinds. The `tilt` control does not apply to SmartShades3.

Confirmed in the device cluster info — reporting is only configured for `attrId 8` (lift/position), never `attrId 9` (tilt).

## Fix

Remove `"tilt"` from `windowCovering` controls. Lift/position reporting continues to work normally.

Closes #12444