### PR TITLE
Add childLock support to TS011F device TO-Q-SY2-163JZT

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15413,6 +15413,7 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOutageMemory: true,
                 indicatorMode: true,
                 onOffCountdown: true,
+                childLock: true,
             }),
         ],
         fromZigbee: [fz.temperature, fzLocal.TS011F_threshold],


### PR DESCRIPTION
Hello.

- Added `childLock` support for the TONGOU TO-Q-SY2-163JZT smart breaker (verified operation via an external converter).
- Supported manufacturer IDs: `_TZ3000_cayepv1a`, `_TZ3000_yi0n4xfd`.
- Device logic specifics: when `childLock` is enabled, the breaker turns off and is completely blocked from turning back on, both via software and via the physical button on the housing.
- Functionality and device behavior have been physically tested on real hardware.
- This feature is critical for safety purposes to prevent accidental or unwanted line activation under load.

Thank you for your project support and your work.

