### PR TITLE
Fix SONOFF SWV configure when optional attribute is unsupported

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -7578,7 +7578,12 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "genOnOff"]);
             await reporting.bind(endpoint, coordinatorEndpoint, ["msFlowMeasurement"]);
             await reporting.onOff(endpoint, {min: 1, max: 1800, change: 0});
-            await endpoint.read("customClusterEwelink", [0x500c, 0x5011]);
+            await endpoint.read("customClusterEwelink", [0x500c]).catch((error) => {
+                logger.warning(`SWV read customClusterEwelink(current_device_status) failed: ${error}`, NS);
+            });
+            await endpoint.read("customClusterEwelink", [0x5011]).catch((error) => {
+                logger.warning(`SWV read customClusterEwelink(lackWaterCloseValveTimeout) failed: ${error}`, NS);
+            });
         },
     },
     {

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -549,6 +549,32 @@ describe("Sonoff TRVZB", () => {
     });
 });
 
+describe("Sonoff SWV", () => {
+    it("continues configuring when optional water shortage auto-close attribute is unsupported", async () => {
+        const device = mockDevice({
+            modelID: "SWV",
+            endpoints: [{ID: 1, inputClusters: ["genPowerCfg", "genOnOff", "msFlowMeasurement"], inputClusterIDs: [0xfc11]}],
+        });
+        const coordinator = mockDevice({modelID: "Coordinator", endpoints: [{ID: 1}]});
+        const endpoint = device.getEndpoint(1);
+        const readFn = endpoint.read as Mock;
+        const swv = await findByDevice(device);
+
+        readFn.mockImplementation((_cluster: string, attributes: number[]) => {
+            if (attributes.includes(0x5011)) {
+                return Promise.reject(new Error("Status 'UNSUPPORTED_ATTRIBUTE'"));
+            }
+
+            return Promise.resolve({});
+        });
+
+        await expect(swv.configure(device, coordinator.getEndpoint(1), swv)).resolves.toBeUndefined();
+
+        expect(readFn).toHaveBeenCalledWith("customClusterEwelink", [0x500c]);
+        expect(readFn).toHaveBeenCalledWith("customClusterEwelink", [0x5011]);
+    });
+});
+
 describe("Sonoff SNZB-02DR2", () => {
     let device: Definition;
     let endpoint: ZHModels.Endpoint;


### PR DESCRIPTION
## Summary

Fixes #12599.

This makes the SONOFF SWV configure step tolerate missing optional private eWeLink attributes:

- reads `current_device_status` (`0x500c`) independently
- reads `lackWaterCloseValveTimeout` (`0x5011`) independently
- logs a warning instead of failing configure when either optional read is rejected

## Why

`auto_close_when_water_shortage` depends on SWV firmware `1.0.4` or later. Devices without that attribute can return `UNSUPPORTED_ATTRIBUTE` for `0x5011`, which currently makes the whole configure step fail even though the valve can otherwise operate normally.

## Tests

- `pnpm exec vitest run --config ./test/vitest.config.mts test/sonoff.test.ts`
- `pnpm run check`
- commit hook: `pnpm run build`
- commit hook: `pnpm run check`
- commit hook: `pnpm test`
