### PR TITLE
feat: add Tongou TOQCB2-80-2P whitelabel

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20219,6 +20219,7 @@ export const definitions: DefinitionWithExtend[] = [
         // Important: respondToMcuVersionResponse should be false otherwise there is an avalanche of commandMcuVersionResponse messages every second.
         // queryIntervalSeconds: is doing a pooling to update the device's parameters, now defined to update data every 3 minutes.
         extend: [tuya.modernExtend.tuyaBase({dp: true, queryIntervalSeconds: 3 * 60})],
+        whiteLabel: [tuya.whitelabel("Tongou", "TOQCB2-80-2P", "Smart circuit breaker (2P)", ["_TZE284_mrffaamu", "_TZE204_mrffaamu"])],
         exposes: [
             tuya.exposes.switch(),
             e.energy(),


### PR DESCRIPTION
Adds a **2-pole (2P)** whitelabel for the Tongou **TOQCB2-80** smart circuit breaker.

The `_TZE284_mrffaamu` / `_TZE204_mrffaamu` fingerprints are now mapped to model `TOQCB2-80-2P` (confirmed on real hardware), so the 2P variant gets its own model name and image instead of the default 4P `TOQCB2-80` entry, which stays unchanged.

Closes #12601

### Device image

- Koenkk/zigbee2mqtt.io#5297 (adds `TOQCB2-80-2P.png`, 512x512, transparent background)

### Notes

- Only the 2P mapping is confirmed for now; other pole variants are tracked in the issue for follow-up.

### Validation

- `tsc --noEmit` passes
- `pnpm run build` succeeds (4363 definitions)
- `vitest` test/checks.test.ts, test/index.test.ts, test/tuya.test.ts all pass
