### PR TITLE
feat(add): add SE-RZ11 boiler control relay module for Enel Homix system

### DIFF
--- a/src/devices/sercomm.ts
+++ b/src/devices/sercomm.ts
@@ -156,4 +156,11 @@ export const definitions: DefinitionWithExtend[] = [
         toZigbee: [],
         exposes: [e.water_leak(), e.battery_low()],
     },
+    {
+        zigbeeModel: ["SE-RZ11"],
+        model: "SE-RZ11",
+        vendor: "Sercomm",
+        description: "Boiler control relay module used in Enel Homix system",
+        extend: [m.onOff({powerOnBehavior: false})],
+    },
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5298

This is the device I want to add: https://www.subito.it/elettrodomestici/modulo-x-caldaia-homix-termostato-ambiente-casa-varese-576181474.htm

I've tested it using external converters, now it's time to make it official :) .

<img width="1483" height="718" alt="Screenshot 2026-07-02 at 08 03 23" src="https://github.com/user-attachments/assets/beac49ef-b48a-4869-890d-370393aa9948" />



