### PR TITLE
Issue 32456: Develco ZHEMI101 converter upgrade bugfix

### DIFF
--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -264,12 +264,14 @@ const zhemi101NormalizeMeterValue = (rawValue: unknown, config: KeyValueAny, isD
     const unitInfo = zhemi101UnitInfo[zhemi101ToNumber(config.unitOfMeasure) ?? -1];
     if (unitInfo === undefined) return undefined;
 
-    const normalized = raw * zhemi101Scale(config) * unitInfo.factorToTarget;
+    // The spec scales electric demand to kW; Z2M's power property is W.
+    const factorToTarget = isDemand && unitInfo.kind === "energy" ? unitInfo.factorToTarget * 1000 : unitInfo.factorToTarget;
+    const normalized = raw * zhemi101Scale(config) * factorToTarget;
     const sourceDecimals = zhemi101DecimalsFromFormatting(
         isDemand ? config.demandFormatting : config.summationFormatting,
         zhemi101DecimalsFromDivisor(config.divisor),
     );
-    const extraDecimals = unitInfo.factorToTarget === 1 ? 0 : unitInfo.factorToTarget < 1 ? Math.ceil(-Math.log10(unitInfo.factorToTarget)) + 2 : 2;
+    const extraDecimals = factorToTarget === 1 ? 0 : factorToTarget < 1 ? Math.ceil(-Math.log10(factorToTarget)) + 2 : 2;
     return utils.precisionRound(normalized, Math.min(9, sourceDecimals + extraDecimals));
 };
 
@@ -1226,7 +1228,7 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             e.energy().withDescription("Normalized cumulative energy. Source units such as kWh or BTU are converted to kWh."),
             e.produced_energy().withDescription("Normalized produced energy, when reported by the meter."),
-            e.power().withUnit("kW").withDescription("Normalized instantaneous demand. Source units such as kW or BTU/h are converted to kW."),
+            e.power().withDescription("Normalized instantaneous demand. Source units such as kW or BTU/h are converted to W."),
             e
                 .numeric("gas", ea.STATE)
                 .withUnit("m³")

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -212,6 +212,23 @@ const zhemi101GetMeterConfig = (
     };
 };
 
+const zhemi101PublishMissingMeterConfig = (payload: KeyValueAny, meta: Fz.Meta, config: KeyValueAny) => {
+    const fields = {
+        unit_of_measure: config.unitOfMeasure,
+        metering_device_type: config.meteringDeviceType,
+        multiplier: config.multiplier,
+        divisor: config.divisor,
+        summation_formatting: config.summationFormatting,
+        demand_formatting: config.demandFormatting,
+    };
+
+    for (const [property, value] of Object.entries(fields)) {
+        if (value !== undefined && meta.state?.[property] == null) {
+            payload[property] = value;
+        }
+    }
+};
+
 const zhemi101GetMeterConfigFromEntity = (entity: KeyValueAny, meta: Tz.Meta): KeyValueAny => {
     const cached = zhemi101MeterConfigCache.get(zhemi101MeterConfigKey(entity)) ?? {};
     const interfaceMode = zhemi101FirstDefined(cached.interfaceMode, meta.state?.interface_mode);
@@ -409,6 +426,7 @@ const develco = {
                 const data = msg.data as KeyValueAny;
                 const payload: KeyValueAny = {};
                 const summationFormatting = zhemi101FirstDefined(data.summaFormatting, data.summationFormatting);
+                zhemi101PublishMissingMeterConfig(payload, meta, config);
 
                 if (data.unitOfMeasure !== undefined) payload.unit_of_measure = data.unitOfMeasure;
                 if (data.meteringDeviceType !== undefined) payload.metering_device_type = data.meteringDeviceType;
@@ -1208,6 +1226,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZHEMI101",
         vendor: "Develco",
         description: "Energy/gas/water meter interface",
+        version: "0.0.1",
         fromZigbee: [develco.fz.metering_zhemi101, develco.fz.pulse_configuration, develco.fz.interface_mode],
         toZigbee: [develco.tz.pulse_configuration, develco.tz.interface_mode_zhemi101, develco.tz.unit_summation_zhemi101],
         endpoint: (device) => {

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -1,7 +1,12 @@
 import {describe, expect, it} from "vitest";
+import {definitions as develcoDefinitions} from "../src/devices/develco";
 import {fromZigbee} from "../src/index";
+import {mockDevice} from "./utils";
 
 describe("converters/fromZigbee", () => {
+    const zhemi101Definition = develcoDefinitions.find((definition) => definition.model === "ZHEMI101");
+    const zhemi101MeteringConverter = zhemi101Definition?.fromZigbee?.find((converter) => converter.cluster === "seMetering");
+
     it("Message with no properties does not error converting battery percentages", () => {
         const payload = fromZigbee.battery.convert(
             // @ts-expect-error mock
@@ -51,6 +56,82 @@ describe("converters/fromZigbee", () => {
             battery: 98,
             voltage: 2700,
         });
+    });
+
+    it("ZHEMI101 converts electricity instantaneous demand to W", () => {
+        const device = mockDevice({
+            modelID: "ZHEMI101",
+            endpoints: [
+                {
+                    ID: 2,
+                    attributes: {seMetering: {attributes: {unitOfMeasure: 0, multiplier: 1, divisor: 1000, meteringDeviceType: 0}}},
+                },
+            ],
+        });
+        const endpoint = device.getEndpoint(2);
+
+        const payload = zhemi101MeteringConverter?.convert(
+            // @ts-expect-error minimal model
+            zhemi101Definition,
+            {
+                data: {instantaneousDemand: 280},
+                endpoint,
+                device,
+                meta: {rawData: Buffer.from([])},
+                groupID: 0,
+                type: "attributeReport",
+                cluster: "seMetering",
+                linkquality: 0,
+            },
+            null,
+            {},
+            {state: {interface_mode: "electricity"}},
+        );
+
+        expect(payload).toStrictEqual({power: 280});
+    });
+
+    it("ZHEMI101 keeps gas and water instantaneous demand in m3/h", () => {
+        for (const [interfaceMode, property] of [
+            ["gas", "flow"],
+            ["water", "flow"],
+        ] as const) {
+            const device = mockDevice({
+                ieeeAddr: interfaceMode === "gas" ? "0x0000000000000001" : "0x0000000000000002",
+                modelID: "ZHEMI101",
+                endpoints: [
+                    {
+                        ID: 2,
+                        attributes: {
+                            seMetering: {
+                                attributes: {unitOfMeasure: 1, multiplier: 1, divisor: 1000, meteringDeviceType: interfaceMode === "gas" ? 1 : 2},
+                            },
+                        },
+                    },
+                ],
+            });
+            const endpoint = device.getEndpoint(2);
+
+            const payload = zhemi101MeteringConverter?.convert(
+                // @ts-expect-error minimal model
+                zhemi101Definition,
+                {
+                    data: {instantaneousDemand: 280},
+                    endpoint,
+                    device,
+                    meta: {rawData: Buffer.from([])},
+                    groupID: 0,
+                    type: "attributeReport",
+                    cluster: "seMetering",
+                    linkquality: 0,
+                },
+                null,
+                {},
+                {state: {interface_mode: interfaceMode}},
+            );
+
+            expect(payload).toStrictEqual({[property]: 0.28});
+        }
     });
 
     it("Device uses reported percentage", () => {

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -85,10 +85,58 @@ describe("converters/fromZigbee", () => {
             },
             null,
             {},
-            {state: {interface_mode: "electricity"}},
+            {state: {interface_mode: "electricity", unit_of_measure: 0, metering_device_type: 0, multiplier: 1, divisor: 1000}},
         );
 
         expect(payload).toStrictEqual({power: 280});
+    });
+
+    it("ZHEMI101 republishes missing metering metadata from stale null state", () => {
+        const device = mockDevice({
+            ieeeAddr: "0x0000000000000003",
+            modelID: "ZHEMI101",
+            endpoints: [
+                {
+                    ID: 2,
+                    attributes: {seMetering: {attributes: {unitOfMeasure: 0, multiplier: 1, divisor: 1000, meteringDeviceType: 0}}},
+                },
+            ],
+        });
+        const endpoint = device.getEndpoint(2);
+
+        const payload = zhemi101MeteringConverter?.convert(
+            // @ts-expect-error minimal model
+            zhemi101Definition,
+            {
+                data: {instantaneousDemand: 280},
+                endpoint,
+                device,
+                meta: {rawData: Buffer.from([])},
+                groupID: 0,
+                type: "attributeReport",
+                cluster: "seMetering",
+                linkquality: 0,
+            },
+            null,
+            {},
+            {
+                state: {
+                    interface_mode: "electricity",
+                    unit_of_measure: null,
+                    metering_device_type: null,
+                    multiplier: null,
+                    divisor: null,
+                },
+            },
+        );
+
+        expect(payload).toStrictEqual({
+            divisor: 1000,
+            metering_device_type: 0,
+            multiplier: 1,
+            power: 280,
+            unit_of_measure: 0,
+        });
     });
 
     it("ZHEMI101 keeps gas and water instantaneous demand in m3/h", () => {
@@ -127,7 +175,15 @@ describe("converters/fromZigbee", () => {
                 },
                 null,
                 {},
-                {state: {interface_mode: interfaceMode}},
+                {
+                    state: {
+                        interface_mode: interfaceMode,
+                        unit_of_measure: 1,
+                        metering_device_type: interfaceMode === "gas" ? 1 : 2,
+                        multiplier: 1,
+                        divisor: 1000,
+                    },
+                },
             );
 
             expect(payload).toStrictEqual({[property]: 0.28});


### PR DESCRIPTION
Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/32456

**Issue Summary**
Some users reported that after https://github.com/Koenkk/zigbee2mqtt/issues/32456 was released, their ZHEMI101 reports power measurements off by a factor of `1000` or by a factor of `0.001`.  
One user reports a corrupt `state` of their ZHEMI101 device in Z2M.

**Description of this fix**
1. Normalizing reported power to `W` - even if the device states it is reporting power as `kW`.  
    This is because it looks as if `W` is the standard unit for reporting power in Z2M.
2. Adding a `version` to the device definition. This will prompt an automatic reconfigure when a newer converter is installed.  
    During this step, any incompatible state from a previous converter's version should be repaired.

**Test Plan**
I verified this, and it works.

1. rebuild the converter  
    ```sh
    pnpm run clean && \
    pnpm run build
    ```
2. copy `dist/devices/develco.js` to your z2m system at `/app/node_modules/zigbee-herdsman-converters/dist/devices/develco.js`
3. restart z2m
4. grep the logs
    ```sh
    grep -n "zhemi101PublishMissingMeterConfig\|version: \"0.0.1\"\|power.*1000" /app/node_modules/zigbee-herdsman-converters/dist/devices/develco.js
    ```
    expect the output to look like this
    ```
    224:const zhemi101PublishMissingMeterConfig = (payload, meta, config) => {
    411:                zhemi101PublishMissingMeterConfig(payload, meta, config);
    755:        version: "0.0.1",
    ```
5. observe that your ZHEMI101 device now exports power correctly scaled, and represented in Watts (`W`)