### PR TITLE
Fix XHS2-UE battery voltage curve

### DIFF
--- a/src/devices/universal_electronics_inc.ts
+++ b/src/devices/universal_electronics_inc.ts
@@ -32,7 +32,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Magnetic door & window contact sensor",
         fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: "3V_2100"}},
+        meta: {battery: {voltageToPercentage: {min: 2500, max: 2800}}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["msTemperatureMeasurement", "genPowerCfg"]);

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {definitions as develcoDefinitions} from "../src/devices/develco";
-import {fromZigbee} from "../src/index";
+import {findByDevice, fromZigbee} from "../src/index";
 import {mockDevice} from "./utils";
 
 describe("converters/fromZigbee", () => {
@@ -218,6 +218,37 @@ describe("converters/fromZigbee", () => {
         expect(payload).toStrictEqual({
             battery: 1,
             voltage: 2700,
+        });
+    });
+
+    it("XHS2-UE uses voltage curve instead of stale reported battery percentage", async () => {
+        const definition = await findByDevice(mockDevice({modelID: "URC4460BC0-X-R", endpoints: []}));
+
+        const payload = fromZigbee.battery.convert(
+            definition,
+            {
+                data: {
+                    batteryVoltage: 28,
+                    batteryPercentageRemaining: 54,
+                },
+                endpoint: null,
+                device: null,
+                meta: null,
+                groupID: null,
+                type: "attributeReport",
+                cluster: "genPowerCfg",
+                linkquality: 0,
+            },
+            null,
+            {},
+            {
+                meta: {},
+            }.meta,
+        );
+
+        expect(payload).toStrictEqual({
+            battery: 100,
+            voltage: 2800,
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes #12608.

This updates the Universal Electronics Inc `XHS2-UE` / `URC4460BC0-X-R` contact sensor battery curve to derive percentage from measured voltage:

- changes `voltageToPercentage` from `3V_2100` to `{min: 2500, max: 2800}`
- adds a regression test that `2800mV` reports `100%` even when the device reports a stale `27%`

## Why

This is the same behavior fixed for the Sylvania `74388` contact sensor in #12486: after a fresh battery change, the device can report a healthy/full voltage while also reporting a stale low battery percentage.

For `XHS2-UE`, the observed state was:

```json
{
    "battery": 27,
    "battery_low": false,
    "contact": true,
    "linkquality": 188,
    "tamper": false,
    "temperature": 20,
    "voltage": 2800
}
```

Using `{min: 2500, max: 2800}` matches the previously merged Sylvania fix and treats `2800mV` as full.

## Tests

- `pnpm exec vitest run --config ./test/vitest.config.mts test/fromZigbee.test.ts`
- `pnpm run check`
- commit hook: `pnpm run build`
- commit hook: `pnpm run check`
- commit hook: `pnpm test`
