### PR TITLE
fix(detect): Detect `_TZ3210_lqb7lcq9` as Nova Digital SA-WK

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6565,7 +6565,14 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.battery(), e.temperature(), e.humidity(), e.battery_voltage()],
     },
     {
-        fingerprint: tuya.fingerprint("TS011F", ["_TZ3000_3zofvcaa", "_TZ3000_pvlvoxvt", "_TZ3000_lqb7lcq9", "_TZ3210_urjf5u18", "_TZ3210_8n4dn1ne"]),
+        fingerprint: tuya.fingerprint("TS011F", [
+            "_TZ3000_3zofvcaa",
+            "_TZ3000_pvlvoxvt",
+            "_TZ3000_lqb7lcq9",
+            "_TZ3210_lqb7lcq9",
+            "_TZ3210_urjf5u18",
+            "_TZ3210_8n4dn1ne",
+        ]),
         model: "TS011F_2_gang_2_usb_wall",
         vendor: "Tuya",
         description: "2 gang 2 usb wall outlet",
@@ -6591,6 +6598,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
         whiteLabel: [
             tuya.whitelabel("Nova Digital", "NTS2-W-B", "2 gang 2 usb wall outlet 4x2", ["_TZ3000_lqb7lcq9"]),
+            tuya.whitelabel("Nova Digital", "SA-WK", "Safira Full Switch 1 gang + socket 20A + USB-A + USB-C 4x2", ["_TZ3210_lqb7lcq9"]),
             tuya.whitelabel("AVATTO", "ZWOT12", "2 gang 2 usb wall outlet 4x2", ["_TZ3210_urjf5u18"]),
             tuya.whitelabel("Coibeu", "ZB414", "2 gang 2 usb wall outlet 4x2", ["_TZ3210_8n4dn1ne"]),
         ],


### PR DESCRIPTION
Nova Digital Safira "Full Switch" (**SA-WK**): 1 physical gang + 20A socket + USB-A + USB-C, 4x2 wall module. It has four independently switchable relays (endpoints 1–4, each with `genOnOff`) and **no** energy metering.

It reports as `TS011F` / `_TZ3210_lqb7lcq9` and currently falls back to `TS011F_plug_1` (single gang + non-existent power monitoring). It is the same 4-gang hardware already covered by `TS011F_2_gang_2_usb_wall`, which includes the Nova Digital **NTS2-W-B** via `_TZ3000_lqb7lcq9` (same base code, newer `_TZ3210_` chip revision).

This PR adds the manufacturer name to the existing definition and a `whiteLabel` entry for the SA-WK.

**Device fingerprint (from the Z2M "Clusters" tab):** endpoints 1–4 each expose `genOnOff`; endpoint 242 is Green Power; no `seMetering`/`haElectricalMeasurement` cluster.

`pnpm check`, `pnpm build` and `pnpm test` (646 tests) all pass locally.
