### PR TITLE
NYCE NCZ-3011-HA: fix IAS enrollment during reconfigure

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1169,9 +1169,9 @@ export const ias_contact_alarm_1: Fz.Converter<"ssIasZone", undefined, "commandS
         };
     },
 };
-export const ias_contact_alarm_1_report: Fz.Converter<"ssIasZone", undefined, "attributeReport"> = {
+export const ias_contact_alarm_1_report: Fz.Converter<"ssIasZone", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "ssIasZone",
-    type: "attributeReport",
+    type: ["attributeReport", "readResponse"],
     convert: (model, msg, publish, options, meta) => {
         const zoneStatus = msg.data.zoneStatus;
         if (zoneStatus !== undefined) {

--- a/src/devices/nyce.ts
+++ b/src/devices/nyce.ts
@@ -2,9 +2,49 @@ import * as fz from "../converters/fromZigbee";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
+
+async function readNyceIasState(endpoint: Zh.Endpoint) {
+    return await endpoint.read("ssIasZone", ["zoneState", "iasCieAddr", "zoneStatus"], {sendPolicy: "immediate"});
+}
+
+function hasExpectedNyceIasState(state: {zoneState?: number; iasCieAddr?: string}, coordinatorIeeeAddress: string): boolean {
+    return state.zoneState === 1 && state.iasCieAddr?.toLowerCase() === coordinatorIeeeAddress.toLowerCase();
+}
+
+// NYCE NCZ-3011-HA fails IAS CIE address write during interview: https://github.com/Koenkk/zigbee2mqtt/issues/32480
+// This is fixable in the configure step. Usually it is enough to read the iasState to finish the enrollment; but this code can also attempt to re-write it.
+async function ensureNyceIasEnrollment(endpoint: Zh.Endpoint, coordinatorEndpoint: Zh.Endpoint) {
+    const coordinatorIeeeAddress = coordinatorEndpoint.deviceIeeeAddress;
+    let state = await readNyceIasState(endpoint);
+
+    if (hasExpectedNyceIasState(state, coordinatorIeeeAddress)) {
+        return;
+    }
+
+    let enrollmentError: unknown;
+
+    try {
+        await endpoint.write("ssIasZone", {iasCieAddr: coordinatorIeeeAddress}, {sendPolicy: "immediate"});
+        await endpoint.command("ssIasZone", "enrollRsp", {enrollrspcode: 0, zoneid: 23}, {disableDefaultResponse: true, sendPolicy: "immediate"});
+    } catch (error) {
+        enrollmentError = error;
+    }
+
+    await utils.sleep(500);
+    state = await readNyceIasState(endpoint);
+
+    if (!hasExpectedNyceIasState(state, coordinatorIeeeAddress)) {
+        throw new Error(
+            `NYCE IAS enrollment failed; expected zoneState=1 and iasCieAddr=${coordinatorIeeeAddress}, got ${JSON.stringify(state)}${
+                enrollmentError ? ` after enrollment error: ${enrollmentError}` : ""
+            }`,
+        );
+    }
+}
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -26,12 +66,13 @@ export const definitions: DefinitionWithExtend[] = [
         model: "NCZ-3011-HA",
         vendor: "Nyce",
         description: "Door/window sensor",
-        fromZigbee: [fz.ias_contact_alarm_1, fz.battery],
+        fromZigbee: [fz.ias_contact_alarm_1, fz.ias_contact_alarm_1_report, fz.battery],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
             await reporting.batteryPercentageRemaining(endpoint);
+            await ensureNyceIasEnrollment(endpoint, coordinatorEndpoint);
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.battery()],
     },


### PR DESCRIPTION
Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/32480 (part 2/2)

**From the ticket**
> - I learned that the device merely does not confirm the successful IAS enrollment during the interview step.
> - most of the time, the enrollment did work, but it requires probing the device, and reading the `ssIasZone.zoneState` and `ssIasZone.iasCieAddr` attributes. after this read was successful, everything works fine.

This change alters the reconfigure logic for [NYCE NCZ-3011-HA](https://www.zigbee2mqtt.io/devices/NCZ-3011-HA.html) devices, such that it tries to correct any IAS enrollment errors that might have happened during the interview process.