### PR TITLE
Update moes.ts

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -999,7 +999,7 @@ export const definitions: DefinitionWithExtend[] = [
                 e.min_temperature_limit(),
                 e
                     .climate()
-                    .withSetpoint("current_heating_setpoint", 5, 45, heatingStepSize, ea.STATE_SET)
+                    .withSetpoint("current_heating_setpoint", 5, 90, heatingStepSize, ea.STATE_SET)
                     .withLocalTemperature(ea.STATE)
                     .withLocalTemperatureCalibration(
                         -30,


### PR DESCRIPTION

Adds support for the Moes BHT-002 thermostat variant with fingerprint `_TZE200_5toc8efa`. This device is commonly used for boiler temperature control and supports temperature setting in the range of 5–90 °C.
