### PR TITLE
fix: Tuya cover moesCalibrationTime ENUM8 -> UINT16

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -5311,7 +5311,7 @@ const tuyaClusters = {
                 tuyaMovingState: {name: "tuyaMovingState", ID: 0xf000, type: Zcl.DataType.ENUM8, write: true, max: 0xff},
                 tuyaCalibration: {name: "tuyaCalibration", ID: 0xf001, type: Zcl.DataType.ENUM8, write: true, max: 0xff},
                 tuyaMotorReversal: {name: "tuyaMotorReversal", ID: 0xf002, type: Zcl.DataType.ENUM8, write: true, max: 0xff},
-                moesCalibrationTime: {name: "moesCalibrationTime", ID: 0xf003, type: Zcl.DataType.ENUM8, write: true, max: 0xffff},
+                moesCalibrationTime: {name: "moesCalibrationTime", ID: 0xf003, type: Zcl.DataType.UINT16, write: true, max: 0xffff},
                 tuyaSwitchType: {name: "tuyaSwitchType", ID: 0x8000, type: Zcl.DataType.ENUM8, write: true, max: 0xff},
             },
             commands: {},

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {Zcl} from "zigbee-herdsman";
 import {findByDevice, type Tz} from "../src/index";
 import * as tuya from "../src/lib/tuya";
 import type {Fz} from "../src/lib/types";
@@ -78,6 +79,29 @@ describe("lib/tuya", () => {
             for (const c of [-9, -5.5, -0.5, 0, 0.5, 5.5, 6, 9]) {
                 expect(conv.from(conv.to(c))).toBe(c);
             }
+        });
+    });
+
+    describe("closuresWindowCovering custom cluster (Tuya covers)", () => {
+        // Regression: moesCalibrationTime was declared as ENUM8 (a single byte,
+        // max 255). The calibration_time converter writes value * 10 and the
+        // exposed max is 500 s -> 5000, which does not fit in a byte:
+        //   - calibration_time 26 -> 260 throws RangeError (> 255) before sending
+        //   - smaller values (e.g. 25 -> 250) are rejected on-air as
+        //     INVALID_DATA_TYPE
+        // The attribute must be UINT16 for value * 10 (up to 5000) to encode.
+        it("declares moesCalibrationTime as UINT16 so value*10 fits", async () => {
+            const device = mockDevice({
+                modelID: "TS130F",
+                manufacturerName: "_TZ3000_1dd0d5yi",
+                endpoints: [{ID: 1, inputClusters: ["closuresWindowCovering"]}],
+            });
+            const definition = await findByDevice(device);
+            // Registers the custom cluster on the device (deviceAddCustomCluster).
+            await definition.configure?.(device, device.getEndpoint(1), definition);
+
+            const cluster = device.customClusters.closuresWindowCovering;
+            expect(cluster.attributes.moesCalibrationTime).toMatchObject({ID: 0xf003, type: Zcl.DataType.UINT16});
         });
     });
 });


### PR DESCRIPTION
## Problem

`calibration_time` can no longer be written to Tuya TS130F cover controllers (e.g. Moes **MS-108ZR**, `_TZ3000_1dd0d5yi`). Any attempt to set it fails, so newly added devices are stuck at their factory default and existing ones cannot be re-configured.

Two symptoms, depending on the value:

- **`calibration_time: 26`** → `RangeError [ERR_OUT_OF_RANGE]: ... moesCalibrationTime: 260 ... must be >= 0 and <= 255. Received 260`
- **`calibration_time: 25`** (and other in-byte values) → device rejects the write with `Status 'INVALID_DATA_TYPE'`

## Root cause

The `moesCalibrationTime` attribute (`0xf003`) on the `closuresWindowCovering` custom cluster is declared as `ENUM8`:

```ts
moesCalibrationTime: {name: "moesCalibrationTime", ID: 0xf003, type: Zcl.DataType.ENUM8, write: true, max: 0xffff},
```

`ENUM8` is a single byte (0–255). The `calibration_time` converter sends `value * 10`, and the exposed max is `500` s → `5000`, which needs 16 bits:

- `26 * 10 = 260` overflows the byte → `RangeError` before transmission.
- Even values that fit the byte (`25 * 10 = 250`) are sent with the wrong ZCL data type, so the device replies `INVALID_DATA_TYPE`.

This attribute was previously defined as `UINT16` in `zigbee-herdsman`, and writes worked correctly. When it moved into the converter-side custom cluster it was declared `ENUM8`, which is the regression.

## Fix

Restore the attribute to `UINT16`:

```ts
moesCalibrationTime: {name: "moesCalibrationTime", ID: 0xf003, type: Zcl.DataType.UINT16, write: true, max: 0xffff},
```

## Testing

Verified against a physical Moes MS-108ZR (`_TZ3000_1dd0d5yi`):

- **Before:** `calibration_time` writes fail with `RangeError` (>= 25.5 s) or `INVALID_DATA_TYPE` (any value).
- **After** (validated via an equivalent external converter, then this change): writing `calibration_time: 25` succeeds with no errors, and a fresh read back from the device confirms the value persisted.
