### PR TITLE
Add support for OSRAM 72569 to existing Sylvania device

### DIFF
--- a/src/devices/sylvania.ts
+++ b/src/devices/sylvania.ts
@@ -138,7 +138,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [ledvanceLight({})],
     },
     {
-        zigbeeModel: ["Edge-lit Under Cabinet TW"],
+        zigbeeModel: ["Edge-lit Under Cabinet TW", "LIGHTIFY Conv Under Cabinet TW"],
         model: "72569",
         vendor: "Sylvania",
         description: "SMART+ Zigbee adjustable white edge-lit under cabinet light",


### PR DESCRIPTION
Adding alternate device name for existing Sylvania device model 72569.
The version of this device I have identifies as being manufactured by Osram but I've read there's a bit of a confusing history of early Osram/Sylvania Lightify devices.

They are the same devices as far as I can tell, and the existing device photo is already correct.
