### PR TITLE
fix(ZC-LS02): send motor_direction as boolean instead of enum

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -480,7 +480,7 @@ export const definitions: DefinitionWithExtend[] = [
                 ],
                 [2, "position", tuya.valueConverter.coverPositionInverted],
                 [3, "position", tuya.valueConverter.coverPositionInverted],
-                [5, "motor_direction", tuya.valueConverterBasic.lookup({normal: tuya.enum(0), reversed: tuya.enum(1)})],
+                [5, "motor_direction", tuya.valueConverterBasic.lookup({normal: false, reversed: true})],
                 [13, "battery", tuya.valueConverter.raw],
             ],
         },


### PR DESCRIPTION
## What

One-line fix: change the `motor_direction` datapoint (DP 5) of the Moes ZC-LS02 (`TS0601` / `_TZE284_koxaopnk`) back from an enum mapping to a boolean mapping.

## Why

#12258 gave this device a dedicated definition (fixing inverted position and battery reporting), but in the process changed DP 5 from the boolean mapping it inherited from `TS0601_cover_10` (`{normal: false, reversed: true}`) to `tuya.enum(0)/tuya.enum(1)`. The device silently ignores datapoint writes with the wrong datatype, so setting `motor_direction` has had no effect since that change.

Evidence that the boolean mapping is the correct one for this hardware:
- Before #12258 was merged, direction reversal worked via the shared `TS0601_cover_10` definition (boolean DP 5) — see Koenkk/zigbee2mqtt#31869, where the reporter notes setting motor direction "reverses the motor as expected".
- After updating to a Z2M release containing #12258, setting `motor_direction` stopped doing anything on my ZC-LS02.

## Testing

Tested on my own ZC-LS02 (`_TZE284_koxaopnk`) running the current Z2M release, using an external converter identical to the in-tree definition except for this one line: with the boolean mapping, `motor_direction` → `reversed` inverts the motor again; with the in-tree enum mapping it does nothing. All other functionality (open/close/stop, position, battery) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)