### PR TITLE
Add EC1366

### DIFF
--- a/src/devices/villeroy_boch.ts
+++ b/src/devices/villeroy_boch.ts
@@ -22,5 +22,5 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: 'Villeroy & Boch',
         description: 'My View mirror cabinet',
         extend: [m.light({"colorTemp":{"range":[153,500]}})],
-    };
+    },
 ];

--- a/src/devices/villeroy_boch.ts
+++ b/src/devices/villeroy_boch.ts
@@ -16,4 +16,11 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee home automation kit for mirror",
         extend: [m.light({colorTemp: {range: [160, 450]}})],
     },
+    {
+        zigbeeModel: ['EC1366'],
+        model: 'EC1366',
+        vendor: 'Villeroy & Boch',
+        description: 'My View mirror cabinet',
+        extend: [m.light({"colorTemp":{"range":[153,500]}})],
+    };
 ];

--- a/src/devices/villeroy_boch.ts
+++ b/src/devices/villeroy_boch.ts
@@ -17,10 +17,10 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: [160, 450]}})],
     },
     {
-        zigbeeModel: ['EC1366'],
-        model: 'EC1366',
-        vendor: 'Villeroy & Boch',
-        description: 'My View mirror cabinet',
-        extend: [m.light({"colorTemp":{"range":[153,500]}})],
+        zigbeeModel: ["EC1366"],
+        model: "EC1366",
+        vendor: "Villeroy & Boch",
+        description: "My View mirror cabinet",
+        extend: [m.light({colorTemp: {range: [153, 500]}})],
     },
 ];


### PR DESCRIPTION
This is a mirror cabinet that comes with Zigbee lighting pre-installed. The controller (and probably the rest of the lighting) is manufactured by L&S Lighting. 

There are a lot of variants of the mirror cabinet (finishes, dimensions, etc.) and I can only assume they all use an identical Zigbee module, which is why I haven't used the VB part number for `model`. There can be only one photo so I will use the one from my specific variant (`B48110VJ`).

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5304
