### PR TITLE
fix: Aqara PS-S04D: fix battery never reporting

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5898,7 +5898,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [lumi.fromZigbee.lumi_specific],
         toZigbee: [lumi.toZigbee.lumi_presence, lumi.toZigbee.lumi_motion_sensitivity],
         exposes: [e.power_outage_count(), e.motion_sensitivity_select(["low", "medium", "high"]).withDescription("Presence Detection Sensitivity.")],
-        version: "0.0.1",
+        version: "0.0.2",
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x00ee], {manufacturerCode: manufacturerCode}); // Read OTA data; makes the device expose more attributes related to OTA
@@ -5907,6 +5907,7 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x014f], {manufacturerCode: manufacturerCode}); // Read current PIR interval
             await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x0197], {manufacturerCode: manufacturerCode}); // Read current absence delay timer value
             await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x019a], {manufacturerCode: manufacturerCode}); // Read detection range
+            await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x00f7], {manufacturerCode: manufacturerCode}); // Read battery data; firmware 0.0.0_6542 does not push the 0x00F7 struct on its own
 
             // Configure reporting so presence (0x0142) and PIR detection (0x014d) update autonomously.
             await reporting.bind(endpoint, coordinatorEndpoint, ["manuSpecificLumi"]);
@@ -5922,10 +5923,23 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             lumi.modernExtend.addManuSpecificLumiCluster(),
             lumi.lumiModernExtend.lumiPreventLeave(),
+            m.quirkCheckinInterval("1_HOUR"), // No genPollCtrl; gives the request queue a lifetime so the queued battery read (below) survives until the device wakes
             lumi.lumiModernExtend.lumiBattery({
-                voltageToPercentage: {min: 2850, max: 3000},
-                voltageAttribute: 0x0017, // Attribute: 23
-                //percentageAttribute: 0x0018 // Attribute: 24 // TODO: Should confirm to be sure
+                voltageAttribute: 0x0017, // Attribute: 23 (battery voltage in mV)
+                percentageAttribute: 0x0018, // Attribute: 24 (battery percentage, the device's own gauge; tracks discharge consistently with attribute 23)
+            }),
+            // Firmware 0.0.0_6542 never pushes the 0x00F7 struct that carries battery data, so poll it.
+            // The device is a sleepy end device: the queued read is delivered the next time it wakes up.
+            // https://github.com/Koenkk/zigbee2mqtt/issues/32153
+            m.poll({
+                key: "battery",
+                defaultIntervalSeconds: 4 * 60 * 60,
+                poll: (device) => {
+                    device
+                        .getEndpoint(1)
+                        .read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x00f7], {manufacturerCode, sendPolicy: "queue"})
+                        .catch((error) => logger.debug(`Failed to read battery of '${device.ieeeAddr}' (${error})`, NS));
+                },
             }),
             lumi.lumiModernExtend.fp1ePresence(),
             lumi.lumiModernExtend.fp300PIRDetection(),

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5923,24 +5923,12 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             lumi.modernExtend.addManuSpecificLumiCluster(),
             lumi.lumiModernExtend.lumiPreventLeave(),
-            m.quirkCheckinInterval("1_HOUR"), // No genPollCtrl; gives the request queue a lifetime so the queued battery read (below) survives until the device wakes
+            m.quirkCheckinInterval("1_HOUR"), // No genPollCtrl; gives the request queue a lifetime so fp300BatteryPoll's queued read survives until the device wakes
             lumi.lumiModernExtend.lumiBattery({
                 voltageAttribute: 0x0017, // Attribute: 23 (battery voltage in mV)
                 percentageAttribute: 0x0018, // Attribute: 24 (battery percentage, the device's own gauge; tracks discharge consistently with attribute 23)
             }),
-            // Firmware 0.0.0_6542 never pushes the 0x00F7 struct that carries battery data, so poll it.
-            // The device is a sleepy end device: the queued read is delivered the next time it wakes up.
-            // https://github.com/Koenkk/zigbee2mqtt/issues/32153
-            m.poll({
-                key: "battery",
-                defaultIntervalSeconds: 4 * 60 * 60,
-                poll: (device) => {
-                    device
-                        .getEndpoint(1)
-                        .read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x00f7], {manufacturerCode, sendPolicy: "queue"})
-                        .catch((error) => logger.debug(`Failed to read battery of '${device.ieeeAddr}' (${error})`, NS));
-                },
-            }),
+            lumi.lumiModernExtend.fp300BatteryPoll(),
             lumi.lumiModernExtend.fp1ePresence(),
             lumi.lumiModernExtend.fp300PIRDetection(),
 

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -3316,6 +3316,38 @@ export const lumiModernExtend = {
                 "Indicates whether the PIR sensor detects motion (in mmWave + PIR mode after mmWave presence detection PIR sensors gets turned off so this attribute might change to false although the presence is detected).",
         });
     },
+    fp300BatteryPoll: (): ModernExtend => {
+        // FP300 firmware 0.0.0_6542 no longer pushes the 0x00F7 struct that carries the battery data
+        // (https://github.com/Koenkk/zigbee2mqtt/issues/32153), but it still answers an explicit read while awake.
+        // Rather than gating on a firmware version, track when the struct was last received and only read it back
+        // once it goes stale: firmware that pushes the struct by itself keeps this poll dormant, and on affected
+        // firmware the read response refreshes the timestamp, so reads self-regulate to ~structMaxAgeMs.
+        // The FP300 is a sleepy end device: the read is queued (`sendPolicy: "queue"`) and flushed by the request
+        // queue when the device next wakes; quirkCheckinInterval() in the definition gives the queue its lifetime.
+        const structMaxAgeMs = 4 * 60 * 60 * 1000;
+        const storeKey = "lumi_struct_last_received";
+        const structReceived: Fz.Converter<"manuSpecificLumi", ManuSpecificLumi, ["attributeReport", "readResponse"]> = {
+            cluster: "manuSpecificLumi",
+            type: ["attributeReport", "readResponse"],
+            convert: (model, msg) => {
+                if (msg.data[0x00f7] !== undefined) globalStore.putValue(msg.device, storeKey, Date.now());
+            },
+        };
+        return {
+            ...modernExtend.poll({
+                key: "battery",
+                defaultIntervalSeconds: 60 * 60,
+                poll: (device) => {
+                    if (Date.now() - (globalStore.getValue(device, storeKey, 0) as number) < structMaxAgeMs) return;
+                    device
+                        .getEndpoint(1)
+                        .read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [0x00f7], {manufacturerCode, sendPolicy: "queue"})
+                        .catch((error) => logger.debug(`Failed to read battery of '${device.ieeeAddr}' (${error})`, NS));
+                },
+            }),
+            fromZigbee: [structReceived],
+        };
+    },
     fp300DetectionRange: (args?: {rangeOffset: number; rangesCount: number}): ModernExtend => {
         args = {
             rangeOffset: 0.25,

--- a/test/lumi.test.ts
+++ b/test/lumi.test.ts
@@ -1,10 +1,27 @@
 import {beforeEach, describe, expect, it} from "vitest";
-import {fromZigbee, numericAttributes2Payload, type TrvScheduleConfig, toZigbee, trv} from "../src/lib/lumi";
+import {fromZigbee, lumiModernExtend, numericAttributes2Payload, type TrvScheduleConfig, toZigbee, trv} from "../src/lib/lumi";
 import * as globalStore from "../src/lib/store";
 import type {Definition, Fz, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 describe("lib/lumi", () => {
+    describe("PS-S04D battery", () => {
+        it("decodes battery percentage (tag 24) and voltage (tag 23) from the 0x00F7 struct", () => {
+            const extend = lumiModernExtend.lumiBattery({voltageAttribute: 0x0017, percentageAttribute: 0x0018});
+            // tag 23 (0x17), uint16 (0x21) = 2916 mV; tag 24 (0x18), uint8 (0x20) = 97 %
+            const data = Buffer.from([0x17, 0x21, 0x64, 0x0b, 0x18, 0x20, 0x61]);
+            const result = extend.fromZigbee[0].convert(
+                {model: "PS-S04D"} as Definition,
+                // @ts-expect-error mock
+                {data: {247: data}},
+                null,
+                null,
+                null,
+            );
+            expect(result).toStrictEqual({battery: 97, voltage: 2916});
+        });
+    });
+
     describe("RTCZCGQ11LM configured regions", () => {
         const createPresenceMeta = (state = {}): {device: ReturnType<typeof mockDevice>; meta: Tz.Meta} => {
             const device = mockDevice({modelID: "lumi.motion.ac01", endpoints: [{ID: 1}]});

--- a/test/lumi.test.ts
+++ b/test/lumi.test.ts
@@ -20,6 +20,22 @@ describe("lib/lumi", () => {
             );
             expect(result).toStrictEqual({battery: 97, voltage: 2916});
         });
+
+        it("records when the 0x00F7 struct was last received, keeping the battery poll dormant while fresh", () => {
+            const extend = lumiModernExtend.fp300BatteryPoll();
+            const device = mockDevice({modelID: "lumi.sensor_occupy.agl8", endpoints: [{ID: 1}]}, "EndDevice");
+            expect(globalStore.getValue(device, "lumi_struct_last_received")).toBeUndefined();
+            const before = Date.now();
+            extend.fromZigbee[0].convert(
+                {model: "PS-S04D"} as Definition,
+                // @ts-expect-error mock
+                {data: {247: Buffer.from([0x17, 0x21, 0x64, 0x0b])}, device},
+                null,
+                null,
+                null,
+            );
+            expect(globalStore.getValue(device, "lumi_struct_last_received")).toBeGreaterThanOrEqual(before);
+        });
     });
 
     describe("RTCZCGQ11LM configured regions", () => {


### PR DESCRIPTION
## Problem

On firmware `0.0.0_6542` (the only firmware in the wild for the FP300, fileVersion 16682) the device never pushes the manuSpecificLumi `0x00F7` struct that carries the battery data. #12383 fixed presence/PIR reporting, but `battery`/`voltage` still stay empty forever, and nothing in the definition ever triggers the struct to be sent.

Related: https://github.com/Koenkk/zigbee2mqtt/issues/32153

## Fix

Three pieces, all scoped strictly to `PS-S04D`:

1. **Prime at configure** — `configure` now reads `0x00F7` once (the device is awake during pairing/reconfigure, same as the six reads already there). Definition `version` bumped to `0.0.2` so existing devices re-run configure.
2. **Staleness-gated poll of `0x00F7`** (`fp300BatteryPoll()` in lib/lumi.ts): a fromZigbee converter records when the struct was last received; an hourly timer (via `m.poll`, same pattern as `pollBatteryVoltage` in `profalux.ts`) reads it back only when none has arrived for 4 h. Firmware that pushes the struct autonomously keeps the poll permanently dormant; firmware that doesn't (0.0.0_6542, or any future build with the same regression) self-regulates to a read every ~4–5 h. The read uses `sendPolicy: "queue"`: the FP300 is a sleepy end device, so the read fails immediately and is queued; zigbee-herdsman's implicit check-in delivers it the next time the device sends anything. Since #12383 configures presence reporting with a 3600 s max interval, the device wakes at least hourly — the queued read is always served well before it expires.
3. **`m.quirkCheckinInterval("1_HOUR")`** — the FP300 has no genPollCtrl cluster, so without this `pendingRequestTimeout` is 0 and queued requests are dropped instead of queued (this is the documented purpose of the quirk, already used by many other lumi definitions in this file).

Additionally, this resolves the existing `//percentageAttribute: 0x0018 // TODO: Should confirm to be sure`: confirmed. `lumiBattery` now uses struct tag 24 (`0x0018`, uint8 %) — the device's own battery gauge — as the `battery` source instead of the voltage-curve estimate, with tag 23 (`0x0017`, uint16 mV) still exposed as `voltage`.

Struct layout on `0.0.0_6542`:

| tag | type | meaning |
|---|---|---|
| 23 (0x17) | uint16 | battery voltage, mV |
| 24 (0x18) | uint8 | battery percentage (device's own gauge) |

## Evidence

Running for ~1 month in production on 11 FP300s (all fw `0.0.0_6542`) as an external converter that does functionally the same thing (reading `0x00F7` whenever the device wakes, throttled to 4 h): the struct always answers while the device is awake, and tag 24 tracks discharge consistently with the millivolts in tag 23. Values update reliably across the whole fleet.

The FP310 definition has the same commented-out `percentageAttribute`, but I have no FP310 hardware to confirm its behavior, so it is intentionally left untouched.

## Testing

- Added unit tests: decoding `battery`/`voltage` from a real `0x00F7` payload, and the last-received timestamp recording that keeps the poll dormant.
- `pnpm build`, `pnpm check`, `pnpm test` all pass (653 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
