### PR TITLE
Skip Bosch cable sensor temperature when disabled

### DIFF
--- a/src/lib/bosch.ts
+++ b/src/lib/bosch.ts
@@ -3577,6 +3577,18 @@ export const boschThermostatExtend = {
             scale: 100,
             reporting: {min: 30, max: "MAX", change: 20},
             access: "STATE_GET",
+            fzConvert: (_model, msg, _publish, _options, meta) => {
+                const cableSensorMode = meta.state.cable_sensor_mode ?? msg.endpoint.getClusterAttributeValue("hvacThermostat", "cableSensorMode");
+                if (cableSensorMode === "not_used" || cableSensorMode === 0x00) {
+                    return;
+                }
+
+                const value = msg.data.cableSensorTemperature;
+                if (typeof value !== "number") {
+                    throw new Error("cableSensorTemperature must be a number");
+                }
+                return {cable_sensor_temperature: value / 100};
+            },
         }),
     heaterType: () =>
         m.enumLookup<"hvacThermostat", BoschThermostatCluster>({

--- a/test/bosch.test.ts
+++ b/test/bosch.test.ts
@@ -39,6 +39,66 @@ describe("Bosch thermostats", () => {
         expect(definition.toZigbee.some((converter) => converter.key.includes("weekly_schedule"))).toBe(false);
         expect(JSON.stringify(definition.exposes)).not.toContain("weekly_schedule");
     });
+
+    it("does not publish cable sensor temperature when cable sensor mode is disabled", () => {
+        const device = mockDevice({
+            modelID: "RBSH-RTH0-ZB-EU",
+            manufacturerName: "BOSCH",
+            endpoints: [
+                {
+                    ID: 1,
+                    inputClusters: ["hvacThermostat"],
+                },
+            ],
+        });
+        const extend = boschThermostatExtend.cableSensorTemperature();
+        const converter = extend.fromZigbee?.[0];
+
+        if (!converter?.convert) throw new Error("No fromZigbee converter for cable_sensor_temperature");
+
+        const result = converter.convert(
+            device,
+            {
+                data: {cableSensorTemperature: 2150},
+                endpoint: device.getEndpoint(1),
+            } as never,
+            () => {},
+            {},
+            {state: {cable_sensor_mode: "not_used"}} as never,
+        );
+
+        expect(result).toBeUndefined();
+    });
+
+    it("publishes cable sensor temperature when cable sensor mode is enabled", () => {
+        const device = mockDevice({
+            modelID: "RBSH-RTH0-ZB-EU",
+            manufacturerName: "BOSCH",
+            endpoints: [
+                {
+                    ID: 1,
+                    inputClusters: ["hvacThermostat"],
+                },
+            ],
+        });
+        const extend = boschThermostatExtend.cableSensorTemperature();
+        const converter = extend.fromZigbee?.[0];
+
+        if (!converter?.convert) throw new Error("No fromZigbee converter for cable_sensor_temperature");
+
+        const result = converter.convert(
+            device,
+            {
+                data: {cableSensorTemperature: 2150},
+                endpoint: device.getEndpoint(1),
+            } as never,
+            () => {},
+            {},
+            {state: {cable_sensor_mode: "cable_sensor_without_regulation"}} as never,
+        );
+
+        expect(result).toStrictEqual({cable_sensor_temperature: 21.5});
+    });
 });
 
 describe("Bosch thermostat relayState extension", () => {


### PR DESCRIPTION
Bosch thermostats were still publishing `cable_sensor_temperature` even when the cable sensor mode was `not_used`, which produces a useless zero reading in Home Assistant.

This change keeps the entity exposed but suppresses the publish path while the cable sensor is disabled, and only emits the temperature again when the mode is enabled.

Validation: focused Bosch thermostat regression tests cover both the enabled and disabled cases.
