### PR TITLE
fix(tuya): add missing endpoint mapping for ZN2S-RS02E

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2721,7 +2721,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZN2S-RS02E",
         vendor: "Tuya",
         description: "Two gang switch with colored backlight modes",
-        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        extend: [tuya.modernExtend.tuyaBase({dp: true}), m.deviceEndpoints({endpoints: {l1: 1, l2: 1}})],
         exposes: [
             tuya.exposes.switch().withDescription("All switches"),
             tuya.exposes.switch().withEndpoint("l1"),


### PR DESCRIPTION
endpoint function was lost, causing "Device has no endpoint 'l2'" when commanding per-endpoint topics from HA discovery.

ZN2S-RS02E (TS0601, _TZE284_zpvusbtv) lost its endpoint mapping, so commands published to per-endpoint topics (.../l1/set, .../l2/set) — which HA discovery uses — fail with Device 'X' has no endpoint 'l2'. State updates still work; only commands are broken.
Fix: add m.deviceEndpoints({endpoints: {l1: 1, l2: 1}}) to the extend, same pattern as the neighboring TS0601_3gang_rkbxtclc definition. Verified on hardware — publishing {"state_l2":"ON"} to the base /set topic works, confirming both gangs are on Zigbee endpoint 1 via Tuya DPs.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
