### PR TITLE
Add support for Home Assistant infrared timings for Zozung/Tuya based IR blasters

### DIFF
--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -79,15 +79,18 @@ interface ZosungIrControl {
 }
 
 interface ZosungIRMessage {
-    key_num?: number; // eslint-disable-line @typescript-eslint/naming-convention
+    // biome-ignore lint/style/useNamingConvention: required by protocol schema
+    key_num?: number;
     delay?: number;
     key1?: {
         num?: number;
         freq?: number;
         type?: number;
-        key_code?: string; // eslint-disable-line @typescript-eslint/naming-convention
+        // biome-ignore lint/style/useNamingConvention: required by protocol schema
+        key_code?: string;
     };
-    key_code?: string; // eslint-disable-line @typescript-eslint/naming-convention
+    // biome-ignore lint/style/useNamingConvention: required by protocol schema
+    key_code?: string;
     num?: number;
     freq?: number;
     type?: number;
@@ -96,7 +99,8 @@ interface ZosungIRMessage {
 type InfraredSignal = {
     timings?: number[];
     modulation?: number;
-    repeat_count?: number; // eslint-disable-line @typescript-eslint/naming-convention
+    // biome-ignore lint/style/useNamingConvention: required by protocol schema
+    repeat_count?: number;
 };
 
 export const zosungExtend = {

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -598,7 +598,7 @@ export const fzZosung = {
                 const learnedTimings = decodeTuyaTimings(rcv.buf)
                 logger.debug(`Received: ${learnedIRCode}`, NS);
                 messagesClear(msg.endpoint, seq);
-                await msg.endpoint.command(
+                await msg.endpoint.command<"zosungIRControl", "zosungControlIRCommand00", ZosungIrControl>(
                     "zosungIRControl",
                     "zosungControlIRCommand00",
                     {

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -258,11 +258,7 @@ function calcStringCrc(str: string) {
     );
 }
 
-function bytesToBase64(bytes: Uint8Array): string {
-    return Buffer.from(bytes).toString("base64");
-}
-
-function encodeTuyaTimings(timings: number[]) {
+function encodeTuyaTimings(timings: number[]): string {
     const rawBytes = new Uint8Array(timings.length * 2);
 
     for (let i = 0; i < timings.length; i++) {
@@ -290,7 +286,7 @@ function encodeTuyaTimings(timings: number[]) {
         pos += chunkLen;
     }
 
-    return bytesToBase64(Uint8Array.from(compressed));
+    return Buffer.from(Uint8Array.from(compressed)).toString("base64");
 }
 
 function buildIrMsgFromTimings(obj: InfraredSignal) {

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -86,7 +86,7 @@ interface ZosungIRMessage {
         num?: number;
         freq?: number;
         type?: number;
-        key_code?: string;
+        key_code?: string;  // "@typescript-eslint/camelcase": ["off"]
     };
     key_code?: string,
     num?: number;
@@ -97,7 +97,7 @@ interface ZosungIRMessage {
 type InfraredSignal = {
     timings?: number[];
     modulation?: number;
-    repeat_count?: number;
+    repeat_count?: number;  // "@typescript-eslint/camelcase": ["off"]
 };
 
 export const zosungExtend = {

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -78,6 +78,28 @@ interface ZosungIrControl {
     commandResponses: never;
 }
 
+
+interface ZosungIRMessage {
+    key_num?: number;
+    delay?: number;
+    key1?: {
+        num?: number;
+        freq?: number;
+        type?: number;
+        key_code?: string;
+    };
+    key_code?: string,
+    num?: number;
+    freq?: number;
+    type?: number;
+}
+
+type InfraredSignal = {
+    timings?: number[];
+    modulation?: number;
+    repeat_count?: number;
+};
+
 export const zosungExtend = {
     addZosungIRTransmitCluster: () =>
         m.deviceAddCustomCluster("zosungIRTransmit", {
@@ -268,7 +290,7 @@ function encodeTuyaTimings(timings: number[]) {
     return bytesToBase64(Uint8Array.from(compressed));
 }
 
-function buildIrMsgFromTimings(obj: any) {
+function buildIrMsgFromTimings(obj: InfraredSignal) {
     const timings = obj.timings ?? [];
     const modulation = obj.modulation ?? 38000;
     const repeatCount = obj.repeat_count ?? 0;
@@ -295,32 +317,33 @@ function buildIrMsgFromTimings(obj: any) {
     });
 }
 
-function normalizeIrMsg(value: any | string) {
+function normalizeIrMsg(value: InfraredSignal | ZosungIRMessage | string) {
     if (value === undefined || value === null || value === "") {
         throw new Error("IR code payload is empty");
     }
 
     // Object input.
-    if (typeof value === "object" && value.timings) {
+    if (typeof value === "object" && "timings" in value ) {
         if (Array.isArray(value.timings)) {
             return buildIrMsgFromTimings(value);
         }
 
         // Already full Zosung-style object.
-        if (value.key_num !== undefined && value.key1 !== undefined) {
+        const zozung_value = <ZosungIRMessage>value;
+        if (zozung_value.key_num !== undefined && zozung_value.key1 !== undefined) {
             return JSON.stringify(value);
         }
 
         // Direct key_code object.
-        if (value.key_code !== undefined) {
+        if (zozung_value.key_code !== undefined) {
             return JSON.stringify({
                 key_num: 1,
-                delay: value.delay ?? 300,
+                delay: zozung_value.delay ?? 300,
                 key1: {
-                    num: value.num ?? 1,
-                    freq: value.freq ?? 38000,
-                    type: value.type ?? 1,
-                    key_code: value.key_code,
+                    num: zozung_value.num ?? 1,
+                    freq: zozung_value.freq ?? 38000,
+                    type: zozung_value.type ?? 1,
+                    key_code: zozung_value.key_code,
                 },
             });
         }

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -78,17 +78,16 @@ interface ZosungIrControl {
     commandResponses: never;
 }
 
-/* eslint-disable @typescript-eslint/naming-convention */
 interface ZosungIRMessage {
-    key_num?: number;
+    key_num?: number; // eslint-disable-line @typescript-eslint/naming-convention
     delay?: number;
     key1?: {
         num?: number;
         freq?: number;
         type?: number;
-        key_code?: string;
+        key_code?: string; // eslint-disable-line @typescript-eslint/naming-convention
     };
-    key_code?: string,
+    key_code?: string; // eslint-disable-line @typescript-eslint/naming-convention
     num?: number;
     freq?: number;
     type?: number;
@@ -97,9 +96,8 @@ interface ZosungIRMessage {
 type InfraredSignal = {
     timings?: number[];
     modulation?: number;
-    repeat_count?: number;
+    repeat_count?: number; // eslint-disable-line @typescript-eslint/naming-convention
 };
-/* eslint-enable @typescript-eslint/naming-convention */
 
 export const zosungExtend = {
     addZosungIRTransmitCluster: () =>

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -78,7 +78,7 @@ interface ZosungIrControl {
     commandResponses: never;
 }
 
-
+/* eslint-disable @typescript-eslint/naming-convention */
 interface ZosungIRMessage {
     key_num?: number;
     delay?: number;
@@ -86,7 +86,7 @@ interface ZosungIRMessage {
         num?: number;
         freq?: number;
         type?: number;
-        key_code?: string;  // "@typescript-eslint/camelcase": ["off"]
+        key_code?: string;
     };
     key_code?: string,
     num?: number;
@@ -97,8 +97,9 @@ interface ZosungIRMessage {
 type InfraredSignal = {
     timings?: number[];
     modulation?: number;
-    repeat_count?: number;  // "@typescript-eslint/camelcase": ["off"]
+    repeat_count?: number;
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export const zosungExtend = {
     addZosungIRTransmitCluster: () =>

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -326,7 +326,7 @@ function normalizeIrMsg(value: InfraredSignal | ZosungIRMessage | string) {
     }
 
     // Object input.
-    if (typeof value === "object" && "timings" in value ) {
+    if (typeof value === "object" && "timings" in value) {
         if (Array.isArray(value.timings)) {
             return buildIrMsgFromTimings(value);
         }
@@ -417,37 +417,37 @@ function decodeTuyaTimings(compressed: number[]): number[] {
 
     try {
         while (pos < compressed.length) {
-        const header = compressed[pos++];
-        const blockType = header >> 5;
+            const header = compressed[pos++];
+            const blockType = header >> 5;
 
-        if (blockType === 0) {
-            // Literal block
-            const length = (header & 0x1f) + 1;
-            for (let i = 0; i < length; i++) {
-            if (pos >= compressed.length) throw new Error("Truncated literal");
-            decompressed.push(compressed[pos++]);
+            if (blockType === 0) {
+                // Literal block
+                const length = (header & 0x1f) + 1;
+                for (let i = 0; i < length; i++) {
+                    if (pos >= compressed.length) throw new Error("Truncated literal");
+                    decompressed.push(compressed[pos++]);
+                }
+            } else {
+                // Reference block
+                let length = blockType + 2;
+                if (length === 9) {
+                    // extended length: accumulate 255 bytes per 0xFF then a remainder
+                    while (pos < compressed.length && compressed[pos] === 0xff) {
+                        length += 255;
+                        pos++;
+                    }
+                    if (pos >= compressed.length) throw new Error("Truncated extended length");
+                    length += compressed[pos++];
+                }
+                if (pos >= compressed.length) throw new Error("Truncated distance");
+                const distance = (((header & 0x1f) << 8) | compressed[pos++]) >>> 0;
+                const offset = distance + 1;
+                for (let i = 0; i < length; i++) {
+                    const idx = decompressed.length - offset;
+                    if (idx < 0) throw new Error("Invalid reference offset");
+                    decompressed.push(decompressed[idx]);
+                }
             }
-        } else {
-            // Reference block
-            let length = blockType + 2;
-            if (length === 9) {
-            // extended length: accumulate 255 bytes per 0xFF then a remainder
-            while (pos < compressed.length && compressed[pos] === 0xff) {
-                length += 255;
-                pos++;
-            }
-            if (pos >= compressed.length) throw new Error("Truncated extended length");
-            length += compressed[pos++];
-            }
-            if (pos >= compressed.length) throw new Error("Truncated distance");
-            const distance = (((header & 0x1f) << 8) | compressed[pos++]) >>> 0;
-            const offset = distance + 1;
-            for (let i = 0; i < length; i++) {
-            const idx = decompressed.length - offset;
-            if (idx < 0) throw new Error("Invalid reference offset");
-            decompressed.push(decompressed[idx]);
-            }
-        }
         }
     } catch {
         // truncated or malformed stream: stop decoding and continue with what we have
@@ -621,7 +621,7 @@ export const fzZosung = {
             const rcv = messagesGet(msg.endpoint, seq);
             if (rcv) {
                 const learnedIRCode = rcv.buf.toString("base64");
-                const learnedTimings = decodeTuyaTimings(rcv.buf)
+                const learnedTimings = decodeTuyaTimings(rcv.buf);
                 logger.debug(`Received: ${learnedIRCode}`, NS);
                 messagesClear(msg.endpoint, seq);
                 await msg.endpoint.command<"zosungIRControl", "zosungControlIRCommand00", ZosungIrControl>(

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -233,6 +233,215 @@ function calcStringCrc(str: string) {
     );
 }
 
+function bytesToBase64(bytes: Uint8Array): string {
+    return Buffer.from(bytes).toString("base64");
+}
+
+function encodeTuyaTimings(timings: number[]) {
+    const rawBytes = new Uint8Array(timings.length * 2);
+
+    for (let i = 0; i < timings.length; i++) {
+        const v = Math.abs(Math.trunc(Number(timings[i])));
+
+        if (!Number.isFinite(v) || v > 0xffff) {
+            throw new Error(`Invalid timing at index ${i}: ${timings[i]}`);
+        }
+
+        rawBytes[i * 2] = v & 0xff;
+        rawBytes[i * 2 + 1] = (v >> 8) & 0xff;
+    }
+
+    const compressed = [];
+    let pos = 0;
+
+    while (pos < rawBytes.length) {
+        const chunkLen = Math.min(32, rawBytes.length - pos);
+        compressed.push((chunkLen - 1) & 0x1f);
+
+        for (let i = 0; i < chunkLen; i++) {
+            compressed.push(rawBytes[pos + i]);
+        }
+
+        pos += chunkLen;
+    }
+
+    return bytesToBase64(Uint8Array.from(compressed));
+}
+
+function buildIrMsgFromTimings(obj: any) {
+    const timings = obj.timings ?? [];
+    const modulation = obj.modulation ?? 38000;
+    const repeatCount = obj.repeat_count ?? 0;
+
+    if (!Array.isArray(timings) || timings.length === 0) {
+        throw new Error("timings must be a non-empty array");
+    }
+
+    if (typeof modulation !== "number" || modulation <= 30000) {
+        throw new Error("Invalid modulation frequency");
+    }
+
+    const encoded = encodeTuyaTimings(timings);
+
+    return JSON.stringify({
+        key_num: 1,
+        delay: 300,
+        key1: {
+            num: 1 + repeatCount,
+            freq: modulation,
+            type: 1,
+            key_code: encoded,
+        },
+    });
+}
+
+function normalizeIrMsg(value: any | string) {
+    if (value === undefined || value === null || value === "") {
+        throw new Error("IR code payload is empty");
+    }
+
+    // Object input.
+    if (typeof value === "object" && value.timings) {
+        if (Array.isArray(value.timings)) {
+            return buildIrMsgFromTimings(value);
+        }
+
+        // Already full Zosung-style object.
+        if (value.key_num !== undefined && value.key1 !== undefined) {
+            return JSON.stringify(value);
+        }
+
+        // Direct key_code object.
+        if (value.key_code !== undefined) {
+            return JSON.stringify({
+                key_num: 1,
+                delay: value.delay ?? 300,
+                key1: {
+                    num: value.num ?? 1,
+                    freq: value.freq ?? 38000,
+                    type: value.type ?? 1,
+                    key_code: value.key_code,
+                },
+            });
+        }
+
+        return JSON.stringify(value);
+    }
+
+    if (typeof value !== "string") {
+        value = String(value);
+    }
+
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+        throw new Error("IR code payload is empty");
+    }
+
+    // JSON string input.
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+        try {
+            const parsed = JSON.parse(trimmed);
+
+            if (parsed && typeof parsed === "object") {
+                if (Array.isArray(parsed.timings)) {
+                    return buildIrMsgFromTimings(parsed);
+                }
+
+                if (parsed.key_num !== undefined && parsed.key1 !== undefined) {
+                    return JSON.stringify(parsed);
+                }
+
+                if (parsed.key_code !== undefined) {
+                    return JSON.stringify({
+                        key_num: 1,
+                        delay: parsed.delay ?? 300,
+                        key1: {
+                            num: parsed.num ?? 1,
+                            freq: parsed.freq ?? 38000,
+                            type: parsed.type ?? 1,
+                            key_code: parsed.key_code,
+                        },
+                    });
+                }
+            }
+        } catch (err) {
+            logger.debug(`JSON parse failed, treating as captured key_code: ${err}`, NS);
+        }
+    }
+
+    // Fallback:
+    // Captured base64 strings like H4IKjQP7... are key_code only,
+    // not full Zosung messages. Wrap them.
+    return JSON.stringify({
+        key_num: 1,
+        delay: 300,
+        key1: {
+            num: 1,
+            freq: 38000,
+            type: 1,
+            key_code: trimmed,
+        },
+    });
+}
+
+function decodeTuyaTimings(compressed: number[]): number[] {
+    const decompressed: number[] = [];
+    let pos = 0;
+
+    try {
+        while (pos < compressed.length) {
+        const header = compressed[pos++];
+        const blockType = header >> 5;
+
+        if (blockType === 0) {
+            // Literal block
+            const length = (header & 0x1f) + 1;
+            for (let i = 0; i < length; i++) {
+            if (pos >= compressed.length) throw new Error("Truncated literal");
+            decompressed.push(compressed[pos++]);
+            }
+        } else {
+            // Reference block
+            let length = blockType + 2;
+            if (length === 9) {
+            // extended length: accumulate 255 bytes per 0xFF then a remainder
+            while (pos < compressed.length && compressed[pos] === 0xff) {
+                length += 255;
+                pos++;
+            }
+            if (pos >= compressed.length) throw new Error("Truncated extended length");
+            length += compressed[pos++];
+            }
+            if (pos >= compressed.length) throw new Error("Truncated distance");
+            const distance = (((header & 0x1f) << 8) | compressed[pos++]) >>> 0;
+            const offset = distance + 1;
+            for (let i = 0; i < length; i++) {
+            const idx = decompressed.length - offset;
+            if (idx < 0) throw new Error("Invalid reference offset");
+            decompressed.push(decompressed[idx]);
+            }
+        }
+        }
+    } catch {
+        // truncated or malformed stream: stop decoding and continue with what we have
+    }
+
+    // Interpret decompressed bytes as little-endian 16-bit unsigned values
+    const numTimings = Math.floor(decompressed.length / 2);
+    if (numTimings === 0) return [];
+
+    const timings = new Array(numTimings);
+    for (let i = 0; i < numTimings; i++) {
+        const lo = decompressed[i * 2];
+        const hi = decompressed[i * 2 + 1];
+        const val = (hi << 8) | lo;
+        // alternate sign: even index positive, odd index negative
+        timings[i] = i % 2 === 0 ? val : -val;
+    }
+    return timings;
+}
+
 export const fzZosung = {
     zosung_send_ir_code_01: {
         cluster: "zosungIRTransmit",
@@ -386,9 +595,10 @@ export const fzZosung = {
             const rcv = messagesGet(msg.endpoint, seq);
             if (rcv) {
                 const learnedIRCode = rcv.buf.toString("base64");
+                const learnedTimings = decodeTuyaTimings(rcv.buf)
                 logger.debug(`Received: ${learnedIRCode}`, NS);
                 messagesClear(msg.endpoint, seq);
-                await msg.endpoint.command<"zosungIRControl", "zosungControlIRCommand00", ZosungIrControl>(
+                await msg.endpoint.command(
                     "zosungIRControl",
                     "zosungControlIRCommand00",
                     {
@@ -398,6 +608,10 @@ export const fzZosung = {
                 );
                 return {
                     learned_ir_code: learnedIRCode,
+                    learned_ir_timings: {
+                        modulation: 38000,
+                        timings: learnedTimings,
+                    },
                 };
             }
         },
@@ -408,21 +622,10 @@ export const tzZosung = {
     zosung_ir_code_to_send: {
         key: ["ir_code_to_send"],
         convertSet: async (entity, key, value, meta) => {
-            if (!value) {
-                logger.error("There is no IR code to send", NS);
-                return;
-            }
-            const irMsg = JSON.stringify({
-                key_num: 1,
-                delay: 300,
-                key1: {
-                    num: 1,
-                    freq: 38000,
-                    type: 1,
-                    key_code: value,
-                },
-            });
-            logger.debug(`Sending IR code: ${JSON.stringify(value)}`, NS);
+            const irMsg = normalizeIrMsg(value);
+
+            logger.debug(`Sending IR code: ${irMsg}`, NS);
+
             const seq = nextSeq(entity);
             messagesSet(entity, seq, irMsg);
             await entity.command<"zosungIRTransmit", "zosungSendIRCode00", ZosungIrTransmit>(
@@ -462,5 +665,6 @@ export const tzZosung = {
 export const presetsZosung = {
     learn_ir_code: () => e.binary("learn_ir_code", ea.SET, "ON", "OFF").withDescription("Turn on to learn new IR code"),
     learned_ir_code: () => e.text("learned_ir_code", ea.STATE).withDescription("The IR code learned by device"),
-    ir_code_to_send: () => e.text("ir_code_to_send", ea.SET).withDescription("The IR code to send by device"),
+    learned_ir_timings: () => e.text("learned_ir_timings", ea.STATE).withDescription("The IR timings learned by device"),
+    ir_code_to_send: () => e.text("ir_code_to_send", ea.SET).withDescription("The IR code or timings to send by device"),
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Adds converters for Zozung based IR blasters:
- to encode the Home Assistant infrared timing format into the Tuya based base64 IR code format.
- to decode the leared Tuya based base64 IR code format into the Home Assistant timings format.

A PR to add MQTT infrared entities should follow later after https://github.com/home-assistant/core/pull/172796 has been merged.

The tests were done with a Tuya iH-F8260, Universal smart IR remote control, model: _TZ3290_gnl5a6a5xvql7c2a

The `external_converter` that was sucessfully tested with:


```js
import * as tuya from "zigbee-herdsman-converters/lib/tuya";
import * as zosung from "zigbee-herdsman-converters/lib/zosung";
import * as exposes from "zigbee-herdsman-converters/lib/exposes";
import * as globalStore from "zigbee-herdsman-converters/lib/store";
import {logger} from "zigbee-herdsman-converters/lib/logger";

const NS = "ext_converter";

const fzZosung = zosung.fzZosung;
const tzZosung = zosung.tzZosung;
const e = exposes.presets;
const ez = zosung.presetsZosung;
const ea = exposes.access;

function nextSeq(entity) {
    const seq = (globalStore.getValue(entity, "seq", -1) + 1) % 0x10000;
    globalStore.putValue(entity, "seq", seq);
    return seq;
}
function messagesSet(entity, seq, data) {
    globalStore.putValue(entity, "irMessageInfo", {seq, data});
}
function messagesGet(entity, seq) {
    const info = globalStore.getValue(entity, "irMessageInfo");
    if (!info) {
        logger.debug("Ignoring, no message send yet", NS);
        return;
    }

    const expected = info.seq ?? 0;
    if (expected !== seq) {
        throw new Error(`Unexpected sequence value (expected: ${expected} current: ${seq}).`);
    }

    return info.data;
}

function messagesClear(entity, seq) {
    const info = globalStore.getValue(entity, "irMessageInfo");
    if (!info) {
        logger.debug("Nothing to clear", NS);
        return;
    }

    const expected = info.seq ?? 0;
    if (expected !== seq) {
        throw new Error(`Unexpected sequence value (expected: ${expected} current: ${seq}).`);
    }

    globalStore.clearValue(entity, "irMessageInfo");
}
function bytesToBase64(bytes) {
    return Buffer.from(bytes).toString("base64");
}

function encodeTuyaTimings(timings) {
    const rawBytes = new Uint8Array(timings.length * 2);

    for (let i = 0; i < timings.length; i++) {
        const v = Math.abs(Math.trunc(Number(timings[i])));

        if (!Number.isFinite(v) || v > 0xffff) {
            throw new Error(`Invalid timing at index ${i}: ${timings[i]}`);
        }

        rawBytes[i * 2] = v & 0xff;
        rawBytes[i * 2 + 1] = (v >> 8) & 0xff;
    }

    const compressed = [];
    let pos = 0;

    while (pos < rawBytes.length) {
        const chunkLen = Math.min(32, rawBytes.length - pos);
        compressed.push((chunkLen - 1) & 0x1f);

        for (let i = 0; i < chunkLen; i++) {
            compressed.push(rawBytes[pos + i]);
        }

        pos += chunkLen;
    }

    return bytesToBase64(Uint8Array.from(compressed));
}

function buildIrMsgFromTimings(obj) {
    const timings = obj.timings;
    const modulation = obj.modulation ?? 38000;
    const repeatCount = obj.repeat_count ?? 0;

    if (!Array.isArray(timings) || timings.length === 0) {
        throw new Error("timings must be a non-empty array");
    }

    if (typeof modulation !== "number" || modulation <= 30000) {
        throw new Error("Invalid modulation frequency");
    }

    const encoded = encodeTuyaTimings(timings);

    return JSON.stringify({
        key_num: 1,
        delay: 300,
        key1: {
            num: 1 + repeatCount,
            freq: modulation,
            type: 1,
            key_code: encoded,
        },
    });
}

function normalizeIrMsg(value) {
    if (value === undefined || value === null || value === "") {
        throw new Error("IR code payload is empty");
    }

    // Object input.
    if (typeof value === "object") {
        if (Array.isArray(value.timings)) {
            return buildIrMsgFromTimings(value);
        }

        // Already full Zosung-style object.
        if (value.key_num !== undefined && value.key1 !== undefined) {
            return JSON.stringify(value);
        }

        // Direct key_code object.
        if (value.key_code !== undefined) {
            return JSON.stringify({
                key_num: 1,
                delay: value.delay ?? 300,
                key1: {
                    num: value.num ?? 1,
                    freq: value.freq ?? 38000,
                    type: value.type ?? 1,
                    key_code: value.key_code,
                },
            });
        }

        return JSON.stringify(value);
    }

    if (typeof value !== "string") {
        value = String(value);
    }

    const trimmed = value.trim();

    if (!trimmed) {
        throw new Error("IR code payload is empty");
    }

    // JSON string input.
    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
        try {
            const parsed = JSON.parse(trimmed);

            if (parsed && typeof parsed === "object") {
                if (Array.isArray(parsed.timings)) {
                    return buildIrMsgFromTimings(parsed);
                }

                if (parsed.key_num !== undefined && parsed.key1 !== undefined) {
                    return JSON.stringify(parsed);
                }

                if (parsed.key_code !== undefined) {
                    return JSON.stringify({
                        key_num: 1,
                        delay: parsed.delay ?? 300,
                        key1: {
                            num: parsed.num ?? 1,
                            freq: parsed.freq ?? 38000,
                            type: parsed.type ?? 1,
                            key_code: parsed.key_code,
                        },
                    });
                }
            }
        } catch (err) {
            logger.debug(`JSON parse failed, treating as captured key_code: ${err.message}`, NS);
        }
    }

    // Fallback:
    // Captured base64 strings like H4IKjQP7... are key_code only,
    // not full Zosung messages. Wrap them.
    return JSON.stringify({
        key_num: 1,
        delay: 300,
        key1: {
            num: 1,
            freq: 38000,
            type: 1,
            key_code: trimmed,
        },
    });
}

function decodeTuyaTimings(compressed) {
    const decompressed = [];
    let pos = 0;

    try {
        while (pos < compressed.length) {
        const header = compressed[pos++];
        const blockType = header >> 5;

        if (blockType === 0) {
            // Literal block
            const length = (header & 0x1f) + 1;
            for (let i = 0; i < length; i++) {
            if (pos >= compressed.length) throw new Error("Truncated literal");
            decompressed.push(compressed[pos++]);
            }
        } else {
            // Reference block
            let length = blockType + 2;
            if (length === 9) {
            // extended length: accumulate 255 bytes per 0xFF then a remainder
            while (pos < compressed.length && compressed[pos] === 0xff) {
                length += 255;
                pos++;
            }
            if (pos >= compressed.length) throw new Error("Truncated extended length");
            length += compressed[pos++];
            }
            if (pos >= compressed.length) throw new Error("Truncated distance");
            const distance = (((header & 0x1f) << 8) | compressed[pos++]) >>> 0;
            const offset = distance + 1;
            for (let i = 0; i < length; i++) {
            const idx = decompressed.length - offset;
            if (idx < 0) throw new Error("Invalid reference offset");
            decompressed.push(decompressed[idx]);
            }
        }
        }
    } catch {
        // truncated or malformed stream: stop decoding and continue with what we have
    }

    // Interpret decompressed bytes as little-endian 16-bit unsigned values
    const numTimings = Math.floor(decompressed.length / 2);
    if (numTimings === 0) return [];

    const timings = new Array(numTimings);
    for (let i = 0; i < numTimings; i++) {
        const lo = decompressed[i * 2];
        const hi = decompressed[i * 2 + 1];
        const val = (hi << 8) | lo;
        // alternate sign: even index positive, odd index negative
        timings[i] = i % 2 === 0 ? val : -val;
    }
    return timings;
}

const tzLocal = {
    zosung_ir_code_to_send: {
        key: ["ir_code_to_send"],

        convertSet: async (entity, key, value, meta) => {
            const irMsg = normalizeIrMsg(value);

            logger.debug(`Sending IR code: ${irMsg}`, NS);

            const seq = nextSeq(entity);
            messagesSet(entity, seq, irMsg);

            await entity.command(
                "zosungIRTransmit",
                "zosungSendIRCode00",
                {
                    seq,
                    length: irMsg.length,
                    unk1: 0,
                    unk2: 0xe004,
                    unk3: 1,
                    cmd: 2,
                    unk4: 0,
                },
                {
                    timeout: 10000,
                    disableDefaultResponse: true,
                },
            );

            logger.debug(`IR send initiated, seq=${seq}`, NS);
        },

        convertGet: async () => {
            return;
        },
    },
    zosung_send_ir_code_05: {
        cluster: "zosungIRTransmit",
        type: ["commandZosungSendIRCode05Resp"],
        convert: async (model, msg, publish, options, meta) => {
            logger.debug(`"IR-Message-Code05" received (msg:${JSON.stringify(msg.data)})`, NS);
            const seq = msg.data.seq;
            const rcv = messagesGet(msg.endpoint, seq);
            if (rcv) {
                const learnedIRCode = rcv.buf.toString("base64");
                const learnedTimings = decodeTuyaTimings(rcv.buf)
                logger.debug(`Received: ${learnedIRCode}`, NS);
                messagesClear(msg.endpoint, seq);
                await msg.endpoint.command(
                    "zosungIRControl",
                    "zosungControlIRCommand00",
                    {
                        data: Buffer.from(JSON.stringify({study: 1})),
                    },
                    {disableDefaultResponse: true},
                );
                return {
                    learned_ir_code: learnedIRCode,
                    learned_ir_timings: {
                        modulation: 38000,
                        timings: learnedTimings,
                    },
                };
            }
        },
    },
};

export default [
    {
        fingerprint: tuya.fingerprint("TS1201", [
            "_TZ3290_gnl5a6a5xvql7c2a",
        ]),

        model: "TS1201",
        description: "Universal smart IR remote control CUSTOM",

        extend: [
            zosung.zosungExtend.addZosungIRTransmitCluster(),
            zosung.zosungExtend.addZosungIRControlCluster(),
        ],

        fromZigbee: [
            fzZosung.zosung_send_ir_code_00,
            fzZosung.zosung_send_ir_code_01,
            fzZosung.zosung_send_ir_code_02,
            fzZosung.zosung_send_ir_code_03,
            fzZosung.zosung_send_ir_code_04,
            tzLocal.zosung_send_ir_code_05,
        ],

        toZigbee: [
            tzLocal.zosung_ir_code_to_send,
            tzZosung.zosung_learn_ir_code,
        ],

        exposes: [
            ez.learn_ir_code(),
            ez.learned_ir_code(),
            e.text("learned_ir_timings", ea.STATE).withDescription("The IR timings learned by device"),
            ez.ir_code_to_send(),
        ],

        whiteLabel: [
            tuya.whitelabel(
                "Tuya",
                "iH-F8260",
                "Universal smart IR remote control CUSTOM",
                ["_TZ3290_gnl5a6a5xvql7c2a"],
            ),
        ],
    },
];
```
