### PR TITLE
Update frient.ts to support Frient Smart DIN Relay 2

### DIFF
--- a/src/devices/frient.ts
+++ b/src/devices/frient.ts
@@ -62,4 +62,24 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         ota: true,
     },
+    {
+        zigbeeModel: ["SMRZB-342"],
+        model: "SMRZB-342",
+        vendor: "Frient",
+        description: "Smart DIN Relay 2",
+        extend: [
+            m.onOff({powerOnBehavior: false, configureReporting: false}),
+            m.electricityMeter({
+                voltage: {divisor: 100, multiplier: 1},
+                current: {divisor: 1000, multiplier: 1},
+                power: {divisor: 1, multiplier: 1},
+                energy: {divisor: 1000, multiplier: 1},
+            }),
+            m.deviceTemperature(),
+        ],
+        ota: true,
+        endpoint: () => {
+            return {default: 2};
+        },
+    },
 ];


### PR DESCRIPTION
Adds support for Frient Smart DIN Relay 2, SMRZB-342 / EAN 5713594004495.

Tested:
- state
- power
- voltage
- current
- energy
- device_temperature

Notes:
- Functional endpoint is endpoint 2.
- Endpoint 1 appears present but does not respond correctly.
- On/off configure reporting is disabled to avoid endpoint 1 timeout during configuration.
- Confirmed scaling:
  - voltage divisor 100
  - current divisor 1000
  - energy divisor 1000
  - power divisor 1

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [PR-#5309](https://github.com/Koenkk/zigbee2mqtt.io/pull/5309)
