### PR TITLE
feat: add support for Atlantic Group Galapagos electric radiator (100050060900)

### DIFF
--- a/src/devices/atlantic.ts
+++ b/src/devices/atlantic.ts
@@ -118,4 +118,28 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint232, coordinatorEndpoint, ["haDiagnostic"]);
         },
     },
+    {
+        zigbeeModel: ["100050060900", "100050060900 "],
+        model: "100050060900",
+        vendor: "Atlantic Group",
+        description: "Galapagos electric radiator",
+        fromZigbee: [fz.thermostat, fz.occupancy, fz.metering],
+        toZigbee: [tz.thermostat_local_temperature, tz.thermostat_occupied_heating_setpoint, tz.thermostat_system_mode, tz.currentsummdelivered],
+        exposes: [
+            e.climate().withLocalTemperature().withSetpoint("occupied_heating_setpoint", 5, 30, 0.5).withSystemMode(["off", "heat"]),
+            e.occupancy(),
+            e.energy().withAccess(ea.STATE_GET),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["hvacThermostat", "msOccupancySensing", "seMetering"]);
+            await reporting.thermostatTemperature(endpoint);
+            await reporting.thermostatOccupiedHeatingSetpoint(endpoint);
+            await reporting.thermostatSystemMode(endpoint);
+            await reporting.occupancy(endpoint);
+            await reporting.currentSummDelivered(endpoint);
+            // The device reports seMetering multiplier=1000/divisor=1000 while currentSummDelivered is in Wh
+            endpoint.saveClusterAttributeKeyValue("seMetering", {multiplier: 1, divisor: 1000});
+        },
+    },
 ];


### PR DESCRIPTION
Link to picture pull request: Koenkk/zigbee2mqtt.io#5313

Add support for the Atlantic Group Galapagos electric radiator (Zigbee model `100050060900`), a 2024 French radiator line that joins directly over Zigbee 3.0 with an install code.

The definition exposes climate (heat/off, 5-30 °C setpoint, local temperature), the built-in occupancy sensor, and energy from the seMetering cluster. I tested it on real hardware (firmware 1.1.11) through Zigbee2MQTT 2.12.1 with an EmberZNet coordinator.

A few firmware quirks explain the choices in the definition:

- seMetering reports multiplier=1000 and divisor=1000 while currentSummDelivered is in Wh, so configure saves multiplier=1/divisor=1000 instead of reading them from the device.
- instantaneousDemand answers UNSUPPORTED_ATTRIBUTE, so there's no power expose.
- hvacThermostat runningState rejects both reads and reporting configuration.
- The device announces its model ID with a trailing space, hence the two zigbeeModel entries.

One pairing note for users finding this device: the QR code printed on the radiator encodes the EUI64 with reversed byte order (same finding as home-assistant/core#155014), so the install code must be added with the corrected IEEE address.
