### PR TITLE
fix(moes): ZC-LS02 battery polling + stop mcuVersion flood (_TZE284_koxaopnk)

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -461,7 +461,19 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZC-LS02",
         vendor: "Moes",
         description: "Roller blind motor",
-        extend: [tuya.modernExtend.tuyaBase({dp: true, respondToMcuVersionResponse: true})],
+        // This motor never reports battery spontaneously; DP 13 (battery) is only sent in
+        // response to a dataQuery. Without polling, `battery` stays null forever. Confirmed
+        // on hardware: dp 13 -> 100 only arrives after a dataQuery. Poll periodically and on
+        // device announce so the battery level is reported reliably.
+        extend: [
+            tuya.modernExtend.tuyaBase({
+                dp: true,
+                respondToMcuVersionResponse: true,
+                queryOnConfigure: true,
+                queryOnDeviceAnnounce: true,
+                queryIntervalSeconds: 4 * 60 * 60,
+            }),
+        ],
         exposes: [
             e.cover_position().setAccess("position", ea.STATE_SET),
             e.enum("motor_direction", ea.STATE_SET, ["normal", "reversed"]).withDescription("Set the motor direction"),

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -473,7 +473,7 @@ export const definitions: DefinitionWithExtend[] = [
                 dp: true,
                 queryOnConfigure: true,
                 queryOnDeviceAnnounce: true,
-                queryIntervalSeconds: 4 * 60 * 60,
+                queryIntervalSeconds: 24 * 60 * 60,
             }),
         ],
         exposes: [

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -465,10 +465,12 @@ export const definitions: DefinitionWithExtend[] = [
         // response to a dataQuery. Without polling, `battery` stays null forever. Confirmed
         // on hardware: dp 13 -> 100 only arrives after a dataQuery. Poll periodically and on
         // device announce so the battery level is reported reliably.
+        // respondToMcuVersionResponse is left at its default (false): with it enabled, one
+        // of the units gets stuck in an mcuVersionRequest/Response ping-pong (~3x/s) that
+        // floods the network/MQTT (see https://github.com/Koenkk/zigbee2mqtt/issues/28367).
         extend: [
             tuya.modernExtend.tuyaBase({
                 dp: true,
-                respondToMcuVersionResponse: true,
                 queryOnConfigure: true,
                 queryOnDeviceAnnounce: true,
                 queryIntervalSeconds: 4 * 60 * 60,


### PR DESCRIPTION
Two fixes for the Moes ZC-LS02 roller blind motor (`TS0601` / `_TZE284_koxaopnk`), both verified on real hardware (3 units).

## 1. Battery stays `null` — needs polling
The device exposes `battery`, but the value stayed `null`/unknown indefinitely.

**Root cause:** this motor never reports battery spontaneously. DP 13 (battery) is only sent in response to a Tuya `dataQuery`. The definition didn't poll, so on units that were never solicited the battery DP never arrived.

**Diagnosis (debug logging):** none of the units emitted DP 13 during normal operation (movement, state/position reports) — only DP 1/2/3/7. After issuing a `dataQuery`, every unit immediately returned `dp 13 → 100`:

```
Received Zigbee message ... commandDataReport ... {"dpValues":[{"data":[0,0,0,100],"datatype":2,"dp":13}]}
```

**Fix:** enable `queryOnConfigure` / `queryOnDeviceAnnounce` / `queryIntervalSeconds` (4 h) on `tuyaBase`. A 4 h interval keeps battery drain negligible while still surfacing a low battery in time for alerts. Three units went from `null` to `100`.

## 2. `respondToMcuVersionResponse` causes an mcuVersion flood
The previous definition set `respondToMcuVersionResponse: true`. On one of the units this triggers an endless `mcuVersionRequest`/`commandMcuVersionResponse` ping-pong (~3×/s) that floods the network and MQTT with duplicate reports (~8 publishes/s of identical state).

**Diagnosis (debug logging, 20 s window):**

```
Cortina direita -> Z2M : commandMcuVersionResponse   x64
Z2M -> Cortina direita : mcuVersionRequest           x65
```

**Fix:** remove `respondToMcuVersionResponse` (back to the library default of `false`, as recommended in #28367). After the change: `65 mcuVersionRequest / 20 s → 0`, and the unit dropped from the busiest device on the network to negligible. Battery and direction control are unaffected.

## Testing
- Verified in production on 3 real devices: `battery` now reports, and the mcuVersion flood is gone.
- `npm run check`, `npm run build` and `npm test` (650/650) all pass locally.
