### PR TITLE
feat(zemismart): add _TZE204_58of2pfn fingerprint

### DIFF
--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -470,7 +470,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_1n2kyphz", "_TZE200_shkxsgis", "_TZE204_shkxsgis"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_1n2kyphz", "_TZE200_shkxsgis", "_TZE204_shkxsgis", "_TZE204_58of2pfn"]),
         model: "TB26-4",
         vendor: "Zemismart",
         description: "4-gang smart wall switch",


### PR DESCRIPTION
## Description

Add `_TZE204_58of2pfn` to the existing Zemismart TB26-4 fingerprint list.

This device behaves identically to the existing TB26-4 definition, so no converter changes are required.

## Tested

- Zigbee2MQTT 2.12.1
- Successfully paired
- All 4 relays can be controlled
- State reporting works correctly