### PR TITLE
TS110E on_off fix add logic to use the correct state for  multi switches

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -3311,10 +3311,11 @@ const tuyaTz = {
         key: ["state", "brightness"],
         convertSet: async (entity, key, value, meta) => {
             const {message, state} = meta;
-            const brightnessKey = Object.keys(state).find((k) => k.startsWith("brightness_l")) && "ID" in entity ? `brightness_l${entity.ID}` : "brightness";
+            const brightnessKey =
+                Object.keys(state).find((k) => k.startsWith("brightness_l")) && "ID" in entity ? `brightness_l${entity.ID}` : "brightness";
             const stateKey = Object.keys(state).find((k) => k.startsWith("state_l")) && "ID" in entity ? `state_l${entity.ID}` : "state";
-            if (message.state === "OFF"  || (message.state != null && message.brightness == null)) {
-                return  await tz.on_off.convertSet(entity, key, value, meta);
+            if (message.state === "OFF" || (message.state != null && message.brightness == null)) {
+                return await tz.on_off.convertSet(entity, key, value, meta);
             }
             if (message.brightness != null) {
                 // If state includes brightness assume we need to use a custom lookup
@@ -3333,9 +3334,9 @@ const tuyaTz = {
                         "genLevelCtrl",
                         "moveToLevelTuya",
                         {level, transtime: 100},
-                        utils.getOptions(meta.mapped, entity)
+                        utils.getOptions(meta.mapped, entity),
                     );
-               }  
+                }
 
                 return {state: {state: "ON", brightness}};
             }

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -3311,8 +3311,8 @@ const tuyaTz = {
         key: ["state", "brightness"],
         convertSet: async (entity, key, value, meta) => {
             const {message, state} = meta;
-            const brightnessKey = Object.keys(state).find((k) => k.startsWith("brightness_l")) ? `brightness_l${entity.ID}` : "brightness";
-            const stateKey = Object.keys(state).find((k) => k.startsWith("state_l")) ? `state_l${entity.ID}` : "state";
+            const brightnessKey = Object.keys(state).find((k) => k.startsWith("brightness_l")) && "ID" in entity ? `brightness_l${entity.ID}` : "brightness";
+            const stateKey = Object.keys(state).find((k) => k.startsWith("state_l")) && "ID" in entity ? `state_l${entity.ID}` : "state";
             if (message.state === "OFF"  || (message.state != null && message.brightness == null)) {
                 return  await tz.on_off.convertSet(entity, key, value, meta);
             }
@@ -3328,7 +3328,7 @@ const tuyaTz = {
                     const level = utils.mapNumberRange(brightness, 0, 254, 0, 1000);
 
                     // set brightness
-                    await entity.command(
+                    await entity.command<"genLevelCtrl", "moveToLevelTuya", TuyaGenLevelCtrl>(
                         "genLevelCtrl",
                         "moveToLevelTuya",
                         {level, transtime: 100},

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -3311,24 +3311,32 @@ const tuyaTz = {
         key: ["state", "brightness"],
         convertSet: async (entity, key, value, meta) => {
             const {message, state} = meta;
-            if (message.state === "OFF" || (message.state != null && message.brightness == null)) {
-                return await tz.on_off.convertSet(entity, key, value, meta);
+            const brightnessKey = Object.keys(state).find((k) => k.startsWith("brightness_l")) ? `brightness_l${entity.ID}` : "brightness";
+            const stateKey = Object.keys(state).find((k) => k.startsWith("state_l")) ? `state_l${entity.ID}` : "state";
+            if (message.state === "OFF"  || (message.state != null && message.brightness == null)) {
+                return  await tz.on_off.convertSet(entity, key, value, meta);
             }
             if (message.brightness != null) {
-                // set brightness
-                if (state.state === "OFF") {
-                    await entity.command("genOnOff", "on", {}, utils.getOptions(meta.mapped, entity));
-                }
-
+                // If state includes brightness assume we need to use a custom lookup    
                 const brightness = utils.toNumber(message.brightness, "brightness");
-                const level = utils.mapNumberRange(brightness, 0, 254, 0, 1000);
-                await entity.command<"genLevelCtrl", "moveToLevelTuya", TuyaGenLevelCtrl>(
-                    "genLevelCtrl",
-                    "moveToLevelTuya",
-                    {level, transtime: 100},
-                    utils.getOptions(meta.mapped, entity),
-                );
-                return {state: {state: "ON", brightness}};
+                 // we allow at most 1 incase its a rounding/ float precision issue
+                const brightnessUnchanged = Math.abs(utils.mapNumberRange(brightness, 0, 254, 0, 254) - utils.toNumber(state[brightnessKey], "brightness")) <= 1;
+                // if the brightness is unchanged then we need to force it on due to weirdness with moveToLevelTuya
+                if (state[stateKey] === "OFF" && brightnessUnchanged ) {
+                    await entity.command("genOnOff", "on", {}, utils.getOptions(meta.mapped, entity));
+                } else {
+                    const level = utils.mapNumberRange(brightness, 0, 254, 0, 1000);
+
+                    // set brightness
+                    await entity.command(
+                        "genLevelCtrl",
+                        "moveToLevelTuya",
+                        {level, transtime: 100},
+                        utils.getOptions(meta.mapped, entity)
+                    );
+               }  
+
+              return {state: {state:"ON", brightness}};
             }
         },
         convertGet: async (entity, key, meta) => {

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -3313,30 +3313,26 @@ const tuyaTz = {
             const {message, state} = meta;
             const brightnessKey = Object.keys(state).find((k) => k.startsWith("brightness_l")) ? `brightness_l${entity.ID}` : "brightness";
             const stateKey = Object.keys(state).find((k) => k.startsWith("state_l")) ? `state_l${entity.ID}` : "state";
-            if (message.state === "OFF"  || (message.state != null && message.brightness == null)) {
-                return  await tz.on_off.convertSet(entity, key, value, meta);
+            if (message.state === "OFF" || (message.state != null && message.brightness == null)) {
+                return await tz.on_off.convertSet(entity, key, value, meta);
             }
             if (message.brightness != null) {
-                // If state includes brightness assume we need to use a custom lookup    
+                // If state includes brightness assume we need to use a custom lookup
                 const brightness = utils.toNumber(message.brightness, "brightness");
-                 // we allow at most 1 incase its a rounding/ float precision issue
-                const brightnessUnchanged = Math.abs(utils.mapNumberRange(brightness, 0, 254, 0, 254) - utils.toNumber(state[brightnessKey], "brightness")) <= 1;
+                // we allow at most 1 incase its a rounding/ float precision issue
+                const brightnessUnchanged =
+                    Math.abs(utils.mapNumberRange(brightness, 0, 254, 0, 254) - utils.toNumber(state[brightnessKey], "brightness")) <= 1;
                 // if the brightness is unchanged then we need to force it on due to weirdness with moveToLevelTuya
-                if (state[stateKey] === "OFF" && brightnessUnchanged ) {
+                if (state[stateKey] === "OFF" && brightnessUnchanged) {
                     await entity.command("genOnOff", "on", {}, utils.getOptions(meta.mapped, entity));
                 } else {
                     const level = utils.mapNumberRange(brightness, 0, 254, 0, 1000);
 
                     // set brightness
-                    await entity.command(
-                        "genLevelCtrl",
-                        "moveToLevelTuya",
-                        {level, transtime: 100},
-                        utils.getOptions(meta.mapped, entity)
-                    );
-               }  
+                    await entity.command("genLevelCtrl", "moveToLevelTuya", {level, transtime: 100}, utils.getOptions(meta.mapped, entity));
+                }
 
-              return {state: {state:"ON", brightness}};
+                return {state: {state: "ON", brightness}};
             }
         },
         convertGet: async (entity, key, meta) => {


### PR DESCRIPTION
resolves https://github.com/Koenkk/zigbee2mqtt/issues/32246

Basically when you send a same brightness command `moveToLevelTuya` will only turn on the device if the brightness changes, this is due to the helper assuming the state is always state but with multi switches we need to handle `state_l1` for example

this workaround just does a lookup, if we have a `state_` blah then assume we need it to work like that

I'm unsure if other parts of the device suffer a similar fate assuming that it should be i.e `brightness` vs `brightness_l1` but it may?

i assume the reason device would still turn on when the brightness changes is a side effect of the device itself and how it handles `moveToLevelTuya`


