### PR TITLE
Add support for Nova Digital NFZB-2

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -230,6 +230,7 @@ import {definitions as nodieby} from "./nodieby";
 import {definitions as nodon} from "./nodon";
 import {definitions as nordtronic} from "./nordtronic";
 import {definitions as nous} from "./nous";
+import {definitions as novaDigital} from "./nova_digital";
 import {definitions as novo} from "./novo";
 import {definitions as nue3a} from "./nue_3a";
 import {definitions as nyce} from "./nyce";
@@ -606,6 +607,7 @@ const definitions: DefinitionWithExtend[] = [
     ...nordtronic,
     ...nous,
     ...nobo,
+    ...novaDigital,
     ...novo,
     ...nue3a,
     ...nyce,

--- a/src/devices/nova_digital.ts
+++ b/src/devices/nova_digital.ts
@@ -1,0 +1,35 @@
+import * as reporting from "../lib/reporting";
+import * as tuya from "../lib/tuya";
+import type {DefinitionWithExtend} from "../lib/types";
+
+export const definitions: DefinitionWithExtend[] = [
+    {
+        fingerprint: tuya.fingerprint("TS0002", ["_TZ3210_5ksufhqi"]),
+        model: "NFZB-2",
+        vendor: "Nova Digital",
+        description: "2-Gang switch with backlight, countdown and inching",
+        extend: [
+            tuya.modernExtend.tuyaBase(),
+            tuya.modernExtend.tuyaOnOff({
+                powerOutageMemory: true,
+                backlightModeOffOn: true,
+                indicatorMode: true,
+                onOffCountdown: true,
+                inchingSwitch: true,
+                endpoints: ["l1", "l2"],
+            }),
+            tuya.clusters.addTuyaCommonPrivateCluster(),
+        ],
+        endpoint: () => {
+            return {l1: 1, l2: 2};
+        },
+        meta: {multiEndpoint: true},
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genOnOff"]);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
+            await reporting.onOff(device.getEndpoint(1));
+            await reporting.onOff(device.getEndpoint(2));
+        },
+    },
+];


### PR DESCRIPTION
## Summary

- add a dedicated Nova Digital NFZB-2 definition for `TS0002` / `_TZ3210_5ksufhqi`
- expose both switch endpoints together with power outage memory, backlight mode, indicator mode, countdown, and inching controls
- configure `genOnOff` binding and reporting for both endpoints so physical switch actions update their Zigbee2MQTT state

## Motivation

The device was previously matched by the generic Tuya TS0002 definition, but physical on/off actions were not reported. A device-specific definition is required to configure on/off reporting while preserving the Tuya features supported by this model.

## Validation

- tested the equivalent external converter on a physical Nova Digital NFZB-2
- verified physical on/off reporting for both endpoints
- verified the exposed Tuya controls, including power outage memory and inching
- `pnpm run build`
- `pnpm run check`
- `pnpm test` (650 tests passed)

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5316
