### PR TITLE
Shelly WS90: Exposing solar capacitor voltage

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1961,6 +1961,17 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Weather station",
         extend: [
             m.battery({voltage: true}),
+            m.numeric({
+                name: "capacitor_voltage",
+                cluster: "genPowerCfg",
+                attribute: "battery2Voltage",
+                description: "Capacitor Voltage",
+                unit: "V",
+                scale: 10,
+                reporting: {min: "10_SECONDS", max: "1_HOUR", change: 1},
+                access: "STATE_GET",
+                entityCategory: "diagnostic",
+            }),
             m.illuminance(),
             m.temperature(),
             m.pressure(),


### PR DESCRIPTION
This is a small tweak for the Shelly Ecowitt WS90 Weather Station. Purpose is to expose the 'battery2 voltage', which I believe is the voltage of the super capacitor that's powered by the built-in solar panel. 

See docs here: https://shelly-api-docs.shelly.cloud/docs-ble/Devices/BLU_ZB/wstation/#zigbee