### PR TITLE
Add support for FNB56-COS06FB2.1

### DIFF
--- a/src/devices/feibit.ts
+++ b/src/devices/feibit.ts
@@ -298,4 +298,14 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Power plug",
         extend: [m.onOff({powerOnBehavior: false})],
     },
+    {
+        zigbeeModel: ["FB56-COS02HM1.4"],
+        model: "FB56-COS02HM1.4",
+        vendor: "Feibit",
+        description: "Carbon monoxide sensor",
+        extend: [
+            m.battery({voltageToPercentage: {min: 2500, max: 3000}, voltage: true}),
+            m.iasZoneAlarm({zoneType: "carbon_monoxide", zoneAttributes: ["alarm_1", "battery_low", "tamper"]}),
+        ],
+    },
 ];

--- a/src/devices/feibit.ts
+++ b/src/devices/feibit.ts
@@ -79,7 +79,7 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [e.smoke(), e.battery_low(), e.tamper(), e.battery()],
     },
     {
-        zigbeeModel: ["FNB56-COS06FB1.7", "FNB56-COS06FB2.1"],
+        zigbeeModel: ["FNB56-COS06FB1.7", "FNB56-COS06FB2.1", "FB56-COS02HM1.4"],
         model: "SCA01ZB",
         vendor: "Feibit",
         description: "Smart carbon monoxide sensor",
@@ -297,15 +297,5 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Feibit",
         description: "Power plug",
         extend: [m.onOff({powerOnBehavior: false})],
-    },
-    {
-        zigbeeModel: ["FB56-COS02HM1.4"],
-        model: "FB56-COS02HM1.4",
-        vendor: "Feibit",
-        description: "Carbon monoxide sensor",
-        extend: [
-            m.battery({voltageToPercentage: {min: 2500, max: 3000}, voltage: true}),
-            m.iasZoneAlarm({zoneType: "carbon_monoxide", zoneAttributes: ["alarm_1", "battery_low", "tamper"]}),
-        ],
     },
 ];


### PR DESCRIPTION
Ref https://github.com/Koenkk/zigbee2mqtt/issues/30738 and https://github.com/Koenkk/zigbee2mqtt/issues/32533. 
@Koenkk , I believe this should make the device work?

Content of the automatically generated definition (https://github.com/Koenkk/zigbee2mqtt/issues/30738) 
```
    zigbeeModel: ['FB56-COS02HM1.4'],
    model: 'FB56-COS02HM1.4',
    vendor: 'Feibit,co.ltd   ',
```

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
