### PR TITLE
Update Philips light extension with color options

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -296,7 +296,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "929004308301",
         vendor: "Philips",
         description: "Hue Turaco outdoor wall light",
-        extend: [philips.m.light()],
+        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
     },
     {
         zigbeeModel: ["LWA023"],


### PR DESCRIPTION
In the last release I added the Philips Turaco Light. 
I forgot to add color options, so currently it is not possible to control the color temp and color :(

I copied the extend: part from a similiar philips bulb with the same functionality - I hope that works..