### PR TITLE
feat(exposes): add withDefault for composite feature defaults

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -2355,14 +2355,17 @@ const sonoffExtend = {
         const exposes = e
             .composite("cyclic_timed_irrigation", "cyclic_timed_irrigation", ea.ALL)
             .withDescription("Smart water valve cycle timing irrigation")
-            .withFeature(e.numeric("current_count", ea.STATE).withDescription("Number of times it has been executed").withUnit("times"))
+            .withFeature(
+                e.numeric("current_count", ea.STATE).withDescription("Number of times it has been executed").withUnit("times").withDefault(0),
+            )
             .withFeature(
                 e
                     .numeric("total_number", ea.STATE_SET)
                     .withDescription("Total times of circulating irrigation")
                     .withUnit("times")
                     .withValueMin(0)
-                    .withValueMax(100),
+                    .withValueMax(100)
+                    .withDefault(1),
             )
             .withFeature(
                 e
@@ -2370,7 +2373,8 @@ const sonoffExtend = {
                     .withDescription("Single irrigation duration")
                     .withUnit("seconds")
                     .withValueMin(0)
-                    .withValueMax(86400),
+                    .withValueMax(86400)
+                    .withDefault(60),
             )
             .withFeature(
                 e
@@ -2378,7 +2382,8 @@ const sonoffExtend = {
                     .withDescription("Time interval between two adjacent irrigation")
                     .withUnit("seconds")
                     .withValueMin(0)
-                    .withValueMax(86400),
+                    .withValueMax(86400)
+                    .withDefault(60),
             );
         const fromZigbee = [
             {
@@ -2477,14 +2482,17 @@ const sonoffExtend = {
         const exposes = e
             .composite("cyclic_quantitative_irrigation", "cyclic_quantitative_irrigation", ea.ALL)
             .withDescription("Smart water valve circulating quantitative irrigation")
-            .withFeature(e.numeric("current_count", ea.STATE).withDescription("Number of times it has been executed").withUnit("times"))
+            .withFeature(
+                e.numeric("current_count", ea.STATE).withDescription("Number of times it has been executed").withUnit("times").withDefault(0),
+            )
             .withFeature(
                 e
                     .numeric("total_number", ea.STATE_SET)
                     .withDescription("Total times of circulating irrigation")
                     .withUnit("times")
                     .withValueMin(0)
-                    .withValueMax(100),
+                    .withValueMax(100)
+                    .withDefault(1),
             )
             .withFeature(
                 e
@@ -2492,7 +2500,8 @@ const sonoffExtend = {
                     .withDescription("Single irrigation capacity")
                     .withUnit("liter")
                     .withValueMin(0)
-                    .withValueMax(6500),
+                    .withValueMax(6500)
+                    .withDefault(1),
             )
             .withFeature(
                 e
@@ -2500,7 +2509,8 @@ const sonoffExtend = {
                     .withDescription("Time interval between two adjacent irrigation")
                     .withUnit("seconds")
                     .withValueMin(0)
-                    .withValueMax(86400),
+                    .withValueMax(86400)
+                    .withDefault(60),
             );
         const fromZigbee = [
             {

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -14,6 +14,7 @@ import type {Access, LevelConfigFeatures, Range} from "./types";
 import {getLabelFromName} from "./utils";
 
 export type Feature = Numeric | Binary | Enum | Composite | List | Text;
+export type DefaultValue = number | string | boolean;
 export interface HomeAssistant {
     type?: "valve";
     entityCategory?: "config" | "diagnostic";
@@ -32,6 +33,8 @@ export class Base {
     description?: string;
     features?: Feature[];
     category?: "config" | "diagnostic";
+    // Cards need explicit defaults to build complete payloads for new atomic composites, which must be written as one object.
+    default?: DefaultValue;
     homeassistant?: HomeAssistant;
 
     withEndpoint(endpointName: string) {
@@ -78,6 +81,11 @@ export class Base {
     withCategory(category: "config" | "diagnostic") {
         this.category = category;
         this.validateCategory();
+        return this;
+    }
+
+    withDefault(value: DefaultValue) {
+        this.default = value;
         return this;
     }
 
@@ -134,6 +142,9 @@ export class Base {
             target.features = this.features.map((f) => f.clone());
         }
         target.category = this.category;
+        if (this.default !== undefined) {
+            target.default = this.default;
+        }
         target.homeassistant = this.homeassistant ? {...this.homeassistant} : undefined;
     }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,6 @@
 import {beforeEach, describe, expect, it} from "vitest";
 import type {Device} from "zigbee-herdsman/dist/controller/model";
+import {access, presets} from "../src/lib/exposes";
 import type {Tz} from "../src/lib/types";
 import {batteryVoltageToPercentage, getFromLookup, getFromLookupByValue, getTransition, mapNumberRange, toNumber} from "../src/lib/utils";
 import {mockDevice} from "./utils";
@@ -229,6 +230,30 @@ describe("utils", () => {
             it("should return first matching key", () => {
                 expect(getFromLookupByValue("same", {first: "same", second: "same", third: "different"})).toStrictEqual("first");
             });
+        });
+    });
+
+    describe("exposes defaults", () => {
+        it("sets explicit defaults", () => {
+            const expose = presets.numeric("irrigation_duration", access.ALL).withDefault(60);
+
+            expect(expose.default).toBe(60);
+        });
+
+        it("preserves defaults when cloned", () => {
+            const expose = presets
+                .composite("cyclic_timed_irrigation", "cyclic_timed_irrigation", access.ALL)
+                .withFeature(presets.numeric("total_number", access.STATE_SET).withDefault(1));
+
+            const clone = expose.clone();
+
+            expect(clone.features[0].default).toBe(1);
+        });
+
+        it("does not serialize unset defaults", () => {
+            const expose = presets.numeric("irrigation_interval", access.ALL);
+
+            expect(JSON.parse(JSON.stringify(expose))).not.toHaveProperty("default");
         });
     });
 });


### PR DESCRIPTION
## Summary

Adds an optional per-feature `default` value to exposes via a new `withDefault(value)` builder on `Base`, and seeds defaults on the SONOFF cyclic timed/quantitative irrigation composites.

## Why

A `composite` must be written to the device as **one complete object** in a single message; its fields are not independently writable (this is the whole point of `composite` — see #12495 and #12510 which were reverted by #12647 because the SONOFF valve needs the full config in one write and new/empty plan slots have no cached state to merge).

A companion Home Assistant composite-editor card (and potentially other consumers) needs sensible per-field **defaults** so it can pre-fill a new/empty composite slot and build a complete payload. This adds that capability without changing any converter logic — only optional metadata.

## Changes
- `src/lib/exposes.ts`: optional `Base.default` + `withDefault()`, preserved through clone/copy (only when set, so serialized exposes are unchanged when unused).
- `src/devices/sonoff.ts`: `.withDefault(...)` on the cyclic timed/quantitative irrigation composite features (values within declared ranges).
- `test/utils.test.ts`: tests for setting/cloning and non-serialization when unset.

## Companion work
Consumed by a Zigbee2MQTT change that discovers settable composites for Home Assistant and a custom Lovelace card that edits them (linked separately).