### PR TITLE
feat(sonoff): retain SWV irrigation plan slots by index

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -22,6 +22,7 @@ import {
     YEAR_2000_IN_UTC,
     zclArrayValueToBytes,
 } from "../lib/sonoff";
+import * as globalStore from "../lib/store";
 import * as tuya from "../lib/tuya";
 import type {
     Configure,
@@ -5885,50 +5886,65 @@ const sonoffExtend = {
                 e.text("create_datetime", ea.SET).withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
             );
 
-            const irrigationPlanReport = e
-                .composite("irrigation_plan_report", "irrigation_plan_report", ea.STATE)
-                .withDescription("Irrigation plan report")
-                .withFeature(e.numeric("plan_index", ea.STATE))
-                .withFeature(e.binary("enable_state", ea.STATE, true, false))
-                .withFeature(e.enum("loop_type_mode", ea.STATE, ["odd_days", "even_days", "day_interval", "weekdays"]))
-                .withFeature(e.numeric("loop_type_interval_days", ea.STATE).withDescription("Effective when loop_type_mode is day_interval"))
-                .withFeature(
+            const createIrrigationPlanReportExpose = (name: string, description: string): exposes.Composite => {
+                const expose = e
+                    .composite(name, name, ea.STATE)
+                    .withDescription(description)
+                    .withFeature(e.numeric("plan_index", ea.STATE))
+                    .withFeature(e.binary("enable_state", ea.STATE, true, false))
+                    .withFeature(e.enum("loop_type_mode", ea.STATE, ["odd_days", "even_days", "day_interval", "weekdays"]))
+                    .withFeature(e.numeric("loop_type_interval_days", ea.STATE).withDescription("Effective when loop_type_mode is day_interval"))
+                    .withFeature(
+                        e
+                            .composite("loop_type_week_days", "loop_type_week_days", ea.STATE)
+                            .withDescription("Effective when loop_type_mode is weekdays")
+                            .withFeature(e.binary("sunday", ea.STATE, true, false))
+                            .withFeature(e.binary("monday", ea.STATE, true, false))
+                            .withFeature(e.binary("tuesday", ea.STATE, true, false))
+                            .withFeature(e.binary("wednesday", ea.STATE, true, false))
+                            .withFeature(e.binary("thursday", ea.STATE, true, false))
+                            .withFeature(e.binary("friday", ea.STATE, true, false))
+                            .withFeature(e.binary("saturday", ea.STATE, true, false)),
+                    )
+                    .withFeature(e.text("enable_date", ea.STATE).withDescription("Enable date in local YYYY-MM-DD format (local day start)"))
+                    .withFeature(e.text("start_time", ea.STATE).withDescription("Start time in local HH:mm format (24-hour)"))
+                    .withFeature(
+                        e.enum(
+                            "irrigation_mode",
+                            ea.STATE,
+                            hasFlowMeter ? ["duration", "capacity", "duration_with_interval"] : ["duration", "duration_with_interval"],
+                        ),
+                    )
+                    .withFeature(e.numeric("irrigation_total_duration", ea.STATE))
+                    .withFeature(e.numeric("irrigation_duration", ea.STATE))
+                    .withFeature(e.numeric("interval_duration", ea.STATE));
+                if (hasFlowMeter) {
+                    const unitValues =
+                        utils.isDummyDevice(device) || SWVZNEFirmwareSupportsUnifiedImperialGallon(device as Zh.Device)
+                            ? ["us_gallon", "liter", "imperial_gallon"]
+                            : ["us_gallon", "liter"];
+                    expose.withFeature(e.enum("irrigation_amount_unit", ea.STATE, unitValues));
+                    expose.withFeature(e.numeric("irrigation_amount", ea.STATE)).withFeature(e.numeric("fail_safe", ea.STATE));
+                }
+                return expose.withFeature(
                     e
-                        .composite("loop_type_week_days", "loop_type_week_days", ea.STATE)
-                        .withDescription("Effective when loop_type_mode is weekdays")
-                        .withFeature(e.binary("sunday", ea.STATE, true, false))
-                        .withFeature(e.binary("monday", ea.STATE, true, false))
-                        .withFeature(e.binary("tuesday", ea.STATE, true, false))
-                        .withFeature(e.binary("wednesday", ea.STATE, true, false))
-                        .withFeature(e.binary("thursday", ea.STATE, true, false))
-                        .withFeature(e.binary("friday", ea.STATE, true, false))
-                        .withFeature(e.binary("saturday", ea.STATE, true, false)),
-                )
-                .withFeature(e.text("enable_date", ea.STATE).withDescription("Enable date in local YYYY-MM-DD format (local day start)"))
-                .withFeature(e.text("start_time", ea.STATE).withDescription("Start time in local HH:mm format (24-hour)"))
-                .withFeature(
-                    e.enum(
-                        "irrigation_mode",
-                        ea.STATE,
-                        hasFlowMeter ? ["duration", "capacity", "duration_with_interval"] : ["duration", "duration_with_interval"],
-                    ),
-                )
-                .withFeature(e.numeric("irrigation_total_duration", ea.STATE))
-                .withFeature(e.numeric("irrigation_duration", ea.STATE))
-                .withFeature(e.numeric("interval_duration", ea.STATE));
-            if (hasFlowMeter) {
-                const unitValues =
-                    utils.isDummyDevice(device) || SWVZNEFirmwareSupportsUnifiedImperialGallon(device as Zh.Device)
-                        ? ["us_gallon", "liter", "imperial_gallon"]
-                        : ["us_gallon", "liter"];
-                irrigationPlanReport.withFeature(e.enum("irrigation_amount_unit", ea.STATE, unitValues));
-                irrigationPlanReport.withFeature(e.numeric("irrigation_amount", ea.STATE)).withFeature(e.numeric("fail_safe", ea.STATE));
-            }
-            irrigationPlanReport.withFeature(
-                e.text("create_datetime", ea.STATE).withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
+                        .text("create_datetime", ea.STATE)
+                        .withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
+                );
+            };
+
+            const irrigationPlanReport = createIrrigationPlanReportExpose(
+                "irrigation_plan_report",
+                "Last irrigation plan report received from the device.",
+            );
+            const irrigationPlanSlotReports = Array.from({length: 6}, (_, planIndex) =>
+                createIrrigationPlanReportExpose(`irrigation_plan_report_${planIndex}`, `Cached irrigation plan report for plan_index ${planIndex}.`),
             );
 
-            return [irrigationPlanSettings, irrigationPlanReport].flatMap((expose) => exposeCompositeEndpoints(expose, endpointNames));
+            // The device reports all six slots when joining, then only the changed slot; the protocol has no per-slot query command.
+            return [irrigationPlanSettings, irrigationPlanReport, ...irrigationPlanSlotReports].flatMap((expose) =>
+                exposeCompositeEndpoints(expose, endpointNames),
+            );
         };
 
         const fromZigbee: Fz.Converter<"customClusterEwelink", SonoffSwvzn, ["raw"]>[] = [
@@ -6056,7 +6072,25 @@ const sonoffExtend = {
                             create_datetime: createDatetimeISO,
                         };
 
-                        return {[property]: plan};
+                        const endpointName = endpointNames ? utils.getKey(model.endpoint?.(meta.device) ?? {}, msg.endpoint.ID) : undefined;
+                        const storeKey = `irrigation_plan_reports_${endpointName ?? "default"}`;
+                        const storeEntity = meta.device ?? msg.device ?? msg.endpoint;
+                        const result: KeyValueAny = {[property]: plan};
+                        const slotProperty = utils.postfixWithEndpointName(`irrigation_plan_report_${planIndex}`, msg, model, meta);
+                        if (!storeEntity) {
+                            result[slotProperty] = plan;
+                            return result;
+                        }
+                        const reportsByIndex = utils.isObject(globalStore.getValue(storeEntity, storeKey, {}))
+                            ? {...globalStore.getValue(storeEntity, storeKey, {})}
+                            : {};
+                        reportsByIndex[planIndex] = plan;
+                        globalStore.putValue(storeEntity, storeKey, reportsByIndex);
+
+                        for (const [cachedPlanIndex, cachedPlan] of Object.entries(reportsByIndex)) {
+                            result[utils.postfixWithEndpointName(`irrigation_plan_report_${cachedPlanIndex}`, msg, model, meta)] = cachedPlan;
+                        }
+                        return result;
                     }
                 },
             },

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -22,6 +22,7 @@ import {
     YEAR_2000_IN_UTC,
     zclArrayValueToBytes,
 } from "../lib/sonoff";
+import * as globalStore from "../lib/store";
 import * as tuya from "../lib/tuya";
 import type {
     Configure,
@@ -6579,50 +6580,65 @@ const sonoffExtend = {
                 e.text("create_datetime", ea.SET).withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
             );
 
-            const irrigationPlanReport = e
-                .composite("irrigation_plan_report", "irrigation_plan_report", ea.STATE)
-                .withDescription("Irrigation plan report")
-                .withFeature(e.numeric("plan_index", ea.STATE))
-                .withFeature(e.binary("enable_state", ea.STATE, true, false))
-                .withFeature(e.enum("loop_type_mode", ea.STATE, ["odd_days", "even_days", "day_interval", "weekdays"]))
-                .withFeature(e.numeric("loop_type_interval_days", ea.STATE).withDescription("Effective when loop_type_mode is day_interval"))
-                .withFeature(
+            const createIrrigationPlanReportExpose = (name: string, description: string): exposes.Composite => {
+                const expose = e
+                    .composite(name, name, ea.STATE)
+                    .withDescription(description)
+                    .withFeature(e.numeric("plan_index", ea.STATE))
+                    .withFeature(e.binary("enable_state", ea.STATE, true, false))
+                    .withFeature(e.enum("loop_type_mode", ea.STATE, ["odd_days", "even_days", "day_interval", "weekdays"]))
+                    .withFeature(e.numeric("loop_type_interval_days", ea.STATE).withDescription("Effective when loop_type_mode is day_interval"))
+                    .withFeature(
+                        e
+                            .composite("loop_type_week_days", "loop_type_week_days", ea.STATE)
+                            .withDescription("Effective when loop_type_mode is weekdays")
+                            .withFeature(e.binary("sunday", ea.STATE, true, false))
+                            .withFeature(e.binary("monday", ea.STATE, true, false))
+                            .withFeature(e.binary("tuesday", ea.STATE, true, false))
+                            .withFeature(e.binary("wednesday", ea.STATE, true, false))
+                            .withFeature(e.binary("thursday", ea.STATE, true, false))
+                            .withFeature(e.binary("friday", ea.STATE, true, false))
+                            .withFeature(e.binary("saturday", ea.STATE, true, false)),
+                    )
+                    .withFeature(e.text("enable_date", ea.STATE).withDescription("Enable date in local YYYY-MM-DD format (local day start)"))
+                    .withFeature(e.text("start_time", ea.STATE).withDescription("Start time in local HH:mm format (24-hour)"))
+                    .withFeature(
+                        e.enum(
+                            "irrigation_mode",
+                            ea.STATE,
+                            hasFlowMeter ? ["duration", "capacity", "duration_with_interval"] : ["duration", "duration_with_interval"],
+                        ),
+                    )
+                    .withFeature(e.numeric("irrigation_total_duration", ea.STATE))
+                    .withFeature(e.numeric("irrigation_duration", ea.STATE))
+                    .withFeature(e.numeric("interval_duration", ea.STATE));
+                if (hasFlowMeter) {
+                    const unitValues =
+                        utils.isDummyDevice(device) || SWVZNEFirmwareSupportsUnifiedImperialGallon(device as Zh.Device)
+                            ? ["us_gallon", "liter", "imperial_gallon"]
+                            : ["us_gallon", "liter"];
+                    expose.withFeature(e.enum("irrigation_amount_unit", ea.STATE, unitValues));
+                    expose.withFeature(e.numeric("irrigation_amount", ea.STATE)).withFeature(e.numeric("fail_safe", ea.STATE));
+                }
+                return expose.withFeature(
                     e
-                        .composite("loop_type_week_days", "loop_type_week_days", ea.STATE)
-                        .withDescription("Effective when loop_type_mode is weekdays")
-                        .withFeature(e.binary("sunday", ea.STATE, true, false))
-                        .withFeature(e.binary("monday", ea.STATE, true, false))
-                        .withFeature(e.binary("tuesday", ea.STATE, true, false))
-                        .withFeature(e.binary("wednesday", ea.STATE, true, false))
-                        .withFeature(e.binary("thursday", ea.STATE, true, false))
-                        .withFeature(e.binary("friday", ea.STATE, true, false))
-                        .withFeature(e.binary("saturday", ea.STATE, true, false)),
-                )
-                .withFeature(e.text("enable_date", ea.STATE).withDescription("Enable date in local YYYY-MM-DD format (local day start)"))
-                .withFeature(e.text("start_time", ea.STATE).withDescription("Start time in local HH:mm format (24-hour)"))
-                .withFeature(
-                    e.enum(
-                        "irrigation_mode",
-                        ea.STATE,
-                        hasFlowMeter ? ["duration", "capacity", "duration_with_interval"] : ["duration", "duration_with_interval"],
-                    ),
-                )
-                .withFeature(e.numeric("irrigation_total_duration", ea.STATE))
-                .withFeature(e.numeric("irrigation_duration", ea.STATE))
-                .withFeature(e.numeric("interval_duration", ea.STATE));
-            if (hasFlowMeter) {
-                const unitValues =
-                    utils.isDummyDevice(device) || SWVZNEFirmwareSupportsUnifiedImperialGallon(device as Zh.Device)
-                        ? ["us_gallon", "liter", "imperial_gallon"]
-                        : ["us_gallon", "liter"];
-                irrigationPlanReport.withFeature(e.enum("irrigation_amount_unit", ea.STATE, unitValues));
-                irrigationPlanReport.withFeature(e.numeric("irrigation_amount", ea.STATE)).withFeature(e.numeric("fail_safe", ea.STATE));
-            }
-            irrigationPlanReport.withFeature(
-                e.text("create_datetime", ea.STATE).withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
+                        .text("create_datetime", ea.STATE)
+                        .withDescription("Create datetime in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00)"),
+                );
+            };
+
+            const irrigationPlanReport = createIrrigationPlanReportExpose(
+                "irrigation_plan_report",
+                "Last irrigation plan report received from the device.",
+            );
+            const irrigationPlanSlotReports = Array.from({length: 6}, (_, planIndex) =>
+                createIrrigationPlanReportExpose(`irrigation_plan_report_${planIndex}`, `Cached irrigation plan report for plan_index ${planIndex}.`),
             );
 
-            return [irrigationPlanSettings, irrigationPlanReport].flatMap((expose) => exposeCompositeEndpoints(expose, endpointNames));
+            // The device reports all six slots when joining, then only the changed slot; the protocol has no per-slot query command.
+            return [irrigationPlanSettings, irrigationPlanReport, ...irrigationPlanSlotReports].flatMap((expose) =>
+                exposeCompositeEndpoints(expose, endpointNames),
+            );
         };
 
         const fromZigbee: Fz.Converter<"customClusterEwelink", SonoffSwvzn, ["raw"]>[] = [
@@ -6750,7 +6766,25 @@ const sonoffExtend = {
                             create_datetime: createDatetimeISO,
                         };
 
-                        return {[property]: plan};
+                        const endpointName = endpointNames ? utils.getKey(model.endpoint?.(meta.device) ?? {}, msg.endpoint.ID) : undefined;
+                        const storeKey = `irrigation_plan_reports_${endpointName ?? "default"}`;
+                        const storeEntity = meta.device ?? msg.device ?? msg.endpoint;
+                        const result: KeyValueAny = {[property]: plan};
+                        const slotProperty = utils.postfixWithEndpointName(`irrigation_plan_report_${planIndex}`, msg, model, meta);
+                        if (!storeEntity) {
+                            result[slotProperty] = plan;
+                            return result;
+                        }
+                        const reportsByIndex = utils.isObject(globalStore.getValue(storeEntity, storeKey, {}))
+                            ? {...globalStore.getValue(storeEntity, storeKey, {})}
+                            : {};
+                        reportsByIndex[planIndex] = plan;
+                        globalStore.putValue(storeEntity, storeKey, reportsByIndex);
+
+                        for (const [cachedPlanIndex, cachedPlan] of Object.entries(reportsByIndex)) {
+                            result[utils.postfixWithEndpointName(`irrigation_plan_report_${cachedPlanIndex}`, msg, model, meta)] = cachedPlan;
+                        }
+                        return result;
                     }
                 },
             },

--- a/test/sonoff.test.ts
+++ b/test/sonoff.test.ts
@@ -2,6 +2,7 @@ import type {Mock} from "vitest";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import type {Models as ZHModels} from "zigbee-herdsman";
 import {findByDevice} from "../src/index";
+import * as globalStore from "../src/lib/store";
 import type {Definition, Fz, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
@@ -634,13 +635,17 @@ describe("Sonoff SNZB-02DR2", () => {
 
 describe("Sonoff SWV-ZFE", () => {
     let device: Definition;
+    let zigbeeDevice: ZHModels.Device;
     let endpoint: ZHModels.Endpoint;
     let writeFn: Mock;
     let commandFn: Mock;
     let meta: Tz.Meta;
+    let fzMeta: Fz.Meta;
 
     beforeEach(async () => {
-        device = await findByDevice(mockDevice({modelID: "SWV-ZFE", endpoints: [{ID: 1}]}));
+        globalStore.clear();
+        zigbeeDevice = mockDevice({modelID: "SWV-ZFE", endpoints: [{ID: 1}]});
+        device = await findByDevice(zigbeeDevice);
 
         writeFn = vi.fn();
         commandFn = vi.fn();
@@ -708,6 +713,76 @@ describe("Sonoff SWV-ZFE", () => {
             publish: null,
             endpoint_name: null,
         };
+        fzMeta = {
+            state: {},
+            device: zigbeeDevice,
+            deviceExposesChanged: null,
+        };
+    });
+
+    const makeIrrigationPlanReportFrame = (planIndex: number, startMinutes: number, irrigationDuration: number): Buffer => {
+        const payload = Buffer.alloc(28);
+        let offset = 0;
+        payload.writeUInt8(planIndex, offset++);
+        payload.writeUInt8(1, offset++);
+        payload.writeUInt16BE(0x0305, offset);
+        offset += 2;
+        payload.writeUInt32BE(835574400, offset);
+        offset += 4;
+        payload.writeUInt8(0, offset++);
+        payload.writeUInt32BE(startMinutes * 60, offset);
+        offset += 4;
+        payload.writeUInt16BE(20, offset);
+        offset += 2;
+        payload.writeUInt16BE(irrigationDuration, offset);
+        offset += 2;
+        payload.writeUInt16BE(3, offset);
+        offset += 2;
+        payload.writeUInt8(1, offset++);
+        payload.writeUInt16BE(50, offset);
+        offset += 2;
+        payload.writeUInt16BE(30, offset);
+        offset += 2;
+        payload.writeUInt32BE(1782023400, offset);
+
+        return Buffer.concat([Buffer.from([0x18, 0x00, 0x09]), payload]);
+    };
+
+    const convertRawIrrigationPlanReport = (frame: Buffer) => {
+        const msg: Fz.Message<"customClusterEwelink", undefined, "raw"> = {
+            data: frame,
+            endpoint: {ID: 1} as ZHModels.Endpoint,
+            device: zigbeeDevice,
+            meta: {},
+            groupID: null,
+            type: "raw",
+            cluster: "customClusterEwelink",
+            linkquality: 0,
+        };
+
+        for (const converter of device.fromZigbee.filter(
+            (candidate) => candidate.cluster === "customClusterEwelink" && candidate.type.includes("raw"),
+        )) {
+            const result = converter.convert(device, msg, null, null, fzMeta);
+            if (result) return result;
+        }
+    };
+
+    describe("fromZigbee", () => {
+        it("retains irrigation plan reports by plan index", () => {
+            const first = convertRawIrrigationPlanReport(makeIrrigationPlanReportFrame(0, 6 * 60 + 30, 9));
+            const second = convertRawIrrigationPlanReport(makeIrrigationPlanReportFrame(2, 9 * 60 + 20, 2));
+
+            expect(first).toMatchObject({
+                irrigation_plan_report: {plan_index: 0, start_time: "06:30", irrigation_duration: 9},
+                irrigation_plan_report_0: {plan_index: 0, start_time: "06:30", irrigation_duration: 9},
+            });
+            expect(second).toMatchObject({
+                irrigation_plan_report: {plan_index: 2, start_time: "09:20", irrigation_duration: 2},
+                irrigation_plan_report_0: {plan_index: 0, start_time: "06:30", irrigation_duration: 9},
+                irrigation_plan_report_2: {plan_index: 2, start_time: "09:20", irrigation_duration: 2},
+            });
+        });
     });
 
     describe("toZigbee", () => {


### PR DESCRIPTION
## What

Adds per-slot retention for SONOFF SWV/SWV-ZFE irrigation plan reports:

- keeps the existing `irrigation_plan_report` as the last report received
- adds `irrigation_plan_report_0` ... `irrigation_plan_report_5` so reports are retained by `plan_index` instead of overwritten
- documents the limitation that the device protocol reports a single plan object at a time and no confirmed safe active per-slot read command is known yet

## Why

The valve supports up to 6 irrigation plan slots, but the current converter exposes only the last pushed report. When the device reports another slot, Home Assistant loses the previous slot state. Retaining by `plan_index` lets HA show/read each slot independently once the device has pushed it.

## Discovery / live test

Tested on live SONOFF SWV-ZFE `Bewässerungsventil` (`0xa4c1381456c7ffff`, firmware 1.0.7) in Zigbee2MQTT 2.12.1-dev.

Safe discovery steps:

- Existing `irrigation_schedule_status` GET reads attribute `irrigationScheduleStatus` and does not trigger plan reports.
- Existing plan report state before the change showed only the last pushed report (`plan_index: 2`).
- A conservative candidate command using custom cluster `0xfc11`, command id `0x09`, payload `[0]` was sent once and again after restart. Zigbee2MQTT logged the outgoing `customClusterEwelink.readIrrigationPlan({data:[0]})`, but the device did not return an `irrigationPlanReport`; therefore active on-demand read is not included in this PR.

Live deployed fallback build confirmed:

- Zigbee2MQTT starts healthy.
- HA discovery/state includes `irrigation_plan_report_0` ... `_5` alongside the legacy `irrigation_plan_report`.
- Slot entities are initially empty until the device pushes those specific slots, which is expected for retention-only behavior.

Screenshot: `plan-slots-01-devtools-states.png` captured from HA Developer Tools.

## Validation

- `corepack pnpm run check` passes (Biome prints an existing schema-version info).
- `corepack pnpm run build` passes.
- `corepack pnpm exec vitest run test/sonoff.test.ts` has the new retention test passing; one unrelated existing SWV configure test fails in this sandbox because installed `zigbee-herdsman@10.6.2` makes `Device.save()` access undefined internals.
- `corepack pnpm test` has the Sonoff tests including the new test passing; one unrelated `batteryState.test.ts` test times out at 5s in this sandbox.

cc @CubeZ2mDeveloper

Related: Koenkk/zigbee2mqtt#32545, #12647
