### PR TITLE
feat: Shelly WS90: expose battery voltage

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1960,7 +1960,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "Weather station",
         extend: [
-            m.battery(),
+            m.battery({voltage: true}),
             m.illuminance(),
             m.temperature(),
             m.pressure(),


### PR DESCRIPTION
https://shelly-api-docs.shelly.cloud/docs-ble/Devices/BLU_ZB/wstation/#zigbee
> 0x0001	Power config	0x0020	Battery voltage	r