### PR TITLE
fix: Change action_transition_time unit to seconds

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1427,7 +1427,7 @@ export const command_move_to_level: Fz.Converter<"genLevelCtrl", undefined, ["co
         const payload: KeyValueAny = {
             action: postfixWithEndpointName("brightness_move_to_level", msg, model, meta),
             action_level: msg.data.level,
-            action_transition_time: msg.data.transtime / 100,
+            action_transition_time: msg.data.transtime / 10,
         };
         addActionGroup(payload, msg, model);
 
@@ -1489,7 +1489,7 @@ export const command_step: Fz.Converter<"genLevelCtrl", undefined, ["commandStep
         const payload: KeyValueAny = {
             action: postfixWithEndpointName(`brightness_step_${direction}`, msg, model, meta),
             action_step_size: msg.data.stepsize,
-            action_transition_time: msg.data.transtime / 100,
+            action_transition_time: msg.data.transtime / 10,
         };
         addActionGroup(payload, msg, model);
 
@@ -1559,7 +1559,7 @@ export const command_step_color_temperature: Fz.Converter<"lightingColorCtrl", u
         };
 
         if (msg.data.transtime !== undefined) {
-            payload.action_transition_time = msg.data.transtime / 100;
+            payload.action_transition_time = msg.data.transtime / 10;
         }
 
         addActionGroup(payload, msg, model);
@@ -1608,7 +1608,7 @@ export const command_step_hue: Fz.Converter<"lightingColorCtrl", undefined, ["co
         const payload = {
             action: postfixWithEndpointName(`color_hue_step_${direction}`, msg, model, meta),
             action_step_size: msg.data.stepsize,
-            action_transition_time: msg.data.transtime / 100,
+            action_transition_time: msg.data.transtime / 10,
         };
         addActionGroup(payload, msg, model);
         return payload;
@@ -1623,7 +1623,7 @@ export const command_step_saturation: Fz.Converter<"lightingColorCtrl", undefine
         const payload = {
             action: postfixWithEndpointName(`color_saturation_step_${direction}`, msg, model, meta),
             action_step_size: msg.data.stepsize,
-            action_transition_time: msg.data.transtime / 100,
+            action_transition_time: msg.data.transtime / 10,
         };
         addActionGroup(payload, msg, model);
         return payload;
@@ -1724,7 +1724,7 @@ export const command_move_to_hue: Fz.Converter<"lightingColorCtrl", undefined, "
         const payload = {
             action: postfixWithEndpointName("move_to_hue", msg, model, meta),
             action_hue: msg.data.hue,
-            action_transition_time: msg.data.transtime / 100,
+            action_transition_time: msg.data.transtime / 10,
             action_direction: msg.data.direction === 0 ? "decrement" : "increment",
         };
         addActionGroup(payload, msg, model);

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -276,7 +276,7 @@ describe("converters/fromZigbee", () => {
             expect(payload.action).toBe("color_temperature_step_up");
             expect(payload.action_step_size).toBe(5);
             expect(payload.action_color_temperature_delta).toBe(5);
-            expect(payload.action_transition_time).toBe(1);
+            expect(payload.action_transition_time).toBe(10);
         });
 
         it("emits negative action_color_temperature_delta when stepping down", () => {
@@ -291,7 +291,7 @@ describe("converters/fromZigbee", () => {
             expect(payload.action).toBe("color_temperature_step_down");
             expect(payload.action_step_size).toBe(10);
             expect(payload.action_color_temperature_delta).toBe(-10);
-            expect(payload.action_transition_time).toBe(0.5);
+            expect(payload.action_transition_time).toBe(5);
         });
 
         it("does not include action_transition_time when transtime is undefined", () => {


### PR DESCRIPTION
I checked the spec, all level commands have transition time in deciseconds.
Any idea why it was divided by 100?

<img width="539" height="50" alt="image" src="https://github.com/user-attachments/assets/96248b4a-b3ea-41cb-abd4-ece7e75a59e4" />

<img width="303" height="152" alt="image" src="https://github.com/user-attachments/assets/3f97ea73-c59e-48be-84d8-5620a54ab7e5" />

<img width="449" height="185" alt="image" src="https://github.com/user-attachments/assets/baff5ebc-3a0b-41ac-9274-21ccc06ed113" />
