### PR TITLE
fix: Leviton DG3HL: expose and preserve dimmer configuration

### DIFF
--- a/src/devices/leviton.ts
+++ b/src/devices/leviton.ts
@@ -1,9 +1,11 @@
+import {Zcl} from "zigbee-herdsman";
+
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValue} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
@@ -21,6 +23,17 @@ const fzLocal = {
             }
         },
     } satisfies Fz.Converter<"genLevelCtrl", undefined, ["attributeReport", "readResponse"]>,
+    restore_execute_if_off_after_power_cycle: {
+        cluster: "genLevelCtrl",
+        type: ["attributeReport"],
+        convert: async (model, msg, publish, options, meta) => {
+            // DG3HL does not announce after a mains cycle, but its first level report always uses TSN 1.
+            const levelConfig = meta.state.level_config as KeyValue | undefined;
+            if (msg.data.currentLevel !== undefined && msg.meta.zclTransactionSequenceNumber === 1 && levelConfig?.execute_if_off === true) {
+                await msg.endpoint.write("genLevelCtrl", {options: 1});
+            }
+        },
+    } satisfies Fz.Converter<"genLevelCtrl", undefined, ["attributeReport"]>,
 };
 
 export const definitions: DefinitionWithExtend[] = [
@@ -43,7 +56,56 @@ export const definitions: DefinitionWithExtend[] = [
         model: "DG3HL-1BW",
         vendor: "Leviton",
         description: "Indoor Decora smart Zigbee 3.0 certified plug-in dimmer",
-        extend: [m.light({effect: false, configureReporting: true})],
+        fromZigbee: [fzLocal.restore_execute_if_off_after_power_cycle],
+        extend: [
+            m.deviceAddCustomCluster("lightingBallastCfg", {
+                name: "lightingBallastCfg",
+                ID: Zcl.Clusters.lightingBallastCfg.ID,
+                attributes: {
+                    powerOnLevel: {name: "powerOnLevel", ID: 0x0012, type: Zcl.DataType.UINT8, write: true, max: 0xff},
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+            m.light({
+                effect: false,
+                configureReporting: true,
+                powerOnBehavior: false,
+                ota: true,
+                levelConfig: {features: ["on_transition_time", "off_transition_time", "on_level", "execute_if_off"]},
+            }),
+            m.numeric({
+                name: "ballast_minimum_level",
+                cluster: "lightingBallastCfg",
+                attribute: "minLevel",
+                description: "Specifies the minimum light output of the ballast",
+                access: "ALL",
+                valueMin: 1,
+                valueMax: 254,
+                entityCategory: "config",
+            }),
+            m.numeric({
+                name: "ballast_maximum_level",
+                cluster: "lightingBallastCfg",
+                attribute: "maxLevel",
+                description: "Specifies the maximum light output of the ballast",
+                access: "ALL",
+                valueMin: 1,
+                valueMax: 254,
+                entityCategory: "config",
+            }),
+            m.numeric({
+                name: "ballast_power_on_level",
+                cluster: "lightingBallastCfg",
+                attribute: "powerOnLevel",
+                description: "Level applied after mains power returns; 255 restores the previous level",
+                access: "ALL",
+                valueMin: 1,
+                valueMax: 255,
+                entityCategory: "config",
+            }),
+            m.identify(),
+        ],
     },
     {
         zigbeeModel: ["DG15A"],

--- a/test/leviton.test.ts
+++ b/test/leviton.test.ts
@@ -1,0 +1,99 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {Zcl} from "zigbee-herdsman";
+import {findByDevice} from "../src/index";
+import type {Definition, Expose, Fz, KeyValueAny, Tz} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+function buildDevice() {
+    return mockDevice({
+        modelID: "DG3HL",
+        manufacturerName: "Leviton",
+        endpoints: [
+            {
+                ID: 1,
+                inputClusters: ["genBasic", "genIdentify", "genGroups", "genScenes", "genOnOff", "genLevelCtrl", "lightingBallastCfg"],
+                outputClusters: ["genOta"],
+            },
+        ],
+    });
+}
+
+function getExposeNames(expose: Expose): string[] {
+    return [expose.name, ...(expose.features?.flatMap(getExposeNames) ?? [])].filter((name): name is string => name !== undefined);
+}
+
+describe("Leviton DG3HL-1BW", () => {
+    let device: ReturnType<typeof mockDevice>;
+    let definition: Definition;
+
+    beforeEach(async () => {
+        device = buildDevice();
+        definition = await findByDevice(device);
+        await definition.configure?.(device, device.getEndpoint(1), definition);
+    });
+
+    it("exposes only the supported level and ballast configuration", () => {
+        const exposes = definition.exposes as Expose[];
+        const names = exposes.flatMap(getExposeNames);
+
+        expect(names).toContain("on_transition_time");
+        expect(names).toContain("off_transition_time");
+        expect(names).toContain("on_level");
+        expect(names).toContain("execute_if_off");
+        expect(names).toContain("ballast_minimum_level");
+        expect(names).toContain("ballast_maximum_level");
+        expect(names).toContain("ballast_power_on_level");
+        expect(names).toContain("identify");
+        expect(names).not.toContain("power_on_behavior");
+        expect(names).not.toContain("ballast_status_non_operational");
+        expect(names).not.toContain("ballast_status_lamp_failure");
+    });
+
+    it("allows the tested power-on level value 255", async () => {
+        expect(device.customClusters.lightingBallastCfg.attributes.powerOnLevel).toMatchObject({
+            ID: 0x0012,
+            type: Zcl.DataType.UINT8,
+            max: 0xff,
+        });
+
+        const converter = definition.toZigbee.find((candidate) => candidate.key.includes("ballast_power_on_level")) as Tz.Converter;
+        await converter.convertSet(device.getEndpoint(1), "ballast_power_on_level", 255, {
+            device,
+            mapped: definition,
+            message: {ballast_power_on_level: 255},
+            state: {},
+        } as Tz.Meta);
+
+        expect(device.getEndpoint(1).write).toHaveBeenCalledWith("lightingBallastCfg", {powerOnLevel: 255}, undefined);
+    });
+
+    it.each([
+        {description: "restores a saved true setting on the boot report", sequence: 1, currentLevel: 126, executeIfOff: true, writes: 1},
+        {description: "does not override a saved false setting", sequence: 1, currentLevel: 126, executeIfOff: false, writes: 0},
+        {description: "ignores later level reports", sequence: 2, currentLevel: 126, executeIfOff: true, writes: 0},
+        {description: "ignores unrelated reports", sequence: 1, currentLevel: undefined, executeIfOff: true, writes: 0},
+    ])("$description", async ({sequence, currentLevel, executeIfOff, writes}) => {
+        const converter = definition.fromZigbee.find(
+            (candidate) => candidate.cluster === "genLevelCtrl" && candidate.type.length === 1 && candidate.type[0] === "attributeReport",
+        ) as Fz.Converter;
+        const endpoint = device.getEndpoint(1);
+        endpoint.write.mockClear();
+
+        await converter.convert(
+            definition,
+            {
+                data: currentLevel === undefined ? {} : {currentLevel},
+                endpoint,
+                device,
+                type: "attributeReport",
+                meta: {zclTransactionSequenceNumber: sequence},
+            } as Fz.Message,
+            () => {},
+            {},
+            {device, state: {level_config: {execute_if_off: executeIfOff}} as KeyValueAny} as Fz.Meta,
+        );
+
+        expect(endpoint.write).toHaveBeenCalledTimes(writes);
+        if (writes === 1) expect(endpoint.write).toHaveBeenCalledWith("genLevelCtrl", {options: 1});
+    });
+});


### PR DESCRIPTION
I know this is an older device, but I wanted to add support for a couple specific behaviors and figured I'd flesh the rest of it out while I was working on it. The only question I have is whether it makes sense to expose the OTA endpoint since I couldn't find any updated firmware. I've sent a note to Leviton asking them for a copy - their certifications show newer firmware does exist. Also, not sure how you feel about the pretty meaningless tests, but they're there if you want em.

## Summary

- expose the DG3HL's tested Level Control settings: `on_transition_time`, `off_transition_time`, `on_level`, and `execute_if_off`
- expose the three useful, writable Ballast Configuration settings: minimum level, maximum level, and power-on level
- enable Identify and OTA support advertised by the device
- restore `execute_if_off` after a mains power cycle when the saved Zigbee2MQTT state says it should be enabled
- keep the standard `m.light()` command behavior, including normal `MoveToLevel` and `MoveToLevelWithOnOff` handling

Most of this change is declarative and uses standard modern extensions. The only device-specific converter handles one firmware quirk: the DG3HL clears the Level Control `ExecuteIfOff` option after losing mains power and does not send a `deviceAnnounce` when it comes back. That means the announce-based restoration used by some other lights cannot work for this device.

## Exposed behavior

### Level Control

The light now exposes:

- `on_transition_time`
- `off_transition_time`
- `on_level`, including the standard `previous` value
- `execute_if_off`

A brightness command with an explicit on/off state continues to use the standard `MoveToLevelWithOnOff` path. A plain `MoveToLevel` command can update `CurrentLevel` while the load remains off when `execute_if_off` is enabled. With `on_level` set to `previous`, a later direct-bound or Zigbee On command uses that preloaded level.

Mains startup level is controlled by the device's Ballast Configuration `powerOnLevel` attribute.

### Ballast Configuration

Only the useful writable controls are exposed:

- `ballast_minimum_level`
- `ballast_maximum_level`
- `ballast_power_on_level`

The generic Zigbee cluster definition currently limits `powerOnLevel` to 254. The DG3HL was verified to accept 255 and use it as the “restore previous level” sentinel, so the cluster override raises that limit only for this model. Fixed physical limits and ballast-status diagnostics are intentionally not exposed.

## Hardware verification / Testing

Tested on a Leviton DG3HL-1BW with firmware `0x03000025` (reported decimal version `50331685`).

### Ballast levels

- read the original minimum and maximum values as 10 and 254
- wrote the minimum level to 60 and confirmed a direct read returned 60
- sent a below-minimum brightness request through the standard command path; the reported level remained clamped to 60 and the load transitioned off
- wrote `powerOnLevel` as 255, confirmed it by direct read, and observed the previous level restored after mains power returned

### On level, transitions, and off-state preload

- wrote `on_level` to 160 and confirmed a subsequent On command used level 160
- restored `on_level` to `previous` (255)
- wrote and read back separate 2-second on and off transition times and observed the transitions
- enabled `execute_if_off`, turned the load off, then sent a plain `MoveToLevel`; `CurrentLevel` changed without turning the load on
- sent a later On command with `on_level=previous`; the device turned on at the preloaded level
- confirmed commands containing an on/off state still use the normal `MoveToLevelWithOnOff` behavior

This is the behavior needed by controllers such as Adaptive Lighting: they can preload the next brightness while the dimmer is off without energizing the load, and a physical/direct-bound On command then uses that brightness.

### Power-cycle quirk

The volatile option was tested with Zigbee2MQTT debug logging and explicit attribute reads:

1. A direct `level_config` read returned `options=1` before removing mains power.
2. After a mains cycle, the DG3HL did not send `deviceAnnounce`.
3. Its startup traffic was a `genOnOff` attribute report with transaction sequence number 0, followed about three seconds later by a `genLevelCtrl.currentLevel` report with transaction sequence number 1.
4. A direct read after startup returned `options=0`, confirming the firmware had cleared the bit rather than Zigbee2MQTT merely showing cached state.
5. With the restoration converter loaded, the sequence-1 level report caused a write of `{options: 1}`.
6. A subsequent direct read returned `options=1`.

The restoration checks the saved `level_config.execute_if_off` value and writes only when it is exactly `true`; users who leave the option disabled are not changed. Zigbee transaction sequence numbers wrap, so an ordinary later report can eventually also use sequence number 1. In that case the guarded operation is an infrequent, idempotent rewrite of the already-requested value.

### Other capabilities

- triggered Identify and observed the device flash red
- confirmed the endpoint advertises the OTA cluster and that an OTA query works; no newer image was available during the test

## Automated validation

Added DG3HL-specific tests covering:

- the exact retained level and ballast exposes and omission of unsupported/diagnostic fields
- the device-scoped `powerOnLevel=255` schema and write
- restoration when `execute_if_off` is saved as true
- no restoration when it is false
- ignoring later sequence numbers and unrelated reports

Validation run on the squashed commit:

- `pnpm run check`
- `pnpm run build`
- `pnpm test` (22 test files, 651 tests passed)

The commit hook reran the build and full test suite successfully while creating the final commit.
