### PR TITLE
feat: eWeLink CK-BL702-MSW-01(7010) / Mumubiz CZV20: expose countdown auto-off timer

### DIFF
--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -45,6 +45,16 @@ const fzLocal = {
             }
         },
     } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
+    ewelink_countdown: {
+        cluster: "genOnOff",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            // genOnOff.onTime holds the remaining on-time in 1/10 s while a timed-off countdown is running.
+            if (msg.data.onTime !== undefined) {
+                return {countdown: Math.round(msg.data.onTime / 10)};
+            }
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
 };
 
 const tzLocal = {
@@ -59,9 +69,41 @@ const tzLocal = {
             await entity.read("genOnOff", ["onOff"]);
         },
     } satisfies Tz.Converter,
+    ewelink_countdown: {
+        key: ["countdown"],
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertNumber(value, key);
+            const seconds = Math.round(value);
+            if (seconds <= 0) {
+                await entity.command("genOnOff", "off", {}, utils.getOptions(meta.mapped, entity));
+                return {state: {state: "OFF", countdown: 0}};
+            }
+            // genOnOff.onWithTimedOff expects ontime/offwaittime in 1/10 s; onTime is a uint16 capped at 0xFFFE.
+            const ontime = Math.min(seconds * 10, 0xfffe);
+            await entity.command("genOnOff", "onWithTimedOff", {ctrlbits: 0, ontime, offwaittime: 0}, utils.getOptions(meta.mapped, entity));
+            return {state: {state: "ON", countdown: Math.floor(ontime / 10)}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read("genOnOff", ["onTime"]);
+        },
+    } satisfies Tz.Converter,
 };
 
 const ewelinkExtend = {
+    countdown: (): ModernExtend => {
+        const exposes = [
+            e
+                .numeric("countdown", ea.STATE_SET)
+                .withUnit("s")
+                .withValueMin(0)
+                .withValueMax(6500)
+                .withValueStep(1)
+                .withDescription("Turn the device on and automatically turn it off again after this many seconds (0 disables the timer)"),
+        ];
+        const fromZigbee = [fzLocal.ewelink_countdown];
+        const toZigbee = [tzLocal.ewelink_countdown];
+        return {exposes, fromZigbee, toZigbee, isModernExtend: true};
+    },
     addCustomClusterSiren: (): ModernExtend => {
         return m.deviceAddCustomCluster("customEwelinkSiren", {
             name: "customEwelinkSiren",
@@ -113,7 +155,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "CK-BL702-MSW-01(7010)",
         vendor: "eWeLink",
         description: "CMARS Zigbee smart plug",
-        extend: [m.onOff({skipDuplicateTransaction: true}), m.skipDefaultResponse()],
+        extend: [m.onOff({skipDuplicateTransaction: true}), m.skipDefaultResponse(), ewelinkExtend.countdown()],
         whiteLabel: [
             {
                 vendor: "Mumubiz",


### PR DESCRIPTION
Adds a `countdown` numeric (0–6500 s) to the eWeLink `CK-BL702-MSW-01(7010)` plug that turns the device on and automatically turns it off again after the given time via `genOnOff onWithTimedOff` (setting `0` turns it off). The `onTime` attribute is decoded back into `countdown` for feedback when reported.

Primarily useful for the **Mumubiz CZV20** water valve (a white-label of this plug, added in #11859) — e.g. run irrigation / pool filling for a fixed time and auto-close. The genOnOff `on_time`/`off_wait_time` set-payload already works on this definition; this exposes it as a first-class control so it shows up in the frontend / Home Assistant.