### PR TITLE
Tuya TS0002_power: expose per-endpoint countdown auto-off timer

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7270,6 +7270,7 @@ export const definitions: DefinitionWithExtend[] = [
                 switchType: true,
                 endpoints: ["l1", "l2"],
                 electricalMeasurements: true,
+                onOffCountdown: true,
             }),
         ],
         endpoint: (device) => {


### PR DESCRIPTION
Enables `onOffCountdown` on the `tuyaOnOff` extend of the `TS0002_power` definition, so the two relays expose `countdown_l1` / `countdown_l2` (numeric, 0–43200 s).

Each countdown turns its relay on and automatically turns it off again after the set time via the standard `genOnOff` `onWithTimedOff` command; the `genOnOff` `onTime` attribute is decoded back into the countdown value for feedback. It reuses the existing `tuyaFz.on_off_countdown` / `tuyaTz.on_off_countdown` converters — no custom fz/tz.

**Hardware-validated end to end** on `_TZ3000_irrmjcgi` (Tuya XSH01B): setting `countdown_l1`/`countdown_l2` turns the corresponding relay on and it auto-switches-off after the configured seconds, and the remaining time is reported back. Power/energy measurement is unaffected. Used to run a pool filter pump for a fixed duration and auto-close.

The four fingerprints already grouped under `TS0002_power` (`_TZ3000_aaifmpuq`, `_TZ3000_irrmjcgi`, `_TZ3000_huvxrx4i`, `_TZ3000_pxfjrzyj`) are the same 2-gang power-metering module, so the timer is enabled for all of them.

Build, `biome check`, and the definition/tuya/index tests pass locally.