### PR TITLE
Fix AOYAN AY-101Z and AY301Z matching

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2154,7 +2154,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.temperature(), m.humidity(), m.battery()],
     },
     {
-        zigbeeModel: ["TS0203", "ZG-102Z"],
+        zigbeeModel: ["TS0203", "ZG-102Z", "AY-101Z"],
         model: "TS0203",
         vendor: "Tuya",
         description: "Door/window sensor",
@@ -3738,7 +3738,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-301Z"],
+        zigbeeModel: ["ZG-301Z", "AY301Z"],
         fingerprint: [
             ...tuya.fingerprint("TS0001", [
                 "_TZ3000_hktqahrq",


### PR DESCRIPTION
Fixes AOYAN devices that report their own model IDs by adding the reported model IDs to the base definitions.\n\nChanges:\n- Add AY-101Z to the TS0203 zigbeeModel list\n- Add AY301Z to the WHD02/ZG-301Z zigbeeModel list\n\nValidation:\n- biome check src/devices/tuya.ts