### PR TITLE
fix: improve Aqara T3 light configs

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -3300,10 +3300,11 @@ export const definitions: DefinitionWithExtend[] = [
             lumi.modernExtend.addManuSpecificLumiCluster(),
             lumiZigbeeOTA(),
             lumiLight({
-                colorTemp: true,
                 color: false,
+                colorTemp: true,
+                colorTempRange: [166, 370],
                 powerOutageMemory: "enum",
-                levelConfig: {features: ["on_off_transition_time", "on_transition_time", "off_transition_time", "execute_if_off", "on_level"]},
+                levelConfig: {features: ["on_transition_time", "off_transition_time", "on_level"]},
             }),
             m.numeric({
                 name: "min_brightness",


### PR DESCRIPTION
The removed attributes do NOT work on this device:
- `on_off_transition_time` (`on_transition_time` and `off_transition_time` do work)
- `execute_if_off`

And color temperature (similar to many other Aqara lights) only goes down to 166.

