### PR TITLE
fix: EGLO 900878: add whitelabel of 900024/12253

### DIFF
--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -214,6 +214,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "900024/12253",
         vendor: "EGLO",
         description: "RGB light",
+        whiteLabel: [{vendor: "EGLO", model: "900878", description: "ANDREAS-Z pendant light"}],
         extend: [m.light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"]}})],
     },
     {


### PR DESCRIPTION
The EGLO **ANDREAS-Z** pendant light ([article 900878](https://www.eglo.com/at/pendelleuchte-andreas-z-900878.html)) reports the same `zigbeeModel` as the already supported `900024/12253`, so it is matched by that definition and works fine — it just shows up under a foreign product name (900024 = SALITERAS-Z ceiling light, 12253 = connect.2 bulb).

Adding it as a white label, following `EGLO 901463: mark as whitelabel of EBF_RGB_Zm` (#12391).

## Verification

Read from the device (AwoX-based, ember coordinator):

```
modelId              EGLO_ZM_RGB_TW
manufacturerName     AwoX          manufacturerID  4417
swBuildId            3.0.0_1562    hwVersion       60
colorCapabilities    25            -> hue/saturation + xy + color temperature
colorTempPhysicalMin 153           colorTempPhysicalMax  370
```

Identical to what the existing definition declares (`colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"]}`), so no capability change is needed — this is purely about naming.

## Notes

- No device picture included: white labels reuse the parent image, and the existing EGLO white label `12239` has none either (`images/devices/12239.png` → 404). Happy to add one if you prefer.
- `pnpm run check`, `pnpm run build` and `pnpm test` (691 tests) pass.