### PR TITLE
fix: Aqara DS-K02D/DS-K02E: disable presentValue reporting instead of max=0

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -83,9 +83,11 @@ async function configureAqaraH2EuShutterSwitch(device: Zh.Device, coordinatorEnd
     for (const endpointName of aqaraH2EuShutterSwitchEndpointNames) {
         const endpoint = device.getEndpoint(aqaraH2EuShutterSwitchEndpoints[endpointName]);
         await reporting.bind(endpoint, coordinatorEndpoint, ["manuSpecificLumi", "genMultistateInput"]);
-        // Set report max to 0 to prevent stale actions being published
+        // Disable reporting for presentValue (max=0xFFFF = "shall not issue reports", ZCL).
+        // Button presses are firmware-generated unsolicited reports and keep working;
+        // an active reporting entry caused the hourly stale action replays.
         // https://github.com/Koenkk/zigbee2mqtt/issues/32059
-        await endpoint.configureReporting("genMultistateInput", reporting.payload("presentValue", 0, 0, 1));
+        await endpoint.configureReporting("genMultistateInput", reporting.payload("presentValue", 0, 65535, 1));
         // Initialize Aqara's per-button multi-click setting on startup.
         await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [aqaraH2EuShutterSwitchMultiClickAttribute], {
             manufacturerCode,
@@ -5217,7 +5219,7 @@ export const definitions: DefinitionWithExtend[] = [
                 }
             },
         },
-        version: "0.0.1",
+        version: "0.0.2",
         configure: configureAqaraH2EuShutterSwitch,
         extend: [
             lumi.modernExtend.addManuSpecificLumiCluster(),


### PR DESCRIPTION
Sets max_report_interval to 0xFFFF (disable reporting) instead of 0 on the wireless button endpoints, as discussed in koenkk/zigbee2mqtt#32059. Button presses are firmware-generated unsolicited reports and are unaffected — tested on 7 devices (fw 4122) for 3 days: zero ghost actions, 20/20 physical presses delivered, survives Z2M restarts. Version bumped so deployed devices get reconfigured once.