### PR TITLE
Feature/add cover open closed inversion

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1769,7 +1769,7 @@ export const identify: Fz.Converter<"genIdentify", undefined, ["attributeReport"
 export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "closuresWindowCovering",
     type: ["attributeReport", "readResponse"],
-    options: [exposes.options.invert_cover()],
+    options: [exposes.options.invert_position(), exposes.options.invert_cover(), exposes.options.invert_state()],
     convert: (model, msg, publish, options, meta) => {
         const result: KeyValueAny = {};
         // Zigbee officially expects 'open' to be 0 and 'closed' to be 100 whereas
@@ -1777,13 +1777,15 @@ export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefin
         // For zigbee-herdsman-converters: open = 100, close = 0
         // ubisys J1 will report 255 if lift or tilt positions are not known, so skip that.
         const metaInvert = model.meta?.coverInverted;
-        const invert = metaInvert ? !options.invert_cover : options.invert_cover;
+        const invertPositionCombine = options.invert_position ?? options.invert_cover;
+        const invertPosition = metaInvert ? !invertPositionCombine : invertPositionCombine;
+        const invertState = metaInvert ? !options.invert_state : options.invert_state;
         const coverStateFromTilt = model.meta?.coverStateFromTilt;
         if (msg.data.currentPositionLiftPercentage !== undefined && msg.data.currentPositionLiftPercentage <= 100) {
             const value = msg.data.currentPositionLiftPercentage;
-            result[postfixWithEndpointName("position", msg, model, meta)] = invert ? value : 100 - value;
+            result[postfixWithEndpointName("position", msg, model, meta)] = invertPosition ? value : 100 - value;
             if (!coverStateFromTilt) {
-                result[postfixWithEndpointName("state", msg, model, meta)] = metaInvert
+                result[postfixWithEndpointName("state", msg, model, meta)] = invertState
                     ? value === 0
                         ? "CLOSE"
                         : "OPEN"
@@ -1794,9 +1796,9 @@ export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefin
         }
         if (msg.data.currentPositionTiltPercentage !== undefined && msg.data.currentPositionTiltPercentage <= 100) {
             const value = msg.data.currentPositionTiltPercentage;
-            result[postfixWithEndpointName("tilt", msg, model, meta)] = invert ? value : 100 - value;
+            result[postfixWithEndpointName("tilt", msg, model, meta)] = invertPosition ? value : 100 - value;
             if (coverStateFromTilt) {
-                result[postfixWithEndpointName("state", msg, model, meta)] = metaInvert
+                result[postfixWithEndpointName("state", msg, model, meta)] = invertState
                     ? value === 100
                         ? "OPEN"
                         : "CLOSE"

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1769,7 +1769,7 @@ export const identify: Fz.Converter<"genIdentify", undefined, ["attributeReport"
 export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "closuresWindowCovering",
     type: ["attributeReport", "readResponse"],
-    options: [exposes.options.invert_position(), exposes.options.invert_cover(), exposes.options.invert_state()],
+    options: [exposes.options.invert_cover(), exposes.options.invert_cover_state()],
     convert: (model, msg, publish, options, meta) => {
         const result: KeyValueAny = {};
         // Zigbee officially expects 'open' to be 0 and 'closed' to be 100 whereas
@@ -1777,9 +1777,8 @@ export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefin
         // For zigbee-herdsman-converters: open = 100, close = 0
         // ubisys J1 will report 255 if lift or tilt positions are not known, so skip that.
         const metaInvert = model.meta?.coverInverted;
-        const invertPositionCombine = options.invert_position ?? options.invert_cover;
-        const invertPosition = metaInvert ? !invertPositionCombine : invertPositionCombine;
-        const invertState = metaInvert ? !options.invert_state : options.invert_state;
+        const invertPosition = metaInvert ? !options.invert_cover : options.invert_cover;
+        const invertState = metaInvert ? !options.invert_cover_state : options.invert_cover_state;
         const coverStateFromTilt = model.meta?.coverStateFromTilt;
         if (msg.data.currentPositionLiftPercentage !== undefined && msg.data.currentPositionLiftPercentage <= 100) {
             const value = msg.data.currentPositionLiftPercentage;

--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1769,7 +1769,7 @@ export const identify: Fz.Converter<"genIdentify", undefined, ["attributeReport"
 export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "closuresWindowCovering",
     type: ["attributeReport", "readResponse"],
-    options: [exposes.options.invert_cover(), exposes.options.invert_cover_state()],
+    options: [exposes.options.invert_cover()],
     convert: (model, msg, publish, options, meta) => {
         const result: KeyValueAny = {};
         // Zigbee officially expects 'open' to be 0 and 'closed' to be 100 whereas
@@ -1777,14 +1777,13 @@ export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefin
         // For zigbee-herdsman-converters: open = 100, close = 0
         // ubisys J1 will report 255 if lift or tilt positions are not known, so skip that.
         const metaInvert = model.meta?.coverInverted;
-        const invertPosition = metaInvert ? !options.invert_cover : options.invert_cover;
-        const invertState = metaInvert ? !options.invert_cover_state : options.invert_cover_state;
+        const invert = metaInvert ? !options.invert_cover : options.invert_cover;
         const coverStateFromTilt = model.meta?.coverStateFromTilt;
         if (msg.data.currentPositionLiftPercentage !== undefined && msg.data.currentPositionLiftPercentage <= 100) {
             const value = msg.data.currentPositionLiftPercentage;
-            result[postfixWithEndpointName("position", msg, model, meta)] = invertPosition ? value : 100 - value;
+            result[postfixWithEndpointName("position", msg, model, meta)] = invert ? value : 100 - value;
             if (!coverStateFromTilt) {
-                result[postfixWithEndpointName("state", msg, model, meta)] = invertState
+                result[postfixWithEndpointName("state", msg, model, meta)] = invert
                     ? value === 0
                         ? "CLOSE"
                         : "OPEN"
@@ -1795,9 +1794,9 @@ export const cover_position_tilt: Fz.Converter<"closuresWindowCovering", undefin
         }
         if (msg.data.currentPositionTiltPercentage !== undefined && msg.data.currentPositionTiltPercentage <= 100) {
             const value = msg.data.currentPositionTiltPercentage;
-            result[postfixWithEndpointName("tilt", msg, model, meta)] = invertPosition ? value : 100 - value;
+            result[postfixWithEndpointName("tilt", msg, model, meta)] = invert ? value : 100 - value;
             if (coverStateFromTilt) {
-                result[postfixWithEndpointName("state", msg, model, meta)] = invertState
+                result[postfixWithEndpointName("state", msg, model, meta)] = invert
                     ? value === 100
                         ? "OPEN"
                         : "CLOSE"

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -667,7 +667,7 @@ export const squawk: Tz.Converter = {
 };
 export const cover_state: Tz.Converter = {
     key: ["state"],
-    options: [exposes.options.invert_state()],
+    options: [exposes.options.invert_cover_state()],
     convertSet: async (entity, key, value, meta) => {
         const lookup = {
             open: "upOpen" as const,
@@ -684,7 +684,7 @@ export const cover_state: Tz.Converter = {
             off: "upOpen" as const,
         };
         utils.assertString(value, key);
-        const commandLookup = meta.options.invert_state ? invertedLookup : lookup;
+        const commandLookup = meta.options.invert_cover_state ? invertedLookup : lookup;
         await entity.command(
             "closuresWindowCovering",
             utils.getFromLookup(value.toLowerCase(), commandLookup),
@@ -695,12 +695,13 @@ export const cover_state: Tz.Converter = {
 };
 export const cover_position_tilt: Tz.Converter = {
     key: ["position", "tilt"],
-    options: [exposes.options.invert_position(), exposes.options.invert_cover(), exposes.options.cover_position_tilt_disable_report()],
+    options: [exposes.options.invert_cover(), exposes.options.cover_position_tilt_disable_report()],
     convertSet: async (entity, key, value, meta) => {
         utils.assertNumber(value, key);
         const isPosition = key === "position";
-        const invertPosition = meta.options.invert_position ?? meta.options.invert_cover;
-        const invert = !(utils.getMetaValue(entity, meta.mapped, "coverInverted", "allEqual", false) ? !invertPosition : invertPosition);
+        const invert = !(utils.getMetaValue(entity, meta.mapped, "coverInverted", "allEqual", false)
+            ? !meta.options.invert_cover
+            : meta.options.invert_cover);
         const disableReport = utils.getMetaValue(entity, meta.mapped, "coverPositionTiltDisableReport", "allEqual", false)
             ? !meta.options.cover_position_tilt_disable_report
             : meta.options.cover_position_tilt_disable_report;

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -667,6 +667,7 @@ export const squawk: Tz.Converter = {
 };
 export const cover_state: Tz.Converter = {
     key: ["state"],
+    options: [exposes.options.invert_state()],
     convertSet: async (entity, key, value, meta) => {
         const lookup = {
             open: "upOpen" as const,
@@ -675,19 +676,31 @@ export const cover_state: Tz.Converter = {
             on: "upOpen" as const,
             off: "downClose" as const,
         };
+        const invertedLookup = {
+            open: "downClose" as const,
+            close: "upOpen" as const,
+            stop: "stop" as const,
+            on: "downClose" as const,
+            off: "upOpen" as const,
+        };
         utils.assertString(value, key);
-        await entity.command("closuresWindowCovering", utils.getFromLookup(value.toLowerCase(), lookup), {}, utils.getOptions(meta.mapped, entity));
+        const commandLookup = meta.options.invert_state ? invertedLookup : lookup;
+        await entity.command(
+            "closuresWindowCovering",
+            utils.getFromLookup(value.toLowerCase(), commandLookup),
+            {},
+            utils.getOptions(meta.mapped, entity),
+        );
     },
 };
 export const cover_position_tilt: Tz.Converter = {
     key: ["position", "tilt"],
-    options: [exposes.options.invert_cover(), exposes.options.cover_position_tilt_disable_report()],
+    options: [exposes.options.invert_position(), exposes.options.invert_cover(), exposes.options.cover_position_tilt_disable_report()],
     convertSet: async (entity, key, value, meta) => {
         utils.assertNumber(value, key);
         const isPosition = key === "position";
-        const invert = !(utils.getMetaValue(entity, meta.mapped, "coverInverted", "allEqual", false)
-            ? !meta.options.invert_cover
-            : meta.options.invert_cover);
+        const invertPosition = meta.options.invert_position ?? meta.options.invert_cover;
+        const invert = !(utils.getMetaValue(entity, meta.mapped, "coverInverted", "allEqual", false) ? !invertPosition : invertPosition);
         const disableReport = utils.getMetaValue(entity, meta.mapped, "coverPositionTiltDisableReport", "allEqual", false)
             ? !meta.options.cover_position_tilt_disable_report
             : meta.options.cover_position_tilt_disable_report;

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -667,7 +667,7 @@ export const squawk: Tz.Converter = {
 };
 export const cover_state: Tz.Converter = {
     key: ["state"],
-    options: [exposes.options.invert_cover_state()],
+    options: [exposes.options.invert_cover()],
     convertSet: async (entity, key, value, meta) => {
         const lookup = {
             open: "upOpen" as const,
@@ -684,7 +684,10 @@ export const cover_state: Tz.Converter = {
             off: "upOpen" as const,
         };
         utils.assertString(value, key);
-        const commandLookup = meta.options.invert_cover_state ? invertedLookup : lookup;
+        const invert = utils.getMetaValue(entity, meta.mapped, "coverInverted", "allEqual", false)
+            ? !meta.options.invert_cover
+            : meta.options.invert_cover;
+        const commandLookup = invert ? invertedLookup : lookup;
         await entity.command(
             "closuresWindowCovering",
             utils.getFromLookup(value.toLowerCase(), commandLookup),

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -33,6 +33,7 @@ export class Base {
     features?: Feature[];
     category?: "config" | "diagnostic";
     homeassistant?: HomeAssistant;
+    legacyNames?: string[];
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -86,6 +87,11 @@ export class Base {
         return this;
     }
 
+    withLegacyNames(...names: string[]) {
+        this.legacyNames = names;
+        return this;
+    }
+
     validateCategory() {
         switch (this.category) {
             case "config":
@@ -135,6 +141,7 @@ export class Base {
         }
         target.category = this.category;
         target.homeassistant = this.homeassistant ? {...this.homeassistant} : undefined;
+        target.legacyNames = this.legacyNames ? [...this.legacyNames] : undefined;
     }
 }
 

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -841,9 +841,17 @@ export const options = {
             .withDescription(
                 `Number of digits after decimal point for ${name}, takes into effect on next report of device. This option can only decrease the precision, not increase it.`,
             ),
+    invert_position: () =>
+        new Binary("invert_position", access.SET, true, false).withDescription(
+            "Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false).",
+        ),
     invert_cover: () =>
         new Binary("invert_cover", access.SET, true, false).withDescription(
-            "Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false).",
+            "Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false) (deprecated, use invert_position).",
+        ),
+    invert_state: () =>
+        new Binary("invert_state", access.SET, true, false).withDescription(
+            "Inverts the cover state (open/close), independent of the position (default false).",
         ),
     illuminance_raw: () => new Binary("illuminance_raw", access.SET, true, false).withDescription("Expose the raw illuminance value."),
     color_sync: () =>

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -11,7 +11,7 @@ import type {
 } from "./constants";
 import {thermostatSetpointChangeSource} from "./constants";
 import type {Access, LevelConfigFeatures, Range} from "./types";
-import {formatLabel} from "./utils";
+import {getLabelFromName} from "./utils";
 
 export type Feature = Numeric | Binary | Enum | Composite | List | Text;
 export interface HomeAssistant {
@@ -199,10 +199,10 @@ export class Binary extends Base {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     value_toggle?: string;
 
-    constructor(name: string, access: number, valueOn: string | boolean, valueOff: string | boolean, label?: string) {
+    constructor(name: string, access: number, valueOn: string | boolean, valueOff: string | boolean) {
         super();
         this.name = name;
-        this.label = formatLabel(label ?? name);
+        this.label = getLabelFromName(name);
         this.property = name;
         this.access = access;
         this.value_on = valueOn;
@@ -232,10 +232,10 @@ export class List extends Base {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     length_max?: number;
 
-    constructor(name: string, access: number, itemType: Numeric | Binary | Composite | Text | Enum, label?: string) {
+    constructor(name: string, access: number, itemType: Numeric | Binary | Composite | Text | Enum) {
         super();
         this.name = name;
-        this.label = formatLabel(label ?? name);
+        this.label = getLabelFromName(name);
         this.property = name;
         this.access = access;
         this.item_type = itemType;
@@ -273,10 +273,10 @@ export class Numeric extends Base {
     value_step?: number;
     presets?: {name: string; value: number | string; description: string}[];
 
-    constructor(name: string, access: number, label?: string) {
+    constructor(name: string, access: number) {
         super();
         this.name = name;
-        this.label = formatLabel(label ?? name);
+        this.label = getLabelFromName(name);
         this.property = name;
         this.access = access;
     }
@@ -326,10 +326,10 @@ export class Enum extends Base {
     property = "";
     values: (string | number)[];
 
-    constructor(name: string, access: number, values: (string | number)[], label?: string) {
+    constructor(name: string, access: number, values: (string | number)[]) {
         super();
         this.name = name;
-        this.label = formatLabel(label ?? name);
+        this.label = getLabelFromName(name);
         this.property = name;
         this.access = access;
         this.values = values;
@@ -346,10 +346,10 @@ export class Text extends Base {
     type = "text" as const;
     property = "";
 
-    constructor(name: string, access: number, label?: string) {
+    constructor(name: string, access: number) {
         super();
         this.name = name;
-        this.label = formatLabel(label ?? name);
+        this.label = getLabelFromName(name);
         this.property = name;
         this.access = access;
     }
@@ -366,11 +366,11 @@ export class Composite extends Base {
     property = "";
     features: Feature[] = [];
 
-    constructor(name: string, property: string, access: number, label?: string) {
+    constructor(name: string, property: string, access: number) {
         super();
         this.property = property;
         this.name = name;
-        this.label = formatLabel(label ?? name);
+        this.label = getLabelFromName(name);
         this.access = access;
     }
 
@@ -849,9 +849,9 @@ export const options = {
                 `Number of digits after decimal point for ${name}, takes into effect on next report of device. This option can only decrease the precision, not increase it.`,
             ),
     invert_cover: () =>
-        new Binary("invert_cover", access.SET, true, false, "Invert cover position").withDescription(
-            "Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false).",
-        ),
+        new Binary("invert_cover", access.SET, true, false)
+            .withLabel("Invert cover position")
+            .withDescription("Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false)."),
     invert_cover_state: () =>
         new Binary("invert_cover_state", access.SET, true, false).withDescription(
             "Inverts the cover state (open/close), independent of the position (default false).",

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -11,7 +11,7 @@ import type {
 } from "./constants";
 import {thermostatSetpointChangeSource} from "./constants";
 import type {Access, LevelConfigFeatures, Range} from "./types";
-import {getLabelFromName} from "./utils";
+import {formatLabel} from "./utils";
 
 export type Feature = Numeric | Binary | Enum | Composite | List | Text;
 export interface HomeAssistant {
@@ -192,10 +192,10 @@ export class Binary extends Base {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     value_toggle?: string;
 
-    constructor(name: string, access: number, valueOn: string | boolean, valueOff: string | boolean) {
+    constructor(name: string, access: number, valueOn: string | boolean, valueOff: string | boolean, label?: string) {
         super();
         this.name = name;
-        this.label = getLabelFromName(name);
+        this.label = formatLabel(label ?? name);
         this.property = name;
         this.access = access;
         this.value_on = valueOn;
@@ -225,10 +225,10 @@ export class List extends Base {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     length_max?: number;
 
-    constructor(name: string, access: number, itemType: Numeric | Binary | Composite | Text | Enum) {
+    constructor(name: string, access: number, itemType: Numeric | Binary | Composite | Text | Enum, label?: string) {
         super();
         this.name = name;
-        this.label = getLabelFromName(name);
+        this.label = formatLabel(label ?? name);
         this.property = name;
         this.access = access;
         this.item_type = itemType;
@@ -266,10 +266,10 @@ export class Numeric extends Base {
     value_step?: number;
     presets?: {name: string; value: number | string; description: string}[];
 
-    constructor(name: string, access: number) {
+    constructor(name: string, access: number, label?: string) {
         super();
         this.name = name;
-        this.label = getLabelFromName(name);
+        this.label = formatLabel(label ?? name);
         this.property = name;
         this.access = access;
     }
@@ -319,10 +319,10 @@ export class Enum extends Base {
     property = "";
     values: (string | number)[];
 
-    constructor(name: string, access: number, values: (string | number)[]) {
+    constructor(name: string, access: number, values: (string | number)[], label?: string) {
         super();
         this.name = name;
-        this.label = getLabelFromName(name);
+        this.label = formatLabel(label ?? name);
         this.property = name;
         this.access = access;
         this.values = values;
@@ -339,10 +339,10 @@ export class Text extends Base {
     type = "text" as const;
     property = "";
 
-    constructor(name: string, access: number) {
+    constructor(name: string, access: number, label?: string) {
         super();
         this.name = name;
-        this.label = getLabelFromName(name);
+        this.label = formatLabel(label ?? name);
         this.property = name;
         this.access = access;
     }
@@ -359,11 +359,11 @@ export class Composite extends Base {
     property = "";
     features: Feature[] = [];
 
-    constructor(name: string, property: string, access: number) {
+    constructor(name: string, property: string, access: number, label?: string) {
         super();
         this.property = property;
         this.name = name;
-        this.label = getLabelFromName(name);
+        this.label = formatLabel(label ?? name);
         this.access = access;
     }
 
@@ -841,16 +841,12 @@ export const options = {
             .withDescription(
                 `Number of digits after decimal point for ${name}, takes into effect on next report of device. This option can only decrease the precision, not increase it.`,
             ),
-    invert_position: () =>
-        new Binary("invert_position", access.SET, true, false).withDescription(
+    invert_cover: () =>
+        new Binary("invert_cover", access.SET, true, false, "Invert cover position").withDescription(
             "Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false).",
         ),
-    invert_cover: () =>
-        new Binary("invert_cover", access.SET, true, false).withDescription(
-            "Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false) (deprecated, use invert_position).",
-        ),
-    invert_state: () =>
-        new Binary("invert_state", access.SET, true, false).withDescription(
+    invert_cover_state: () =>
+        new Binary("invert_cover_state", access.SET, true, false).withDescription(
             "Inverts the cover state (open/close), independent of the position (default false).",
         ),
     illuminance_raw: () => new Binary("illuminance_raw", access.SET, true, false).withDescription("Expose the raw illuminance value."),

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -849,12 +849,8 @@ export const options = {
                 `Number of digits after decimal point for ${name}, takes into effect on next report of device. This option can only decrease the precision, not increase it.`,
             ),
     invert_cover: () =>
-        new Binary("invert_cover", access.SET, true, false)
-            .withLabel("Invert cover position")
-            .withDescription("Inverts the cover position, false: open=100,close=0, true: open=0,close=100 (default false)."),
-    invert_cover_state: () =>
-        new Binary("invert_cover_state", access.SET, true, false).withDescription(
-            "Inverts the cover state (open/close), independent of the position (default false).",
+        new Binary("invert_cover", access.SET, true, false).withDescription(
+            "Inverts the cover position and state, false: open=100,close=0, true: open=0,close=100 (default false).",
         ),
     illuminance_raw: () => new Binary("illuminance_raw", access.SET, true, false).withDescription("Expose the raw illuminance value."),
     color_sync: () =>

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -33,7 +33,6 @@ export class Base {
     features?: Feature[];
     category?: "config" | "diagnostic";
     homeassistant?: HomeAssistant;
-    legacyNames?: string[];
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -87,11 +86,6 @@ export class Base {
         return this;
     }
 
-    withLegacyNames(...names: string[]) {
-        this.legacyNames = names;
-        return this;
-    }
-
     validateCategory() {
         switch (this.category) {
             case "config":
@@ -141,7 +135,6 @@ export class Base {
         }
         target.category = this.category;
         target.homeassistant = this.homeassistant ? {...this.homeassistant} : undefined;
-        target.legacyNames = this.legacyNames ? [...this.legacyNames] : undefined;
     }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -387,7 +387,7 @@ export function toCamelCase(value: KeyValueAny | string) {
     return value.replace(/_([a-z])/g, (x, y) => y.toUpperCase());
 }
 
-export function formatLabel(name: string) {
+export function getLabelFromName(name: string) {
     const label = name.replace(/_/g, " ");
     return label.length === 0 ? label : label[0].toUpperCase() + label.slice(1);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -387,7 +387,7 @@ export function toCamelCase(value: KeyValueAny | string) {
     return value.replace(/_([a-z])/g, (x, y) => y.toUpperCase());
 }
 
-export function getLabelFromName(name: string) {
+export function formatLabel(name: string) {
     const label = name.replace(/_/g, " ");
     return label.length === 0 ? label : label[0].toUpperCase() + label.slice(1);
 }

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -252,6 +252,92 @@ describe("converters/fromZigbee", () => {
         });
     });
 
+    describe("cover_position_tilt", () => {
+        const makeMsg = (data: Record<string, number>) => ({
+            data,
+            endpoint: null,
+            device: null,
+            meta: null,
+            groupID: null,
+            type: "attributeReport" as const,
+            cluster: "closuresWindowCovering" as const,
+            linkquality: 0,
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+        const convert = (data: Record<string, number>, modelMeta: Record<string, unknown>, options: Record<string, any>) =>
+            fromZigbee.cover_position_tilt.convert(
+                // @ts-expect-error mock
+                {meta: modelMeta},
+                makeMsg(data),
+                null,
+                options,
+                {meta: {}},
+            );
+
+        it("converts a fully-open lift percentage using the default (non-inverted) convention", () => {
+            const payload = convert({currentPositionLiftPercentage: 0}, {}, {});
+            expect(payload).toStrictEqual({position: 100, state: "OPEN"});
+        });
+
+        it("converts a fully-closed lift percentage using the default convention", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {});
+            expect(payload).toStrictEqual({position: 0, state: "CLOSE"});
+        });
+
+        it("invert_position flips the position but leaves state derived from the raw value", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_position: true});
+            expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
+        });
+
+        it("legacy invert_cover behaves the same as invert_position", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_cover: true});
+            expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
+        });
+
+        it("invert_position takes precedence over invert_cover when both are set", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_position: false, invert_cover: true});
+            expect(payload).toStrictEqual({position: 0, state: "CLOSE"});
+        });
+
+        it("invert_state flips only the OPEN/CLOSE label, not the position", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_state: true});
+            expect(payload).toStrictEqual({position: 0, state: "OPEN"});
+        });
+
+        it("invert_position and invert_state combine independently", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_position: true, invert_state: true});
+            expect(payload).toStrictEqual({position: 100, state: "OPEN"});
+        });
+
+        it("device-level coverInverted meta alone preserves pre-existing behaviour", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {coverInverted: true}, {});
+            expect(payload).toStrictEqual({position: 100, state: "OPEN"});
+        });
+
+        it("invert_state on a coverInverted device flips state back", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {coverInverted: true}, {invert_state: true});
+            expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
+        });
+
+        it("derives state from tilt when coverStateFromTilt is set", () => {
+            const payload = convert({currentPositionTiltPercentage: 0}, {coverStateFromTilt: true}, {});
+            expect(payload).toStrictEqual({tilt: 100, state: "OPEN"});
+        });
+
+        it("invert_state also flips tilt-derived state", () => {
+            const payload = convert({currentPositionTiltPercentage: 0}, {coverStateFromTilt: true}, {invert_state: true});
+            expect(payload).toStrictEqual({tilt: 100, state: "CLOSE"});
+        });
+
+        it("decodes cover_mode bits", () => {
+            const payload = convert({windowCoveringMode: 0b1011}, {}, {});
+            expect(payload).toStrictEqual({
+                cover_mode: {reversed: true, calibration: true, maintenance: false, led: true},
+            });
+        });
+    });
+
     describe("command_step_color_temperature", () => {
         const makeMsg = (stepmode: number, stepsize: number, transtime?: number) => ({
             data: {stepmode, stepsize, ...(transtime !== undefined ? {transtime} : {})},

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -285,28 +285,18 @@ describe("converters/fromZigbee", () => {
             expect(payload).toStrictEqual({position: 0, state: "CLOSE"});
         });
 
-        it("invert_position flips the position but leaves state derived from the raw value", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_position: true});
-            expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
-        });
-
-        it("legacy invert_cover behaves the same as invert_position", () => {
+        it("invert_cover flips the position but leaves state derived from the raw value", () => {
             const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_cover: true});
             expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
         });
 
-        it("invert_position takes precedence over invert_cover when both are set", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_position: false, invert_cover: true});
-            expect(payload).toStrictEqual({position: 0, state: "CLOSE"});
-        });
-
-        it("invert_state flips only the OPEN/CLOSE label, not the position", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_state: true});
+        it("invert_cover_state flips only the OPEN/CLOSE label, not the position", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_cover_state: true});
             expect(payload).toStrictEqual({position: 0, state: "OPEN"});
         });
 
-        it("invert_position and invert_state combine independently", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_position: true, invert_state: true});
+        it("invert_cover and invert_cover_state combine independently", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_cover: true, invert_cover_state: true});
             expect(payload).toStrictEqual({position: 100, state: "OPEN"});
         });
 
@@ -315,8 +305,8 @@ describe("converters/fromZigbee", () => {
             expect(payload).toStrictEqual({position: 100, state: "OPEN"});
         });
 
-        it("invert_state on a coverInverted device flips state back", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {coverInverted: true}, {invert_state: true});
+        it("invert_cover_state on a coverInverted device flips state back", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {coverInverted: true}, {invert_cover_state: true});
             expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
         });
 
@@ -325,8 +315,8 @@ describe("converters/fromZigbee", () => {
             expect(payload).toStrictEqual({tilt: 100, state: "OPEN"});
         });
 
-        it("invert_state also flips tilt-derived state", () => {
-            const payload = convert({currentPositionTiltPercentage: 0}, {coverStateFromTilt: true}, {invert_state: true});
+        it("invert_cover_state also flips tilt-derived state", () => {
+            const payload = convert({currentPositionTiltPercentage: 0}, {coverStateFromTilt: true}, {invert_cover_state: true});
             expect(payload).toStrictEqual({tilt: 100, state: "CLOSE"});
         });
 

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -285,18 +285,8 @@ describe("converters/fromZigbee", () => {
             expect(payload).toStrictEqual({position: 0, state: "CLOSE"});
         });
 
-        it("invert_cover flips the position but leaves state derived from the raw value", () => {
+        it("invert_cover flips both position and state together", () => {
             const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_cover: true});
-            expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
-        });
-
-        it("invert_cover_state flips only the OPEN/CLOSE label, not the position", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_cover_state: true});
-            expect(payload).toStrictEqual({position: 0, state: "OPEN"});
-        });
-
-        it("invert_cover and invert_cover_state combine independently", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {}, {invert_cover: true, invert_cover_state: true});
             expect(payload).toStrictEqual({position: 100, state: "OPEN"});
         });
 
@@ -305,9 +295,9 @@ describe("converters/fromZigbee", () => {
             expect(payload).toStrictEqual({position: 100, state: "OPEN"});
         });
 
-        it("invert_cover_state on a coverInverted device flips state back", () => {
-            const payload = convert({currentPositionLiftPercentage: 100}, {coverInverted: true}, {invert_cover_state: true});
-            expect(payload).toStrictEqual({position: 100, state: "CLOSE"});
+        it("invert_cover on a coverInverted device cancels back to the non-inverted combination", () => {
+            const payload = convert({currentPositionLiftPercentage: 100}, {coverInverted: true}, {invert_cover: true});
+            expect(payload).toStrictEqual({position: 0, state: "CLOSE"});
         });
 
         it("derives state from tilt when coverStateFromTilt is set", () => {
@@ -315,9 +305,9 @@ describe("converters/fromZigbee", () => {
             expect(payload).toStrictEqual({tilt: 100, state: "OPEN"});
         });
 
-        it("invert_cover_state also flips tilt-derived state", () => {
-            const payload = convert({currentPositionTiltPercentage: 0}, {coverStateFromTilt: true}, {invert_cover_state: true});
-            expect(payload).toStrictEqual({tilt: 100, state: "CLOSE"});
+        it("invert_cover flips tilt-derived state too", () => {
+            const payload = convert({currentPositionTiltPercentage: 0}, {coverStateFromTilt: true}, {invert_cover: true});
+            expect(payload).toStrictEqual({tilt: 0, state: "CLOSE"});
         });
 
         it("decodes cover_mode bits", () => {

--- a/test/toZigbee.test.ts
+++ b/test/toZigbee.test.ts
@@ -1,6 +1,6 @@
 import {beforeEach, describe, expect, test, vi} from "vitest";
 import * as zhc from "../src";
-import type {Tz} from "../src/lib/types";
+import type {KeyValue, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 describe("toZigbee converters", () => {
@@ -362,6 +362,105 @@ describe("toZigbee converters", () => {
                 {movemode: 1, rate: 25, minimum: 0, maximum: 600, optionsMask: 0, optionsOverride: 0},
                 {},
             );
+        });
+    });
+
+    describe("cover_state", () => {
+        let device: ReturnType<typeof mockDevice>;
+
+        beforeEach(() => {
+            device = mockDevice({modelID: "test_cover", endpoints: [{ID: 1}]});
+        });
+
+        const makeMeta = (options: KeyValue = {}): Tz.Meta => ({
+            state: {},
+            device,
+            message: null,
+            // @ts-expect-error mock
+            mapped: {meta: {}},
+            options,
+            publish: null,
+            endpoint_name: null,
+        });
+
+        test("sends upOpen for open and downClose for close by default", async () => {
+            const converter = zhc.toZigbee.cover_state;
+            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta());
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
+
+            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta());
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
+        });
+
+        test("invert_state swaps open and close commands", async () => {
+            const converter = zhc.toZigbee.cover_state;
+            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_state: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
+
+            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta({invert_state: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
+        });
+
+        test("stop is unaffected by invert_state", async () => {
+            const converter = zhc.toZigbee.cover_state;
+            await converter.convertSet(device.endpoints[0], "state", "stop", makeMeta({invert_state: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "stop", {}, {});
+        });
+    });
+
+    describe("cover_position_tilt", () => {
+        let device: ReturnType<typeof mockDevice>;
+
+        beforeEach(() => {
+            device = mockDevice({modelID: "test_cover", endpoints: [{ID: 1}]});
+        });
+
+        const makeMeta = (options: KeyValue = {}, mappedMeta: KeyValue = {}): Tz.Meta => ({
+            state: {},
+            device,
+            message: null,
+            // @ts-expect-error mock
+            mapped: {meta: mappedMeta},
+            options,
+            publish: null,
+            endpoint_name: null,
+        });
+
+        test("sends the inverted percentage by default (position 100 -> device value 0)", async () => {
+            const converter = zhc.toZigbee.cover_position_tilt;
+            const result = await converter.convertSet(device.endpoints[0], "position", 100, makeMeta());
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToLiftPercentage", {percentageliftvalue: 0}, {});
+            expect(result).toStrictEqual({state: {position: 100}});
+        });
+
+        test("invert_position sends the value through unchanged", async () => {
+            const converter = zhc.toZigbee.cover_position_tilt;
+            await converter.convertSet(device.endpoints[0], "position", 100, makeMeta({invert_position: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToLiftPercentage", {percentageliftvalue: 100}, {});
+        });
+
+        test("legacy invert_cover behaves the same as invert_position", async () => {
+            const converter = zhc.toZigbee.cover_position_tilt;
+            await converter.convertSet(device.endpoints[0], "position", 100, makeMeta({invert_cover: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToLiftPercentage", {percentageliftvalue: 100}, {});
+        });
+
+        test("device-level coverInverted meta combines with invert_position", async () => {
+            const converter = zhc.toZigbee.cover_position_tilt;
+            await converter.convertSet(device.endpoints[0], "position", 100, makeMeta({}, {coverInverted: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToLiftPercentage", {percentageliftvalue: 100}, {});
+        });
+
+        test("tilt uses goToTiltPercentage", async () => {
+            const converter = zhc.toZigbee.cover_position_tilt;
+            await converter.convertSet(device.endpoints[0], "tilt", 30, makeMeta());
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToTiltPercentage", {percentagetiltvalue: 70}, {});
+        });
+
+        test("cover_position_tilt_disable_report suppresses the optimistic state", async () => {
+            const converter = zhc.toZigbee.cover_position_tilt;
+            const result = await converter.convertSet(device.endpoints[0], "position", 100, makeMeta({cover_position_tilt_disable_report: true}));
+            expect(result).toBeUndefined();
         });
     });
 

--- a/test/toZigbee.test.ts
+++ b/test/toZigbee.test.ts
@@ -392,18 +392,18 @@ describe("toZigbee converters", () => {
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
         });
 
-        test("invert_state swaps open and close commands", async () => {
+        test("invert_cover_state swaps open and close commands", async () => {
             const converter = zhc.toZigbee.cover_state;
-            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_state: true}));
+            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_cover_state: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
 
-            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta({invert_state: true}));
+            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta({invert_cover_state: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
         });
 
-        test("stop is unaffected by invert_state", async () => {
+        test("stop is unaffected by invert_cover_state", async () => {
             const converter = zhc.toZigbee.cover_state;
-            await converter.convertSet(device.endpoints[0], "state", "stop", makeMeta({invert_state: true}));
+            await converter.convertSet(device.endpoints[0], "state", "stop", makeMeta({invert_cover_state: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "stop", {}, {});
         });
     });
@@ -433,19 +433,13 @@ describe("toZigbee converters", () => {
             expect(result).toStrictEqual({state: {position: 100}});
         });
 
-        test("invert_position sends the value through unchanged", async () => {
-            const converter = zhc.toZigbee.cover_position_tilt;
-            await converter.convertSet(device.endpoints[0], "position", 100, makeMeta({invert_position: true}));
-            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToLiftPercentage", {percentageliftvalue: 100}, {});
-        });
-
-        test("legacy invert_cover behaves the same as invert_position", async () => {
+        test("invert_cover sends the value through unchanged", async () => {
             const converter = zhc.toZigbee.cover_position_tilt;
             await converter.convertSet(device.endpoints[0], "position", 100, makeMeta({invert_cover: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToLiftPercentage", {percentageliftvalue: 100}, {});
         });
 
-        test("device-level coverInverted meta combines with invert_position", async () => {
+        test("device-level coverInverted meta combines with invert_cover", async () => {
             const converter = zhc.toZigbee.cover_position_tilt;
             await converter.convertSet(device.endpoints[0], "position", 100, makeMeta({}, {coverInverted: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "goToLiftPercentage", {percentageliftvalue: 100}, {});

--- a/test/toZigbee.test.ts
+++ b/test/toZigbee.test.ts
@@ -372,12 +372,12 @@ describe("toZigbee converters", () => {
             device = mockDevice({modelID: "test_cover", endpoints: [{ID: 1}]});
         });
 
-        const makeMeta = (options: KeyValue = {}): Tz.Meta => ({
+        const makeMeta = (options: KeyValue = {}, mappedMeta: KeyValue = {}): Tz.Meta => ({
             state: {},
             device,
             message: null,
             // @ts-expect-error mock
-            mapped: {meta: {}},
+            mapped: {meta: mappedMeta},
             options,
             publish: null,
             endpoint_name: null,
@@ -392,19 +392,31 @@ describe("toZigbee converters", () => {
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
         });
 
-        test("invert_cover_state swaps open and close commands", async () => {
+        test("invert_cover swaps open and close commands", async () => {
             const converter = zhc.toZigbee.cover_state;
-            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_cover_state: true}));
+            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_cover: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
 
-            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta({invert_cover_state: true}));
+            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta({invert_cover: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
         });
 
-        test("stop is unaffected by invert_cover_state", async () => {
+        test("stop is unaffected by invert_cover", async () => {
             const converter = zhc.toZigbee.cover_state;
-            await converter.convertSet(device.endpoints[0], "state", "stop", makeMeta({invert_cover_state: true}));
+            await converter.convertSet(device.endpoints[0], "state", "stop", makeMeta({invert_cover: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "stop", {}, {});
+        });
+
+        test("device-level coverInverted meta swaps commands the same way invert_cover does", async () => {
+            const converter = zhc.toZigbee.cover_state;
+            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({}, {coverInverted: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
+        });
+
+        test("invert_cover on a coverInverted device cancels back to the normal commands", async () => {
+            const converter = zhc.toZigbee.cover_state;
+            await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_cover: true}, {coverInverted: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
         });
     });
 


### PR DESCRIPTION
## Problem
For window covering devices, the state (OPEN/CLOSE) published by fz.cover_position_tilt was derived from the raw position value using only the device-definition's coverInverted meta flag — it never consulted the user-facing invert_cover option at all. This meant that if a device's percentage reporting was inverted and a user enabled invert_cover to fix it, the position value would come out correct but state would then be wrong, with no way to fix it independently.

see [`#27213 - Cover State flip`](https://github.com/Koenkk/zigbee2mqtt/issues/27213)

## Changes
- Added invert_cover_state — a new option that inverts the OPEN/CLOSE state independently of position, for both:
   - fz.cover_position_tilt: the derived state value (for both lift- and tilt-based state derivation)
   - tz.cover_state: which raw ZCL command (upOpen/downClose) gets sent for open/close
- invert_cover keeps its existing name/property (no config-breaking rename), but now has an explicit, clearer label — "Invert cover position" — to read as a clean pair alongside invert_cover_state.
- Added legacyNames/withLegacyNames(...) to the base Expose class — schema-only groundwork for a future option-rename migration path (e.g. eventually marking invert_cover_position as replacing invert_cover). Not yet used by any option, as it requires change to the zigbee2mqtt repository settingsMigration.ts.
- Added tests for fz.cover_position_tilt, tz.cover_position_tilt, and tz.cover_state covering: default (non-inverted) behavior, invert_cover affecting only position, invert_cover_state affecting only the OPEN/CLOSE label/commands independently, both combined, interaction with the device-level coverInverted meta, tilt-derived state, and cover_mode bit decoding.

## Testing
tsc --noEmit — clean
pnpm run check (biome) — clean
pnpm run test — 709/709 passing
