### PR TITLE
fix: Allow schema and type override for Home Assistant infrared discovery type

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1366,7 +1366,15 @@ export const definitions: DefinitionWithExtend[] = [
             fz.battery,
         ],
         toZigbee: [tzZosung.zosung_ir_code_to_send, tzZosung.zosung_learn_ir_code],
-        exposes: [ez.learn_ir_code(), ez.learned_ir_code(), ez.learned_ir_timings(), ez.ir_code_to_send(), e.battery(), e.battery_voltage()],
+        exposes: [
+            ez.learn_ir_code(),
+            ez.learned_ir_code(),
+            ez.learned_ir_timings(),
+            ez.ir_code_to_send(),
+            ez.ir_emitter(),
+            e.battery(),
+            e.battery_voltage(),
+        ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await endpoint.read("genPowerCfg", ["batteryVoltage", "batteryPercentageRemaining"]);

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -14423,7 +14423,7 @@ export const definitions: DefinitionWithExtend[] = [
             fzZosung.zosung_send_ir_code_05,
         ],
         toZigbee: [tzZosung.zosung_ir_code_to_send, tzZosung.zosung_learn_ir_code],
-        exposes: [ez.learn_ir_code(), ez.learned_ir_code(), ez.learned_ir_timings(), ez.ir_code_to_send()],
+        exposes: [ez.learn_ir_code(), ez.learned_ir_code(), ez.learned_ir_timings(), ez.ir_code_to_send(), ez.ir_emitter()],
         whiteLabel: [
             tuya.whitelabel("Tuya", "UFO-R4Z", "Universal smart IR remote control", ["_TZ3290_rlkmy85q4pzoxobl", "_TZ3290_gnl5a6a5xvql7c2a"]),
             tuya.whitelabel("QA", "QAIRZPRO", "Infrared hub pro", ["_TZ3290_jxvzqatwgsaqzx1u", "_TZ3290_lypnqvlem5eq1ree"]),
@@ -27993,6 +27993,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription(
                     "The IR code to send by device (Support SmartIR IR code library. IR remote Firmware ID must be Firmware ID>01062026)",
                 ),
+            ez.ir_emitter().withDescription("IR emitter feature. IR remote Firmware ID must be Firmware ID>01062026)"),
             e.enum("switch1_on", ea.STATE_SET, ["study", "registered", "unregistered"]).withDescription("Switch 1 on IR code Study and Study status"),
             e
                 .enum("switch1_off", ea.STATE_SET, ["study", "registered", "unregistered"])

--- a/src/devices/wmun.ts
+++ b/src/devices/wmun.ts
@@ -14,7 +14,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZS05",
         vendor: "WMUN",
         description: "Universal smart IR remote control on batteries",
-        exposes: [ez.learn_ir_code(), ez.learned_ir_code(), ez.learned_ir_timings(), ez.ir_code_to_send()],
+        exposes: [ez.learn_ir_code(), ez.learned_ir_code(), ez.learned_ir_timings(), ez.ir_code_to_send(), ez.ir_emitter()],
         extend: [zosung.zosungExtend.addZosungIRTransmitCluster(), zosung.zosungExtend.addZosungIRControlCluster(), m.battery()],
         fromZigbee: [
             fzZosung.zosung_send_ir_code_00,

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -15,7 +15,8 @@ import {getLabelFromName} from "./utils";
 
 export type Feature = Numeric | Binary | Enum | Composite | List | Text;
 export interface HomeAssistant {
-    type?: "valve";
+    type?: "valve" | "infrared";
+    schema?: "emitter" | "receiver";
     entityCategory?: "config" | "diagnostic";
     deviceClass?: string;
     enabledByDefault?: boolean;

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -642,7 +642,7 @@ export const fzZosung = {
 
 export const tzZosung = {
     zosung_ir_code_to_send: {
-        key: ["ir_code_to_send"],
+        key: ["ir_code_to_send", "ir_emitter"],
         convertSet: async (entity, key, value, meta) => {
             const irMsg = normalizeIrMsg(value);
 
@@ -687,6 +687,11 @@ export const tzZosung = {
 export const presetsZosung = {
     learn_ir_code: () => e.binary("learn_ir_code", ea.SET, "ON", "OFF").withDescription("Turn on to learn new IR code"),
     learned_ir_code: () => e.text("learned_ir_code", ea.STATE).withDescription("The IR code learned by device"),
-    learned_ir_timings: () => e.text("learned_ir_timings", ea.STATE).withDescription("The IR timings learned by device"),
+    learned_ir_timings: () =>
+        e
+            .text("learned_ir_timings", ea.STATE)
+            .withDescription("The IR timings learned by device")
+            .withHomeAssistant({type: "infrared", schema: "receiver"}),
     ir_code_to_send: () => e.text("ir_code_to_send", ea.SET).withDescription("The IR code or timings to send by device"),
+    ir_emitter: () => e.text("ir_emitter", ea.SET).withDescription("IR emitter feature").withHomeAssistant({type: "infrared", schema: "emitter"}),
 };

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -633,6 +633,7 @@ export const fzZosung = {
                     learned_ir_timings: {
                         modulation: 38000,
                         timings: learnedTimings,
+                        timestamp: Date.now(),
                     },
                 };
             }


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
The PR allows to override the Home Assistant discovery type for infrared entities and set the schema.
This should allow to use `expose.withHomeAssistant()` in Zigbee2MQTT to override the type to `infrared` and the `schema`.

The initial PR only allows to override the type, this PR adds the `schema` attribute: https://github.com/Koenkk/zigbee2mqtt/pull/32549.