### PR TITLE
Add Paulmann CCT-I light support

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -32,6 +32,13 @@ const fzLocal = {
 
 export const definitions: DefinitionWithExtend[] = [
     {
+        fingerprint: [{modelID: "CCT-I", manufacturerName: "Paulmann Licht GmbH"}],
+        model: "CCT-I",
+        vendor: "Paulmann",
+        description: "Tunable white light controller with integrated motion sensor (tested with Skyla 948.64)",
+        extend: [m.light({colorTemp: {range: [153, 370]}})],
+    },
+    {
         zigbeeModel: ["94842"],
         model: "94842",
         vendor: "Paulmann",


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5335

## Summary

- Add a precise fingerprint for the Paulmann `CCT-I` controller (`Paulmann Licht GmbH`).
- Expose its standard tunable-white light features through `m.light()`.
- Keep the device-reported color temperature range of 153-370 mireds.
- Deliberately do not expose occupancy: the device advertises only standard light clusters, and no distinct PIR telegram has been observed.

## Tested hardware

- Product: Paulmann Skyla 948.64
- Zigbee model: `CCT-I`
- Manufacturer: `Paulmann Licht GmbH`
- Software build: `1400-0001`
- Endpoint 1 server clusters: `genBasic`, `genGroups`, `genIdentify`, `genOnOff`, `genLevelCtrl`, `genScenes`, `lightingColorCtrl`, `touchlink`
- Endpoint 1 client clusters: `genOta`

The generic model name is intentional because `CCT-I` identifies the controller rather than a unique luminaire SKU. The same detection string was also reported in the follow-up discussion on #10702. Skyla 948.64 is the hardware used for this contribution.

Paulmann documents the integrated PIR as a local 30-second light function, including while connected to Zigbee; it is not represented by a motion or illuminance cluster on this device:

- Product: https://de.paulmann.com/p/led-aussenwandleuchte-smart-home-zigbee-3.0-skyla-daemmerungsgesteuerter-bewegungsmelder-ir-insektenfreundlich-ip44-226x164mm-tunable-warm-10w-840lm-230v-anthrazit-aluminium/94864
- Manual: https://content.paulmann.com/media/50/8d/31/1707375059/94864_V01.pdf

## Hardware smoke test

Tested as an external converter with Zigbee2MQTT 2.12.1 and zigbee-herdsman-converters 26.76.0:

- Device changed from `Automatically generated definition` / `supported: false` to model `CCT-I`, source `external`, `supported: true`.
- Existing Home Assistant entity ID and MQTT unique ID were preserved: `light.haustur_lampe` / `0x00158d0009a60273_light_zigbee2mqtt`.
- On/off, 35% brightness at 3000 K, and 70% brightness at 4000 K were applied and reported back correctly.
- Effects are exposed on the light entity.
- `power_on_behavior` is readable as `previous`; it was not changed.
- No occupancy entity is created.

## Validation

- `pnpm run check --fix`
- `pnpm run build`
- `pnpm test` (713 tests passed)