### PR TITLE
Add Moes ZSS-QT-LTH-C 3-in-1 brightness/temperature/humidity sensor (TS0222, _TZ3000_ubuikmgo)

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -1196,6 +1196,14 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.illuminance()],
     },
     {
+        fingerprint: tuya.fingerprint("TS0222", ["_TZ3000_ubuikmgo"]),
+        model: "ZSS-QT-LTH-C",
+        vendor: "Moes",
+        description: "Smart 3-in-1 brightness, temperature and humidity sensor",
+        configure: tuya.configureMagicPacket,
+        extend: [m.battery(), m.temperature(), m.humidity(), m.illuminance()],
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_fhn3negr"]),
         model: "SH4-ZB",
         vendor: "Moes",


### PR DESCRIPTION
## Description

Adds support for the Moes **Smart 3-in-1 Sensor** (brightness / temperature / humidity), sold as **ZSS-QT-LTH-C** — a sibling of the existing Moes ZSS-QT-LS-C light sensor.

- Zigbee model: `TS0222`
- Manufacturer name: `_TZ3000_ubuikmgo`
- Power: 2×AAA battery or micro-USB 5V/1A (end device)
- Input clusters: `msIlluminanceMeasurement`, `msTemperatureMeasurement`, `msRelativeHumidity`, `genPowerCfg`, `genBasic`, `ssIasZone` (unused)
- Measuring ranges (from the box): 0–3000 lux, −10…60 °C, 0–100 %RH

## Why a separate definition (not a fingerprint in `TS0222_temperature_humidity`)

`TS0222_temperature_humidity` uses `fzLocal.TS0222_humidity`, which multiplies humidity ×10 for its devices. This device reports the **standard scale** — adding the fingerprint there would produce 10× inflated humidity. A dedicated definition with plain modernExtend converters matches the hardware.

## Tested

Running as an equivalent external definition on Zigbee2MQTT 2.12.1 for several hours:
- illuminance ~900 lx in daylight, sane dusk values
- temperature 26.8 °C, humidity 64.5 %RH (matches a reference hygrometer)
- battery 100 %, reports roughly every minute on USB power

<details><summary>Device endpoints (from database.db after pairing)</summary>

```json
{"1":{"clusters":{"input":["genPowerCfg","genIdentify","msTemperatureMeasurement","msRelativeHumidity","msIlluminanceMeasurement","ssIasZone","genBasic"],"output":["genIdentify","genOta","genTime"]}}}
```

</details>

A device image PR to zigbee2mqtt.io will follow.
