### PR TITLE
fix: BTicino F20T60A and FC80GCS: Remove unused converters

### DIFF
--- a/src/devices/bticino.ts
+++ b/src/devices/bticino.ts
@@ -55,20 +55,6 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [legrandExtend.addLegrandDevicesCluster(), m.light({configureReporting: true})],
     },
     {
-        zigbeeModel: ["Bticino Din power consumption module "],
-        model: "F20T60A",
-        description: "DIN power consumption module (same as Legrand 412015)",
-        vendor: "BTicino",
-        extend: [legrandExtend.addLegrandDevicesCluster(), m.onOff(), m.electricityMeter({cluster: "electrical"})],
-        fromZigbee: [fz.identify, fzLegrand.cluster_fc01],
-        toZigbee: [tzLegrand.legrand_device_mode, tzLegrand.identify],
-        exposes: [
-            e
-                .enum("device_mode", ea.ALL, ["switch", "auto"])
-                .withDescription("switch: allow on/off, auto will use wired action via C1/C2 on contactor for example with HC/HP"),
-        ],
-    },
-    {
         zigbeeModel: ["Power socket Bticino Serie LL "],
         model: "L4531C",
         vendor: "BTicino",

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -514,7 +514,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "DIN power consumption module",
         whiteLabel: [
             {vendor: "Legrand", description: "DIN power consumption module", model: "412172", fingerprint: [{modelID: " Smart shedder module"}]},
-            {vendor: "BTicino", description: "DIN power consumption module", model: "FC80GCS", fingerprint: [{modelID: " Smart shedder module"}]},
+            {vendor: "BTicino", description: "DIN power consumption module", model: "FC80GCS", whiteLabelOf: "412172"},
             {vendor: "BTicino", description: "DIN power consumption module", model: "F20T60A"},
         ],
         ota: true,

--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -515,6 +515,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [
             {vendor: "Legrand", description: "DIN power consumption module", model: "412172", fingerprint: [{modelID: " Smart shedder module"}]},
             {vendor: "BTicino", description: "DIN power consumption module", model: "FC80GCS", fingerprint: [{modelID: " Smart shedder module"}]},
+            {vendor: "BTicino", description: "DIN power consumption module", model: "F20T60A"},
         ],
         ota: true,
         fromZigbee: [fz.identify, fz.metering, fz.electrical_measurement, fzLegrand.power_alarm, fzLegrand.cluster_fc01],


### PR DESCRIPTION
- https://github.com/Koenkk/zigbee-herdsman-converters/issues/12709

> The modelID is ` DIN power consumption module\u0000\u0000` which matches the legrand one, so the F20T60A in ~~devices.js~~ bitcino.ts is never used (because that modelID is `Bticino Din power consumption module `)