### PR TITLE
Enable OTA for Paulmann CCT-I

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -36,6 +36,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "CCT-I",
         vendor: "Paulmann",
         description: "Tunable white light controller with integrated motion sensor (tested with Skyla 948.64)",
+        ota: true,
         extend: [m.light({colorTemp: {range: [153, 370]}})],
     },
     {


### PR DESCRIPTION
## Summary

- enable generic Zigbee OTA support for the Paulmann `CCT-I`
- expose Zigbee2MQTT's standard update check and custom firmware workflow

## Hardware evidence

Tested with a Paulmann Skyla 948.64 running `softwareBuildID: 1400-0001`.

The device actively sends `genOta` `commandQueryNextImageRequest` messages with:

- manufacturer code: `4632` (`0x1218`)
- image type: `4364` (`0x110c`)
- installed file version: `1`

Zigbee2MQTT currently responds with `NO_IMAGE_AVAILABLE` because the default OTA index does not contain a verified Paulmann image for this target yet. This PR deliberately does not add or reference an unverified firmware binary.

Follow-up to #12712.

## Tests

- `pnpm run check --fix`
- `pnpm run build`
- `pnpm test` (713 tests)
