### PR TITLE
feat: add AwoX EZMB-RGB-TW-I2C (EGLO 12254)

### DIFF
--- a/src/devices/awox.ts
+++ b/src/devices/awox.ts
@@ -400,6 +400,14 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light({colorTemp: {range: [153, 370]}})],
     },
     {
+        zigbeeModel: ["EZMB-RGB-TW-I2C"],
+        model: "EZMB-RGB-TW-I2C",
+        vendor: "AwoX",
+        description: "EGLO Connect-Z LED G95 13.5W RGB + tunable white",
+        extend: [m.light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"], enhancedHue: true}})],
+        whiteLabel: [{vendor: "EGLO", model: "12254"}],
+    },
+    {
         fingerprint: [
             {
                 type: "Router",


### PR DESCRIPTION
Adds support for AwoX EZMB-RGB-TW-I2C (white-label EGLO 12254, EGLO Connect-Z LED G95 13.5W RGB + tunable white).

Tested locally via external converter on z2m:
* on/off, brightness, color temp (153–370 mired), and xy/hs color with enhanced hue all working.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5343