### PR TITLE
feat(improve): Add dewpoint and VPD for SONOFF SNZB-02B/02M/02UL

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -7127,6 +7127,50 @@ const sonoffExtend = {
             isModernExtend: true,
         };
     },
+
+    temperatureHumidityCalculatedValues(): ModernExtend {
+        const calculate = (temperature: number, humidity: number): KeyValue => {
+            const saturatedVaporPressure = 0.61078 * Math.exp((17.27 * temperature) / (temperature + 237.3));
+            const actualVaporPressure = (humidity / 100) * saturatedVaporPressure;
+            const vpd = utils.precisionRound(saturatedVaporPressure - actualVaporPressure, 2);
+
+            if (humidity <= 0) {
+                return {vpd};
+            }
+
+            const alpha = (17.27 * temperature) / (temperature + 237.7) + Math.log(humidity / 100);
+            const dewPoint = utils.precisionRound((237.7 * alpha) / (17.27 - alpha), 1);
+            return {dew_point: dewPoint, vpd};
+        };
+        const exposes: Expose[] = [
+            e.numeric("dew_point", ea.STATE).withUnit("°C").withDescription("Calculated dew point temperature"),
+            e.numeric("vpd", ea.STATE).withUnit("kPa").withDescription("Calculated vapor pressure deficit"),
+        ];
+        const fromZigbee: Fz.Converter<"msTemperatureMeasurement" | "msRelativeHumidity", undefined, ["attributeReport", "readResponse"]>[] = [
+            {
+                cluster: "msTemperatureMeasurement",
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg, publish, options, meta) => {
+                    if (msg.data.measuredValue === undefined || !utils.isNumber(meta.state.humidity)) return;
+                    return calculate(msg.data.measuredValue / 100, meta.state.humidity);
+                },
+            },
+            {
+                cluster: "msRelativeHumidity",
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg, publish, options, meta) => {
+                    if (msg.data.measuredValue === undefined || !utils.isNumber(meta.state.temperature)) return;
+                    return calculate(meta.state.temperature, msg.data.measuredValue / 100);
+                },
+            },
+        ];
+
+        return {
+            exposes,
+            fromZigbee,
+            isModernExtend: true,
+        };
+    },
 };
 
 export const definitions: DefinitionWithExtend[] = [
@@ -10458,6 +10502,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.battery(),
             m.temperature({reporting: {min: 5, max: 3600, change: 20}}),
             m.humidity({valueMin: 0, valueMax: 100, reporting: {min: 5, max: 3600, change: 100}}),
+            sonoffExtend.temperatureHumidityCalculatedValues(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
 
             // attributes
@@ -10524,6 +10569,7 @@ export const definitions: DefinitionWithExtend[] = [
                 precision: 2,
                 zigbeeCommandOptions: {manufacturerCode: 0x1286},
             }),
+            sonoffExtend.temperatureHumidityCalculatedValues(),
             m.numeric<"customClusterEwelink", SonoffSnzb02m>({
                 name: "temperature_calibration",
                 cluster: "customClusterEwelink",
@@ -11538,6 +11584,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.battery(),
             m.temperature({valueMin: 0, valueMax: 50}),
             m.humidity({valueMin: 5, valueMax: 95}),
+            sonoffExtend.temperatureHumidityCalculatedValues(),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             m.numeric<"customClusterEwelink", SonoffSnzb02ul>({
                 name: "comfort_temperature_min",


### PR DESCRIPTION
## Summary

- Improve SONOFF SNZB-02B, SNZB-02M, and SNZB-02UL support with calculated dewpoint and VPD values.

## Changes

- Update `src/devices/sonoff.ts` to expose calculated `dewpoint` and `vpd` values for the supported temperature and humidity sensors.

## Testing

Tested with Zigbee2MQTT.
- Verified that temperature and humidity reports produce the expected `dewpoint` and `vpd` states.
- Verified calculated values update when temperature or humidity changes.