### PR TITLE
fix(NodOn): fix wired input, endpoint 242 and identify for SIN-4-1-20/SIN-4-1-21/SIN-4-2-20

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -351,7 +351,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SIN-4-1-20",
         vendor: "NodOn",
         description: "Multifunction relay switch",
-        extend: [m.onOff(), nodonModernExtend.impulseMode(), nodonModernExtend.switchTypeOnOff()],
+        endpoint: (device) => ({default: 1}),
+        extend: [m.identify(), m.onOff(), nodonModernExtend.impulseMode(), nodonModernExtend.switchTypeOnOff()],
+        configure: async (device) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.bind("genOnOff", endpoint);
+        },
         ota: true,
     },
     {
@@ -367,12 +372,18 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SIN-4-1-21",
         vendor: "NodOn",
         description: "Multifunction relay switch with metering",
+        endpoint: (device) => ({default: 1}),
         extend: [
+            m.identify(),
             m.onOff({powerOnBehavior: true}),
             m.electricityMeter({cluster: "metering"}),
             nodonModernExtend.impulseMode(),
             nodonModernExtend.switchTypeOnOff(),
         ],
+        configure: async (device) => {
+            const endpoint = device.getEndpoint(1);
+            await endpoint.bind("genOnOff", endpoint);
+        },
         ota: true,
     },
     {
@@ -381,11 +392,18 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "NodOn",
         description: "Lighting relay switch",
         extend: [
-            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
+            m.identify(),
+            m.deviceEndpoints({endpoints: {default: 1, l1: 1, l2: 2}}),
             m.onOff({endpointNames: ["l1", "l2"]}),
             nodonModernExtend.switchTypeOnOff({endpointName: "l1"}),
             nodonModernExtend.switchTypeOnOff({endpointName: "l2"}),
         ],
+        configure: async (device) => {
+            const ep1 = device.getEndpoint(1);
+            const ep2 = device.getEndpoint(2);
+            await ep1.bind("genOnOff", ep1);
+            await ep2.bind("genOnOff", ep2);
+        },
         ota: true,
     },
     {


### PR DESCRIPTION
Three issues on `SIN-4-1-20`, `SIN-4-1-21` and `SIN-4-2-20`:

1. Wired input doesn't control the relay by default. It sends a `genOnOff` `Toggle` command to whatever the endpoint is bound to — with no bind at all, it only reaches the coordinator and does nothing. Adding this self-bind also makes it show up in the Bind tab, so users can remove it or rebind the wired input to control a different device instead.
2. Endpoint 242 (Green Power proxy) not mapped, same issue already fixed on `FPS-4-1-00`/`SIN-4-FP-20`/`SIN-4-FP-21`.
3. `m.identify()` missing on all three, unlike every other NodOn definition here.
