### PR TITLE
Shelly Presence Gen4 (S4SN-0U61X): full sensor and zone configuration

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1,5 +1,6 @@
 import {Zcl, ZSpec} from "zigbee-herdsman";
 import * as fz from "../converters/fromZigbee";
+import type {Feature} from "../lib/exposes";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
@@ -13,13 +14,255 @@ const ea = exposes.access;
 const SHELLY_ENDPOINT_ID = 239;
 const SHELLY_OPTIONS = {profileId: ZSpec.CUSTOM_SHELLY_PROFILE_ID};
 const SHELLY_PRESENCE_MAX_ZONES = 10;
+// The device reports occupancy per tracked person, one endpoint each - not per zone. Shelly's own
+// definition exposes all ten unconditionally, and it has to stay that way: a second person only
+// shows up on the second endpoint, so gating these on anything would hide people.
+const SHELLY_PRESENCE_TARGET_ENDPOINTS = Array.from({length: 10}, (_, index) => String(index + 1));
 const SHELLY_RPC_DATA_READ_TIMEOUT = 10000;
 // The RPC cluster cannot deliver a response over Zigbee: the device acknowledges a read of the
 // Data attribute but never sends the Read Attributes Response. Shelly confirmed this as a known
 // firmware limitation and it is still present in firmware 2.0.0, so everything that would read
 // through the RPC cluster is disabled - it would only produce empty values and a timeout per
-// attempt. Flip this once a firmware answers again.
+// attempt. Flip this once a firmware answers again to restore zone discovery.
 const SHELLY_RPC_CAN_READ = false;
+// A device leaves the factory with one presence zone, and it carries this id.
+const SHELLY_PRESENCE_FIRST_ZONE_ID = 200;
+// Shelly.GetComponents answers in pages (7 components per page on a Presence Gen4); this bounds
+// the paging loop so a device reporting an inconsistent total cannot spin it forever.
+const SHELLY_COMPONENT_PAGE_LIMIT = 10;
+// A PresenceZone reports its thresholds as presence_thr/absence_thr, while the API documents them
+// as presence_delay/absence_delay. Keep the documented names - they say what the value means - for
+// the exposes and translate at the RPC boundary. PresenceZone.SetConfig discards unknown keys
+// without reporting an error, so a wrong name here fails silently: prefer whichever name the zone
+// config actually carries and fall back to the name observed on the device.
+const SHELLY_PRESENCE_ZONE_FIELDS: Record<string, string> = {
+    presence_delay: "presence_thr",
+    absence_delay: "absence_thr",
+};
+// The device reports this once the fine-tuning values no longer match one of the presets. It is
+// never accepted on write, but listing it keeps the reported state a value the enum knows.
+const SHELLY_PRESENCE_SENSITIVITY_CUSTOM = "custom";
+
+// Presence.SetConfig takes a single nested config object, so every sensor setting is described by
+// its path inside that object and handled by one shared converter. The ranges and value lists are
+// the ones the device enforces itself - it rejects anything outside them.
+interface ShellyPresenceSetting {
+    key: string;
+    path: readonly string[];
+    expose: () => Feature;
+}
+
+// The settings are grouped so a consuming integration can show them as folders instead of two dozen
+// values side by side - and because one group travels in a single Presence.SetConfig command.
+interface ShellyPresenceSettingGroup {
+    key: string;
+    label: string;
+    description: string;
+    settings: readonly ShellyPresenceSetting[];
+}
+
+// Merges a value at its path into a config object, so a whole group can be written in one command.
+const shellyMergeConfig = (config: KeyValue, path: readonly string[], value: unknown): void => {
+    let cursor = config;
+    for (const segment of path.slice(0, -1)) {
+        if (typeof cursor[segment] !== "object" || cursor[segment] === null) cursor[segment] = {};
+        cursor = cursor[segment] as KeyValue;
+    }
+    cursor[path[path.length - 1]] = value;
+};
+
+const num = (name: string, min: number, max: number, step: number, label: string, description: string, unit?: string) => {
+    const expose = e
+        .numeric(name, ea.STATE_SET)
+        .withValueMin(min)
+        .withValueMax(max)
+        .withValueStep(step)
+        .withLabel(label)
+        .withDescription(description);
+    return unit ? expose.withUnit(unit) : expose;
+};
+
+const SHELLY_PRESENCE_SETTING_GROUPS: readonly ShellyPresenceSettingGroup[] = [
+    {
+        key: "mounting",
+        label: "Mounting",
+        description:
+            "How and where the sensor is mounted. Write-only: the device cannot report these back over Zigbee, so they show what was last set from here",
+        settings: [
+            {
+                key: "installation_height",
+                path: ["sensor", "height"],
+                expose: () => num("installation_height", 0, 5, 0.1, "Installation height", "Height the sensor is mounted at", "m"),
+            },
+            {
+                key: "sensor_position",
+                path: ["sensor", "position"],
+                expose: () =>
+                    e
+                        .enum("sensor_position", ea.STATE_SET, ["center", "left", "right"])
+                        .withLabel("Sensor position")
+                        .withDescription("Where the sensor is mounted on the wall"),
+            },
+            {
+                key: "sensor_flipped",
+                path: ["sensor", "flipped"],
+                expose: () =>
+                    e
+                        .binary("sensor_flipped", ea.STATE_SET, true, false)
+                        .withLabel("Sensor flipped")
+                        .withDescription("Sensor is mounted rotated by 180 degrees"),
+            },
+        ],
+    },
+    {
+        key: "detection",
+        label: "Detection",
+        description:
+            "How the radar decides that someone is there. Write-only: the device cannot report these back over Zigbee, so they show what was last set from here",
+        settings: [
+            {
+                key: "sensitivity",
+                path: ["sensor", "sensitivity"],
+                expose: () =>
+                    e
+                        .enum("sensitivity", ea.STATE_SET, ["low", "medium", "high", SHELLY_PRESENCE_SENSITIVITY_CUSTOM])
+                        .withLabel("Sensitivity")
+                        .withDescription("Detection responsiveness. Reported as 'custom' while the fine-tuning values differ from a preset"),
+            },
+            {
+                key: "radar_power",
+                path: ["sensor", "power"],
+                expose: () =>
+                    e
+                        .enum("radar_power", ea.STATE_SET, ["low", "medium", "high"])
+                        .withLabel("Radar power")
+                        .withDescription("Transmit power of the radar sensor"),
+            },
+            {
+                key: "minimum_range",
+                path: ["zmin"],
+                expose: () => num("minimum_range", 0, 5, 0.1, "Minimum range", "Lower detection limit", "m"),
+            },
+            {
+                key: "maximum_range",
+                path: ["zmax"],
+                expose: () => num("maximum_range", 0, 5, 0.1, "Maximum range", "Upper detection limit", "m"),
+            },
+            {
+                key: "tracked_objects",
+                path: ["num_tracks"],
+                expose: () => num("tracked_objects", 1, 10, 1, "Tracked objects", "How many objects the sensor tracks at once"),
+            },
+        ],
+    },
+    {
+        key: "leds",
+        label: "LEDs",
+        description:
+            "Brightness of the status LEDs and their night mode. Write-only: the device cannot report these back over Zigbee, so they show what was last set from here",
+        settings: [
+            {
+                key: "brightness",
+                path: ["leds", "brightness"],
+                expose: () => num("brightness", 0, 100, 1, "Brightness", "Brightness of the status LEDs, 0 turns them off", "%"),
+            },
+            {
+                key: "night_mode",
+                path: ["leds", "night_mode", "enable"],
+                expose: () =>
+                    e
+                        .binary("night_mode", ea.STATE_SET, true, false)
+                        .withLabel("Night mode")
+                        .withDescription("Limit the LED brightness during the configured night hours"),
+            },
+            {
+                key: "night_mode_brightness",
+                path: ["leds", "night_mode", "brightness"],
+                expose: () => num("night_mode_brightness", 0, 100, 1, "Night mode brightness", "Brightness limit while night mode is active", "%"),
+            },
+        ],
+    },
+    {
+        key: "tuning",
+        label: "Fine-tuning",
+        description:
+            "Detection internals. Changing any of these makes the device report its sensitivity as 'custom'. Write-only: the device cannot report these back over Zigbee, so they show what was last set from here",
+        settings: [
+            {
+                key: "detection_points",
+                path: ["sensor", "points"],
+                expose: () => num("detection_points", 10, 100, 1, "Detection points", "Object recognition threshold"),
+            },
+            {
+                key: "velocity_threshold",
+                path: ["sensor", "velocity"],
+                expose: () => num("velocity_threshold", 0, 1, 0.01, "Velocity threshold", "Velocity threshold"),
+            },
+            {
+                key: "snr_threshold",
+                path: ["sensor", "snr"],
+                expose: () => num("snr_threshold", 10, 100, 1, "SNR threshold", "Signal-to-noise threshold"),
+            },
+            {
+                key: "maximum_velocity_difference",
+                path: ["sensor", "max_velocity"],
+                expose: () =>
+                    num(
+                        "maximum_velocity_difference",
+                        1,
+                        50,
+                        1,
+                        "Maximum velocity difference",
+                        "Largest velocity difference still treated as one object",
+                    ),
+            },
+            {
+                key: "motion_activation_threshold",
+                path: ["sensor", "state", "det_act_thr"],
+                expose: () =>
+                    num("motion_activation_threshold", 1, 100, 1, "Motion activation threshold", "How readily a detected object counts as active"),
+            },
+            {
+                key: "motion_release_threshold",
+                path: ["sensor", "state", "det_free_thr"],
+                expose: () =>
+                    num("motion_release_threshold", 1, 100, 1, "Motion release threshold", "How readily a detected object is released again"),
+            },
+            {
+                key: "tracking_loss_threshold",
+                path: ["sensor", "state", "act_free_thr"],
+                expose: () =>
+                    num(
+                        "tracking_loss_threshold",
+                        1,
+                        1000,
+                        1,
+                        "Tracking loss threshold",
+                        "How long an active object may be lost before it is released",
+                    ),
+            },
+            {
+                key: "stillness_tracking_threshold",
+                path: ["sensor", "state", "stat_free_thr"],
+                expose: () =>
+                    num("stillness_tracking_threshold", 1, 1000, 1, "Stillness tracking threshold", "How long a motionless object stays tracked"),
+            },
+            {
+                key: "stillness_timeout_threshold",
+                path: ["sensor", "state", "sleep_free_thr"],
+                expose: () =>
+                    num(
+                        "stillness_timeout_threshold",
+                        1,
+                        65535,
+                        1,
+                        "Stillness timeout threshold",
+                        "How long a sleeping object stays tracked before it is released",
+                    ),
+            },
+        ],
+    },
+];
 
 const NS = "zhc:shelly";
 
@@ -52,10 +295,17 @@ const shellyDeviceEndpoints = (endpoints: Record<string, number>): ModernExtend 
 });
 
 const shellyPresenceEndpointNames = (device: Zh.Device | DummyDevice): string[] => {
-    const count =
-        !utils.isDummyDevice(device) && typeof device.meta.presence_zone_count === "number"
-            ? Math.min(Math.max(Math.trunc(device.meta.presence_zone_count), 1), SHELLY_PRESENCE_MAX_ZONES)
-            : SHELLY_PRESENCE_MAX_ZONES;
+    // Without a device (documentation/expose generation) show what the hardware can do. On a real
+    // device use the discovered zone count, and before discovery assume the single main zone that
+    // every Presence Gen4 has: exposing all ten up front would create nine zones that never report
+    // and leave them orphaned once the real count shrinks the list.
+    let count = SHELLY_PRESENCE_MAX_ZONES;
+    if (!utils.isDummyDevice(device)) {
+        count =
+            typeof device.meta.presence_zone_count === "number"
+                ? Math.min(Math.max(Math.trunc(device.meta.presence_zone_count), 1), SHELLY_PRESENCE_MAX_ZONES)
+                : 1;
+    }
 
     return Array.from({length: count}, (_, index) => String(index + 1));
 };
@@ -524,8 +774,8 @@ const shellyModernExtend = {
         return result;
     },
     shellyPresenceOccupancy(): ModernExtend {
-        const exposesFn: DefinitionExposesFunction = (device) => {
-            return shellyPresenceEndpointNames(device).map((endpointName) => e.occupancy().withAccess(ea.STATE_GET).withEndpoint(endpointName));
+        const exposesFn: DefinitionExposesFunction = () => {
+            return SHELLY_PRESENCE_TARGET_ENDPOINTS.map((endpointName) => e.occupancy().withAccess(ea.STATE_GET).withEndpoint(endpointName));
         };
 
         const fromZigbee: Fz.Converter<"msOccupancySensing">[] = [
@@ -536,7 +786,7 @@ const shellyModernExtend = {
                     if (!("occupancy" in msg.data)) return;
 
                     const endpointName = utils.getEndpointName(msg, model, meta).toString();
-                    if (!shellyPresenceEndpointNames(meta.device).includes(endpointName)) return;
+                    if (!SHELLY_PRESENCE_TARGET_ENDPOINTS.includes(endpointName)) return;
 
                     return {[utils.postfixWithEndpointName("occupancy", msg, model, meta)]: (msg.data.occupancy & 1) > 0};
                 },
@@ -552,7 +802,32 @@ const shellyModernExtend = {
             },
         ];
 
-        return {exposes: [exposesFn], fromZigbee, toZigbee, isModernExtend: true};
+        // The presence sensor only pushes occupancy autonomously once reporting is configured on
+        // the msOccupancySensing cluster of each target endpoint; without this it just answers reads.
+        // Every tracked person reports on its own endpoint, so all of them need reporting - a second
+        // person would otherwise never arrive. A single endpoint failing must not abort the rest.
+        const configure: Configure[] = [
+            async (device, coordinatorEndpoint) => {
+                for (const endpointName of SHELLY_PRESENCE_TARGET_ENDPOINTS) {
+                    const endpoint = device.getEndpoint(Number(endpointName));
+                    if (!endpoint) continue;
+                    try {
+                        await m.setupAttributes(
+                            endpoint,
+                            coordinatorEndpoint,
+                            "msOccupancySensing",
+                            [{attribute: "occupancy", min: "MIN", max: "1_HOUR", change: 0}],
+                            true,
+                            false,
+                        );
+                    } catch (e) {
+                        logger.warning(`Failed to set up occupancy reporting on endpoint ${endpointName}: ${e}`, NS);
+                    }
+                }
+            },
+        ];
+
+        return {exposes: [exposesFn], fromZigbee, toZigbee, configure, isModernExtend: true};
     },
     shellyRPCSetup(features: string[] = []): ModernExtend {
         // Set helper variables
@@ -565,6 +840,9 @@ const shellyModernExtend = {
         const featureOnePMInputMode = features.includes("1PMInputMode");
         const featureCoverTiltAuto = features.includes("CoverTiltAuto");
         const featurePresenceZonesAuto = features.includes("PresenceZonesAuto");
+        const featurePresenceZoneConfig = features.includes("PresenceZoneConfig");
+        const featurePresenceSensorConfig = features.includes("PresenceSensorConfig");
+        const featureEcoMode = features.includes("EcoMode");
 
         // Generic helper functions
         const validateTime = (value: string) => {
@@ -577,6 +855,39 @@ const shellyModernExtend = {
         const rpcSendRaw = shellyRpcSendRaw;
         const rpcSend = shellyRpcSend;
         const rpcRequest = shellyRpcRequest;
+
+        // Writes reach the device but a single delivery can still fail, and the presence sensor has
+        // no fallback ZCL cluster to fall back on - so a write is retried a few times with a short
+        // pause. Reads are a different matter: the firmware never answers one (see
+        // SHELLY_RPC_CAN_READ), so retrying a read cannot help. The read variant below stays only
+        // for the zone discovery it serves, which is dormant for the same reason.
+        const RPC_MAX_ATTEMPTS = 3;
+        const RPC_RETRY_PAUSE = 1500;
+        const rpcRequestWithRetry = async (endpoint: Zh.Endpoint | Zh.Group, method: string, params?: object): Promise<KeyValue | undefined> => {
+            for (let attempt = 0; attempt < RPC_MAX_ATTEMPTS; attempt++) {
+                if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, RPC_RETRY_PAUSE));
+                const response = await rpcRequest(endpoint, method, params);
+                const result = response?.result ?? response?.params ?? response;
+                if (result) {
+                    assertObject<KeyValue>(result);
+                    return result;
+                }
+            }
+            return undefined;
+        };
+        const rpcSendWithRetry = async (endpoint: Zh.Endpoint | Zh.Group, method: string, params?: object): Promise<void> => {
+            let lastError: unknown;
+            for (let attempt = 0; attempt < RPC_MAX_ATTEMPTS; attempt++) {
+                if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, RPC_RETRY_PAUSE));
+                try {
+                    await rpcSend(endpoint, method, params);
+                    return;
+                } catch (e) {
+                    lastError = e;
+                }
+            }
+            throw lastError;
+        };
 
         const rpcReceive = async (endpoint: Zh.Endpoint | Zh.Group, key: string) => {
             logger.debug(`||| shellyRPC rpcReceive(${key})`, NS);
@@ -610,6 +921,21 @@ const shellyModernExtend = {
         const getShellySwitchMode = async (endpoint: Zh.Endpoint | Zh.Group, id: number): Promise<string | undefined> => {
             const config = await getShellySwitchConfig(endpoint, id);
             return typeof config?.in_mode === "string" ? config.in_mode : undefined;
+        };
+
+        // Maps a per-zone endpoint name ("1".."N") to the device's RPC PresenceZone id. This
+        // numbering counts zones and is unrelated to the occupancy endpoints, which count tracked
+        // people - presence_delay_1 is the first zone, occupancy_1 is the first person.
+        // Discovery caches the real ids in device.meta, but it needs an RPC read, which the
+        // firmware cannot answer over Zigbee (see SHELLY_RPC_CAN_READ). A device leaves the factory
+        // with a single zone, so fall back to the id the main zone carries - that keeps the one
+        // zone every device has configurable.
+        const presenceZoneIdForEndpoint = (device: Zh.Device, endpointName: string): number | undefined => {
+            const index = Number(endpointName) - 1;
+            if (!Number.isInteger(index) || index < 0) return undefined;
+            const ids = device.meta.presence_zone_ids;
+            if (Array.isArray(ids) && typeof ids[index] === "number") return ids[index] as number;
+            return SHELLY_PRESENCE_FIRST_ZONE_ID + index;
         };
 
         // Features for exposes
@@ -965,33 +1291,160 @@ const shellyModernExtend = {
                 }
             });
         }
-        if (featurePresenceZonesAuto) {
+        if (featurePresenceZonesAuto && SHELLY_RPC_CAN_READ) {
             configure.push(async (device) => {
                 const ep = device.getEndpoint(SHELLY_ENDPOINT_ID);
                 if (!ep) return;
                 try {
-                    const response = await rpcRequest(ep, "Shelly.GetConfig");
-                    const result = response?.result ?? response?.params ?? response;
-                    if (!result) return;
-                    assertObject<KeyValue>(result);
+                    // PresenceZones are dynamic components: Shelly.GetConfig never lists them, only
+                    // Shelly.GetComponents does. `dynamic_only` keeps the answer short, but it also
+                    // covers virtual components, so filter for the presencezone prefix. The answer
+                    // is paginated, so keep asking until every announced component has been seen.
+                    const zoneIds: number[] = [];
+                    let offset = 0;
+                    let total = Number.POSITIVE_INFINITY;
+                    for (let page = 0; page < SHELLY_COMPONENT_PAGE_LIMIT && offset < total; page++) {
+                        const result = await rpcRequestWithRetry(ep, "Shelly.GetComponents", {dynamic_only: true, offset});
+                        if (!result) return;
+                        const components = result.components;
+                        if (!Array.isArray(components) || components.length === 0) break;
 
-                    let zoneCount = Object.keys(result).filter((key) => /^presencezone:\d+$/.test(key)).length;
-                    if (zoneCount === 0) {
-                        const presenceConfig = result.presence;
-                        if (presenceConfig) {
-                            assertObject<KeyValue>(presenceConfig);
-                            zoneCount = typeof presenceConfig.main_zone === "string" ? 1 : 0;
+                        for (const component of components) {
+                            const key = (component as KeyValue)?.key;
+                            const match = typeof key === "string" ? /^presencezone:(\d+)$/.exec(key) : null;
+                            if (match) zoneIds.push(Number(match[1]));
                         }
+                        total = typeof result.total === "number" ? result.total : components.length;
+                        offset += components.length;
                     }
+                    if (offset < total) {
+                        logger.warning(`Stopped reading presence components after ${offset} of ${total}; some zones may be missing`, NS);
+                    }
+
+                    zoneIds.sort((a, b) => a - b);
+                    const zoneCount = zoneIds.length;
                     if (zoneCount < 1 || zoneCount > SHELLY_PRESENCE_MAX_ZONES) return;
 
+                    let metaChanged = false;
                     if (device.meta.presence_zone_count !== zoneCount) {
                         device.meta.presence_zone_count = zoneCount;
-                        device.save();
+                        metaChanged = true;
                     }
+                    if (JSON.stringify(device.meta.presence_zone_ids) !== JSON.stringify(zoneIds)) {
+                        device.meta.presence_zone_ids = zoneIds;
+                        metaChanged = true;
+                    }
+                    if (metaChanged) device.save();
                 } catch (e) {
                     logger.warning(`Failed to read presence zones during configure, using last known or default exposed zones: ${e}`, NS);
                 }
+            });
+        }
+        if (featurePresenceZoneConfig) {
+            const presenceZoneKeys = ["presence_delay", "absence_delay"];
+            exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
+                if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
+                return shellyPresenceEndpointNames(device).flatMap((endpointName) => [
+                    e
+                        .numeric("presence_delay", ea.STATE_SET)
+                        .withValueMin(0)
+                        .withValueMax(3600)
+                        .withValueStep(1)
+                        .withUnit("s")
+                        .withLabel("Presence delay")
+                        .withDescription(
+                            "Time presence must be continuously detected before this zone is reported occupied. " +
+                                "The device cannot report this value back over Zigbee, so it shows what was last set",
+                        )
+                        .withCategory("config")
+                        .withEndpoint(endpointName),
+                    e
+                        .numeric("absence_delay", ea.STATE_SET)
+                        .withValueMin(0)
+                        .withValueMax(3600)
+                        .withValueStep(1)
+                        .withUnit("s")
+                        .withLabel("Absence delay")
+                        .withDescription(
+                            "Time without presence before this zone is reported empty. " +
+                                "The device cannot report this value back over Zigbee, so it shows what was last set",
+                        )
+                        .withCategory("config")
+                        .withEndpoint(endpointName),
+                ]);
+            });
+            toZigbee.push({
+                key: presenceZoneKeys,
+                convertSet: async (entity, key, value, meta) => {
+                    utils.assertEndpoint(entity);
+                    utils.assertString(meta.endpoint_name, "endpoint_name");
+                    const zoneId = presenceZoneIdForEndpoint(entity.getDevice(), meta.endpoint_name);
+                    if (zoneId === undefined) throw new Error(`No Shelly presence zone for endpoint ${meta.endpoint_name}`);
+                    const seconds = Math.min(3600, Math.max(0, Math.round(value as number)));
+                    const ep = getRPCEndpoint(entity);
+                    await rpcSendWithRetry(ep, "PresenceZone.SetConfig", {id: zoneId, config: {[SHELLY_PRESENCE_ZONE_FIELDS[key]]: seconds}});
+                    return {state: {[key]: seconds}};
+                },
+            });
+        }
+        if (featurePresenceSensorConfig) {
+            exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
+                if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
+                return SHELLY_PRESENCE_SETTING_GROUPS.map((group) => {
+                    const composite = e.composite(group.key, group.key, ea.STATE_SET).withLabel(group.label).withDescription(group.description);
+                    for (const setting of group.settings) composite.withFeature(setting.expose());
+                    return composite.withCategory("config");
+                });
+            });
+            toZigbee.push({
+                key: SHELLY_PRESENCE_SETTING_GROUPS.map((group) => group.key),
+                convertSet: async (entity, key, value, meta) => {
+                    const group = SHELLY_PRESENCE_SETTING_GROUPS.find((candidate) => candidate.key === key);
+                    if (!group) return;
+                    assertObject<KeyValue>(value);
+
+                    // Only the values actually given travel; the rest of the group stays as it is.
+                    const config: KeyValue = {};
+                    const state: KeyValue = {};
+                    for (const setting of group.settings) {
+                        const given = value[setting.key];
+                        if (given === undefined) continue;
+                        if (setting.key === "sensitivity" && given === SHELLY_PRESENCE_SENSITIVITY_CUSTOM) {
+                            throw new Error(
+                                "Sensitivity 'custom' is reported by the device, not set: adjust the individual detection thresholds instead",
+                            );
+                        }
+                        shellyMergeConfig(config, setting.path, given);
+                        state[setting.key] = given as KeyValue[string];
+                    }
+                    if (Object.keys(state).length === 0) return;
+
+                    utils.assertEndpoint(entity);
+                    await rpcSendWithRetry(getRPCEndpoint(entity), "Presence.SetConfig", {config});
+                    return {state: {[key]: state}};
+                },
+            });
+        }
+        if (featureEcoMode) {
+            exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
+                if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
+                return [
+                    e
+                        .binary("eco_mode", ea.STATE_SET, true, false)
+                        .withLabel("Eco mode")
+                        .withDescription(
+                            "Reduce CPU and radio activity to lower power consumption (may slightly increase response latency). Write-only: the device cannot report this back over Zigbee, so it shows what was last set from here",
+                        )
+                        .withCategory("config"),
+                ];
+            });
+            toZigbee.push({
+                key: ["eco_mode"],
+                convertSet: async (entity, key, value, meta) => {
+                    const ep = getRPCEndpoint(entity);
+                    await rpcSendWithRetry(ep, "Sys.SetConfig", {config: {device: {eco_mode: value === true}}});
+                    return {state: {eco_mode: value === true}};
+                },
             });
         }
         return {exposes, fromZigbee, toZigbee, configure, isModernExtend: true};
@@ -2343,13 +2796,17 @@ export const definitions: DefinitionWithExtend[] = [
         model: "S4SN-0U61X",
         vendor: "Shelly",
         description: "Presence Gen4 Zigbee",
+        // The occupancy endpoints only report once reporting is configured on all ten of them, which
+        // this definition sets up. Devices paired before this version have no such configuration, so
+        // bump the patch version to have the application re-configure them.
+        version: "0.0.1",
         extend: [
             m.deviceEndpoints({endpoints: {"1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9, "10": 10}}),
             shellyModernExtend.shellyPresenceOccupancy(),
             ...shellyModernExtend.shellyLightLevel(),
             m.identify(),
             ...shellyModernExtend.shellyCustomClusters(),
-            shellyModernExtend.shellyRPCSetup(["PresenceZonesAuto"]),
+            shellyModernExtend.shellyRPCSetup(["PresenceZonesAuto", "PresenceZoneConfig", "PresenceSensorConfig", "EcoMode"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
     },

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -8,6 +8,14 @@ const getFeatureNames = (expose: Expose): string[] => {
     return "features" in expose && expose.features ? expose.features.map((feature) => feature.name) : [];
 };
 
+// The Shelly RPC protocol may split a single JSON command across multiple `data` writes.
+// Reassemble every shellyRPCCluster data write into the full command string for assertions.
+const sentRpcData = (endpoint: {write: ReturnType<typeof vi.fn>}): string =>
+    endpoint.write.mock.calls
+        .filter((call) => call[0] === "shellyRPCCluster" && typeof (call[1] as {data?: unknown})?.data === "string")
+        .map((call) => (call[1] as {data: string}).data)
+        .join("");
+
 describe("Shelly 2PM Gen4 cover mode", () => {
     const mockShelly2PMCover = (read?: ReturnType<typeof vi.fn>) =>
         mockDevice({
@@ -136,6 +144,21 @@ describe("Shelly Wi-Fi setup", () => {
             ],
         });
 
+    // Reading the Wi-Fi state through the RPC cluster only gains the untruncated SSID, and the
+    // firmware cannot answer an RPC read over Zigbee at all. Every attempt costs two timeouts
+    // before the setup cluster - which does answer - gets its turn, on every Gen4 device.
+    it("reads the Wi-Fi state through the setup cluster without trying RPC first", async () => {
+        const device = mockShelly2PMCover();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key?.includes("wifi_config")) as Tz.Converter;
+        const publish = vi.fn();
+
+        await converter.convertGet?.(device.getEndpoint(1), "wifi_config", {device, message: {}, publish} as never);
+
+        expect(sentRpcData(device.getEndpoint(239) as never)).toBe("");
+        expect(device.getEndpoint(239).read).toHaveBeenCalledWith("shellyWiFiSetupCluster", expect.any(Array), expect.any(Object));
+    });
+
     it("uses the cached full Shelly Wi-Fi SSID when the setup cluster reports a shortened name", async () => {
         const device = mockShelly2PMCover();
         const definition = await findByDevice(device);
@@ -214,7 +237,10 @@ describe("Shelly Presence Gen4", () => {
             .map((expose) => expose.endpoint);
     };
 
-    it("falls back to all possible zone endpoints until the device config is read", async () => {
+    // The occupancy endpoints are the tracked PEOPLE, not zones - the device reports each detected
+    // person on its own endpoint. They must never depend on a zone count, or a second person is
+    // silently dropped. Shelly's own definition exposes all ten unconditionally.
+    it("exposes an occupancy endpoint for every person the device can track", async () => {
         const device = mockShellyPresence();
         const definition = await findByDevice(device);
 
@@ -222,43 +248,308 @@ describe("Shelly Presence Gen4", () => {
         expect(occupancyEndpoints(definition, device)).toStrictEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
     });
 
-    it("uses the persisted PresenceZone count for occupancy exposes", async () => {
+    it("keeps every occupancy endpoint even when only one zone is known", async () => {
+        const device = mockShellyPresence();
+        device.meta.presence_zone_count = 1;
+        const definition = await findByDevice(device);
+        const exposes = definition.exposes as DefinitionExposesFunction;
+        const names = exposes(device, {}).map((expose) => `${expose.name}_${expose.endpoint}`);
+
+        expect(occupancyEndpoints(definition, device)).toHaveLength(10);
+        // The zone delays follow the zone, not the tracked people.
+        expect(names).toContain("presence_delay_1");
+        expect(names).not.toContain("presence_delay_2");
+    });
+
+    it("exposes presence_delay and absence_delay for each detected zone", async () => {
         const device = mockShellyPresence();
         device.meta.presence_zone_count = 2;
         const definition = await findByDevice(device);
+        const exposes = definition.exposes as DefinitionExposesFunction;
+        const names = exposes(device, {}).map((expose) => `${expose.name}_${expose.endpoint}`);
 
-        expect(occupancyEndpoints(definition, device)).toStrictEqual(["1", "2"]);
+        expect(names).toEqual(expect.arrayContaining(["presence_delay_1", "absence_delay_1", "presence_delay_2", "absence_delay_2"]));
+        expect(names).not.toContain("presence_delay_3");
     });
 
-    it("persists the PresenceZone count from Shelly.GetConfig during configure", async () => {
-        const response = JSON.stringify({
-            id: 1,
-            result: {
-                presence: {main_zone: "presencezone:200"},
-                "presencezone:200": {id: 200, name: "Room"},
-                "presencezone:201": {id: 201, name: "Desk"},
-                "presencezone:202": {id: 202, name: "Door"},
-            },
-        });
-        const read = vi.fn((cluster: string, attributes: string[]) => {
-            if (cluster === "shellyRPCCluster" && attributes.includes("rxCtl")) return Promise.resolve({rxCtl: response.length});
-            if (cluster === "shellyRPCCluster" && attributes.includes("data")) return Promise.resolve({data: response});
-            return Promise.resolve({});
-        });
-        const device = mockShellyPresence(read);
-        const save = vi.spyOn(device, "save").mockImplementation(() => {});
+    it("writes PresenceZone.SetConfig to the mapped zone id when setting a delay", async () => {
+        const device = mockShellyPresence();
+        device.meta.presence_zone_ids = [200, 201, 202];
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("presence_delay")) as Tz.Converter;
+
+        const result = await converter.convertSet?.(device.getEndpoint(2), "presence_delay", 45, {
+            endpoint_name: "2",
+            message: {},
+            state: {},
+            device,
+        } as never);
+
+        const command = sentRpcData(device.getEndpoint(239) as never);
+        expect(command).toContain('"method":"PresenceZone.SetConfig"');
+        expect(command).toContain('"id":201');
+        expect(command).toContain('"presence_thr":45');
+        expect(result).toStrictEqual({state: {presence_delay: 45}});
+    });
+
+    // The firmware cannot answer an RPC read over Zigbee, so nothing configured through the RPC
+    // cluster may offer one. A device query walks every converter that has a convertGet regardless
+    // of the access flags, so the read has to be gone, not just marked unavailable.
+    it("offers no RPC-backed reads at all", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const rpcKeys = ["presence_delay", "absence_delay", "eco_mode", "mounting", "detection", "leds", "tuning"];
+
+        for (const key of rpcKeys) {
+            const converter = definition.toZigbee.find((c) => c.key?.includes(key)) as Tz.Converter;
+            expect(converter, `no converter for ${key}`).toBeDefined();
+            expect(converter.convertGet, `${key} must not be readable`).toBeUndefined();
+        }
+
+        const exposes = definition.exposes as DefinitionExposesFunction;
+        for (const expose of exposes(device, {})) {
+            if (!expose.name || !rpcKeys.includes(expose.name)) continue;
+            // settable and shown, but never fetched from the device
+            expect(expose.access & 0b100, `${expose.name} must not announce GET`).toBe(0);
+            expect(expose.access & 0b010, `${expose.name} must stay settable`).toBe(0b010);
+        }
+    });
+
+    it("does not read the zone back after writing a delay", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("presence_delay")) as Tz.Converter;
+
+        const result = await converter.convertSet?.(device.getEndpoint(1), "presence_delay", 45, {
+            endpoint_name: "1",
+            message: {},
+            state: {},
+            device,
+        } as never);
+
+        const command = sentRpcData(device.getEndpoint(239) as never);
+        expect(command).toContain('"method":"PresenceZone.SetConfig"');
+        expect(command).not.toContain("GetConfig");
+        expect(result).toStrictEqual({state: {presence_delay: 45}});
+    });
+
+    it("does not read the sensor back after writing a group", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("detection")) as Tz.Converter;
+
+        await converter.convertSet?.(device.getEndpoint(1), "detection", {sensitivity: "high"}, {message: {}, state: {}, device} as never);
+
+        const command = sentRpcData(device.getEndpoint(239) as never);
+        expect(command).toContain('"method":"Presence.SetConfig"');
+        expect(command).not.toContain("GetConfig");
+    });
+
+    it("makes no discovery attempt while the firmware cannot answer reads", async () => {
+        const device = mockShellyPresence();
         const definition = await findByDevice(device);
 
         await definition.configure?.(device, mockShellyPresence().getEndpoint(1), definition);
 
-        expect(device.meta.presence_zone_count).toBe(3);
-        expect(save).toHaveBeenCalledTimes(1);
-        expect(device.getEndpoint(239).write).toHaveBeenCalledWith(
-            "shellyRPCCluster",
-            {data: expect.stringContaining("Shelly.GetConfig")},
-            expect.any(Object),
-        );
-        expect(occupancyEndpoints(definition, device)).toStrictEqual(["1", "2", "3"]);
+        expect(sentRpcData(device.getEndpoint(239) as never)).toBe("");
+    });
+
+    // Zone ids can only be learned through an RPC read, and the firmware cannot answer those over
+    // Zigbee. A factory device has exactly one zone, so the main zone id has to carry the write.
+    it("writes to the main zone id when no zone ids could be discovered", async () => {
+        const device = mockShellyPresence();
+        expect(device.meta.presence_zone_ids).toBeUndefined();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("absence_delay")) as Tz.Converter;
+
+        await converter.convertSet?.(device.getEndpoint(1), "absence_delay", 90, {
+            endpoint_name: "1",
+            message: {},
+            state: {},
+            device,
+        } as never);
+
+        const command = sentRpcData(device.getEndpoint(239) as never);
+        expect(command).toContain('"method":"PresenceZone.SetConfig"');
+        expect(command).toContain('"id":200');
+        expect(command).toContain('"absence_thr":90');
+    });
+
+    it("clamps out-of-range delays to the 0-3600 second bounds", async () => {
+        const device = mockShellyPresence();
+        device.meta.presence_zone_ids = [200];
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("absence_delay")) as Tz.Converter;
+
+        await converter.convertSet?.(device.getEndpoint(1), "absence_delay", 99999, {endpoint_name: "1", message: {}, state: {}, device} as never);
+
+        expect(sentRpcData(device.getEndpoint(239) as never)).toContain('"absence_thr":3600');
+    });
+
+    // A group travels in ONE command, and only the values actually given are sent.
+    it("writes a whole group in a single Presence.SetConfig and sends only what was given", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("detection")) as Tz.Converter;
+
+        const result = await converter.convertSet?.(device.getEndpoint(1), "detection", {sensitivity: "high", tracked_objects: 4}, {
+            message: {},
+            state: {},
+            device,
+        } as never);
+
+        const command = sentRpcData(device.getEndpoint(239) as never);
+        expect(command.split('"method":"Presence.SetConfig"').length - 1).toBe(1);
+        expect(command).toContain('"sensitivity":"high"');
+        expect(command).toContain('"num_tracks":4');
+        expect(command).not.toContain("zmin");
+        expect(result).toStrictEqual({state: {detection: {sensitivity: "high", tracked_objects: 4}}});
+    });
+
+    // The settings are grouped so a consuming integration shows folders instead of two dozen
+    // values side by side; the ranges are the ones the device enforces itself.
+    it("groups the sensor settings and keeps the device's own ranges", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const exposes = definition.exposes as DefinitionExposesFunction;
+        const groups = new Map(exposes(device, {}).map((expose) => [expose.name, expose]));
+        const featureOf = (group: string, name: string) => (groups.get(group) as {features?: Expose[]})?.features?.find((f) => f.name === name);
+
+        expect([...groups.keys()]).toEqual(expect.arrayContaining(["mounting", "detection", "leds", "tuning"]));
+        expect(featureOf("mounting", "installation_height")).toMatchObject({value_min: 0, value_max: 5, unit: "m"});
+        expect(featureOf("mounting", "sensor_position")).toMatchObject({values: ["center", "left", "right"]});
+        expect(featureOf("detection", "maximum_range")).toMatchObject({value_min: 0, value_max: 5, unit: "m"});
+        expect(featureOf("detection", "tracked_objects")).toMatchObject({value_min: 1, value_max: 10});
+        expect(featureOf("detection", "radar_power")).toMatchObject({values: ["low", "medium", "high"]});
+        expect(featureOf("leds", "brightness")).toMatchObject({value_min: 0, value_max: 100, unit: "%"});
+        expect(featureOf("leds", "night_mode")).toMatchObject({type: "binary"});
+        expect(featureOf("tuning", "detection_points")).toMatchObject({value_min: 10, value_max: 100});
+        expect(featureOf("tuning", "velocity_threshold")).toMatchObject({value_min: 0, value_max: 1});
+        expect(featureOf("tuning", "snr_threshold")).toMatchObject({value_min: 10, value_max: 100});
+        expect(featureOf("tuning", "maximum_velocity_difference")).toMatchObject({value_min: 1, value_max: 50});
+        expect(featureOf("tuning", "motion_activation_threshold")).toMatchObject({value_min: 1, value_max: 100});
+        expect(featureOf("tuning", "tracking_loss_threshold")).toMatchObject({value_min: 1, value_max: 1000});
+        expect(featureOf("tuning", "stillness_timeout_threshold")).toMatchObject({value_min: 1, value_max: 65535});
+    });
+
+    it("merges several deeply nested thresholds into one nested config", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("tuning")) as Tz.Converter;
+
+        await converter.convertSet?.(device.getEndpoint(1), "tuning", {stillness_timeout_threshold: 900, motion_activation_threshold: 2}, {
+            message: {},
+            state: {},
+            device,
+        } as never);
+
+        expect(sentRpcData(device.getEndpoint(239) as never)).toContain('"state":{"det_act_thr":2,"sleep_free_thr":900}');
+    });
+
+    // The device reports 'custom' once the fine-tuning values deviate from a preset, but only
+    // accepts the three presets on write. Listing it keeps the reported state a valid value.
+    it("lists the reported custom sensitivity but refuses to write it", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const exposes = definition.exposes as DefinitionExposesFunction;
+        const detection = exposes(device, {}).find((expose) => expose.name === "detection") as {features?: Expose[]};
+        const converter = definition.toZigbee.find((c) => c.key.includes("detection")) as Tz.Converter;
+
+        expect(detection.features?.find((f) => f.name === "sensitivity")).toMatchObject({
+            values: ["low", "medium", "high", "custom"],
+        });
+        await expect(
+            converter.convertSet?.(device.getEndpoint(1), "detection", {sensitivity: "custom"}, {message: {}, state: {}, device} as never),
+        ).rejects.toThrow(/custom/i);
+    });
+
+    // Discovered ids stay authoritative where they exist; the main-zone fallback only fills the gap.
+    it("prefers a discovered zone id over the main zone fallback", async () => {
+        const device = mockShellyPresence();
+        device.meta.presence_zone_ids = [207];
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("presence_delay")) as Tz.Converter;
+
+        await converter.convertSet?.(device.getEndpoint(1), "presence_delay", 10, {
+            endpoint_name: "1",
+            message: {},
+            state: {},
+            device,
+        } as never);
+
+        expect(sentRpcData(device.getEndpoint(239) as never)).toContain('"id":207');
+    });
+
+    it("exposes an eco_mode switch", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const exposes = definition.exposes as DefinitionExposesFunction;
+        const names = exposes(device, {}).map((expose) => expose.name);
+        expect(names).toContain("eco_mode");
+    });
+
+    it("writes Sys.SetConfig when eco_mode is set", async () => {
+        const device = mockShellyPresence();
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key.includes("eco_mode")) as Tz.Converter;
+
+        const result = await converter.convertSet?.(device.getEndpoint(239), "eco_mode", true, {message: {}, state: {}, device} as never);
+
+        const command = sentRpcData(device.getEndpoint(239) as never);
+        expect(command).toContain('"method":"Sys.SetConfig"');
+        expect(command).toContain('"eco_mode":true');
+        expect(result).toStrictEqual({state: {eco_mode: true}});
+    });
+
+    // Reporting has to reach every tracked-person endpoint. Configuring only the first one is what
+    // the device did before, and it makes a second person arrive nowhere.
+    it("configures occupancy reporting on every tracked-person endpoint", async () => {
+        const device = mockShellyPresence();
+        const coordinator = mockShellyPresence().getEndpoint(1);
+        const definition = await findByDevice(device);
+
+        await definition.configure?.(device, coordinator, definition);
+
+        for (const endpointName of ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]) {
+            expect(device.getEndpoint(Number(endpointName)).configureReporting).toHaveBeenCalledWith("msOccupancySensing", expect.anything());
+        }
+    });
+
+    // A sleeping or unreachable endpoint makes the coordinator report a delivery failure. That must
+    // not abort configure, or one bad endpoint costs the device its whole occupancy reporting.
+    it("keeps configuring the remaining endpoints when one of them fails", async () => {
+        const device = mockShellyPresence();
+        const coordinator = mockShellyPresence().getEndpoint(1);
+        const definition = await findByDevice(device);
+        vi.mocked(device.getEndpoint(3).configureReporting).mockRejectedValueOnce(new Error("Delivery failed for '6137'"));
+
+        await definition.configure?.(device, coordinator, definition);
+
+        expect(device.getEndpoint(10).configureReporting).toHaveBeenCalledWith("msOccupancySensing", expect.anything());
+    });
+
+    it("retries a delay write when the first RPC send fails", async () => {
+        const device = mockShellyPresence();
+        device.meta.presence_zone_ids = [200];
+        const definition = await findByDevice(device);
+        const ep = device.getEndpoint(239) as unknown as {write: ReturnType<typeof vi.fn>};
+        let attempts = 0;
+        ep.write = vi.fn(() => {
+            attempts++;
+            if (attempts === 1) return Promise.reject(new Error("Send command failed: timed out"));
+            return Promise.resolve({});
+        });
+        const converter = definition.toZigbee.find((c) => c.key.includes("presence_delay")) as Tz.Converter;
+
+        const result = await converter.convertSet?.(device.getEndpoint(1), "presence_delay", 30, {
+            endpoint_name: "1",
+            message: {},
+            state: {},
+            device,
+        } as never);
+
+        expect(attempts).toBeGreaterThan(1);
+        expect(result).toStrictEqual({state: {presence_delay: 30}});
     });
 });
 


### PR DESCRIPTION
> Builds on #12732 and contains its commit, because the configuration here depends on the `SHELLY_RPC_CAN_READ` flag introduced there. Once #12732 is merged this PR reduces to its own second commit. Reviewing the second commit alone is enough.

The Shelly Presence Gen4 arrived with occupancy, light level and zone discovery. Everything that decides how it actually detects — mounting, range, sensitivity and the fine-tuning behind it — was reachable only through the Shelly app. And the little configuration that was exposed did not work.

### The per-zone thresholds were written under names the device does not have

A zone reports `presence_thr` and `absence_thr`. The API documentation calls them `presence_delay` and `absence_delay`, and that is what the converter sent. `PresenceZone.SetConfig` discards a key it does not know **and still answers with success**, so every write was silently dropped — nothing in the logs pointed at it.

The exposes keep the documented names, which say what the value means; the wire uses what the zone actually carries.

### Everything configured here can be written, never read

This is the central limitation of the device and it deserves to be stated plainly rather than discovered.

The sensor accepts a setting and applies it, but it cannot report any of them back over Zigbee (#12732). So a configuration value shown by an integration is **the value last written from there** — not a reading off the device. Change something in the Shelly app and nothing here notices. On a device that has never been written to from Zigbee, these values are simply unset.

Because a configuration field that quietly means something other than what the user assumes is worse than no field at all, **every one of these exposes says so in its own description**, and the same sentence appears on the per-zone delays and on eco mode.

Two consequences follow:

- **The reads are removed, not just marked unavailable.** For the configuration converters there is no `convertGet` at all. Access flags alone would not do: a consuming integration walks every converter that *has* a `convertGet` and calls it regardless of the flags, so a converter that merely declares itself unreadable still pays a full timeout per key and per endpoint.
- **Zone ids come only from an RPC read**, so discovery cannot run. A device leaves the factory with a single zone and the delays now address it by its main zone id; discovered ids still take precedence where they exist. For the same reason a device with no known count exposes the main zone instead of all ten — otherwise nine zones that never report are created and vanish again once a count is known.

### What is exposed now

`Presence.SetConfig` takes one nested config object, so instead of a converter per setting each one is described by its path inside that object and handled by a single shared converter:

- **Mounting** — installation height, sensor position, flipped
- **Detection** — sensitivity, radar power, minimum and maximum range, tracked objects
- **LEDs** — brightness, night mode and its brightness
- **Fine-tuning** — detection points, velocity, SNR, maximum velocity difference and the five state thresholds

Every range and value list is the one the device enforces itself, read off its own rejection messages rather than taken from the documentation.

`sensitivity` needs care: the device accepts only `low`, `medium` and `high`, but reports `custom` as soon as the fine-tuning values differ from a preset. The enum lists `custom` so the reported state stays a value it knows, and writing it is refused with a message pointing at the individual thresholds.

### Occupancy is per tracked person, not per zone

The occupancy endpoints are the people the sensor tracks, one endpoint each. Reporting was not configured at all before, so occupancy only ever answered a read; it is now set up on all ten endpoints, and presence arrives on its own. One endpoint failing no longer aborts the rest, so an unreachable endpoint costs its own reporting rather than everyone's.

The two numberings are independent: `presence_delay_1` addresses the first zone, `occupancy_1` the first tracked person.

### Testing

- Full suite green. The write-only property is covered directly: one test walks every configuration key and asserts that none of their converters has a `convertGet` and none of their exposes announces GET; others assert that a write sends no `GetConfig` afterwards and that configure makes no RPC attempt at all while the firmware cannot answer.
- Payload shapes verified against the hardware over its HTTP RPC, which carries the same calls: the real converter builds each command, the leaf value is replaced with an invalid one, and the device must reject it naming the exact field path. All configuration fields confirmed this way without writing anything.
- Writes verified end to end over Zigbee on a Presence Gen4 (firmware 2.0.0-beta3): zone threshold, top-level and `sensor.state` paths all reach the device, and a partial write leaves its sibling fields untouched. Each value was restored afterwards and the restore verified against a snapshot taken beforehand.
- Confirmed in daily use on that device by its owner: detection and the configured delays behave as expected.
