### PR TITLE
Shelly Gen4: stop offering settings the device cannot report

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -623,14 +623,19 @@ const shellyModernExtend = {
             e.text("rpc_rxctl", ea.STATE_GET).withLabel("RxCtl").withDescription("RX bytes available").withCategory("diagnostic"),
             e.text("rpc_data", ea.STATE_GET).withLabel("Data").withDescription("RX Data").withCategory("diagnostic"),
         ];
+        // The device applies these but cannot report any of them back over Zigbee, so what a value
+        // shows is what was last written from here - never a reading off the device. Say so on every
+        // one of them: a configuration field that quietly means something else than the user assumes
+        // is worse than no field at all.
+        const WRITE_ONLY = "The device cannot report this back over Zigbee, so it shows what was last set from here";
         const exposesPowerstripUI: Expose[] = [
             e
                 .enum("led_mode", ea.STATE_SET, ["off", "switch", "power"])
                 .withLabel("LED Mode")
-                .withDescription("Controls the behaviour of the LED rings around the sockets")
+                .withDescription(`Controls the behaviour of the LED rings around the sockets. ${WRITE_ONLY}`)
                 .withCategory("config"),
             e
-                .composite("led_colors", "led_colors", ea.ALL)
+                .composite("led_colors", "led_colors", ea.STATE_SET)
                 .withFeature(featurePercentage("on_r", "Red (on)"))
                 .withFeature(featurePercentage("on_g", "Green (on)"))
                 .withFeature(featurePercentage("on_b", "Blue (on)"))
@@ -640,24 +645,28 @@ const shellyModernExtend = {
                 .withFeature(featurePercentage("off_b", "Blue (off)"))
                 .withFeature(featurePercentage("off_brightness", "Brightness (off)"))
                 .withLabel("LED colors in 'switch' mode")
+                .withDescription(`Colors of the LED rings while the LED mode is 'switch'. ${WRITE_ONLY}`)
                 .withCategory("config"),
-            featurePercentage("led_power_brightness", "LED brightness in 'power' mode").withCategory("config"),
+            featurePercentage("led_power_brightness", "LED brightness in 'power' mode")
+                .withDescription(`Brightness of the LED rings while the LED mode is 'power'. ${WRITE_ONLY}`)
+                .withCategory("config"),
             e
-                .composite("led_night_mode", "led_night_mode", ea.ALL)
+                .composite("led_night_mode", "led_night_mode", ea.STATE_SET)
                 .withFeature(e.binary("enable", ea.STATE_SET, true, false))
                 .withFeature(featurePercentage("brightness", "Brightness"))
                 .withFeature(e.text("from", ea.STATE_SET).withLabel("Active from").withDescription("hh:mm"))
                 .withFeature(e.text("until", ea.STATE_SET).withLabel("Active until").withDescription("hh:mm"))
                 .withLabel("LED night mode")
-                .withDescription("Adjust LED brightness during night time")
+                .withDescription(`Adjust LED brightness during night time. ${WRITE_ONLY}`)
                 .withCategory("config"),
             e
-                .composite("buttons_enabled", "buttons_enabled", ea.ALL)
+                .composite("buttons_enabled", "buttons_enabled", ea.STATE_SET)
                 .withFeature(featureButtonEnabled(0))
                 .withFeature(featureButtonEnabled(1))
                 .withFeature(featureButtonEnabled(2))
                 .withFeature(featureButtonEnabled(3))
                 .withLabel("Buttons enabled")
+                .withDescription(`Whether each socket button switches its own socket or is detached. ${WRITE_ONLY}`)
                 .withCategory("config"),
         ];
 
@@ -1624,9 +1633,12 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
-        exposes: [
+        // The switch input endpoint only exists when an input is actually wired. Without it the
+        // setting has nothing to address, and a state that can never hold a value is worse than
+        // none - so expose it the same way the 2PM already does, conditional on the endpoint.
+        exposes: (device) => [
             e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_single", "input_1_double", "input_1_triple", "input_1_hold"]),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
+            ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
             m.deviceEndpoints({endpoints: {sw1: 2}}),
@@ -1652,9 +1664,12 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
-        exposes: [
+        // The switch input endpoint only exists when an input is actually wired. Without it the
+        // setting has nothing to address, and a state that can never hold a value is worse than
+        // none - so expose it the same way the 2PM already does, conditional on the endpoint.
+        exposes: (device) => [
             e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_single", "input_1_double", "input_1_triple", "input_1_hold"]),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
+            ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
             m.deviceEndpoints({endpoints: {sw1: 2}}),
@@ -1680,9 +1695,12 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
-        exposes: [
+        // The switch input endpoint only exists when an input is actually wired. Without it the
+        // setting has nothing to address, and a state that can never hold a value is worse than
+        // none - so expose it the same way the 2PM already does, conditional on the endpoint.
+        exposes: (device) => [
             e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_single", "input_1_double", "input_1_triple", "input_1_hold"]),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
+            ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
             m.deviceEndpoints({endpoints: {sw1: 2}}),
@@ -1710,9 +1728,12 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
-        exposes: [
+        // The switch input endpoint only exists when an input is actually wired. Without it the
+        // setting has nothing to address, and a state that can never hold a value is worse than
+        // none - so expose it the same way the 2PM already does, conditional on the endpoint.
+        exposes: (device) => [
             e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_single", "input_1_double", "input_1_triple", "input_1_hold"]),
-            e.enum("switch_type", ea.ALL, ["toggle", "momentary"]).withDescription("Switch input type").withCategory("config").withEndpoint("sw1"),
+            ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
             m.deviceEndpoints({endpoints: {sw1: 2}}),

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -521,3 +521,76 @@ describe("Shelly Presence Gen4", () => {
         expect(occupancyEndpoints(definition, device)).toStrictEqual(["1", "2", "3"]);
     });
 });
+
+// Endpoint layouts below are the ones real devices report (read off a live installation), not
+// invented ones - the whole point of these tests is what happens when hardware differs.
+describe("Shelly Gen4 settings the device cannot report", () => {
+    const exposesOf = async (device: ReturnType<typeof mockDevice>) => {
+        const definition = await findByDevice(device);
+        return typeof definition.exposes === "function" ? (definition.exposes as DefinitionExposesFunction)(device, {}) : definition.exposes;
+    };
+
+    const mockPowerStrip = () =>
+        mockDevice({
+            modelID: "Power Strip",
+            manufacturerName: "Shelly",
+            endpoints: [
+                ...Array.from({length: 4}, (_, index) => ({ID: index + 1, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: []})),
+                {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: []},
+            ],
+        });
+
+    // The RPC cluster cannot answer a read, so none of these has a convertGet at all. Announcing
+    // GET offers the user a refresh that can never do anything - not even once the firmware is fixed.
+    it("does not announce a read for power strip settings that have no read converter", async () => {
+        const device = mockPowerStrip();
+        const definition = await findByDevice(device);
+        const exposes = await exposesOf(device);
+
+        for (const name of ["led_colors", "led_night_mode", "buttons_enabled"]) {
+            const expose = exposes.find((e) => e.name === name);
+            expect(expose, `${name} is missing`).toBeDefined();
+            expect(definition.toZigbee.find((c) => c.key?.includes(name))?.convertGet, `${name} unexpectedly has a convertGet`).toBeUndefined();
+            expect(expose.access & 0b100, `${name} must not announce GET`).toBe(0);
+        }
+    });
+
+    // A configuration value that silently means something else than the user assumes is worse than
+    // none at all: what is shown is the last value written from here, never a reading.
+    it("tells the user that power strip settings cannot be read back", async () => {
+        const exposes = await exposesOf(mockPowerStrip());
+
+        for (const name of ["led_mode", "led_colors", "led_power_brightness", "led_night_mode", "buttons_enabled"]) {
+            const expose = exposes.find((e) => e.name === name);
+            expect(expose, `${name} is missing`).toBeDefined();
+            expect(expose.description ?? "", `${name} does not mention that it cannot be read back`).toContain("cannot report");
+        }
+    });
+
+    const mockOnePM = (withSwitchInput: boolean) =>
+        mockDevice({
+            modelID: "Mini1PM",
+            manufacturerName: "Shelly",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: [25]},
+                ...(withSwitchInput ? [{ID: 2, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]}] : []),
+                {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: []},
+            ],
+        });
+
+    // A 1PM Mini only reports the switch input endpoint when an input is actually wired. Without it
+    // the setting has nothing to address, and a state that can never hold a value is worse than none.
+    it("exposes no switch_type on a 1PM Mini that has no switch input endpoint", async () => {
+        const names = (await exposesOf(mockOnePM(false))).map((e) => e.name);
+
+        expect(names).not.toContain("switch_type");
+    });
+
+    it("exposes switch_type on a 1PM Mini that has a switch input endpoint", async () => {
+        const exposes = await exposesOf(mockOnePM(true));
+        const switchType = exposes.find((e) => e.name === "switch_type");
+
+        expect(switchType).toBeDefined();
+        expect(switchType.endpoint).toBe("sw1");
+    });
+});


### PR DESCRIPTION
Two Gen4 devices show configuration that can never hold a value, in different ways.

### Power strip: settings that announce a read nobody can serve

The LED and button settings go out through the RPC cluster, which cannot answer a read over Zigbee ([#12732](https://github.com/Koenkk/zigbee-herdsman-converters/pull/12732), [#10276](https://github.com/Koenkk/zigbee-herdsman-converters/pull/10276)). Three of them were declared `ea.ALL` and so offered a refresh — but none of these converters has a `convertGet` at all, and none would gain one if the firmware were fixed, because there is nothing to re-enable. They are settable now, not readable.

The author of the original power strip PR ([#10659](https://github.com/Koenkk/zigbee-herdsman-converters/pull/10659)) put it plainly at the time: *"It won't return anything useful on read, so this pull request only implements writes."* The access flags did not follow.

### And none of them said what that means for the value on display

What a configuration value shows is **the value last written from here** — never a reading off the device. Change something in the Shelly app and nothing here notices. On a device that has never been written to from Zigbee, these values are simply unset.

Every one of them now says so in its own description, because a configuration field that quietly means something other than what the user assumes is worse than no field at all. `led_colors` and `buttons_enabled` also got the description they were missing entirely — until now the first showed up under the bare key `led_colors`.

### Single-channel Gen4: a switch input that is not there

`S4SW-001X8EU`, `S4SW-001X16EU`, `S4SW-001P8EU` and `S4SW-001P16EU` exposed `switch_type` unconditionally. The switch input endpoint, however, only exists when an input is actually wired: on a device without one, `configure` finds no endpoint, skips the bind and the read, and the state stays empty forever.

It is now exposed the way the 2PM already does it — through `shellySwitchInputExposes`, which filters on the endpoints the device actually reports. Devices with a wired input are unaffected.

### Testing

Full suite green. The new tests use the endpoint layouts real devices report rather than invented ones, since that is exactly what the change turns on: a power strip on `[1,2,3,4,239,242]`, and a 1PM Mini both with and without its input endpoint. They assert that the three settings announce no GET and have no `convertGet`, that every power strip setting says it cannot be read back, and that `switch_type` appears only when the endpoint exists.
