### PR TITLE
Shelly 2PM Gen4: switch input mode is mapped to the wrong endpoints in switch mode

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -561,7 +561,14 @@ const shellyModernExtend = {
         const featureDev = features.includes("Dev");
         const featurePowerstripUI = features.includes("PowerstripUI");
         const featurePowerstripPowerOnBehavior = features.includes("PowerstripPowerOnBehavior");
-        const featureTwoPMInputMode = features.includes("2PMInputMode");
+        // The two 2PM variants put their switch inputs on different endpoints: the cover on 2 and 3,
+        // the switch-mode device on 3 and 4, because there 1 and 2 are its two relays. A single
+        // shared mapping cannot serve both - it would read the second relay as the first input.
+        const twoPMInputEndpoints = features.includes("2PMCoverInputMode")
+            ? {sw1: 2, sw2: 3}
+            : features.includes("2PMSwitchInputMode")
+              ? {sw1: 3, sw2: 4}
+              : undefined;
         const featureOnePMInputMode = features.includes("1PMInputMode");
         const featureCoverTiltAuto = features.includes("CoverTiltAuto");
         const featurePresenceZonesAuto = features.includes("PresenceZonesAuto");
@@ -874,11 +881,11 @@ const shellyModernExtend = {
                 },
             });
         }
-        if (featureTwoPMInputMode) {
+        if (twoPMInputEndpoints) {
             const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
             exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
                 if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
-                return Object.keys(shellySwitchInputEndpoints(device, {sw1: 2, sw2: 3})).map((endpoint) =>
+                return Object.keys(shellySwitchInputEndpoints(device, twoPMInputEndpoints)).map((endpoint) =>
                     e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint(endpoint),
                 );
             });
@@ -1851,7 +1858,7 @@ export const definitions: DefinitionWithExtend[] = [
             shellyDeviceEndpoints({sw1: 2, sw2: 3}),
             shellyModernExtend.shellyWindowCovering(),
             ...shellyModernExtend.shellyCustomClusters(),
-            shellyModernExtend.shellyRPCSetup(["2PMInputMode", "CoverTiltAuto"]),
+            shellyModernExtend.shellyRPCSetup(["2PMCoverInputMode", "CoverTiltAuto"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
         configure: async (device, coordinatorEndpoint) => {
@@ -1924,7 +1931,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.electricityMeter({producedEnergy: true, acFrequency: true, endpointNames: ["l1", "l2"]}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
             ...shellyModernExtend.shellyCustomClusters(),
-            shellyModernExtend.shellyRPCSetup(["2PMInputMode"]),
+            shellyModernExtend.shellyRPCSetup(["2PMSwitchInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
         ],
         configure: async (device, coordinatorEndpoint) => {

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -334,3 +334,88 @@ describe("Shelly Gen4 settings the device cannot report", () => {
         expect(switchType.endpoint).toBe("sw1");
     });
 });
+
+// The two 2PM variants place their switch inputs on different endpoints: the cover has them on 2
+// and 3, the switch-mode device on 3 and 4, because 1 and 2 are its two relays. Endpoint layouts
+// below are taken from the definitions' own fingerprints.
+describe("Shelly 2PM Gen4 switch input endpoints", () => {
+    const RPC_ENDPOINTS = [
+        {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: []},
+        {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
+    ];
+
+    // Two relays, no switch inputs wired - the layout a switch-mode 2PM reports on its own.
+    const mockSwitchWithoutInputs = () =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: []},
+                {ID: 2, profileID: 260, deviceID: 266, inputClusterIDs: [4, 5, 6, 2820, 1794], outputClusterIDs: []},
+                ...RPC_ENDPOINTS,
+            ],
+        });
+
+    const mockSwitchWithInputs = () =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: [25]},
+                {ID: 2, profileID: 260, deviceID: 266, inputClusterIDs: [4, 5, 6, 2820, 1794], outputClusterIDs: []},
+                {ID: 3, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 4, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 5, inputClusterIDs: [], outputClusterIDs: [3, 4, 6, 8, 258]},
+                ...RPC_ENDPOINTS,
+            ],
+        });
+
+    const mockCoverWithInputs = () =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 514, inputClusterIDs: [0, 3, 4, 5, 258], outputClusterIDs: [25]},
+                {ID: 2, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 3, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 4, inputClusterIDs: [], outputClusterIDs: [3, 4, 6, 8, 258]},
+                ...RPC_ENDPOINTS,
+            ],
+        });
+
+    const exposeNames = async (device: ReturnType<typeof mockDevice>) => {
+        const definition = await findByDevice(device);
+        const exposes = typeof definition.exposes === "function" ? (definition.exposes as DefinitionExposesFunction)(device, {}) : definition.exposes;
+        return {model: definition.model, names: exposes.map((e) => `${e.name}${e.endpoint ? `_${e.endpoint}` : ""}`)};
+    };
+
+    // Endpoints 1 and 2 are the relays here. Reading them as switch inputs invents an input the
+    // device does not have.
+    it("offers no switch input mode on a switch-mode 2PM whose inputs are not wired", async () => {
+        const {model, names} = await exposeNames(mockSwitchWithoutInputs());
+
+        expect(model).toBe("S4SW-002P16EU-SWITCH");
+        expect(names.filter((name) => name.startsWith("switch_mode"))).toStrictEqual([]);
+    });
+
+    // Guard, not proof: with both inputs wired the two mappings happen to produce the same endpoint
+    // names even while pointing at different endpoints. It only keeps the wired case from breaking
+    // while the unwired one above is fixed.
+    it("keeps both switch inputs exposed on a switch-mode 2PM that has them wired", async () => {
+        const {model, names} = await exposeNames(mockSwitchWithInputs());
+
+        expect(model).toBe("S4SW-002P16EU-SWITCH");
+        expect(names).toContain("switch_type_sw1");
+        expect(names).toContain("switch_type_sw2");
+        expect(names).toContain("switch_mode_sw1");
+        expect(names).toContain("switch_mode_sw2");
+    });
+
+    it("keeps the cover-mode 2PM on its own input endpoints", async () => {
+        const {model, names} = await exposeNames(mockCoverWithInputs());
+
+        expect(model).toBe("S4SW-002P16EU-COVER");
+        expect(names).toContain("switch_mode_sw1");
+        expect(names).toContain("switch_mode_sw2");
+    });
+});


### PR DESCRIPTION
The two 2PM Gen4 variants place their switch inputs on different endpoints. The cover has them on 2 and 3; the switch-mode device on 3 and 4, because there endpoints 1 and 2 are its two relays.

Each definition already says exactly that, and `switch_type` follows it:

| | endpoint map | `switch_type` |
|---|---|---|
| `S4SW-002P16EU-COVER` | `{sw1: 2, sw2: 3}` | `shellySwitchInputExposes(device, {sw1: 2, sw2: 3})` |
| `S4SW-002P16EU-SWITCH` | `{l1: 1, l2: 2, sw1: 3, sw2: 4}` | `shellySwitchInputExposes(device, {sw1: 3, sw2: 4})` |

The switch input **mode** did not follow it. It sits in the shared `shellyRPCSetup` block, which had the cover's mapping hardcoded as `{sw1: 2, sw2: 3}` and applied it to both variants. On a switch-mode device that reads **endpoint 2 — the second relay — as the first switch input**.

### What it looks like on a device

On a switch-mode 2PM with no inputs wired, the device reports only `[1, 2, 239, 242]`. Endpoints 3 and 4 do not exist, so `switch_type` correctly stays away — while `switch_mode` appeared anyway, offered for an input the device does not have. Observed on such a device.

With both inputs wired the two settings end up describing the same physical input under names that point at different endpoints: `switch_type_sw1` addresses endpoint 3, `switch_mode_sw1` endpoint 2.

### The change

The mapping now comes from the variant instead of being shared, so each device uses the endpoints its own definition already declares. `2PMInputMode` becomes `2PMCoverInputMode` and `2PMSwitchInputMode`; both names are used once each, and the cover's behaviour is unchanged.

### Testing

Full suite green. The new tests build their devices from the endpoint layouts in the definitions' own fingerprints, and cover all three cases: a switch-mode 2PM without wired inputs offers no `switch_mode` at all, one with wired inputs keeps both, and the cover keeps its own endpoints. The existing cover test that reads `switch_mode_sw2` off endpoint 3 continues to pass unchanged.
