### PR TITLE
fix: improve infrared emitter description

### DIFF
--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -694,5 +694,9 @@ export const presetsZosung = {
             .withDescription("The IR timings learned by device")
             .withHomeAssistant({type: "infrared", schema: "receiver"}),
     ir_code_to_send: () => e.text("ir_code_to_send", ea.SET).withDescription("The IR code or timings to send by device"),
-    ir_emitter: () => e.text("ir_emitter", ea.SET).withDescription("IR emitter feature").withHomeAssistant({type: "infrared", schema: "emitter"}),
+    ir_emitter: () =>
+        e
+            .text("ir_emitter", ea.SET)
+            .withDescription("The IR code or timings to send by device")
+            .withHomeAssistant({type: "infrared", schema: "emitter"}),
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
A description update for `ir_emitter` was missed in #12708

When publishing the value should reset, like it does for an `action`, I assume we should fix this in `Zigbee2MQTT`.