### PR TITLE
feat(detect): Detect `_TZE284_aoah6bv8` as Tuya TS0601_smoke_co (Moes JKD-513COM-Z)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11100,10 +11100,11 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6ycgarab"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6ycgarab", "_TZE284_aoah6bv8"]),
         model: "TS0601_smoke_co",
         vendor: "Tuya",
         description: "Dual smoke CO sensor",
+        whiteLabel: [tuya.whitelabel("Moes", "JKD-513COM-Z", "Dual smoke & CO alarm", ["_TZE284_aoah6bv8"])],
         exposes: [
             e.smoke(),
             e


### PR DESCRIPTION
`TS0601` / `_TZE284_aoah6bv8` is a Moes JKD-513COM-Z 2-in-1 smoke + CO alarm. It is the same hardware as the already-supported `_TZE284_6ycgarab`, sold under the Moes brand.

Reported in Koenkk/zigbee2mqtt#32242, where two independent users saw the device pair correctly but never report any state. Both were using a hand-written external converter that omits the `queryOnDeviceAnnounce` / `forceTimeUpdates` block — one of them concluded the unit was defective and returned it. The existing `TS0601_smoke_co` definition already has that block, so reusing it fixes the reports.

Verified on my own device (Z2M 2.12.1, zigbee-herdsman-converters 26.76.0) by running the existing definition as an external converter with only the fingerprint changed:

```
{"carbon_monoxide":false,"smoke":false,"smoke_state":"none"}
```

`smoke` (DP 1), `smoke_state` and `carbon_monoxide` (DP 18) report correctly after a device announce. `battery` (DP 15) arrives a few hours after pairing, as reported by others for `_TZE284_6ycgarab`.

Datapoints match the existing definition exactly — no new DP, no behaviour change for `_TZE284_6ycgarab`. Added a white label so the device shows under its retail name.

### Device signature

```json
{"modelID":"TS0601","manufacturerName":"_TZE284_aoah6bv8","manufacturerID":4417,"powerSource":"Battery","type":"EndDevice","endpoints":{"1":{"profileID":260,"deviceID":81,"inputClusters":[4,5,61184,0,60672],"outputClusters":[25,10]}},"appVersion":80,"zclVersion":3}
```