### PR TITLE
fix: Shelly Gen4: harden switch and button input handling

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1915,6 +1915,7 @@ const fzLocal = {
         cluster: "genOnOff",
         type: ["commandToggle"],
         convert: (model, msg, publish, options, meta) => {
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
             const event = utils.getFromLookup(msg.endpoint.ID, {1: "single", 2: "double", 3: "triple"});
             return {action: event};
         },
@@ -1924,6 +1925,7 @@ const fzLocal = {
         cluster: "genScenes",
         type: ["commandRecall"],
         convert: (model, msg, publish, options, meta) => {
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
             const event = utils.getFromLookup(`${msg.endpoint.ID}`, {"1": "single_long", "2": "double_long", "3": "triple_long"});
             return {action: event};
         },
@@ -1933,6 +1935,7 @@ const fzLocal = {
         cluster: "genOnOff",
         type: ["commandOn", "commandOff", "commandToggle"],
         convert: (model, msg, publish, options, meta) => {
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
             const event = utils.getFromLookup(`${msg.endpoint.ID}_${msg.type}`, {
                 "1_commandOn": "1_single",
                 "1_commandOff": "2_single",
@@ -1951,6 +1954,7 @@ const fzLocal = {
         cluster: "genLevelCtrl",
         type: ["commandStep"],
         convert: (model, msg, publish, options, meta) => {
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
             const event = utils.getFromLookup(`${msg.endpoint.ID}_${msg.data.stepmode}`, {
                 "1_0": "1_hold",
                 "1_1": "2_hold",
@@ -1965,6 +1969,7 @@ const fzLocal = {
         cluster: "genScenes",
         type: ["commandRecall"],
         convert: (model, msg, publish, options, meta) => {
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
             const event = utils.getFromLookup(`${msg.endpoint.ID}_${msg.data.sceneid}`, {
                 "1_1": "1_double",
                 "2_1": "2_double",

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2113,7 +2113,12 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
-            m.deviceEndpoints({endpoints: {sw1: 2}}),
+            // The endpoint map must only name endpoints the device actually has: the application
+            // builds its property parser from these names and resolves them with a non-null
+            // assertion, so naming sw1 on a device without a wired input crashes every
+            // switch_type_sw1/switch_mode_sw1 set with "Cannot read properties of undefined
+            // (reading 'ID')" (Koenkk/zigbee2mqtt#31951).
+            shellyDeviceEndpoints({sw1: 2}),
             m.onOff({powerOnBehavior: false}),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
@@ -2144,7 +2149,12 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
-            m.deviceEndpoints({endpoints: {sw1: 2}}),
+            // The endpoint map must only name endpoints the device actually has: the application
+            // builds its property parser from these names and resolves them with a non-null
+            // assertion, so naming sw1 on a device without a wired input crashes every
+            // switch_type_sw1/switch_mode_sw1 set with "Cannot read properties of undefined
+            // (reading 'ID')" (Koenkk/zigbee2mqtt#31951).
+            shellyDeviceEndpoints({sw1: 2}),
             m.onOff({powerOnBehavior: false}),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
@@ -2175,7 +2185,12 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
-            m.deviceEndpoints({endpoints: {sw1: 2}}),
+            // The endpoint map must only name endpoints the device actually has: the application
+            // builds its property parser from these names and resolves them with a non-null
+            // assertion, so naming sw1 on a device without a wired input crashes every
+            // switch_type_sw1/switch_mode_sw1 set with "Cannot read properties of undefined
+            // (reading 'ID')" (Koenkk/zigbee2mqtt#31951).
+            shellyDeviceEndpoints({sw1: 2}),
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter({producedEnergy: true, acFrequency: true}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),
@@ -2208,7 +2223,12 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellySwitchInputExposes(device, {sw1: 2}),
         ],
         extend: [
-            m.deviceEndpoints({endpoints: {sw1: 2}}),
+            // The endpoint map must only name endpoints the device actually has: the application
+            // builds its property parser from these names and resolves them with a non-null
+            // assertion, so naming sw1 on a device without a wired input crashes every
+            // switch_type_sw1/switch_mode_sw1 set with "Cannot read properties of undefined
+            // (reading 'ID')" (Koenkk/zigbee2mqtt#31951).
+            shellyDeviceEndpoints({sw1: 2}),
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter({producedEnergy: true, acFrequency: true}),
             shellyModernExtend.shellyPowerFactorInt16Fix(),

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -928,20 +928,6 @@ const shellyModernExtend = {
             return endpoint;
         };
 
-        const getShellySwitchConfig = async (endpoint: Zh.Endpoint | Zh.Group, id: number): Promise<KeyValue | undefined> => {
-            if (!SHELLY_RPC_CAN_READ) return undefined;
-            const response = await rpcRequest(endpoint, "Switch.GetConfig", {id});
-            const result = response?.result ?? response?.params ?? response;
-            if (!result) return undefined;
-            assertObject<KeyValue>(result);
-            return result;
-        };
-
-        const getShellySwitchMode = async (endpoint: Zh.Endpoint | Zh.Group, id: number): Promise<string | undefined> => {
-            const config = await getShellySwitchConfig(endpoint, id);
-            return typeof config?.in_mode === "string" ? config.in_mode : undefined;
-        };
-
         // Maps a per-zone endpoint name ("1".."N") to the device's RPC PresenceZone id. This
         // numbering counts zones and is unrelated to the occupancy endpoints, which count tracked
         // people - presence_delay_1 is the first zone, occupancy_1 is the first person.
@@ -1219,12 +1205,19 @@ const shellyModernExtend = {
                 },
             });
         }
+        // switch_mode travels over the RPC cluster, which the firmware cannot answer over Zigbee
+        // (see SHELLY_RPC_CAN_READ): no convertGet - a device query walks every converter that has
+        // one regardless of the access flags - and the exposes say so instead of announcing GET.
         if (twoPMInputEndpoints) {
             const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
             exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
                 if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
                 return Object.keys(shellySwitchInputEndpoints(device, twoPMInputEndpoints)).map((endpoint) =>
-                    e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint(endpoint),
+                    e
+                        .enum("switch_mode", ea.STATE_SET, inModeValues)
+                        .withDescription(`Switch input mode. ${WRITE_ONLY}`)
+                        .withCategory("config")
+                        .withEndpoint(endpoint),
                 );
             });
             toZigbee.push({
@@ -1235,25 +1228,6 @@ const shellyModernExtend = {
                     await rpcSend(ep, "Switch.SetConfig", {id: switchId, config: {in_mode: value}});
                     return {state: {switch_mode: value}};
                 },
-                convertGet: async (entity, key, meta) => {
-                    const switchId = meta.endpoint_name === "sw1" ? 0 : 1;
-                    const ep = getRPCEndpoint(entity);
-                    const mode = await getShellySwitchMode(ep, switchId);
-                    if (mode) {
-                        meta.publish({[meta.endpoint_name ? `switch_mode_${meta.endpoint_name}` : "switch_mode"]: mode});
-                    }
-                },
-            });
-            configure.push(async (device) => {
-                const ep = device.getEndpoint(SHELLY_ENDPOINT_ID);
-                if (!ep) return;
-                try {
-                    for (const id of [0, 1]) {
-                        await getShellySwitchConfig(ep, id);
-                    }
-                } catch (e) {
-                    logger.warning(`Failed to read switch_mode during configure, use get to retry: ${e}`, NS);
-                }
             });
         }
         if (featureOnePMInputMode) {
@@ -1261,7 +1235,11 @@ const shellyModernExtend = {
             exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
                 if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
                 return Object.keys(shellySwitchInputEndpoints(device, {sw1: 2})).map((endpoint) =>
-                    e.enum("switch_mode", ea.ALL, inModeValues).withDescription("Switch input mode").withCategory("config").withEndpoint(endpoint),
+                    e
+                        .enum("switch_mode", ea.STATE_SET, inModeValues)
+                        .withDescription(`Switch input mode. ${WRITE_ONLY}`)
+                        .withCategory("config")
+                        .withEndpoint(endpoint),
                 );
             });
             toZigbee.push({
@@ -1271,22 +1249,6 @@ const shellyModernExtend = {
                     await rpcSend(ep, "Switch.SetConfig", {id: 0, config: {in_mode: value}});
                     return {state: {switch_mode: value}};
                 },
-                convertGet: async (entity, key, meta) => {
-                    const ep = getRPCEndpoint(entity);
-                    const mode = await getShellySwitchMode(ep, 0);
-                    if (mode) {
-                        meta.publish({[meta.endpoint_name ? `switch_mode_${meta.endpoint_name}` : "switch_mode"]: mode});
-                    }
-                },
-            });
-            configure.push(async (device) => {
-                const ep = device.getEndpoint(SHELLY_ENDPOINT_ID);
-                if (!ep) return;
-                try {
-                    await getShellySwitchConfig(ep, 0);
-                } catch (e) {
-                    logger.warning(`Failed to read switch_mode during configure, use get to retry: ${e}`, NS);
-                }
             });
         }
         if (featureCoverTiltAuto && SHELLY_RPC_CAN_READ) {

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2091,6 +2091,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "1 Mini Gen 4",
         ota: true,
+        // The genOnOff/genScenes bindings and the switchType read in configure were added after
+        // this device was first released; bump the patch version so already paired devices get
+        // re-configured and their input events start arriving (same rule as the BLU remotes).
+        version: "0.0.1",
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
         // The switch input endpoint only exists when an input is actually wired. Without it the
@@ -2127,6 +2131,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "1 Gen 4",
         ota: true,
+        // The genOnOff/genScenes bindings and the switchType read in configure were added after
+        // this device was first released; bump the patch version so already paired devices get
+        // re-configured and their input events start arriving (same rule as the BLU remotes).
+        version: "0.0.1",
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
         // The switch input endpoint only exists when an input is actually wired. Without it the
@@ -2163,6 +2171,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "1PM Mini Gen 4",
         ota: true,
+        // The genOnOff/genScenes bindings and the switchType read in configure were added after
+        // this device was first released; bump the patch version so already paired devices get
+        // re-configured and their input events start arriving (same rule as the BLU remotes).
+        version: "0.0.1",
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
         // The switch input endpoint only exists when an input is actually wired. Without it the
@@ -2201,6 +2213,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "1PM Gen 4",
         ota: true,
+        // The genOnOff/genScenes bindings and the switchType read in configure were added after
+        // this device was first released; bump the patch version so already paired devices get
+        // re-configured and their input events start arriving (same rule as the BLU remotes).
+        version: "0.0.1",
         fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
         // The switch input endpoint only exists when an input is actually wired. Without it the
@@ -2294,6 +2310,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "2PM Gen4 (Cover mode)",
         ota: true,
+        // The genOnOff/genScenes bindings and the switchType read in configure were added after
+        // this device was first released; bump the patch version so already paired devices get
+        // re-configured and their input events start arriving (same rule as the BLU remotes).
+        version: "0.0.1",
         fromZigbee: [fzLocal.two_switch_inputs_events, fzLocal.two_switch_inputs_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
         exposes: (device) => [
@@ -2365,6 +2385,10 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Shelly",
         description: "2PM Gen4 (Switch mode)",
         ota: true,
+        // The genOnOff/genScenes bindings and the switchType read in configure were added after
+        // this device was first released; bump the patch version so already paired devices get
+        // re-configured and their input events start arriving (same rule as the BLU remotes).
+        version: "0.0.1",
         fromZigbee: [fzLocal.two_switch_inputs_events, fzLocal.two_switch_inputs_scene_events, fzLocal.switch_input_type],
         toZigbee: [tzLocal.switch_input_type],
         exposes: (device) => [

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -4,7 +4,19 @@ import type {Feature} from "../lib/exposes";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
-import type {Configure, DefinitionExposesFunction, DefinitionWithExtend, DummyDevice, Expose, Fz, KeyValue, ModernExtend, Tz, Zh} from "../lib/types";
+import type {
+    Configure,
+    Definition,
+    DefinitionExposesFunction,
+    DefinitionWithExtend,
+    DummyDevice,
+    Expose,
+    Fz,
+    KeyValue,
+    ModernExtend,
+    Tz,
+    Zh,
+} from "../lib/types";
 import * as utils from "../lib/utils";
 import {assertObject, determineEndpoint, sleep} from "../lib/utils";
 
@@ -1887,6 +1899,17 @@ const handlePosition = e
     .enum("handle_position", ea.STATE, ["closed", "tilted", "open"])
     .withDescription("Handle position: closed, tilted (partly open), or open");
 
+// Resolves which switch input (1 or 2) sent a message, from the definition's own endpoint map:
+// the cover-mode 2PM has its inputs on endpoints 2/3, the switch-mode 2PM on 3/4 and the
+// single-channel devices on 2 - a fixed endpoint list cannot serve them all. Messages from any
+// other endpoint return undefined and must be ignored, not mislabeled as input 1.
+const shellyInputNumber = (model: Definition, msg: {device: Zh.Device; endpoint: Zh.Endpoint}): number | undefined => {
+    const endpoints = model.endpoint?.(msg.device) ?? {};
+    if (endpoints.sw1 === msg.endpoint.ID) return 1;
+    if (endpoints.sw2 === msg.endpoint.ID) return 2;
+    return undefined;
+};
+
 const fzLocal = {
     one_button_events: {
         cluster: "genOnOff",
@@ -1972,19 +1995,18 @@ const fzLocal = {
         },
     } satisfies Fz.Converter<"genScenes", undefined, ["commandRecall"]>,
 
+    // The input numbering comes from the definition's endpoint map (see shellyInputNumber): a
+    // fixed endpoint lookup broke the cover-mode 2PM, whose inputs live on endpoints 2/3 while
+    // the switch-mode device has them on 3/4 - input 1 threw and input 2 was reported as input 1.
     two_switch_inputs_events: {
         cluster: "genOnOff",
         type: ["commandOn", "commandOff", "commandToggle"],
         convert: (model, msg, publish, options, meta) => {
-            const event = utils.getFromLookup(`${msg.endpoint.ID}_${msg.type}`, {
-                "3_commandOn": "input_1_on",
-                "3_commandOff": "input_1_off",
-                "3_commandToggle": "input_1_toggle",
-                "4_commandOn": "input_2_on",
-                "4_commandOff": "input_2_off",
-                "4_commandToggle": "input_2_toggle",
-            });
-            return {action: event};
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            const input = shellyInputNumber(model, msg);
+            if (input === undefined) return;
+            const event = utils.getFromLookup(msg.type, {commandOn: "on", commandOff: "off", commandToggle: "toggle"});
+            return {action: `input_${input}_${event}`};
         },
     } satisfies Fz.Converter<"genOnOff", undefined, ["commandOn", "commandOff", "commandToggle"]>,
 
@@ -1992,21 +2014,18 @@ const fzLocal = {
         cluster: "genScenes",
         type: ["commandRecall"],
         convert: (model, msg, publish, options, meta) => {
-            const event = utils.getFromLookup(`${msg.endpoint.ID}_${msg.data.sceneid}`, {
-                "3_1": "input_1_single",
-                "4_1": "input_2_single",
-                "3_2": "input_1_double",
-                "4_2": "input_2_double",
-                "3_3": "input_1_triple",
-                "4_3": "input_2_triple",
-                "3_4": "input_1_hold",
-                "4_4": "input_2_hold",
-                "3_5": "input_1_toggle",
-                "4_5": "input_2_toggle",
-                "3_11": "input_1_hold",
-                "4_11": "input_2_hold",
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            const input = shellyInputNumber(model, msg);
+            if (input === undefined) return;
+            const event = utils.getFromLookup(`${msg.data.sceneid}`, {
+                "1": "single",
+                "2": "double",
+                "3": "triple",
+                "4": "hold",
+                "5": "toggle",
+                "11": "hold",
             });
-            return {action: event};
+            return {action: `input_${input}_${event}`};
         },
     } satisfies Fz.Converter<"genScenes", undefined, ["commandRecall"]>,
 
@@ -2014,7 +2033,8 @@ const fzLocal = {
         cluster: "genOnOff",
         type: ["commandOn", "commandOff", "commandToggle"],
         convert: (model, msg, publish, options, meta) => {
-            if (msg.endpoint.ID !== 2) return {};
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            if (shellyInputNumber(model, msg) !== 1) return;
             const event = utils.getFromLookup(msg.type, {
                 commandOn: "input_1_on",
                 commandOff: "input_1_off",
@@ -2028,7 +2048,8 @@ const fzLocal = {
         cluster: "genScenes",
         type: ["commandRecall"],
         convert: (model, msg, publish, options, meta) => {
-            if (msg.endpoint.ID !== 2) return {};
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            if (shellyInputNumber(model, msg) !== 1) return;
             const event = utils.getFromLookup(`${msg.data.sceneid}`, {
                 "1": "input_1_single",
                 "2": "input_1_double",

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -812,6 +812,25 @@ describe("Shelly 2PM Gen4 switch input events", () => {
         expect(await convertCommand(device, 4, "commandOn", {}, 7)).toBeUndefined();
     });
 
+    // The single-channel devices route through the same map-based resolver: with a wired input
+    // the filtered map names sw1 -> endpoint 2, so the events keep arriving exactly as before.
+    it("keeps single-channel input events working when the input is wired", async () => {
+        const device = mockDevice({
+            modelID: "Mini1PM",
+            manufacturerName: "Shelly",
+            ieeeAddr: "0x000000000000e106",
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: [25]},
+                {ID: 2, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                ...RPC_ENDPOINTS,
+            ],
+        });
+        expect((await findByDevice(device)).model).toBe("S4SW-001P8EU");
+
+        expect(await convertCommand(device, 2, "commandOn", {}, 8)).toStrictEqual({action: "input_1_on"});
+        expect(await convertCommand(device, 2, "commandRecall", {sceneid: 4}, 9)).toStrictEqual({action: "input_1_hold"});
+    });
+
     it("publishes a repeated transaction only once", async () => {
         const device = mockSwitch("0x000000000000e104");
 

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -819,3 +819,49 @@ describe("Shelly 2PM Gen4 switch input events", () => {
         expect(await convertCommand(device, 3, "commandOn", {}, 42)).toBeUndefined();
     });
 });
+
+// The genOnOff/genScenes bindings and the switchType read in configure were added to these
+// definitions after their devices shipped. Without a version bump the application never
+// re-configures already paired devices, so their input events silently never arrive - the
+// BLU remotes bumped to 0.0.2 for exactly this kind of binding fix.
+describe("Shelly Gen4 switch definitions carry the re-configure version bump", () => {
+    const RPC_ENDPOINTS = [
+        {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: []},
+        {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
+    ];
+    const SINGLE_CHANNEL = [{ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6], outputClusterIDs: [25]}, ...RPC_ENDPOINTS];
+    const cases: [string, ReturnType<typeof mockDevice>][] = [
+        ["S4SW-001X8EU", mockDevice({modelID: "Mini1", manufacturerName: "Shelly", endpoints: SINGLE_CHANNEL})],
+        ["S4SW-001X16EU", mockDevice({modelID: "1", manufacturerName: "Shelly", endpoints: SINGLE_CHANNEL})],
+        ["S4SW-001P8EU", mockDevice({modelID: "Mini1PM", manufacturerName: "Shelly", endpoints: SINGLE_CHANNEL})],
+        ["S4SW-001P16EU", mockDevice({modelID: "1PM", manufacturerName: "Shelly", endpoints: SINGLE_CHANNEL})],
+        [
+            "S4SW-002P16EU-COVER",
+            mockDevice({
+                modelID: "2PM",
+                manufacturerName: "Shelly",
+                endpoints: [{ID: 1, profileID: 260, deviceID: 514, inputClusterIDs: [0, 3, 4, 5, 258], outputClusterIDs: []}, ...RPC_ENDPOINTS],
+            }),
+        ],
+        [
+            "S4SW-002P16EU-SWITCH",
+            mockDevice({
+                modelID: "2PM",
+                manufacturerName: "Shelly",
+                ieeeAddr: "0x000000000000e105",
+                endpoints: [
+                    {ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: []},
+                    {ID: 2, profileID: 260, deviceID: 266, inputClusterIDs: [4, 5, 6, 2820, 1794], outputClusterIDs: []},
+                    ...RPC_ENDPOINTS,
+                ],
+            }),
+        ],
+    ];
+
+    it.each(cases)("%s", async (expectedModel, device) => {
+        const definition = await findByDevice(device);
+        expect(definition.model).toBe(expectedModel);
+        expect(definition.configure).toBeDefined();
+        expect(definition.version).toBe("0.0.1");
+    });
+});

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -710,3 +710,94 @@ describe("Shelly 2PM Gen4 switch input endpoints", () => {
         expect(names).toContain("switch_mode_sw2");
     });
 });
+
+// The input action events must follow the definition's endpoint map, like switch_type/switch_mode
+// already do: the cover-mode 2PM has its inputs on endpoints 2/3, the switch-mode device on 3/4.
+// A fixed endpoint lookup made cover input 1 throw and reported cover input 2 as input 1.
+describe("Shelly 2PM Gen4 switch input events", () => {
+    const RPC_ENDPOINTS = [
+        {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: []},
+        {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
+    ];
+
+    const mockCover = (ieeeAddr: string) =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            ieeeAddr,
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 514, inputClusterIDs: [0, 3, 4, 5, 258], outputClusterIDs: [25]},
+                {ID: 2, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 3, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 4, inputClusterIDs: [], outputClusterIDs: [3, 4, 6, 8, 258]},
+                ...RPC_ENDPOINTS,
+            ],
+        });
+
+    const mockSwitch = (ieeeAddr: string) =>
+        mockDevice({
+            modelID: "2PM",
+            manufacturerName: "Shelly",
+            ieeeAddr,
+            endpoints: [
+                {ID: 1, profileID: 260, deviceID: 266, inputClusterIDs: [0, 3, 4, 5, 6, 2820, 1794], outputClusterIDs: [25]},
+                {ID: 2, profileID: 260, deviceID: 266, inputClusterIDs: [4, 5, 6, 2820, 1794], outputClusterIDs: []},
+                {ID: 3, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 4, inputClusterIDs: [7], outputClusterIDs: [3, 4, 5, 6]},
+                {ID: 5, inputClusterIDs: [], outputClusterIDs: [3, 4, 6, 8, 258]},
+                ...RPC_ENDPOINTS,
+            ],
+        });
+
+    const convertCommand = async (
+        device: ReturnType<typeof mockDevice>,
+        endpointId: number,
+        type: string,
+        data: Record<string, unknown>,
+        sequence: number,
+    ) => {
+        const definition = await findByDevice(device);
+        const cluster = type === "commandRecall" ? "genScenes" : "genOnOff";
+        const converter = definition.fromZigbee.find(
+            (c) => c.cluster === cluster && (Array.isArray(c.type) ? c.type.includes(type) : c.type === type),
+        ) as Fz.Converter;
+        return converter.convert(
+            definition,
+            {data, endpoint: device.getEndpoint(endpointId), device, type, meta: {zclTransactionSequenceNumber: sequence}} as never,
+            vi.fn(),
+            {},
+            {device, state: {}, deviceExposesChanged: () => {}} as never,
+        );
+    };
+
+    it("maps cover input 1 (endpoint 2) and input 2 (endpoint 3) to their own actions", async () => {
+        const device = mockCover("0x000000000000e101");
+        expect((await findByDevice(device)).model).toBe("S4SW-002P16EU-COVER");
+
+        expect(await convertCommand(device, 2, "commandOn", {}, 1)).toStrictEqual({action: "input_1_on"});
+        expect(await convertCommand(device, 3, "commandOn", {}, 2)).toStrictEqual({action: "input_2_on"});
+        expect(await convertCommand(device, 2, "commandRecall", {sceneid: 2}, 3)).toStrictEqual({action: "input_1_double"});
+        expect(await convertCommand(device, 3, "commandRecall", {sceneid: 11}, 4)).toStrictEqual({action: "input_2_hold"});
+    });
+
+    it("keeps the switch-mode inputs on endpoints 3 and 4", async () => {
+        const device = mockSwitch("0x000000000000e102");
+        expect((await findByDevice(device)).model).toBe("S4SW-002P16EU-SWITCH");
+
+        expect(await convertCommand(device, 3, "commandOff", {}, 5)).toStrictEqual({action: "input_1_off"});
+        expect(await convertCommand(device, 4, "commandToggle", {}, 6)).toStrictEqual({action: "input_2_toggle"});
+    });
+
+    it("ignores commands from endpoints that are no switch input instead of throwing", async () => {
+        const device = mockCover("0x000000000000e103");
+
+        expect(await convertCommand(device, 4, "commandOn", {}, 7)).toBeUndefined();
+    });
+
+    it("publishes a repeated transaction only once", async () => {
+        const device = mockSwitch("0x000000000000e104");
+
+        expect(await convertCommand(device, 3, "commandOn", {}, 42)).toStrictEqual({action: "input_1_on"});
+        expect(await convertCommand(device, 3, "commandOn", {}, 42)).toBeUndefined();
+    });
+});

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -709,6 +709,24 @@ describe("Shelly 2PM Gen4 switch input endpoints", () => {
         expect(names).toContain("switch_mode_sw1");
         expect(names).toContain("switch_mode_sw2");
     });
+
+    // switch_mode travels over the RPC cluster, which the firmware cannot answer over Zigbee:
+    // announcing GET offers a refresh that can never do anything, and a device query walks every
+    // converter that has a convertGet - so the read has to be gone and the expose has to say so.
+    it("marks switch_mode write-only and offers no read", async () => {
+        const device = mockSwitchWithInputs();
+        const definition = await findByDevice(device);
+        const exposes = (definition.exposes as DefinitionExposesFunction)(device, {});
+
+        for (const endpoint of ["sw1", "sw2"]) {
+            const expose = exposes.find((e) => e.name === "switch_mode" && e.endpoint === endpoint);
+            expect(expose, `switch_mode_${endpoint} is missing`).toBeDefined();
+            expect(expose.access & 0b100, `switch_mode_${endpoint} must not announce GET`).toBe(0);
+            expect(expose.access & 0b010, `switch_mode_${endpoint} must stay settable`).toBe(0b010);
+            expect(expose.description ?? "").toContain("cannot report");
+        }
+        expect(definition.toZigbee.find((c) => c.key?.includes("switch_mode"))?.convertGet).toBeUndefined();
+    });
 });
 
 // The input action events must follow the definition's endpoint map, like switch_type/switch_mode


### PR DESCRIPTION
## What users see today

- Changing `switch_type`/`switch_mode` on a single-channel Gen4 without a wired input crashes the publish with `Cannot read properties of undefined (reading 'ID')` — reported by three users in Koenkk/zigbee2mqtt#31951. The definitions name `sw1 -> endpoint 2` even when that endpoint does not exist, and the application resolves the name with a non-null assertion.
- On a cover-mode 2PM with wired inputs in detached mode, input 1 throws (`Key '2_commandOn' not found`) and input 2 is reported as `input_1_*`: the action converters used a fixed endpoint table (3/4), but the cover variant has its inputs on endpoints 2/3 — the same endpoint split #12736 fixed for `switch_type`/`switch_mode`, still present in the event converters.
- Devices paired before the bindings arrived in configure (#12011/#12059/#12096) never get their input action events, because the definitions carry no `version` — the application only configures new pairings. A user in Koenkk/zigbee2mqtt#30637 had to re-interview manually to make the clusters appear.

## Changes (one commit each)

1. **Single-channel endpoint maps are filtered** through the same helper the 2PM variants already use — absent input endpoints are no longer named, which removes the crash precondition.
2. **Input action events resolve their input number from the definition's endpoint map** instead of a fixed endpoint table, so both 2PM variants and the single-channel devices report the correct input; messages from endpoints that are no switch input are ignored instead of throwing.
3. **All button/scene converters gained the standard `hasAlreadyProcessedMessage` guard** the stock command converters use, so a retransmitted frame cannot trigger automations twice.
4. **`switch_mode` no longer announces a read it cannot deliver**: it is written through the RPC cluster, which the firmware cannot answer over Zigbee (see `SHELLY_RPC_CAN_READ`, #12732). The dormant convertGet/configure reads are gone and the expose says the shown value is the last one written — same declaration style as the other unreadable Gen4 settings (#12735).
5. **The six switch definitions bump `version` to `0.0.1`** so already paired devices are re-configured once and their bindings arrive — the rule the BLU remotes applied for their own binding fix (#11547) and the Presence Gen4 documents on its version field.

## Tests

- `pnpm run build && pnpm run check && pnpm test` green on every commit (pre-commit hook), 743 tests total.
- New coverage: cover-variant input events on endpoints 2/3, switch-variant on 3/4, non-input endpoints ignored, single-channel wired-input events unchanged, duplicate transaction published once, `switch_mode` exposes no GET and carries the write-only note, all six definitions carry the version bump.

Addresses Koenkk/zigbee2mqtt#31951, Koenkk/zigbee2mqtt#30637.
