### PR TITLE
fix: Shelly WS90: discard non-value markers and recover the rain rate after a counter reset

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -562,7 +562,13 @@ function calculateRainRate(meta: WS90Meta, precipitation: number | undefined): n
     const precipDelta = precipitation - history.value;
 
     if (timeDeltaMs < 60000) return null;
-    if (precipDelta < 0) return 0;
+    if (precipDelta < 0) {
+        // The cumulative counter was reset (battery change, restart). Rebase the history on the
+        // new counter - otherwise the delta stays negative and the rate reports 0 until the new
+        // counter overtakes the old value, which for a cumulative rain counter can take months.
+        meta.precipHistory = {value: precipitation, time: now};
+        return 0;
+    }
 
     meta.precipHistory = {value: precipitation, time: now};
 

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -650,6 +650,15 @@ function calculateWeatherCondition(state: {[key: string]: number | boolean | und
 }
 
 /**
+ * The station reports the ZCL non-value marker (all bits set for the attribute type) when a
+ * reading is unavailable - a gustSpeed of 0xffff was published as 6553.5 m/s and fed into the
+ * calculations (https://github.com/Koenkk/zigbee2mqtt/issues/31048). Scale a raw value only
+ * when it is a real reading, otherwise contribute nothing.
+ */
+const ws90Scaled = (name: string, raw: unknown, invalid: number): {[key: string]: number} | undefined =>
+    typeof raw === "number" && raw !== invalid ? {[name]: raw / 10} : undefined;
+
+/**
  * Update calculated values whenever we get new sensor data (uses device.meta for persistence)
  */
 function updateWS90CalculatedValues(device: Zh.Device, payload: {[key: string]: number | boolean}): {[key: string]: number | string | null} {
@@ -1784,10 +1793,9 @@ const shellyModernExtend = {
                 type: ["attributeReport", "readResponse"],
                 convert: (model, msg, publish, options, meta) => {
                     const data = msg.data as KeyValue;
-                    if (data.uvIndex !== undefined) {
-                        const uv_index = (data.uvIndex as number) / 10;
-                        const calculated = updateWS90CalculatedValues(msg.device, {uv_index});
-                        return calculated;
+                    const payload = ws90Scaled("uv_index", data.uvIndex, 0xff);
+                    if (payload) {
+                        return updateWS90CalculatedValues(msg.device, payload);
                     }
                 },
             },
@@ -1796,10 +1804,11 @@ const shellyModernExtend = {
                 type: ["attributeReport", "readResponse"],
                 convert: (model, msg, publish, options, meta) => {
                     const data = msg.data as KeyValue;
-                    const payload: {[key: string]: number} = {};
-                    if (data.windSpeed !== undefined) payload.wind_speed = (data.windSpeed as number) / 10;
-                    if (data.windDirection !== undefined) payload.wind_direction = (data.windDirection as number) / 10;
-                    if (data.gustSpeed !== undefined) payload.gust_speed = (data.gustSpeed as number) / 10;
+                    const payload: {[key: string]: number} = {
+                        ...(ws90Scaled("wind_speed", data.windSpeed, 0xffff) ?? {}),
+                        ...(ws90Scaled("wind_direction", data.windDirection, 0xffff) ?? {}),
+                        ...(ws90Scaled("gust_speed", data.gustSpeed, 0xffff) ?? {}),
+                    };
                     const calculated = updateWS90CalculatedValues(msg.device, payload);
                     return calculated;
                 },
@@ -1809,11 +1818,10 @@ const shellyModernExtend = {
                 type: ["attributeReport", "readResponse"],
                 convert: (model, msg, publish, options, meta) => {
                     const data = msg.data as KeyValue;
-                    const payload: {[key: string]: number | boolean} = {};
+                    const payload: {[key: string]: number | boolean} = {
+                        ...(ws90Scaled("precipitation", data.precipitation, 0xffffff) ?? {}),
+                    };
                     if (data.rainStatus !== undefined) payload.rain_status = Boolean(data.rainStatus);
-                    if (data.precipitation !== undefined) {
-                        payload.precipitation = (data.precipitation as number) / 10;
-                    }
 
                     // Calculate rain_rate (it's a calculated value, not a base sensor value)
                     const ws90Meta = getWS90Meta(msg.device);
@@ -2491,6 +2499,7 @@ export const definitions: DefinitionWithExtend[] = [
                 name: "wind_speed",
                 cluster: "shellyWS90Wind",
                 attribute: "windSpeed",
+                fzConvert: (model, msg) => ws90Scaled("wind_speed", msg.data.windSpeed, 0xffff),
                 valueMin: 0,
                 valueMax: 140,
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 1},
@@ -2503,6 +2512,7 @@ export const definitions: DefinitionWithExtend[] = [
                 name: "wind_direction",
                 cluster: "shellyWS90Wind",
                 attribute: "windDirection",
+                fzConvert: (model, msg) => ws90Scaled("wind_direction", msg.data.windDirection, 0xffff),
                 valueMin: 0,
                 valueMax: 360,
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 1},
@@ -2515,6 +2525,7 @@ export const definitions: DefinitionWithExtend[] = [
                 name: "gust_speed",
                 cluster: "shellyWS90Wind",
                 attribute: "gustSpeed",
+                fzConvert: (model, msg) => ws90Scaled("gust_speed", msg.data.gustSpeed, 0xffff),
                 valueMin: 0,
                 valueMax: 140,
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 1},
@@ -2537,6 +2548,7 @@ export const definitions: DefinitionWithExtend[] = [
                 name: "uv_index",
                 cluster: "shellyWS90UV",
                 attribute: "uvIndex",
+                fzConvert: (model, msg) => ws90Scaled("uv_index", msg.data.uvIndex, 0xff),
                 valueMin: 0,
                 valueMax: 11,
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 1},
@@ -2569,6 +2581,7 @@ export const definitions: DefinitionWithExtend[] = [
                 name: "precipitation",
                 cluster: "shellyWS90Rain",
                 attribute: "precipitation",
+                fzConvert: (model, msg) => ws90Scaled("precipitation", msg.data.precipitation, 0xffffff),
                 valueMin: 0,
                 valueMax: 100000,
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 1},

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -467,6 +467,7 @@ interface WS90Meta {
     state?: {[key: string]: number | boolean};
     precipHistory?: {value: number; time: number};
     pressureHistory?: {value: number; time: number};
+    lastSave?: number;
 }
 
 /**
@@ -709,8 +710,14 @@ function updateWS90CalculatedValues(device: Zh.Device, payload: {[key: string]: 
     const condition = calculateWeatherCondition(state);
     if (condition !== null) result.weather_condition = condition;
 
-    // Save device meta to persist across restarts
-    device.save();
+    // Persist across restarts - but not on every report: the station reports as often as
+    // every 10 seconds, and each save writes the whole device database to disk. The histories
+    // only advance on the minute scale, so a crash loses at most a minute of history progress.
+    const now = Date.now();
+    if (meta.lastSave === undefined || now - meta.lastSave >= 60000) {
+        meta.lastSave = now;
+        device.save();
+    }
 
     return result;
 }
@@ -1835,7 +1842,6 @@ const shellyModernExtend = {
                     // Include rain_rate in calculated values
                     calculated.rain_rate = rain_rate;
 
-                    msg.device.save();
                     return calculated; // Only calculated values; m.binary()/m.numeric() handle base rain values
                 },
             },

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -758,4 +758,36 @@ describe("Shelly WS90 rain rate", () => {
         vi.setSystemTime(new Date("2026-07-22T10:06:00Z"));
         expect(report(500).rain_rate).toBe(300); // +40 mm in 2 min since the reset
     });
+
+    // The station reports the ZCL non-value marker (all bits set) when a reading is unavailable -
+    // a gustSpeed of 0xffff was published as 6553.5 m/s (Koenkk/zigbee2mqtt#31048). Markers must
+    // contribute nothing, neither as a measurement nor to the calculated values.
+    it("discards the non-value markers instead of publishing them as measurements", async () => {
+        const device = mockWS90();
+        const definition = await findByDevice(device);
+        const meta = {device, state: {}, deviceExposesChanged: () => {}} as never;
+        const convertAll = (cluster: string, data: Record<string, unknown>) =>
+            Object.assign(
+                {},
+                ...definition.fromZigbee
+                    .filter((c) => c.cluster === cluster)
+                    .map(
+                        (c) =>
+                            (c as Fz.Converter).convert(
+                                definition,
+                                {data, endpoint: device.getEndpoint(1), device, type: "attributeReport"} as never,
+                                vi.fn(),
+                                {},
+                                meta,
+                            ) ?? {},
+                    ),
+            ) as Record<string, unknown>;
+
+        expect(convertAll("shellyWS90Wind", {gustSpeed: 0xffff}).gust_speed).toBeUndefined();
+        expect(convertAll("shellyWS90Wind", {windSpeed: 0xffff}).wind_speed).toBeUndefined();
+        expect(convertAll("shellyWS90UV", {uvIndex: 0xff}).uv_index).toBeUndefined();
+        expect(convertAll("shellyWS90Rain", {precipitation: 0xffffff}).precipitation).toBeUndefined();
+        // A real reading still scales as before.
+        expect(convertAll("shellyWS90Wind", {windSpeed: 123}).wind_speed).toBe(12.3);
+    });
 });

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import {describe, expect, it, vi} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 import {findByDevice} from "../src/index";
 import type {DefinitionExposesFunction, Expose, Fz, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
@@ -708,5 +708,54 @@ describe("Shelly 2PM Gen4 switch input endpoints", () => {
         expect(model).toBe("S4SW-002P16EU-COVER");
         expect(names).toContain("switch_mode_sw1");
         expect(names).toContain("switch_mode_sw2");
+    });
+});
+
+describe("Shelly WS90 rain rate", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const mockWS90 = () =>
+        mockDevice({
+            modelID: "Ecowitt WS90",
+            manufacturerName: "Shelly",
+            endpoints: [{ID: 1, profileID: 260, deviceID: 12, inputClusterIDs: [0, 1, 3, 0x400, 0x402, 0x403, 0x405], outputClusterIDs: []}],
+        });
+
+    // The precipitation counter is cumulative. After a reset (battery change, restart) the stored
+    // history must be rebased on the new counter value - otherwise the delta stays negative and
+    // the rate reports 0 until the new counter overtakes the old one, which can take months.
+    it("recovers the rain rate after the cumulative counter resets", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-07-22T10:00:00Z"));
+        const device = mockWS90();
+        const definition = await findByDevice(device);
+        expect(definition.model).toBe("WS90");
+        const rainConverters = definition.fromZigbee.filter((c) => c.cluster === "shellyWS90Rain");
+        expect(rainConverters.length).toBeGreaterThan(0);
+        const meta = {device, state: {}, deviceExposesChanged: () => {}} as never;
+        const report = (raw: number) =>
+            Object.assign(
+                {},
+                ...rainConverters.map(
+                    (c) =>
+                        (c as Fz.Converter).convert(
+                            definition,
+                            {data: {precipitation: raw}, endpoint: device.getEndpoint(1), device, type: "attributeReport"} as never,
+                            vi.fn(),
+                            {},
+                            meta,
+                        ) ?? {},
+                ),
+            ) as Record<string, unknown>;
+
+        expect(report(5000).rain_rate).toBe(0); // 500 mm - initial sample
+        vi.setSystemTime(new Date("2026-07-22T10:02:00Z"));
+        expect(report(6000).rain_rate).toBe(300); // +100 mm in 2 min, capped at 300 mm/h
+        vi.setSystemTime(new Date("2026-07-22T10:04:00Z"));
+        expect(report(100).rain_rate).toBe(0); // counter reset to 10 mm - history is rebased
+        vi.setSystemTime(new Date("2026-07-22T10:06:00Z"));
+        expect(report(500).rain_rate).toBe(300); // +40 mm in 2 min since the reset
     });
 });

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -759,6 +759,41 @@ describe("Shelly WS90 rain rate", () => {
         expect(report(500).rain_rate).toBe(300); // +40 mm in 2 min since the reset
     });
 
+    // The station reports as often as every 10 seconds and every save writes the whole device
+    // database to disk. The calculated-value converters used to save on every single report
+    // (twice on rain reports); persist at most once a minute instead.
+    it("persists the device meta at most once a minute", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-07-22T12:00:00Z"));
+        const device = mockWS90();
+        const definition = await findByDevice(device);
+        const save = vi.spyOn(device, "save");
+        const wind = definition.fromZigbee.filter((c) => c.cluster === "shellyWS90Wind");
+        const meta = {device, state: {}, deviceExposesChanged: () => {}} as never;
+        const report = (windSpeed: number) => {
+            for (const c of wind) {
+                (c as Fz.Converter).convert(
+                    definition,
+                    {data: {windSpeed}, endpoint: device.getEndpoint(1), device, type: "attributeReport"} as never,
+                    vi.fn(),
+                    {},
+                    meta,
+                );
+            }
+        };
+
+        report(10);
+        vi.setSystemTime(new Date("2026-07-22T12:00:10Z"));
+        report(20);
+        vi.setSystemTime(new Date("2026-07-22T12:00:20Z"));
+        report(30);
+        expect(save).toHaveBeenCalledTimes(1);
+
+        vi.setSystemTime(new Date("2026-07-22T12:01:01Z"));
+        report(40);
+        expect(save).toHaveBeenCalledTimes(2);
+    });
+
     // The station reports the ZCL non-value marker (all bits set) when a reading is unavailable -
     // a gustSpeed of 0xffff was published as 6553.5 m/s (Koenkk/zigbee2mqtt#31048). Markers must
     // contribute nothing, neither as a measurement nor to the calculated values.


### PR DESCRIPTION
## What users see today

In Koenkk/zigbee2mqtt#31048 a WS90 shows a gust speed of **6553 m/s**: that is the ZCL non-value marker (`0xffff`, all bits set) the station reports when a reading is unavailable, scaled by 10 and published as a measurement. The markers also feed the calculated values (wind chill, heat stress, weather condition). And after the cumulative precipitation counter resets (battery change, restart), the rain rate sticks at 0 until the new counter overtakes the old value — for a cumulative rain counter that can take months.

## Changes (one commit each)

1. **Recover the rain rate after a counter reset**: a negative precipitation delta now rebases the stored history on the new counter value instead of leaving it pointing at the old one.
2. **Discard the non-value markers** (`0xffff` for the uint16 wind attributes, `0xff` for the uint8 UV index, `0xffffff` for the uint24 precipitation) in both places that scale raw values — the numeric converters and the calculated-value converters — so an unavailable reading contributes nothing.

3. **Persist the device meta at most once a minute**: the calculated-value converters called `device.save()` on every single report — twice on rain reports — and the station reports as often as every 10 seconds, so the whole device database was rewritten to disk continuously. The persisted histories only advance on the minute scale; a crash now loses at most a minute of history progress.

This does not touch the reported zero drops from the issue: a zero can be a real reading for these attributes, only the all-bits-set markers are provably invalid.

## Tests

- `pnpm run build && pnpm run check && pnpm test` green on every commit (pre-commit hook), 734 tests total.
- New coverage: rain rate recovers after a simulated counter reset; each marker contributes nothing while a real reading still scales as before.

Reference: Koenkk/zigbee2mqtt#31048.
