### PR TITLE
fix: Shelly Gen4: write only the given Wi-Fi fields

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1649,46 +1649,49 @@ const shellyModernExtend = {
                     assertObject<KeyValue>(value);
                     const ep = determineEndpoint(entity, meta, "shellyWiFiSetupCluster");
 
-                    const attr1 = {
-                        enabled: value.enabled === true,
-                        ssid: value.ssid || "",
-                    };
-                    await ep.write("shellyWiFiSetupCluster", attr1, SHELLY_OPTIONS);
+                    // Stage only the fields actually given: every staged attribute is applied by
+                    // actionCode 1, so an absent field must not travel as its empty default - a
+                    // payload of only {enabled} used to wipe the stored credentials, and one of
+                    // only {ssid, password} silently wrote enabled=false (#12617). The ssid and
+                    // password never travel empty: clearing credentials over Zigbee is exactly
+                    // the accident this fixes. The static network fields may travel empty on
+                    // purpose (clearing them when switching back to DHCP).
+                    const staged: Partial<ShellyWiFiSetup["attributes"]> = {};
+                    if (typeof value.enabled === "boolean") staged.enabled = value.enabled;
+                    if (typeof value.ssid === "string" && value.ssid !== "") staged.ssid = value.ssid;
+                    if (typeof value.password === "string" && value.password !== "") staged.password = value.password;
+                    if (typeof value.static_ip === "string") staged.staticIp = value.static_ip;
+                    if (typeof value.net_mask === "string") staged.netMask = value.net_mask;
+                    if (typeof value.gateway === "string") staged.gateway = value.gateway;
+                    if (typeof value.name_server === "string") staged.nameServer = value.name_server;
+                    if (Object.keys(staged).length === 0) return;
 
-                    const attr2 = {
-                        password: value.password || "",
-                    };
-                    await ep.write("shellyWiFiSetupCluster", attr2, SHELLY_OPTIONS);
+                    // Keep the proven write grouping (small multi-attribute frames, password on
+                    // its own), but skip groups with nothing to write.
+                    const groups: Partial<ShellyWiFiSetup["attributes"]>[] = [
+                        {enabled: staged.enabled, ssid: staged.ssid},
+                        {password: staged.password},
+                        {staticIp: staged.staticIp, netMask: staged.netMask},
+                        {gateway: staged.gateway, nameServer: staged.nameServer},
+                    ];
+                    for (const group of groups) {
+                        const attrs = Object.fromEntries(Object.entries(group).filter(([, attrValue]) => attrValue !== undefined)) as Partial<
+                            ShellyWiFiSetup["attributes"]
+                        >;
+                        if (Object.keys(attrs).length === 0) continue;
+                        await ep.write<"shellyWiFiSetupCluster", ShellyWiFiSetup>("shellyWiFiSetupCluster", attrs, SHELLY_OPTIONS);
+                    }
+                    await ep.write<"shellyWiFiSetupCluster", ShellyWiFiSetup>("shellyWiFiSetupCluster", {actionCode: 1}, SHELLY_OPTIONS);
 
-                    const attr3 = {
-                        staticIp: value.static_ip || "",
-                        netMask: value.net_mask || "",
-                    };
-                    await ep.write("shellyWiFiSetupCluster", attr3, SHELLY_OPTIONS);
-
-                    const attr4 = {
-                        gateway: value.gateway || "",
-                        nameServer: value.name_server || "",
-                    };
-                    await ep.write("shellyWiFiSetupCluster", attr4, SHELLY_OPTIONS);
-
-                    const attr5 = {
-                        actionCode: 1,
-                    };
-                    await ep.write("shellyWiFiSetupCluster", attr5, SHELLY_OPTIONS);
-
-                    return {
-                        state: {
-                            wifi_config: {
-                                enabled: attr1.enabled,
-                                ssid: attr1.ssid === "" ? undefined : attr1.ssid,
-                                static_ip: attr3.staticIp === "" ? undefined : attr3.staticIp,
-                                net_mask: attr3.netMask === "" ? undefined : attr3.netMask,
-                                gateway: attr4.gateway === "" ? undefined : attr4.gateway,
-                                name_server: attr4.nameServer === "" ? undefined : attr4.nameServer,
-                            },
-                        },
-                    };
+                    // Optimistic state: only what was written; the password stays write-only.
+                    const written: KeyValue = {};
+                    if (staged.enabled !== undefined) written.enabled = staged.enabled;
+                    if (staged.ssid !== undefined) written.ssid = staged.ssid;
+                    if (staged.staticIp !== undefined) written.static_ip = staged.staticIp;
+                    if (staged.netMask !== undefined) written.net_mask = staged.netMask;
+                    if (staged.gateway !== undefined) written.gateway = staged.gateway;
+                    if (staged.nameServer !== undefined) written.name_server = staged.nameServer;
+                    return {state: {wifi_config: written}};
                 },
             },
         ];

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import {afterEach, describe, expect, it, vi} from "vitest";
+import {Zcl} from "zigbee-herdsman";
 import {findByDevice} from "../src/index";
 import type {DefinitionExposesFunction, Expose, Fz, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
@@ -210,6 +211,90 @@ describe("Shelly Wi-Fi setup", () => {
         expect(device.getEndpoint(239).write).toHaveBeenCalledWith("shellyWiFiSetupCluster", {actionCode: 0}, expect.any(Object));
         expect(read).toHaveBeenCalledWith("shellyWiFiSetupCluster", ["status", "ip", "enabled", "dhcp", "ssid"], expect.any(Object));
         expect(publish).not.toHaveBeenCalled();
+    });
+
+    // Every staged attribute is applied by actionCode 1, so only the fields actually given may
+    // travel: a payload of only {enabled} used to wipe the stored credentials, and one of only
+    // {ssid, password} silently disabled Wi-Fi (#12617).
+    const wifiWrites = (device: ReturnType<typeof mockDevice>) =>
+        vi
+            .mocked(device.getEndpoint(239).write)
+            .mock.calls.filter((call) => call[0] === "shellyWiFiSetupCluster")
+            .map((call) => call[1] as Record<string, unknown>);
+
+    const wifiSet = async (device: ReturnType<typeof mockDevice>, payload: Record<string, unknown>) => {
+        // deviceAddCustomCluster registers this during onEvent/configure on a real device; the
+        // mock runs neither, and determineEndpoint needs the cluster to resolve the endpoint.
+        device.addCustomCluster("shellyWiFiSetupCluster", {
+            ID: 0xfc02,
+            manufacturerCode: Zcl.ManufacturerCode.SHELLY,
+            attributes: {
+                status: {ID: 0x0000, type: Zcl.DataType.CHAR_STR},
+                ip: {ID: 0x0001, type: Zcl.DataType.CHAR_STR},
+                actionCode: {ID: 0x0002, type: Zcl.DataType.UINT8},
+                dhcp: {ID: 0x0003, type: Zcl.DataType.BOOLEAN},
+                enabled: {ID: 0x0004, type: Zcl.DataType.BOOLEAN},
+                ssid: {ID: 0x0005, type: Zcl.DataType.CHAR_STR},
+                password: {ID: 0x0006, type: Zcl.DataType.CHAR_STR},
+                staticIp: {ID: 0x0007, type: Zcl.DataType.CHAR_STR},
+                netMask: {ID: 0x0008, type: Zcl.DataType.CHAR_STR},
+                gateway: {ID: 0x0009, type: Zcl.DataType.CHAR_STR},
+                nameServer: {ID: 0x000a, type: Zcl.DataType.CHAR_STR},
+            },
+            commands: {},
+            commandsResponse: {},
+        });
+        const definition = await findByDevice(device);
+        const converter = definition.toZigbee.find((c) => c.key?.includes("wifi_config")) as Tz.Converter;
+        return converter.convertSet?.(device.getEndpoint(239), "wifi_config", payload, {device, message: {}, state: {}} as never);
+    };
+
+    it("toggling only enabled does not touch the stored credentials", async () => {
+        const device = mockShelly2PMCover();
+
+        const result = await wifiSet(device, {enabled: false});
+
+        expect(wifiWrites(device)).toStrictEqual([{enabled: false}, {actionCode: 1}]);
+        expect(result).toStrictEqual({state: {wifi_config: {enabled: false}}});
+    });
+
+    it("setting only credentials does not silently disable Wi-Fi", async () => {
+        const device = mockShelly2PMCover();
+
+        await wifiSet(device, {ssid: "TestNet", password: "secret"});
+
+        expect(wifiWrites(device)).toStrictEqual([{ssid: "TestNet"}, {password: "secret"}, {actionCode: 1}]);
+    });
+
+    it("a full set still writes every group", async () => {
+        const device = mockShelly2PMCover();
+
+        await wifiSet(device, {
+            enabled: true,
+            ssid: "TestNet",
+            password: "secret",
+            static_ip: "10.0.0.2",
+            net_mask: "255.255.255.0",
+            gateway: "10.0.0.1",
+            name_server: "10.0.0.1",
+        });
+
+        expect(wifiWrites(device)).toStrictEqual([
+            {enabled: true, ssid: "TestNet"},
+            {password: "secret"},
+            {staticIp: "10.0.0.2", netMask: "255.255.255.0"},
+            {gateway: "10.0.0.1", nameServer: "10.0.0.1"},
+            {actionCode: 1},
+        ]);
+    });
+
+    it("an empty payload writes nothing, not even the apply", async () => {
+        const device = mockShelly2PMCover();
+
+        const result = await wifiSet(device, {});
+
+        expect(wifiWrites(device)).toStrictEqual([]);
+        expect(result).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
## What users see today

Toggling only Wi-Fi `enabled` over Zigbee **wipes the stored SSID and password** — reported and confirmed on the device in #12617. The `wifi_config` convertSet stages every attribute with empty-string fallbacks (`ssid: value.ssid || ""`, `password: value.password || ""`) before `actionCode: 1` applies the lot, so anything absent from the payload travels as its empty default. The same lines cut the other way too: a payload of only `{ssid, password}` silently writes `enabled: false`.

## Change

Stage only the fields actually given (the same only-given-values pattern the Presence sensor groups in this file already use):

- a payload of only `{enabled}` writes exactly `enabled` + apply — the stored credentials stay untouched
- a payload of only `{ssid, password}` no longer touches `enabled`
- `ssid`/`password` never travel empty — clearing credentials over Zigbee is exactly the accident this fixes
- the static network fields may still travel empty on purpose (clearing them when switching back to DHCP)
- an empty payload writes nothing, not even the apply
- the proven write grouping (small multi-attribute frames, password on its own) is kept
- optimistic state returns only the written fields; the password stays write-only

What no converter change can solve: re-enabling Wi-Fi still requires re-sending the password, because the setup cluster applies whatever is staged and caching the password client-side is the security problem already named in the issue. That limitation stays with the firmware.

## Tests

- `pnpm run build && pnpm run check && pnpm test` green (pre-commit hook), 735 tests.
- New coverage: enabled-only toggle writes no credentials, credentials-only set does not touch enabled, full set writes every group, empty payload writes nothing.

Fixes #12617
