### PR TITLE
fix: Shelly: do not serialize RPC transactions of different devices against each other

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -398,19 +398,21 @@ interface ShellyLightLevel {
     commandResponses: never;
 }
 
-let shellyRpcSending = false;
+// Since RPC messages require multiple writes to complete, requests to the SAME device must not
+// interleave. Different devices are independent though - a network with many Gen4 devices must
+// not queue every RPC transaction behind one global lock.
+const shellyRpcBusy = new Set<string>();
 
-const shellyRpcLock = async <T>(callback: () => Promise<T>): Promise<T> => {
-    // Since RPC messages require multiple writes to complete, we have to make sure
-    // we're not interleaving request/response transactions accidentally.
-    while (shellyRpcSending) {
+const shellyRpcLock = async <T>(endpoint: Zh.Endpoint | Zh.Group, callback: () => Promise<T>): Promise<T> => {
+    const key = utils.isEndpoint(endpoint) ? endpoint.getDevice().ieeeAddr : "group";
+    while (shellyRpcBusy.has(key)) {
         await sleep(200);
     }
+    shellyRpcBusy.add(key);
     try {
-        shellyRpcSending = true;
         return await callback();
     } finally {
-        shellyRpcSending = false;
+        shellyRpcBusy.delete(key);
     }
 };
 
@@ -433,7 +435,7 @@ const shellyRpcSendRawUnlocked = async (endpoint: Zh.Endpoint | Zh.Group, messag
 };
 
 const shellyRpcSendRaw = async (endpoint: Zh.Endpoint | Zh.Group, message: string) =>
-    shellyRpcLock(async () => await shellyRpcSendRawUnlocked(endpoint, message));
+    shellyRpcLock(endpoint, async () => await shellyRpcSendRawUnlocked(endpoint, message));
 
 const shellyRpcSend = async (endpoint: Zh.Endpoint | Zh.Group, method: string, params: object = undefined) => {
     const command = {
@@ -445,7 +447,7 @@ const shellyRpcSend = async (endpoint: Zh.Endpoint | Zh.Group, method: string, p
 };
 
 const shellyRpcRequest = async (endpoint: Zh.Endpoint | Zh.Group, method: string, params: object = undefined): Promise<KeyValue | undefined> => {
-    return await shellyRpcLock(async () => {
+    return await shellyRpcLock(endpoint, async () => {
         const command = {
             id: 1,
             method: method,

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1032,7 +1032,12 @@ const shellyModernExtend = {
                 .withCategory("config"),
         ];
 
-        const fromZigbee: Fz.Converter<"shellyRPCCluster", ShellyRPC, ["attributeReport", "readResponse"]>[] = [
+        // The RPC receive accumulator only serves the Dev diagnostics: nothing but their reads can
+        // produce shellyRPCCluster responses (the firmware answers no RPC read, see
+        // SHELLY_RPC_CAN_READ), and registering it unconditionally would publish the undeclared
+        // rpc_rxctl/rpc_data state keys on devices that expose no such fields.
+        const fromZigbee: Fz.Converter<"shellyRPCCluster", ShellyRPC, ["attributeReport", "readResponse"]>[] = [];
+        const fromZigbeeDev: Fz.Converter<"shellyRPCCluster", ShellyRPC, ["attributeReport", "readResponse"]>[] = [
             {
                 cluster: "shellyRPCCluster",
                 type: ["attributeReport", "readResponse"],
@@ -1194,6 +1199,7 @@ const shellyModernExtend = {
 
         if (featureDev) {
             exposes.push(...exposesDev);
+            fromZigbee.push(...fromZigbeeDev);
             toZigbee.push(...toZigbeeDev);
         }
         if (featurePowerstripUI) {
@@ -1544,9 +1550,6 @@ const shellyModernExtend = {
                 );
                 await endpoint.read<"shellyWiFiSetupCluster", ShellyWiFiSetup>("shellyWiFiSetupCluster", ["staticIp", "netMask"], SHELLY_OPTIONS);
                 await endpoint.read<"shellyWiFiSetupCluster", ShellyWiFiSetup>("shellyWiFiSetupCluster", ["gateway", "nameServer"], SHELLY_OPTIONS);
-                if (meta) {
-                    published = true;
-                }
             } catch (e) {
                 logger.warning(`Failed to read Wi-Fi state through Shelly setup cluster; leaving previous state unchanged: ${e}`, NS);
             }
@@ -2055,7 +2058,7 @@ const fzLocal = {
         cluster: "genOnOffSwitchCfg",
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
-            if (!Object.hasOwn(msg.data, "switchType")) return {};
+            if (!Object.hasOwn(msg.data, "switchType")) return;
             const property = utils.postfixWithEndpointName("switch_type", msg, model, meta);
             return {[property]: utils.getFromLookup(msg.data.switchType as number, {0: "toggle", 1: "momentary"})};
         },
@@ -2778,12 +2781,8 @@ export const definitions: DefinitionWithExtend[] = [
                 cluster: "hvacThermostat",
                 type: ["attributeReport", "readResponse"],
                 convert: (model, msg, publish, options, meta) => {
-                    const result: KeyValue = {};
-                    if (msg.data.alarmMask !== undefined) {
-                        const alarmMask = msg.data.alarmMask;
-                        result.calibration_ok = !((alarmMask & (1 << 2)) > 0);
-                    }
-                    return result;
+                    if (msg.data.alarmMask === undefined) return;
+                    return {calibration_ok: !((msg.data.alarmMask & (1 << 2)) > 0)};
                 },
             } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
         ],

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -1000,3 +1000,44 @@ describe("Shelly WS90 rain rate", () => {
         expect(convertAll("shellyWS90Wind", {windSpeed: 123}).wind_speed).toBe(12.3);
     });
 });
+
+// Hygiene guarantees: the RPC diagnostics converter only exists with the Dev feature, and the
+// per-device RPC lock must not serialize different devices against each other.
+describe("Shelly RPC hygiene", () => {
+    const mockPresence = (ieeeAddr: string) =>
+        mockDevice({
+            modelID: "Presence",
+            manufacturerName: "Shelly",
+            ieeeAddr,
+            endpoints: [
+                ...Array.from({length: 10}, (_, index) => ({ID: index + 1, inputClusterIDs: [0, 3, 1030, 0xfc21], outputClusterIDs: []})),
+                {ID: 239, profileID: 49153, deviceID: 8193, inputClusterIDs: [64513, 64514], outputClusterIDs: []},
+                {ID: 242, profileID: 41440, deviceID: 97, inputClusterIDs: [], outputClusterIDs: [33]},
+            ],
+        });
+
+    it("does not serialize RPC writes of different devices against each other", async () => {
+        const deviceA = mockPresence("0x000000000000f102");
+        const deviceB = mockPresence("0x000000000000f103");
+        const definition = await findByDevice(deviceA);
+        const converter = definition.toZigbee.find((c) => c.key?.includes("eco_mode")) as Tz.Converter;
+
+        // Device A's transaction hangs on its FIRST write and holds A's lock; the remaining
+        // chunk writes after the release fall back to the default resolving mock.
+        let releaseA: (value: Record<string, unknown>) => void = () => {};
+        vi.mocked(deviceA.getEndpoint(239).write).mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    releaseA = resolve;
+                }),
+        );
+        const pendingA = converter.convertSet?.(deviceA.getEndpoint(239), "eco_mode", true, {device: deviceA, message: {}, state: {}} as never);
+
+        // Device B must complete although A is still holding its own lock.
+        const resultB = await converter.convertSet?.(deviceB.getEndpoint(239), "eco_mode", true, {device: deviceB, message: {}, state: {}} as never);
+        expect(resultB).toStrictEqual({state: {eco_mode: true}});
+
+        releaseA({});
+        await pendingA;
+    });
+});

--- a/test/shelly.test.ts
+++ b/test/shelly.test.ts
@@ -1016,6 +1016,12 @@ describe("Shelly RPC hygiene", () => {
             ],
         });
 
+    it("registers no RPC diagnostics converter without the Dev feature", async () => {
+        const definition = await findByDevice(mockPresence("0x000000000000f101"));
+
+        expect(definition.fromZigbee.some((c) => c.cluster === "shellyRPCCluster")).toBe(false);
+    });
+
     it("does not serialize RPC writes of different devices against each other", async () => {
         const deviceA = mockPresence("0x000000000000f102");
         const deviceB = mockPresence("0x000000000000f103");


### PR DESCRIPTION
## What users see today

The Shelly RPC lock is a single module-global flag: a hanging transaction on one device — e.g. the write retry loop against an unreachable device (three attempts with 1.5 s pauses) — blocks RPC configuration writes to **every other Shelly on the network** for its whole duration. The multi-write transaction only needs to be atomic per device: the chunks travel to separate unicast targets with separate reassembly buffers.

## Changes

1. **`fix:` Key the RPC lock by device** (ieee address) so transactions of different devices no longer serialize against each other. Same-device atomicity is unchanged — the whole TxCtl→chunks sequence stays under one acquisition. A test proves device B completes while device A is holding its own lock.
2. **`refactor:` Zero-effect cleanup while here**, each verifiably inert today: the RPC diagnostics converter is only registered with the Dev feature (nothing else can produce `shellyRPCCluster` responses while the firmware answers no RPC read — see `SHELLY_RPC_CAN_READ` —, and it published undeclared `rpc_rxctl`/`rpc_data` state keys), a dead `published`-flag branch in the Wi-Fi refresh is gone, and the TRV alarm and `switchType` converters return nothing instead of an empty object — the TRV one used to emit an empty publish on every single thermostat report.

## Tests

- `pnpm run build && pnpm run check && pnpm test` green on both commits (pre-commit hook), 748 tests on this branch.
- New coverage: different devices do not serialize against each other; no RPC diagnostics converter is registered without the Dev feature.
