### PR TITLE
feat(NodOn): add support for SEM-4-3-20 three-phase energy meter

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -8,8 +8,8 @@ import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import {nodonPilotWire} from "../lib/nodon";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, ModernExtend} from "../lib/types";
-import {isDummyDevice} from "../lib/utils";
+import type {DefinitionWithExtend, Fz, KeyValue, ModernExtend} from "../lib/types";
+import {isDummyDevice, postfixWithEndpointName} from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -335,6 +335,150 @@ export const definitions: DefinitionWithExtend[] = [
             },
         ],
         exposes: [e.enum("energy_reset", ea.SET, ["reset"]).withDescription("Reset all energy counters to 0").withCategory("config")],
+        ota: true,
+    },
+    {
+        zigbeeModel: ["SEM-4-3-20"],
+        model: "SEM-4-3-20",
+        vendor: "NodOn",
+        description: "3CT Energy Meter",
+        endpoint: (device) => ({default: 1}),
+        extend: (() => {
+            const meter = m.electricityMeter({
+                threePhase: true,
+                voltage: {min: 10, max: 3600, change: 100},
+                current: {min: 10, max: 3600, change: 100},
+                power: {min: 10, max: 3600, change: 250},
+                acFrequency: {min: 60, max: 3600, change: 10},
+                producedEnergy: {min: 300, max: 3600, change: 100},
+                energy: {min: 300, max: 3600, change: 100},
+            });
+            // electricityMeter()'s base voltage/current/power/energy exposes have no per-phase
+            // suffix for Phase A (only Phase B/C get '_phase_b'/'_phase_c'); this device measures
+            // 3 phases so all labels are made explicit rather than leaving Phase A implicit.
+            const relabel = (name: string, label: string) => {
+                const found = meter.exposes?.find((exp) => typeof exp !== "function" && exp.name === name);
+                if (found && typeof found !== "function") found.withLabel(label);
+            };
+            relabel("voltage", "Voltage - Phase A");
+            relabel("current", "Current - Phase A");
+            relabel("power", "Active power - Phase A");
+            relabel("voltage_phase_b", "Voltage - Phase B");
+            relabel("current_phase_b", "Current - Phase B");
+            relabel("power_phase_b", "Active power - Phase B");
+            relabel("voltage_phase_c", "Voltage - Phase C");
+            relabel("current_phase_c", "Current - Phase C");
+            relabel("power_phase_c", "Active power - Phase C");
+            relabel("energy", "Total consumed energy");
+            relabel("produced_energy", "Total produced energy");
+            return [m.identify(), meter];
+        })(),
+        toZigbee: [
+            {
+                key: ["energy_reset"],
+                convertSet: async (entity, _key, _value, _meta) => {
+                    // genBasic/resetFactDefault resets all cluster attributes to factory defaults.
+                    // Network membership, bindings and configureReporting are not affected (ZCL spec).
+                    await entity.command("genBasic", "resetFactDefault", {});
+                    return {state: {}};
+                },
+            },
+        ],
+        exposes: [
+            e.enum("energy_reset", ea.SET, ["reset"]).withDescription("Reset all energy counters to 0").withCategory("config"),
+
+            e.power_factor().withAccess(ea.STATE).withLabel("Power factor - Phase A"),
+            e.power_factor_phase_b().withAccess(ea.STATE).withLabel("Power factor - Phase B"),
+            e.power_factor_phase_c().withAccess(ea.STATE).withLabel("Power factor - Phase C"),
+            e.power_reactive().withAccess(ea.STATE).withLabel("Reactive power - Phase A"),
+            e.power_reactive_phase_b().withAccess(ea.STATE).withLabel("Reactive power - Phase B"),
+            e.power_reactive_phase_c().withAccess(ea.STATE).withLabel("Reactive power - Phase C"),
+            e.power_apparent().withAccess(ea.STATE).withLabel("Apparent power - Phase A"),
+            e.power_apparent_phase_b().withAccess(ea.STATE).withLabel("Apparent power - Phase B"),
+            e.power_apparent_phase_c().withAccess(ea.STATE).withLabel("Apparent power - Phase C"),
+
+            e.numeric("total_active_power", ea.STATE).withUnit("W").withDescription("Total active power across all 3 phases"),
+            e.numeric("total_reactive_power", ea.STATE).withUnit("VAR").withDescription("Total reactive power across all 3 phases"),
+            e.numeric("total_apparent_power", ea.STATE).withUnit("VA").withDescription("Total apparent power across all 3 phases"),
+
+            // Phase A/B/C energy: NodOn repurposes seMetering's tariff-tier attributes
+            // (currentTier1/2/3SummDelivered/Received) to carry per-phase energy on this
+            // 3-phase device — not tariffs. `tariffs` is never passed to m.electricityMeter()
+            // above, so none of these are exposed automatically; all 3 phases must be added
+            // manually. Property name stays energy_tier_N/produced_energy_tier_N (fz.metering
+            // hardcodes it), only the frontend label is overridden.
+            e.numeric("energy_tier_1", ea.STATE).withLabel("Consumed energy - Phase A").withUnit("kWh").withDescription("Energy consumed by Phase A"),
+            e
+                .numeric("produced_energy_tier_1", ea.STATE)
+                .withLabel("Produced energy - Phase A")
+                .withUnit("kWh")
+                .withDescription("Energy exported by Phase A"),
+            e.numeric("energy_tier_2", ea.STATE).withLabel("Consumed energy - Phase B").withUnit("kWh").withDescription("Energy consumed by Phase B"),
+            e
+                .numeric("produced_energy_tier_2", ea.STATE)
+                .withLabel("Produced energy - Phase B")
+                .withUnit("kWh")
+                .withDescription("Energy exported by Phase B"),
+            e.numeric("energy_tier_3", ea.STATE).withLabel("Consumed energy - Phase C").withUnit("kWh").withDescription("Energy consumed by Phase C"),
+            e
+                .numeric("produced_energy_tier_3", ea.STATE)
+                .withLabel("Produced energy - Phase C")
+                .withUnit("kWh")
+                .withDescription("Energy exported by Phase C"),
+        ],
+        fromZigbee: [
+            // totalActivePower (0x0304), totalReactivePower (0x0305), totalApparentPower (0x0306)
+            // are not handled by fz.electrical_measurement
+            {
+                cluster: "haElectricalMeasurement",
+                type: ["attributeReport", "readResponse"],
+                convert: (model, msg, _publish, _options, meta) => {
+                    const payload: KeyValue = {};
+                    const getFactor = (key: string) => {
+                        const mult = msg.endpoint.getClusterAttributeValue("haElectricalMeasurement", `${key}Multiplier`) as number;
+                        const div = msg.endpoint.getClusterAttributeValue("haElectricalMeasurement", `${key}Divisor`) as number;
+                        return mult && div ? mult / div : 1;
+                    };
+                    if (msg.data.totalActivePower !== undefined) {
+                        payload[postfixWithEndpointName("total_active_power", msg, model, meta)] = msg.data.totalActivePower * getFactor("acPower");
+                    }
+                    if (msg.data.totalReactivePower !== undefined) {
+                        payload[postfixWithEndpointName("total_reactive_power", msg, model, meta)] =
+                            msg.data.totalReactivePower * getFactor("acPower");
+                    }
+                    if (msg.data.totalApparentPower !== undefined) {
+                        payload[postfixWithEndpointName("total_apparent_power", msg, model, meta)] =
+                            msg.data.totalApparentPower * getFactor("acPower");
+                    }
+                    return payload;
+                },
+            } satisfies Fz.Converter<"haElectricalMeasurement", undefined, ["attributeReport", "readResponse"]>,
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await m.setupAttributes(endpoint, coordinatorEndpoint, "haElectricalMeasurement", [
+                {attribute: "reactivePower", min: 10, max: 3600, change: 250},
+                {attribute: "reactivePowerPhB", min: 10, max: 3600, change: 250},
+                {attribute: "reactivePowerPhC", min: 10, max: 3600, change: 250},
+                {attribute: "apparentPower", min: 10, max: 3600, change: 250},
+                {attribute: "apparentPowerPhB", min: 10, max: 3600, change: 250},
+                {attribute: "apparentPowerPhC", min: 10, max: 3600, change: 250},
+                {attribute: "powerFactor", min: 60, max: 3600, change: 20},
+                {attribute: "powerFactorPhB", min: 60, max: 3600, change: 20},
+                {attribute: "powerFactorPhC", min: 60, max: 3600, change: 20},
+                {attribute: "totalActivePower", min: 10, max: 3600, change: 250},
+                {attribute: "totalReactivePower", min: 10, max: 3600, change: 250},
+                {attribute: "totalApparentPower", min: 10, max: 3600, change: 250},
+            ]);
+            await m.setupAttributes(endpoint, coordinatorEndpoint, "seMetering", [
+                {attribute: "currentTier1SummDelivered", min: 300, max: 3600, change: 100},
+                {attribute: "currentTier1SummReceived", min: 300, max: 3600, change: 100},
+                {attribute: "currentTier2SummDelivered", min: 300, max: 3600, change: 100},
+                {attribute: "currentTier2SummReceived", min: 300, max: 3600, change: 100},
+                {attribute: "currentTier3SummDelivered", min: 300, max: 3600, change: 100},
+                {attribute: "currentTier3SummReceived", min: 300, max: 3600, change: 100},
+            ]);
+        },
         ota: true,
     },
     {


### PR DESCRIPTION
Adds support for the NodOn SEM-4-3-20, a DIN-rail energy meter reading three-phase power via
3 external CT clamps (Phase A/B/C).

Exposes voltage/current/active/reactive/apparent power and power factor per phase, AC frequency,
total energy consumed/produced, and per-phase energy consumed/produced. Tested on 2 physical
devices through Zigbee2MQTT 2.12.0.

A couple of firmware quirks explain the choices in the definition:

- The `seMetering` cluster has no native per-phase energy attribute — the ZCL spec doesn't define
  one. The firmware reports Phase A/B/C energy via `currentTier1/2/3SummDelivered/Received`
  instead, attributes ZHC's own `tariffs` option treats as day/night tariff tiers rather than
  phases. This definition keeps the `energy_tier_N`/`produced_energy_tier_N` property names (what
  `fz.metering` produces) but overrides the exposed label to reflect what they actually are on
  this device.
- `reactivePower`/`apparentPower`/`powerFactor` (all 3 phases) and the 3 `total*Power` attributes
  (0x0304/5/6, not parsed by `fz.electrical_measurement`) have no matching key in
  `MeterArgs`/`configureLookup`, so `configure` sets up their reporting via the exported
  `setupAttributes()` helper instead.
- Every exposed measurement is labeled with its phase, including the attributes ZHC's convention
  otherwise leaves unsuffixed for Phase A (`voltage`/`current`/`power`/`power_factor`/
  `power_reactive`/`power_apparent`) — deliberate on a dedicated 3-phase meter, where we'd rather
  make every value's phase explicit than have Phase A be implicit.

Verified locally: `tsc --noEmit`, `biome check --error-on-warnings`, and `vitest run` (full suite,
731/731 tests) all pass against `upstream/master`.

Link to picture pull request: Koenkk/zigbee2mqtt.io#5354

