### PR TITLE
SV01 Keen Vents Require Explicit currentLevel Report Config

### DIFF
--- a/src/devices/keen_home.ts
+++ b/src/devices/keen_home.ts
@@ -60,7 +60,7 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
-            const payload = [{ attribute: "currentLevel" as const, minimumReportInterval: 5, maximumReportInterval: 65534, reportableChange: 1 }];
+            const payload = [{attribute: "currentLevel" as const, minimumReportInterval: 5, maximumReportInterval: 65534, reportableChange: 1}];
             await endpoint.configureReporting("genLevelCtrl", payload);
             const binds = ["genLevelCtrl", "genPowerCfg", "msTemperatureMeasurement", "msPressureMeasurement"];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);

--- a/src/devices/keen_home.ts
+++ b/src/devices/keen_home.ts
@@ -60,6 +60,8 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {battery: {dontDividePercentage: true}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
+            const payload = [{ attribute: "currentLevel" as const, minimumReportInterval: 5, maximumReportInterval: 65534, reportableChange: 1 }];
+            await endpoint.configureReporting("genLevelCtrl", payload);
             const binds = ["genLevelCtrl", "genPowerCfg", "msTemperatureMeasurement", "msPressureMeasurement"];
             await reporting.bind(endpoint, coordinatorEndpoint, binds);
             await reporting.temperature(endpoint);


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Opening as a draft in hopes that someone can test this. I had noticed that many of my Keen vents did not change whether they were open or closed and didn't change their % open. I resolved the issue by configuring reporting via the following in keen_home.ts

const payload = [{ attribute: "currentLevel" as const, minimumReportInterval: 5, maximumReportInterval: 65534, reportableChange: 1 }];
await endpoint.configureReporting("genLevelCtrl", payload);

I later noticed that two of my vents reported these things without the extra config. I did some testing and my vents with the model number SV01 required an explicit reporting config and the ones starting with SV02 did not. In summary:

SV01:
Move command
→ motor moves
→ currentLevel changes internally
→ no report unless reporting was configured

SV02:
Move command
→ motor moves
→ firmware sends currentLevel report automatically

It is my belief that:

### The SV02 firmware has a built-in reporting configuration

OR

### The SV02 firmware sends unsolicited attribute reports

If there is anyone with both SV01 and SV02 it would be an interesting test to see it they notice this same difference and if so, then perhaps this converter change to explicitly configure currentLevel reporting would be a good idea for the SV01 models. 