### PR TITLE
feat: Philips Hue plugs: expose Power-on behavior

### DIFF
--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -764,6 +764,11 @@ const philipsModernExtend = {
     onOff: (args?: modernExtend.OnOffArgs) => {
         args = {ota: true, ...args};
         const result = modernExtend.onOff(args);
+
+        const customCluster2 = philipsModernExtend.addManuSpecificPhilips2Cluster();
+        result.onEvent = [...customCluster2.onEvent, ...(result.onEvent ?? [])];
+        result.configure = [...customCluster2.configure, ...(result.configure ?? [])];
+
         return result;
     },
     twilightOnOff: () => {

--- a/src/lib/philips.ts
+++ b/src/lib/philips.ts
@@ -762,9 +762,8 @@ const philipsModernExtend = {
         return result;
     },
     onOff: (args?: modernExtend.OnOffArgs) => {
-        args = {powerOnBehavior: false, ota: true, ...args};
+        args = {ota: true, ...args};
         const result = modernExtend.onOff(args);
-        result.toZigbee.push(philipsTz.hue_power_on_behavior, philipsTz.hue_power_on_error);
         return result;
     },
     twilightOnOff: () => {


### PR DESCRIPTION
Not sure why Power-on behavior was missing on these plugs..
It works on [Philips 929002240401](https://www.zigbee2mqtt.io/devices/929002240401.html#philips-929002240401). It also has the Philips cluster