### PR TITLE
Clear last published timings for Tuya IR blaster and add override option for HA `value_template`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -21,6 +21,7 @@ export interface HomeAssistant {
     deviceClass?: string;
     enabledByDefault?: boolean;
     icon?: string;
+    valueTemplate?: string | null;
 }
 
 export class Base {

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -628,6 +628,11 @@ export const fzZosung = {
                     },
                     {disableDefaultResponse: true},
                 );
+
+                // Clear learned IR timings for HA
+                clearTimeout(globalStore.getValue(msg.endpoint, "timer"));
+                globalStore.putValue(msg.endpoint, "timer", setTimeout(() => publish({learned_ir_timings: ""}), 500).unref());
+
                 return {
                     learned_ir_code: learnedIRCode,
                     learned_ir_timings: {
@@ -689,14 +694,16 @@ export const presetsZosung = {
     learn_ir_code: () => e.binary("learn_ir_code", ea.SET, "ON", "OFF").withDescription("Turn on to learn new IR code"),
     learned_ir_code: () => e.text("learned_ir_code", ea.STATE).withDescription("The IR code learned by device"),
     learned_ir_timings: () =>
-        e
-            .text("learned_ir_timings", ea.STATE)
-            .withDescription("The IR timings learned by device")
-            .withHomeAssistant({type: "infrared", schema: "receiver"}),
+        e.text("learned_ir_timings", ea.STATE).withDescription("The IR timings learned by device").withHomeAssistant({
+            type: "infrared",
+            schema: "receiver",
+            valueTemplate:
+                "{{ iif(as_timestamp(now()) | int - value_json.learned_ir_timings.timestamp / 1000 < 5, value_json.learned_ir_timings | tojson, None) }}",
+        }),
     ir_code_to_send: () => e.text("ir_code_to_send", ea.SET).withDescription("The IR code or timings to send by device"),
     ir_emitter: () =>
         e
             .text("ir_emitter", ea.SET)
             .withDescription("The IR code or timings to send by device")
-            .withHomeAssistant({type: "infrared", schema: "emitter"}),
+            .withHomeAssistant({type: "infrared", schema: "emitter", valueTemplate: null}),
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Clear last published timings for Tuya IR blaster and add override option for HA `value_template`

This PR also fixes biome.json, which was not in sync