### PR TITLE
fix: LEDVANCE 4099854295232/4099854293276: silence periodic divisor-constant reports

### DIFF
--- a/src/devices/ledvance.ts
+++ b/src/devices/ledvance.ts
@@ -1,6 +1,41 @@
 import {ledvanceLight, ledvanceOnOff} from "../lib/ledvance";
 import * as m from "../lib/modernExtend";
-import type {DefinitionWithExtend} from "../lib/types";
+import type {DefinitionWithExtend, ModernExtend} from "../lib/types";
+
+// The plugs report the six divisor/multiplier constants of the electrical measurement cluster
+// every 5 minutes - values that never change, and which `electricityMeter()` reads actively during
+// configure anyway. Silencing them removes about three quarters of these devices' radio traffic.
+//
+// Runs after electricityMeter (last entry in `extend`) and is guarded: silencing is an
+// optimization, the measurement reporting is the fix, so this must never fail the configure run.
+// Same reasoning as setupAttributes' own read loop, and it also covers variants that lack one of
+// the attributes.
+const silenceDivisorReporting: ModernExtend = {
+    configure: [
+        async (device, coordinatorEndpoint) => {
+            try {
+                await m.setupAttributes(
+                    device,
+                    coordinatorEndpoint,
+                    "haElectricalMeasurement",
+                    [
+                        {attribute: "acPowerDivisor", min: 1, max: 0xffff, change: 1},
+                        {attribute: "acPowerMultiplier", min: 1, max: 0xffff, change: 1},
+                        {attribute: "acCurrentDivisor", min: 1, max: 0xffff, change: 1},
+                        {attribute: "acCurrentMultiplier", min: 1, max: 0xffff, change: 1},
+                        {attribute: "acVoltageDivisor", min: 1, max: 0xffff, change: 1},
+                        {attribute: "acVoltageMultiplier", min: 1, max: 0xffff, change: 1},
+                    ],
+                    true,
+                    false,
+                );
+            } catch {
+                // never fail the configure run over an optimization
+            }
+        },
+    ],
+    isModernExtend: true,
+};
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -43,6 +78,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "4099854295232",
         vendor: "LEDVANCE",
         description: "SMART+ Plug indoor EU with energy meter ",
+        version: "0.0.1",
         whiteLabel: [
             {
                 model: "4099854295256",
@@ -50,14 +86,15 @@ export const definitions: DefinitionWithExtend[] = [
                 fingerprint: [{modelID: "PLUG EU EM T, black"}],
             },
         ],
-        extend: [ledvanceOnOff(), m.electricityMeter()],
+        extend: [ledvanceOnOff(), m.electricityMeter(), silenceDivisorReporting],
     },
     {
         zigbeeModel: ["PLUG COMPACT OUTDOOR EU EM T", "PLUG COMPACT EU EM T"],
         model: "4099854293276",
         vendor: "LEDVANCE",
         description: "SMART+ Compact outdoor plug EU with energy meter",
-        extend: [ledvanceOnOff(), m.electricityMeter()],
+        version: "0.0.1",
+        extend: [ledvanceOnOff(), m.electricityMeter(), silenceDivisorReporting],
         ota: true,
     },
     {

--- a/test/ledvance.test.ts
+++ b/test/ledvance.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it, vi} from "vitest";
+import {findByDevice} from "../src/index";
+import {mockDevice} from "./utils";
+
+const DIVISOR_ATTRIBUTES = [
+    "acPowerDivisor",
+    "acPowerMultiplier",
+    "acCurrentDivisor",
+    "acCurrentMultiplier",
+    "acVoltageDivisor",
+    "acVoltageMultiplier",
+];
+
+const plug = (modelID: string) =>
+    mockDevice({
+        modelID,
+        manufacturerName: "LEDVANCE",
+        endpoints: [
+            {
+                ID: 1,
+                inputClusters: ["genBasic", "genIdentify", "genGroups", "genScenes", "genOnOff", "haElectricalMeasurement", "seMetering"],
+                attributes: {
+                    haElectricalMeasurement: {
+                        attributes: {
+                            acPowerDivisor: 10,
+                            acPowerMultiplier: 1,
+                            acCurrentDivisor: 1000,
+                            acCurrentMultiplier: 1,
+                            acVoltageDivisor: 1,
+                            acVoltageMultiplier: 1,
+                        },
+                    },
+                    seMetering: {attributes: {divisor: 100, multiplier: 1}},
+                },
+            },
+        ],
+    });
+
+type ReportItem = {attribute: string; minimumReportInterval: number; maximumReportInterval: number; reportableChange: number};
+
+// Every attribute handed to configureReporting for the given cluster, flattened across the chunked calls.
+function reportedAttributes(endpoint: ReturnType<typeof plug>["endpoints"][0], cluster = "haElectricalMeasurement"): ReportItem[] {
+    return vi
+        .mocked(endpoint.configureReporting)
+        .mock.calls.filter((call: unknown[]) => call[0] === cluster)
+        .flatMap((call: unknown[]) => call[1] as ReportItem[]);
+}
+
+async function configured(modelID: string) {
+    const device = plug(modelID);
+    const coordinator = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).getEndpoint(1);
+    const definition = await findByDevice(device);
+    return {device, coordinator, definition, endpoint: device.getEndpoint(1)};
+}
+
+describe.each(["PLUG EU EM T", "PLUG COMPACT EU EM T"])("LEDVANCE energy meter plug (%s)", (modelID) => {
+    it("silences all six divisor/multiplier constants", async () => {
+        const {device, coordinator, definition, endpoint} = await configured(modelID);
+
+        await definition.configure?.(device, coordinator, definition);
+
+        const silenced = reportedAttributes(endpoint)
+            .filter((a) => a.maximumReportInterval === 0xffff)
+            .map((a) => a.attribute)
+            .sort();
+        expect(silenced).toStrictEqual([...DIVISOR_ATTRIBUTES].sort());
+    });
+
+    // The regression this guard exists for: silencing is an optimization, the base electricityMeter
+    // reporting is the fix. A delivery failure while silencing must not take the measurement
+    // reporting down with it.
+    it("still configures the measurements when silencing fails", async () => {
+        const {device, coordinator, definition, endpoint} = await configured(modelID);
+
+        vi.mocked(endpoint.configureReporting).mockImplementation((_cluster: unknown, items: unknown) => {
+            const attributes = (items as ReportItem[]).map((i) => i.attribute);
+            if (attributes.some((a) => DIVISOR_ATTRIBUTES.includes(a))) {
+                return Promise.reject(new Error("Delivery failed"));
+            }
+            return Promise.resolve();
+        });
+
+        await expect(definition.configure?.(device, coordinator, definition)).resolves.not.toThrow();
+
+        expect(reportedAttributes(endpoint).map((a) => a.attribute)).toContain("activePower");
+    });
+});


### PR DESCRIPTION
The two LEDVANCE energy-meter plugs (`4099854295232` indoor, `4099854293276` compact outdoor) report the six divisor/multiplier constants of `haElectricalMeasurement` (`acPowerDivisor`, `acPowerMultiplier`, `acCurrentDivisor`, `acCurrentMultiplier`, `acVoltageDivisor`, `acVoltageMultiplier`) **every five minutes**. These values never change, and `electricityMeter()` already reads them during configure. Over a 14 h device-debug capture they accounted for roughly **three quarters** of these devices' frames.

Setting their maximum reporting interval to `0xFFFF` stops the periodic reports. Verified on hardware by writing it and reading the reporting table back: all six sit at 65535 afterwards and the five-minute cycle is gone, with the device still responding normally.

### Notes
- `silenceDivisorReporting` runs last in `extend` and swallows its own errors on purpose: silencing is an optimization, the measurement reporting is the actual fix — a `Delivery failed` while silencing must not take the configure run down with it. That is what the second test guards.
- Both definitions get `version: "0.0.1"` so already-paired devices reconfigure.
- Scope reduced to the divisor-silencing only, per review — the reporting-parameter change is dropped; the frontend-less reporting default will be taken up on the ioBroker side.