### PR TITLE
fix(sonoff): MINI-ZBRBS: add missing 'none' (0) value for motor_trave…

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -9716,6 +9716,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "motor_travel_calibration_action",
                 lookup: {
+                    none: 0,
                     start_automatic: 2,
                     start_manual: 3,
                     clear: 4,


### PR DESCRIPTION
### What
Adds `none: 0` to the `motor_travel_calibration_action` enum lookup for SONOFF MINI-ZBRBS.

### Why
The device reports `motorTravelCalibrationAction = 0` (idle / no action pending), e.g. shortly after pairing or boot, but the enum lookup only covers 2, 3, 4, 7 and 8 (start_automatic, start_manual, clear, manual_2_fully_opened, manual_3_fully_closed). This causes a recurring converter warning on every such report:

```
Error while processing converters ... cluster 'customClusterEwelink' type 'attributeReport,readResponse' message: Expected one of: 2, 3, 4, 7, 8, got: '0'
```

Observed consistently across three separate MINI-ZBRBS units on the same network (ioBroker.zigbee, converters 26.81.0, herdsman 10.6.2), always with raw value 0 for this attribute.

### Note for maintainers
`access` is currently `ALL`, so this also exposes `none` as a settable option (write 0) in addition to fixing the read path. Happy to change this to a read-only accommodation for `0` if that is preferred instead of exposing it as a selectable action - let me know and I will adjust.

### Tested
Applied on top of current master (26.87.0). Have not been able to test an actual write of `none` against physical hardware, only confirmed the read path no longer throws for the observed real-world traffic.