### PR TITLE
Fix: simplify template on infrared receiver entity to avoid warnings when the value is reset

### DIFF
--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -697,8 +697,7 @@ export const presetsZosung = {
         e.text("learned_ir_timings", ea.STATE).withDescription("The IR timings learned by device").withHomeAssistant({
             type: "infrared",
             schema: "receiver",
-            valueTemplate:
-                "{{ iif(as_timestamp(now()) | int - value_json.learned_ir_timings.timestamp / 1000 < 5, value_json.learned_ir_timings | tojson, None) }}",
+            valueTemplate: "{{ value_json.learned_ir_timings | tojson }}",
         }),
     ir_code_to_send: () => e.text("ir_code_to_send", ea.SET).withDescription("The IR code or timings to send by device"),
     ir_emitter: () =>


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Fix: simplify template on infrared receiver entity to avoid warnings when the value is reset
