### PR TITLE
[_TZ3210_mja6r5ix] use `moveToLevelWithOnOffDisable`

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4090,7 +4090,8 @@ export const definitions: DefinitionWithExtend[] = [
                 e.getDevice().manufacturerName === "_TZB210_417ikxay" ||
                 e.getDevice().manufacturerName === "_TZB210_qzsxaqqe" ||
                 e.getDevice().manufacturerName === "_TZB210_u3ri0968" || // https://github.com/Koenkk/zigbee2mqtt/issues/31733
-                e.getDevice().manufacturerName === "_TZB210_rs0ufzwg", // https://github.com/Koenkk/zigbee2mqtt/issues/31872
+                e.getDevice().manufacturerName === "_TZB210_rs0ufzwg" || // https://github.com/Koenkk/zigbee2mqtt/issues/31872
+                e.getDevice().manufacturerName === "_TZ3210_mja6r5ix", // https://github.com/Koenkk/zigbee2mqtt/issues/32428
         },
         toZigbee: [tzLocal.TS0505B_1_transitionFixesOnOffBrightness],
         configure: (device, coordinatorEndpoint) => {


### PR DESCRIPTION
fixes https://github.com/Koenkk/zigbee2mqtt/issues/32428

Likely the same root cause as https://github.com/Koenkk/zigbee2mqtt/issues/32658 ("resets its brightness to 1%"), since level 3 out of 254 is ~1%.

On this manufacturer, `moveToLevelWithOnOff` lights the bulb but leaves the reported attributes behind: `genOnOff.onOff` stays at `0` and `genLevelCtrl.currentLevel` drops to `3`. The read-back performed by `TS0505B_1_transitionFixesOnOffBrightness` then reports the light as off at 1% while it is physically on at the requested brightness.

Reading the attributes straight from the device after an off/on cycle, with `{"state":"ON","brightness":180}`:

| | `onOff` | `currentLevel` |
|---|---|---|
| before | `0` | `3` |
| after | `1` | `180` |

With the flag enabled the brightness goes through `moveToLevel` and the state through an explicit `genOnOff` command, which keeps both attributes in sync.

Device: `TS0505B` / `_TZ3210_mja6r5ix`, `swBuildId` `z.1.0`, `appVersion` 112 — the same firmware reported in #32428.

tested with external_converter:

```js
import * as tuya from "zigbee-herdsman-converters/lib/tuya";

export default {
    fingerprint: [{modelID: "TS0505B", manufacturerName: "_TZ3210_mja6r5ix", priority: 1}],
    model: "TS0505B_1_1",
    vendor: "Tuya",
    description: "Zigbee 3.0 18W led light bulb E27 RGBCW",
    extend: [
        tuya.modernExtend.tuyaLight({
            colorTemp: {range: [153, 500]},
            color: true,
        }),
    ],
    meta: {
        applyRedFix: true,
        moveToLevelWithOnOffDisable: true,
    },
    configure: (device, coordinatorEndpoint) => {
        device.getEndpoint(1).saveClusterAttributeKeyValue("lightingColorCtrl", {colorCapabilities: 29});
    },
};
```
