### PR TITLE
Add SAV-DL6IN-24V-12W

### DIFF
--- a/src/devices/gledopto.ts
+++ b/src/devices/gledopto.ts
@@ -1383,4 +1383,12 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
+    {
+        zigbeeModel: ["SAV-DL6IN-24V-12W"],
+        model: "SAV-DL6IN-24V-12W",
+        vendor: "Savolar",
+        ota: true,
+        description: "Zigbee 12W Downlight RGB+CCT with external antenna design",
+        extend: [gledoptoLight({colorTemp: {range: [158, 495]}, color: true, powerOnBehavior: true})],
+    },
 ];


### PR DESCRIPTION
Add SAV-DL6IN-24V-12W

Model: SAV-DL6IN-24V-12W
Vendor: Savolar
Description: Zigbee 12W Downlight RGB+CCT with external antenna design