### PR TITLE
fix: Expose Tuya infrared learning ir code switch as button to Home Assistant

### DIFF
--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -15,7 +15,7 @@ import {getLabelFromName} from "./utils";
 
 export type Feature = Numeric | Binary | Enum | Composite | List | Text;
 export interface HomeAssistant {
-    type?: "valve" | "infrared";
+    type?: "infrared" | "button" | "valve";
     schema?: "emitter" | "receiver";
     entityCategory?: "config" | "diagnostic";
     deviceClass?: string;

--- a/src/lib/zosung.ts
+++ b/src/lib/zosung.ts
@@ -691,7 +691,8 @@ export const tzZosung = {
 };
 
 export const presetsZosung = {
-    learn_ir_code: () => e.binary("learn_ir_code", ea.SET, "ON", "OFF").withDescription("Turn on to learn new IR code"),
+    learn_ir_code: () =>
+        e.binary("learn_ir_code", ea.SET, "ON", "OFF").withDescription("Turn on to learn new IR code").withHomeAssistant({type: "button"}),
     learned_ir_code: () => e.text("learned_ir_code", ea.STATE).withDescription("The IR code learned by device"),
     learned_ir_timings: () =>
         e.text("learned_ir_timings", ea.STATE).withDescription("The IR timings learned by device").withHomeAssistant({


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
## Breaking change

Users will need to update there automations in Home Assistant as the type changes from `switch` to `button`, so the entity ID will change.

## Proposed changes

This will expose the "learn ir code" function as a `button` to Home Assistant instead of a `switch`.
In the old situation the the learning mode would be activated regardless of what command (off or on) was sent.

<img width="480" height="70" alt="afbeelding" src="https://github.com/user-attachments/assets/9f197a04-782f-486c-b1d9-aa7a70e1b437" />
