### PR TITLE
feat(add): Shelly Flood S (S4SN-0071Z)

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2485,6 +2485,17 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        fingerprint: [{modelID: "Flood S", manufacturerName: "Shelly"}],
+        model: "S4SN-0071Z",
+        vendor: "Shelly",
+        description: "Flood S Gen 4",
+        extend: [
+            m.battery({percentageReportingConfig: false}),
+            m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low", "trouble"]}),
+            ...shellyModernExtend.shellyCustomClusters(),
+        ],
+    },
+    {
         fingerprint: [{modelID: "Ecowitt WS90", manufacturerName: "Shelly"}],
         model: "WS90",
         vendor: "Shelly",


### PR DESCRIPTION
Adds support for the **Shelly Flood S Gen4** (`S4SN-0071Z`), which currently interviews but stays unsupported (`modelID: "Flood S"`, `manufacturerName: "Shelly"`).

It's the sibling of the already-supported Flood Gen4 (`S4SN-0071A`) and presents the same Zigbee side — a single IAS Zone (water leak) plus battery — so the definition mirrors it.

**Verified on real hardware:** the device reports the water-leak alarm over Zigbee (IAS zone status → `water_leak` true) and battery level.

Endpoints from the coordinator DB: ep1 in `[genBasic, genPowerCfg, genIdentify, ssIasZone]`, out `[genOta]` — no RPC/Wi-Fi clusters, so it's a plain IAS sensor.

Note: the device image (`S4SN-0071Z.png`) isn't part of this repo and would need to be added to the zigbee2mqtt image set separately.