### PR TITLE
fix: handle Somfy Glydea spurious zero reports using command context

### DIFF
--- a/src/devices/somfy.ts
+++ b/src/devices/somfy.ts
@@ -3,9 +3,237 @@ import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend} from "../lib/types";
+import * as globalStore from "../lib/store";
+import type {DefinitionWithExtend, Fz, KeyValueAny, Tz, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
 
 const e = exposes.presets;
+
+type GlydeaTarget = number | "stop";
+
+type GlydeaState = {
+    /**
+     * Expected final position in Zigbee2MQTT coordinates:
+     * 0 = closed, 100 = open.
+     *
+     * "stop" means that an explicit stop command was sent.
+     * undefined means that no Z2M command context is available.
+     */
+    target?: GlydeaTarget;
+
+    /**
+     * True after the device reports windowCoveringType=0.
+     * This allows stale command context to be discarded when a later
+     * movement starts outside Zigbee2MQTT.
+     */
+    stopped: boolean;
+};
+
+const glydeaStateKey = "glydea_position_state";
+
+function getGlydeaState(endpoint: Zh.Endpoint): GlydeaState {
+    return globalStore.getValue(endpoint, glydeaStateKey, {
+        stopped: false,
+    });
+}
+
+function saveGlydeaState(endpoint: Zh.Endpoint, state: GlydeaState): void {
+    globalStore.putValue(endpoint, glydeaStateKey, state);
+}
+
+function getGlydeaEndpoints(entity: Zh.Endpoint | Zh.Group): Zh.Endpoint[] {
+    return utils.isEndpoint(entity) ? [entity] : entity.members;
+}
+
+function setGlydeaTarget(entity: Zh.Endpoint | Zh.Group, target: GlydeaTarget): void {
+    for (const endpoint of getGlydeaEndpoints(entity)) {
+        const state = getGlydeaState(endpoint);
+
+        state.target = target;
+        state.stopped = false;
+
+        saveGlydeaState(endpoint, state);
+    }
+}
+
+function clearGlydeaTarget(entity: Zh.Endpoint | Zh.Group): void {
+    for (const endpoint of getGlydeaEndpoints(entity)) {
+        const state = getGlydeaState(endpoint);
+
+        delete state.target;
+
+        saveGlydeaState(endpoint, state);
+    }
+}
+
+const fzLocal = {
+    glydeaPosition: {
+        ...fz.cover_position_tilt,
+
+        convert: (model, msg, publish, options, meta) => {
+            const converted = fz.cover_position_tilt.convert(model, msg, publish, options, meta) as KeyValueAny | undefined;
+
+            /*
+             * An explicit read is authoritative. It is not part of the
+             * faulty movement-stop reporting sequence.
+             */
+            if (msg.type === "readResponse") {
+                return converted;
+            }
+
+            const state = getGlydeaState(msg.endpoint);
+
+            const coveringType = msg.data.windowCoveringType;
+
+            if (coveringType !== undefined) {
+                const moving = coveringType !== 0;
+
+                if (moving) {
+                    /*
+                     * When a new movement starts after the preceding
+                     * operation stopped, and no new Z2M command replaced
+                     * the state, treat it as externally initiated.
+                     */
+                    if (state.stopped) {
+                        delete state.target;
+                    }
+
+                    state.stopped = false;
+                } else {
+                    state.stopped = true;
+                }
+
+                saveGlydeaState(msg.endpoint, state);
+            }
+
+            const rawPosition = msg.data.currentPositionLiftPercentage;
+
+            /*
+             * Only raw zero is affected by the Glydea bug.
+             * All normal position reports pass through unchanged.
+             */
+            if (rawPosition !== 0) {
+                return converted;
+            }
+
+            /*
+             * Without command context it is impossible to distinguish
+             * a real raw-zero endpoint from the device's faulty raw-zero
+             * report. Preserve standard Z2M behaviour in that case.
+             */
+            if (state.target === undefined) {
+                return converted;
+            }
+
+            const convertedPosition = converted?.position;
+
+            /*
+             * A zero after STOP is always spurious.
+             *
+             * For OPEN, CLOSE and exact-position commands, compare with
+             * the expected position in exposed Z2M coordinates.
+             *
+             * convertedPosition was produced by the standard converter,
+             * so options such as invert_cover have already been applied.
+             */
+            const spurious = state.target === "stop" || convertedPosition !== state.target;
+
+            delete state.target;
+
+            saveGlydeaState(msg.endpoint, state);
+
+            return spurious ? {} : converted;
+        },
+    } satisfies Fz.Converter<"closuresWindowCovering", undefined, ["attributeReport", "readResponse"]>,
+};
+
+const tzLocal = {
+    glydeaCoverState: {
+        ...tz.cover_state,
+
+        convertSet: async (entity, key, value, meta) => {
+            utils.assertString(value, key);
+
+            const normalized = value.toLowerCase();
+
+            let target: GlydeaTarget | undefined;
+
+            switch (normalized) {
+                case "open":
+                case "on":
+                    target = 100;
+                    break;
+
+                case "close":
+                case "off":
+                    target = 0;
+                    break;
+
+                case "stop":
+                    target = "stop";
+                    break;
+            }
+
+            if (target !== undefined) {
+                setGlydeaTarget(entity, target);
+            }
+
+            const convertSet = tz.cover_state.convertSet;
+
+            if (convertSet === undefined) {
+                throw new Error("cover_state converter does not support convertSet");
+            }
+
+            try {
+                return await convertSet(entity, key, value, meta);
+            } catch (error) {
+                if (target !== undefined) {
+                    clearGlydeaTarget(entity);
+                }
+
+                throw error;
+            }
+        },
+    } satisfies Tz.Converter,
+
+    glydeaCoverPositionTilt: {
+        ...tz.cover_position_tilt,
+
+        convertSet: async (entity, key, value, meta) => {
+            const tracksPosition = key === "position";
+
+            if (tracksPosition) {
+                utils.assertNumber(value, key);
+
+                setGlydeaTarget(entity, value);
+            }
+
+            const convertSet = tz.cover_position_tilt.convertSet;
+
+            if (convertSet === undefined) {
+                throw new Error("cover_position_tilt converter does not support convertSet");
+            }
+
+            try {
+                return await convertSet(entity, key, value, meta);
+            } catch (error) {
+                if (tracksPosition) {
+                    clearGlydeaTarget(entity);
+                }
+
+                throw error;
+            }
+        },
+    } satisfies Tz.Converter,
+};
+
+const glydeaWindowCovering = m.windowCovering({
+    controls: ["lift"],
+});
+
+glydeaWindowCovering.fromZigbee = [fzLocal.glydeaPosition];
+
+glydeaWindowCovering.toZigbee = [tzLocal.glydeaCoverState, tzLocal.glydeaCoverPositionTilt];
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -128,7 +356,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "9028412A",
         vendor: "Somfy",
         description: "Glydea Curtain motor Zigbee module",
-        extend: [m.windowCovering({controls: ["lift"]})],
+        extend: [glydeaWindowCovering],
     },
     {
         zigbeeModel: ["Tilt & Lift 25 WF Roller"],

--- a/test/somfy.test.ts
+++ b/test/somfy.test.ts
@@ -1,0 +1,210 @@
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {findByDevice} from "../src/index";
+import * as globalStore from "../src/lib/store";
+import type {Fz, KeyValue, Tz} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+describe("Somfy Glydea Ultra Curtain", () => {
+    beforeEach(() => {
+        globalStore.clear();
+    });
+
+    async function setup() {
+        const device = mockDevice({
+            ieeeAddr: "0x4cc206fffe316577",
+            modelID: "Glydea Ultra Curtain",
+            manufacturerName: "SOMFY",
+            endpoints: [
+                {
+                    ID: 1,
+                    inputClusters: ["closuresWindowCovering"],
+                },
+            ],
+        });
+
+        const definition = await findByDevice(device);
+
+        const endpoint = device.getEndpoint(1);
+
+        const fromConverter = definition.fromZigbee.find((converter) => converter.cluster === "closuresWindowCovering");
+
+        const stateConverter = definition.toZigbee.find((converter) => converter.key?.includes("state"));
+
+        const positionConverter = definition.toZigbee.find((converter) => converter.key?.includes("position"));
+
+        if (!fromConverter || !stateConverter?.convertSet || !positionConverter?.convertSet) {
+            throw new Error("Glydea converters not found");
+        }
+
+        const stateConvertSet = stateConverter.convertSet;
+        const positionConvertSet = positionConverter.convertSet;
+
+        const convert = (data: Record<string, number>, options: KeyValue = {}, type: "attributeReport" | "readResponse" = "attributeReport") => {
+            const message = {
+                data,
+                endpoint,
+                device,
+                meta: {
+                    rawData: Buffer.alloc(0),
+                },
+                groupID: 0,
+                type,
+                cluster: "closuresWindowCovering",
+                linkquality: 0,
+            } as Fz.Message<"closuresWindowCovering", undefined, ["attributeReport", "readResponse"]>;
+
+            return fromConverter.convert(definition, message, () => {}, options, {
+                state: {},
+                device,
+                deviceExposesChanged: () => {},
+            });
+        };
+
+        const createMeta = (message: KeyValue, options: KeyValue = {}): Tz.Meta => ({
+            message,
+            device,
+            mapped: definition,
+            options,
+            state: {},
+            endpoint_name: undefined,
+            publish: () => {},
+        });
+
+        const sendState = async (state: string, options: KeyValue = {}) => {
+            await stateConvertSet(endpoint, "state", state, createMeta({state}, options));
+        };
+
+        const sendPosition = async (position: number, options: KeyValue = {}) => {
+            await positionConvertSet(endpoint, "position", position, createMeta({position}, options));
+        };
+
+        return {
+            convert,
+            sendPosition,
+            sendState,
+        };
+    }
+
+    it("filters the spurious zero after closing", async () => {
+        const {convert, sendState} = await setup();
+
+        await sendState("CLOSE");
+
+        expect(
+            convert({
+                currentPositionLiftPercentage: 100,
+            }),
+        ).toStrictEqual({
+            position: 0,
+            state: "CLOSE",
+        });
+
+        expect(
+            convert({
+                currentPositionLiftPercentage: 0,
+            }),
+        ).toStrictEqual({});
+    });
+
+    it("filters the spurious zero after stop", async () => {
+        const {convert, sendState} = await setup();
+
+        await sendState("STOP");
+
+        expect(
+            convert({
+                currentPositionLiftPercentage: 0,
+            }),
+        ).toStrictEqual({});
+    });
+
+    it("filters the spurious zero after an intermediate target", async () => {
+        const {convert, sendPosition} = await setup();
+
+        await sendPosition(60);
+
+        expect(
+            convert({
+                currentPositionLiftPercentage: 40,
+            }),
+        ).toStrictEqual({
+            position: 60,
+            state: "OPEN",
+        });
+
+        expect(
+            convert({
+                currentPositionLiftPercentage: 0,
+            }),
+        ).toStrictEqual({});
+    });
+
+    it("accepts a genuine fully-open endpoint", async () => {
+        const {convert, sendState} = await setup();
+
+        await sendState("OPEN");
+
+        expect(
+            convert({
+                currentPositionLiftPercentage: 0,
+            }),
+        ).toStrictEqual({
+            position: 100,
+            state: "OPEN",
+        });
+    });
+
+    it("preserves invert_cover for position targets", async () => {
+        const {convert, sendPosition} = await setup();
+
+        const options = {
+            invert_cover: true,
+        };
+
+        await sendPosition(0, options);
+
+        expect(
+            convert(
+                {
+                    currentPositionLiftPercentage: 0,
+                },
+                options,
+            ),
+        ).toMatchObject({
+            position: 0,
+        });
+    });
+
+    it("does not change reports without command context", async () => {
+        const {convert} = await setup();
+
+        expect(
+            convert({
+                currentPositionLiftPercentage: 0,
+            }),
+        ).toStrictEqual({
+            position: 100,
+            state: "OPEN",
+        });
+    });
+
+    it("never filters an explicit read response", async () => {
+        const {convert, sendState} = await setup();
+
+        await sendState("CLOSE");
+
+        expect(
+            convert(
+                {
+                    currentPositionLiftPercentage: 0,
+                },
+                {},
+                "readResponse",
+            ),
+        ).toStrictEqual({
+            position: 100,
+            state: "OPEN",
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fix the Somfy Glydea Ultra Zigbee module (`9028412A`) incorrectly publishing a fully-open position when movement stops.

The module can send an additional raw `currentPositionLiftPercentage: 0` report after a movement. The standard cover converter interprets that raw value as fully open, which can overwrite the actual final position.

## Important: previous implementation superseded

This PR **completely replaces and supersedes the earlier percentage-threshold implementation**.

The previous version attempted to identify a genuine fully-open endpoint by checking whether the preceding raw position was within an arbitrary percentage of zero.

That approach is no longer relevant and should not be used as the basis for reviewing this PR.

Further hardware testing showed that the threshold-based approach was not sufficiently robust because:

- the threshold was inherently arbitrary;
- it assumed that the motor reports predictable intermediate positions near the endpoint;
- different Glydea modules report intermediate positions differently;
- some modules report only a final position;
- a valid endpoint could be rejected when the expected preceding percentage was not reported;
- a spurious zero could be accepted when the preceding position happened to fall within the threshold.

The current implementation contains **no percentage threshold** and does not depend on a particular sequence of intermediate reports.

## New approach

The converter now tracks the exact command sent to each Glydea endpoint by Zigbee2MQTT.

The tracked command context is:

- `OPEN`: expected exposed position is `100`;
- `CLOSE`: expected exposed position is `0`;
- `STOP`: no new endpoint position is expected;
- exact position command: the requested exposed position is expected.

When the device reports raw position zero, the report is first processed by the standard `fz.cover_position_tilt` converter.

The result is then compared with the known command target:

- a zero report matching the requested endpoint is accepted;
- a zero report conflicting with the requested endpoint is discarded;
- a zero report following an explicit `STOP` command is discarded;
- a zero report matching an exact requested position is accepted.

Because the comparison uses the result of the standard converter, normal cover options such as `invert_cover` have already been applied.

## Conservative behaviour without command context

When no Zigbee2MQTT command context is available, the converter preserves the normal Zigbee2MQTT behaviour.

This is intentional.

For example, when a curtain is operated using a physical control or another Zigbee controller, the received raw-zero report may not contain enough information to distinguish a genuine fully-open endpoint from the module's faulty trailing zero.

The converter therefore does not guess in that situation.

Explicit `readResponse` messages are also treated as authoritative and are never filtered.

## Implementation

- Wrap `fz.cover_position_tilt` for Glydea-specific incoming-report handling.
- Wrap `tz.cover_state` to track `OPEN`, `CLOSE`, and `STOP`.
- Wrap `tz.cover_position_tilt` to track exact position targets.
- Store command context per endpoint using Zigbee2MQTT's global store.
- Continue using the standard converters for actual Zigbee commands and position conversion.
- Preserve `invert_cover` and other standard cover behaviour.
- Remove all percentage-based heuristics.

## Tests

Tests cover:

- filtering the spurious zero after closing;
- filtering the spurious zero after an explicit stop;
- filtering the spurious zero after an intermediate position target;
- accepting a genuine fully-open endpoint;
- preserving `invert_cover`;
- preserving normal behaviour without command context;
- never filtering an explicit position read.

## Hardware testing

Tested on multiple physical Somfy Glydea Ultra curtain motors.

Confirmed:

- an intermediate stop no longer produces an incorrect fully-open position;
- a fully closed curtain no longer reopens in Zigbee2MQTT state;
- genuine fully-open and fully-closed endpoints continue to work;
- `invert_cover` continues to work;
- differences in intermediate position-reporting behaviour do not affect the command-context logic.

Addresses Koenkk/zigbee2mqtt#31490.
