### PR TITLE
fix(tuya): accept over_voltage_threshold for 110-127V grids on TS011F_with_threshold

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -16495,7 +16495,9 @@ export const definitions: DefinitionWithExtend[] = [
                 e.binary("over_current_breaker", ea.STATE_SET, "ON", "OFF").withDescription("Over-current breaker"),
                 e
                     .numeric("over_voltage_threshold", ea.STATE_SET)
-                    .withValueMin(220)
+                    // Min 90 (not 220) so thresholds for 100-127V grids are accepted too;
+                    // the device firmware itself takes values in this range.
+                    .withValueMin(90)
                     .withValueMax(265)
                     .withValueStep(1)
                     .withUnit("V")


### PR DESCRIPTION
## Summary

The `over_voltage_threshold` expose on `TS011F_with_threshold` had `withValueMin(220)` — a 230V-grid assumption. On 100–127V grids (Brazil, US, Japan, Mexico, ...) the correct over-voltage trip point is around 135–140V, which the device firmware happily accepts and reports back (verified on 7× Tongou TO-Q-SY2-163JZT / `_TZ3000_cayepv1a` on a live 127V installation, device reporting `rmsVoltage: 129`). The expose range however:

- makes Zigbee2MQTT reject any set below 220V, and
- publishes `min: 220` via Home Assistant MQTT discovery, so HA continuously logs `Invalid value for number....over_voltage_threshold: 137 (range 220.0 - 265.0)` for the device-reported state.

This PR lowers the minimum to 90V. The sibling `under_voltage_threshold` in the same expose block already supports low-voltage grids (`withValueMin(75)`), so this brings the two in line. The trip value is user-configured, so the wider range carries no risk for 230V-grid users — their existing values remain valid.

Fixes Koenkk/zigbee2mqtt#32689

## Testing

What's verified on the live 127V installation: the firmware itself accepts a 137V threshold (set out-of-band) and reports it back, so only the expose range stands in the way. I have 7 of these breakers and can test a dev build with this change if helpful.