### PR TITLE
Add support for Nova Digital ZBCMR-02 roller blind motor

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -9718,6 +9718,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE200_68nvbi09",
             "_TZE200_vexa5o82",
             "_TZE200_sfqyhvpv",
+            "_TZE284_n73badib",
         ]),
         model: "TS0601_cover_3",
         vendor: "Tuya",
@@ -9739,6 +9740,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Hiladuo", "B09M3R35GC", "Motorized roller shade", ["_TZE200_9p5xmj5r"]),
             tuya.whitelabel("Tuya", "MYQ-RM25-1.3/25-BZ", "Tubular roller blind motor", ["_TZE200_vexa5o82"]),
             tuya.whitelabel("Shaman", "25EB-1/30-TYZ", "Motorized roller shade", ["_TZE200_sfqyhvpv"]),
+            tuya.whitelabel("Nova Digital", "ZBCMR-02", "Roller Blind Motor", ["_TZE284_n73badib"]),
         ],
         meta: {
             // All datapoints go in here


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request:

There seems to be two different devices by Nova Digital with the same model name "ZBCMR-02".
There is already a picture available:
https://github.com/Koenkk/zigbee2mqtt.io/blob/master/public/images/devices/ZBCMR-02.png

But the model I have on hand is slightly different:
https://github.com/bmnascimento/zigbee2mqtt.io/tree/image-ZBCMR-02/public/images/devices/ZBCMR-02.png

Also, I found there is a PR already for the other version of the device:
https://github.com/Koenkk/zigbee-herdsman-converters/pull/12177

I have tested the device I have on hand and it worked perfectly with the already existing model "TS0601_cover_3".

Which image should I use and what device name to use in the code considering the conflict? Thank you for your time.