### PR TITLE
fix: use correct expose key for battery voltage on TS0601_water_valve and TS0601_water_meter

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2506,7 +2506,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "battery_voltage", tuya.valueConverter.divideBy100],
+                [26, "voltage", tuya.valueConverter.divideBy100],
             ],
         },
         // Optional: Add device-specific options
@@ -2829,7 +2829,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "battery_voltage", tuya.valueConverter.divideBy100],
+                [26, "voltage", tuya.valueConverter.divideBy100],
             ],
         },
         options: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2390,7 +2390,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.numeric("flow_rate", ea.STATE).withUnit("L/h").withDescription("Instantaneous water flow rate"),
             e.binary("auto_clean", ea.STATE_SET, "ON", "OFF").withDescription("Auto clean"),
             e.temperature(),
-            e.numeric("battery_voltage", ea.STATE).withUnit("V").withDescription("Battery voltage").withCategory("diagnostic"),
+            e.battery_voltage(),
             e.text("meter_id", ea.STATE).withDescription("Meter identification number"),
             e.text("faults", ea.STATE).withDescription("Active fault status"),
             e.enum("report_period", ea.STATE_SET, ["1h", "2h", "3h", "4h", "6h", "8h", "12h", "24h"]).withDescription("Report period"),
@@ -2506,7 +2506,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "battery_voltage", tuya.valueConverter.divideBy100],
+                [26, "voltage", tuya.valueConverter.divideBy100],
             ],
         },
         // Optional: Add device-specific options
@@ -2657,7 +2657,7 @@ export const definitions: DefinitionWithExtend[] = [
                 // DP 22 - Outlet Water Temperature
                 [22, "outlet_water_temperature", tuya.valueConverter.divideBy100],
                 // DP 24 - Power Supply Voltage
-                [24, "battery_voltage", tuya.valueConverter.multiplyBy10],
+                [24, "voltage", tuya.valueConverter.multiplyBy10],
             ],
         },
         options: [
@@ -2699,7 +2699,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("report_period", ea.STATE_SET, ["1h", "2h", "3h", "4h", "6h", "8h", "12h", "24h"]).withDescription("Report period"),
             e.text("meter_id", ea.STATE).withDescription("Meter identification number"),
             e.temperature(),
-            e.numeric("battery_voltage", ea.STATE).withUnit("V").withDescription("Battery voltage").withCategory("diagnostic"),
+            e.battery_voltage(),
             e.text("faults", ea.STATE).withDescription("Active fault status"),
         ],
         meta: {
@@ -2829,7 +2829,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "battery_voltage", tuya.valueConverter.divideBy100],
+                [26, "voltage", tuya.valueConverter.divideBy100],
             ],
         },
         options: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2390,7 +2390,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.numeric("flow_rate", ea.STATE).withUnit("L/h").withDescription("Instantaneous water flow rate"),
             e.binary("auto_clean", ea.STATE_SET, "ON", "OFF").withDescription("Auto clean"),
             e.temperature(),
-            e.battery_voltage(),
+            e.numeric("battery_voltage", ea.STATE).withUnit("V").withDescription("Battery voltage").withCategory("diagnostic"),
             e.text("meter_id", ea.STATE).withDescription("Meter identification number"),
             e.text("faults", ea.STATE).withDescription("Active fault status"),
             e.enum("report_period", ea.STATE_SET, ["1h", "2h", "3h", "4h", "6h", "8h", "12h", "24h"]).withDescription("Report period"),
@@ -2506,7 +2506,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "voltage", tuya.valueConverter.divideBy100],
+                [26, "battery_voltage", tuya.valueConverter.divideBy100],
             ],
         },
         // Optional: Add device-specific options
@@ -2699,7 +2699,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("report_period", ea.STATE_SET, ["1h", "2h", "3h", "4h", "6h", "8h", "12h", "24h"]).withDescription("Report period"),
             e.text("meter_id", ea.STATE).withDescription("Meter identification number"),
             e.temperature(),
-            e.battery_voltage(),
+            e.numeric("battery_voltage", ea.STATE).withUnit("V").withDescription("Battery voltage").withCategory("diagnostic"),
             e.text("faults", ea.STATE).withDescription("Active fault status"),
         ],
         meta: {
@@ -2829,7 +2829,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "voltage", tuya.valueConverter.divideBy100],
+                [26, "battery_voltage", tuya.valueConverter.divideBy100],
             ],
         },
         options: [


### PR DESCRIPTION
## Description

The `e.battery_voltage()` expose creates a sensor with key `voltage`, but the `tuyaDatapoints` mapping for DP 26 was writing to `battery_voltage`. This mismatch causes the voltage sensor to always show as **Unknown** in the Zigbee2MQTT frontend and Home Assistant.

The raw `battery_voltage` field in the MQTT state payload does contain the correct value (e.g. `3.7`), but the UI sensor bound to `voltage` remains `null` because nothing writes to that key.

## Fix

Changed DP 26 mapping key from `battery_voltage` to `voltage` so it matches the expose definition:

```diff
- [26, "battery_voltage", tuya.valueConverter.divideBy100],
+ [26, "voltage", tuya.valueConverter.divideBy100],
```

## Affected devices

| Model | Description | Fingerprints |
|-------|-------------|-------------|
| TS0601_water_valve | Ultrasonic water meter valve | _TZE284_vuwtqx0t, _TZE200_vuwtqx0t |
| TS0601_water_meter | Ultrasonic water meter | _TZE200_h367laha |

## Verification

MQTT payload before fix:
```json
{"battery_voltage": 3.7, "voltage": null}
```

After fix, `voltage` will correctly report the value from DP 26.