### PR TITLE
Fix #12740 - add custom attributes/cluster to the device

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -2284,6 +2284,7 @@ export const definitions: DefinitionWithExtend[] = [
             namron.toZigbee.namron_thermostat_child_lock,
         ],
         extend: [
+            namron.namronExtend.addNamronHvacThermostatCluster(),
             m.onOff({powerOnBehavior: false}),
             m.electricityMeter({voltage: false}),
             m.binary<"hvacThermostat", namron.NamronHvacThermostat>({


### PR DESCRIPTION
Fix https://github.com/Koenkk/zigbee-herdsman-converters/issues/12740
Add the custom attributes to the device. 

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
