### PR TITLE
Add Beca BAC-001 thermostat (_TZE204_hpkusvom)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -570,6 +570,11 @@ const bindSlotTS0601SmartSceneKnob = async (entity: Zh.Endpoint | Zh.Group, slot
     await tuya.sendDataPointRaw(entity as Zh.Endpoint, 102, payload, "dataRequest", 0x10 + (slot - 1));
 };
 
+// The BAC-001 reports its power state (dp 1) and its operating mode (dp 2) on separate datapoints,
+// combine both into a single `system_mode` in which the power state maps to `off`.
+const bac001SystemMode = (meta: Fz.Meta): ThermostatSystemMode =>
+    meta.state.power_state_device === false ? "off" : ((meta.state.system_mode_device as ThermostatSystemMode) ?? "cool");
+
 const trv603ScheduleConverter = (dayNumber: number) => {
     return {
         from: (value: unknown) => {
@@ -7590,6 +7595,76 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
         whiteLabel: [tuya.whitelabel("Tuya", "BAC-003", "FCU thermostat temperature controller", ["_TZE204_dzuqwsyg"])],
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_hpkusvom"]),
+        model: "BAC-001",
+        vendor: "Tuya",
+        description: "Heating/cooling thermostat with fan control",
+        extend: [tuya.modernExtend.tuyaBase({dp: true, forceTimeUpdates: true, timeStart: "1970"})],
+        exposes: [
+            e
+                .climate()
+                .withSystemMode(["off", "cool", "heat", "fan_only"], ea.STATE_SET)
+                .withSetpoint("current_heating_setpoint", 5, 35, 0.5, ea.STATE_SET)
+                .withLocalTemperature(ea.STATE)
+                .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
+                .withFanMode(["low", "medium", "high", "auto"], ea.STATE_SET),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [
+                    1,
+                    null,
+                    {
+                        from: (v: boolean, meta: Fz.Meta) => {
+                            meta.state.power_state_device = v;
+                            return {system_mode: bac001SystemMode(meta)};
+                        },
+                    },
+                ],
+                [
+                    2,
+                    "system_mode",
+                    {
+                        to: async (v: string, meta: Tz.Meta) => {
+                            const ep = meta.device.endpoints[0];
+                            if (v === "off") {
+                                await tuya.sendDataPointBool(ep, 1, false, "dataRequest", 1);
+                                return;
+                            }
+                            await tuya.sendDataPointBool(ep, 1, true, "dataRequest", 1);
+                            await tuya.sendDataPointEnum(ep, 2, utils.getFromLookup(v, {cool: 0, heat: 1, fan_only: 2}), "dataRequest", 1);
+                        },
+                        from: (v: number, meta: Fz.Meta) => {
+                            meta.state.system_mode_device = ["cool", "heat", "fan_only"][v];
+                            return bac001SystemMode(meta);
+                        },
+                    },
+                ],
+                [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
+                [24, "local_temperature", tuya.valueConverter.divideBy10],
+                [
+                    27,
+                    "local_temperature_calibration",
+                    {
+                        // Negative values are reported as a 32 bit two's complement
+                        from: (v: number) => (v > 0x7fffffff ? v - 0x100000000 : v),
+                        to: (v: number) => (v < 0 ? 0x100000000 + v : v),
+                    },
+                ],
+                [
+                    28,
+                    "fan_mode",
+                    tuya.valueConverterBasic.lookup({
+                        low: tuya.enum(0),
+                        medium: tuya.enum(1),
+                        high: tuya.enum(2),
+                        auto: tuya.enum(3),
+                    }),
+                ],
+            ],
+        },
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_qq9mpfhw"]),


### PR DESCRIPTION
Adds support for the Beca BAC-001 heating/cooling thermostat with fan control
  (`TS0601` / `_TZE204_hpkusvom`).

  Closes https://github.com/Koenkk/zigbee2mqtt/issues/31502

  Device picture PR: Koenkk/zigbee2mqtt.io/pull/5372

  ### Datapoints

  | DP | Exposed as | Notes |
  |----|------------|-------|
  | 1  | `system_mode` | power state, mapped to `off` |
  | 2  | `system_mode` | `cool` / `heat` / `fan_only` |
  | 16 | `current_heating_setpoint` | /10 |
  | 24 | `local_temperature` | /10 |
  | 27 | `local_temperature_calibration` | negatives are 32 bit two's complement |
  | 28 | `fan_mode` | `low` / `medium` / `high` / `auto` |

  The device reports its power state and its operating mode on two separate
  datapoints, and `off` is not one of the values of DP 2. Exposing these
  separately leaves Home Assistant without a working mode control on the climate
  entity, so both are combined into a single `system_mode` the same approach
  already used by the sibling BAC-002-ALZB in this file.

  `forceTimeUpdates` with `timeStart: "1970"` is required, without it the
  schedule/time presets on the device do not work.

  ### Tested

  Verified on hardware (app version 74): on/off via `system_mode`, switching
  between cool/heat/fan_only, setpoint, local temperature, calibration
  (including negative values) and fan speed.

  ### Not implemented

  The device has further settings whose datapoints have not been identified yet:
  screen brightness, 12h/24h clock, child lock, min/max allowed temperature,
  display modes and energy saving mode. These can be added later once the DPs
  are known.

