### PR TITLE
fix(wirenboard): correct CO2 unit for WB-MSW-ZIGBEE_v.4_official

### DIFF
--- a/src/devices/wirenboard.ts
+++ b/src/devices/wirenboard.ts
@@ -855,7 +855,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.temperature({reporting: false}),
             m.humidity({reporting: false}),
             m.occupancy({reporting: false}),
-            m.co2({scale: 1, reporting: false}),
+            m.co2({reporting: false}),
             // Custom attributes
             m.numeric({
                 name: "noise_level",


### PR DESCRIPTION
The official Wiren Board firmware for WB-MSW-ZIGBEE v.4 reported CO2 in the
Carbon Dioxide Concentration Measurement cluster (0x040D) as raw ppm, which is
why this converter carried a `scale: 1` override on `m.co2`.

Per the ZCL spec (R8 §4.13.2.1.1.1, Table 4-47) the `MeasuredValue` of that
cluster is a *fraction of 1* (range 0..1), i.e. ppm × 1e-6. The firmware has
been fixed to report the fraction per spec, so the override is no longer
correct: drop `scale: 1` and use the default 1e-6 scaling.

Paired with the device firmware change (WB-MSW-ZIGBEE v.4 official firmware,
OTA version 0x00010039 and later). Older firmware reporting raw ppm will now
read ~1e6× too low — users must update the firmware together with this change.