### PR TITLE
fix: Shelly S4SN-0071A/S4SN-0071Z: merge Flood and Flood S into one definition

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2474,21 +2474,21 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: [{modelID: "Flood", manufacturerName: "Shelly"}],
+        fingerprint: [
+            {modelID: "Flood", manufacturerName: "Shelly"},
+            {modelID: "Flood S", manufacturerName: "Shelly"},
+        ],
         model: "S4SN-0071A",
         vendor: "Shelly",
         description: "Flood Gen 4",
-        extend: [
-            m.battery({percentageReportingConfig: false}),
-            m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low", "trouble"]}),
-            ...shellyModernExtend.shellyCustomClusters(),
+        whiteLabel: [
+            {
+                vendor: "Shelly",
+                model: "S4SN-0071Z",
+                description: "Flood S Gen 4",
+                fingerprint: [{modelID: "Flood S", manufacturerName: "Shelly"}],
+            },
         ],
-    },
-    {
-        fingerprint: [{modelID: "Flood S", manufacturerName: "Shelly"}],
-        model: "S4SN-0071Z",
-        vendor: "Shelly",
-        description: "Flood S Gen 4",
         extend: [
             m.battery({percentageReportingConfig: false}),
             m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low", "trouble"]}),


### PR DESCRIPTION
Follow-up to #12796, as suggested by @andrei-lazarov in the review there.

The Flood (`S4SN-0071A`) and Flood S (`S4SN-0071Z`) are identical on the Zigbee side (same clusters, same `extend`), so this merges them into a single definition and expresses the Flood S as a whitelabel — dropping the duplicated block.

They report distinct modelIDs (`Flood` / `Flood S`), so both are listed in `fingerprint`; the whitelabel carries its own fingerprint, so the Flood S keeps its own model number, description and image (`S4SN-0071Z`).

Verified `findByDevice` resolves both:
- modelID `Flood` → `S4SN-0071A` (Flood Gen 4)
- modelID `Flood S` → `S4SN-0071Z` (Flood S Gen 4)

No image change — both device images already exist.