### PR TITLE
fix: Shelly 1/1 Mini, 1PM/1PM Mini: merge identical variants into whitelabels

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2099,9 +2099,18 @@ const tzLocal = {
 export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["Mini1", "1 Mini"],
+        fingerprint: [{modelID: "1", manufacturerName: "Shelly"}],
         model: "S4SW-001X8EU",
         vendor: "Shelly",
         description: "1 Mini Gen 4",
+        whiteLabel: [
+            {
+                vendor: "Shelly",
+                model: "S4SW-001X16EU",
+                description: "1 Gen 4",
+                fingerprint: [{modelID: "1", manufacturerName: "Shelly"}],
+            },
+        ],
         ota: true,
         // The genOnOff/genScenes bindings and the switchType read in configure were added after
         // this device was first released; bump the patch version so already paired devices get
@@ -2138,91 +2147,18 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "1", manufacturerName: "Shelly"}],
-        model: "S4SW-001X16EU",
-        vendor: "Shelly",
-        description: "1 Gen 4",
-        ota: true,
-        // The genOnOff/genScenes bindings and the switchType read in configure were added after
-        // this device was first released; bump the patch version so already paired devices get
-        // re-configured and their input events start arriving (same rule as the BLU remotes).
-        version: "0.0.1",
-        fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
-        toZigbee: [tzLocal.switch_input_type],
-        // The switch input endpoint only exists when an input is actually wired. Without it the
-        // setting has nothing to address, and a state that can never hold a value is worse than
-        // none - so expose it the same way the 2PM already does, conditional on the endpoint.
-        exposes: (device) => [
-            e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_single", "input_1_double", "input_1_triple", "input_1_hold"]),
-            ...shellySwitchInputExposes(device, {sw1: 2}),
-        ],
-        extend: [
-            // The endpoint map must only name endpoints the device actually has: the application
-            // builds its property parser from these names and resolves them with a non-null
-            // assertion, so naming sw1 on a device without a wired input crashes every
-            // switch_type_sw1/switch_mode_sw1 set with "Cannot read properties of undefined
-            // (reading 'ID')" (Koenkk/zigbee2mqtt#31951).
-            shellyDeviceEndpoints({sw1: 2}),
-            m.onOff({powerOnBehavior: false}),
-            ...shellyModernExtend.shellyCustomClusters(),
-            shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
-            shellyModernExtend.shellyWiFiSetup(),
-        ],
-        configure: async (device, coordinatorEndpoint) => {
-            const ep = device.getEndpoint(2);
-            if (ep) {
-                await ep.bind("genOnOff", coordinatorEndpoint);
-                await ep.bind("genScenes", coordinatorEndpoint);
-                await ep.read("genOnOffSwitchCfg", ["switchType"]);
-            }
-        },
-    },
-    {
-        zigbeeModel: ["Mini1PM", "1PM Mini"],
+        zigbeeModel: ["Mini1PM", "1PM Mini", "1PM"],
         model: "S4SW-001P8EU",
         vendor: "Shelly",
         description: "1PM Mini Gen 4",
-        ota: true,
-        // The genOnOff/genScenes bindings and the switchType read in configure were added after
-        // this device was first released; bump the patch version so already paired devices get
-        // re-configured and their input events start arriving (same rule as the BLU remotes).
-        version: "0.0.1",
-        fromZigbee: [fzLocal.one_switch_input_events, fzLocal.one_switch_input_scene_events, fzLocal.switch_input_type],
-        toZigbee: [tzLocal.switch_input_type],
-        // The switch input endpoint only exists when an input is actually wired. Without it the
-        // setting has nothing to address, and a state that can never hold a value is worse than
-        // none - so expose it the same way the 2PM already does, conditional on the endpoint.
-        exposes: (device) => [
-            e.action(["input_1_on", "input_1_off", "input_1_toggle", "input_1_single", "input_1_double", "input_1_triple", "input_1_hold"]),
-            ...shellySwitchInputExposes(device, {sw1: 2}),
+        whiteLabel: [
+            {
+                vendor: "Shelly",
+                model: "S4SW-001P16EU",
+                description: "1PM Gen 4",
+                fingerprint: [{modelID: "1PM"}],
+            },
         ],
-        extend: [
-            // The endpoint map must only name endpoints the device actually has: the application
-            // builds its property parser from these names and resolves them with a non-null
-            // assertion, so naming sw1 on a device without a wired input crashes every
-            // switch_type_sw1/switch_mode_sw1 set with "Cannot read properties of undefined
-            // (reading 'ID')" (Koenkk/zigbee2mqtt#31951).
-            shellyDeviceEndpoints({sw1: 2}),
-            m.onOff({powerOnBehavior: false}),
-            m.electricityMeter({producedEnergy: true, acFrequency: true}),
-            ...shellyModernExtend.shellyCustomClusters(),
-            shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
-            shellyModernExtend.shellyWiFiSetup(),
-        ],
-        configure: async (device, coordinatorEndpoint) => {
-            const ep = device.getEndpoint(2);
-            if (ep) {
-                await ep.bind("genOnOff", coordinatorEndpoint);
-                await ep.bind("genScenes", coordinatorEndpoint);
-                await ep.read("genOnOffSwitchCfg", ["switchType"]);
-            }
-        },
-    },
-    {
-        zigbeeModel: ["1PM"],
-        model: "S4SW-001P16EU",
-        vendor: "Shelly",
-        description: "1PM Gen 4",
         ota: true,
         // The genOnOff/genScenes bindings and the switchType read in configure were added after
         // this device was first released; bump the patch version so already paired devices get


### PR DESCRIPTION
Follow-up to #12811 (Flood/Flood S merge). Prompted by @andrei-lazarov's whitelabel suggestion there, I went through the rest of the Shelly definitions for the same pattern and found two more pairs that are identical on the Zigbee side:

- **1** (`S4SW-001X16EU`) and **1 Mini** (`S4SW-001X8EU`)
- **1PM** (`S4SW-001P16EU`) and **1PM Mini** (`S4SW-001P8EU`)

Within each pair the definitions are byte-identical in `fromZigbee` / `toZigbee` / `exposes` / `extend` / `configure` — the only differences are the model number and the matching key (the physical difference is form factor / rating, invisible to the converter). Both pre-existing definitions already carried the same `shellyRPCSetup(["1PMInputMode"])`, so the merge changes nothing there.

Each pair is merged into one definition, expressing the non-primary variant as a whitelabel so it keeps its own model number, description and image:
- `1` matches by `fingerprint` with `manufacturerName` (the modelID `1` is too generic for a bare `zigbeeModel`) — same as the Flood.
- `1PM` matches by `zigbeeModel`, so it joins the primary `zigbeeModel` list and the whitelabel relabels it by modelID — same as the existing BLU RC Button 4 definition.

Verified `findByDevice` resolves all four (1 Mini/Mini1 → `S4SW-001X8EU`, 1 → `S4SW-001X16EU`, 1PM Mini/Mini1PM → `S4SW-001P8EU`, 1PM → `S4SW-001P16EU`). No image change — all device images already exist.