### PR TITLE
Add BHT-209-GCZB thermostat support

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4828,7 +4828,7 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
-        {
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_4cgmagba"]),
         model: "BHT-209-GCZB",
         vendor: "Beca",
@@ -4844,21 +4844,14 @@ export const definitions: DefinitionWithExtend[] = [
                 .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
                 .withSystemMode(["heat"], ea.STATE)
                 .withRunningState(["idle", "heat"], ea.STATE),
-            e
-                .max_temperature_limit()
-                .withUnit("°C")
-                .withValueMin(35)
-                .withValueMax(45)
-                .withValueStep(1),
+            e.max_temperature_limit().withUnit("°C").withValueMin(35).withValueMax(45).withValueStep(1),
             e
                 .deadzone_temperature()
                 .withValueMin(1)
                 .withValueMax(5)
                 .withValueStep(1)
                 .withDescription("The delta between local_temperature and current_heating_setpoint to trigger heating"),
-            e
-                .binary("heating_mode", ea.STATE_SET, "ON", "OFF")
-                .withDescription("ON = heating, OFF = cooling. Must stay ON for boiler control"),
+            e.binary("heating_mode", ea.STATE_SET, "ON", "OFF").withDescription("ON = heating, OFF = cooling. Must stay ON for boiler control"),
         ],
         meta: {
             tuyaDatapoints: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4828,6 +4828,52 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
     },
+        {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_4cgmagba"]),
+        model: "BHT-209-GCZB",
+        vendor: "Beca",
+        description: "Battery Zigbee thermostat with dry contact for boiler control",
+        extend: [tuya.modernExtend.tuyaBase({dp: true, forceTimeUpdates: true, timeStart: "1970"})],
+        exposes: [
+            e.binary("state", ea.STATE_SET, "ON", "OFF").withDescription("Turn the thermostat on/off"),
+            e.child_lock(),
+            e
+                .climate()
+                .withLocalTemperature(ea.STATE)
+                .withSetpoint("current_heating_setpoint", 5, 45, 0.5, ea.STATE_SET)
+                .withLocalTemperatureCalibration(-9, 9, 1, ea.STATE_SET)
+                .withSystemMode(["heat"], ea.STATE)
+                .withRunningState(["idle", "heat"], ea.STATE),
+            e
+                .max_temperature_limit()
+                .withUnit("°C")
+                .withValueMin(35)
+                .withValueMax(45)
+                .withValueStep(1),
+            e
+                .deadzone_temperature()
+                .withValueMin(1)
+                .withValueMax(5)
+                .withValueStep(1)
+                .withDescription("The delta between local_temperature and current_heating_setpoint to trigger heating"),
+            e
+                .binary("heating_mode", ea.STATE_SET, "ON", "OFF")
+                .withDescription("ON = heating, OFF = cooling. Must stay ON for boiler control"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tuya.valueConverter.onOff],
+                [16, "current_heating_setpoint", tuya.valueConverter.divideBy10],
+                [18, "deadzone_temperature", tuya.valueConverter.raw],
+                [24, "local_temperature", tuya.valueConverter.divideBy10],
+                [27, "local_temperature_calibration", tuya.valueConverter.raw],
+                [34, "max_temperature_limit", tuya.valueConverter.raw],
+                [36, "running_state", tuya.valueConverterBasic.lookup({idle: 1, heat: 0})],
+                [40, "child_lock", tuya.valueConverter.lockUnlock],
+                [104, "heating_mode", tuya.valueConverterBasic.lookup({ON: true, OFF: false})],
+            ],
+        },
+    },
     {
         // AR331 Pro: 6 presets (auto/manual/holiday/eco/comfort/standby), 8-slot daily schedules,
         // boost heating, frost protection, summer mode, override temperature, open-window detection.


### PR DESCRIPTION

<img width="4000" height="3000" alt="20260730_232602" src="https://github.com/user-attachments/assets/1e30d570-be61-4908-90ef-131b87f0fbad" />
Adds support for the Beca BHT-209-GCZB, a battery-powered Zigbee thermostat with a dry-contact relay for boiler on/off control.

**Device**
- Model: BHT-209-GCZB (Beca)
- Fingerprint: `TS0601` / `_TZE284_4cgmagba`
- Power: Battery (sleepy end device)

**Testing**

Tested on physical hardware. Every datapoint was verified two ways: by changing the setting on the unit and confirming the reported value in debug logs, and by writing each control from Home Assistant and confirming the device echoed the change back.

Confirmed working: on/off state, setpoint, local temperature, running state, child lock, heating/cooling mode, max temperature limit, deadzone, and local temperature calibration.

**Datapoints**

| DP | Feature | Notes |
|----|---------|-------|
| 1 | state (on/off) | |
| 16 | current_heating_setpoint | ÷10 |
| 18 | deadzone_temperature | raw — whole degrees, not ÷10 | | 24 | local_temperature | ÷10 |
| 27 | local_temperature_calibration | raw, signed whole degrees | | 34 | max_temperature_limit | raw |
| 36 | running_state | inverted: 0 = heat, 1 = idle | | 40 | child_lock | |
| 104 | heating_mode | must be ON for the boiler contact to operate |

**Notes**
- DP 18 and DP 27 report whole-degree integers, so they use `raw` rather than `divideBy10` (verified by stepping the values on the unit).
- DP 36 running_state is inverted compared to the usual Tuya convention.
- No battery datapoint was observed across multiple full rejoins and extended operation; this variant appears not to report battery over Zigbee.
- DP 102 (boolean, mostly 0) and DP 103 (integer, 1–2) are emitted but their function could not be determined, so they are omitted.

Happy to run further tests on the device if needed.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.

