### PR TITLE
fix: SONOFF valves: fix Home Assistant control

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -10208,7 +10208,8 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior: false,
                 skipDuplicateTransaction: true,
                 configureReporting: false,
-                homeassistant: {type: "valve"},
+                // homeassistant: {type: "valve"},
+                // needs https://github.com/Koenkk/zigbee2mqtt/pull/32367
             }),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             sonoffExtend.swvznGenTimeCompatResponse(),
@@ -10349,7 +10350,8 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior: false,
                 skipDuplicateTransaction: true,
                 configureReporting: false,
-                homeassistant: {type: "valve"},
+                // homeassistant: {type: "valve"},
+                // needs https://github.com/Koenkk/zigbee2mqtt/pull/32367
             }),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             sonoffExtend.swvznGenTimeCompatResponse(),
@@ -10491,7 +10493,8 @@ export const definitions: DefinitionWithExtend[] = [
                 powerOnBehavior: false,
                 skipDuplicateTransaction: true,
                 configureReporting: false,
-                homeassistant: {type: "valve"},
+                // homeassistant: {type: "valve"},
+                // needs https://github.com/Koenkk/zigbee2mqtt/pull/32367
             }),
             m.bindCluster({cluster: "genPollCtrl", clusterType: "input"}),
             sonoffExtend.swvznGenTimeCompatResponse(),


### PR DESCRIPTION
Valve type isn't implemented yet:
- https://github.com/Koenkk/zigbee2mqtt/pull/32367

Home Assistant sends open/close. But Zigbee2MQTT expects on/off.

> error:    z2m: Publish 'set' 'state' to 'sonoff' failed: 'Error: 'close' not allowed, choose between: toggle,off,on'

We must remove it, or merge the PR above. Otherwise the valves won't be usable in HA after the next Z2M release.

cc @MaxRink

Thanks Xploder on Discord for noticing