### PR TITLE
fix: Tuya TS011F_plug_1: Fix current scale

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11309,6 +11309,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TS011F_plug_1",
         description: "Smart plug (with power monitoring)",
         vendor: "Tuya",
+        version: "0.0.1",
         whiteLabel: [
             {vendor: "LELLKI", model: "TS011F_plug"},
             {vendor: "BlitzWolf", model: "BW-SHP15"},

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11415,8 +11415,9 @@ export const definitions: DefinitionWithExtend[] = [
                 "acVoltageDivisor",
                 "acPowerMultiplier",
                 "acPowerDivisor",
-                "acCurrentMultiplier",
-                "acCurrentDivisor",
+                // "acCurrentMultiplier",
+                // "acCurrentDivisor",
+                // Some devices report wrong divisor. Zbeacon TS011F v1.0.5 gives 1, but it's actually 1000
             ] as const) {
                 try {
                     await endpoint.read("haElectricalMeasurement", [attr]);


### PR DESCRIPTION
Tuya is unpredictable 🙂 This caused some issues @Nirostar:
- https://github.com/Koenkk/zigbee-herdsman-converters/pull/12545

Thanks yousaf465 for reporting on Discord:

> Zbeacon TS011F v1.0.5 reports acCurrentDivisor 1, but it needs 1000.

The original PR only needs custom power and voltage. So I removed the custom current. Reverted to the default 1000.

- Probably related https://github.com/Koenkk/zigbee2mqtt/discussions/32711