### PR TITLE
Rename `motor_run_status` to `moving` for SONOFF MINI-ZBRBS

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -9718,7 +9718,7 @@ export const definitions: DefinitionWithExtend[] = [
                 access: "STATE_GET",
             }),
             m.enumLookup<"customClusterEwelink", SonoffEwelink>({
-                name: "motor_run_status",
+                name: "moving",
                 lookup: {Stop: 0, Forward: 1, Reverse: 2},
                 cluster: "customClusterEwelink",
                 attribute: "motorRunStatus",

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -9719,7 +9719,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.enumLookup<"customClusterEwelink", SonoffEwelink>({
                 name: "moving",
-                lookup: {Stop: 0, Forward: 1, Reverse: 2},
+                lookup: {stop: 0, forward: 1, reverse: 2},
                 cluster: "customClusterEwelink",
                 attribute: "motorRunStatus",
                 description: "The motor's current operating status, such as forward rotation, reverse rotation, and stop.",


### PR DESCRIPTION
As mentioned in https://github.com/Koenkk/zigbee2mqtt/pull/32702#discussion_r3692999068.