### PR TITLE
fix: match NUL padded modelID when several candidates exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,14 @@ function removeFromExternalDefinitionsLookup(zigbeeModel: string | undefined, de
     }
 }
 
+/**
+ * Some devices pad `modelID` with NUL bytes or surrounding whitespace. Strip that so lookups
+ * and comparisons use the same form as the value declared in `zigbeeModel`.
+ */
+function normalizeModelID(modelID: string): string {
+    return modelID.replace(/\0(.|\n)*$/g, "").trim();
+}
+
 function getFromExternalDefinitionsLookup(zigbeeModel: string | undefined): DefinitionWithExtend[] | undefined {
     const lookupModel = zigbeeModel ? zigbeeModel.toLowerCase() : "null";
 
@@ -139,7 +147,7 @@ function getFromExternalDefinitionsLookup(zigbeeModel: string | undefined): Defi
         return externalDefinitionsLookup.get(lookupModel);
     }
 
-    return externalDefinitionsLookup.get(lookupModel.replace(/\0(.|\n)*$/g, "").trim());
+    return externalDefinitionsLookup.get(normalizeModelID(lookupModel));
 }
 
 export function removeExternalDefinitions(converterName?: string): void {
@@ -216,7 +224,7 @@ async function getFromIndex(zigbeeModel: string | undefined): Promise<Definition
         return await getDefinitions(indexes);
     }
 
-    indexes = MODELS_INDEX[lookupModel.replace(/\0(.|\n)*$/g, "").trim()];
+    indexes = MODELS_INDEX[normalizeModelID(lookupModel)];
 
     if (indexes) {
         logger.debug(`Getting definitions for: ${indexes}`, NS);
@@ -562,10 +570,15 @@ export async function findDefinition(device: Zh.Device, generateForUnknown = fal
             return fingerprintMatch.definition;
         }
 
-        // Match based on fingerprint failed, return first matching definition based on zigbeeModel
-        for (const candidate of candidates) {
-            if (candidate.zigbeeModel && device.modelID && candidate.zigbeeModel.includes(device.modelID)) {
-                return candidate;
+        // Match based on fingerprint failed, return first matching definition based on zigbeeModel.
+        // A candidate can be here because the lookups above matched the normalized modelID, so compare against that form too.
+        if (device.modelID) {
+            const normalizedModelID = normalizeModelID(device.modelID);
+
+            for (const candidate of candidates) {
+                if (candidate.zigbeeModel?.some((zigbeeModel) => zigbeeModel === device.modelID || zigbeeModel === normalizedModelID)) {
+                    return candidate;
+                }
             }
         }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -404,6 +404,33 @@ describe("ZHC", () => {
         expect(definitionWithExtPresent.model).toStrictEqual("ZY-M100-S_1");
     });
 
+    it("finds definition by NUL padded model ID", async () => {
+        const device = mockDevice({modelID: "lumi.sensor_motion\u0000", endpoints: []}, "Router");
+
+        expect((await findByDevice(device)).model).toStrictEqual("RTCGQ01LM");
+    });
+
+    it("finds definition by NUL padded model ID when an external converter adds a second candidate", async () => {
+        const device = mockDevice({modelID: "lumi.sensor_motion\u0000", endpoints: []}, "Router");
+
+        expect((await findByDevice(device)).model).toStrictEqual("RTCGQ01LM");
+
+        addExternalDefinition({
+            zigbeeModel: ["lumi.sensor_motion"],
+            model: "mock-model",
+            vendor: "dummy",
+            description: "dummy",
+            fromZigbee: [],
+            toZigbee: [],
+            exposes: [],
+            externalConverterName: "mock-model.js",
+        });
+
+        expect((await findByDevice(device))?.model).toStrictEqual("mock-model");
+        removeExternalDefinitions("mock-model.js");
+        expect((await findByDevice(device)).model).toStrictEqual("RTCGQ01LM");
+    });
+
     it("exposes light with endpoint", () => {
         const expected = {
             type: "light",


### PR DESCRIPTION
`findDefinition` strips NUL padding and whitespace from `modelID` in both `getFromIndex` and `getFromExternalDefinitionsLookup`, but the final fallback compares `candidate.zigbeeModel` against the raw `device.modelID`. A device that pads its `modelID` gets found by the normalized lookup, then matches nothing, and falls back to a generated definition.

You only hit this with two or more candidates. A single candidate returns earlier through the `candidates.length === 1` short circuit, which never reaches the comparison. Installing an external converter for a model that already has a built-in definition is enough to get there.

I ran into it on the Atlantic Galapagos radiator from #12649. It reports `modelID` as `100050060900\0`. While my external converter was the only candidate it worked fine. Once the built-in definition shipped in v26.80.0 and both were loaded, the radiator dropped to a generated definition and lost its climate entity.

I pulled the existing normalization into a `normalizeModelID` helper and used it in the comparison too. Two tests come with it: one for a padded `modelID` with a single candidate, one where an external converter adds a second. The second fails on master.
