### PR TITLE
fix: correct battery voltage display for TS0601_water_valve and TS0601_water_meter

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2511,7 +2511,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "voltage", tuya.valueConverter.divideBy100],
+                [26, "voltage", tuya.valueConverter.multiplyBy10],
             ],
         },
         // Optional: Add device-specific options
@@ -2834,7 +2834,7 @@ export const definitions: DefinitionWithExtend[] = [
                     },
                 ],
                 [22, "temperature", tuya.valueConverter.divideBy100],
-                [26, "voltage", tuya.valueConverter.divideBy100],
+                [26, "voltage", tuya.valueConverter.multiplyBy10],
             ],
         },
         options: [


### PR DESCRIPTION
## Problem

The battery voltage sensor for TS0601_water_valve and TS0601_water_meter displays **3.7 mV** in Home Assistant instead of the correct **3.7 V**.

### Root cause

The `e.battery_voltage()` expose creates a sensor with:
- key: `voltage`
- unit: `mV`
- device_class: `voltage`

The DP 26 mapping uses `divideBy100`, which converts the raw value `370` to `3.7`. Home Assistant then displays this as **3.7 mV** (0.0037 V), which is incorrect.

### MQTT payload

```json
{"voltage": 3.7}
```

The device reports battery voltage in centivolts (e.g. 370 cV = 3.7 V). After `divideBy100`, the value becomes 3.7, but the unit is `mV`, so HA shows 3.7 mV instead of 3700 mV.

## Fix

Change `divideBy100` to `multiplyBy10` for DP 26 mapping:

```diff
- [26, "voltage", tuya.valueConverter.divideBy100],
+ [26, "voltage", tuya.valueConverter.multiplyBy10],
```

This converts the raw value `370` to `3700`, which HA correctly displays as **3700 mV = 3.7 V**.

## Affected devices

- TS0601_water_valve (`_TZE284_vuwtqx0t`, `_TZE200_vuwtqx0t`)
- TS0601_water_meter (`_TZE200_h367laha`)