### PR TITLE
Update TS0601 from _TZE204_lb0fsvba

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2011,9 +2011,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Current with sign: positive = consumption, negative = production"),
             te
                 .leakageCurrent()
-                .withDescription(
-                    "Current measured by the external ring. Place it over BOTH live and neutral wires to detect leakage current",
-                ),
+                .withDescription("Current measured by the external ring. Place it over BOTH live and neutral wires to detect leakage current"),
             e.device_temperature(),
             te.circuitBreakerFaults(),
             exposes.enum("clear_fault", ea.STATE_SET, ["CLEAR"]).withDescription("Clear the stored faults"),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1918,6 +1918,26 @@ const fzLocal = {
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
 };
 
+const fzSigned: Fz.Converter = {
+    cluster: "manuSpecificTuya",
+    type: ["commandDataReport", "commandDataResponse"],
+    convert: (model, msg, publish, options, meta) => {
+        const state = meta.state || {};
+        const power = state.power as number | undefined;
+        const current = state.current as number | undefined;
+        const status = state.status;
+
+        if (power === undefined && current === undefined) return {};
+
+        const sign = status !== undefined && String(status).toLowerCase().includes("prod") ? -1 : 1;
+
+        const result: KeyValueAny = {};
+        if (power !== undefined) result.power_signed = sign * Math.abs(power);
+        if (current !== undefined) result.current_signed = sign * Math.abs(current);
+        return result;
+    },
+};
+
 export const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_rjjsib2d"]),
@@ -1960,153 +1980,90 @@ export const definitions: DefinitionWithExtend[] = [
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_lb0fsvba"]),
         model: "ZBN-DJ-63",
         vendor: "Tuya",
-        description: "Smart circuit breaker",
-        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        description: "Smart circuit breaker with bidirectional metering",
+        fromZigbee: [fzSigned],
+        extend: [tuya.modernExtend.tuyaBase({dp: true, queryOnConfigure: true})],
         exposes: [
-            e.switch().setAccess("state", ea.STATE_SET).withDescription("Circuit Breaker Switch"),
-            e.energy().withDescription("Total Forward Energy (kWh)").withAccess(ea.STATE),
-            exposes.numeric("reverse_energy", ea.STATE).withUnit("kWh").withDescription("Total Reverse Energy (kWh)"),
-            e.power().withDescription("Active Power (W)").withAccess(ea.STATE),
-            e.voltage().withDescription("Phase A Voltage (V)").withAccess(ea.STATE),
-            e.current().withDescription("Phase A Current (A)").withAccess(ea.STATE),
-            exposes.numeric("temperature", ea.STATE).withUnit("°C").withDescription("Current Temperature"),
-
-            exposes.binary("switch_prepayment", ea.STATE_SET, "ON", "OFF").withDescription("Prepaid Function Switch"),
-            exposes.binary("clear_energy", ea.SET, "ON", "OFF").withDescription("Clear Remaining Available Energy"),
-            exposes.numeric("balance_energy", ea.STATE).withUnit("kWh").withDescription("Remaining Available Energy Display (kWh)"),
-            exposes.numeric("charge_energy", ea.SET).withValueMin(0).withValueMax(999999).withUnit("kWh").withDescription("Energy Recharge"),
-
-            exposes.binary("over_current_breaker", ea.ALL, "ON", "OFF").withDescription("Overcurrent Alarm Enabled"),
+            te
+                .switch()
+                .withDescription(
+                    "On/off state of the circuit (WARNING: It may automatically switch ON after a fault is cleared. See Reclosing option)",
+                ),
+            te.countdown().withValueMax(86400),
+            te
+                .powerOnBehavior()
+                .withAccess(ea.STATE_SET)
+                .withDescription("State to apply after a power outage (It takes ~35s to check faults before applying)"),
+            te.inchingSwitch2(),
+            te.circuitBreakerStatus(),
+            e.power(),
+            e.current(),
+            e.voltage(),
+            e.energy(),
+            e.energy_produced(),
             exposes
-                .numeric("over_current_threshold", ea.ALL)
-                .withValueMin(10)
-                .withValueMax(63)
+                .numeric("power_signed", ea.STATE)
+                .withUnit("W")
+                .withDescription("Active power with sign: positive = consumption, negative = production"),
+            exposes
+                .numeric("current_signed", ea.STATE)
                 .withUnit("A")
-                .withDescription("Overcurrent Threshold"),
-            exposes.binary("over_voltage_breaker", ea.ALL, "ON", "OFF").withDescription("Overvoltage Alarm Enabled"),
-            exposes
-                .numeric("over_voltage_threshold", ea.ALL)
-                .withValueMin(240)
-                .withValueMax(260)
-                .withUnit("V")
-                .withDescription("Overvoltage Threshold"),
-            exposes.binary("under_voltage_breaker", ea.ALL, "ON", "OFF").withDescription("Undervoltage Alarm Enabled"),
-            exposes
-                .numeric("under_voltage_threshold", ea.ALL)
-                .withValueMin(195)
-                .withValueMax(220)
-                .withUnit("V")
-                .withDescription("Undervoltage Threshold"),
-            exposes.numeric("leakage_current", ea.STATE).withUnit("mA").withDescription("Residual Current Display"),
-            exposes.binary("leakage_breaker", ea.ALL, "ON", "OFF").withDescription("Leakage Current Alarm Enabled"),
-            exposes.numeric("leakage_delay", ea.STATE_SET).withValueMin(1).withValueMax(9999).withUnit("s").withDescription("Leakage Delay"),
-            exposes
-                .numeric("leakage_threshold", ea.ALL)
-                .withValueMin(10)
-                .withValueMax(99)
-                .withUnit("mA")
-                .withDescription("Leakage Current Threshold"),
-            exposes.binary("high_temperature_breaker", ea.ALL, "ON", "OFF").withDescription("Temperature Alarm Enabled"),
-            exposes
-                .numeric("high_temperature_threshold", ea.ALL)
-                .withValueMin(10)
-                .withValueMax(85)
-                .withUnit("°C")
-                .withDescription("Temperature Threshold"),
-
-            exposes.numeric("countdown", ea.STATE_SET).withValueMin(0).withValueMax(43200).withUnit("s").withDescription("Countdown Timer"),
-            exposes
-                .numeric("power_on_delay", ea.STATE_SET)
-                .withValueMin(1)
-                .withValueMax(9999)
-                .withUnit("s")
-                .withDescription("Power-On Delay Energization Time"),
-            exposes.numeric("recover_count", ea.STATE_SET).withValueMin(0).withValueMax(999).withDescription("Reclosing Attempt Limit"),
-            exposes.binary("recover_enable", ea.STATE_SET, "ON", "OFF").withDescription("Reclosing Enable"),
-
-            exposes
-                .enum("fault", ea.STATE, [
-                    "clear",
-                    "short_circuit_alarm",
-                    "surge_alarm",
-                    "overload_alarm",
-                    "leakagecurr_alarm",
-                    "temp_dif_fault",
-                    "fire_alarm",
-                    "high_power_alarm",
-                    "self_test_alarm",
-                    "ov_cr",
-                    "unbalance_alarm",
-                    "ov_vol",
-                    "undervoltage_alarm",
-                    "miss_phase_alarm",
-                    "outage_alarm",
-                    "magnetism_alarm",
-                    "credit_alarm",
-                    "no_balance_alarm",
-                ])
-                .withDescription("Fault Alarm"),
-
-            exposes.enum("relay_power_on_state", ea.STATE_SET, ["Off", "On", "Restore"]).withDescription("Relay Power-On State Setting"),
+                .withDescription("Current with sign: positive = consumption, negative = production"),
+            te
+                .leakageCurrent()
+                .withDescription(
+                    "Current measured by the external ring. Place it over BOTH live and neutral wires to detect leakage current",
+                ),
+            e.device_temperature(),
+            te.circuitBreakerFaults(),
+            exposes.enum("clear_fault", ea.STATE_SET, ["CLEAR"]).withDescription("Clear the stored faults"),
+            te
+                .reclosing()
+                .withDescription(
+                    "Automatically attempt switching ON the circuit after it was turned OFF by a detected fault (WARNING: It seems this happens even when disabled)",
+                ),
+            te.reclosing_delay(),
+            te.reclosing_count(),
+            te.energyPrepayment(),
+            te.energyBalance(),
+            te.energyBalanceAdd(),
+            te.energyBalanceReset(),
+            te.leakageCurrentAndTemperatureAlarm(),
+            te.overCurrentThresholdTime(),
+            te.currentAndVoltageAlarm(),
+            te.lostFlowAlarm(),
+            te.lostFlowThresholdTime(),
         ],
         meta: {
             tuyaDatapoints: [
-                [1, "energy", tuya.valueConverter.divideBy100],
-                [6, null, tuya.valueConverter.phaseVariant2],
-                [
-                    9,
-                    "fault",
-                    tuya.valueConverterBasic.lookup({
-                        clear: 0,
-                        short_circuit_alarm: 1 << 0,
-                        surge_alarm: 1 << 1,
-                        overload_alarm: 1 << 2,
-                        leakagecurr_alarm: 1 << 3,
-                        temp_dif_fault: 1 << 4,
-                        fire_alarm: 1 << 5,
-                        high_power_alarm: 1 << 6,
-                        self_test_alarm: 1 << 7,
-                        ov_cr: 1 << 8,
-                        unbalance_alarm: 1 << 9,
-                        ov_vol: 1 << 10,
-                        undervoltage_alarm: 1 << 11,
-                        miss_phase_alarm: 1 << 12,
-                        outage_alarm: 1 << 13,
-                        magnetism_alarm: 1 << 14,
-                        credit_alarm: 1 << 15,
-                        no_balance_alarm: 1 << 16,
-                    }),
-                ],
-                [11, "switch_prepayment", tuya.valueConverter.onOff],
-                [12, "clear_energy", tuya.valueConverter.onOff],
-                [13, "balance_energy", tuya.valueConverter.divideBy100],
-                [14, "charge_energy", tuya.valueConverter.divideBy100],
-                [15, "leakage_current", tuya.valueConverter.raw],
-                [16, "state", tuya.valueConverter.onOff],
-                [17, null, tuya.valueConverter.threshold_2],
-                [17, "leakage_threshold", tuya.valueConverter.threshold_2],
-                [17, "leakage_breaker", tuya.valueConverter.threshold_2],
-                [17, "high_temperature_threshold", tuya.valueConverter.threshold_2],
-                [17, "high_temperature_breaker", tuya.valueConverter.threshold_2],
-                [18, null, tuya.valueConverter.threshold_3],
-                [18, "over_current_threshold", tuya.valueConverter.threshold_3],
-                [18, "over_current_breaker", tuya.valueConverter.threshold_3],
-                [18, "over_voltage_threshold", tuya.valueConverter.threshold_3],
-                [18, "over_voltage_breaker", tuya.valueConverter.threshold_3],
-                [18, "under_voltage_threshold", tuya.valueConverter.threshold_3],
-                [18, "under_voltage_breaker", tuya.valueConverter.threshold_3],
-                [102, "recover_count", tuya.valueConverter.raw],
-                [103, "temperature", tuya.valueConverter.raw],
-                [104, "recover_enable", tuya.valueConverter.onOff],
-                [105, "countdown", tuya.valueConverter.countdown],
-                [106, "cycle_time", tuya.valueConverter.raw],
-                [107, "leakage_delay", tuya.valueConverter.raw],
-                [110, "reverse_energy", tuya.valueConverter.divideBy100],
-                [119, "power_on_delay", tuya.valueConverter.raw],
-                [124, "alarm_over_current_count", tuya.valueConverter.raw],
-                [125, "alarm_low_current_count", tuya.valueConverter.raw],
-                [127, "status", tuya.valueConverter.raw],
-                [134, "relay_power_on_state", tuya.valueConverterBasic.lookup({Off: 0, On: 1, Restore: 2})],
+                [1, "energy", tvc.divideBy100],
+                [6, null, tvc.phaseVariant4],
+                [9, "faults", tvc.circuitBreakerFaults],
+                [11, "prepayment", tvc.onOff],
+                [12, "energy_balance_reset", tvc.reset],
+                [13, "energy_balance", tvc.divideBy100],
+                [14, "energy_balance_add", tvc.energyBalanceAdd],
+                [15, "leakage_current", tvc.raw],
+                [16, "state", tvc.onOffWithZeros],
+                [17, "alarm_set_1", tvc.threshold_4],
+                [18, "alarm_set_2", tvc.threshold_5],
+                [20, "clear_fault", tvc.reset],
+                [101, null, null],
+                [102, "reclosing_count", tvc.raw],
+                [103, "device_temperature", tvc.raw],
+                [104, "reclosing", tvc.onOff],
+                [105, "countdown", tvc.raw],
+                [106, "cycle_schedule", tvc.cycleSchedule],
+                [107, "reclosing_delay", tvc.raw],
+                [108, "random_timing", tvc.raw],
+                [109, "inching", tvc.inchingSwitch2],
+                [110, "energy_produced", tvc.divideBy100],
+                [119, "power_on_delay", tvc.raw],
+                [124, "over_current_threshold_time", tvc.raw],
+                [125, "lost_flow_threshold_time", tvc.raw],
+                [126, "alarm_set_3", tvc.threshold_6],
+                [127, "status", tvc.circuitBreakerStatus],
+                [134, "power_on_behavior", tvc.powerOnBehaviorEnum],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1918,7 +1918,7 @@ const fzLocal = {
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
 };
 
-const fzSigned: Fz.Converter = {
+const fzSigned = {
     cluster: "manuSpecificTuya",
     type: ["commandDataReport", "commandDataResponse"],
     convert: (model, msg, publish, options, meta) => {
@@ -1936,7 +1936,7 @@ const fzSigned: Fz.Converter = {
         if (current !== undefined) result.current_signed = sign * Math.abs(current);
         return result;
     },
-};
+} satisfies Fz.Converter<"manuSpecificTuya", undefined, ["commandDataReport", "commandDataResponse"]>;
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -2011,7 +2011,9 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Current with sign: positive = consumption, negative = production"),
             te
                 .leakageCurrent()
-                .withDescription("Current measured by the external ring. Place it over BOTH live and neutral wires to detect leakage current"),
+                .withDescription(
+                    "Current measured by the external ring. Place it over BOTH live and neutral wires to detect leakage current",
+                ),
             e.device_temperature(),
             te.circuitBreakerFaults(),
             exposes.enum("clear_fault", ea.STATE_SET, ["CLEAR"]).withDescription("Clear the stored faults"),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2011,7 +2011,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withDescription("Current with sign: positive = consumption, negative = production"),
             te
                 .leakageCurrent()
-                .withDescription("Current measured by the external ring. Place it over BOTH live and neutral wires to detect leakage current"),
+                .withDescription("Current·measured·by·the·external·ring.·Place·it·over·BOTH·live·and·neutral·wires·to·detect·leakage·current"),
             e.device_temperature(),
             te.circuitBreakerFaults(),
             exposes.enum("clear_fault", ea.STATE_SET, ["CLEAR"]).withDescription("Clear the stored faults"),


### PR DESCRIPTION
See https://github.com/Koenkk/zigbee2mqtt/issues/32724#issuecomment-5159221474

Changes

1. DP6 (power/current/voltage): phaseVariant2 → phaseVariant4
Root cause of the stale values — the previous variant used the wrong byte offsets when parsing the payload, so power/current stopped updating correctly. phaseVariant4 decodes it properly.

2. DP9 (faults): single enum → circuitBreakerFaults (bitmap)
Previously mapped as one enum value; now decoded as a bitmap via tvc.circuitBreakerFaults, correctly exposing multiple simultaneous fault conditions as a list.

3. DP20: new clear_fault reset control
New — allows clearing stored faults via tvc.reset (enum, value CLEAR). Didn't exist in the previous definition at all.

4. DP127 (status): raw → circuitBreakerStatus
Now properly decoded into off / consumption / production, instead of an undecoded raw value.

5. New fzSigned converter
Runs after datapoint processing, reads power, current, and status from meta.state, and derives power_signed / current_signed (positive = consumption, negative = production) — useful for PV setups where import/export direction matters.

6. extend: added queryOnConfigure: true
Ensures values are queried on configure rather than only on device-initiated reports.

7. description: extended with "with bidirectional metering"

Known limitation

After a reconfigure, over_voltage_threshold reverts to the device default (275 V) instead of retaining the previously configured value. Documented but not fixed in this PR.

Verified
Tested on real hardware