### PR TITLE
Add homeassistant argument to numeric and binary in modernExtend

### DIFF
--- a/src/devices/futurehome.ts
+++ b/src/devices/futurehome.ts
@@ -374,6 +374,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueMax: 32,
                 valueStep: 1,
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 1},
+                homeassistant: {icon: "mdi:target"},
                 zigbeeCommandOptions: {manufacturerCode: Zcl.ManufacturerCode.FUTUREHOME_AS},
             }),
             futurehomeExtend.chargerSessionTimings(),

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2895,11 +2895,25 @@ export interface BinaryArgs<Cl extends string | number, Custom extends TCustomCl
     access?: "STATE" | "STATE_GET" | "STATE_SET" | "SET" | "ALL";
     label?: string;
     entityCategory?: "config" | "diagnostic";
+    homeassistant?: exposes.HomeAssistant;
 }
 export function binary<Cl extends string | number, Custom extends TCustomCluster | undefined = undefined>(
     args: BinaryArgs<Cl, Custom>,
 ): ModernExtend {
-    const {name, valueOn, valueOff, cluster, attribute, description, zigbeeCommandOptions, endpointName, reporting, label, entityCategory} = args;
+    const {
+        name,
+        valueOn,
+        valueOff,
+        cluster,
+        attribute,
+        description,
+        zigbeeCommandOptions,
+        endpointName,
+        reporting,
+        label,
+        entityCategory,
+        homeassistant,
+    } = args;
     const attributeKey = isString(attribute) ? attribute : attribute.ID;
     const access = ea[args.access ?? "ALL"];
 
@@ -2907,6 +2921,7 @@ export function binary<Cl extends string | number, Custom extends TCustomCluster
     if (endpointName) expose = expose.withEndpoint(endpointName);
     if (label) expose = expose.withLabel(label);
     if (entityCategory) expose = expose.withCategory(entityCategory);
+    if (homeassistant) expose = expose.withHomeAssistant(homeassistant);
 
     const fromZigbee = [
         {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -2756,6 +2756,7 @@ export interface NumericArgs<Cl extends string | number, Custom extends TCustomC
     entityCategory?: "config" | "diagnostic";
     precision?: number;
     fzConvert?: Fz.Converter<Cl, Custom, ["attributeReport", "readResponse"]>["convert"];
+    homeassistant?: exposes.HomeAssistant;
 }
 export function numeric<Cl extends string | number, Custom extends TCustomCluster | undefined = undefined>(
     args: NumericArgs<Cl, Custom>,
@@ -2776,6 +2777,7 @@ export function numeric<Cl extends string | number, Custom extends TCustomCluste
         entityCategory,
         precision,
         fzConvert,
+        homeassistant,
     } = args;
 
     const endpoints = args.endpointNames;
@@ -2793,6 +2795,7 @@ export function numeric<Cl extends string | number, Custom extends TCustomCluste
         if (valueStep !== undefined) expose = expose.withValueStep(valueStep);
         if (label !== undefined) expose = expose.withLabel(label);
         if (entityCategory) expose = expose.withCategory(entityCategory);
+        if (homeassistant) expose = expose.withHomeAssistant(homeassistant);
 
         return expose;
     };


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
