### PR TITLE
Add fingerprint for TS0601 6-gang switch (_TZE284_tokhh9pf)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -29032,6 +29032,7 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE204_y8ficeai"}],
+                        {modelID: "TS0601", manufacturerName: "_TZE284_tokhh9pf"},
         model: "TS0601_6gang_switch",
         vendor: "Tuya",
         description: "6 gang touch panel switch with backlight and child lock",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -29031,8 +29031,10 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE204_y8ficeai"}],
-                        {modelID: "TS0601", manufacturerName: "_TZE284_tokhh9pf"},
+        fingerprint: [
+            {modelID: "TS0601", manufacturerName: "_TZE204_y8ficeai"},
+            {modelID: "TS0601", manufacturerName: "_TZE284_tokhh9pf"},
+        ],
         model: "TS0601_6gang_switch",
         vendor: "Tuya",
         description: "6 gang touch panel switch with backlight and child lock",


### PR DESCRIPTION
## Description

This PR adds support for the Tuya TS0601 6-gang touch switch with manufacturer name `_TZE284_tokhh9pf`.

The device is functionally identical to the already supported `_TZE204_y8ficeai` variant. The only required change is adding a new fingerprint.

## Verification

The device was paired with Zigbee2MQTT 2.13.0 and initially appeared as unsupported.

After adding the new fingerprint to the existing `TS0601_6gang_switch` definition, Zigbee2MQTT automatically recognized the device and exposed all six switches correctly.

I verified the following on the physical device:

- ✅ Channel 1
- ✅ Channel 2
- ✅ Channel 3
- ✅ Channel 4
- ✅ Channel 5
- ✅ Channel 6
- ✅ Multi-endpoint
- ✅ On/Off control

### Device information

- Zigbee model: `TS0601`
- Manufacturer: `_TZE284_tokhh9pf`

No other code changes were required.

I confirmed compatibility by testing the physical device. After adding the new fingerprint, it was recognized by the existing TS0601_6gang_switch definition and all six channels worked without any further code changes.
<img width="1079" height="875" alt="Captura de tela 2026-08-04 191326" src="https://github.com/user-attachments/assets/88b22da1-be0c-4d5e-b886-0b61504cee2b" />
<img width="835" height="766" alt="Captura de tela 2026-08-04 202151" src="https://github.com/user-attachments/assets/3a0e786b-be1f-4dbe-8c31-ad7adca4f50e" />
