### PR TITLE
fix: NodOn SEM-4-1-00: bump definition version to trigger reconfigure

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -306,6 +306,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SEM-4-1-00",
         vendor: "NodOn",
         description: "Energy monitoring sensor",
+        version: "0.0.1",
         extend: [
             m.identify(),
             m.electricityMeter({


### PR DESCRIPTION
Devices paired before #12548 (merged) don't automatically pick up the new, much lighter `apparentPower`/`powerFactor` reporting config — this definition never had a `version` field, so Z2M's reconfigure-on-definition-change mechanism (#11148) never fires for it.
