### PR TITLE
Fix: Color Temperatur Range for 929004581801

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -200,7 +200,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "929004581801",
         vendor: "Philips",
         description: "Hue Festavia globe outdoor string lights (7 meter with 10 bulbs)",
-        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true, gradient: {extraEffects: ["sparkle", "opal", "glisten"]}})],
+        extend: [philips.m.light({colorTemp: {range: [50, 1000]}, color: true, gradient: {extraEffects: ["sparkle", "opal", "glisten"]}})],
     },
     {
         zigbeeModel: ["LCX030"],


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

The other Festavia Globe Variants already have the correct range.