### PR TITLE
fix(exposes): set contact HA name to null to avoid duplicate Door

### DIFF
--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -21,6 +21,7 @@ export interface HomeAssistant {
     deviceClass?: string;
     enabledByDefault?: boolean;
     icon?: string;
+    name?: string | null;
     valueTemplate?: string | null;
 }
 
@@ -1024,7 +1025,10 @@ export const presets = {
                 "Indicates whether a plug is physically attached. Device does not have to pull power or even be connected electrically (state of this binary switch can be ON even if main power switch is OFF)",
             )
             .withCategory("diagnostic"),
-    contact: () => new Binary("contact", access.STATE, false, true).withDescription("Indicates if the contact is closed (= true) or open (= false)"),
+    contact: () =>
+        new Binary("contact", access.STATE, false, true)
+            .withDescription("Indicates if the contact is closed (= true) or open (= false)")
+            .withHomeAssistant({name: null}),
     cover_position: () => new Cover().withPosition(),
     cover_position_tilt: () => new Cover().withPosition().withTilt(),
     cover_tilt: () => new Cover().withTilt(),

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -1028,7 +1028,7 @@ export const presets = {
     contact: () =>
         new Binary("contact", access.STATE, false, true)
             .withDescription("Indicates if the contact is closed (= true) or open (= false)")
-            .withHomeAssistant({name: null}),
+            .withHomeAssistant({name: null}), // Prevents HA from appending the device class to the device name (e.g. "Garage Door Door")
     cover_position: () => new Cover().withPosition(),
     cover_position_tilt: () => new Cover().withPosition().withTilt(),
     cover_tilt: () => new Cover().withTilt(),


### PR DESCRIPTION
## Summary

Sets contact sensor name to `null` in Home Assistant to avoid duplicating "Door" in name.

Related: https://github.com/Koenkk/zigbee2mqtt/pull/32752