### PR TITLE
fix: Philips 7299760PH (Hue Bloom): add color temp range

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -835,7 +835,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "7299760PH",
         vendor: "Philips",
         description: "Hue Bloom",
-        extend: [philips.m.light({color: true})],
+        extend: [philips.m.light({color: true, colorTemp: {range: [153, 500]}})],
     },
     {
         zigbeeModel: ["929002375901"],


### PR DESCRIPTION
The Hue Bloom (7299760PH) definition only exposes `color: true`, so color temperature control is missing. Add `colorTemp: {range: [153, 500]}`. Tested on a real device (LLC012).

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
