### PR TITLE
FIX: Implement external temperature management for Shelly BLU TRV

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2196,11 +2196,7 @@ function shellyTRVGetRemoteSensing(endpoint: Zh.Endpoint, state: KeyValue = {}, 
 async function shellyTRVEnableRemoteTemperature(endpoint: Zh.Endpoint, remoteSensing: number): Promise<number> {
     const enabled = remoteSensing | 1;
     if (enabled !== remoteSensing) {
-        await endpoint.write(
-            "hvacThermostat",
-            {remoteSensing: enabled},
-            {disableResponse: true, disableDefaultResponse: true},
-        );
+        await endpoint.write("hvacThermostat", {remoteSensing: enabled}, {disableResponse: true, disableDefaultResponse: true});
     }
     return enabled;
 }
@@ -2208,10 +2204,7 @@ async function shellyTRVEnableRemoteTemperature(endpoint: Zh.Endpoint, remoteSen
 /**
  * Sends an external temperature as the attribute report of a bound Temperature Measurement server.
  */
-async function shellyTRVSendExternalTemperature(
-    endpoint: Zh.Endpoint,
-    request: ShellyTRVExternalTemperatureRequest,
-): Promise<void> {
+async function shellyTRVSendExternalTemperature(endpoint: Zh.Endpoint, request: ShellyTRVExternalTemperatureRequest): Promise<void> {
     await endpoint.report(
         "msTemperatureMeasurement",
         {measuredValue: request.measuredValue},
@@ -2281,10 +2274,7 @@ const fzShellyTRVExternalTemperature = {
 
         if (shellyTRVExternalTemperatureIsExpired(request)) {
             shellyTRVClearExternalTemperatureRequest(msg.device);
-            logger.warning(
-                `External temperature ${request.temperature} °C was not confirmed by '${msg.device.ieeeAddr}'`,
-                NS,
-            );
+            logger.warning(`External temperature ${request.temperature} °C was not confirmed by '${msg.device.ieeeAddr}'`, NS);
             return;
         }
 

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -4,7 +4,6 @@ import type {Feature} from "../lib/exposes";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
-import * as globalStore from "../lib/store";
 import type {
     Configure,
     Definition,
@@ -398,7 +397,7 @@ interface ShellyTRVExternalTemperatureRequest {
     attempts: number;
 }
 
-const SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY = "shelly_trv_external_temperature_request";
+const SHELLY_TRV_EXTERNAL_TEMPERATURE_META_KEY = "shelly_trv_external_temperature_request";
 const SHELLY_TRV_EXTERNAL_TEMPERATURE_MIN_RETRY_INTERVAL_MS = 1500;
 const SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_ATTEMPTS = 30;
 const SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_AGE_MS = 60 * 60 * 1000;
@@ -2111,24 +2110,39 @@ const tzLocal = {
 };
 
 /**
- * Returns the pending external temperature request for a TRV.
+ * Returns the persisted pending external temperature request for a TRV.
  */
 function shellyTRVGetExternalTemperatureRequest(device: Zh.Device): ShellyTRVExternalTemperatureRequest | undefined {
-    return globalStore.getValue(device, SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY) as ShellyTRVExternalTemperatureRequest | undefined;
+    const request = device.meta[SHELLY_TRV_EXTERNAL_TEMPERATURE_META_KEY];
+    if (typeof request !== "object" || request === null) return undefined;
+
+    return request as ShellyTRVExternalTemperatureRequest;
 }
 
 /**
- * Stores the pending external temperature request for a TRV.
+ * Stores the pending external temperature request in the device metadata.
+ *
+ * The request itself is persisted immediately so delivery can resume after a
+ * Zigbee2MQTT restart. Retry bookkeeping may stay in memory because createdAt
+ * remains persisted and still bounds the request lifetime across restarts.
  */
-function shellyTRVPutExternalTemperatureRequest(device: Zh.Device, request: ShellyTRVExternalTemperatureRequest): void {
-    globalStore.putValue(device, SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY, request);
+function shellyTRVPutExternalTemperatureRequest(
+    device: Zh.Device,
+    request: ShellyTRVExternalTemperatureRequest,
+    persist = true,
+): void {
+    device.meta[SHELLY_TRV_EXTERNAL_TEMPERATURE_META_KEY] = request;
+    if (persist) device.save();
 }
 
 /**
- * Clears the pending external temperature request for a TRV.
+ * Clears the persisted pending external temperature request for a TRV.
  */
-function shellyTRVClearExternalTemperatureRequest(device: Zh.Device | string): void {
-    globalStore.clearValue(device, SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY);
+function shellyTRVClearExternalTemperatureRequest(device: Zh.Device): void {
+    if (!(SHELLY_TRV_EXTERNAL_TEMPERATURE_META_KEY in device.meta)) return;
+
+    delete device.meta[SHELLY_TRV_EXTERNAL_TEMPERATURE_META_KEY];
+    device.save();
 }
 
 /**
@@ -2159,7 +2173,7 @@ function shellyTRVReserveExternalTemperatureAttempt(
         lastAttemptAt: Date.now(),
         attempts: request.attempts + 1,
     };
-    shellyTRVPutExternalTemperatureRequest(device, reserved);
+    shellyTRVPutExternalTemperatureRequest(device, reserved, false);
     return reserved;
 }
 
@@ -2317,33 +2331,21 @@ const tzShellyTRVExternalTemperature = {
 } satisfies Tz.Converter;
 
 /**
- * Restores pending delivery state after a restart and retries when the TRV announces itself.
+ * Retries a persisted pending external temperature when the TRV announces itself.
  */
 const shellyTRVExternalTemperatureOnEvent: OnEvent.Handler = (event) => {
-    if (event.type === "stop") {
-        shellyTRVClearExternalTemperatureRequest(event.data.ieeeAddr);
-        return;
-    }
-
-    if (event.type === "start") {
-        const request = shellyTRVGetExternalTemperatureRequest(event.data.device);
-        if (request) return;
-
-        const temperature = event.data.state.external_temperature;
-        const localTemperature = event.data.state.local_temperature;
-        const remoteSensing = shellyTRVRemoteSensingFromState(event.data.state);
-        if (typeof temperature !== "number" || typeof localTemperature !== "number" || (remoteSensing & 1) === 0) return;
-        if (Math.round(temperature * 100) === Math.round(localTemperature * 100)) return;
-
-        shellyTRVPutExternalTemperatureRequest(event.data.device, shellyTRVCreateExternalTemperatureRequest(temperature));
-        return;
-    }
-
     if (event.type !== "deviceAnnounce") return;
 
     const endpoint = event.data.device.getEndpoint(1);
     const request = shellyTRVGetExternalTemperatureRequest(event.data.device);
-    if (!endpoint || !request || shellyTRVExternalTemperatureIsExpired(request)) return;
+    if (!endpoint || !request) return;
+
+    if (shellyTRVExternalTemperatureIsExpired(request)) {
+        shellyTRVClearExternalTemperatureRequest(event.data.device);
+        logger.warning(`External temperature ${request.temperature} °C was not confirmed by '${event.data.device.ieeeAddr}'`, NS);
+        return;
+    }
+
     if (Date.now() - request.lastAttemptAt < SHELLY_TRV_EXTERNAL_TEMPERATURE_MIN_RETRY_INTERVAL_MS) return;
 
     const remoteSensing = shellyTRVGetRemoteSensing(endpoint, event.data.state);

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -4,6 +4,7 @@ import type {Feature} from "../lib/exposes";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
+import * as globalStore from "../lib/store";
 import type {
     Configure,
     Definition,
@@ -14,6 +15,7 @@ import type {
     Fz,
     KeyValue,
     ModernExtend,
+    OnEvent,
     Tz,
     Zh,
 } from "../lib/types";
@@ -384,6 +386,22 @@ interface ShellyTRVManualMode {
     };
     commandResponses: never;
 }
+
+/**
+ * Tracks an external temperature until the TRV reports the same value as its local temperature.
+ */
+interface ShellyTRVExternalTemperatureRequest {
+    temperature: number;
+    measuredValue: number;
+    createdAt: number;
+    lastAttemptAt: number;
+    attempts: number;
+}
+
+const SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY = "shelly_trv_external_temperature_request";
+const SHELLY_TRV_EXTERNAL_TEMPERATURE_MIN_RETRY_INTERVAL_MS = 1500;
+const SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_ATTEMPTS = 30;
+const SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_AGE_MS = 60 * 60 * 1000;
 
 interface ShellyLightLevel {
     attributes: {
@@ -2092,6 +2110,259 @@ const tzLocal = {
     } satisfies Tz.Converter,
 };
 
+/**
+ * Returns the pending external temperature request for a TRV.
+ */
+function shellyTRVGetExternalTemperatureRequest(device: Zh.Device): ShellyTRVExternalTemperatureRequest | undefined {
+    return globalStore.getValue(device, SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY) as ShellyTRVExternalTemperatureRequest | undefined;
+}
+
+/**
+ * Stores the pending external temperature request for a TRV.
+ */
+function shellyTRVPutExternalTemperatureRequest(device: Zh.Device, request: ShellyTRVExternalTemperatureRequest): void {
+    globalStore.putValue(device, SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY, request);
+}
+
+/**
+ * Clears the pending external temperature request for a TRV.
+ */
+function shellyTRVClearExternalTemperatureRequest(device: Zh.Device | string): void {
+    globalStore.clearValue(device, SHELLY_TRV_EXTERNAL_TEMPERATURE_STORE_KEY);
+}
+
+/**
+ * Creates a new confirmation-tracked external temperature request.
+ */
+function shellyTRVCreateExternalTemperatureRequest(temperature: number): ShellyTRVExternalTemperatureRequest {
+    return {
+        temperature,
+        measuredValue: Math.round(temperature * 100),
+        createdAt: Date.now(),
+        lastAttemptAt: 0,
+        attempts: 0,
+    };
+}
+
+/**
+ * Reserves one delivery attempt before asynchronous Zigbee traffic starts.
+ *
+ * Updating the store synchronously prevents several reports from the same wake window
+ * from scheduling duplicate retries.
+ */
+function shellyTRVReserveExternalTemperatureAttempt(
+    device: Zh.Device,
+    request: ShellyTRVExternalTemperatureRequest,
+): ShellyTRVExternalTemperatureRequest {
+    const reserved = {
+        ...request,
+        lastAttemptAt: Date.now(),
+        attempts: request.attempts + 1,
+    };
+    shellyTRVPutExternalTemperatureRequest(device, reserved);
+    return reserved;
+}
+
+/**
+ * Reconstructs the thermostat RemoteSensing bit mask from the cached state.
+ */
+function shellyTRVRemoteSensingFromState(state: KeyValue): number {
+    if (typeof state.remote_sensing_raw === "number") return state.remote_sensing_raw;
+
+    if (typeof state.remote_sensing !== "object" || state.remote_sensing === null) return 0;
+    const remoteSensing = state.remote_sensing as KeyValue;
+    let value = 0;
+    if (remoteSensing.local_temperature === "remotely") value |= 1;
+    if (remoteSensing.outdoor_temperature === "remotely") value |= 1 << 1;
+    if (remoteSensing.occupancy === "remotely") value |= 1 << 2;
+    return value;
+}
+
+/**
+ * Returns the best available RemoteSensing bit mask without querying the sleeping device.
+ */
+function shellyTRVGetRemoteSensing(endpoint: Zh.Endpoint, state: KeyValue = {}, reportedValue?: number): number {
+    if (reportedValue !== undefined) return reportedValue;
+
+    const cached = endpoint.getClusterAttributeValue("hvacThermostat", "remoteSensing");
+    if (typeof cached === "number") return cached;
+
+    return shellyTRVRemoteSensingFromState(state);
+}
+
+/**
+ * Enables the external local-temperature source while preserving the other RemoteSensing bits.
+ */
+async function shellyTRVEnableRemoteTemperature(endpoint: Zh.Endpoint, remoteSensing: number): Promise<number> {
+    const enabled = remoteSensing | 1;
+    if (enabled !== remoteSensing) {
+        await endpoint.write(
+            "hvacThermostat",
+            {remoteSensing: enabled},
+            {disableResponse: true, disableDefaultResponse: true},
+        );
+    }
+    return enabled;
+}
+
+/**
+ * Sends an external temperature as the attribute report of a bound Temperature Measurement server.
+ */
+async function shellyTRVSendExternalTemperature(
+    endpoint: Zh.Endpoint,
+    request: ShellyTRVExternalTemperatureRequest,
+): Promise<void> {
+    await endpoint.report(
+        "msTemperatureMeasurement",
+        {measuredValue: request.measuredValue},
+        {
+            direction: Zcl.Direction.SERVER_TO_CLIENT,
+            srcEndpoint: 1,
+            disableResponse: true,
+            disableDefaultResponse: true,
+        },
+    );
+}
+
+/**
+ * Enables remote sensing and sends the currently reserved external temperature request.
+ */
+async function shellyTRVDeliverExternalTemperature(
+    endpoint: Zh.Endpoint,
+    request: ShellyTRVExternalTemperatureRequest,
+    remoteSensing: number,
+): Promise<void> {
+    await shellyTRVEnableRemoteTemperature(endpoint, remoteSensing);
+    await shellyTRVSendExternalTemperature(endpoint, request);
+}
+
+/**
+ * Checks whether the TRV has confirmed the requested value while using the remote source.
+ */
+function shellyTRVExternalTemperatureIsConfirmed(
+    request: ShellyTRVExternalTemperatureRequest,
+    localTemperature: number | undefined,
+    remoteSensing: number,
+): boolean {
+    return localTemperature === request.measuredValue && (remoteSensing & 1) !== 0;
+}
+
+/**
+ * Checks whether a request reached its bounded retry limit.
+ */
+function shellyTRVExternalTemperatureIsExpired(request: ShellyTRVExternalTemperatureRequest): boolean {
+    return (
+        request.attempts >= SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_ATTEMPTS ||
+        Date.now() - request.createdAt >= SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_AGE_MS
+    );
+}
+
+/**
+ * Confirms an external temperature from incoming thermostat reports and retries an unconfirmed value during a wake window.
+ */
+const fzShellyTRVExternalTemperature = {
+    cluster: "hvacThermostat",
+    type: ["attributeReport", "readResponse"],
+    convert: (model, msg, publish, options, meta) => {
+        const request = shellyTRVGetExternalTemperatureRequest(msg.device);
+        if (!request) return;
+
+        const remoteSensing = shellyTRVGetRemoteSensing(
+            msg.endpoint,
+            meta.state,
+            typeof msg.data.remoteSensing === "number" ? msg.data.remoteSensing : undefined,
+        );
+
+        if (shellyTRVExternalTemperatureIsConfirmed(request, msg.data.localTemp, remoteSensing)) {
+            shellyTRVClearExternalTemperatureRequest(msg.device);
+            logger.debug(`External temperature ${request.temperature} °C was confirmed by '${msg.device.ieeeAddr}'`, NS);
+            return;
+        }
+
+        if (shellyTRVExternalTemperatureIsExpired(request)) {
+            shellyTRVClearExternalTemperatureRequest(msg.device);
+            logger.warning(
+                `External temperature ${request.temperature} °C was not confirmed by '${msg.device.ieeeAddr}'`,
+                NS,
+            );
+            return;
+        }
+
+        if (Date.now() - request.lastAttemptAt < SHELLY_TRV_EXTERNAL_TEMPERATURE_MIN_RETRY_INTERVAL_MS) return;
+
+        const reserved = shellyTRVReserveExternalTemperatureAttempt(msg.device, request);
+        shellyTRVDeliverExternalTemperature(msg.endpoint, reserved, remoteSensing).catch((error) =>
+            logger.debug(`Failed to retry external temperature for '${msg.device.ieeeAddr}': ${error}`, NS),
+        );
+    },
+} satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>;
+
+/**
+ * Stores and sends an external temperature while marking the request as pending until the TRV confirms it.
+ */
+const tzShellyTRVExternalTemperature = {
+    key: ["external_temperature"],
+    convertSet: async (entity, key, value, meta) => {
+        utils.assertEndpoint(entity);
+        utils.assertNumber(value, key);
+        if (value < -40 || value > 85) {
+            throw new Error(`External temperature must be between -40 and 85 °C, got ${value}`);
+        }
+
+        const temperature = Math.round(value * 100) / 100;
+        const request = shellyTRVCreateExternalTemperatureRequest(temperature);
+        shellyTRVPutExternalTemperatureRequest(entity.getDevice(), request);
+
+        const remoteSensing = shellyTRVGetRemoteSensing(entity, meta.state);
+        const reserved = shellyTRVReserveExternalTemperatureAttempt(entity.getDevice(), request);
+
+        try {
+            await shellyTRVDeliverExternalTemperature(entity, reserved, remoteSensing);
+        } catch (error) {
+            logger.debug(`Initial external temperature delivery to '${entity.getDevice().ieeeAddr}' failed: ${error}`, NS);
+        }
+
+        return {state: {external_temperature: temperature}};
+    },
+} satisfies Tz.Converter;
+
+/**
+ * Restores pending delivery state after a restart and retries when the TRV announces itself.
+ */
+const shellyTRVExternalTemperatureOnEvent: OnEvent.Handler = (event) => {
+    if (event.type === "stop") {
+        shellyTRVClearExternalTemperatureRequest(event.data.ieeeAddr);
+        return;
+    }
+
+    if (event.type === "start") {
+        const request = shellyTRVGetExternalTemperatureRequest(event.data.device);
+        if (request) return;
+
+        const temperature = event.data.state.external_temperature;
+        const localTemperature = event.data.state.local_temperature;
+        const remoteSensing = shellyTRVRemoteSensingFromState(event.data.state);
+        if (typeof temperature !== "number" || typeof localTemperature !== "number" || (remoteSensing & 1) === 0) return;
+        if (Math.round(temperature * 100) === Math.round(localTemperature * 100)) return;
+
+        shellyTRVPutExternalTemperatureRequest(event.data.device, shellyTRVCreateExternalTemperatureRequest(temperature));
+        return;
+    }
+
+    if (event.type !== "deviceAnnounce") return;
+
+    const endpoint = event.data.device.getEndpoint(1);
+    const request = shellyTRVGetExternalTemperatureRequest(event.data.device);
+    if (!endpoint || !request || shellyTRVExternalTemperatureIsExpired(request)) return;
+    if (Date.now() - request.lastAttemptAt < SHELLY_TRV_EXTERNAL_TEMPERATURE_MIN_RETRY_INTERVAL_MS) return;
+
+    const remoteSensing = shellyTRVGetRemoteSensing(endpoint, event.data.state);
+    const reserved = shellyTRVReserveExternalTemperatureAttempt(event.data.device, request);
+    shellyTRVDeliverExternalTemperature(endpoint, reserved, remoteSensing).catch((error) =>
+        logger.debug(`Failed to deliver external temperature after announce from '${event.data.device.ieeeAddr}': ${error}`, NS),
+    );
+};
+
 // =============================================================================
 // Device Definitions
 // =============================================================================
@@ -2702,6 +2973,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Thermostatic radiator valve",
         fromZigbee: [
             fz.thermostat,
+            fzShellyTRVExternalTemperature,
             {
                 cluster: "hvacThermostat",
                 type: ["attributeReport", "readResponse"],
@@ -2712,6 +2984,7 @@ export const definitions: DefinitionWithExtend[] = [
             } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>,
         ],
         toZigbee: [
+            tzShellyTRVExternalTemperature,
             {
                 key: ["calibrate"],
                 convertSet: async (entity, key, value, meta) => {
@@ -2727,6 +3000,13 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             e.binary("calibration_ok", ea.STATE, true, false).withDescription("Calibration OK").withCategory("diagnostic"),
             e.enum("calibrate", ea.SET, ["trigger"]).withDescription("Trigger valve calibration").withCategory("config"),
+            e
+                .numeric("external_temperature", ea.STATE_SET)
+                .withUnit("°C")
+                .withValueMin(-40)
+                .withValueMax(85)
+                .withValueStep(0.01)
+                .withDescription("External room temperature used by the thermostat"),
         ],
         extend: [
             m.battery(),
@@ -2780,6 +3060,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.identify(),
         ],
+        onEvent: shellyTRVExternalTemperatureOnEvent,
     },
     {
         fingerprint: [{modelID: "Presence", manufacturerName: "Shelly"}],

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2126,11 +2126,7 @@ function shellyTRVGetExternalTemperatureRequest(device: Zh.Device): ShellyTRVExt
  * Zigbee2MQTT restart. Retry bookkeeping may stay in memory because createdAt
  * remains persisted and still bounds the request lifetime across restarts.
  */
-function shellyTRVPutExternalTemperatureRequest(
-    device: Zh.Device,
-    request: ShellyTRVExternalTemperatureRequest,
-    persist = true,
-): void {
+function shellyTRVPutExternalTemperatureRequest(device: Zh.Device, request: ShellyTRVExternalTemperatureRequest, persist = true): void {
     device.meta[SHELLY_TRV_EXTERNAL_TEMPERATURE_META_KEY] = request;
     if (persist) device.save();
 }


### PR DESCRIPTION
Add support for supplying an external room temperature to the Shelly BLU TRV through the Zigbee Temperature Measurement cluster.

The TRV accepts external temperatures as server-to-client attribute reports on cluster 0x0402. Since it is a sleepy end device, an individual report can be missed while its receiver is inactive. Direct writes to measuredValue are not supported and are rejected with NOT_AUTHORIZED.

Implement confirmation-driven delivery without exposing transport diagnostics:

- expose external_temperature as the requested room temperature;
- enable RemoteSensing bit 0 while preserving the other sensing-source bits;
- send the value as a Temperature Measurement measuredValue report;
- keep the requested value internally until localTemp confirms it;
- retry after incoming thermostat activity, when the TRV is likely awake;
- stop immediately once the reported local temperature matches the request;
- bound retries to 30 attempts or 60 minutes;
- restore an unconfirmed request after a Zigbee2MQTT restart;
- retry when the device announces itself;
- log confirmation and final expiry

The existing thermostat, calibration, manual-mode, valve-position, battery and identify functionality remains unchanged.

Validated on a physical BLU TRV in 12 consecutive tests, including a change from 25 °C to 1 °C. Each requested value was confirmed through local_temperature.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
