### PR TITLE
fix(schneider): keep PowerTag empty-payload messages on the debounce …

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -1390,16 +1390,16 @@ const fzLocal = {
         type: ["commandNotification", "commandCommissioningNotification"],
         convert: async (model, msg, publish, options, meta) => {
             if (msg.type !== "commandNotification") {
-                return;
+                return {...meta.state};
             }
 
             const commandID = msg.data.commandID;
 
             if (utils.hasAlreadyProcessedMessage(msg, model, msg.data.frameCounter, `${msg.device.ieeeAddr}_${commandID}`)) {
-                return;
+                return {...meta.state};
             }
 
-            if (commandID >= 0xe0) return; // Skip op commands
+            if (commandID >= 0xe0) return {...meta.state}; // Skip op commands
 
             const rxAfterTx = msg.data.options & (1 << 11);
             const ret: KeyValue = {};
@@ -1546,7 +1546,14 @@ const fzLocal = {
                 );
             }
 
-            return ret;
+            if (Object.keys(ret).length > 0) return ret;
+
+            // The PowerTag also sends frames the converter produces no data for
+            // (0xa3 multi-cluster report, acCurrentOverload-only frames). An empty
+            // payload triggers the publishLastSeen fallback, which republishes the
+            // full cached state and bypasses the debounce; return the cached state so
+            // these frames merge into the debounce instead.
+            return {...meta.state};
         },
     } satisfies Fz.Converter<"greenPower", undefined, ["commandNotification", "commandCommissioningNotification"]>,
     wiser_device_info: {


### PR DESCRIPTION
…path

PowerTag greenPower devices (EKO01825 etc.) retransmit readings and also send frames the converter produces no data for (0xa3 multi-cluster report, acCurrentOverload-only frames). Returning an empty payload triggers Z2M's publishLastSeen fallback, which republishes the full cached state immediately — bypassing the per-device debounce and causing ~3 extra publishes per 5s reporting window. Returning meta.state for those messages routes everything through the debounce, collapsing each window into a single merged publish. With debounce: 0 the behavior is unchanged (the fallback already published the full cache). Verified on an ELKO EKO01825: 35 → 12 publishes/min.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
