### PR TITLE
feat(tuya): add _TZ3000_bbebkwjk to TS0001_switch_1_gang

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -16738,7 +16738,14 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_bmqxalil", "_TZ3000_w1tcofu8", "_TZ3000_ma3mhpx2", "_TZ3000_wijoqjk1", "_TZ3000_5rpu3r0d", "_TZ3000_bbebkwjk"]),
+        fingerprint: tuya.fingerprint("TS0001", [
+            "_TZ3000_bmqxalil",
+            "_TZ3000_w1tcofu8",
+            "_TZ3000_ma3mhpx2",
+            "_TZ3000_wijoqjk1",
+            "_TZ3000_5rpu3r0d",
+            "_TZ3000_bbebkwjk",
+        ]),
         model: "TS0001_switch_1_gang",
         vendor: "Tuya",
         description: "1-Gang switch with backlight",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -16738,7 +16738,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_bmqxalil", "_TZ3000_w1tcofu8", "_TZ3000_ma3mhpx2", "_TZ3000_wijoqjk1", "_TZ3000_5rpu3r0d"]),
+        fingerprint: tuya.fingerprint("TS0001", ["_TZ3000_bmqxalil", "_TZ3000_w1tcofu8", "_TZ3000_ma3mhpx2", "_TZ3000_wijoqjk1", "_TZ3000_5rpu3r0d", "_TZ3000_bbebkwjk"]),
         model: "TS0001_switch_1_gang",
         vendor: "Tuya",
         description: "1-Gang switch with backlight",
@@ -16749,7 +16749,7 @@ export const definitions: DefinitionWithExtend[] = [
                 backlightModeOffOn: (m) => m !== "_TZ3000_5rpu3r0d",
                 switchType: (m) => m === "_TZ3000_5rpu3r0d",
                 onOffCountdown: (m) => m === "_TZ3000_5rpu3r0d",
-                indicatorMode: (m) => m === "_TZ3000_5rpu3r0d",
+                indicatorMode: (m) => ["_TZ3000_5rpu3r0d", "_TZ3000_bbebkwjk"].includes(m),
             }),
         ],
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
TS0001 `_TZ3000_bbebkwjk` currently falls through to the generic TS0001 definition (`tuyaOnOff()` with no arguments), so backlight and indicator controls are not exposed, despite the device supporting both.

Verified via the Zigbee2MQTT dev console, endpoint 1, genOnOff:

  Read result of 'genOnOff': {"tuyaBacklightMode":2,"tuyaBacklightSwitch":1}

Both attributes return live values and writes are honoured, confirmed on the physical LED. Tested with an external converter using backlightModeOffOn + indicatorMode before submitting this.

Adding the fingerprint to TS0001_switch_1_gang and extending the indicatorMode gate accordingly. backlightModeOffOn needs no change, as it already applies to everything except _TZ3000_5rpu3r0d.

Device: 1 gang wall switch, mains/neutral, Zigbee2MQTT 2.13.0-1.
