### PR TITLE
fix: Moes ZHT-S03: remove forceTimeUpdates

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -138,7 +138,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZHT-S03",
         vendor: "Moes",
         description: "Zigbee wall thermostat",
-        extend: [tuya.modernExtend.tuyaBase({dp: true, forceTimeUpdates: true, timeStart: "1970"})],
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"})],
         exposes: [
             e.child_lock(),
             e


### PR DESCRIPTION
User on Discord gets time-out errors 

```
[08/08/2026, 12:49:03] zhc:tuya: Failed to sync time with '0xa4c138fb101cff99' (Error: ZCL command 0xa4c138fb101cff99/1 manuSpecificTuya.mcuSyncTime({"payloadSize":8,"payload":[106,119,23,166,106,119,37,182]}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":false,"direction":0,"reservedBits":0,"writeUndiv":false}) failed ({"target":36442,"apsFrame":{"profileId":260,"clusterId":61184,"sourceEndpoint":1,"destinationEndpoint":1,"options":4416,"groupId":0,"sequence":111},"zclSequence":115,"commandIdentifier":11} timed out after 10000ms))
```