### PR TITLE
feat: add _TZE204_qujphad5 fingerprint to Tuya TYBAC-006

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -19591,7 +19591,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_mpbki2zm"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_mpbki2zm", "_TZE204_qujphad5"]),
         model: "TYBAC-006",
         vendor: "Tuya",
         description: "Wall-mount thermostat for 2-pipe fan-coil unit",


### PR DESCRIPTION
Adds _TZE204_qujphad5 to the TYBAC-006 fingerprint list. Device is a Tuya TS0601 wall-mount thermostat for 2-pipe fan-coil units, same UI/form factor as the existing _TZE204_mpbki2zm TYBAC-006 unit. Datapoints verified to match on a physical unit (setpoint, system mode, fan mode, eco mode, min/max temp limit, schedule).