### PR TITLE
fix(lumi): enroll SJCGQ12LM (water leak T1) as IAS Zone in configure

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2084,6 +2084,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [lumi.fromZigbee.lumi_basic, fz.ias_water_leak_alarm_1, lumi.fromZigbee.lumi_specific],
         toZigbee: [],
         exposes: [e.battery(), e.water_leak(), e.battery_low(), e.tamper(), e.battery_voltage()],
+        version: "0.0.1",
         configure: async (device, coordinatorEndpoint) => {
             await ensureLumiIasEnrollment(device.getEndpoint(1), coordinatorEndpoint);
         },

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -8,7 +8,7 @@ import * as lumi from "../lib/lumi";
 import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend, ModernExtend, Zh} from "../lib/types";
-import {assertNumber} from "../lib/utils";
+import {assertNumber, sleep} from "../lib/utils";
 
 const e = exposes.presets;
 const ea = exposes.access;
@@ -93,6 +93,25 @@ async function configureAqaraH2EuShutterSwitch(device: Zh.Device, coordinatorEnd
         await endpoint.read<"manuSpecificLumi", ManuSpecificLumi>("manuSpecificLumi", [aqaraH2EuShutterSwitchMultiClickAttribute], {
             manufacturerCode,
         });
+    }
+}
+
+async function ensureLumiIasEnrollment(endpoint: Zh.Endpoint, coordinatorEndpoint: Zh.Endpoint) {
+    const coordinatorIeeeAddress = coordinatorEndpoint.deviceIeeeAddress;
+    const isEnrolled = (state: {zoneState?: number; iasCieAddr?: string}) =>
+        state.zoneState === 1 && state.iasCieAddr?.toLowerCase() === coordinatorIeeeAddress.toLowerCase();
+
+    if (isEnrolled(await endpoint.read("ssIasZone", ["zoneState", "iasCieAddr"], {sendPolicy: "immediate"}))) {
+        return;
+    }
+
+    await endpoint.write("ssIasZone", {iasCieAddr: coordinatorIeeeAddress}, {sendPolicy: "immediate"});
+    await endpoint.command("ssIasZone", "enrollRsp", {enrollrspcode: 0, zoneid: 23}, {disableDefaultResponse: true, sendPolicy: "immediate"});
+    await sleep(500);
+
+    const state = await endpoint.read("ssIasZone", ["zoneState", "iasCieAddr"], {sendPolicy: "immediate"});
+    if (!isEnrolled(state)) {
+        throw new Error(`IAS enrollment failed; expected zoneState=1 and iasCieAddr=${coordinatorIeeeAddress}, got ${JSON.stringify(state)}`);
     }
 }
 
@@ -2065,6 +2084,9 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [lumi.fromZigbee.lumi_basic, fz.ias_water_leak_alarm_1, lumi.fromZigbee.lumi_specific],
         toZigbee: [],
         exposes: [e.battery(), e.water_leak(), e.battery_low(), e.tamper(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint) => {
+            await ensureLumiIasEnrollment(device.getEndpoint(1), coordinatorEndpoint);
+        },
         extend: [lumi.modernExtend.addManuSpecificLumiCluster(), m.quirkCheckinInterval("1_HOUR"), lumiZigbeeOTA()],
     },
     {

--- a/test/lumi.test.ts
+++ b/test/lumi.test.ts
@@ -1,4 +1,5 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
+import {findByDevice} from "../src/index";
 import {fromZigbee, lumiModernExtend, numericAttributes2Payload, type TrvScheduleConfig, toZigbee, trv} from "../src/lib/lumi";
 import * as globalStore from "../src/lib/store";
 import type {Definition, Fz, Tz} from "../src/lib/types";
@@ -1005,5 +1006,57 @@ describe("lib/lumi", () => {
                 expect(result).toStrictEqual({});
             });
         });
+    });
+});
+
+describe("SJCGQ12LM IAS enrollment", () => {
+    const coordinatorIeeeAddr = "0x00124b002a2ebcfd";
+    const notEnrolled = {zoneState: 0, iasCieAddr: "0x0000000000000000"};
+    const enrolled = {zoneState: 1, iasCieAddr: coordinatorIeeeAddr};
+
+    const setup = async (read: ReturnType<typeof vi.fn<() => Promise<Record<string, unknown>>>>) => {
+        const device = mockDevice(
+            {
+                modelID: "lumi.flood.agl02",
+                manufacturerName: "LUMI",
+                endpoints: [{ID: 1, inputClusters: ["genBasic", "ssIasZone", "genIdentify", "genPowerCfg"], read}],
+            },
+            "EndDevice",
+        );
+        const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}], ieeeAddr: coordinatorIeeeAddr}).getEndpoint(1);
+
+        return {device, endpoint: device.getEndpoint(1), coordinatorEndpoint, definition: await findByDevice(device)};
+    };
+
+    it("enrolls the device when it reports zoneState 0", async () => {
+        const read = vi.fn().mockResolvedValueOnce(notEnrolled).mockResolvedValueOnce(enrolled);
+        const {device, endpoint, coordinatorEndpoint, definition} = await setup(read);
+
+        await definition.configure?.(device, coordinatorEndpoint, definition);
+
+        expect(endpoint.write).toHaveBeenCalledWith("ssIasZone", {iasCieAddr: coordinatorIeeeAddr}, {sendPolicy: "immediate"});
+        expect(endpoint.command).toHaveBeenCalledWith(
+            "ssIasZone",
+            "enrollRsp",
+            {enrollrspcode: 0, zoneid: 23},
+            {disableDefaultResponse: true, sendPolicy: "immediate"},
+        );
+    });
+
+    it("leaves an already enrolled device alone", async () => {
+        const read = vi.fn().mockResolvedValue(enrolled);
+        const {device, endpoint, coordinatorEndpoint, definition} = await setup(read);
+
+        await definition.configure?.(device, coordinatorEndpoint, definition);
+
+        expect(endpoint.write).not.toHaveBeenCalled();
+        expect(endpoint.command).not.toHaveBeenCalled();
+    });
+
+    it("fails when the device stays unenrolled", async () => {
+        const read = vi.fn().mockResolvedValue(notEnrolled);
+        const {device, coordinatorEndpoint, definition} = await setup(read);
+
+        await expect(definition.configure?.(device, coordinatorEndpoint, definition)).rejects.toThrow("IAS enrollment failed");
     });
 });


### PR DESCRIPTION
Fixes the Aqara Water Leak Sensor T1 (`SJCGQ12LM` / `lumi.flood.agl02`) never reporting `water_leak`.

### Problem

The device pairs, interviews as `SUCCESSFUL`, and `last_seen` updates on a button press — but `water_leak` stays frozen at `false` forever. Shorting the probes produces no Zigbee frame at all; the only thing the device ever sends is `genBasic attributeReport {"modelId":"lumi.flood.agl02"}`.

Reading the IAS Zone attributes on real hardware shows why:

```
z2m: Received Zigbee message from 'Water sensor', type 'readResponse', cluster 'ssIasZone',
  data '{"iasCieAddr":"0x0000000000000000","zoneState":0,"zoneStatus":33,"zoneType":42}'
```

- `zoneType: 42` (0x2A) — correct water sensor type
- `zoneStatus: 33` — bit 0 (Alarm1) **is set**; the hardware detects the shorted probes correctly
- `zoneState: 0` — NOT_ENROLLED, and `iasCieAddr` is all zeros

Per the IAS Zone spec an unenrolled zone must not send `commandStatusChangeNotification`, so the alarm never leaves the device.

### Cause

`zigbee-herdsman` does perform IAS enrollment during the interview, but lumi devices match the `lumi..*` modelID quirk in `Device.interview()`:

```
Interview procedure failed but got modelID matching 'lumi..*', assuming interview succeeded
```

That shortcut marks a failed interview as successful and returns before the enrollment step ever runs. For most lumi devices this is harmless (they use the manufacturer-specific `0xFF01` attribute), but `lumi.flood.agl02` is a genuine IAS Zone device and ends up permanently unenrolled. Re-pairing does not fix it — it just hits the same quirk again.

### Fix

Enroll in `configure()`, mirroring the existing NYCE `NCZ-3011-HA` fix in `src/devices/nyce.ts` (added for the same class of problem in Koenkk/zigbee2mqtt#32480): read the current IAS state, and if it is not already enrolled to this coordinator, write `iasCieAddr` and send `enrollRsp`, then verify `zoneState` actually became 1.

### Verified on hardware

Aqara Water Leak Sensor T1, dateCode 20230825, appVersion 32, on Zigbee2MQTT 2.13.0 with a ZStack3x0 coordinator. Running the equivalent write + `enrollRsp` by hand over MQTT immediately fixed the device:

```
z2m: Received Zigbee message from 'Water sensor', type 'commandStatusChangeNotification',
  cluster 'ssIasZone', data '{"delay":0,"extendedstatus":0,"zoneID":23,"zonestatus":33}'
z2m:mqtt: MQTT publish: topic 'zigbee2mqtt/Water sensor', payload '{... "water_leak":true}'
```

`water_leak` then tracked the probes across three open/short cycles with no button press needed (`zonestatus` 33 → `true`, 32 → `false`).

### Scope

Only `SJCGQ12LM` is changed here, since that is the device I could verify. Other lumi definitions using `fz.ias_*_alarm_*` (e.g. `SJCGQ13LM` / `lumi.flood.acn001`, `JTQJ-BF-01LM/BW`) are likely affected by the same quirk and could get the same treatment — happy to extend the PR if you want it applied more broadly.

### Checks run locally

`tsc --noEmit`, `pnpm run check` (biome), and `test/index.test.ts` + `test/checkDefinition.test.ts` all pass. The full vitest suite was too slow to complete on the Raspberry Pi this was developed on, so I left it to CI.
