### PR TITLE
feat: Ubisys: Add `operational_status` converter

### DIFF
--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -1065,6 +1065,7 @@ export const definitions: DefinitionWithExtend[] = [
             ubisysModernExtend.addCustomClusterManuSpecificUbisysDeviceSetup(),
             ubisysModernExtend.addCustomClusterClosuresWindowCovering(),
             ubisysModernExtend.pollCurrentSummDelivered(3),
+            ubisysModernExtend.operationalStatus(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
@@ -1074,6 +1075,8 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.instantaneousDemand(endpoint3);
             await reporting.bind(endpoint1, coordinatorEndpoint, ["closuresWindowCovering"]);
             await reporting.currentPositionLiftPercentage(endpoint1);
+            const payload = reporting.payload<"closuresWindowCovering", UbisysClosuresWindowCovering>("operationalStatus", 1, 3600, 0);
+            await endpoint1.configureReporting("closuresWindowCovering", payload);
         },
         onEvent: (event) => {
             /*

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -109,6 +109,20 @@ const ubisys = {
                 return {configure_device_setup: result};
             },
         } satisfies Fz.Converter<"manuSpecificUbisysDeviceSetup", UbisysDeviceSetup, ["attributeReport", "readResponse"]>,
+        operational_status: {
+            cluster: "closuresWindowCovering",
+            type: ["attributeReport", "readResponse"],
+            convert: (model, msg, publish, options, meta) => {
+                if (msg.data.operationalStatus !== undefined) {
+                    const status = msg.data.operationalStatus;
+                    const operationalStatus = status & 3;
+                    const operationalStatusValues = {0: "stopped", 1: "opening", 2: "closing"};
+                    return {
+                        operational_status: utils.getFromLookup(operationalStatus, operationalStatusValues),
+                    };
+                }
+            },
+        } satisfies Fz.Converter<"closuresWindowCovering", UbisysClosuresWindowCovering, ["attributeReport", "readResponse"]>,
     },
     tz: {
         configure_j1: {
@@ -1011,7 +1025,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "J1",
         vendor: "Ubisys",
         description: "Shutter control J1",
-        fromZigbee: [fz.cover_position_tilt, fz.metering, ubisys.fz.configure_device_setup],
+        fromZigbee: [fz.cover_position_tilt, fz.metering, ubisys.fz.configure_device_setup, ubisys.fz.operational_status],
         toZigbee: [
             tz.cover_state,
             tz.cover_position_tilt,

--- a/src/devices/ubisys.ts
+++ b/src/devices/ubisys.ts
@@ -1075,7 +1075,7 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.instantaneousDemand(endpoint3);
             await reporting.bind(endpoint1, coordinatorEndpoint, ["closuresWindowCovering"]);
             await reporting.currentPositionLiftPercentage(endpoint1);
-            const payload = reporting.payload<"closuresWindowCovering", UbisysClosuresWindowCovering>("operationalStatus", 1, 3600, 0);
+            const payload = reporting.payload<"closuresWindowCovering", UbisysClosuresWindowCovering>("operationalStatus", 0, 65000, 0);
             await endpoint1.configureReporting("closuresWindowCovering", payload);
         },
         onEvent: (event) => {

--- a/src/lib/ubisys.ts
+++ b/src/lib/ubisys.ts
@@ -4,7 +4,16 @@ import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import {presets as e, access as ea} from "./exposes";
 import {logger} from "./logger";
-import {type BinaryArgs, binary, deviceAddCustomCluster, type NumericArgs, numeric, setupConfigureForReporting} from "./modernExtend";
+import {
+    type BinaryArgs,
+    binary,
+    deviceAddCustomCluster,
+    type EnumLookupArgs,
+    enumLookup,
+    type NumericArgs,
+    numeric,
+    setupConfigureForReporting,
+} from "./modernExtend";
 import type {Configure, Fz, ModernExtend, Tz, Zh} from "./types";
 
 const NS = "zhc:ubisys";
@@ -717,6 +726,19 @@ export const ubisysModernExtend = {
             valueMin: 1,
             valueMax: 30,
             unit: "ºC",
+            ...args,
+        }),
+    operationalStatus: (args?: Partial<EnumLookupArgs<"closuresWindowCovering", UbisysClosuresWindowCovering>>) =>
+        enumLookup<"closuresWindowCovering", UbisysClosuresWindowCovering>({
+            name: "operational_status",
+            cluster: "closuresWindowCovering",
+            attribute: "operationalStatus",
+            entityCategory: "diagnostic",
+            description:
+                "This attribute contains two bits which will be set while the motor is active. " +
+                "Thus, devices that do not support positioning or move at a slow pace can still provide feedback.",
+            access: "STATE_GET",
+            lookup: {stopped: 0x00, opening: 0x01, closing: 0x02},
             ...args,
         }),
 };


### PR DESCRIPTION
The custom attribute `operational_status` can be used to determine movement direction of window coverings.
It's basically the same as `motor_state` used by Bosch devices. 😊