### PR TITLE
Fix AOYAN AY205Z white label matching

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15749,7 +15749,7 @@ export const definitions: DefinitionWithExtend[] = [
                 model: "AY205Z",
                 vendor: "AOYAN",
                 description: "PIR 24Ghz human presence sensor",
-                fingerprint: [{modelID: "AY205Z", manufacturerName: "AOYAN"}],
+                fingerprint: [{modelID: "AY205Z", manufacturerName: "AOYAN"}, {manufacturerName: "AOYAN"}],
             },
         ],
     },


### PR DESCRIPTION
Adds a manufacturerName fallback to the AY205Z whiteLabel fingerprint so devices that report padded model IDs still show as AOYAN/AY205Z.