### PR TITLE
Moes ZHT-002 updated definition

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -619,7 +619,7 @@ const trv603ScheduleConverter = (dayNumber: number) => {
 };
 
 const zht002ProgrammingModeConverter = {
-    from: (v: unknown) => v,
+    from: (v: unknown) => v as KeyValue,
     to: (v: KeyValue, meta: Tz.Meta) => {
         let existing: KeyValue = {};
         if (meta?.state?.programming_mode && typeof meta.state.programming_mode === "object") {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11000,9 +11000,7 @@ export const definitions: DefinitionWithExtend[] = [
                 ];
                 let composite = e
                     .composite("programming_mode", "programming_mode", ea.STATE_SET)
-                    .withDescription(
-                        "Schedule: W=Weekdays, S=Saturday, U=Sunday. 4 slots each with hour(h), minute(m), temperature(t).",
-                    );
+                    .withDescription("Schedule: W=Weekdays, S=Saturday, U=Sunday. 4 slots each with hour(h), minute(m), temperature(t).");
                 for (const group of groups) {
                     for (let slot = 0; slot < 4; slot++) {
                         const offset = group.start + slot * 4;

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -618,6 +618,22 @@ const trv603ScheduleConverter = (dayNumber: number) => {
     };
 };
 
+const zht002ProgrammingModeConverter = {
+    from: (v: unknown) => v,
+    to: (v: KeyValue, meta: Tz.Meta) => {
+        let existing: KeyValue = {};
+        if (meta?.state?.programming_mode && typeof meta.state.programming_mode === "object") {
+            existing = {...(meta.state.programming_mode as KeyValue)};
+        }
+        const merged = {...existing, ...v};
+        const buffer: number[] = [];
+        for (let i = 0; i < 48; i++) {
+            buffer[i] = (merged[i.toString()] as number) || 0;
+        }
+        return buffer;
+    },
+};
+
 // AR331 Pro (DP 106): holiday start/end as 9-byte LE: [prefix, ts_start_LE4, ts_end_LE4]
 const ar331ProHolidayTimeConverter = {
     from: (v: number[]) => {
@@ -10956,9 +10972,6 @@ export const definitions: DefinitionWithExtend[] = [
             e.eco_mode(),
             e.temperature_sensor_select(["IN", "AL", "OU"]).withLabel("Sensor").withDescription("Choose which sensor to use. Default: AL"),
             e.enum("valve_state", ea.STATE, ["close", "open"]).withDescription("State of the valve"),
-            e
-                .text("workdays_schedule", ea.STATE_SET)
-                .withDescription('Workdays schedule, 4 entries max, example: "06:00/20°C 11:20/22°C 16:59/15°C 22:00/25°C"'),
             e.min_temperature().withValueMin(0).withValueMax(20),
             e.max_temperature().withValueMin(20).withValueMax(50),
             e
@@ -10978,9 +10991,44 @@ export const definitions: DefinitionWithExtend[] = [
                 .withValueMin(1)
                 .withValueStep(1)
                 .withPreset("default", 1, "Default value")
-                .withDescription("The difference between the local temperature that triggers heating and the set temperature"),
-
-            e.enum("working_day", ea.STATE_SET, ["disabled", "5-2", "6-1", "7"]).withDescription("Workday setting"),
+                .withDescription("The difference between local temp and set temp that triggers heating"),
+            (() => {
+                const groups = [
+                    {name: "W", start: 0},
+                    {name: "S", start: 16},
+                    {name: "U", start: 32},
+                ];
+                let composite = e
+                    .composite("programming_mode", "programming_mode", ea.STATE_SET)
+                    .withDescription(
+                        "Schedule: W=Weekdays, S=Saturday, U=Sunday. 4 slots each with hour(h), minute(m), temperature(t).",
+                    );
+                for (const group of groups) {
+                    for (let slot = 0; slot < 4; slot++) {
+                        const offset = group.start + slot * 4;
+                        const label = `${group.name}${slot + 1}`;
+                        composite = composite.withFeature(
+                            e.numeric(offset.toString(), ea.STATE_SET).withValueMin(0).withValueMax(23).withDescription(`${label}h`),
+                        );
+                        composite = composite.withFeature(
+                            e
+                                .numeric((offset + 1).toString(), ea.STATE_SET)
+                                .withValueMin(0)
+                                .withValueMax(59)
+                                .withDescription(`${label}m`),
+                        );
+                        composite = composite.withFeature(
+                            e
+                                .numeric((offset + 3).toString(), ea.STATE_SET)
+                                .withValueMin(5)
+                                .withValueMax(45)
+                                .withUnit("°C")
+                                .withDescription(`${label}t`),
+                        );
+                    }
+                }
+                return composite;
+            })(),
         ],
         meta: {
             tuyaDatapoints: [
@@ -10996,26 +11044,6 @@ export const definitions: DefinitionWithExtend[] = [
                 [16, "local_temperature", tuya.valueConverter.divideBy10],
                 [18, "min_temperature", tuya.valueConverter.raw],
                 [19, "local_temperature_calibration", tuya.valueConverter.localTemperatureCalibration],
-                [
-                    23,
-                    "working_day",
-                    tuya.valueConverterBasic.lookup((_, device) => {
-                        if (device.manufacturerName === "_TZE204_xalsoe3m") {
-                            return {
-                                disabled: tuya.enum(0),
-                                "5-2": tuya.enum(1),
-                                "6-1": tuya.enum(2),
-                                "7": tuya.enum(3),
-                            };
-                        }
-                        return {
-                            disabled: tuya.enum(0),
-                            "5-2": tuya.enum(2),
-                            "6-1": tuya.enum(1),
-                            "7": tuya.enum(3),
-                        };
-                    }),
-                ],
                 [
                     32,
                     "sensor",
@@ -11037,7 +11065,7 @@ export const definitions: DefinitionWithExtend[] = [
                     }),
                 ],
                 [50, "current_heating_setpoint", tuya.valueConverter.raw],
-                [68, "programming_mode", tuya.valueConverter.raw],
+                [68, "programming_mode", zht002ProgrammingModeConverter],
                 [101, "max_temperature_limit", tuya.valueConverter.raw],
                 [102, "deadzone_temperature", tuya.valueConverter.raw],
             ],


### PR DESCRIPTION
The ZHT-002 thermostat uses a specific programming_mode format for scheduling heating.
workdays_schedule is not defined on the payload as per the existing configuration.

PROGRAMMING_MODE FORMAT SPECIFICATION:

- DATA STRUCTURE

Type: ARRAY with exactly 48 values (or OBJECT with keys '0'-'47')
Format: [value1, value2, value3, ..., value48]
Represents: 3 day types × 4 slots per day × 4 values per slot

- DAY SECTIONS

Indices 0-15: Workdays (Monday-Friday) - Same schedule applied to all 5 days
Indices 16-31: Saturday - Separate schedule for Saturday
Indices 32-47: Sunday - Separate schedule for Sunday

- SLOT STRUCTURE

Each programming slot uses 4 consecutive values: [HOUR, MINUTE, 0, TEMPERATURE]

Position breakdown per slot:

Index 0 (mod 4): HOUR (0-23, 24-hour format)
Index 1 (mod 4): MINUTE (0, 15, 30, 45)
Index 2 (mod 4): UNKNOWN (always 0, reserved)
Index 3 (mod 4): TEMPERATURE (15-30°C)
Example slot: [8, 0, 0, 17]
Meaning: 08:00 → 17°C

- COMPLETE STRUCTURE

Workday slots (0-15):
Slot 1 (indices 0-3): [HOUR, MINUTE, 0, TEMP]
Slot 2 (indices 4-7): [HOUR, MINUTE, 0, TEMP]
Slot 3 (indices 8-11): [HOUR, MINUTE, 0, TEMP]
Slot 4 (indices 12-15): [HOUR, MINUTE, 0, TEMP]

Saturday slots (16-31):
Slot 1 (indices 16-19): [HOUR, MINUTE, 0, TEMP]
Slot 2 (indices 20-23): [HOUR, MINUTE, 0, TEMP]
Slot 3 (indices 24-27): [HOUR, MINUTE, 0, TEMP]
Slot 4 (indices 28-31): [HOUR, MINUTE, 0, TEMP]

Sunday slots (32-47):
Slot 1 (indices 32-35): [HOUR, MINUTE, 0, TEMP]
Slot 2 (indices 36-39): [HOUR, MINUTE, 0, TEMP]
Slot 3 (indices 40-43): [HOUR, MINUTE, 0, TEMP]
Slot 4 (indices 44-47): [HOUR, MINUTE, 0, TEMP]

TYPICAL PAYLOAD STRUCTURE
{
"programming_mode": [
8,0,0,17, 11,0,0,17, 17,0,0,21, 19,0,0,17,
8,0,0,17, 11,0,0,17, 17,0,0,21, 19,0,0,17,
8,0,0,17, 11,0,0,17, 17,0,0,21, 19,0,0,17
],
"system_mode": "auto",
"working_day": "enabled",
"state": "HEAT"
}