### PR TITLE
feat(add): StuckAtPrototype AirCube

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -320,6 +320,7 @@ import {definitions as spotmau} from "./spotmau";
 import {definitions as sprut} from "./sprut";
 import {definitions as stello} from "./stello";
 import {definitions as stelpro} from "./stelpro";
+import {definitions as stuckatprototype} from "./stuckatprototype";
 import {definitions as sunricher} from "./sunricher";
 import {definitions as superled} from "./superled";
 import {definitions as swann} from "./swann";
@@ -699,6 +700,7 @@ const definitions: DefinitionWithExtend[] = [
     ...sprut,
     ...stello,
     ...stelpro,
+    ...stuckatprototype,
     ...sunricher,
     ...superled,
     ...swann,

--- a/src/devices/stuckatprototype.ts
+++ b/src/devices/stuckatprototype.ts
@@ -1,0 +1,123 @@
+import {Zcl} from "zigbee-herdsman";
+
+import * as m from "../lib/modernExtend";
+import type {Configure, DefinitionExposesFunction, DefinitionWithExtend, DummyDevice, Expose, ModernExtend, Zh} from "../lib/types";
+import * as utils from "../lib/utils";
+
+const AIR_QUALITY_CLUSTER = "aircubeAirQuality";
+
+/**
+ * The AirCube ships as two hardware variants that enumerate with the SAME
+ * `modelID` ("AirCube") from a single firmware image:
+ *   - Base: ENS210 (temp/RH) + ENS16x (eCO2, tVOC, VOC level).
+ *   - Pro : SCD41 (true CO2, msCO2 cluster) + VCNL4040 (ambient light,
+ *           msIlluminanceMeasurement cluster) on top of the ENS16x set.
+ * The Pro-only clusters are only added to the endpoint when the hardware is a
+ * Pro, so CO2 and illuminance are exposed only when the device actually
+ * implements the cluster. Both the exposes and the configure are gated: an
+ * ungated m.co2()/m.illuminance() configure calls getEndpointsWithCluster(),
+ * which throws on a Base unit that has no such cluster. Pattern mirrors
+ * third_reality.ts conditionalPressure().
+ */
+function whenClusterPresent(cluster: string, extend: ModernExtend): ModernExtend {
+    const present = (device: Zh.Device | DummyDevice): boolean => {
+        if (utils.isDummyDevice(device)) return true; // documentation generation: always show
+        return device.endpoints?.some((endpoint: Zh.Endpoint) => endpoint.supportsInputCluster(cluster)) ?? false;
+    };
+
+    const exposeFn: DefinitionExposesFunction = (device, options) => {
+        if (!present(device)) return [];
+        const result: Expose[] = [];
+        for (const item of extend.exposes ?? []) {
+            if (typeof item === "function") result.push(...item(device, options));
+            else result.push(item);
+        }
+        return result;
+    };
+
+    return {
+        ...extend,
+        exposes: [exposeFn],
+        configure: (extend.configure ?? []).map((configureFn): Configure => {
+            return async (device, coordinatorEndpoint, definition) => {
+                if (present(device)) await configureFn(device, coordinatorEndpoint, definition);
+            };
+        }),
+        isModernExtend: true,
+    };
+}
+
+export const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ["AirCube"],
+        model: "AirCube",
+        vendor: "StuckAtPrototype",
+        description: "AirCube air quality monitor",
+        extend: [
+            m.deviceAddCustomCluster(AIR_QUALITY_CLUSTER, {
+                name: AIR_QUALITY_CLUSTER,
+                ID: 0xfc01,
+                attributes: {
+                    eco2: {name: "eco2", ID: 0x0000, type: Zcl.DataType.UINT16},
+                    etvoc: {name: "etvoc", ID: 0x0001, type: Zcl.DataType.UINT16},
+                    aqi: {name: "aqi", ID: 0x0002, type: Zcl.DataType.UINT16},
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+            m.temperature({reporting: {min: "10_SECONDS", max: "1_MINUTE", change: 50}}),
+            m.humidity({reporting: {min: "10_SECONDS", max: "1_MINUTE", change: 100}}),
+            m.numeric({
+                name: "eco2",
+                cluster: AIR_QUALITY_CLUSTER,
+                attribute: {ID: 0x0000, type: Zcl.DataType.UINT16},
+                label: "Equivalent CO2",
+                description: "Equivalent CO2 estimated from VOC (ENS16x)",
+                unit: "ppm",
+                access: "STATE_GET",
+                valueMin: 400,
+                valueMax: 8192,
+                reporting: {min: "10_SECONDS", max: "1_MINUTE", change: 50},
+            }),
+            m.numeric({
+                name: "voc",
+                cluster: AIR_QUALITY_CLUSTER,
+                attribute: {ID: 0x0001, type: Zcl.DataType.UINT16},
+                label: "VOC parts",
+                description: "Equivalent total VOC (tVOC)",
+                unit: "ppb",
+                access: "STATE_GET",
+                valueMin: 0,
+                valueMax: 65535,
+                reporting: {min: "10_SECONDS", max: "1_MINUTE", change: 10},
+            }),
+            m.numeric({
+                name: "aqi",
+                cluster: AIR_QUALITY_CLUSTER,
+                attribute: {ID: 0x0002, type: Zcl.DataType.UINT16},
+                label: "VOC level",
+                description: "TVOC-derived VOC level (0-500)",
+                access: "STATE_GET",
+                valueMin: 0,
+                valueMax: 500,
+                reporting: {min: "10_SECONDS", max: "1_MINUTE", change: 5},
+            }),
+            m.numeric({
+                name: "brightness",
+                cluster: "genAnalogOutput",
+                attribute: "presentValue",
+                label: "Brightness",
+                description: "LED brightness",
+                unit: "%",
+                access: "ALL",
+                valueMin: 0,
+                valueMax: 100,
+                valueStep: 1,
+                precision: 0,
+                reporting: {min: "10_SECONDS", max: "1_MINUTE", change: 5},
+            }),
+            whenClusterPresent("msCO2", m.co2()),
+            whenClusterPresent("msIlluminanceMeasurement", m.illuminance()),
+        ],
+    },
+];

--- a/test/stuckatprototype.test.ts
+++ b/test/stuckatprototype.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, test, vi} from "vitest";
+import {findByDevice} from "../src";
+import type {Definition, Expose, Zh} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+// Real endpoint/cluster descriptors captured from paired hardware (herdsman
+// database): endpoint 10, HA profile 260, temperature-sensor device 770.
+// Base = ENS210 + ENS16x, Pro adds SCD41 (msCO2 / 0x040D) and VCNL4040
+// (msIlluminanceMeasurement / 0x0400). The 0xFC01 custom cluster carries
+// eCO2/tVOC/VOC-level on both variants.
+const BASE_CLUSTERS = ["genBasic", "genIdentify", "genAnalogOutput", "msTemperatureMeasurement", "msRelativeHumidity"];
+const PRO_CLUSTERS = [...BASE_CLUSTERS, "msIlluminanceMeasurement", "msCO2"];
+
+function mockAirCube(inputClusters: string[]): Zh.Device {
+    return mockDevice(
+        {
+            modelID: "AirCube",
+            manufacturerName: "StuckAtPrototype",
+            endpoints: [{ID: 10, profileID: 260, deviceID: 770, inputClusters, inputClusterIDs: [0xfc01]}],
+        },
+        "EndDevice",
+    );
+}
+
+function exposeNames(definition: Definition, device: Zh.Device): string[] {
+    const exposes = typeof definition.exposes === "function" ? definition.exposes(device, {}) : (definition.exposes ?? []);
+    return (exposes as Expose[]).map((expose) => expose.name);
+}
+
+describe("StuckAtPrototype AirCube", () => {
+    test("Pro exposes CO2 + illuminance and configures their reporting", async () => {
+        const device = mockAirCube(PRO_CLUSTERS);
+        const definition = await findByDevice(device);
+        expect(definition.model).toBe("AirCube");
+
+        expect(exposeNames(definition, device)).toEqual(
+            expect.arrayContaining(["temperature", "humidity", "eco2", "voc", "aqi", "brightness", "co2", "illuminance"]),
+        );
+        // Brightness is the only writable value.
+        expect(definition.toZigbee?.find((converter) => converter.key.includes("brightness"))?.convertSet).toBeDefined();
+
+        const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).endpoints[0];
+        await definition.configure?.(device, coordinatorEndpoint, definition);
+
+        const reporting = vi.mocked(device.endpoints[0].configureReporting).mock.calls.map((call) => call[0]);
+        expect(reporting).toContain("msCO2");
+        expect(reporting).toContain("msIlluminanceMeasurement");
+    });
+
+    test("Base matches the same definition, hides Pro-only values, and configure does not throw", async () => {
+        const device = mockAirCube(BASE_CLUSTERS);
+        const definition = await findByDevice(device);
+        expect(definition.model).toBe("AirCube");
+
+        const names = exposeNames(definition, device);
+        expect(names).toEqual(expect.arrayContaining(["temperature", "humidity", "eco2", "voc", "aqi", "brightness"]));
+        expect(names).not.toContain("co2");
+        expect(names).not.toContain("illuminance");
+
+        // Regression: an ungated m.co2()/m.illuminance() configure calls
+        // getEndpointsWithCluster(), which throws on a Base unit lacking the
+        // cluster. The gate must skip it instead.
+        const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).endpoints[0];
+        await expect(definition.configure?.(device, coordinatorEndpoint, definition)).resolves.toBeUndefined();
+
+        const reporting = vi.mocked(device.endpoints[0].configureReporting).mock.calls.map((call) => call[0]);
+        expect(reporting).not.toContain("msCO2");
+        expect(reporting).not.toContain("msIlluminanceMeasurement");
+    });
+});


### PR DESCRIPTION
The [AirCube](https://github.com/StuckAtPrototype/AirCube) (StuckAtPrototype, Apache-2.0) is an ESP32-H2 Zigbee air quality monitor. It ships in two hardware variants that enumerate with the same `AirCube` modelID from a single firmware image:

- **Base** (ENS210 + ENS16x): temperature, humidity, eCO2, tVOC and a TVOC-derived VOC level, plus LED brightness.
- **Pro**: additionally true CO2 (Sensirion SCD41, `msCO2`) and illuminance (VCNL4040, `msIlluminanceMeasurement`).

Both variants share one modelID and differ only in which clusters the hardware implements, so this is a single definition whose CO2 and illuminance **exposes and `configure`** are gated on cluster presence (`supportsInputCluster`), following the `third_reality.ts` `conditionalPressure()` pattern. Gating the `configure` — not just the exposes — is required so a Base unit does not fail `configure` on the absent clusters.

eCO2 / tVOC / VOC-level are read from the device's custom `0xFC01` cluster; brightness is the writable Analog Output `presentValue`. The device exposes no OTA cluster, so no `ota`.

Ported from the manufacturer's own published Zigbee2MQTT converter — credit to **StuckAtPrototype**.

**Verification:** `pnpm build`, `pnpm check` and `pnpm test` all pass; `test/stuckatprototype.test.ts` covers Base/Pro exposes discrimination and that `configure` does not throw on a Base unit. Verified against real Pro hardware (endpoint 10, input clusters `[0, 3, 13, 1024, 1026, 1029, 1037, 64513]`); the Base path follows the manufacturer's published cluster set / ZHA quirk signature and is gated by cluster presence.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5395