### PR TITLE
fix: Nous B4Z TS130F stale position after movement to absolute position

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -785,28 +785,6 @@ const sixGangIndicatorDatapoints: Tuya.MetaTuyaDataPoints = [
     ),
 ];
 
-// Correct certain TS130F covers that report the requested position while moving,
-// but then incorrectly revert to the original start position when
-// reporting STOP.
-const ts130fPositionFixStoreKey = "ts130f_position_fix";
-
-interface Ts130fPositionFixState {
-    startPosition: number;
-    targetPosition: number;
-    rawTargetPosition?: number;
-    correctionInProgress: boolean;
-}
-
-const clearTs130fPositionFix = (entity: Zh.Endpoint | Zh.Group): void => {
-    if (utils.isGroup(entity)) {
-        for (const member of entity.members) {
-            globalStore.clearValue(member, ts130fPositionFixStoreKey);
-        }
-    } else {
-        globalStore.clearValue(entity, ts130fPositionFixStoreKey);
-    }
-};
-
 const tzLocal = {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     TS0301_dual_rail_2: {
@@ -1421,54 +1399,9 @@ const tzLocal = {
             return {state: {sensitivity: value}};
         },
     } satisfies Tz.Converter,
-    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-    TS130F_cover_state: {
-        ...tz.cover_state,
-        convertSet: async (entity, key, value, meta) => {
-            // Any new state invalidates the previous position transaction.
-            clearTs130fPositionFix(entity);
-            return await tz.cover_state.convertSet(entity, key, value, meta);
-        },
-    } satisfies Tz.Converter,
-    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
-    TS130F_cover_position_tilt: {
-        ...tz.cover_position_tilt,
-        convertSet: async (entity, key, value, meta) => {
-            // Any new cover command invalidates the previous position transaction.
-            clearTs130fPositionFix(entity);
-
-            if (key !== "position" || !utils.isEndpoint(entity)) {
-                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
-            }
-
-            utils.assertNumber(value, key);
-
-            const startPosition = meta.state.position;
-
-            // Only track intermediate movements from a known position.
-            if (!utils.isNumber(startPosition) || value <= 0 || value >= 100 || value === startPosition) {
-                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
-            }
-
-            const pending: Ts130fPositionFixState = {
-                startPosition,
-                targetPosition: value,
-                correctionInProgress: false,
-            };
-
-            globalStore.putValue(entity, ts130fPositionFixStoreKey, pending);
-
-            try {
-                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
-            } catch (error) {
-                if (globalStore.getValue(entity, ts130fPositionFixStoreKey) === pending) {
-                    clearTs130fPositionFix(entity);
-                }
-                throw error;
-            }
-        },
-    } satisfies Tz.Converter,
 };
+
+const ts130fPositionKey = "ts130f_position";
 
 const fzLocal = {
     // FUT035Z+ (_TZB210_ue01a0s2) reports RF color temperature changes
@@ -2145,106 +2078,40 @@ const fzLocal = {
             return payload;
         },
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
-    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    // The Nous B4Z reports the position it started the movement from instead of the position it
+    // reached when reporting `moving: STOP`, publish the last position reported while moving instead.
+    // https://github.com/Koenkk/zigbee-herdsman-converters/pull/12887
+    // biome-ignore lint/style/useNamingConvention: existing
     TS130F_cover_position_tilt: {
         ...fz.cover_position_tilt,
         convert: (model, msg, publish, options, meta) => {
-            const converted = fz.cover_position_tilt.convert(model, msg, publish, options, meta) as KeyValueAny | undefined;
+            const result = fz.cover_position_tilt.convert(model, msg, publish, options, meta) as KeyValueAny | undefined;
+            const property = postfixWithEndpointName("position", msg, model, meta);
+            const position = result?.[property];
+            const moving = msg.data.tuyaMovingState;
+            if (meta.device.manufacturerName !== "_TZ3000_yruungrl" || moving === undefined || !utils.isNumber(position)) return result;
 
-            const pending = globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) as Ts130fPositionFixState | undefined;
-
-            const rawPosition = msg.data.currentPositionLiftPercentage;
-            const movingState = msg.data.tuyaMovingState;
-
-            if (pending === undefined || !utils.isNumber(rawPosition) || rawPosition > 100) {
-                return converted;
+            if (moving !== 1 /* STOP */) {
+                // Remember the position the movement started from and the position reported while moving.
+                const start = globalStore.getValue(msg.endpoint, ts130fPositionKey)?.start ?? meta.state[property];
+                globalStore.putValue(msg.endpoint, ts130fPositionKey, {start, position, raw: msg.data.currentPositionLiftPercentage});
+                return result;
             }
 
-            const positionProperty = utils.postfixWithEndpointName("position", msg, model, meta);
-            const position = converted?.[positionProperty];
-
-            // UP/DOWN: remember the raw Zigbee target once the device acknowledges
-            // the requested logical position while moving.
-            if (movingState === 0 || movingState === 2) {
-                if (position === pending.targetPosition) {
-                    pending.rawTargetPosition = rawPosition;
-                    globalStore.putValue(msg.endpoint, ts130fPositionFixStoreKey, pending);
-                } else if (pending.rawTargetPosition !== undefined) {
-                    // The device started reporting another position while moving.
-                    // This is not the failure pattern we are looking for.
-                    clearTs130fPositionFix(msg.endpoint);
-                }
-
-                return converted;
+            const moved = globalStore.getValue(msg.endpoint, ts130fPositionKey);
+            globalStore.clearValue(msg.endpoint, ts130fPositionKey);
+            // Only correct when the reported position is exactly the one the movement started from,
+            // any other position is a legitimate (e.g. manual) stop.
+            if (moved !== undefined && position === moved.start && position !== moved.position) {
+                logger.debug(`Correcting stale position ${position} to ${moved.position}`, NS);
+                result[property] = moved.position;
+                result[postfixWithEndpointName("state", msg, model, meta)] = moved.position === 0 ? "CLOSE" : "OPEN";
+                // Also correct the position on the device itself, it keeps reporting the stale one otherwise.
+                msg.endpoint
+                    .write("closuresWindowCovering", {currentPositionLiftPercentage: moved.raw}, utils.getOptions(model, msg.endpoint))
+                    .catch((error) => logger.warning(`Failed to correct stale position: ${error}`, NS));
             }
-
-            if (movingState === 1) {
-                // We only repair a transaction after the target was explicitly
-                // acknowledged while moving.
-                if (pending.rawTargetPosition === undefined) {
-                    clearTs130fPositionFix(msg.endpoint);
-                    return converted;
-                }
-
-                // Normal successful completion.
-                if (position === pending.targetPosition) {
-                    clearTs130fPositionFix(msg.endpoint);
-                    return converted;
-                }
-
-                // Exact failure pattern:
-                //
-                // start S -> command T -> T + moving -> S + STOP
-                //
-                // Suppress the stale position and repair the device attribute.
-                if (position === pending.startPosition) {
-                    if (!pending.correctionInProgress) {
-                        pending.correctionInProgress = true;
-                        globalStore.putValue(msg.endpoint, ts130fPositionFixStoreKey, pending);
-
-                        const staleResult = converted;
-                        const rawTargetPosition = pending.rawTargetPosition;
-
-                        logger.debug(`Correcting stale TS130F position from ${pending.startPosition} to ${pending.targetPosition}`, NS);
-
-                        void msg.endpoint
-                            .write(
-                                "closuresWindowCovering",
-                                {currentPositionLiftPercentage: rawTargetPosition},
-                                utils.getOptions(model, msg.endpoint),
-                            )
-                            .then(() => {
-                                if (globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) === pending) {
-                                    clearTs130fPositionFix(msg.endpoint);
-                                }
-                            })
-                            .catch((error) => {
-                                if (globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) === pending) {
-                                    clearTs130fPositionFix(msg.endpoint);
-
-                                    logger.warning(`Failed to correct stale TS130F position: ${error}`, NS);
-
-                                    // The correction failed, so expose the actual stale
-                                    // device state instead of leaving an optimistic value.
-                                    if (staleResult !== undefined) {
-                                        publish(staleResult);
-                                    }
-                                }
-                            });
-                    }
-
-                    // tuya.fz.cover_options still processes the same report and
-                    // publishes moving=STOP. Only position/state are suppressed here.
-                    return {};
-                }
-
-                // Any other final position (e.g. 99 when start=100) is considered
-                // a legitimate intermediate/manual stop.
-                clearTs130fPositionFix(msg.endpoint);
-                return converted;
-            }
-
-            return converted;
+            return result;
         },
     } satisfies Fz.Converter<"closuresWindowCovering", tuya.TuyaClosuresWindowCovering, ["attributeReport", "readResponse"]>,
 };
@@ -6152,7 +6019,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "Curtain/blind switch",
         fromZigbee: [
-            fz.cover_position_tilt,
+            fzLocal.TS130F_cover_position_tilt,
             tuya.fz.indicator_mode,
             tuya.fz.cover_options,
             tuya.fz.backlight_mode_off_on,
@@ -6198,6 +6065,7 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "LoraTap", model: "SC400"},
             tuya.whitelabel("LoraTap", "SC500ZB", "Smart curtain/shutter switch", ["_TZ3000_e3vhyirx", "_TZ3000_femsaaua"]),
             tuya.whitelabel("LoraTap", "SC500ZB-v4", "Smart curtain/shutter switch", ["_TZ3000_5iixzdo7"]),
+            tuya.whitelabel("Nous", "B4Z", "Curtain switch", ["_TZ3000_yruungrl"]),
             tuya.whitelabel("Nous", "L12Z", "Smart Zigbee Curtain Module L12Z", ["_TZ3000_jwv3cwak"]),
             tuya.whitelabel("Zemismart", "ZN-LC1E", "Smart curtain/shutter switch", ["_TZ3000_74hsp7qy"]),
             tuya.whitelabel("Girier", "TS130F_GIRIER", "Smart curtain switch", ["_TZ3210_dwytrmda"]),
@@ -6238,60 +6106,6 @@ export const definitions: DefinitionWithExtend[] = [
             }
             return exps;
         },
-    },
-    {
-        fingerprint: tuya.fingerprint("TS130F", ["_TZ3000_yruungrl"]),
-        model: "B4Z",
-        vendor: "Nous",
-        description: "Blind/curtain motor controller",
-        fromZigbee: [
-            fzLocal.TS130F_cover_position_tilt,
-            tuya.fz.indicator_mode,
-            tuya.fz.cover_options,
-            tuya.fz.backlight_mode_off_on,
-            tuya.fz.switch_type_curtain,
-        ],
-        toZigbee: [
-            tzLocal.TS130F_cover_state,
-            tzLocal.TS130F_cover_position_tilt,
-            tuya.tz.cover_calibration,
-            tuya.tz.cover_reversal,
-            tuya.tz.backlight_indicator_mode_2,
-            tuya.tz.backlight_indicator_mode_1,
-            tuya.tz.switch_type_curtain,
-        ],
-        meta: {coverInverted: true},
-        exposes: [
-            e.cover_position(),
-            e.enum("moving", ea.STATE, ["UP", "STOP", "DOWN"]),
-            e.binary("motor_reversal", ea.ALL, "ON", "OFF"),
-            e.binary("calibration", ea.ALL, "ON", "OFF"),
-            e.numeric("calibration_time", ea.ALL).withValueMin(0).withValueMax(500).withUnit("s"),
-            e.enum("switch_type_curtain", ea.ALL, ["flip-switch", "sync-switch", "button-switch"]).withDescription("External switch type"),
-        ],
-        extend: [
-            tuyaBase(),
-            tuya.clusters.addTuyaClosuresWindowCoveringCluster(),
-            m.deviceAddCustomCluster("closuresWindowCovering", {
-                name: "closuresWindowCovering",
-                ID: 0x0102,
-                attributes: {
-                    currentPositionLiftPercentage: {
-                        name: "currentPositionLiftPercentage",
-                        ID: 0x0008,
-                        type: DataType.UINT8,
-                        report: true,
-                        scene: true,
-                        max: 100,
-                        default: 0,
-                        write: true,
-                    },
-                },
-                commands: {},
-                commandsResponse: {},
-            }),
-            tuya.modernExtend.tuyaCoverSwitchType(),
-        ],
     },
     {
         fingerprint: tuya.fingerprint("TS130F", ["_TZ3000_1dd0d5yi"]),
@@ -12445,7 +12259,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6ycgarab", "_TZE284_aoah6bv8"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6ycgarab", "_TZE284_aoah6bv8", "_TZE2841000000_6ycgarab"]),
         model: "TS0601_smoke_co",
         vendor: "Tuya",
         description: "Dual smoke CO sensor",
@@ -23930,7 +23744,7 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaSendCommand: "sendData",
             tuyaDatapoints: [
-                //          [1, 'presence', tuya.valueConverter.trueFalse1],
+                //			[1, 'presence', tuya.valueConverter.trueFalse1],
                 [101, "entry_sensitivity", tuya.valueConverter.raw],
                 [102, "entry_distance", tuya.valueConverter.divideBy100],
                 [103, "departure_delay", tuya.valueConverter.raw],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -12259,7 +12259,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6ycgarab", "_TZE284_aoah6bv8", "_TZE2841000000_6ycgarab"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_6ycgarab", "_TZE284_aoah6bv8"]),
         model: "TS0601_smoke_co",
         vendor: "Tuya",
         description: "Dual smoke CO sensor",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -785,6 +785,28 @@ const sixGangIndicatorDatapoints: Tuya.MetaTuyaDataPoints = [
     ),
 ];
 
+// Correct certain TS130F covers that report the requested position while moving,
+// but then incorrectly revert to the original start position when
+// reporting STOP.
+const ts130fPositionFixStoreKey = "ts130f_position_fix";
+
+interface Ts130fPositionFixState {
+    startPosition: number;
+    targetPosition: number;
+    rawTargetPosition?: number;
+    correctionInProgress: boolean;
+}
+
+const clearTs130fPositionFix = (entity: Zh.Endpoint | Zh.Group): void => {
+    if (utils.isGroup(entity)) {
+        for (const member of entity.members) {
+            globalStore.clearValue(member, ts130fPositionFixStoreKey);
+        }
+    } else {
+        globalStore.clearValue(entity, ts130fPositionFixStoreKey);
+    }
+};
+
 const tzLocal = {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     TS0301_dual_rail_2: {
@@ -1397,6 +1419,53 @@ const tzLocal = {
             value = utils.toNumber(value, "sensitivity");
             await entity.write("ssIasZone", {currentZoneSensitivityLevel: value as number});
             return {state: {sensitivity: value}};
+        },
+    } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS130F_cover_state: {
+        ...tz.cover_state,
+        convertSet: async (entity, key, value, meta) => {
+            // Any new state invalidates the previous position transaction.
+            clearTs130fPositionFix(entity);
+            return await tz.cover_state.convertSet(entity, key, value, meta);
+        },
+    } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS130F_cover_position_tilt: {
+        ...tz.cover_position_tilt,
+        convertSet: async (entity, key, value, meta) => {
+            // Any new cover command invalidates the previous position transaction.
+            clearTs130fPositionFix(entity);
+
+            if (key !== "position" || !utils.isEndpoint(entity)) {
+                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
+            }
+
+            utils.assertNumber(value, key);
+
+            const startPosition = meta.state.position;
+
+            // Only track intermediate movements from a known position.
+            if (!utils.isNumber(startPosition) || value <= 0 || value >= 100 || value === startPosition) {
+                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
+            }
+
+            const pending: Ts130fPositionFixState = {
+                startPosition,
+                targetPosition: value,
+                correctionInProgress: false,
+            };
+
+            globalStore.putValue(entity, ts130fPositionFixStoreKey, pending);
+
+            try {
+                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
+            } catch (error) {
+                if (globalStore.getValue(entity, ts130fPositionFixStoreKey) === pending) {
+                    clearTs130fPositionFix(entity);
+                }
+                throw error;
+            }
         },
     } satisfies Tz.Converter,
 };
@@ -2076,6 +2145,108 @@ const fzLocal = {
             return payload;
         },
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS130F_cover_position_tilt: {
+        ...fz.cover_position_tilt,
+        convert: (model, msg, publish, options, meta) => {
+            const converted = fz.cover_position_tilt.convert(model, msg, publish, options, meta) as KeyValueAny | undefined;
+
+            const pending = globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) as Ts130fPositionFixState | undefined;
+
+            const rawPosition = msg.data.currentPositionLiftPercentage;
+            const movingState = msg.data.tuyaMovingState;
+
+            if (pending === undefined || !utils.isNumber(rawPosition) || rawPosition > 100) {
+                return converted;
+            }
+
+            const positionProperty = utils.postfixWithEndpointName("position", msg, model, meta);
+            const position = converted?.[positionProperty];
+
+            // UP/DOWN: remember the raw Zigbee target once the device acknowledges
+            // the requested logical position while moving.
+            if (movingState === 0 || movingState === 2) {
+                if (position === pending.targetPosition) {
+                    pending.rawTargetPosition = rawPosition;
+                    globalStore.putValue(msg.endpoint, ts130fPositionFixStoreKey, pending);
+                } else if (pending.rawTargetPosition !== undefined) {
+                    // The device started reporting another position while moving.
+                    // This is not the failure pattern we are looking for.
+                    clearTs130fPositionFix(msg.endpoint);
+                }
+
+                return converted;
+            }
+
+            if (movingState === 1) {
+                // We only repair a transaction after the target was explicitly
+                // acknowledged while moving.
+                if (pending.rawTargetPosition === undefined) {
+                    clearTs130fPositionFix(msg.endpoint);
+                    return converted;
+                }
+
+                // Normal successful completion.
+                if (position === pending.targetPosition) {
+                    clearTs130fPositionFix(msg.endpoint);
+                    return converted;
+                }
+
+                // Exact failure pattern:
+                //
+                // start S -> command T -> T + moving -> S + STOP
+                //
+                // Suppress the stale position and repair the device attribute.
+                if (position === pending.startPosition) {
+                    if (!pending.correctionInProgress) {
+                        pending.correctionInProgress = true;
+                        globalStore.putValue(msg.endpoint, ts130fPositionFixStoreKey, pending);
+
+                        const staleResult = converted;
+                        const rawTargetPosition = pending.rawTargetPosition;
+
+                        logger.debug(`Correcting stale TS130F position from ${pending.startPosition} to ${pending.targetPosition}`, NS);
+
+                        void msg.endpoint
+                            .write(
+                                "closuresWindowCovering",
+                                {currentPositionLiftPercentage: rawTargetPosition},
+                                utils.getOptions(model, msg.endpoint),
+                            )
+                            .then(() => {
+                                if (globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) === pending) {
+                                    clearTs130fPositionFix(msg.endpoint);
+                                }
+                            })
+                            .catch((error) => {
+                                if (globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) === pending) {
+                                    clearTs130fPositionFix(msg.endpoint);
+
+                                    logger.warning(`Failed to correct stale TS130F position: ${error}`, NS);
+
+                                    // The correction failed, so expose the actual stale
+                                    // device state instead of leaving an optimistic value.
+                                    if (staleResult !== undefined) {
+                                        publish(staleResult);
+                                    }
+                                }
+                            });
+                    }
+
+                    // tuya.fz.cover_options still processes the same report and
+                    // publishes moving=STOP. Only position/state are suppressed here.
+                    return {};
+                }
+
+                // Any other final position (e.g. 99 when start=100) is considered
+                // a legitimate intermediate/manual stop.
+                clearTs130fPositionFix(msg.endpoint);
+                return converted;
+            }
+
+            return converted;
+        },
+    } satisfies Fz.Converter<"closuresWindowCovering", tuya.TuyaClosuresWindowCovering, ["attributeReport", "readResponse"]>,
 };
 
 // MS032Z stair light controller - DP 125, the six running-light effects.
@@ -6027,7 +6198,6 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "LoraTap", model: "SC400"},
             tuya.whitelabel("LoraTap", "SC500ZB", "Smart curtain/shutter switch", ["_TZ3000_e3vhyirx", "_TZ3000_femsaaua"]),
             tuya.whitelabel("LoraTap", "SC500ZB-v4", "Smart curtain/shutter switch", ["_TZ3000_5iixzdo7"]),
-            tuya.whitelabel("Nous", "B4Z", "Curtain switch", ["_TZ3000_yruungrl"]),
             tuya.whitelabel("Nous", "L12Z", "Smart Zigbee Curtain Module L12Z", ["_TZ3000_jwv3cwak"]),
             tuya.whitelabel("Zemismart", "ZN-LC1E", "Smart curtain/shutter switch", ["_TZ3000_74hsp7qy"]),
             tuya.whitelabel("Girier", "TS130F_GIRIER", "Smart curtain switch", ["_TZ3210_dwytrmda"]),
@@ -6068,6 +6238,52 @@ export const definitions: DefinitionWithExtend[] = [
             }
             return exps;
         },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS130F", ["_TZ3000_yruungrl"]),
+        model: "B4Z",
+        vendor: "Nous",
+        description: "Blind/curtain motor controller",
+        fromZigbee: [
+            fzLocal.TS130F_cover_position_tilt,
+            tuya.fz.indicator_mode,
+            tuya.fz.cover_options,
+            tuya.fz.backlight_mode_off_on,
+            tuya.fz.switch_type_curtain,
+        ],
+        toZigbee: [
+            tzLocal.TS130F_cover_state,
+            tzLocal.TS130F_cover_position_tilt,
+            tuya.tz.cover_calibration,
+            tuya.tz.cover_reversal,
+            tuya.tz.backlight_indicator_mode_2,
+            tuya.tz.backlight_indicator_mode_1,
+            tuya.tz.switch_type_curtain,
+        ],
+        meta: {coverInverted: true},
+        extend: [
+            tuyaBase(),
+            tuya.clusters.addTuyaClosuresWindowCoveringCluster(),
+            m.deviceAddCustomCluster("closuresWindowCovering", {
+                name: "closuresWindowCovering",
+                ID: 0x0102,
+                attributes: {
+                    currentPositionLiftPercentage: {
+                        name: "currentPositionLiftPercentage",
+                        ID: 0x0008,
+                        type: DataType.UINT8,
+                        report: true,
+                        scene: true,
+                        max: 100,
+                        default: 0,
+                        write: true,
+                    },
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+            tuya.modernExtend.tuyaCoverSwitchType(),
+        ],
     },
     {
         fingerprint: tuya.fingerprint("TS130F", ["_TZ3000_1dd0d5yi"]),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -646,6 +646,28 @@ const ar331ProHolidayTimeConverter = {
     },
 };
 
+// Correct certain TS130F covers that report the requested position while moving,
+// but then incorrectly revert to the original start position when
+// reporting STOP.
+const ts130fPositionFixStoreKey = "ts130f_position_fix";
+
+interface Ts130fPositionFixState {
+    startPosition: number;
+    targetPosition: number;
+    rawTargetPosition?: number;
+    correctionInProgress: boolean;
+}
+
+const clearTs130fPositionFix = (entity: Zh.Endpoint | Zh.Group): void => {
+    if (utils.isGroup(entity)) {
+        for (const member of entity.members) {
+            globalStore.clearValue(member, ts130fPositionFixStoreKey);
+        }
+    } else {
+        globalStore.clearValue(entity, ts130fPositionFixStoreKey);
+    }
+};
+
 const tzLocal = {
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     TS0301_dual_rail_2: {
@@ -1260,6 +1282,53 @@ const tzLocal = {
             value = utils.toNumber(value, "sensitivity");
             await entity.write("ssIasZone", {currentZoneSensitivityLevel: value as number});
             return {state: {sensitivity: value}};
+        },
+    } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS130F_cover_state: {
+        ...tz.cover_state,
+        convertSet: async (entity, key, value, meta) => {
+            // Any new state invalidates the previous position transaction.
+            clearTs130fPositionFix(entity);
+            return await tz.cover_state.convertSet(entity, key, value, meta);
+        },
+    } satisfies Tz.Converter,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS130F_cover_position_tilt: {
+        ...tz.cover_position_tilt,
+        convertSet: async (entity, key, value, meta) => {
+            // Any new cover command invalidates the previous position transaction.
+            clearTs130fPositionFix(entity);
+
+            if (key !== "position" || !utils.isEndpoint(entity)) {
+                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
+            }
+
+            utils.assertNumber(value, key);
+
+            const startPosition = meta.state.position;
+
+            // Only track intermediate movements from a known position.
+            if (!utils.isNumber(startPosition) || value <= 0 || value >= 100 || value === startPosition) {
+                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
+            }
+
+            const pending: Ts130fPositionFixState = {
+                startPosition,
+                targetPosition: value,
+                correctionInProgress: false,
+            };
+
+            globalStore.putValue(entity, ts130fPositionFixStoreKey, pending);
+
+            try {
+                return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
+            } catch (error) {
+                if (globalStore.getValue(entity, ts130fPositionFixStoreKey) === pending) {
+                    clearTs130fPositionFix(entity);
+                }
+                throw error;
+            }
         },
     } satisfies Tz.Converter,
 };
@@ -1916,6 +1985,108 @@ const fzLocal = {
             return payload;
         },
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
+    // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
+    TS130F_cover_position_tilt: {
+        ...fz.cover_position_tilt,
+        convert: (model, msg, publish, options, meta) => {
+            const converted = fz.cover_position_tilt.convert(model, msg, publish, options, meta) as KeyValueAny | undefined;
+
+            const pending = globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) as Ts130fPositionFixState | undefined;
+
+            const rawPosition = msg.data.currentPositionLiftPercentage;
+            const movingState = msg.data.tuyaMovingState;
+
+            if (pending === undefined || !utils.isNumber(rawPosition) || rawPosition > 100) {
+                return converted;
+            }
+
+            const positionProperty = utils.postfixWithEndpointName("position", msg, model, meta);
+            const position = converted?.[positionProperty];
+
+            // UP/DOWN: remember the raw Zigbee target once the device acknowledges
+            // the requested logical position while moving.
+            if (movingState === 0 || movingState === 2) {
+                if (position === pending.targetPosition) {
+                    pending.rawTargetPosition = rawPosition;
+                    globalStore.putValue(msg.endpoint, ts130fPositionFixStoreKey, pending);
+                } else if (pending.rawTargetPosition !== undefined) {
+                    // The device started reporting another position while moving.
+                    // This is not the failure pattern we are looking for.
+                    clearTs130fPositionFix(msg.endpoint);
+                }
+
+                return converted;
+            }
+
+            if (movingState === 1) {
+                // We only repair a transaction after the target was explicitly
+                // acknowledged while moving.
+                if (pending.rawTargetPosition === undefined) {
+                    clearTs130fPositionFix(msg.endpoint);
+                    return converted;
+                }
+
+                // Normal successful completion.
+                if (position === pending.targetPosition) {
+                    clearTs130fPositionFix(msg.endpoint);
+                    return converted;
+                }
+
+                // Exact failure pattern:
+                //
+                // start S -> command T -> T + moving -> S + STOP
+                //
+                // Suppress the stale position and repair the device attribute.
+                if (position === pending.startPosition) {
+                    if (!pending.correctionInProgress) {
+                        pending.correctionInProgress = true;
+                        globalStore.putValue(msg.endpoint, ts130fPositionFixStoreKey, pending);
+
+                        const staleResult = converted;
+                        const rawTargetPosition = pending.rawTargetPosition;
+
+                        logger.debug(`Correcting stale TS130F position from ${pending.startPosition} to ${pending.targetPosition}`, NS);
+
+                        void msg.endpoint
+                            .write(
+                                "closuresWindowCovering",
+                                {currentPositionLiftPercentage: rawTargetPosition},
+                                utils.getOptions(model, msg.endpoint),
+                            )
+                            .then(() => {
+                                if (globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) === pending) {
+                                    clearTs130fPositionFix(msg.endpoint);
+                                }
+                            })
+                            .catch((error) => {
+                                if (globalStore.getValue(msg.endpoint, ts130fPositionFixStoreKey) === pending) {
+                                    clearTs130fPositionFix(msg.endpoint);
+
+                                    logger.warning(`Failed to correct stale TS130F position: ${error}`, NS);
+
+                                    // The correction failed, so expose the actual stale
+                                    // device state instead of leaving an optimistic value.
+                                    if (staleResult !== undefined) {
+                                        publish(staleResult);
+                                    }
+                                }
+                            });
+                    }
+
+                    // tuya.fz.cover_options still processes the same report and
+                    // publishes moving=STOP. Only position/state are suppressed here.
+                    return {};
+                }
+
+                // Any other final position (e.g. 99 when start=100) is considered
+                // a legitimate intermediate/manual stop.
+                clearTs130fPositionFix(msg.endpoint);
+                return converted;
+            }
+
+            return converted;
+        },
+    } satisfies Fz.Converter<"closuresWindowCovering", tuya.TuyaClosuresWindowCovering, ["attributeReport", "readResponse"]>,
 };
 
 export const definitions: DefinitionWithExtend[] = [
@@ -5672,7 +5843,6 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "LoraTap", model: "SC400"},
             tuya.whitelabel("LoraTap", "SC500ZB", "Smart curtain/shutter switch", ["_TZ3000_e3vhyirx", "_TZ3000_femsaaua"]),
             tuya.whitelabel("LoraTap", "SC500ZB-v4", "Smart curtain/shutter switch", ["_TZ3000_5iixzdo7"]),
-            tuya.whitelabel("Nous", "B4Z", "Curtain switch", ["_TZ3000_yruungrl"]),
             tuya.whitelabel("Nous", "L12Z", "Smart Zigbee Curtain Module L12Z", ["_TZ3000_jwv3cwak"]),
             tuya.whitelabel("Zemismart", "ZN-LC1E", "Smart curtain/shutter switch", ["_TZ3000_74hsp7qy"]),
             tuya.whitelabel("Girier", "TS130F_GIRIER", "Smart curtain switch", ["_TZ3210_dwytrmda"]),
@@ -5713,6 +5883,52 @@ export const definitions: DefinitionWithExtend[] = [
             }
             return exps;
         },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS130F", ["_TZ3000_yruungrl"]),
+        model: "B4Z",
+        vendor: "Nous",
+        description: "Blind/curtain motor controller",
+        fromZigbee: [
+            fzLocal.TS130F_cover_position_tilt,
+            tuya.fz.indicator_mode,
+            tuya.fz.cover_options,
+            tuya.fz.backlight_mode_off_on,
+            tuya.fz.switch_type_curtain,
+        ],
+        toZigbee: [
+            tzLocal.TS130F_cover_state,
+            tzLocal.TS130F_cover_position_tilt,
+            tuya.tz.cover_calibration,
+            tuya.tz.cover_reversal,
+            tuya.tz.backlight_indicator_mode_2,
+            tuya.tz.backlight_indicator_mode_1,
+            tuya.tz.switch_type_curtain,
+        ],
+        meta: {coverInverted: true},
+        extend: [
+            tuyaBase(),
+            tuya.clusters.addTuyaClosuresWindowCoveringCluster(),
+            m.deviceAddCustomCluster("closuresWindowCovering", {
+                name: "closuresWindowCovering",
+                ID: 0x0102,
+                attributes: {
+                    currentPositionLiftPercentage: {
+                        name: "currentPositionLiftPercentage",
+                        ID: 0x0008,
+                        type: DataType.UINT8,
+                        report: true,
+                        scene: true,
+                        max: 100,
+                        default: 0,
+                        write: true,
+                    },
+                },
+                commands: {},
+                commandsResponse: {},
+            }),
+            tuya.modernExtend.tuyaCoverSwitchType(),
+        ],
     },
     {
         fingerprint: tuya.fingerprint("TS130F", ["_TZ3000_1dd0d5yi"]),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6261,6 +6261,14 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.tz.switch_type_curtain,
         ],
         meta: {coverInverted: true},
+        exposes: [
+            e.cover_position(),
+            e.enum("moving", ea.STATE, ["UP", "STOP", "DOWN"]),
+            e.binary("motor_reversal", ea.ALL, "ON", "OFF"),
+            e.binary("calibration", ea.ALL, "ON", "OFF"),
+            e.numeric("calibration_time", ea.ALL).withValueMin(0).withValueMax(500).withUnit("s"),
+            e.enum("switch_type_curtain", ea.ALL, ["flip-switch", "sync-switch", "button-switch"]).withDescription("External switch type"),
+        ],
         extend: [
             tuyaBase(),
             tuya.clusters.addTuyaClosuresWindowCoveringCluster(),
@@ -23922,7 +23930,7 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaSendCommand: "sendData",
             tuyaDatapoints: [
-                //			[1, 'presence', tuya.valueConverter.trueFalse1],
+                //          [1, 'presence', tuya.valueConverter.trueFalse1],
                 [101, "entry_sensitivity", tuya.valueConverter.raw],
                 [102, "entry_distance", tuya.valueConverter.divideBy100],
                 [103, "departure_delay", tuya.valueConverter.raw],


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#32794.

Problem

Some Nous B4Z curtain controllers ("TS130F", manufacturer "_TZ3000_yruungrl") intermittently revert "currentPositionLiftPercentage" to the position from before an intermediate absolute-position movement.

The observed sequence is:

1. The cover starts at position "S".
2. An intermediate target position "T" is requested.
3. The device reports "T" together with "UP"/"DOWN" while moving.
4. The motor physically reaches approximately "T".
5. When stopping, the device incorrectly reports "S" again together with "STOP".

A direct ZCL read afterwards also returns the stale position.

This PR adds a device-specific workaround for the Nous B4Z ("_TZ3000_yruungrl").

For intermediate absolute-position commands it:

- remembers the starting and requested positions;
- waits until the device explicitly acknowledges the requested position while moving;
- detects only the specific failure sequence "S -> T + moving -> S + STOP";
- suppresses the stale final position in that case;
- writes the previously acknowledged target back to "currentPositionLiftPercentage".

The transaction state is cleared for normal completion, another cover command, unexpected movement reports, or other final positions, so manual stops and unrelated position changes continue to use the device-reported value.

The workaround is limited to the affected "_TZ3000_yruungrl" fingerprint rather than changing the generic TS130F handling.

This is my first contribution to this project so please bear with me 😜, but I hopefully understood the code right. 

Related issue

Koenkk/zigbee2mqtt#32794