### PR TITLE
Schneider Electric:  add custom attributes in lightingBallastCfg to devices configured with dimmingMode

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -2238,6 +2238,7 @@ export const definitions: DefinitionWithExtend[] = [
                 levelConfig: {features: ["on_level", "current_level_startup"]},
             }),
             m.lightingBallast(),
+            schneiderElectricExtend.addSchneiderLightingBallastCfgCluster(),
             schneiderElectricExtend.dimmingMode(),
         ],
         whiteLabel: [
@@ -2314,6 +2315,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.lightingBallast(),
             m.identify(),
+            schneiderElectricExtend.addSchneiderLightingBallastCfgCluster(),
             schneiderElectricExtend.dimmingMode(),
             indicatorMode(),
         ],
@@ -3760,6 +3762,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             schneiderElectricExtend.addOccupancyConfigurationCluster(),
             schneiderElectricExtend.occupancyConfiguration(),
+            schneiderElectricExtend.addSchneiderLightingBallastCfgCluster(),
             schneiderElectricExtend.dimmingMode(),
         ],
         whiteLabel: [
@@ -3794,6 +3797,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             schneiderElectricExtend.addOccupancyConfigurationCluster(),
             schneiderElectricExtend.occupancyConfiguration(),
+            schneiderElectricExtend.addSchneiderLightingBallastCfgCluster(),
             schneiderElectricExtend.dimmingMode(),
         ],
         whiteLabel: [


### PR DESCRIPTION
The following models were updated: "NH3516A", "WDE002386", "NH3527A" and "NHMOTION/UNIDIM/1"

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

