### PR TITLE
Fix AOYAN AY02SZ white label matching

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24247,7 +24247,7 @@ export const definitions: DefinitionWithExtend[] = [
                 model: "AY02SZ",
                 vendor: "AOYAN",
                 description: "Vibration sensor",
-                fingerprint: [{modelID: "AY02SZ", manufacturerName: "AOYAN"}],
+                fingerprint: [{modelID: "AY02SZ", manufacturerName: "AOYAN"}, {manufacturerName: "AOYAN"}],
             },
         ],
         extend: [tuya.modernExtend.tuyaBase({dp: true})],


### PR DESCRIPTION
Adds a manufacturerName fallback to the AY02SZ whiteLabel fingerprint so devices that report padded model IDs still show as AOYAN/AY02SZ.