### PR TITLE
fix: PTM 215Z: match Friends of Hue source-ID range (Senic & Gira smart switch)

### DIFF
--- a/src/devices/enocean.ts
+++ b/src/devices/enocean.ts
@@ -133,7 +133,10 @@ const fzLocal = {
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        fingerprint: [{modelID: "GreenPower_2", ieeeAddr: /^0x00000000017.....$/}],
+        fingerprint: [
+            {modelID: "GreenPower_2", ieeeAddr: /^0x00000000017.....$/},
+            {modelID: "GreenPower_2", ieeeAddr: /^0x0000000001a4....$/},
+        ],
         model: "PTM 215Z",
         vendor: "EnOcean",
         description: "Pushbutton transmitter module",
@@ -165,6 +168,7 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "LED-Trading", model: "9125"},
             {vendor: "Feller", description: "Smart light control for Philips Hue", model: "4120.2.S.FMI.61"},
             {vendor: "Namron", description: " Zigbee FOH Green Bryter K4", model: "4512727"},
+            {vendor: "Senic & Gira", description: "Friends of Hue smart switch", model: "100120"},
         ],
     },
     {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -256,6 +256,20 @@ describe("ZHC", () => {
         expect(definition.model).toStrictEqual("PTM 216Z");
     });
 
+    it("finds definition by fingerprint - GP - PTM 215Z Friends of Hue range", async () => {
+        const device = mockDevice(
+            {
+                modelID: "GreenPower_2",
+                endpoints: [{ID: 242, profileID: undefined, deviceID: undefined, inputClusters: [], outputClusters: []}],
+                ieeeAddr: "0x0000000001a41678",
+            },
+            "GreenPower",
+        );
+        const definition = await findByDevice(device);
+
+        expect(definition.model).toStrictEqual("PTM 215Z");
+    });
+
     it("does not throw when exposes function throws", async () => {
         const illuminanceRawSpy = vi.spyOn(presets, "illuminance_raw").mockImplementationOnce(() => {
             throw new Error("Failed");


### PR DESCRIPTION
The Senic & Gira Friends of Hue smart switch (SKU 100120) is built on the EnOcean PTM 215Z FOH-7 DB module. It emits the standard PTM 215Z Green Power command vocabulary, but its EnOcean source-ID block starts at `0x01A4xxxx`, which the current fingerprint regex (`/^0x00000000017.....$/`) doesn't cover — so Z2M falls back to the generated Green Power definition (`recall_sceneN`, no action entity).

This adds a second fingerprint entry for the `0x01A4xxxx` block plus a whiteLabel entry. Verified on real hardware (source ID `0x0000000001a41678`): all four rockers publish `press_1`/`release_1` … `press_4`/`release_4` correctly with this definition.

The new range is kept deliberately narrow (4 fixed nibbles vs 3 for the `0x017` block) since I have one confirmed device; happy to widen to `/^0x0000000001a.....$/` if you know the FoH allocation is broader.