### PR TITLE
Add AOYAN AY301Z-2CH

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3914,6 +3914,29 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        zigbeeModel: ["AY301Z-2CH"],
+        fingerprint: [{modelID: "AY301Z-2CH", manufacturerName: "AOYAN"}],
+        model: "AY301Z-2CH",
+        vendor: "AOYAN",
+        description: "2 gang wall switch module",
+        extend: [
+            tuya.modernExtend.tuyaBase(),
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
+            tuya.modernExtend.tuyaOnOff({
+                switchType: true,
+                onOffCountdown: true,
+                endpoints: ["l1", "l2"],
+            }),
+        ],
+        configure: async (device, coordinatorEndpoint) => {
+            await tuya.configureMagicPacket(device, coordinatorEndpoint);
+
+            for (const endpoint of [device.getEndpoint(1), device.getEndpoint(2)]) {
+                await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff"]);
+                await reporting.onOff(endpoint);
+            }
+        },
+    },    {
         fingerprint: tuya.fingerprint("TS011F", [
             "_TZ3000_mvn6jl7x",
             "_TZ3000_raviyuvk",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3936,7 +3936,8 @@ export const definitions: DefinitionWithExtend[] = [
                 await reporting.onOff(endpoint);
             }
         },
-    },    {
+    },
+    {
         fingerprint: tuya.fingerprint("TS011F", [
             "_TZ3000_mvn6jl7x",
             "_TZ3000_raviyuvk",


### PR DESCRIPTION
Adds support for the AOYAN AY301Z-2CH 2 gang wall switch module.

Device image: https://github.com/Koenkk/zigbee2mqtt.io/pull/5401
