### PR TITLE
Detect _TZ3210_fawk5xjv as Nova Digital NFZB-03

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8191,7 +8191,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: tuya.fingerprint("TS0003", ["_TZ3000_fawk5xjv", "_TZ3000_bvij6kod", "_TZ3000_aracgljk"]),
+        fingerprint: tuya.fingerprint("TS0003", ["_TZ3000_fawk5xjv", "_TZ3000_bvij6kod", "_TZ3000_aracgljk", "_TZ3210_fawk5xjv"]),
         model: "NFZB-03",
         vendor: "Nova Digital",
         description: "3 gang switch with power-on behavior and indicator mode",
@@ -8206,6 +8206,7 @@ export const definitions: DefinitionWithExtend[] = [
                 indicatorMode: true,
                 backlightModeOffOn: true,
                 inchingSwitch: true,
+                onOffCountdown: true,
             }),
         ],
     },


### PR DESCRIPTION
Detect the `_TZ3210_fawk5xjv` firmware variant of the Nova Digital NFZB-03 3-gang switch, matching the existing `_TZ3000_fawk5xjv` definition in `src/devices/tuya.ts`.

The `_TZ3210` prefix is the newer Tuya app framework; the identical `fawk5xjv` suffix indicates the same device profile, so the fingerprint is added to the existing definition rather than creating a duplicate (the `Model should be unique` test would fail otherwise).

Also enables `onOffCountdown`, which the newer `_TZ3210` generation supports (same option set as the Nova Digital NFZB-2, #12658).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
