### PR TITLE
fix: Philips LTW015 and LCB001: correct color temp range

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -1319,7 +1319,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "548727",
         vendor: "Philips",
         description: "Hue White and Color Ambiance BR30 with bluetooth",
-        extend: [philips.m.light({colorTemp: {range: undefined}, color: true})],
+        extend: [philips.m.light({colorTemp: {range: [153, 500]}, color: true})],
     },
     {
         zigbeeModel: ["LCB002"],
@@ -1854,7 +1854,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "9290011998B",
         vendor: "Philips",
         description: "Hue white ambiance E26",
-        extend: [philips.m.light({colorTemp: {range: undefined}})],
+        extend: [philips.m.light({colorTemp: {range: [153, 454]}})],
     },
     {
         zigbeeModel: ["LTA002"],


### PR DESCRIPTION
Both definitions used `range: undefined`, which falls back to the generic 150-500 mired default rather than the hardware limits.

Read from hardware via `lightingColorCtrl`:
LTW015 (9290011998B):
{"colorCapabilities":16,"colorTempPhysicalMax":454,"colorTempPhysicalMin":153}

LCB001 (548727):
{"colorCapabilities":31,"colorTempPhysicalMax":500,"colorTempPhysicalMin":153}
