### PR TITLE
fix: sync FUT035Z+ RF color temperature

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1281,6 +1281,25 @@ const tzLocal = {
 };
 
 const fzLocal = {
+    // FUT035Z+ (_TZB210_ue01a0s2) reports RF color temperature changes
+// as raw lightingColorCtrl frames without updating colorTemperature.
+    FUT035Z_rf_color_temp: {
+        cluster: "lightingColorCtrl",
+        type: "raw",
+        convert: (model, msg, publish, options, meta) => {
+            if (meta.device.manufacturerName !== "_TZB210_ue01a0s2") return;
+
+            if (!Buffer.isBuffer(msg.data) || msg.data.length < 2) return;
+
+            const raw = msg.data.readUInt16LE(msg.data.length - 2);
+            if (raw < 0 || raw > 1000) return;
+
+            return {
+                color_temp: Math.round(500 - (raw * 347) / 1000),
+            };
+        },
+    } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
+
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     TS0301_dual_rail_2: {
         cluster: "closuresWindowCovering",
@@ -6923,6 +6942,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TS0502B",
         vendor: "Tuya",
         description: "Light controller",
+        fromZigbee: [fzLocal.FUT035Z_rf_color_temp],
         whiteLabel: [
             tuya.whitelabel("Mercator Ikuü", "SMI7040", "Ford Batten Light", ["_TZ3000_zw7wr5uo"]),
             {

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1282,8 +1282,8 @@ const tzLocal = {
 
 const fzLocal = {
     // FUT035Z+ (_TZB210_ue01a0s2) reports RF color temperature changes
-// as raw lightingColorCtrl frames without updating colorTemperature.
-    FUT035Z_rf_color_temp: {
+    // as raw lightingColorCtrl frames without updating colorTemperature.
+    FUT035ZrfColorTemp: {
         cluster: "lightingColorCtrl",
         type: "raw",
         convert: (model, msg, publish, options, meta) => {
@@ -1299,7 +1299,6 @@ const fzLocal = {
             };
         },
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
-
     // biome-ignore lint/style/useNamingConvention: ignored using `--suppress`
     TS0301_dual_rail_2: {
         cluster: "closuresWindowCovering",
@@ -6942,7 +6941,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "TS0502B",
         vendor: "Tuya",
         description: "Light controller",
-        fromZigbee: [fzLocal.FUT035Z_rf_color_temp],
+        fromZigbee: [fzLocal.FUT035ZrfColorTemp],
         whiteLabel: [
             tuya.whitelabel("Mercator Ikuü", "SMI7040", "Ford Batten Light", ["_TZ3000_zw7wr5uo"]),
             {


### PR DESCRIPTION
The MiBoxer FUT035Z+ variant with manufacturer `_TZB210_ue01a0s2` does not update
`color_temp` in Zigbee2MQTT when the color temperature is changed using the MiBoxer
RF remote.

The device reports these RF color temperature changes as raw `lightingColorCtrl`
frames. The reported value ranges from 0 to 1000 and represents the full CCT range
in the opposite direction to the Zigbee color temperature value.

This change adds a device-specific fromZigbee converter for `_TZB210_ue01a0s2`
which converts the raw value to the existing 153–500 color temperature range.

The converter is restricted to this manufacturer variant so other TS0502B devices
using the shared definition are unaffected.

Tested with the physical device and MiBoxer RF remote.

Tested values:
- 0% -> 500
- 25% -> 413
- 50% -> 327
- 75% -> 240
- 100% -> 153

Changes made through the RF remote are now immediately reflected in Zigbee2MQTT,
while normal Zigbee color temperature control continues to work.