### PR TITLE
Fix Paulmann RGBWW device identification using softwareBuildID

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -363,11 +363,38 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light()],
     },
     {
-        zigbeeModel: ["RGBWW"],
-        model: "291.52",
+        fingerprint: [{
+            modelID: "RGBWW",
+            manufacturerName: "Paulmann Licht GmbH",
+            softwareBuildID: "PIIC5405",
+        }],
+        model: "291.48",
         vendor: "Paulmann",
-        description: "Smart Home Zigbee LED bulb 4,9W Matt E14 RGBW",
+        description: "Smart Home Zigbee LED Reflector GU10 4.8W RGBWW",
         extend: [m.light({colorTemp: {range: [153, 454]}, color: {modes: ["xy", "hs"]}})],
+        whiteLabel: [
+            {
+                vendor: "Paulmann",
+                model: "291.53",
+            },
+        ],
+    },
+    {
+        fingerprint: [{
+            modelID: "RGBWW",
+            manufacturerName: "Paulmann Licht GmbH",
+            softwareBuildID: "PIIC5809",
+        }],
+        model: "291.46",
+        vendor: "Paulmann",
+        description: "Smart Home Zigbee LED bulb 4.9W Matt E14 RGBWW",
+        extend: [m.light({colorTemp: {range: [153, 454]}, color: {modes: ["xy", "hs"]}})],
+        whiteLabel: [
+            {
+                vendor: "Paulmann",
+                model: "291.52",
+            },
+        ],
     },
     {
         fingerprint: tuya.fingerprint("TS000F", ["_TZ3210_hjxqqofs\u0000"]),

--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -363,11 +363,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.light()],
     },
     {
-        fingerprint: [{
-            modelID: "RGBWW",
-            manufacturerName: "Paulmann Licht GmbH",
-            softwareBuildID: "PIIC5405",
-        }],
+        fingerprint: [
+            {
+                modelID: "RGBWW",
+                manufacturerName: "Paulmann Licht GmbH",
+                softwareBuildID: "PIIC5405",
+            },
+        ],
         model: "291.48",
         vendor: "Paulmann",
         description: "Smart Home Zigbee LED Reflector GU10 4.8W RGBWW",
@@ -380,11 +382,13 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        fingerprint: [{
-            modelID: "RGBWW",
-            manufacturerName: "Paulmann Licht GmbH",
-            softwareBuildID: "PIIC5809",
-        }],
+        fingerprint: [
+            {
+                modelID: "RGBWW",
+                manufacturerName: "Paulmann Licht GmbH",
+                softwareBuildID: "PIIC5809",
+            },
+        ],
         model: "291.46",
         vendor: "Paulmann",
         description: "Smart Home Zigbee LED bulb 4.9W Matt E14 RGBWW",


### PR DESCRIPTION
This change replaces the generic:

```ts
zigbeeModel: ["RGBWW"]
```

mapping with firmware-specific fingerprints.

## Problem

Multiple Paulmann products expose the same Zigbee model identifier:

```text
RGBWW
```

The existing implementation therefore identifies all RGBWW devices as:

```text
291.52
Smart Home Zigbee LED bulb 4,9W Matt E14 RGBW
```

This causes incorrect identification of the GU10 variant.

## Tested devices

### Paulmann 29148 (GU10 RGBWW)

```json
{
  "manufacturerName": "Paulmann Licht GmbH",
  "modelId": "RGBWW",
  "swBuildId": "PIIC5405",
  "hwVersion": 112
}
```

### Paulmann 29146 (E14 RGBWW)

```json
{
  "manufacturerName": "Paulmann Licht GmbH",
  "modelId": "RGBWW",
  "swBuildId": "PIIC5809",
  "hwVersion": 112
}
```

## Changes

Added firmware-specific fingerprints:

| Product | softwareBuildID |
|----------|----------------|
| 29148 | PIIC5405 |
| 29146 | PIIC5809 |

## White labels

The retail multipacks are modeled as white labels:

| Physical lamp | Retail package |
|--------------|---------------|
| 29146 | 291.52 (3-pack) |
| 29148 | 29153 (3-pack) |

## Result

- 29148 GU10 bulbs are identified correctly.
- 29146 E14 bulbs are identified correctly.
- 29152 remains available as a whiteLabel for 29146.
- 29153 remains available as a whiteLabel for 29148.
- Devices are no longer incorrectly matched solely on `modelId = RGBWW`.

Fixes #32678

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
