### PR TITLE
feat(add): PIR313-L

### DIFF
--- a/src/devices/owon.ts
+++ b/src/devices/owon.ts
@@ -903,6 +903,31 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.onOff(), m.electricityMeter({cluster: "metering"})],
     },
     {
+        fingerprint: [
+            {
+                modelID: "PIR313",
+                manufacturerName: "OWON",
+                endpoints: [
+                    {
+                        ID: 2,
+                        profileID: 260,
+                        deviceID: 262,
+                        inputClusters: [1, 0, 3, 1024],
+                        outputClusters: [3],
+                    },
+                ],
+            },
+        ],
+        model: "PIR313-L",
+        vendor: "OWON",
+        description: "Light sensor",
+        extend: [
+            m.illuminance({
+                reporting: {min: 300, max: 3600, change: 100},
+            }),
+        ],
+    },
+    {
         zigbeeModel: ["PIR313-E", "PIR313"],
         model: "PIR313-E",
         vendor: "OWON",


### PR DESCRIPTION
Previously detected as PIR313-E, but this device only emits illuminance, and with the E definition, this isn't visible/working.

Detect the PIR313-L (which identifies itself also as PIR313) based on its characteristics via fingerprint.  Only expose illuminance.  Do not publish battery state because even though advertised, it always seems to be 0, which is confusing and misleading.

The image for this PIR313-L should be identical to PIR313-E in zigbee2mqtt.io/public/images/devices.

For this commit, I've used ChatGPT extensively to understand how to add a new entry that would just match this device, and not break the PIR313-E support.

Fixes: https://github.com/Koenkk/zigbee-herdsman-converters/issues/12285

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
