### PR TITLE
Update candeo.ts

### DIFF
--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -295,17 +295,17 @@ const fzLocal = {
         },
     } satisfies Fz.Converter<"genOnOff", CandeoOnOff, ["commandOn", "commandOff", "commandToggle", "commandRelease"]>,
     rd1p_rem_lite_ep2: {
-    cluster: "genOnOff",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const lookup: {[key: number]: string} = {0: "OFF", 1: "ON"};
-        if (Object.hasOwn(msg.data, rd1pREMLiteEP2Attribute)) {
-            const value = msg.data[rd1pREMLiteEP2Attribute] as number;
-            return {rem_lite_ep2: lookup[value]};
-        }
-        return undefined;
-    },
-} satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
+        cluster: "genOnOff",
+        type: ["attributeReport", "readResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            const lookup: {[key: number]: string} = {0: "OFF", 1: "ON"};
+            if (Object.hasOwn(msg.data, rd1pREMLiteEP2Attribute)) {
+                const value = msg.data[rd1pREMLiteEP2Attribute] as number;
+                return {rem_lite_ep2: lookup[value]};
+            }
+            return undefined;
+        },
+    } satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
 };
 
 const tzLocal = {
@@ -352,7 +352,7 @@ const tzLocal = {
     rd1p_rem_lite_ep2: {
         key: ["rem_lite_ep2"],
         convertSet: async (entity, key, value, meta) => {
-            const lookup : {[key: string]: boolean} = {"off": false, "on": true};
+            const lookup: {[key: string]: boolean} = {off: false, on: true};
             const v = utils.getFromLookup(value, lookup);
             await entity.write("genOnOff", {[rd1pREMLiteEP2Attribute]: {value: v, type: 0x10}});
             return {state: {rem_lite_ep2: value}};
@@ -1113,19 +1113,15 @@ export const definitions: DefinitionWithExtend[] = [
             }),
         ],
         fromZigbee: [fzLocal.rd1p_rem_lite_ep2, fzLocal.rd1p_knob_press],
-        toZigbee: [tzLocal.rd1p_rem_lite_ep2,],
+        toZigbee: [tzLocal.rd1p_rem_lite_ep2],
         exposes: [
-            e
-                .action([
-                    "double_pressed",
-                    "held",
-                    "released",
-                ])
-                .withEndpoint("l2"),
+            e.action(["double_pressed", "held", "released"]).withEndpoint("l2"),
             e
                 .binary("rem_lite_ep2", ea.ALL, "ON", "OFF")
                 .withLabel("Extra button commands")
-                .withDescription("When set to ON, extra button commands (double press, hold, release) functionality will be enabled. Please note: a 0.5s delay is added to a single knob press action when this setting is active.")
+                .withDescription(
+                    "When set to ON, extra button commands (double press, hold, release) functionality will be enabled. Please note: a 0.5s delay is added to a single knob press action when this setting is active.",
+                )
                 .withCategory("config"),
         ],
         meta: {},
@@ -1148,7 +1144,7 @@ export const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: [
             {modelID: "C-ZB-RD1P-DPM", manufacturerName: "Candeo"},
-            {modelID: 'C-ZB-RD1Pv2-DPM', manufacturerName: 'Candeo'}
+            {modelID: "C-ZB-RD1Pv2-DPM", manufacturerName: "Candeo"},
         ],
         model: "C-ZB-RD1P-DPM",
         vendor: "Candeo",
@@ -1208,7 +1204,7 @@ export const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: [
             {modelID: "C-ZB-RD1P-REM", manufacturerName: "Candeo"},
-            {modelID: 'C-ZB-RD1Pv2-REM', manufacturerName: 'Candeo'}
+            {modelID: "C-ZB-RD1Pv2-REM", manufacturerName: "Candeo"},
         ],
         model: "C-ZB-RD1P-REM",
         vendor: "Candeo",

--- a/src/devices/candeo.ts
+++ b/src/devices/candeo.ts
@@ -51,6 +51,7 @@ const rd1pKnobActionsMap: {[key: string]: string} = {
     commandStepWithOnOff: "rotating_",
     commandStop: "stopped_rotating",
 };
+const rd1pREMLiteEP2Attribute = 0x8000;
 const kineticRFButtonMultiPressActions: {[key: number]: string} = {
     1: "single",
     2: "double",
@@ -293,6 +294,18 @@ const fzLocal = {
             return payload;
         },
     } satisfies Fz.Converter<"genOnOff", CandeoOnOff, ["commandOn", "commandOff", "commandToggle", "commandRelease"]>,
+    rd1p_rem_lite_ep2: {
+    cluster: "genOnOff",
+    type: ["attributeReport", "readResponse"],
+    convert: (model, msg, publish, options, meta) => {
+        const lookup: {[key: number]: string} = {0: "OFF", 1: "ON"};
+        if (Object.hasOwn(msg.data, rd1pREMLiteEP2Attribute)) {
+            const value = msg.data[rd1pREMLiteEP2Attribute] as number;
+            return {rem_lite_ep2: lookup[value]};
+        }
+        return undefined;
+    },
+} satisfies Fz.Converter<"genOnOff", undefined, ["attributeReport", "readResponse"]>,
 };
 
 const tzLocal = {
@@ -334,6 +347,18 @@ const tzLocal = {
         },
         convertGet: async (entity, key, meta) => {
             await entity.read("genBasic", [minimumBrightnessLevelAttribute], {manufacturerCode: manufacturerSpecificMinimumBrightnessClusterCode});
+        },
+    } satisfies Tz.Converter,
+    rd1p_rem_lite_ep2: {
+        key: ["rem_lite_ep2"],
+        convertSet: async (entity, key, value, meta) => {
+            const lookup : {[key: string]: boolean} = {"off": false, "on": true};
+            const v = utils.getFromLookup(value, lookup);
+            await entity.write("genOnOff", {[rd1pREMLiteEP2Attribute]: {value: v, type: 0x10}});
+            return {state: {rem_lite_ep2: value}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.read("genOnOff", [rd1pREMLiteEP2Attribute]);
         },
     } satisfies Tz.Converter,
 };
@@ -1052,6 +1077,27 @@ export const definitions: DefinitionWithExtend[] = [
                 current: {min: 5, max: 900, change: 10},
                 energy: {min: 5, max: 1800, change: 50},
             }),
+        ],
+    },
+    {
+        fingerprint: [{modelID: "C-ZB-RD1Pv2-DIM", manufacturerName: "Candeo"}],
+        model: "C-ZB-RD1Pv2-DIM",
+        vendor: "Candeo",
+        description: "Zigbee rotary dimmer pro (dimmer mode)",
+        extend: [
+            m.light({
+                levelConfig: {features: ["on_level", "current_level_startup", "on_transition_time", "off_transition_time"]},
+                configureReporting: true,
+                levelReportingConfig: {min: 1, max: 3600, change: 1},
+                powerOnBehavior: true,
+                effect: false,
+            }),
+            m.electricityMeter({
+                power: {min: 5, max: 300, change: 10},
+                voltage: {min: 5, max: 600, change: 500},
+                current: {min: 5, max: 900, change: 10},
+                energy: {min: 5, max: 1800, change: 50},
+            }),
             m.deviceAddCustomCluster("genOnOff", {
                 name: "genOnOff",
                 ID: 6,
@@ -1066,17 +1112,48 @@ export const definitions: DefinitionWithExtend[] = [
                 commandsResponse: {},
             }),
         ],
+        fromZigbee: [fzLocal.rd1p_rem_lite_ep2, fzLocal.rd1p_knob_press],
+        toZigbee: [tzLocal.rd1p_rem_lite_ep2,],
+        exposes: [
+            e
+                .action([
+                    "double_pressed",
+                    "held",
+                    "released",
+                ])
+                .withEndpoint("l2"),
+            e
+                .binary("rem_lite_ep2", ea.ALL, "ON", "OFF")
+                .withLabel("Extra button commands")
+                .withDescription("When set to ON, extra button commands (double press, hold, release) functionality will be enabled. Please note: a 0.5s delay is added to a single knob press action when this setting is active.")
+                .withCategory("config"),
+        ],
+        meta: {},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint3 = device.getEndpoint(3);
+            if (endpoint3) {
+                const index = device.endpoints.indexOf(endpoint3);
+                if (index !== -1) {
+                    device.endpoints.splice(index, 1);
+                    device.save();
+                }
+            }
+            const endpoint1 = device.getEndpoint(1);
+            await endpoint1.read("genOnOff", [rd1pREMLiteEP2Attribute]);
+            const endpoint2 = device.getEndpoint(2);
+            await endpoint2.bind("genOnOff", coordinatorEndpoint);
+            await endpoint2.bind("genLevelCtrl", coordinatorEndpoint);
+        },
     },
     {
-        fingerprint: [{modelID: "C-ZB-RD1P-DPM", manufacturerName: "Candeo"}],
+        fingerprint: [
+            {modelID: "C-ZB-RD1P-DPM", manufacturerName: "Candeo"},
+            {modelID: 'C-ZB-RD1Pv2-DPM', manufacturerName: 'Candeo'}
+        ],
         model: "C-ZB-RD1P-DPM",
         vendor: "Candeo",
         description: "Zigbee rotary dimmer pro (dual purpose mode)",
         extend: [
-            m.deviceEndpoints({
-                endpoints: {l1: 1, l2: 2},
-                multiEndpointSkip: ["power", "current", "voltage", "energy"],
-            }),
             m.light({
                 levelConfig: {features: ["on_level", "current_level_startup", "on_transition_time", "off_transition_time"]},
                 configureReporting: true,
@@ -1129,20 +1206,32 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "C-ZB-RD1P-REM", manufacturerName: "Candeo"}],
+        fingerprint: [
+            {modelID: "C-ZB-RD1P-REM", manufacturerName: "Candeo"},
+            {modelID: 'C-ZB-RD1Pv2-REM', manufacturerName: 'Candeo'}
+        ],
         model: "C-ZB-RD1P-REM",
         vendor: "Candeo",
         description: "Zigbee rotary dimmer pro (remote mode)",
         extend: [
-            m.deviceEndpoints({
-                endpoints: {l1: 1, l2: 2},
-                multiEndpointSkip: ["power", "current", "voltage", "energy"],
-            }),
             m.electricityMeter({
                 power: {min: 5, max: 300, change: 10},
                 voltage: {min: 5, max: 600, change: 500},
                 current: {min: 5, max: 900, change: 10},
                 energy: {min: 5, max: 1800, change: 50},
+            }),
+            m.deviceAddCustomCluster("genOnOff", {
+                name: "genOnOff",
+                ID: 6,
+                attributes: {},
+                commands: {
+                    release: {
+                        name: "release",
+                        ID: 0x03,
+                        parameters: [],
+                    },
+                },
+                commandsResponse: {},
             }),
         ],
         fromZigbee: [fzLocal.rd1p_knob_rotation, fzLocal.rd1p_knob_press],


### PR DESCRIPTION
Adds support for Candeo RD1P devices with v2 firmware.

For C-ZB-RD1P-DPM / C-ZB-RD1Pv2-DPM and C-ZB-RD1P-REM / C-ZB-RD1Pv2-REM - no functionality change (same converter)

For C-ZB-RD1P-DIM / C-ZB-RD1Pv2-DIM - functionality changes between firmware (different converter for each)

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->