### PR TITLE
Add CK-TLSR8656-Z23SE11HW-01(7019) model

### DIFF
--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -270,7 +270,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.temperature(), m.humidity(), m.battery()],
     },
     {
-        zigbeeModel: ["SNZB-05", "CK-TLSR8656-SS5-01(7019)"],
+        zigbeeModel: ["SNZB-05", "CK-TLSR8656-SS5-01(7019)", "CK-TLSR8656-Z23SE11HW-01(7019)"],
         model: "SNZB-05",
         vendor: "eWeLink",
         description: "Zigbee water sensor",
@@ -284,6 +284,17 @@ export const definitions: DefinitionWithExtend[] = [
                         type: "EndDevice",
                         manufacturerName: "eWeLink",
                         modelID: "CK-TLSR8656-SS5-01(7019)",
+                    },
+                ],
+            },
+            {
+                vendor: "eWeLink",
+                model: "CK-TLSR8656-Z23SE11HW-01(7019)",
+                fingerprint: [
+                    {
+                        type: "EndDevice",
+                        manufacturerName: "eWeLink",
+                        modelID: "CK-TLSR8656-Z23SE11HW-01(7019)",
                     },
                 ],
             },


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5415

Adds the eWeLink CK-TLSR8656-Z23SE11HW-01(7019) water leak sensor as a
white label of SNZB-05.

The `(7019)` suffix is eWeLink's product code for their water sensor —
the same definition already covers `CK-TLSR8656-SS5-01(7019)`. This is
the same device with a different hardware revision string, so it follows
the existing grouping pattern used for the (7035) smoke alarm.

Device info:
- modelID: CK-TLSR8656-Z23SE11HW-01(7019)
- manufacturerName: eWeLink