### PR TITLE
fix: correct STB3L-125-ZJ phase mapping

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -200,6 +200,16 @@ const storeLocal = {
 };
 
 const convLocal = {
+    phaseVariant2WithPhaseByManufacturer: (phase: string, tze204Phase: string) => {
+        const defaultConverter = tuya.valueConverter.phaseVariant2WithPhase(phase);
+        const tze204Converter = tuya.valueConverter.phaseVariant2WithPhase(tze204Phase);
+        return {
+            from: (v: string, meta: Fz.Meta) => {
+                const converter = meta.device.manufacturerName === "_TZE204_wbhaespm" ? tze204Converter : defaultConverter;
+                return converter.from(v);
+            },
+        };
+    },
     novaDigitalToDmBrightness: {
         from: (value: unknown) => {
             const clamped = Math.max(10, Math.min(1000, Number(value) || 10));
@@ -12180,9 +12190,9 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaDatapoints: [
                 [1, "energy", tuya.valueConverter.divideBy100],
-                [6, null, tuya.valueConverter.phaseVariant2WithPhase("a")],
+                [6, null, convLocal.phaseVariant2WithPhaseByManufacturer("a", "c")],
                 [7, null, tuya.valueConverter.phaseVariant2WithPhase("b")],
-                [8, null, tuya.valueConverter.phaseVariant2WithPhase("c")],
+                [8, null, convLocal.phaseVariant2WithPhaseByManufacturer("c", "a")],
                 [9, "faults", tuya.valueConverter.circuitBreakerFaults],
                 [16, "state", tuya.valueConverter.onOff],
                 [17, null, tuya.valueConverter.threshold_2],


### PR DESCRIPTION
Fixes #12917

The `_TZE204_wbhaespm` variant of the SUTON `STB3L-125-ZJ` reports the three phase datapoints in C/B/A order instead of A/B/C.

Verified by loading one physical phase at a time on two identical `_TZE204_wbhaespm` devices with `applicationVersion: 74`:

- DP6 = phase C
- DP7 = phase B
- DP8 = phase A

This PR keeps the existing `STB3L-125-ZJ` definition and applies the swapped A/C mapping only for `_TZE204_wbhaespm`.

The existing A/B/C mapping is preserved for `_TZE200_wbhaespm` and `_TZE284_wbhaespm`, since their phase order has not been verified.

Validation completed successfully:

- `pnpm run build`
- `pnpm run check`
- `pnpm test`
- `pnpm run bench`