### PR TITLE
feat(add): 929004321101

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -4862,7 +4862,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
-        zigbeeModel: ["929004321001"],
+        zigbeeModel: ["929004321001", "929004321101"],
         model: "929004321001",
         vendor: "Philips",
         description: "Hue Play Floor lamp large",


### PR DESCRIPTION
Adds model number 929004321101 to the existing 929004321001 definition.

Same product (Hue Play floor lamp large), different regional article number. The device paired as an automatically generated definition because the model ID did not match.
