### PR TITLE
fix: SONOFF ZBMINIR2: De-duplicate configuration

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -9512,11 +9512,7 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint, {min: 1, max: 1800, change: 0});
-            await endpoint.read<"customClusterEwelink", SonoffEwelink>(
-                "customClusterEwelink",
-                ["radioPower", 0x0001, 0x0014, 0x0015, 0x0016, 0x0017],
-                defaultResponseOptions,
-            );
+            await endpoint.read<"customClusterEwelink", SonoffEwelink>("customClusterEwelink", ["externalTriggerMode"], defaultResponseOptions);
         },
     },
     {

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -9453,7 +9453,8 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee smart switch",
         exposes: [],
         extend: [
-            m.commandsOnOff({commands: ["toggle"]}),
+            // binding and reporting are handled in configure block, skip duplication
+            m.commandsOnOff({commands: ["toggle"], bind: false}),
             m.onOff({configureReporting: false}),
             sonoffExtend.addCustomClusterEwelink(),
             m.binary<"customClusterEwelink", SonoffEwelink>({


### PR DESCRIPTION
I noticed some duplicated commands in Wireshark.

1. Each `m.binary` and `m.numeric` already reads its respective attribute once. There's no need to read them again in `configure`

2. OnOff binding also happens twice. I removed the one in `m.commandsOnOff`

Tested on real device (v1.0.8). Everything is done only once now. Device still works as expected.