### PR TITLE
fix: SONOFF ZBM5 no-Neutral: fix configure still failing

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -10995,7 +10995,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Zigbee Smart one-channel wall switch (type 120)",
         ota: true,
         extend: [
-            m.commandsOnOff({commands: ["toggle"]}),
+            m.commandsOnOff({commands: ["toggle"], bind: false}),
             m.onOff(),
             sonoffExtend.addCustomClusterEwelink(),
             m.enumLookup<"customClusterEwelink", SonoffEwelink>({
@@ -11043,7 +11043,7 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2}}),
-            m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2"]}),
+            m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2"], bind: false}),
             m.onOff({endpointNames: ["l1", "l2"]}),
             sonoffExtend.addCustomClusterEwelink(),
             m.enumLookup<"customClusterEwelink", SonoffEwelink>({
@@ -11096,7 +11096,7 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
         extend: [
             m.deviceEndpoints({endpoints: {l1: 1, l2: 2, l3: 3}}),
-            m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2", "l3"]}),
+            m.commandsOnOff({commands: ["toggle"], endpointNames: ["l1", "l2", "l3"], bind: false}),
             m.onOff({endpointNames: ["l1", "l2", "l3"]}),
             sonoffExtend.addCustomClusterEwelink(),
             m.enumLookup<"customClusterEwelink", SonoffEwelink>({

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -11018,11 +11018,9 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
-            try {
-                await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            utils.attachOutputCluster(device, endpoint1, "genOnOff");
+            device.save();
+            await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint1, {min: 1, max: 1800, change: 0});
             await endpoint1.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
             await endpoint1.read("customClusterEwelink", [0x0010, 0x0018, 0x0019], defaultResponseOptions);
@@ -11068,20 +11066,15 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
-            try {
-                await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            utils.attachOutputCluster(device, endpoint1, "genOnOff");
+            const endpoint2 = device.getEndpoint(2);
+            utils.attachOutputCluster(device, endpoint2, "genOnOff");
+            device.save();
+            await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint1, {min: 1, max: 1800, change: 0});
             await endpoint1.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
             await endpoint1.read("customClusterEwelink", [0x0010, 0x0018, 0x0019], defaultResponseOptions);
-            const endpoint2 = device.getEndpoint(2);
-            try {
-                await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint2, {min: 1, max: 1805, change: 0});
             await endpoint2.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
         },
@@ -11126,28 +11119,20 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
-            try {
-                await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            utils.attachOutputCluster(device, endpoint1, "genOnOff");
+            const endpoint2 = device.getEndpoint(2);
+            utils.attachOutputCluster(device, endpoint2, "genOnOff");
+            const endpoint3 = device.getEndpoint(3);
+            utils.attachOutputCluster(device, endpoint3, "genOnOff");
+            device.save();
+            await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint1, {min: 1, max: 1800, change: 0});
             await endpoint1.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
             await endpoint1.read("customClusterEwelink", [0x0010, 0x0018, 0x0019], defaultResponseOptions);
-            const endpoint2 = device.getEndpoint(2);
-            try {
-                await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint2, {min: 1, max: 1805, change: 0});
             await endpoint2.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
-            const endpoint3 = device.getEndpoint(3);
-            try {
-                await reporting.bind(endpoint3, coordinatorEndpoint, ["genOnOff"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            await reporting.bind(endpoint3, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint3, {min: 1, max: 1810, change: 0});
             await endpoint3.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
         },

--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -9557,11 +9557,9 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
-            try {
-                await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            utils.attachOutputCluster(device, endpoint1, "genOnOff");
+            device.save();
+            await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint1, {min: 1, max: 1800, change: 0});
             await endpoint1.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
             await endpoint1.read("customClusterEwelink", [0x0010, 0x0018, 0x0019], defaultResponseOptions);
@@ -9607,20 +9605,15 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
-            try {
-                await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            utils.attachOutputCluster(device, endpoint1, "genOnOff");
+            const endpoint2 = device.getEndpoint(2);
+            utils.attachOutputCluster(device, endpoint2, "genOnOff");
+            device.save();
+            await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint1, {min: 1, max: 1800, change: 0});
             await endpoint1.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
             await endpoint1.read("customClusterEwelink", [0x0010, 0x0018, 0x0019], defaultResponseOptions);
-            const endpoint2 = device.getEndpoint(2);
-            try {
-                await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint2, {min: 1, max: 1805, change: 0});
             await endpoint2.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
         },
@@ -9665,28 +9658,20 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint1 = device.getEndpoint(1);
-            try {
-                await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            utils.attachOutputCluster(device, endpoint1, "genOnOff");
+            const endpoint2 = device.getEndpoint(2);
+            utils.attachOutputCluster(device, endpoint2, "genOnOff");
+            const endpoint3 = device.getEndpoint(3);
+            utils.attachOutputCluster(device, endpoint3, "genOnOff");
+            device.save();
+            await reporting.bind(endpoint1, coordinatorEndpoint, ["genOnOff", "customClusterEwelink"]);
             await reporting.onOff(endpoint1, {min: 1, max: 1800, change: 0});
             await endpoint1.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
             await endpoint1.read("customClusterEwelink", [0x0010, 0x0018, 0x0019], defaultResponseOptions);
-            const endpoint2 = device.getEndpoint(2);
-            try {
-                await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            await reporting.bind(endpoint2, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint2, {min: 1, max: 1805, change: 0});
             await endpoint2.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
-            const endpoint3 = device.getEndpoint(3);
-            try {
-                await reporting.bind(endpoint3, coordinatorEndpoint, ["genOnOff"]);
-            } catch {
-                // https://github.com/Koenkk/zigbee2mqtt/issues/32679
-            }
+            await reporting.bind(endpoint3, coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(endpoint3, {min: 1, max: 1810, change: 0});
             await endpoint3.read("genOnOff", [0x0000, 0x4003], defaultResponseOptions);
         },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11854,7 +11854,7 @@ export const definitions: DefinitionWithExtend[] = [
                 divisor: 100,
                 multiplier: 1,
             });
-            utils.attachOutputCluster(device, "genOta");
+            utils.attachOutputCluster(device, endpoint, "genOta");
             device.save();
         },
     },
@@ -11947,7 +11947,7 @@ export const definitions: DefinitionWithExtend[] = [
                 divisor: 100,
                 multiplier: 1,
             });
-            utils.attachOutputCluster(device, "genOta");
+            utils.attachOutputCluster(device, endpoint, "genOta");
             device.save();
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -11504,7 +11504,7 @@ export const definitions: DefinitionWithExtend[] = [
                 divisor: 100,
                 multiplier: 1,
             });
-            utils.attachOutputCluster(device, "genOta");
+            utils.attachOutputCluster(device, endpoint, "genOta");
             device.save();
         },
     },
@@ -11597,7 +11597,7 @@ export const definitions: DefinitionWithExtend[] = [
                 divisor: 100,
                 multiplier: 1,
             });
-            utils.attachOutputCluster(device, "genOta");
+            utils.attachOutputCluster(device, endpoint, "genOta");
             device.save();
         },
     },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -554,9 +554,8 @@ export function noOccupancySince(endpoint: Zh.Endpoint, options: KeyValueAny, pu
     }
 }
 
-export function attachOutputCluster(device: Zh.Device, clusterKey: string) {
+export function attachOutputCluster(device: Zh.Device, endpoint: Zh.Endpoint, clusterKey: string) {
     const clusterId = Zcl.Utils.getCluster(clusterKey, device.manufacturerID, device.customClusters).ID;
-    const endpoint = device.getEndpoint(1);
 
     if (!endpoint.outputClusters.includes(clusterId)) {
         endpoint.outputClusters.push(clusterId);


### PR DESCRIPTION
The ZBM5 in no-Neutral mode does not advertise the output OnOff cluster, causing configuration to fail
- https://github.com/Koenkk/zigbee2mqtt/issues/32679

The previous fix was not enough, because there is one more bind in `m.commandsOnOff`
- https://github.com/Koenkk/zigbee-herdsman-converters/pull/12814

But the bindings fail at Z2M level. So attaching the cluster should allow the bind command.
If it works, this is a cleaner fix: `utils.attachOutputCluster(device, endpoint1, "genOnOff");`

I made sure the cluster is attached before the binds. But I don't have the device to test further.

It might also help in this issue
- https://github.com/Koenkk/zigbee2mqtt/discussions/31557