### PR TITLE
feat: fix IAS max_duration limits and move to modernExtend

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -1931,15 +1931,6 @@ export const ias_enroll: Fz.Converter<"ssIasZone", undefined, ["attributeReport"
         };
     },
 };
-export const ias_wd: Fz.Converter<"ssIasWd", undefined, ["attributeReport", "readResponse"]> = {
-    cluster: "ssIasWd",
-    type: ["attributeReport", "readResponse"],
-    convert: (model, msg, publish, options, meta) => {
-        const result: KeyValueAny = {};
-        if (msg.data.maxDuration !== undefined) result.max_duration = msg.data.maxDuration;
-        return result;
-    },
-};
 export const power_source: Fz.Converter<"genBasic", undefined, ["attributeReport", "readResponse"]> = {
     cluster: "genBasic",
     type: ["attributeReport", "readResponse"],

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -608,16 +608,6 @@ export const warning: Tz.Converter = {
         );
     },
 };
-export const ias_max_duration: Tz.Converter = {
-    key: ["max_duration"],
-    convertSet: async (entity, key, value, meta) => {
-        await entity.write("ssIasWd", {maxDuration: value as number});
-        return {state: {max_duration: value}};
-    },
-    convertGet: async (entity, key, meta) => {
-        await entity.read("ssIasWd", ["maxDuration"]);
-    },
-};
 export const warning_simple: Tz.Converter = {
     key: ["alarm"],
     convertSet: async (entity, key, value, meta) => {

--- a/src/devices/adurosmart.ts
+++ b/src/devices/adurosmart.ts
@@ -149,20 +149,16 @@ export const definitions: DefinitionWithExtend[] = [
         model: "81868",
         vendor: "AduroSmart",
         description: "Siren",
-        fromZigbee: [fz.battery, fz.ias_wd, fz.ias_enroll, fz.ias_siren],
-        toZigbee: [tz.warning_simple, tz.ias_max_duration, tz.warning],
+        fromZigbee: [fz.battery, fz.ias_enroll, fz.ias_siren],
+        toZigbee: [tz.warning_simple, tz.warning],
+        extend: [m.iasWarningMaxDuration()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBasic", "ssIasZone", "ssIasWd"]);
             await endpoint.read("ssIasZone", ["zoneState", "iasCieAddr", "zoneId"]);
             await endpoint.read("ssIasWd", ["maxDuration"]);
         },
-        exposes: [
-            e.tamper(),
-            e.warning(),
-            e.numeric("max_duration", ea.ALL).withUnit("s").withValueMin(0).withValueMax(600).withDescription("Duration of Siren"),
-            e.binary("alarm", ea.SET, "ON", "OFF").withDescription("Manual start of siren"),
-        ],
+        exposes: [e.tamper(), e.warning(), e.binary("alarm", ea.SET, "ON", "OFF").withDescription("Manual start of siren")],
     },
     {
         zigbeeModel: ["AD-CTW123001"],

--- a/src/devices/climax.ts
+++ b/src/devices/climax.ts
@@ -111,8 +111,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SRAC-23B-ZBSR",
         vendor: "Climax",
         description: "Smart siren",
-        fromZigbee: [fz.battery, fz.ias_wd, fz.ias_enroll, fz.ias_siren],
-        toZigbee: [tz.warning_simple, tz.ias_max_duration, tz.warning, tz.squawk],
+        fromZigbee: [fz.battery, fz.ias_enroll, fz.ias_siren],
+        toZigbee: [tz.warning_simple, tz.warning, tz.squawk],
+        extend: [m.iasWarningMaxDuration()],
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genBasic", "ssIasZone", "ssIasWd"]);
@@ -124,7 +125,6 @@ export const definitions: DefinitionWithExtend[] = [
             e.tamper(),
             e.warning(),
             e.squawk(),
-            e.numeric("max_duration", ea.ALL).withUnit("s").withValueMin(0).withValueMax(600).withDescription("Duration of Siren"),
             e.binary("alarm", ea.SET, "START", "OFF").withDescription("Manual start of siren"),
         ],
     },

--- a/src/devices/develco.ts
+++ b/src/devices/develco.ts
@@ -830,12 +830,13 @@ export const definitions: DefinitionWithExtend[] = [
             {vendor: "Frient", model: "94430", description: "Smart Intelligent Smoke Alarm"},
             {vendor: "Cavius", model: "2103", description: "RF SMOKE ALARM, 5 YEAR 65MM"},
         ],
-        fromZigbee: [develco.fz.ias_smoke_alarm_1_develco, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
-        toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
+        fromZigbee: [develco.fz.ias_smoke_alarm_1_develco, fz.ias_enroll, develco.fz.fault_status],
+        toZigbee: [tz.warning, tz.warning_simple],
         ota: true,
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
+            m.iasWarningMaxDuration(),
             develcoModernExtend.temperature(), // TODO: ep 38
             m.battery({
                 voltageToPercentage: {min: 2500, max: 3000},
@@ -867,7 +868,6 @@ export const definitions: DefinitionWithExtend[] = [
             e.smoke(),
             e.battery_low(),
             e.test(),
-            e.numeric("max_duration", ea.ALL).withUnit("s").withValueMin(0).withValueMax(600).withDescription("Duration of Siren"),
             e.binary("alarm", ea.SET, "START", "OFF").withDescription("Manual Start of Siren"),
             e
                 .enum("reliability", ea.STATE, ["no_fault_detected", "unreliable_other", "process_error"])
@@ -907,12 +907,13 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Develco",
         description: "Fire detector with siren",
         whiteLabel: [{vendor: "Frient", model: "94431", description: "Smart Intelligent Heat Alarm"}],
-        fromZigbee: [develco.fz.ias_smoke_alarm_1_develco, fz.ias_enroll, fz.ias_wd, develco.fz.fault_status],
-        toZigbee: [tz.warning, tz.ias_max_duration, tz.warning_simple],
+        fromZigbee: [develco.fz.ias_smoke_alarm_1_develco, fz.ias_enroll, develco.fz.fault_status],
+        toZigbee: [tz.warning, tz.warning_simple],
         ota: true,
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
+            m.iasWarningMaxDuration(),
             develcoModernExtend.temperature(), // TODO: ep 38
             m.battery({
                 voltageToPercentage: {min: 2500, max: 3000},
@@ -945,7 +946,6 @@ export const definitions: DefinitionWithExtend[] = [
             e.smoke(),
             e.battery_low(),
             e.test(),
-            e.numeric("max_duration", ea.ALL).withUnit("s").withValueMin(0).withValueMax(600).withDescription("Duration of Siren"),
             e.binary("alarm", ea.SET, "START", "OFF").withDescription("Manual Start of Siren"),
             e
                 .enum("reliability", ea.STATE, ["no_fault_detected", "unreliable_other", "process_error"])
@@ -1361,11 +1361,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SIRZB-110",
         vendor: "Develco",
         description: "Customizable siren",
-        fromZigbee: [fz.ias_enroll, fz.ias_wd, fz.ias_siren],
-        toZigbee: [tz.warning, tz.warning_simple, tz.ias_max_duration, tz.squawk],
+        fromZigbee: [fz.ias_enroll, fz.ias_siren],
+        toZigbee: [tz.warning, tz.warning_simple, tz.squawk],
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
+            m.iasWarningMaxDuration(),
             develcoModernExtend.temperature(),
             m.battery({
                 voltageToPercentage: {min: 2500, max: 3000},
@@ -1393,7 +1394,6 @@ export const definitions: DefinitionWithExtend[] = [
             e.test(),
             e.warning(),
             e.squawk(),
-            e.numeric("max_duration", ea.ALL).withUnit("s").withValueMin(0).withValueMax(900).withDescription("Max duration of the siren"),
             e.binary("alarm", ea.SET, "START", "OFF").withDescription("Manual start of the siren"),
         ],
     },
@@ -1402,11 +1402,12 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SIRZB-111",
         vendor: "Develco",
         description: "Customizable siren",
-        fromZigbee: [fz.ias_enroll, fz.ias_wd, fz.ias_siren],
-        toZigbee: [tz.warning, tz.warning_simple, tz.ias_max_duration, tz.squawk],
+        fromZigbee: [fz.ias_enroll, fz.ias_siren],
+        toZigbee: [tz.warning, tz.warning_simple, tz.squawk],
         extend: [
             develcoModernExtend.addCustomClusterManuSpecificDevelcoGenBasic(),
             develcoModernExtend.readGenBasicPrimaryVersions(),
+            m.iasWarningMaxDuration(),
             m.battery({
                 voltageToPercentage: {min: 2500, max: 3000},
                 percentage: true,
@@ -1433,7 +1434,6 @@ export const definitions: DefinitionWithExtend[] = [
             e.test(),
             e.warning(),
             e.squawk(),
-            e.numeric("max_duration", ea.ALL).withUnit("s").withValueMin(0).withValueMax(900).withDescription("Max duration of the siren"),
             e.binary("alarm", ea.SET, "START", "OFF").withDescription("Manual start of the siren"),
         ],
     },

--- a/src/devices/evology.ts
+++ b/src/devices/evology.ts
@@ -1,6 +1,7 @@
 import * as fz from "../converters/fromZigbee";
 import * as tz from "../converters/toZigbee";
 import * as exposes from "../lib/exposes";
+import * as m from "../lib/modernExtend";
 import * as reporting from "../lib/reporting";
 import type {DefinitionWithExtend} from "../lib/types";
 
@@ -12,8 +13,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "PSE03-V1.1.0",
         vendor: "EVOLOGY",
         description: "Sound and flash siren",
-        fromZigbee: [fz.ias_wd, fz.ias_enroll, fz.ias_siren],
+        fromZigbee: [fz.ias_enroll, fz.ias_siren],
         toZigbee: [tz.warning],
+        extend: [m.iasWarningMaxDuration()],
         meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);

--- a/src/devices/heiman.ts
+++ b/src/devices/heiman.ts
@@ -2640,8 +2640,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "HS2WD-E",
         vendor: "Heiman",
         description: "Smart siren",
-        fromZigbee: [fz.battery, fz.ias_wd],
-        toZigbee: [tz.warning, tz.ias_max_duration],
+        fromZigbee: [fz.battery],
+        toZigbee: [tz.warning],
+        extend: [m.iasWarningMaxDuration()],
         meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
@@ -2651,13 +2652,6 @@ export const definitions: DefinitionWithExtend[] = [
         },
         exposes: [
             e.battery(),
-            e
-                .numeric("max_duration", ea.ALL)
-                .withUnit("s")
-                .withValueMin(0)
-                .withValueMax(600)
-                .withDescription("Max duration of Siren")
-                .withCategory("config"),
             e
                 .warning()
                 .removeFeature("level")
@@ -4117,8 +4111,9 @@ export const definitions: DefinitionWithExtend[] = [
         model: "HS2WD-EF",
         vendor: "Heiman",
         description: "Smart siren",
-        fromZigbee: [fz.battery, fz.ias_wd],
-        toZigbee: [tz.warning, tz.ias_max_duration],
+        fromZigbee: [fz.battery],
+        toZigbee: [tz.warning],
+        extend: [m.iasWarningMaxDuration()],
         meta: {disableDefaultResponse: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
@@ -4128,13 +4123,6 @@ export const definitions: DefinitionWithExtend[] = [
         },
         exposes: [
             e.battery(),
-            e
-                .numeric("max_duration", ea.ALL)
-                .withUnit("s")
-                .withValueMin(0)
-                .withValueMax(1800)
-                .withDescription("Max duration of Siren")
-                .withCategory("config"),
             e
                 .warning()
                 .removeFeature("strobe_level")

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -928,8 +928,6 @@ const tzLocal = {
             if (key === "light") {
                 utils.assertString(value, "light");
                 await entity.command("genOnOff", value.toLowerCase() === "on" ? "on" : "off", {}, utils.getOptions(meta.mapped, entity));
-            } else if (key === "duration") {
-                await entity.write("ssIasWd", {maxDuration: value as number}, utils.getOptions(meta.mapped, entity));
             } else if (key === "volume") {
                 const lookup: KeyValue = {mute: 0, low: 10, medium: 30, high: 50};
                 utils.assertString(value, "volume");
@@ -16641,16 +16639,10 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Smart light & sound siren",
         fromZigbee: [],
         toZigbee: [tz.warning, tzLocal.TS0224],
+        extend: [m.iasWarningMaxDuration()],
         exposes: [
             e.warning(),
             e.binary("light", ea.STATE_SET, "ON", "OFF").withDescription("Turn the light of the alarm ON/OFF"),
-            e
-                .numeric("duration", ea.STATE_SET)
-                .withValueMin(60)
-                .withValueMax(3600)
-                .withValueStep(1)
-                .withUnit("s")
-                .withDescription("Duration of the alarm"),
             e.enum("volume", ea.STATE_SET, ["mute", "low", "medium", "high"]).withDescription("Volume of the alarm"),
         ],
     },

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1937,6 +1937,47 @@ export function iasWarning(args: IasWarningArgs = {}): ModernExtend {
     return {toZigbee, exposes, isModernExtend: true};
 }
 
+export function iasWarningMaxDuration(): ModernExtend {
+    const exposes: Expose[] = [
+        e
+            .numeric("max_duration", ea.ALL)
+            .withUnit("s")
+            .withValueMin(0)
+            .withValueMax(65534)
+            .withValueStep(1)
+            .withDescription("Maximum time that the alarm will be active"),
+    ];
+
+    // previously tz.ias_max_duration
+    const toZigbee: Tz.Converter[] = [
+        {
+            key: ["max_duration"],
+            convertSet: async (entity, key, value, meta) => {
+                await entity.write("ssIasWd", {maxDuration: value as number});
+                return {state: {max_duration: value}};
+            },
+            convertGet: async (entity, key, meta) => {
+                await entity.read("ssIasWd", ["maxDuration"]);
+            },
+        },
+    ];
+
+    // previously fz.ias_wd
+    const fromZigbee = [
+        {
+            cluster: "ssIasWd",
+            type: ["attributeReport", "readResponse"],
+            convert: (model, msg, publish, options, meta) => {
+                const result: KeyValueAny = {};
+                if (msg.data.maxDuration !== undefined) result.max_duration = msg.data.maxDuration;
+                return result;
+            },
+        } satisfies Fz.Converter<"ssIasWd", undefined, ["attributeReport", "readResponse"]>,
+    ];
+
+    return {toZigbee, fromZigbee, exposes, isModernExtend: true};
+}
+
 // #endregion
 
 // #region Smart Energy


### PR DESCRIPTION
Guy on Discord wanted his Tuya alarm to ring for less than 60 seconds.
It seems the exposed limits were arbitrary..

Moved to modernExtend and changed to allow full range

<img width="60%" src="https://github.com/user-attachments/assets/cc8caa60-6119-4f08-a5dc-5739c72b3e69" />
