### PR TITLE
fix: improve Aqara W600 external temperature handling

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -4810,9 +4810,14 @@ function writeW600LumiAttribute(entity: Zh.Endpoint, attribute: string | number,
 }
 
 function getNextW600SensorBindingCounter(entity: Zh.Device | Zh.Endpoint) {
-    const storeKey = getW600DeviceStoreKey(entity);
-    const counter = globalStore.getValue(storeKey, W600_SENSOR_BINDING_COUNTER_STORE_KEY, 0x12);
-    globalStore.putValue(storeKey, W600_SENSOR_BINDING_COUNTER_STORE_KEY, (counter + 1) & 0xff);
+    const device = "ieeeAddr" in entity ? entity : entity.getDevice();
+    const counter =
+        typeof device.meta?.[W600_SENSOR_BINDING_COUNTER_STORE_KEY] === "number" ? device.meta[W600_SENSOR_BINDING_COUNTER_STORE_KEY] : 0x12;
+
+    device.meta ??= {};
+    device.meta[W600_SENSOR_BINDING_COUNTER_STORE_KEY] = (counter + 1) & 0xff;
+    device.save();
+
     return counter;
 }
 
@@ -5629,21 +5634,49 @@ function createW600Thermostat(): ModernExtend {
         .withDescription("Duration in minutes for the current manual override. 0 means until next schedule event, 65535 means indefinitely.");
     extend.exposes?.push(
         e.binary("override_active", ea.STATE, true, false).withLabel("Manual Override").withDescription("Temporary manual override active"),
+        e
+            .numeric("internal_temperature", ea.STATE)
+            .withUnit("°C")
+            .withLabel("Internal radiator temperature")
+            .withDescription("Temperature reported by the W600 physical radiator sensor on endpoint 2")
+            .withCategory("diagnostic"),
+        e
+            .numeric("endpoint_2_occupied_heating_setpoint", ea.STATE)
+            .withUnit("°C")
+            .withLabel("Endpoint 2 heating setpoint")
+            .withDescription("Heating setpoint reported by W600 endpoint 2; kept separate from the active climate target")
+            .withCategory("diagnostic"),
     );
 
     const thermostatConverter = {
         cluster: W600_THERMOSTAT_CLUSTER,
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
-            const result = fz.thermostat.convert(model, msg, publish, options, meta) as KeyValueAny | undefined;
+            const endpoint2 = msg.endpoint.ID === 2;
+            const data = endpoint2 ? {...msg.data} : msg.data;
+            const diagnostics: KeyValue = {};
 
-            if (result && msg.data.tempSetpointHold !== undefined) {
+            if (endpoint2) {
+                if (typeof data.localTemp === "number") diagnostics.internal_temperature = data.localTemp / 100;
+                if (typeof data.occupiedHeatingSetpoint === "number") {
+                    diagnostics.endpoint_2_occupied_heating_setpoint = data.occupiedHeatingSetpoint / 100;
+                }
+                delete data.localTemp;
+                delete data.occupiedHeatingSetpoint;
+            }
+
+            const result = {
+                ...(fz.thermostat.convert(model, endpoint2 ? {...msg, data} : msg, publish, options, meta) as KeyValueAny | undefined),
+                ...diagnostics,
+            };
+
+            if (msg.data.tempSetpointHold !== undefined) {
                 const holdProperty = postfixWithEndpointName("temperature_setpoint_hold", msg, model, meta);
                 result.override_active = msg.data.tempSetpointHold === 1;
                 delete result[holdProperty];
             }
 
-            return result;
+            return Object.keys(result).length > 0 ? result : undefined;
         },
     } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>;
 
@@ -5887,15 +5920,6 @@ function createW600Thermostat(): ModernExtend {
     );
 
     extend.configure ??= [];
-    const configureOverrideActive = modernExtend.setupConfigureForReporting(W600_THERMOSTAT_CLUSTER, "tempSetpointHold", {
-        config: {min: "MIN", max: "1_HOUR", change: 0},
-        access: ea.STATE_GET,
-    });
-
-    if (configureOverrideActive) {
-        extend.configure.push(configureOverrideActive);
-    }
-
     extend.configure.push(async (device) => {
         const endpoint = device.getEndpoint(1);
         await safeW600Read(endpoint, W600_LUMI_CLUSTER, [W600_ATTR_SYSTEM_MODE, W600_ATTR_SCHEDULE, W600_ATTR_PRESET], {manufacturerCode});

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -5635,16 +5635,10 @@ function createW600Thermostat(): ModernExtend {
     extend.exposes?.push(
         e.binary("override_active", ea.STATE, true, false).withLabel("Manual Override").withDescription("Temporary manual override active"),
         e
-            .numeric("internal_temperature", ea.STATE)
+            .numeric("local_temperature_internal", ea.STATE)
             .withUnit("°C")
-            .withLabel("Internal radiator temperature")
-            .withDescription("Temperature reported by the W600 physical radiator sensor on endpoint 2")
-            .withCategory("diagnostic"),
-        e
-            .numeric("endpoint_2_occupied_heating_setpoint", ea.STATE)
-            .withUnit("°C")
-            .withLabel("Endpoint 2 heating setpoint")
-            .withDescription("Heating setpoint reported by W600 endpoint 2; kept separate from the active climate target")
+            .withLabel("Internal sensor temperature")
+            .withDescription("Temperature measured by the thermostat's internal sensor")
             .withCategory("diagnostic"),
     );
 
@@ -5652,31 +5646,19 @@ function createW600Thermostat(): ModernExtend {
         cluster: W600_THERMOSTAT_CLUSTER,
         type: ["attributeReport", "readResponse"],
         convert: (model, msg, publish, options, meta) => {
-            const endpoint2 = msg.endpoint.ID === 2;
-            const data = endpoint2 ? {...msg.data} : msg.data;
-            const diagnostics: KeyValue = {};
+            const result = fz.thermostat.convert(model, msg, publish, options, meta) as KeyValueAny | undefined;
 
-            if (endpoint2) {
-                if (typeof data.localTemp === "number") diagnostics.internal_temperature = data.localTemp / 100;
-                if (typeof data.occupiedHeatingSetpoint === "number") {
-                    diagnostics.endpoint_2_occupied_heating_setpoint = data.occupiedHeatingSetpoint / 100;
-                }
-                delete data.localTemp;
-                delete data.occupiedHeatingSetpoint;
+            if (msg.endpoint.ID === 2) {
+                return result?.local_temperature === undefined ? undefined : {local_temperature_internal: result.local_temperature};
             }
 
-            const result = {
-                ...(fz.thermostat.convert(model, endpoint2 ? {...msg, data} : msg, publish, options, meta) as KeyValueAny | undefined),
-                ...diagnostics,
-            };
-
-            if (msg.data.tempSetpointHold !== undefined) {
+            if (result && msg.data.tempSetpointHold !== undefined) {
                 const holdProperty = postfixWithEndpointName("temperature_setpoint_hold", msg, model, meta);
                 result.override_active = msg.data.tempSetpointHold === 1;
                 delete result[holdProperty];
             }
 
-            return Object.keys(result).length > 0 ? result : undefined;
+            return result;
         },
     } satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>;
 

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -5612,6 +5612,7 @@ function createW600ExternalTempSensor(): ModernExtend {
 
 function createW600Thermostat(): ModernExtend {
     const extend = modernExtend.thermostat({
+        localTemperature: {values: {description: "Current temperature used by the thermostat"}},
         setpoints: {
             values: {occupiedHeatingSetpoint: {min: 5, max: 30, step: 0.5}},
         },

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -4811,8 +4811,9 @@ function writeW600LumiAttribute(entity: Zh.Endpoint, attribute: string | number,
 
 function getNextW600SensorBindingCounter(entity: Zh.Device | Zh.Endpoint) {
     const device = "ieeeAddr" in entity ? entity : entity.getDevice();
+    const storedCounter = device.meta?.[W600_SENSOR_BINDING_COUNTER_STORE_KEY];
     const counter =
-        typeof device.meta?.[W600_SENSOR_BINDING_COUNTER_STORE_KEY] === "number" ? device.meta[W600_SENSOR_BINDING_COUNTER_STORE_KEY] : 0x12;
+        typeof storedCounter === "number" && Number.isInteger(storedCounter) && storedCounter >= 0 && storedCounter <= 0xff ? storedCounter : 0x12;
 
     device.meta ??= {};
     device.meta[W600_SENSOR_BINDING_COUNTER_STORE_KEY] = (counter + 1) & 0xff;


### PR DESCRIPTION
## Summary

Improves Aqara W600 (`WT-A03E` / `lumi.airrtc.aeu005`) external-temperature handling.

- Persist the proprietary `0xFFF2` frame sequence counter in device metadata.
- Do not configure reporting for `hvacThermostat.tempSetpointHold`; W600 devices can reject it with `INSUFFICIENT_SPACE`.
- Keep normal W600 configuration reads.
- Keep endpoint 2 thermostat reports from overwriting the active endpoint 1 climate state.
- Expose the validated endpoint 2 internal sensor reading as:
  - `local_temperature_internal`
