### PR TITLE
TS0601_power_monitoring_switch: add _TZE284_q9qytwfa (Nisko water hea…

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -29141,7 +29141,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE204_apiu8k13"}],
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_apiu8k13", "_TZE284_q9qytwfa"]),
         model: "TS0601_power_monitoring_switch",
         vendor: "Tuya",
         description: "Touch panel switch with power monitoring and timer",


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#32883

Adds _TZE284_q9qytwfa to the existing TS0601_power_monitoring_switch fingerprint. Same Tuya DP set verified by observing commandDataReport while operating the physical controls (DP1 on/off, DP7 countdown 0-120 min, DP21 current, DP22 power, DP23 voltage) — details in the linked issue. Device is the Nisko Zigbee 3.0 water heater controller sold in Israel.