### PR TITLE
 Fix SODA S8 battery_low mapping (string -> boolean)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -15508,14 +15508,7 @@ export const definitions: DefinitionWithExtend[] = [
                         ON: tuya.enum(1),
                     }),
                 ],
-                [
-                    112,
-                    "battery_low",
-                    tuya.valueConverterBasic.lookup({
-                        ON: tuya.enum(0),
-                        OFF: tuya.enum(1),
-                    }),
-                ],
+                [112, "battery_low", tuya.valueConverter.trueFalse0],
                 [113, "duration", tuya.valueConverter.raw],
                 [
                     114,


### PR DESCRIPTION
 Fixes https://github.com/Koenkk/zigbee2mqtt/issues/32856

DP 112 was mapped to the strings "ON"/"OFF" via `valueConverterBasic.lookup`, while `e.battery_low()` declares booleans. The generated Home Assistant discovery payload therefore expects `true`/`false` and never matches the published string, leaving the entity permanently `unknown`.

This replaces the lookup with the standard `tuya.valueConverter.trueFalse0`, which every other Tuya device uses for this attribute (DP 35 on the TRVs, DP 14 on the smoke sensor).

Semantics are unchanged: the lookup mapped DP value 0 -> "ON" (battery low), and `trueFalse0` maps DP value 0 -> true.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

