### PR TITLE
feat(philips): add support for LWM007 (Hue wired dimmer switch, 929004296901)

### DIFF
--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3326,13 +3326,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Hue wired dimmer switch",
         ota: true,
         endpoint: () => ({default: 11}),
-        extend: [m.identify(), philips.m.light()],
-        configure: async (device, coordinatorEndpoint) => {
-            const ep = device.getEndpoint(11);
-            await reporting.bind(ep, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
-            await reporting.onOff(ep, {min: 0, max: 65000, change: 1});
-            await reporting.brightness(ep, {min: 1, max: 3600, change: 1});
-        },
+        extend: [m.identify(), philips.m.light({configureReporting: true})],
     },
     {
         zigbeeModel: ["LLC014"],

--- a/src/devices/philips.ts
+++ b/src/devices/philips.ts
@@ -3320,6 +3320,21 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
     },
     {
+        zigbeeModel: ["LWM007"],
+        model: "929004296901",
+        vendor: "Philips",
+        description: "Hue wired dimmer switch",
+        ota: true,
+        endpoint: () => ({default: 11}),
+        extend: [m.identify(), philips.m.light()],
+        configure: async (device, coordinatorEndpoint) => {
+            const ep = device.getEndpoint(11);
+            await reporting.bind(ep, coordinatorEndpoint, ["genOnOff", "genLevelCtrl"]);
+            await reporting.onOff(ep, {min: 0, max: 65000, change: 1});
+            await reporting.brightness(ep, {min: 1, max: 3600, change: 1});
+        },
+    },
+    {
         zigbeeModel: ["LLC014"],
         model: "7099860PH",
         vendor: "Philips",


### PR DESCRIPTION
Adds support for the Philips Hue wired dimmer switch (12NC 929004296901), one of the in-wall modules Signify introduced in June 2026. It sits behind an existing wall switch and adds on/off plus dimming control to a non-smart dimmable light.

Tested with firmware 1.157.2 (dateCode 20260331) on a deCONZ/ConBee coordinator.

**Device details**
- Model ID: LWM007
- Manufacturer: Signify Netherlands B.V. (manufId 4107)
- Endpoints: 1, 11, 242
- EP 1 — devId 259, in: genBasic, genIdentify, 0xFC00
- EP 11 — devId 257 (Dimmable Light), in: genBasic, genIdentify, genGroups, genScenes, genOnOff, genLevelCtrl, 0x1000, 0xFC03, 0xFC04; out: genOta
- EP 242 — Green Power

**Open questions**
- philips.m.light() exposes effect, effect_speed and effect_color. Some effects work (blink, breathe), colour-based ones obviously cannot, since the module drives a plain dimmable lamp. Happy to restrict the effect list if preferred — I have no way to enumerate which ones the firmware actually accepts.
- 0xFC04 on EP 11 is not present on the on/off variants of the same family. I suspect it holds the dimmer settings the Hue app offers (minimum brightness, dimming curve), but I have not decoded it. Not covered by this PR.
- No separate button events: 0xFC00 on EP 1 stays silent during local operation, verified with debug logging.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
