### PR TITLE
Danfoss Icon: expose icon_application and only expose populated room endpoints

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1593,157 +1593,169 @@ export const definitions: DefinitionWithExtend[] = [
                 l16: 232,
             };
         },
-        exposes: [].concat(
-            ((endpointsCount) => {
-                const features = [];
-
-                for (let i = 1; i <= endpointsCount; i++) {
-                    const epName = `l${i}`;
-
-                    if (i < 16) {
-                        features.push(e.battery().withEndpoint(epName));
-
-                        features.push(
-                            e
-                                .climate()
-                                .withSetpoint("occupied_heating_setpoint", 5, 35, 0.5)
-                                .withLocalTemperature()
-                                .withSystemMode(["heat"])
-                                .withRunningState(["idle", "heat"], ea.STATE)
-                                .withEndpoint(epName),
-                        );
-
-                        features.push(
-                            e
-                                .numeric("abs_min_heat_setpoint_limit", ea.STATE)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Absolute min temperature allowed on the device"),
-                        );
-                        features.push(
-                            e
-                                .numeric("abs_max_heat_setpoint_limit", ea.STATE)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Absolute max temperature allowed on the device"),
-                        );
-
-                        features.push(
-                            e
-                                .numeric("min_heat_setpoint_limit", ea.ALL)
-                                .withValueMin(4)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Min temperature limit set on the device"),
-                        );
-                        features.push(
-                            e
-                                .numeric("max_heat_setpoint_limit", ea.ALL)
-                                .withValueMin(4)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Max temperature limit set on the device"),
-                        );
-
-                        features.push(e.enum("setpoint_change_source", ea.STATE, ["manual", "schedule", "externally"]).withEndpoint(epName));
-
-                        features.push(
-                            e.enum("output_status", ea.STATE_GET, ["inactive", "active"]).withEndpoint(epName).withDescription("Actuator status"),
-                        );
-
-                        features.push(
-                            e
-                                .enum("room_status_code", ea.STATE_GET, [
-                                    "no_error",
-                                    "missing_rt",
-                                    "rt_touch_error",
-                                    "floor_sensor_short_circuit",
-                                    "floor_sensor_disconnected",
-                                ])
-                                .withEndpoint(epName)
-                                .withDescription("Thermostat status"),
-                        );
-
-                        features.push(
-                            e
-                                .enum("room_floor_sensor_mode", ea.STATE_GET, ["comfort", "floor_only", "dual_mode"])
-                                .withEndpoint(epName)
-                                .withDescription("Floor sensor mode"),
-                        );
-                        features.push(
-                            e
-                                .numeric("floor_min_setpoint", ea.ALL)
-                                .withValueMin(18)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Min floor temperature"),
-                        );
-                        features.push(
-                            e
-                                .numeric("floor_max_setpoint", ea.ALL)
-                                .withValueMin(18)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Max floor temperature"),
-                        );
-
-                        features.push(
-                            e.numeric("temperature", ea.STATE_GET).withUnit("°C").withEndpoint(epName).withDescription("Floor temperature"),
-                        );
-                    } else {
-                        features.push(
-                            e
-                                .enum("system_status_code", ea.STATE_GET, [
-                                    "no_error",
-                                    "missing_expansion_board",
-                                    "missing_radio_module",
-                                    "missing_command_module",
-                                    "missing_master_rail",
-                                    "missing_slave_rail_no_1",
-                                    "missing_slave_rail_no_2",
-                                    "pt1000_input_short_circuit",
-                                    "pt1000_input_open_circuit",
-                                    "error_on_one_or_more_output",
-                                ])
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller Status"),
-                        );
-                        features.push(
-                            e
-                                .enum("system_status_water", ea.STATE_GET, ["hot_water_flow_in_pipes", "cool_water_flow_in_pipes"])
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller Water Status"),
-                        );
-                        features.push(
-                            e
-                                .enum("multimaster_role", ea.STATE_GET, ["invalid_unused", "master", "slave_1", "slave_2"])
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller Role"),
-                        );
-                        features.push(
-                            e
-                                .enum(
-                                    "icon_application",
-                                    ea.STATE_GET,
-                                    Array.from({length: 21}, (_, n) => `${n}`),
-                                )
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller application"),
-                        );
+        exposes: (device) => {
+            // On a real controller only populated rooms register a Zigbee endpoint
+            // (getEndpoint(i) is undefined for an unwired room), so expose only those.
+            // A dummy device (docs generation) or one not yet interviewed has no usable
+            // endpoint list, so expose the full l1..l15 + l16 set instead.
+            const roomEndpoints: number[] = [];
+            let hasMainController = true;
+            if ("endpoints" in device && device.endpoints.length > 0) {
+                for (let i = 1; i <= 15; i++) {
+                    if (device.getEndpoint(i) !== undefined) {
+                        roomEndpoints.push(i);
                     }
                 }
+                hasMainController = device.getEndpoint(232) !== undefined;
+            } else {
+                for (let i = 1; i <= 15; i++) {
+                    roomEndpoints.push(i);
+                }
+            }
 
-                return features;
-            })(16),
-        ),
+            const features = [];
+
+            for (const i of roomEndpoints) {
+                const epName = `l${i}`;
+                features.push(e.battery().withEndpoint(epName));
+
+                features.push(
+                    e
+                        .climate()
+                        .withSetpoint("occupied_heating_setpoint", 5, 35, 0.5)
+                        .withLocalTemperature()
+                        .withSystemMode(["heat"])
+                        .withRunningState(["idle", "heat"], ea.STATE)
+                        .withEndpoint(epName),
+                );
+
+                features.push(
+                    e
+                        .numeric("abs_min_heat_setpoint_limit", ea.STATE)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Absolute min temperature allowed on the device"),
+                );
+                features.push(
+                    e
+                        .numeric("abs_max_heat_setpoint_limit", ea.STATE)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Absolute max temperature allowed on the device"),
+                );
+
+                features.push(
+                    e
+                        .numeric("min_heat_setpoint_limit", ea.ALL)
+                        .withValueMin(4)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Min temperature limit set on the device"),
+                );
+                features.push(
+                    e
+                        .numeric("max_heat_setpoint_limit", ea.ALL)
+                        .withValueMin(4)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Max temperature limit set on the device"),
+                );
+
+                features.push(e.enum("setpoint_change_source", ea.STATE, ["manual", "schedule", "externally"]).withEndpoint(epName));
+
+                features.push(e.enum("output_status", ea.STATE_GET, ["inactive", "active"]).withEndpoint(epName).withDescription("Actuator status"));
+
+                features.push(
+                    e
+                        .enum("room_status_code", ea.STATE_GET, [
+                            "no_error",
+                            "missing_rt",
+                            "rt_touch_error",
+                            "floor_sensor_short_circuit",
+                            "floor_sensor_disconnected",
+                        ])
+                        .withEndpoint(epName)
+                        .withDescription("Thermostat status"),
+                );
+
+                features.push(
+                    e
+                        .enum("room_floor_sensor_mode", ea.STATE_GET, ["comfort", "floor_only", "dual_mode"])
+                        .withEndpoint(epName)
+                        .withDescription("Floor sensor mode"),
+                );
+                features.push(
+                    e
+                        .numeric("floor_min_setpoint", ea.ALL)
+                        .withValueMin(18)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Min floor temperature"),
+                );
+                features.push(
+                    e
+                        .numeric("floor_max_setpoint", ea.ALL)
+                        .withValueMin(18)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Max floor temperature"),
+                );
+
+                features.push(e.numeric("temperature", ea.STATE_GET).withUnit("°C").withEndpoint(epName).withDescription("Floor temperature"));
+            }
+
+            if (hasMainController) {
+                features.push(
+                    e
+                        .enum("system_status_code", ea.STATE_GET, [
+                            "no_error",
+                            "missing_expansion_board",
+                            "missing_radio_module",
+                            "missing_command_module",
+                            "missing_master_rail",
+                            "missing_slave_rail_no_1",
+                            "missing_slave_rail_no_2",
+                            "pt1000_input_short_circuit",
+                            "pt1000_input_open_circuit",
+                            "error_on_one_or_more_output",
+                        ])
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller Status"),
+                );
+                features.push(
+                    e
+                        .enum("system_status_water", ea.STATE_GET, ["hot_water_flow_in_pipes", "cool_water_flow_in_pipes"])
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller Water Status"),
+                );
+                features.push(
+                    e
+                        .enum("multimaster_role", ea.STATE_GET, ["invalid_unused", "master", "slave_1", "slave_2"])
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller Role"),
+                );
+                features.push(
+                    e
+                        .enum(
+                            "icon_application",
+                            ea.STATE_GET,
+                            Array.from({length: 21}, (_, n) => `${n}`),
+                        )
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller application"),
+                );
+            }
+
+            return features;
+        },
         configure: async (device, coordinatorEndpoint) => {
             const options = {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S};
 

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1570,6 +1570,7 @@ export const definitions: DefinitionWithExtend[] = [
             tzLocal.danfoss_system_status_code,
             tzLocal.danfoss_system_status_water,
             tzLocal.danfoss_multimaster_role,
+            tzLocal.danfoss_icon_application,
         ],
         meta: {multiEndpoint: true, thermostat: {dontMapPIHeatingDemand: true}},
         endpoint: (device) => {
@@ -1727,6 +1728,16 @@ export const definitions: DefinitionWithExtend[] = [
                                 .withEndpoint("l16")
                                 .withDescription("Main Controller Role"),
                         );
+                        features.push(
+                            e
+                                .enum(
+                                    "icon_application",
+                                    ea.STATE_GET,
+                                    Array.from({length: 21}, (_, n) => `${n}`),
+                                )
+                                .withEndpoint("l16")
+                                .withDescription("Main Controller application"),
+                        );
                     }
                 }
 
@@ -1795,6 +1806,10 @@ export const definitions: DefinitionWithExtend[] = [
                 ["danfossSystemStatusCode", "danfossSystemStatusWater", "danfossMultimasterRole"],
                 options,
             );
+
+            // Read separately: older 0x80xx firmware variants may not support this attribute,
+            // so an UNSUPPORTED_ATTRIBUTE must not fail the reads above.
+            await mainController.read<"haDiagnostic", DanfossHaDiagnostic>("haDiagnostic", ["danfossIconApplication"], options);
         },
     },
     {
@@ -1997,28 +2012,11 @@ export const definitions: DefinitionWithExtend[] = [
                         );
                         features.push(
                             e
-                                .enum("icon_application", ea.STATE_GET, [
-                                    "1",
-                                    "2",
-                                    "3",
-                                    "4",
-                                    "5",
-                                    "6",
-                                    "7",
-                                    "8",
-                                    "9",
-                                    "10",
-                                    "11",
-                                    "12",
-                                    "13",
-                                    "14",
-                                    "15",
-                                    "16",
-                                    "17",
-                                    "18",
-                                    "19",
-                                    "20",
-                                ])
+                                .enum(
+                                    "icon_application",
+                                    ea.STATE_GET,
+                                    Array.from({length: 21}, (_, n) => `${n}`),
+                                )
                                 .withEndpoint("232")
                                 .withDescription("Main Controller application"),
                         );


### PR DESCRIPTION
Two related improvements to the gen1 Danfoss `Icon` definition, both prompted by a diagnostic from an Icon Basic Main Controller (`0x0200`, added in #8457).

## 1. Expose `icon_application` on the Main Controller
The gen1 `Icon` definition already **decodes** `danfossIconApplication` (in the `danfoss_icon_regulator` fromZigbee converter) but never **exposes** it, so the value ends up in the raw MQTT payload with no matching entity:

```json
"icon_application_l16": "0",
"multimaster_role_l16": "master",
"system_status_code_l16": "no_error",
"system_status_water_l16": "hot_water_flow_in_pipes"
```

`multimaster_role`, `system_status_code` and `system_status_water` are exposed on `l16`; `icon_application` is not. The Icon2 definition already exposes it, so this brings gen1 to parity:
- expose `icon_application` on `l16` (`STATE_GET`), add `tzLocal.danfoss_icon_application` to `toZigbee`, read `danfossIconApplication` in `configure`;
- the new `configure` read is issued as a **separate** `read()` so an `UNSUPPORTED_ATTRIBUTE` on older `0x80xx` firmware can't fail the other reads;
- **enum fix (Icon and Icon2)**: `constants.danfossIconApplication` maps `0..20`, but the Icon2 enum listed only `"1".."20"`; the device reports `"0"` (see payload), which was outside the exposed values. Both enums now cover `"0".."20"`.

## 2. Only expose populated room endpoints
The definition statically exposed all 15 room endpoints (`l1`–`l15`) regardless of how many rooms are wired, producing many empty/null entities (a 3-room controller exposed 12 empty rooms).

On a real controller only populated rooms register a Zigbee endpoint — the existing `configure()` already relies on this (`getEndpoint(i)` is `undefined` for an unwired room; confirmed in #3088, where a 9-room system responded only on endpoints 1–9). `exposes` is now a device-aware function that:
- probes `getEndpoint(1..15)` and exposes only endpoints that exist (probed individually — room→endpoint mapping is not assumed contiguous);
- exposes the `l16` block only when endpoint `232` is present;
- falls back to the full `l1..l15 + l16` set for a dummy device (docs generation) or a device with no interviewed endpoints, so the supported-devices page stays complete.

Endpoint naming (`l1`..`l16`) is unchanged, so existing entity IDs are preserved.

### Behavioral notes
- Rooms added after pairing won't appear until the device is re-interviewed (the endpoint list is an interview-time snapshot; see #3088). This matches how `configure` already behaves.
- Users with partially-populated controllers will see their previously-empty room entities no longer exposed. This is the intended fix — those entities only ever reported `null`.

## Verification
- `npx tsc --noEmit` — clean
- `npx biome check --error-on-warnings src/devices/danfoss.ts` — clean
- `vitest run` `checkDefinition` + `index` + `generateDefinition` — 44 passed, all 4437 definitions processed
- Diagnostic + live state from a real Icon Basic Main Controller (`0x0200`) confirm `icon_application` is reported as `"0"`.
