### PR TITLE
Danfoss Icon: only expose populated room endpoints

### DIFF
--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1593,157 +1593,169 @@ export const definitions: DefinitionWithExtend[] = [
                 l16: 232,
             };
         },
-        exposes: [].concat(
-            ((endpointsCount) => {
-                const features = [];
-
-                for (let i = 1; i <= endpointsCount; i++) {
-                    const epName = `l${i}`;
-
-                    if (i < 16) {
-                        features.push(e.battery().withEndpoint(epName));
-
-                        features.push(
-                            e
-                                .climate()
-                                .withSetpoint("occupied_heating_setpoint", 5, 35, 0.5)
-                                .withLocalTemperature()
-                                .withSystemMode(["heat"])
-                                .withRunningState(["idle", "heat"], ea.STATE)
-                                .withEndpoint(epName),
-                        );
-
-                        features.push(
-                            e
-                                .numeric("abs_min_heat_setpoint_limit", ea.STATE)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Absolute min temperature allowed on the device"),
-                        );
-                        features.push(
-                            e
-                                .numeric("abs_max_heat_setpoint_limit", ea.STATE)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Absolute max temperature allowed on the device"),
-                        );
-
-                        features.push(
-                            e
-                                .numeric("min_heat_setpoint_limit", ea.ALL)
-                                .withValueMin(4)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Min temperature limit set on the device"),
-                        );
-                        features.push(
-                            e
-                                .numeric("max_heat_setpoint_limit", ea.ALL)
-                                .withValueMin(4)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Max temperature limit set on the device"),
-                        );
-
-                        features.push(e.enum("setpoint_change_source", ea.STATE, ["manual", "schedule", "externally"]).withEndpoint(epName));
-
-                        features.push(
-                            e.enum("output_status", ea.STATE_GET, ["inactive", "active"]).withEndpoint(epName).withDescription("Actuator status"),
-                        );
-
-                        features.push(
-                            e
-                                .enum("room_status_code", ea.STATE_GET, [
-                                    "no_error",
-                                    "missing_rt",
-                                    "rt_touch_error",
-                                    "floor_sensor_short_circuit",
-                                    "floor_sensor_disconnected",
-                                ])
-                                .withEndpoint(epName)
-                                .withDescription("Thermostat status"),
-                        );
-
-                        features.push(
-                            e
-                                .enum("room_floor_sensor_mode", ea.STATE_GET, ["comfort", "floor_only", "dual_mode"])
-                                .withEndpoint(epName)
-                                .withDescription("Floor sensor mode"),
-                        );
-                        features.push(
-                            e
-                                .numeric("floor_min_setpoint", ea.ALL)
-                                .withValueMin(18)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Min floor temperature"),
-                        );
-                        features.push(
-                            e
-                                .numeric("floor_max_setpoint", ea.ALL)
-                                .withValueMin(18)
-                                .withValueMax(35)
-                                .withValueStep(0.5)
-                                .withUnit("°C")
-                                .withEndpoint(epName)
-                                .withDescription("Max floor temperature"),
-                        );
-
-                        features.push(
-                            e.numeric("temperature", ea.STATE_GET).withUnit("°C").withEndpoint(epName).withDescription("Floor temperature"),
-                        );
-                    } else {
-                        features.push(
-                            e
-                                .enum("system_status_code", ea.STATE_GET, [
-                                    "no_error",
-                                    "missing_expansion_board",
-                                    "missing_radio_module",
-                                    "missing_command_module",
-                                    "missing_master_rail",
-                                    "missing_slave_rail_no_1",
-                                    "missing_slave_rail_no_2",
-                                    "pt1000_input_short_circuit",
-                                    "pt1000_input_open_circuit",
-                                    "error_on_one_or_more_output",
-                                ])
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller Status"),
-                        );
-                        features.push(
-                            e
-                                .enum("system_status_water", ea.STATE_GET, ["hot_water_flow_in_pipes", "cool_water_flow_in_pipes"])
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller Water Status"),
-                        );
-                        features.push(
-                            e
-                                .enum("multimaster_role", ea.STATE_GET, ["invalid_unused", "master", "slave_1", "slave_2"])
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller Role"),
-                        );
-                        features.push(
-                            e
-                                .enum(
-                                    "icon_application",
-                                    ea.STATE_GET,
-                                    Array.from({length: 21}, (_, n) => `${n}`),
-                                )
-                                .withEndpoint("l16")
-                                .withDescription("Main Controller application"),
-                        );
+        exposes: (device) => {
+            // On a real controller only populated rooms register a Zigbee endpoint
+            // (getEndpoint(i) is undefined for an unwired room), so expose only those.
+            // A dummy device (docs generation) or one not yet interviewed has no usable
+            // endpoint list, so expose the full l1..l15 + l16 set instead.
+            const roomEndpoints: number[] = [];
+            let hasMainController = true;
+            if ("endpoints" in device && device.endpoints.length > 0) {
+                for (let i = 1; i <= 15; i++) {
+                    if (device.getEndpoint(i) !== undefined) {
+                        roomEndpoints.push(i);
                     }
                 }
+                hasMainController = device.getEndpoint(232) !== undefined;
+            } else {
+                for (let i = 1; i <= 15; i++) {
+                    roomEndpoints.push(i);
+                }
+            }
 
-                return features;
-            })(16),
-        ),
+            const features = [];
+
+            for (const i of roomEndpoints) {
+                const epName = `l${i}`;
+                features.push(e.battery().withEndpoint(epName));
+
+                features.push(
+                    e
+                        .climate()
+                        .withSetpoint("occupied_heating_setpoint", 5, 35, 0.5)
+                        .withLocalTemperature()
+                        .withSystemMode(["heat"])
+                        .withRunningState(["idle", "heat"], ea.STATE)
+                        .withEndpoint(epName),
+                );
+
+                features.push(
+                    e
+                        .numeric("abs_min_heat_setpoint_limit", ea.STATE)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Absolute min temperature allowed on the device"),
+                );
+                features.push(
+                    e
+                        .numeric("abs_max_heat_setpoint_limit", ea.STATE)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Absolute max temperature allowed on the device"),
+                );
+
+                features.push(
+                    e
+                        .numeric("min_heat_setpoint_limit", ea.ALL)
+                        .withValueMin(4)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Min temperature limit set on the device"),
+                );
+                features.push(
+                    e
+                        .numeric("max_heat_setpoint_limit", ea.ALL)
+                        .withValueMin(4)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Max temperature limit set on the device"),
+                );
+
+                features.push(e.enum("setpoint_change_source", ea.STATE, ["manual", "schedule", "externally"]).withEndpoint(epName));
+
+                features.push(e.enum("output_status", ea.STATE_GET, ["inactive", "active"]).withEndpoint(epName).withDescription("Actuator status"));
+
+                features.push(
+                    e
+                        .enum("room_status_code", ea.STATE_GET, [
+                            "no_error",
+                            "missing_rt",
+                            "rt_touch_error",
+                            "floor_sensor_short_circuit",
+                            "floor_sensor_disconnected",
+                        ])
+                        .withEndpoint(epName)
+                        .withDescription("Thermostat status"),
+                );
+
+                features.push(
+                    e
+                        .enum("room_floor_sensor_mode", ea.STATE_GET, ["comfort", "floor_only", "dual_mode"])
+                        .withEndpoint(epName)
+                        .withDescription("Floor sensor mode"),
+                );
+                features.push(
+                    e
+                        .numeric("floor_min_setpoint", ea.ALL)
+                        .withValueMin(18)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Min floor temperature"),
+                );
+                features.push(
+                    e
+                        .numeric("floor_max_setpoint", ea.ALL)
+                        .withValueMin(18)
+                        .withValueMax(35)
+                        .withValueStep(0.5)
+                        .withUnit("°C")
+                        .withEndpoint(epName)
+                        .withDescription("Max floor temperature"),
+                );
+
+                features.push(e.numeric("temperature", ea.STATE_GET).withUnit("°C").withEndpoint(epName).withDescription("Floor temperature"));
+            }
+
+            if (hasMainController) {
+                features.push(
+                    e
+                        .enum("system_status_code", ea.STATE_GET, [
+                            "no_error",
+                            "missing_expansion_board",
+                            "missing_radio_module",
+                            "missing_command_module",
+                            "missing_master_rail",
+                            "missing_slave_rail_no_1",
+                            "missing_slave_rail_no_2",
+                            "pt1000_input_short_circuit",
+                            "pt1000_input_open_circuit",
+                            "error_on_one_or_more_output",
+                        ])
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller Status"),
+                );
+                features.push(
+                    e
+                        .enum("system_status_water", ea.STATE_GET, ["hot_water_flow_in_pipes", "cool_water_flow_in_pipes"])
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller Water Status"),
+                );
+                features.push(
+                    e
+                        .enum("multimaster_role", ea.STATE_GET, ["invalid_unused", "master", "slave_1", "slave_2"])
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller Role"),
+                );
+                features.push(
+                    e
+                        .enum(
+                            "icon_application",
+                            ea.STATE_GET,
+                            Array.from({length: 21}, (_, n) => `${n}`),
+                        )
+                        .withEndpoint("l16")
+                        .withDescription("Main Controller application"),
+                );
+            }
+
+            return features;
+        },
         configure: async (device, coordinatorEndpoint) => {
             const options = {manufacturerCode: Zcl.ManufacturerCode.DANFOSS_A_S};
 

--- a/src/devices/danfoss.ts
+++ b/src/devices/danfoss.ts
@@ -1570,6 +1570,7 @@ export const definitions: DefinitionWithExtend[] = [
             tzLocal.danfoss_system_status_code,
             tzLocal.danfoss_system_status_water,
             tzLocal.danfoss_multimaster_role,
+            tzLocal.danfoss_icon_application,
         ],
         meta: {multiEndpoint: true, thermostat: {dontMapPIHeatingDemand: true}},
         endpoint: (device) => {
@@ -1727,6 +1728,16 @@ export const definitions: DefinitionWithExtend[] = [
                                 .withEndpoint("l16")
                                 .withDescription("Main Controller Role"),
                         );
+                        features.push(
+                            e
+                                .enum(
+                                    "icon_application",
+                                    ea.STATE_GET,
+                                    Array.from({length: 21}, (_, n) => `${n}`),
+                                )
+                                .withEndpoint("l16")
+                                .withDescription("Main Controller application"),
+                        );
                     }
                 }
 
@@ -1795,6 +1806,10 @@ export const definitions: DefinitionWithExtend[] = [
                 ["danfossSystemStatusCode", "danfossSystemStatusWater", "danfossMultimasterRole"],
                 options,
             );
+
+            // Read separately: older 0x80xx firmware variants may not support this attribute,
+            // so an UNSUPPORTED_ATTRIBUTE must not fail the reads above.
+            await mainController.read<"haDiagnostic", DanfossHaDiagnostic>("haDiagnostic", ["danfossIconApplication"], options);
         },
     },
     {
@@ -1997,28 +2012,11 @@ export const definitions: DefinitionWithExtend[] = [
                         );
                         features.push(
                             e
-                                .enum("icon_application", ea.STATE_GET, [
-                                    "1",
-                                    "2",
-                                    "3",
-                                    "4",
-                                    "5",
-                                    "6",
-                                    "7",
-                                    "8",
-                                    "9",
-                                    "10",
-                                    "11",
-                                    "12",
-                                    "13",
-                                    "14",
-                                    "15",
-                                    "16",
-                                    "17",
-                                    "18",
-                                    "19",
-                                    "20",
-                                ])
+                                .enum(
+                                    "icon_application",
+                                    ea.STATE_GET,
+                                    Array.from({length: 21}, (_, n) => `${n}`),
+                                )
                                 .withEndpoint("232")
                                 .withDescription("Main Controller application"),
                         );


### PR DESCRIPTION
Makes the gen1 Danfoss `Icon` definition expose only the room endpoints that actually exist, instead of a fixed 15.

> **Depends on #12964** (this branch is stacked on it). If #12964 merges first I'll rebase onto master.

## Problem
The `Icon` definition statically exposes all 15 room endpoints (`l1`–`l15`). A controller with only a few rooms wired therefore produces a large number of empty/null entities in Home Assistant — e.g. a 3-room controller exposes 12 rooms of `battery`/`climate`/`setpoint`/… that are permanently `null`.

## Why this is safe
On a real Icon controller, **only populated rooms register a Zigbee endpoint** — unused rooms have no endpoint at all. The existing `configure()` already relies on exactly this:

```js
for (let i = 1; i <= 15; i++) {
    const endpoint = device.getEndpoint(i);
    if (typeof endpoint !== "undefined") { ... }
}
```

Confirmed by the original converter dev thread (a 9-room system responded only on endpoints 1–9; `getEndpoint(i)` was `undefined` above that): https://github.com/Koenkk/zigbee-herdsman-converters/issues/3088

## Change
`exposes` becomes a device-aware function that:
- probes `getEndpoint(1..15)` and exposes only the endpoints that exist (probed individually — room→endpoint mapping is not assumed contiguous),
- exposes the `l16` main-controller block only when endpoint `232` is present,
- falls back to the **full** `l1..l15 + l16` set for a dummy device (docs generation, `index.ts` `{isDummyDevice: true}`) or a device with no interviewed endpoints, so the supported-devices page and pre-interview state stay complete.

Endpoint naming (`l1`..`l16`) is unchanged, so existing entity IDs are preserved.

## Behavioral notes
- **Rooms added after pairing won't appear until the device is re-interviewed.** The endpoint list is an interview-time snapshot (see #3088 / z2m docs). This matches how the device already behaves for `configure`.
- **Users with partially-populated controllers will see their previously-empty room entities no longer exposed.** This is the intended fix, not a regression — those entities only ever reported `null`. (Whether z2m cleans up the now-removed retained discovery topics is z2m-core behavior.)

## Verification
- `npx tsc --noEmit` — clean
- `npx biome check --error-on-warnings src/devices/danfoss.ts` — clean
- `vitest run` `checkDefinition` + `index` + `generateDefinition` — 44 passed, all 4437 definitions processed (exercises the dummy-device full-set path used by docs/validation).
