### PR TITLE
fix: publish button hold length as action_duration, not duration

### DIFF
--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -7734,7 +7734,7 @@ export const fromZigbee = {
             } else if (state === 1) {
                 if (globalStore.getValue(msg.endpoint, "hold")) {
                     const duration = Date.now() - globalStore.getValue(msg.endpoint, "hold");
-                    publish({action: "release", duration: duration});
+                    publish({action: "release", action_duration: duration});
                     globalStore.putValue(msg.endpoint, "hold", false);
                 }
 

--- a/test/lumi.test.ts
+++ b/test/lumi.test.ts
@@ -1,8 +1,8 @@
-import {beforeEach, describe, expect, it, vi} from "vitest";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {findByDevice} from "../src/index";
 import {fromZigbee, lumiModernExtend, numericAttributes2Payload, type TrvScheduleConfig, toZigbee, trv} from "../src/lib/lumi";
 import * as globalStore from "../src/lib/store";
-import type {Definition, Fz, Tz} from "../src/lib/types";
+import type {Definition, Fz, KeyValueAny, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 describe("lib/lumi", () => {
@@ -1005,6 +1005,51 @@ describe("lib/lumi", () => {
                 );
                 expect(result).toStrictEqual({});
             });
+        });
+    });
+
+    describe("WXKG01LM hold length", () => {
+        const definition = {model: "WXKG01LM"} as Definition;
+
+        const message = (onOff: number, sequence: number, device: ReturnType<typeof mockDevice>) =>
+            ({
+                device,
+                endpoint: device.endpoints[0],
+                data: {onOff},
+                meta: {zclTransactionSequenceNumber: sequence},
+            }) as unknown as Fz.Message<"genOnOff", undefined, "attributeReport">;
+
+        beforeEach(() => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date("2026-08-22T00:00:00Z"));
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("reports the hold length under action_duration, which is not part of the device state", () => {
+            const device = mockDevice({modelID: "lumi.sensor_switch", endpoints: [{ID: 1}]}, "EndDevice");
+            const published: KeyValueAny[] = [];
+
+            fromZigbee.lumi_action_WXKG01LM.convert(definition, message(0, 1, device), (payload) => published.push(payload), {}, null);
+            // The converter calls a press a hold once 1000 ms pass without a release.
+            vi.advanceTimersByTime(1000);
+            vi.advanceTimersByTime(1500);
+            fromZigbee.lumi_action_WXKG01LM.convert(definition, message(1, 2, device), (payload) => published.push(payload), {}, null);
+
+            expect(published).toStrictEqual([{action: "hold"}, {action: "release", action_duration: 1500}]);
+        });
+
+        it("leaves a short press without a duration at all", () => {
+            const device = mockDevice({modelID: "lumi.sensor_switch", endpoints: [{ID: 1}], ieeeAddr: "0x87654321"}, "EndDevice");
+            const published: KeyValueAny[] = [];
+
+            fromZigbee.lumi_action_WXKG01LM.convert(definition, message(0, 3, device), (payload) => published.push(payload), {}, null);
+            vi.advanceTimersByTime(200);
+            fromZigbee.lumi_action_WXKG01LM.convert(definition, message(1, 4, device), (payload) => published.push(payload), {}, null);
+
+            expect(published).toStrictEqual([{action: "single"}]);
         });
     });
 });


### PR DESCRIPTION
Follow-up to Koenkk/zigbee2mqtt#32896, where you agreed to remove `duration` from `CACHE_IGNORE_PROPERTIES` and rename the Aqara one to `action_duration`.

`duration` is currently doing double duty. Several top level exposes declare it as real device state, the Tuya sirens and the Immax TS0219 among them, and those lose the value today because Zigbee2MQTT filters the name out of the state cache. A handful of button converters publish it as an event value, where caching it would be wrong. The filter cannot tell the two apart, so the event value is the one that has to move.

## What changed

`lumi_action_WXKG01LM` published the length of a hold under a bare `duration`. It now uses `action_duration`, which is what `lumi_action_stop` and `lumi_action_move_color_temp` in the same file already call the same value, and which Zigbee2MQTT filters through its `action_.*` pattern rather than a hard-coded entry.

## The duplicate key elsewhere

Three converters publish the release duration twice, once as `action_duration` and once as a bare `duration`: `lumi_action_move_color_temp` and the two Leedarson CCTSwitch handlers. This PR carried a second commit removing the duplicate. You would rather keep it, so that commit is off the branch and those three are untouched.

## Sweep

I went through every converter that writes a top level `duration` into a payload, to be sure the Zigbee2MQTT change does not surface another one:

- `lumi.ts` WXKG01LM and `lumi_action_move_color_temp`, plus `leedarson.ts` in two spots: event values, of which only WXKG01LM is renamed here.
- `immax.ts` `ts0219ssIasWd`: real device state read back from `maxDuration`, and one of the cases that gains from the filter going away.
- `sonoff.ts` and `inovelli.ts`: nested inside composites, so they never surface as a top level `duration` key.
- `legacy.ts`: siren duration state and a timer object, both legitimate.

## Tests

Two cases in `test/lumi.test.ts` covering the WXKG01LM converter, which had none. The first asserts the release payload, and fails on `master` with the bare `duration` key. The second pins the short press path, where no duration is published at all.

`pnpm run check`, `pnpm run build` and `pnpm test` pass locally: 802 tests across 25 files.

## One thing I did not change

`e.action_duration()` in `exposes.ts` declares seconds. Philips and IKEA divide by 1000 before publishing, and Bosch reads deciseconds and divides by 10. The lumi and Leedarson converters have always published milliseconds, so this pull request keeps milliseconds and stays a rename. Neither WXKG01LM nor WXCJKG13LM declares the expose, so nothing contradicts itself in the device definitions today, but tell me if you want the unit fixed and I will send it separately.

## Zigbee2MQTT side

The matching change removing `duration` from `CACHE_IGNORE_PROPERTIES` is Koenkk/zigbee2mqtt#32900, which is already in dev.

---

Assisted by Claude. I read and tested every line, and the reasoning above is my own.
