### PR TITLE
feat(namron): expose writable sensor_mode on Zigbee Edge Thermostat

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -554,6 +554,7 @@ function deriveEdgeThermostatMode(frost: string, vacationMode: string, sensorMod
 }
 
 const edgeSensorModeLookup: KeyValue = {"0": "air", "1": "floor", "2": "both", "3": "air2", "4": "both2", "5": "floor_percent", "6": "percent"};
+const edgeSensorModeValueLookup: KeyValue = {air: 0, floor: 1, both: 2, air2: 3, both2: 4, floor_percent: 5, percent: 6};
 const edgeOnOffLookup: KeyValue = {OFF: 0, ON: 1};
 const edgeOnOffReverseLookup: KeyValue = {"0": "OFF", "1": "ON"};
 const edgeScreenOnTimeLookup: KeyValue = {"0": "always_on", "1": "10s", "2": "60s", "3": "30s"};
@@ -741,6 +742,30 @@ const tzEdge = {
         convertGet: async (entity) => {
             await entity.read("hvacThermostat", [0x8001, 0x8004, 0x801f, 0x8023]);
             await entity.read("hvacThermostat", ["programingOperMode"]);
+        },
+    } satisfies Tz.Converter,
+
+    sensor_mode: {
+        key: ["sensor_mode"],
+        convertSet: async (entity, key, value, meta) => {
+            const raw = edgeSensorModeValueLookup[value as string];
+            if (raw === undefined) throw new Error(`Invalid sensor_mode: ${value}`);
+            await writeEdgeHvac(entity, 0x8004, raw as number, Zcl.DataType.ENUM8);
+            const state: KeyValue = {sensor_mode: value};
+            // "percent" is how this device represents regulator mode, and thermostat_mode is
+            // derived from it, so keep the derived value in step with the write.
+            const merged = Object.assign({}, (meta.state as KeyValue) ?? {}, state) as KeyValue;
+            state["thermostat_mode"] = deriveEdgeThermostatMode(
+                merged["frost"] as string,
+                merged["vacation_mode"] as string,
+                merged["sensor_mode"] as string,
+                merged["programming_operation_mode"] as string,
+                (merged["boost_time_set"] as number) ?? 0,
+            );
+            return {state};
+        },
+        convertGet: async (entity) => {
+            await entity.read("hvacThermostat", [0x8004]);
         },
     } satisfies Tz.Converter,
 
@@ -939,6 +964,7 @@ export const definitions: DefinitionWithExtend[] = [
             tz.thermostat_programming_operation_mode,
             tz.thermostat_temperature_display_mode,
             tzEdge.thermostat_mode,
+            tzEdge.sensor_mode,
             tzEdge.frost,
             tzEdge.keypad_lockout,
             tzEdge.regulator_percentage,
@@ -1054,6 +1080,10 @@ export const definitions: DefinitionWithExtend[] = [
             e.numeric("max_heat_temp", ea.ALL).withUnit("°C").withValueMin(15).withValueMax(35).withValueStep(0.5).withLabel("Max heat temperature"),
             e.enum("thermostat_mode", ea.ALL, ["manual", "schedule", "regulator"]).withLabel("Thermostat mode"),
             e.enum("thermostat_mode_extra", ea.ALL, ["eco", "frost", "holiday"]).withLabel("Special mode"),
+            e
+                .enum("sensor_mode", ea.ALL, ["air", "floor", "both", "percent"])
+                .withLabel("Sensor mode")
+                .withDescription("Sensor the thermostat regulates on. \"percent\" is regulator mode, also set via thermostat_mode."),
             e.binary("frost", ea.STATE_SET, "ON", "OFF").withLabel("Frost Mode"),
             e.enum("temperature_display_mode", ea.STATE_SET, ["celsius", "fahrenheit"]).withLabel("Temperature unit"),
             e

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -1083,7 +1083,7 @@ export const definitions: DefinitionWithExtend[] = [
             e
                 .enum("sensor_mode", ea.ALL, ["air", "floor", "both", "percent"])
                 .withLabel("Sensor mode")
-                .withDescription("Sensor the thermostat regulates on. \"percent\" is regulator mode, also set via thermostat_mode."),
+                .withDescription('Sensor the thermostat regulates on. "percent" is regulator mode, also set via thermostat_mode.'),
             e.binary("frost", ea.STATE_SET, "ON", "OFF").withLabel("Frost Mode"),
             e.enum("temperature_display_mode", ea.STATE_SET, ["celsius", "fahrenheit"]).withLabel("Temperature unit"),
             e


### PR DESCRIPTION
Addresses the `sensor_mode` gap reported in Koenkk/zigbee2mqtt#32845.

`fzEdge.namron_private` already decodes attribute `0x8004` into `sensor_mode`, but there is no toZigbee converter and no expose for it, so the value appears in the payload and can never be set. On this device `0x8004` selects which physical sensor `local_temperature` is taken from, so that choice can currently only be made on the thermostat itself.

This adds `tzEdge.sensor_mode` following the existing `screen_on_time` pattern (write via `writeEdgeHvac(0x8004, ..., ENUM8)`, read via `entity.read`), registers it in `toZigbee`, and exposes it as `ea.ALL`. Purely additive — nothing renamed or removed.

### Keeping `thermostat_mode` consistent

@svhelge asked that `tzEdge.thermostat_mode` and `fzEdge.namron_private` keep behaving as expected. `sensor_mode: percent` is how this device represents regulator mode, and `thermostat_mode` is derived from it, so after writing, the converter recomputes `thermostat_mode` through the same `deriveEdgeThermostatMode()` that `fzEdge.namron_private` uses:

- `sensor_mode: percent` reports `thermostat_mode: regulator`
- any other value falls back to manual/schedule/eco, which is what `tzEdge.thermostat_mode` already does when it leaves regulator mode

### Tested on hardware

Namron 4512783, firmware 20241017 (OTA version 36), via zigbee2mqtt 2.12.1. Each value written to `0x8004` and read back:

| value | name | written | reads back |
|---|---|---|---|
| 0 | air | yes | 0 |
| 1 | floor | yes | 1 |
| 2 | both | yes | 2 |
| 3 | air2 | yes | 3 |
| 4 | both2 | yes | 4 |
| 5 | floor_percent | yes | 5 |
| 6 | percent | yes | 6 |

All seven are accepted and persist; the attribute reads back correctly in every case. Restored to `floor` afterwards. Only `air`, `floor`, `both` and `percent` are exposed — see below.

### Value names

I kept the names `fzEdge.namron_private` already publishes, since changing them would alter values already present in users' state and would also mean touching `deriveEdgeThermostatMode()`, which tests `sensor_mode === "percent"`.

The expose lists only the four whose meaning I can describe (`air`, `floor`, `both`, `percent`). Values 3, 4 and 5 are decoded as `air2`, `both2` and `floor_percent`; the device accepts and persists them, but I could not determine what they actually select, so I did not want to advertise them in a dropdown. The converter still accepts them by name.

@svhelge noted that `lib/namron.ts` `edgeThermostat.sensorMode()` uses `{air: 0, floor: 1, external: 3, regulator: 6}`. `external` is very likely the better name for value 3. Aligning with the library would be a clearer end state, but it renames published values and touches `tzEdge.thermostat_mode`, so it seemed better as a follow-up than bundled into an additive fix. Happy to do it here instead if you would rather.
