### PR TITLE
Add support for MakeGood MG-AU03GPOZLP-XX (TS0601, _TZE284_lq0ffndf) dual GPO + USB-C

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6803,6 +6803,47 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_lq0ffndf"]),
+        model: "MG-AU03GPOZLP-XX",
+        vendor: "Tuya",
+        description:
+            "Double GPO power point with USB-C and energy monitoring (also sold as Smartlink Automation 'Glass smart double power point with USB-C')",
+        whiteLabel: [
+            tuya.whitelabel("EyZEE", "0403-MG-GPO04ZSLP", "Double GPO socket + USB-C + backlight with energy metering", ["_TZE284_lq0ffndf"]),
+        ],
+        extend: [tuya.modernExtend.tuyaBase({dp: true}), m.deviceEndpoints({endpoints: {left: 1, right: 1}})],
+        exposes: [
+            e.switch().withEndpoint("left").setAccess("state", ea.STATE_SET).withDescription("Left socket"),
+            e.switch().withEndpoint("right").setAccess("state", ea.STATE_SET).withDescription("Right socket"),
+            e.voltage(),
+            e.current(),
+            e.power(),
+            e.energy(),
+            e.power_on_behavior().withAccess(ea.STATE_SET),
+            e.child_lock(),
+            tuya.exposes
+                .backlightModeOffOn()
+                .withAccess(ea.STATE_SET)
+                .withDescription(
+                    "Touch-panel LED behaviour when the outlet is switched off: ON keeps a dim standby glow, OFF " +
+                        "goes fully dark. Has no visible effect while the outlet is switched on.",
+                ),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state_left", tuya.valueConverter.onOff],
+                [2, "state_right", tuya.valueConverter.onOff],
+                [14, "power_on_behavior", tuya.valueConverter.powerOnBehavior],
+                [16, "backlight_mode", tuya.valueConverter.onOff],
+                [20, "energy", tuya.valueConverter.divideBy1000],
+                [21, "current", tuya.valueConverter.divideBy1000],
+                [22, "power", tuya.valueConverter.divideBy10],
+                [23, "voltage", tuya.valueConverter.divideBy10],
+                [101, "child_lock", tuya.valueConverter.lockUnlock],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", [
             "_TZE200_nkjintbl",
             "_TZE200_ji1gn7rw",


### PR DESCRIPTION
## Summary

Adds out-of-the-box support for a Tuya `TS0601` / `_TZE284_lq0ffndf` dual GPO power point with USB-C charging, sold under at least three brands: MakeGood (`MG-AU03GPOZLP-XX`, physical part number on the unit), Smartlink Automation ("Glass smart double power point with USB-C"), and EyZEE (`0403-MG-GPO04ZSLP`).

This combines two independently-tested DP maps for the exact same device:

- #31866 (external converter, filed May, auto-closed as stale) confirmed dp1/dp2 (left/right switch), dp16 (backlight), and dp21/22/23 (current/power/voltage).
- #32901 (new device support, filed by me in August) independently re-confirmed the switch/metering DPs via live testing, and additionally confirmed dp14 (`power_on_behavior`) and dp101 (`child_lock`, visually verified — locking makes the touch panel blink on press without operating the relay).

`dp16`/`backlight_mode` needed a correction along the way: my first pass at testing it left both relays switched ON the whole time and saw no visible change, so I initially reported it in #32901 as accepted-but-inert. It turns out the DP only affects the touch-panel LED **while the relay is off** (`OFF` → LED fully dark when the outlet is switched off, `ON` → LED stays a dim standby glow when off) — invisible while the relay is on, which is why both my own test and, presumably, the original #31866 reporter never mentioned this nuance. Added a description on the expose to make that discoverable.

## Test plan

- [x] `pnpm run check` (biome) — clean
- [x] `pnpm run build` (tsc + indexer) — clean, 4442 definitions processed
- [x] `pnpm run test` (vitest) — 800/800 passing, including `checks.test.ts` (model uniqueness, fingerprint uniqueness, etc.) and `tuya.test.ts`
- [x] Verified live against two physical units of this exact hardware: left/right switch, voltage/current/power, power_on_behavior, child_lock, and backlight_mode all confirmed working via Zigbee2MQTT + raw MQTT DP writes, cross-checked against Z2M debug logs (ZCL accept + `commandDataReport` echo) before being wired into the converter.

Closes #32901, relates to #31866.