### PR TITLE
feat: StuckAtPrototype AirCube: expose identify cluster

### DIFF
--- a/src/devices/stuckatprototype.ts
+++ b/src/devices/stuckatprototype.ts
@@ -118,6 +118,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             whenClusterPresent("msCO2", m.co2()),
             whenClusterPresent("msIlluminanceMeasurement", m.illuminance()),
+            m.identify(),
         ],
     },
 ];

--- a/test/stuckatprototype.test.ts
+++ b/test/stuckatprototype.test.ts
@@ -34,7 +34,7 @@ describe("StuckAtPrototype AirCube", () => {
         expect(definition.model).toBe("AirCube");
 
         expect(exposeNames(definition, device)).toEqual(
-            expect.arrayContaining(["temperature", "humidity", "eco2", "voc", "aqi", "brightness", "co2", "illuminance"]),
+            expect.arrayContaining(["temperature", "humidity", "eco2", "voc", "aqi", "brightness", "co2", "illuminance", "identify"]),
         );
         // Brightness is the only writable value.
         expect(definition.toZigbee?.find((converter) => converter.key.includes("brightness"))?.convertSet).toBeDefined();
@@ -53,7 +53,7 @@ describe("StuckAtPrototype AirCube", () => {
         expect(definition.model).toBe("AirCube");
 
         const names = exposeNames(definition, device);
-        expect(names).toEqual(expect.arrayContaining(["temperature", "humidity", "eco2", "voc", "aqi", "brightness"]));
+        expect(names).toEqual(expect.arrayContaining(["temperature", "humidity", "eco2", "voc", "aqi", "brightness", "identify"]));
         expect(names).not.toContain("co2");
         expect(names).not.toContain("illuminance");
 


### PR DESCRIPTION
The AirCube supports `genIdentify` but does not offer it yet, so it is added here in line with the recent identify additions (#12905, #12938).

Verified against paired hardware: the device's only endpoint (10) lists `genIdentify` among its input clusters, on both hardware variants. The existing test fixture already models that cluster set, so both the Base and the Pro test case now assert the `identify` expose as well.

No `version` bump: `m.identify()` adds an expose and a toZigbee converter only, no `configure`, so paired devices do not need to be re-configured.

Build, `check` and the full test suite (800 tests) pass locally.