### PR TITLE
feat: Shelly: expose identify cluster

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2395,6 +2395,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const ep = device.getEndpoint(2);
@@ -2444,6 +2445,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["1PMInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             const ep = device.getEndpoint(2);
@@ -2464,6 +2466,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
+            m.identify(),
         ],
     },
     {
@@ -2482,6 +2485,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.forcePowerSource({powerSource: "Mains (single phase)"}),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
     },
     {
@@ -2545,6 +2549,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["2PMCoverInputMode", "CoverTiltAuto"]),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             for (const epID of [2, 3]) {
@@ -2621,6 +2626,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["2PMSwitchInputMode"]),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             for (const epID of [3, 4]) {
@@ -2667,6 +2673,7 @@ export const definitions: DefinitionWithExtend[] = [
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyRPCSetup(["PowerstripUI", "PowerstripPowerOnBehavior"]),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
     },
     {
@@ -2689,6 +2696,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.battery({percentageReportingConfig: false}),
             m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low", "trouble"]}),
             ...shellyModernExtend.shellyCustomClusters(),
+            m.identify({isSleepy: true}),
         ],
     },
     {
@@ -2822,6 +2830,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             // Calculated values (added by PR #11437)
             shellyModernExtend.ws90CalculatedValues(),
+            m.identify({isSleepy: true}),
         ],
     },
     {
@@ -2837,6 +2846,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.electricityMeter(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
     },
     {
@@ -2860,14 +2870,14 @@ export const definitions: DefinitionWithExtend[] = [
         model: "SBHT-203C",
         vendor: "Shelly",
         description: "Humidity & temperature sensor",
-        extend: [m.battery(), m.temperature(), m.humidity()],
+        extend: [m.battery(), m.temperature(), m.humidity(), m.identify({isSleepy: true})],
     },
     {
         fingerprint: [{modelID: "BLU H&T Display ZB", manufacturerName: "Shelly"}],
         model: "SBHT-103C",
         vendor: "Shelly",
         description: "BLU H&T display Zigbee",
-        extend: [m.battery(), m.temperature(), m.humidity(), ...shellyModernExtend.shellyLightLevel()],
+        extend: [m.battery(), m.temperature(), m.humidity(), ...shellyModernExtend.shellyLightLevel(), m.identify({isSleepy: true})],
     },
     {
         fingerprint: [{modelID: "BLU Remote Control ZB", manufacturerName: "Shelly"}],

--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -2649,6 +2649,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.electricityMeter(),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
     },
     {
@@ -2863,6 +2864,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.commandsLevelCtrl({endpointNames: ["4"]}),
             ...shellyModernExtend.shellyCustomClusters(),
             shellyModernExtend.shellyWiFiSetup(),
+            m.identify(),
         ],
     },
     {


### PR DESCRIPTION
Continues #12905 / #12938 for Shelly: every definition in this file whose device lists `genIdentify` as an input cluster but does not offer the command yet — fourteen of them, which is all that were still missing.

## Which definitions and where the cluster listing comes from

| Model | Source of the cluster listing |
|---|---|
| `S4SW-001X8EU` (1 Mini) | Koenkk/zigbee2mqtt#32751, database entry: ep 1 `[0,3,4,5,6]` |
| `S4SW-001P8EU` (1PM Mini) | own hardware, 5 units: ep 1 carries cluster 3 |
| `S4EM-001PXCEU16` (EM Mini) | Koenkk/zigbee2mqtt#32804, endpoint dump: ep 1 input `genBasic, genIdentify, seMetering, …` |
| `S4EM-002CXCEU` (EM) | #12245 (the PR that added it) documents ep 1 as `genBasic, genIdentify, genGroups, genScenes, genOnOff` |
| `S4SW-002P16EU-COVER` / `-SWITCH` (2PM) | the fingerprints in this file already spell it out: ep 1 `inputClusters: [0, 3, …]`; also confirmed on own hardware (switch mode) |
| `S4PL-00416EU` (Power strip 4) | own hardware, 4 units |
| `S4PL-00116US` (Plug US) | ZHA device signature in zigpy/zha-device-handlers#5182: `model: "Plug US"`, ep 1 input `0x0000, 0x0003, 0x0004, 0x0005, 0x0006, 0x0702, 0x0b04, 0xfc21` |
| `S4SN-0071A` (Flood, + Flood S white label) | own hardware, one of each |
| `WS90` | own hardware |
| `S4DM-0A101WWL` (Dimmer) | Koenkk/zigbee2mqtt#31731, database entry for `Dimmer US`: ep 1 `[0,3,4,5,8,6,2820,1794]`; independently sprut/Hub#4826 for `Dimmer` lists `0003_Identify` on ep 1 |
| `S4DM-0010WW` (Dimmer 0/1-10V PM) | sprut/Hub#4827, cluster tree for `Dimmer 0-1/10`, firmware `1.8.99-dimmer0110vpmg4prod0`: ep 1 input lists `0003_Identify` |
| `SBHT-203C` (BLU H&T) | own hardware, 2 units |
| `SBHT-103C` (BLU H&T Display) | Koenkk/zigbee2mqtt#30881 lists ep 1 input `genBasic, genPowerCfg, genIdentify, …` |

## Notes

- **`isSleepy`** is used for the battery-powered ones (Flood, WS90, BLU H&T, BLU H&T Display) so the description mentions waking the device first. The battery-powered BLU entries that already had `identify` use the plain form; I left them untouched rather than mixing an unrelated change into this PR — say the word and I will align them here.
- **No `endpointNames`**: on every multi-endpoint definition touched here `genIdentify` sits on endpoint 1, which is also the endpoint a suffix-less key resolves to, so the plain form addresses the right endpoint and keeps the property name free of a suffix.
- **No `version` bump**: `identify()` contributes an expose and a toZigbee converter only, no `configure`, so nothing has to be re-configured.

Build, `check` and the full test suite (800 tests) pass locally.