### PR TITLE
feat: LEDVANCE 4099854295232/4099854293276: expose identify cluster

### DIFF
--- a/src/devices/ledvance.ts
+++ b/src/devices/ledvance.ts
@@ -86,7 +86,7 @@ export const definitions: DefinitionWithExtend[] = [
                 fingerprint: [{modelID: "PLUG EU EM T, black"}],
             },
         ],
-        extend: [ledvanceOnOff(), m.electricityMeter(), silenceDivisorReporting],
+        extend: [ledvanceOnOff(), m.electricityMeter(), silenceDivisorReporting, m.identify()],
     },
     {
         zigbeeModel: ["PLUG COMPACT OUTDOOR EU EM T", "PLUG COMPACT EU EM T"],
@@ -94,7 +94,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "LEDVANCE",
         description: "SMART+ Compact outdoor plug EU with energy meter",
         version: "0.0.1",
-        extend: [ledvanceOnOff(), m.electricityMeter(), silenceDivisorReporting],
+        extend: [ledvanceOnOff(), m.electricityMeter(), silenceDivisorReporting, m.identify()],
         ota: true,
     },
     {


### PR DESCRIPTION
In line with #12905 / #12938: both LEDVANCE metering plugs list `genIdentify` as an input cluster on endpoint 1 (`[0, 3, 4, 5, 6, 2821, 2820, 1794, 64528, 64519]`), verified on seven paired units — six `4099854295232` (`PLUG EU EM T`) and one `4099854293276` (`PLUG COMPACT EU EM T`). Being able to make a specific plug blink is useful when several identical ones sit behind furniture.

Limited to these two models on purpose: they are the ones I have a cluster listing for. The rest of the file very likely qualifies as well — happy to extend this PR if you want the whole vendor covered.

No `version` bump: `identify()` adds an expose and a toZigbee converter only, no `configure`.

Build, `check` and the full test suite (800 tests) pass locally.