### PR TITLE
feat: EGLO 900024/12253: expose identify cluster

### DIFF
--- a/src/devices/eglo.ts
+++ b/src/devices/eglo.ts
@@ -215,7 +215,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "EGLO",
         description: "RGB light",
         whiteLabel: [{vendor: "EGLO", model: "900878", description: "ANDREAS-Z pendant light"}],
-        extend: [m.light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"]}})],
+        extend: [m.light({colorTemp: {range: [153, 370]}, color: {modes: ["xy", "hs"]}}), m.identify()],
     },
     {
         zigbeeModel: ["EGLO_ZM_TW_CLP"],


### PR DESCRIPTION
In line with #12905 / #12938: the lamp lists `genIdentify` as an input cluster on endpoint 1 (`[0, 3, 4, 5, 6, 8, 768, 4096, 64599, 10]`), verified on two paired units.

Limited to this model because it is the one I have a cluster listing for; the rest of the file very likely qualifies too — happy to extend the PR if you prefer the whole vendor in one go.

No `version` bump: `identify()` adds an expose and a toZigbee converter only, no `configure`.

Build, `check` and the full test suite (800 tests) pass locally.