### PR TITLE
feat: L&S Lighting 756200027: expose identify cluster

### DIFF
--- a/src/devices/ls.ts
+++ b/src/devices/ls.ts
@@ -85,7 +85,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "L&S Lighting",
         description: "Mec Driver module 1-channel Zigbee (12V)",
         whiteLabel: [{model: "756200028", vendor: "L&S Lighting", description: "Mec Driver module 1-channel Zigbee (24V)"}],
-        extend: [m.light({colorTemp: {range: [153, 500]}})],
+        extend: [m.light({colorTemp: {range: [153, 500]}}), m.identify()],
     },
     {
         fingerprint: [


### PR DESCRIPTION
In line with #12905 / #12938: the driver module lists `genIdentify` as an input cluster on its endpoint 11 (`[0, 3, 4, 5, 6, 8, 768, 4096, 64770]`), verified on two paired units.

Only this definition is touched — it is the one I have a cluster listing for. The 4-channel sibling (`756200030`) is the same product family and presumably qualifies too, but I have no dump for it.

No `version` bump: `identify()` adds an expose and a toZigbee converter only, no `configure`.

Build, `check` and the full test suite (800 tests) pass locally.