### PR TITLE
feat: Aqara: expose identify cluster on seven devices

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -408,7 +408,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         fromZigbee: [lumi.fromZigbee.lumi_action_multistate, lumi.fromZigbee.lumi_action, lumi.fromZigbee.lumi_basic],
         toZigbee: [],
-        extend: [m.quirkCheckinInterval("1_HOUR")],
+        extend: [m.quirkCheckinInterval("1_HOUR"), m.identify({isSleepy: true})],
     },
     {
         zigbeeModel: ["lumi.sensor_switch.aq3", "lumi.sensor_swit"],

--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2070,7 +2070,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [lumi.fromZigbee.lumi_basic, lumi.fromZigbee.lumi_contact],
         toZigbee: [],
         exposes: [e.battery(), e.contact(), e.device_temperature(), e.battery_voltage(), e.power_outage_count(false), e.trigger_count()],
-        extend: [m.quirkCheckinInterval("1_HOUR"), m.forcePowerSource({powerSource: "Battery"})],
+        extend: [m.quirkCheckinInterval("1_HOUR"), m.forcePowerSource({powerSource: "Battery"}), m.identify({isSleepy: true})],
     },
     {
         zigbeeModel: ["lumi.sensor_wleak.aq1"],
@@ -2742,6 +2742,7 @@ export const definitions: DefinitionWithExtend[] = [
                 entityCategory: "diagnostic",
                 zigbeeCommandOptions: {manufacturerCode},
             }),
+            m.identify({isSleepy: true}),
         ],
     },
     {
@@ -2984,7 +2985,7 @@ export const definitions: DefinitionWithExtend[] = [
             await endpoint.read("genBasic", ["powerSource"]);
             await endpoint.read("closuresWindowCovering", ["currentPositionLiftPercentage"]);
         },
-        extend: [lumi.modernExtend.addManuSpecificLumiCluster(), lumiZigbeeOTA()],
+        extend: [lumi.modernExtend.addManuSpecificLumiCluster(), lumiZigbeeOTA(), m.identify({isSleepy: true})],
     },
     {
         zigbeeModel: ["lumi.relay.c2acn01"],
@@ -3747,7 +3748,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [fz.battery, lumi.fromZigbee.lumi_action_multistate, lumi.fromZigbee.lumi_specific, fz.command_toggle],
         toZigbee: [lumi.toZigbee.lumi_switch_click_mode, lumi.toZigbee.lumi_operation_mode_opple],
         meta: {battery: {voltageToPercentage: {min: 2850, max: 3000}}, multiEndpoint: true},
-        extend: [lumi.modernExtend.addManuSpecificLumiCluster(), m.quirkCheckinInterval("1_HOUR")],
+        extend: [lumi.modernExtend.addManuSpecificLumiCluster(), m.quirkCheckinInterval("1_HOUR"), m.identify({isSleepy: true})],
         exposes: [
             e.battery(),
             e.battery_voltage(),
@@ -4058,6 +4059,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.quirkCheckinInterval("1_HOUR"),
             lumiZigbeeOTA(),
             m.illuminance({reporting: false}),
+            m.identify({isSleepy: true}),
         ],
     },
     {
@@ -5256,6 +5258,7 @@ export const definitions: DefinitionWithExtend[] = [
             lumiLockRelay({description: "Lock right switch", endpointName: "right"}),
             lumiMultiClick({description: "Multi-click mode for left down button", endpointName: "left_down"}),
             lumiMultiClick({description: "Multi-click mode for right down button", endpointName: "right_down"}),
+            m.identify(),
         ],
     },
     {


### PR DESCRIPTION
In line with #12905 / #12938. All seven list `genIdentify` as an input cluster:

| Model | Endpoint 1 input clusters | Source |
|---|---|---|
| `MCCGQ11LM` (door/window sensor) | `[0, 3, 65535, 6]` | own hardware, 7 units |
| `WXKG11LM` (wireless mini switch) | `genBasic, genMultistateInput, genIdentify` | Koenkk/zigbee2mqtt#30857 (`lumi.remote.b1acn01`, firmware `3000-0001`) |
| `DWZTCGQ11LM` (vibration sensor) | `[257, 12, 6, 3, 0, 64704]` | own hardware |
| `ZNCLBL01LM` (curtain driver E1) | `[0, 1, 3, 64704, 258, 10]` | own hardware, 2 units |
| `WXKG15LM` (remote switch H1) | `[0, 3, 1]` (also ep 2 `[3]`, ep 3 `[18, 3]`) | own hardware |
| `GZCGQ11LM` (light sensor T1) | `[0, 1024, 3, 1]` | own hardware, 2 units |
| `WS-K08E` (light switch H2 EU) | `[2820, 1794, 18, 5, 4, 6, 3, 0, 64704]` | own hardware |

Notes:

- **`WXKG11LM`** is the one entry not backed by a device of mine: my two units are `lumi.remote.b1acn01`, but their cluster listing was never stored, so the listing above comes from another user's dump of the same model and firmware. The older `lumi.sensor_switch.aq2` shares this definition and I have no listing for it.
- **`isSleepy`** is set on the six battery-powered devices so the description tells users the device may have to be woken up first — for an Aqara sensor that is the difference between "identify is broken" and "press the button once, then send it". The `identify` entries already in this file use the plain form; I did not touch them, but I am happy to align either direction.
- **No `endpointNames`**: on `WXKG15LM` and `WS-K08E` the cluster is present on endpoint 1, which is also the endpoint a suffix-less key resolves to, so the plain form addresses the right endpoint and keeps the property name free of a suffix.
- **No `version` bump**: `identify()` adds an expose and a toZigbee converter only, no `configure`.

Build, `check` and the full test suite (800 tests) pass locally.