### PR TITLE
feat: Tuya TS011F_with_threshold, COOLO CS-201Z: expose identify cluster

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -16686,6 +16686,7 @@ export const definitions: DefinitionWithExtend[] = [
                 onOffCountdown: true,
                 childLock: true,
             }),
+            m.identify(),
         ],
         fromZigbee: [fz.temperature, fzLocal.TS011F_threshold],
         toZigbee: [tzLocal.TS011F_threshold],
@@ -24657,7 +24658,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "CS-201Z",
         vendor: "COOLO",
         description: "Soil moisture sensor",
-        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        extend: [tuya.modernExtend.tuyaBase({dp: true}), m.identify({isSleepy: true})],
         whiteLabel: [
             {
                 model: "AY-303Z",


### PR DESCRIPTION
In line with #12905 / #12938. Both definitions' devices list `genIdentify` as an input cluster on endpoint 1:

| Definition | Endpoint 1 input clusters | Verified on |
|---|---|---|
| `TS011F_with_threshold` (DIN rail switch) | `[0, 3, 4, 5, 6, 1794, 2820, 1026, 57344, 57345]` | five units, `_TZ3000_cayepv1a` (Tongou `TO-Q-SY2-163JZT`) |
| `CS-201Z` (soil moisture sensor) | `[0, 3, 61184, 1026, 1029, 1]` | one unit, `ZG-303Z` / HOBEIAN |

Two things worth flagging:

- The `TS011F_with_threshold` fingerprint covers nine manufacturer names. My listing is from `_TZ3000_cayepv1a` only; the others are the same TS011F DIN rail breaker, but I cannot show a dump for them. If you would rather have this scoped down, say so and I will split it.
- `CS-201Z` is battery-powered, so it uses `{isSleepy: true}` — the description then tells users the device may need to be woken up before the command arrives.

No `version` bump: `identify()` adds an expose and a toZigbee converter only, no `configure`.

Build, `check` and the full test suite (800 tests) pass locally.