### PR TITLE
fix: Namron 4512763: expose battery

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -2402,9 +2402,15 @@ export const definitions: DefinitionWithExtend[] = [
         model: "4512763",
         vendor: "Namron",
         description: "Zigbee movement sensor",
-        fromZigbee: [fz.ias_occupancy_alarm_1],
+        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery],
         toZigbee: [],
-        exposes: [e.occupancy()],
+        exposes: [e.occupancy(), e.tamper(), e.battery_low(), e.battery(), e.battery_voltage()],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
+            await reporting.batteryPercentageRemaining(endpoint);
+            await reporting.batteryVoltage(endpoint);
+        },
     },
     {
         zigbeeModel: ["4512764"],

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -2402,15 +2402,10 @@ export const definitions: DefinitionWithExtend[] = [
         model: "4512763",
         vendor: "Namron",
         description: "Zigbee movement sensor",
-        fromZigbee: [fz.ias_occupancy_alarm_1, fz.battery],
+        fromZigbee: [fz.ias_occupancy_alarm_1],
         toZigbee: [],
-        exposes: [e.occupancy(), e.tamper(), e.battery_low(), e.battery(), e.battery_voltage()],
-        configure: async (device, coordinatorEndpoint) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg"]);
-            await reporting.batteryPercentageRemaining(endpoint);
-            await reporting.batteryVoltage(endpoint);
-        },
+        exposes: [e.occupancy(), e.tamper()],
+        extend: [m.battery({voltage: true, lowStatus: true})],
     },
     {
         zigbeeModel: ["4512764"],


### PR DESCRIPTION
The definition only exposed `occupancy`, but the device has `genPowerCfg` and reports both battery attributes. `fz.ias_occupancy_alarm_1` was already publishing `tamper` and `battery_low` without them being declared in `exposes`.

Adds battery and voltage, and declares tamper and battery_low. Matches the sibling `4512762` door sensor.

Published state after the change:

```
{"battery":60,"battery_low":false,"linkquality":255,"occupancy":false,"tamper":false,"voltage":2800}
```

<details>
<summary>Device dump</summary>

```json
{
  "type": "EndDevice",
  "ieeeAddr": "0xa4c138abcdf8506f",
  "manufId": 4714,
  "manufName": "Namron AS",
  "powerSource": "Battery",
  "modelId": "4512763",
  "epList": [1],
  "endpoints": {
    "1": {
      "profId": 260,
      "epId": 1,
      "devId": 1026,
      "inClusterList": [0, 1, 3, 1280, 32, 2821],
      "outClusterList": [25],
      "clusters": {
        "genPowerCfg": {
          "attributes": {
            "batteryVoltage": 28,
            "batteryPercentageRemaining": 120
          }
        },
        "genBasic": {
          "attributes": {
            "modelId": "4512763",
            "manufacturerName": "Namron AS",
            "powerSource": 3,
            "zclVersion": 3,
            "appVersion": 0,
            "stackVersion": 2,
            "hwVersion": 0,
            "dateCode": "20230327",
            "swBuildId": "2.04"
          }
        },
        "ssIasZone": {
          "attributes": {
            "iasCieAddr": "0x00212effff083e5a",
            "zoneState": 1
          }
        },
        "genPollCtrl": {
          "attributes": {
            "checkinInterval": 28800
          }
        }
      },
      "binds": [
        {
          "cluster": 32,
          "type": "endpoint",
          "deviceIeeeAddress": "0x00212effff083e5a",
          "endpointID": 1
        },
        {
          "cluster": 1,
          "type": "endpoint",
          "deviceIeeeAddress": "0x00212effff083e5a",
          "endpointID": 1
        }
      ],
      "configuredReportings": [
        {
          "cluster": 1,
          "attrId": 33,
          "minRepIntval": 3600,
          "maxRepIntval": 65000,
          "repChange": 10
        }
      ],
      "meta": {}
    }
  }
}
```

</details>

Tested on hardware, swBuildId 2.04, Z2M 2.6.3.