### PR TITLE
Namron 4512792: fix power and current scaling

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -2670,9 +2670,9 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.onOff(),
             m.electricityMeter({
-                power: {multiplier: 1, divisor: 10}, // W
+                power: {multiplier: 1, divisor: 1}, // W
                 voltage: {multiplier: 1, divisor: 10}, // V -> 2383 -> 238.3
-                current: {multiplier: 1, divisor: 100}, // A
+                current: {multiplier: 1, divisor: 1000}, // mA -> 4700 -> 4.7
                 energy: {multiplier: 1, divisor: 100}, // kWh
             }),
         ],

--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -2667,6 +2667,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "4512792",
         vendor: "Namron",
         description: "Simplify 1-2p relay (Zigbee / BT)",
+        version: "0.0.1",
         extend: [
             m.onOff(),
             m.electricityMeter({


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
The `power` and `current` divisors for the `Namron 4512792` are each off by a factor of 10. Verified with a hair dryer that is marked with 1000-1200W, tested live against production zigbee2mqtt (2.13.0) with an external converter before submitting this change.

**Measurements**:

| Load | old Power | old Current | new Power | new Current |
|---|---|---|---|---|
| Lights only | 4 W | 1.7 A | 41 W | 0.17 A |
| Lights + Hairdryer step 1 | 57 W | 24.3 A | 575 W | 2.43 A |
| Lights + Hairdryer step 2 | 110 W | 46.5 A | 1105 W | 4.65 A |

Related: Koenkk/zigbee2mqtt#30231.
