### PR TITLE
URC4460BC0-X-R (XHS2-UE): fix excessive battery drain by configuring genPollCtrl longPollInterval

### DIFF
--- a/src/devices/universal_electronics_inc.ts
+++ b/src/devices/universal_electronics_inc.ts
@@ -38,6 +38,29 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["msTemperatureMeasurement", "genPowerCfg"]);
             await reporting.temperature(endpoint);
             await reporting.batteryVoltage(endpoint);
+            // longPollInterval ships at 8 qs (2 s); the ZHA driver writes 24 qs (6 s).
+            // At 2 s: 43,200 MAC polls/day vs 14,400/day at 6 s — 3× drain difference.
+            // longPollInterval is read-only; must be set via setLongPollInterval command (0x02).
+            try {
+                await endpoint.command("genPollCtrl", "setLongPollInterval", {newLongPollInterval: 24});
+                await endpoint.write("genPollCtrl", {checkinInterval: 13200});
+            } catch {
+                // Sleepy device may not ack before going to sleep; not fatal.
+            }
+        },
+        onEvent: async (event) => {
+            // Battery replacement resets longPollInterval to factory default (8 qs / 2 s).
+            // Reapply on deviceAnnounce to restore the correct value after every battery swap.
+            if (event.type === "deviceAnnounce") {
+                const endpoint = event.data?.device?.getEndpoint(1);
+                if (!endpoint) return;
+                try {
+                    await endpoint.command("genPollCtrl", "setLongPollInterval", {newLongPollInterval: 24});
+                    await endpoint.write("genPollCtrl", {checkinInterval: 13200});
+                } catch {
+                    // Will retry on next announce.
+                }
+            }
         },
         exposes: [e.contact(), e.battery_low(), e.tamper(), e.temperature(), e.battery()],
     },


### PR DESCRIPTION
### Problem

Users of the XHS2-UE magnetic contact sensor report batteries draining in **1–4 weeks** under
Zigbee2MQTT, compared to ~1 year under ZHA or Xfinity's own hub.

Tracking issue: Koenkk/zigbee2mqtt#21490

### Root cause

The device ships with `longPollInterval` at **8 quarter-seconds (2 s)**. The ZHA driver writes
**24 qs (6 s)** during pairing. The current `configure()` step does not touch the genPollCtrl
cluster at all, so every device paired to Z2M runs at the factory default.

| Poll rate | MAC polls/day |
|-----------|--------------|
| 2 s (stock / Z2M before this PR) | 43,200 |
| 6 s (ZHA / this fix) | 14,400 |

28,800 extra MAC layer polls per day, on every sensor, continuously — that is the entire battery
drain story.

Two ZCL details this fix accounts for:

1. `longPollInterval` (attribute 0x0001) is **read-only**. It cannot be set with an attribute
   write. It must be set using the `setLongPollInterval` cluster command (0x02).
2. **A battery replacement resets the device to factory defaults.** Without a `deviceAnnounce`
   handler, every battery swap re-introduces the drain until the user manually reconfigures.

`checkinInterval` is also halved vs. ZHA (6480 qs / 27 min stock vs. 13200 qs / 55 min), though
this contributes less than 1% of the drain difference.

### Fix

- Add `setLongPollInterval(24)` and `write checkinInterval: 13200` to `configure()`.
- Add an `onEvent` handler that reapplies both on `deviceAnnounce` to survive battery swaps.

### Evidence

Tested on 34 XHS2-UE sensors over 23 days after applying this fix as an external converter in a
production installation:

- **Before**: sensors dying within 2–3 weeks after migration from ZHA to Z2M
- **After**: zero battery deaths across all 34 sensors at day 23
- `longPollInterval` confirmed stable at 6 s via live MQTT GET reads at 48 h and 7 days post-configure
- All 34 sensors received the new setting within 52 minutes of deployment (delivered on their next
  genPollCtrl check-in cycle)
