### PR TITLE
fix: remove unsupported battery reporting from BN-600085

### DIFF
--- a/src/devices/dresden_elektronik.ts
+++ b/src/devices/dresden_elektronik.ts
@@ -118,7 +118,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Dresden Elektronik",
         description: "3 part zigbee powered scene switch",
         ota: true,
-        extend: [m.commandsOnOff(), m.commandsLevelCtrl(), m.commandsColorCtrl(), m.commandsScenes(), m.battery()],
+        extend: [m.commandsOnOff(), m.commandsLevelCtrl(), m.commandsColorCtrl(), m.commandsScenes()],
     },
     {
         zigbeeModel: ["Lighting Switch"],


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#32886.

The Dresden Elektronik BN-600085 does not advertise `genPowerCfg` in its input cluster list. Its `m.battery()` extension therefore causes configuration to fail in `getEndpointsWithCluster()`.

Remove the unsupported battery extension while keeping all command converters unchanged.

Validated with:
- `pnpm run check`
- `pnpm run build`
- `pnpm test` (800 tests passed)