### PR TITLE
fix(profalux): correct cluster name in MAI-ZTM20C configure

### DIFF
--- a/src/devices/profalux.ts
+++ b/src/devices/profalux.ts
@@ -248,7 +248,7 @@ export const definitions: DefinitionWithExtend[] = [
             const endpoint2 = device.getEndpoint(2);
             // Bind clusters
             await reporting.bind(endpoint1, coordinatorEndpoint, ["genLevelCtrl"]);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ["genPowerCfg", "closureWindowCovering"]);
+            await reporting.bind(endpoint2, coordinatorEndpoint, ["genPowerCfg", "closuresWindowCovering"]);
             // Configure battery voltage reporting from endpoint 2
             await reporting.batteryVoltage(endpoint2, {min: 3600, max: repInterval.MAX, change: 1});
         },


### PR DESCRIPTION
`configure` for the MAI-ZTM20C cover remote binds a cluster named `closureWindowCovering`, which does not exist. ZCL cluster 0x102 is named `closuresWindowCovering` in zigbee-herdsman, consistently with its siblings `closuresShadeCfg` and `closuresDoorLock`. This same file already uses the correct name on lines 95, 135 and 154.

As a result `configure` throws for every MAI-ZTM20C:
```
    Failed to configure '<device>', attempt 1
    (Error: Cluster with name 'closureWindowCovering' does not exist
      at Object.bind (src/lib/reporting.ts:48:24)
      at configure (src/devices/profalux.ts:177:13))
```

The device is never marked as configured, so Zigbee2MQTT retries on every restart, and battery voltage reporting on endpoint 2 is never set up.

TypeScript cannot catch this: `reporting.bind` takes `(number | string)[]` rather than a cluster-name union, unlike `configureReporting` a few lines below which is generic over the cluster name.

Seen on Zigbee2MQTT 2.8.0 (zigbee-herdsman-converters 25.120.0).

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
