### PR TITLE
feat(zigbeetlc): add Tuya TH05-z (ZTH05) support

### DIFF
--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -281,6 +281,32 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         ota: true,
     },
+    {
+        // ZTH05 (TS0601/_TZE204_upagmta9) with ZigbeeTLc firmware; requires hardware mod
+        // https://pvvx.github.io/TS0601_TZE204/
+        zigbeeModel: ["TH05-z"],
+        model: "TH05-z",
+        vendor: "Tuya",
+        description: "ZTH05 temperature & humidity sensor (pvvx/ZigbeeTLc)",
+        extend: [
+            m.temperature({reporting: {min: "10_SECONDS", max: "1_HOUR", change: 10}}),
+            m.humidity(),
+            extend.enableDisplay,
+            extend.temperatureDisplayMode,
+            extend.comfortSmiley,
+            extend.comfortTemperatureMin,
+            extend.comfortTemperatureMax,
+            extend.comfortHumidityMin,
+            extend.comfortHumidityMax,
+            extend.temperatureCalibration,
+            extend.humidityCalibration,
+            extend.measurementInterval,
+            m.battery({
+                voltage: true,
+            }),
+        ],
+        ota: true,
+    },
     /*
         ZigbeeTLc devices supporting:
         - Temperature (+calibration)


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5437

## Summary
- Add `TH05-z` (Tuya ZTH05 with pvvx/ZigbeeTLc firmware) to `src/devices/zigbeetlc.ts`
- Full LCD + comfort set (display, smiley, calibrations, measurement interval, battery+voltage, OTA)
- Hardware mod required: https://pvvx.github.io/TS0601_TZE204/

## Test plan
- [x] Paired as `TH05-z` after ZigbeeTLc flash
- [x] Temperature / humidity / battery (+ voltage) report
- [x] Display / smiley / calibration / measurement interval exposes work
- [x] OTA via Z2M (optional check)

Made with [Cursor](https://cursor.com)