### PR TITLE
feat(add): CS-T10C

### DIFF
--- a/src/devices/ezviz.ts
+++ b/src/devices/ezviz.ts
@@ -3,6 +3,13 @@ import type {DefinitionWithExtend} from "../lib/types";
 
 export const definitions: DefinitionWithExtend[] = [
     {
+        zigbeeModel: ["CS-T10C-A0-BG"],
+        model: "CS-T10C",
+        vendor: "EZVIZ",
+        description: "Water leak sensor",
+        extend: [m.battery(), m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low"]})],
+    },
+    {
         zigbeeModel: ["CS-T2C-A0-BG"],
         model: "CS-T2C",
         vendor: "EZVIZ",


### PR DESCRIPTION
## Device

| | |
|---|---|
| Vendor | EZVIZ |
| Model | CS-T10C (CS-T10C-A0-BG) |
| Type | Water leak sensor, battery (CR2477-class), EndDevice |
| Zigbee2MQTT | 2.13.0 |
| zigbee-herdsman-converters | 26.90.0 |

Currently matched by the auto-generated fallback (`supported: false`,
`description: "Automatically generated definition"`), so it exposes raw
`alarm_1` / `alarm_2` rather than a `water_leak` binary sensor.

## Interview data

```
modelID        : 'CS-T10C-A0-BG\x00\x00\x00\x00'   <- note trailing NUL bytes
manufacturerName: 'EZVIZ'
powerSource    : Battery
type           : EndDevice
endpoint 1
  input clusters : [0 genBasic, 1 genPowerCfg, 3 genIdentify, 1280 ssIasZone, 65024]
  output clusters: [25 genOta, 65024]
```

Cluster 65024 is manufacturer-specific and not required for the leak/battery
functionality.

## Observed behaviour

The fallback advertises exposes that do not line up with the published state.

Definition exposes (what Home Assistant discovery consumes):

```
battery, alarm_1, alarm_2, tamper, battery_low, linkquality
```

Published state on `zigbee2mqtt/<device>` after a Zone Status Change Notification:

```json
{"alarm_1": false, "alarm_2": false, "battery": 100, "battery_low": false,
 "linkquality": 98, "tamper": false, "water_leak": false}
```

`water_leak` is published but never advertised, so no moisture-class binary sensor
is created. `alarm_1` duplicates `water_leak` under an opaque name, and `alarm_2` is
a decode artifact of the `zoneStatus` bitmap rather than a device feature — see below.

With the definition below the exposes become `battery`, `water_leak`, `tamper`,
`battery_low`, matching what the device actually reports.

## Proposed definition

`src/devices/ezviz.ts` already contains CS-T2C (open/close sensor) which is the
same family and shape — this follows it exactly, with `zoneType: "water_leak"`:

```ts
{
    zigbeeModel: ["CS-T10C-A0-BG"],
    model: "CS-T10C",
    vendor: "EZVIZ",
    description: "Water leak sensor",
    extend: [m.battery(), m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "tamper", "battery_low"]})],
},
```

### Why `alarm_2` is omitted

`alarm_2` is not a feature of this device. The ZCL Zone Type dictates the meaning of
the Alarm1 / Alarm2 bits in `zoneStatus`, and for Water Sensor (`0x002A`) only Alarm1
is assigned — water overflow indication. Alarm2 has no meaning for this zone type, so
the bit is never set and `alarm_2` decodes to a permanent `false`.

Keeping it would also change the generated exposes, since `iasZoneAlarm` collapses to
the plain zone-type name only when a single alarm attribute is listed:

```
alarm_1, alarm_2, tamper, battery_low  ->  water_leak_alarm_1, water_leak_alarm_2, tamper, battery_low
alarm_1, tamper, battery_low           ->  water_leak, tamper, battery_low
```

CS-T2C lists all four, which is why it produces the prefixed pair. Dropping `alarm_2`
here gives the conventional `water_leak` binary sensor and removes an entity that
could only ever read `false`.

### Note on the model ID

The device pads `modelId` with **NUL bytes**, not spaces:
`'CS-T10C-A0-BG\x00\x00\x00\x00'`. Zigbee2MQTT strips these before matching, so
`zigbeeModel: ["CS-T10C-A0-BG"]` matches — this is stated in case a `fingerprint`
is preferred instead.

## Pairing note

The initial interview failed with:

```
ZCL command ssIasZone.read(["iasCieAddr","zoneState"]) failed
Failed to configure: Bind genPowerCfg failed
```

because the sensor slept before responding. Re-triggering the device (bridging the
probes) during the interview lets it complete. This is device behaviour rather than a
converter issue, but may be worth a line in the device page.
