### PR TITLE
feat(openlumi): add gateway model aliases

### DIFF
--- a/src/devices/openlumi.ts
+++ b/src/devices/openlumi.ts
@@ -3,7 +3,7 @@ import type {DefinitionWithExtend} from "../lib/types";
 
 export const definitions: DefinitionWithExtend[] = [
     {
-        zigbeeModel: ["openlumi.gw_router.jn5169"],
+        zigbeeModel: ["openlumi.gw_router.jn5169", "openlumi.gw_router.dgnwg05lm", "openlumi.gw_router.zhwg11lm"],
         model: "GWRJN5169",
         vendor: "OpenLumi",
         description: "Lumi Router (JN5169)",


### PR DESCRIPTION
Add DGNWG05LM and ZHWG11LM model identifiers to the existing OpenLumi GWRJN5169 definition.