### PR TITLE
fix(sonoff): filter out invalid 0 value for TRV timer_mode_target_temp

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -7230,6 +7230,23 @@ const sonoffExtend = {
     },
 };
 
+// Filter out 0 value for timer_mode_target_temp, as 0 indicates "no timer target temperature set"
+// and would be outside the valid range of 4-35°C, causing Home Assistant validation errors.
+// See: https://github.com/Koenkk/zigbee-herdsman-converters/issues/12847
+const trvzbTimerModeTempFzConvert: Fz.Converter<"customSonoffTrvzb", SonoffTrvzb, ["attributeReport", "readResponse"]>["convert"] = (
+    model,
+    msg,
+    publish,
+    options,
+    meta,
+) => {
+    const value = msg.data["temporaryModeTemp"];
+    if (value !== undefined && value !== 0) {
+        return {timer_mode_target_temp: value / 100};
+    }
+    return undefined;
+};
+
 export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["NSPanelP-Router", "Cuber ZLI Router"],
@@ -8299,6 +8316,7 @@ export const definitions: DefinitionWithExtend[] = [
                 valueStep: 0.5,
                 unit: "°C",
                 scale: 100,
+                fzConvert: trvzbTimerModeTempFzConvert,
             }),
             m.numeric<"customSonoffTrvzb", SonoffTrvzb>({
                 name: "temporary_mode_duration",


### PR DESCRIPTION
## Summary

Fix `SONOFF TRVZB` publishing an invalid `timer_mode_target_temp` value of `0` when no timer target temperature is set.

## Changes

* Filter out the invalid `0` value from the `temporaryModeTemp` attribute in the `fromZigbee` converter.
* Prevent `timer_mode_target_temp: 0` from being published when no timer target temperature is configured.

The valid exposed temperature range is `4-35°C`, while the device returns `0` to indicate that no timer target temperature is set. Publishing this value causes validation errors in Home Assistant.

## Related

- Fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/12847