### PR TITLE
feat: Shelly BLU TRV: add external occupancy support

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -397,10 +397,24 @@ interface ShellyTRVExternalTemperatureRequest {
     attempts: number;
 }
 
+/**
+ * Tracks an external occupancy value until the TRV reports the same state.
+ */
+interface ShellyTRVExternalOccupancyRequest {
+    occupancy: boolean;
+    createdAt: number;
+    lastAttemptAt: number;
+    attempts: number;
+}
+
 const SHELLY_TRV_EXTERNAL_TEMPERATURE_META_KEY = "shelly_trv_external_temperature_request";
 const SHELLY_TRV_EXTERNAL_TEMPERATURE_MIN_RETRY_INTERVAL_MS = 1500;
 const SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_ATTEMPTS = 30;
 const SHELLY_TRV_EXTERNAL_TEMPERATURE_MAX_AGE_MS = 60 * 60 * 1000;
+const SHELLY_TRV_EXTERNAL_OCCUPANCY_META_KEY = "shelly_trv_external_occupancy_request";
+const SHELLY_TRV_EXTERNAL_OCCUPANCY_MIN_RETRY_INTERVAL_MS = 1500;
+const SHELLY_TRV_EXTERNAL_OCCUPANCY_MAX_ATTEMPTS = 30;
+const SHELLY_TRV_EXTERNAL_OCCUPANCY_MAX_AGE_MS = 60 * 60 * 1000;
 
 interface ShellyLightLevel {
     attributes: {
@@ -2201,6 +2215,17 @@ function shellyTRVGetRemoteSensing(endpoint: Zh.Endpoint, state: KeyValue = {}, 
 }
 
 /**
+ * Adds every source bit required by a pending external-input request.
+ * This prevents concurrent temperature and occupancy retries from clearing each other's bit.
+ */
+function shellyTRVRequiredRemoteSensing(device: Zh.Device, remoteSensing: number): number {
+    let required = remoteSensing;
+    if (shellyTRVGetExternalTemperatureRequest(device)) required |= 1;
+    if (shellyTRVGetExternalOccupancyRequest(device)) required |= 1 << 2;
+    return required;
+}
+
+/**
  * Enables the external local-temperature source while preserving the other RemoteSensing bits.
  */
 async function shellyTRVEnableRemoteTemperature(endpoint: Zh.Endpoint, remoteSensing: number): Promise<number> {
@@ -2291,7 +2316,7 @@ const fzShellyTRVExternalTemperature = {
         if (Date.now() - request.lastAttemptAt < SHELLY_TRV_EXTERNAL_TEMPERATURE_MIN_RETRY_INTERVAL_MS) return;
 
         const reserved = shellyTRVReserveExternalTemperatureAttempt(msg.device, request);
-        shellyTRVDeliverExternalTemperature(msg.endpoint, reserved, remoteSensing).catch((error) =>
+        shellyTRVDeliverExternalTemperature(msg.endpoint, reserved, shellyTRVRequiredRemoteSensing(msg.device, remoteSensing)).catch((error) =>
             logger.debug(`Failed to retry external temperature for '${msg.device.ieeeAddr}': ${error}`, NS),
         );
     },
@@ -2317,7 +2342,7 @@ const tzShellyTRVExternalTemperature = {
         const reserved = shellyTRVReserveExternalTemperatureAttempt(entity.getDevice(), request);
 
         try {
-            await shellyTRVDeliverExternalTemperature(entity, reserved, remoteSensing);
+            await shellyTRVDeliverExternalTemperature(entity, reserved, shellyTRVRequiredRemoteSensing(entity.getDevice(), remoteSensing));
         } catch (error) {
             logger.debug(`Initial external temperature delivery to '${entity.getDevice().ieeeAddr}' failed: ${error}`, NS);
         }
@@ -2346,9 +2371,198 @@ const shellyTRVExternalTemperatureOnEvent: OnEvent.Handler = (event) => {
 
     const remoteSensing = shellyTRVGetRemoteSensing(endpoint, event.data.state);
     const reserved = shellyTRVReserveExternalTemperatureAttempt(event.data.device, request);
-    shellyTRVDeliverExternalTemperature(endpoint, reserved, remoteSensing).catch((error) =>
+    shellyTRVDeliverExternalTemperature(endpoint, reserved, shellyTRVRequiredRemoteSensing(event.data.device, remoteSensing)).catch((error) =>
         logger.debug(`Failed to deliver external temperature after announce from '${event.data.device.ieeeAddr}': ${error}`, NS),
     );
+};
+
+/**
+ * Returns the persisted pending external occupancy request for a TRV.
+ */
+function shellyTRVGetExternalOccupancyRequest(device: Zh.Device): ShellyTRVExternalOccupancyRequest | undefined {
+    const request = device.meta[SHELLY_TRV_EXTERNAL_OCCUPANCY_META_KEY];
+    if (typeof request !== "object" || request === null) return undefined;
+
+    return request as ShellyTRVExternalOccupancyRequest;
+}
+
+/**
+ * Stores the pending external occupancy request in the device metadata.
+ */
+function shellyTRVPutExternalOccupancyRequest(device: Zh.Device, request: ShellyTRVExternalOccupancyRequest, persist = true): void {
+    device.meta[SHELLY_TRV_EXTERNAL_OCCUPANCY_META_KEY] = request;
+    if (persist) device.save();
+}
+
+/**
+ * Clears the persisted pending external occupancy request for a TRV.
+ */
+function shellyTRVClearExternalOccupancyRequest(device: Zh.Device): void {
+    if (!(SHELLY_TRV_EXTERNAL_OCCUPANCY_META_KEY in device.meta)) return;
+
+    delete device.meta[SHELLY_TRV_EXTERNAL_OCCUPANCY_META_KEY];
+    device.save();
+}
+
+function shellyTRVCreateExternalOccupancyRequest(occupancy: boolean): ShellyTRVExternalOccupancyRequest {
+    return {
+        occupancy,
+        createdAt: Date.now(),
+        lastAttemptAt: 0,
+        attempts: 0,
+    };
+}
+
+function shellyTRVReserveExternalOccupancyAttempt(device: Zh.Device, request: ShellyTRVExternalOccupancyRequest): ShellyTRVExternalOccupancyRequest {
+    const reserved = {
+        ...request,
+        lastAttemptAt: Date.now(),
+        attempts: request.attempts + 1,
+    };
+    shellyTRVPutExternalOccupancyRequest(device, reserved, false);
+    return reserved;
+}
+
+/**
+ * Enables the external occupancy source while preserving the other RemoteSensing bits.
+ */
+async function shellyTRVEnableRemoteOccupancy(endpoint: Zh.Endpoint, remoteSensing: number): Promise<number> {
+    const enabled = remoteSensing | (1 << 2);
+    if (enabled !== remoteSensing) {
+        await endpoint.write("hvacThermostat", {remoteSensing: enabled}, {disableResponse: true, disableDefaultResponse: true});
+    }
+    return enabled;
+}
+
+/**
+ * Sends occupancy as the attribute report of an Occupancy Sensing server.
+ */
+async function shellyTRVSendExternalOccupancy(endpoint: Zh.Endpoint, request: ShellyTRVExternalOccupancyRequest): Promise<void> {
+    await endpoint.report(
+        "msOccupancySensing",
+        {occupancy: request.occupancy ? 1 : 0},
+        {
+            direction: Zcl.Direction.SERVER_TO_CLIENT,
+            srcEndpoint: 1,
+            disableResponse: true,
+            disableDefaultResponse: true,
+        },
+    );
+}
+
+async function shellyTRVDeliverExternalOccupancy(
+    endpoint: Zh.Endpoint,
+    request: ShellyTRVExternalOccupancyRequest,
+    remoteSensing: number,
+): Promise<void> {
+    await shellyTRVEnableRemoteOccupancy(endpoint, remoteSensing);
+    await shellyTRVSendExternalOccupancy(endpoint, request);
+}
+
+function shellyTRVExternalOccupancyIsConfirmed(
+    request: ShellyTRVExternalOccupancyRequest,
+    occupancy: number | undefined,
+    remoteSensing: number,
+): boolean {
+    return occupancy !== undefined && ((occupancy & 1) !== 0) === request.occupancy && (remoteSensing & (1 << 2)) !== 0;
+}
+
+function shellyTRVExternalOccupancyIsExpired(request: ShellyTRVExternalOccupancyRequest): boolean {
+    return (
+        request.attempts >= SHELLY_TRV_EXTERNAL_OCCUPANCY_MAX_ATTEMPTS || Date.now() - request.createdAt >= SHELLY_TRV_EXTERNAL_OCCUPANCY_MAX_AGE_MS
+    );
+}
+
+/**
+ * Confirms external occupancy from thermostat reports and retries it during a wake window.
+ */
+const fzShellyTRVExternalOccupancy = {
+    cluster: "hvacThermostat",
+    type: ["attributeReport", "readResponse"],
+    convert: (model, msg, publish, options, meta) => {
+        const request = shellyTRVGetExternalOccupancyRequest(msg.device);
+        if (!request) return;
+
+        const remoteSensing = shellyTRVGetRemoteSensing(
+            msg.endpoint,
+            meta.state,
+            typeof msg.data.remoteSensing === "number" ? msg.data.remoteSensing : undefined,
+        );
+
+        if (shellyTRVExternalOccupancyIsConfirmed(request, msg.data.occupancy, remoteSensing)) {
+            shellyTRVClearExternalOccupancyRequest(msg.device);
+            logger.debug(`External occupancy ${request.occupancy} was confirmed by '${msg.device.ieeeAddr}'`, NS);
+            return;
+        }
+
+        if (shellyTRVExternalOccupancyIsExpired(request)) {
+            shellyTRVClearExternalOccupancyRequest(msg.device);
+            logger.warning(`External occupancy ${request.occupancy} was not confirmed by '${msg.device.ieeeAddr}'`, NS);
+            return;
+        }
+
+        if (Date.now() - request.lastAttemptAt < SHELLY_TRV_EXTERNAL_OCCUPANCY_MIN_RETRY_INTERVAL_MS) return;
+
+        const reserved = shellyTRVReserveExternalOccupancyAttempt(msg.device, request);
+        shellyTRVDeliverExternalOccupancy(msg.endpoint, reserved, shellyTRVRequiredRemoteSensing(msg.device, remoteSensing)).catch((error) =>
+            logger.debug(`Failed to retry external occupancy for '${msg.device.ieeeAddr}': ${error}`, NS),
+        );
+    },
+} satisfies Fz.Converter<"hvacThermostat", undefined, ["attributeReport", "readResponse"]>;
+
+/**
+ * Stores and sends external occupancy until the TRV confirms the requested state.
+ */
+const tzShellyTRVExternalOccupancy = {
+    key: ["external_occupancy"],
+    convertSet: async (entity, key, value, meta) => {
+        utils.assertEndpoint(entity);
+        if (typeof value !== "boolean") throw new Error(`External occupancy must be true or false, got ${value}`);
+
+        const request = shellyTRVCreateExternalOccupancyRequest(value);
+        shellyTRVPutExternalOccupancyRequest(entity.getDevice(), request);
+
+        const remoteSensing = shellyTRVGetRemoteSensing(entity, meta.state);
+        const reserved = shellyTRVReserveExternalOccupancyAttempt(entity.getDevice(), request);
+
+        try {
+            await shellyTRVDeliverExternalOccupancy(entity, reserved, shellyTRVRequiredRemoteSensing(entity.getDevice(), remoteSensing));
+        } catch (error) {
+            logger.debug(`Initial external occupancy delivery to '${entity.getDevice().ieeeAddr}' failed: ${error}`, NS);
+        }
+
+        return {state: {external_occupancy: value}};
+    },
+} satisfies Tz.Converter;
+
+/**
+ * Retries persisted external occupancy when the TRV announces itself.
+ */
+const shellyTRVExternalOccupancyOnEvent: OnEvent.Handler = (event) => {
+    if (event.type !== "deviceAnnounce") return;
+
+    const endpoint = event.data.device.getEndpoint(1);
+    const request = shellyTRVGetExternalOccupancyRequest(event.data.device);
+    if (!endpoint || !request) return;
+
+    if (shellyTRVExternalOccupancyIsExpired(request)) {
+        shellyTRVClearExternalOccupancyRequest(event.data.device);
+        logger.warning(`External occupancy ${request.occupancy} was not confirmed by '${event.data.device.ieeeAddr}'`, NS);
+        return;
+    }
+
+    if (Date.now() - request.lastAttemptAt < SHELLY_TRV_EXTERNAL_OCCUPANCY_MIN_RETRY_INTERVAL_MS) return;
+
+    const remoteSensing = shellyTRVGetRemoteSensing(endpoint, event.data.state);
+    const reserved = shellyTRVReserveExternalOccupancyAttempt(event.data.device, request);
+    shellyTRVDeliverExternalOccupancy(endpoint, reserved, shellyTRVRequiredRemoteSensing(event.data.device, remoteSensing)).catch((error) =>
+        logger.debug(`Failed to deliver external occupancy after announce from '${event.data.device.ieeeAddr}': ${error}`, NS),
+    );
+};
+
+const shellyTRVExternalInputsOnEvent: OnEvent.Handler = (event) => {
+    shellyTRVExternalTemperatureOnEvent(event);
+    shellyTRVExternalOccupancyOnEvent(event);
 };
 
 // =============================================================================
@@ -2963,6 +3177,7 @@ export const definitions: DefinitionWithExtend[] = [
         fromZigbee: [
             fz.thermostat,
             fzShellyTRVExternalTemperature,
+            fzShellyTRVExternalOccupancy,
             {
                 cluster: "hvacThermostat",
                 type: ["attributeReport", "readResponse"],
@@ -2974,6 +3189,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         toZigbee: [
             tzShellyTRVExternalTemperature,
+            tzShellyTRVExternalOccupancy,
             {
                 key: ["calibrate"],
                 convertSet: async (entity, key, value, meta) => {
@@ -2996,6 +3212,9 @@ export const definitions: DefinitionWithExtend[] = [
                 .withValueMax(85)
                 .withValueStep(0.01)
                 .withDescription("External room temperature used by the thermostat"),
+            e
+                .binary("external_occupancy", ea.STATE_SET, true, false)
+                .withDescription("External occupancy state used to select the occupied or unoccupied heating setpoint"),
         ],
         extend: [
             m.battery(),
@@ -3049,7 +3268,7 @@ export const definitions: DefinitionWithExtend[] = [
             }),
             m.identify(),
         ],
-        onEvent: shellyTRVExternalTemperatureOnEvent,
+        onEvent: shellyTRVExternalInputsOnEvent,
     },
     {
         fingerprint: [{modelID: "Presence", manufacturerName: "Shelly"}],


### PR DESCRIPTION
This change adds external occupancy support to the Shelly BLU TRV. It allows an automation to send an occupied or unoccupied state, which makes the TRV select the corresponding occupied or unoccupied heating setpoint. A practical use case is a window contact: a closed window maps to occupied, while an open window maps to unoccupied so the TRV reduces heating. External temperature and occupancy share the Zigbee RemoteSensing bitmap. Bit 0 represents external temperature and bit 2 external occupancy, resulting in 5 when both are active. The temperature delivery paths are therefore adjusted to preserve both bits during initial delivery and retries. This prevents a temperature retry from accidentally disabling external occupancy, or vice versa. Temperature-only behavior remains unchanged.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->

