### PR TITLE
Update manhot.ts

### DIFF
--- a/src/devices/manhot.ts
+++ b/src/devices/manhot.ts
@@ -585,7 +585,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_hwv3by9k"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_hwv3by9k", "_TZE28C1000000_hwv3by9k"]),
         model: "MH03-8Z-OLED",
         vendor: "Manhot",
         description: "OLED Screen Switch 8 Gang",


### PR DESCRIPTION
"_TZE284_hwv3by9k" and  "_TZE28C1000000_hwv3by9k" are the same device. i have tested this on my local server by adding it as external source and it worked find. the device i have tested on is this one from Ali Express 

https://ar.aliexpress.com/item/1005012308623506.html?spm=a2g0o.store_pc_home.promoteWysiwyg_2003163203112.1005012308623506&gatewayAdapt=glo2ara#nav-specification

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
