### PR TITLE
feat: Moes ZS-SF-EUC-WH-MS: add _TZE28C1000000_i8sdouy0 + full DP mapping

### DIFF
--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -492,23 +492,35 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        // DP mapping from the official Moes protocol document shared by @adeelnawaz
+        // in Koenkk/zigbee2mqtt#31244 (2026-07). DP 7 (backlight_switch) tested and
+        // confirmed on _TZE28C1000000_i8sdouy0 hardware. See #12731 for background.
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0", "_TZE28C1000000_i8sdouy0"]),
         model: "ZS-SF-EUC-WH-MS",
         vendor: "Moes",
         description: "Star feather Zigbee curtain switch",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         options: [exposes.options.invert_cover()],
-        exposes: [te.coverPosition()],
+        exposes: [
+            te.coverPosition(),
+            e.enum("calibration", ea.STATE_SET, ["start", "end"]).withDescription("Calibration mode"),
+            e.binary("backlight_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable or disable button backlight"),
+            e.enum("motor_direction", ea.STATE_SET, ["normal", "reversed"]).withDescription("Direction of motor movement"),
+            e
+                .numeric("motor_working_time", ea.STATE_SET)
+                .withUnit("s")
+                .withValueMin(10)
+                .withValueMax(180)
+                .withDescription("Full travel time of the motor (10-180s)"),
+        ],
         meta: {
-            // DP 10 (u32 seconds, likely calibration_time by common Tuya convention) accepts writes
-            // with echoed dataReport, but writing it induces an intermittent electrical hang on
-            // _TZE28C1000000_i8sdouy0: the internal relay clicks but the motor does not move,
-            // recoverable only by physically inverting the switched leg (a mains power-cycle alone
-            // does NOT clear it). Left unmapped pending investigation. Additional unmapped DPs
-            // observed spontaneously (static values): 3=1, 7=1, 8=0, 101=1. See #12731.
             tuyaDatapoints: [
                 [1, "state", tuya.valueConverter.coverAction],
                 [2, "position", tuya.valueConverter.coverPosition],
+                [3, "calibration", tuya.valueConverterBasic.lookup({start: tuya.enum(0), end: tuya.enum(1)})],
+                [7, "backlight_switch", tuya.valueConverter.onOff],
+                [8, "motor_direction", tuya.valueConverterBasic.lookup({normal: tuya.enum(0), reversed: tuya.enum(1)})],
+                [10, "motor_working_time", tuya.valueConverter.raw],
             ],
         },
     },

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -492,9 +492,6 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        // DP mapping from the official Moes protocol document shared by @adeelnawaz
-        // in Koenkk/zigbee2mqtt#31244 (2026-07). DP 7 (backlight_switch) tested and
-        // confirmed on _TZE28C1000000_i8sdouy0 hardware. See #12731 for background.
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0", "_TZE28C1000000_i8sdouy0"]),
         model: "ZS-SF-EUC-WH-MS",
         vendor: "Moes",

--- a/src/devices/moes.ts
+++ b/src/devices/moes.ts
@@ -492,7 +492,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_upt8lzi0", "_TZE28C1000000_i8sdouy0"]),
         model: "ZS-SF-EUC-WH-MS",
         vendor: "Moes",
         description: "Star feather Zigbee curtain switch",
@@ -500,6 +500,12 @@ export const definitions: DefinitionWithExtend[] = [
         options: [exposes.options.invert_cover()],
         exposes: [te.coverPosition()],
         meta: {
+            // DP 10 (u32 seconds, likely calibration_time by common Tuya convention) accepts writes
+            // with echoed dataReport, but writing it induces an intermittent electrical hang on
+            // _TZE28C1000000_i8sdouy0: the internal relay clicks but the motor does not move,
+            // recoverable only by physically inverting the switched leg (a mains power-cycle alone
+            // does NOT clear it). Left unmapped pending investigation. Additional unmapped DPs
+            // observed spontaneously (static values): 3=1, 7=1, 8=0, 101=1. See #12731.
             tuyaDatapoints: [
                 [1, "state", tuya.valueConverter.coverAction],
                 [2, "position", tuya.valueConverter.coverPosition],


### PR DESCRIPTION
## Device

Adds `_TZE28C1000000_i8sdouy0` to the existing Moes ZS-SF-EUC-WH-MS entry and maps the full DP protocol.

- **New fingerprint**: `_TZE28C1000000_i8sdouy0` (TS0601)
- **Existing fingerprint kept**: `_TZE284_upt8lzi0`
- **Vendor**: Moes / **Model**: ZS-SF-EUC-WH-MS
- **Purchased**: European version, directly from the official Moes web store on 2026-08-08 — [product page](https://moeshouse.com/products/star-feather-zigbee-smart-curtain-switch-anti-glare-touch-panel)

## ✅ What is validated on `_TZE28C1000000_i8sdouy0` hardware

- **DP 1** (`state`): OPEN / STOP / CLOSE control — in use throughout testing
- **DP 2** (`position`): position reporting during motion — in use throughout testing
- **DP 7** (`backlight_switch`): round-trip tested — writing `OFF` physically turns off the button backlight; writing `ON` restores it. Values echoed via `commandDataReport` and reflected in HA state.

## ⚠️ What is NOT validated on this hardware

The remaining DPs are mapped from the official Moes protocol document (shared by @adeelnawaz in [Koenkk/zigbee2mqtt#31244](https://github.com/Koenkk/zigbee2mqtt/issues/31244)) and reported working on the sibling variant `_TZE284_upt8lzi0` by @adeelnawaz and on `_TZE284_kq1l5eu5` by @rojoricardo. **I have not exercised them end-to-end on my fingerprint.**

- **DP 3** (`calibration` start/end): not tested
- **DP 8** (`motor_direction` normal/reversed): not tested
- **DP 10** (`motor_working_time` 10–180s): not tested end-to-end AND known caveat below

### Known caveat with DP 10 on my hardware

In an earlier experiment (before I found @adeelnawaz's protocol document), I wrote DP 10 directly with values in 24–30 (within the Moes-documented 10–180 s range, but below the Tuya standard minimum of 30 in tenths of seconds). This produced an intermittent electrical fault where the internal relay clicks but the motor does not move. Recovery required physically removing the switch from the circuit and manually driving the motor by direct mains wiring, then reinstalling — a breaker-level power-cycle did NOT clear it.

Unclear whether that was caused by:
- Below-minimum values under the Tuya standard's units (30–9000 in 0.1 s) vs the Moes doc's units (10–180 in s) — the two docs conflict;
- Missing `configureMagicPacket`/related boilerplate in that earlier converter iteration;
- Something specific to `_TZE28C1000000_i8sdouy0` firmware.

**I have not reproduced the hang since switching to the `modernExtend.tuyaBase({dp: true})`-based converter this PR uses, but I have also not written to DP 10 again to prove it doesn't happen.** DP 10 is exposed as writable per the official spec — flagged here so reviewers and future users of this variant know the risk.

## Full DP mapping (from the official Moes protocol document)

| DP  | Feature             | Type / range                 |
|-----|---------------------|------------------------------|
| 1   | `state`             | OPEN / STOP / CLOSE          |
| 2   | `position`          | 0–100 %                      |
| 3   | `calibration`       | start / end                  |
| 7   | `backlight_switch`  | ON / OFF                     |
| 8   | `motor_direction`   | normal / reversed            |
| 10  | `motor_working_time`| 10–180 s (full travel time)  |

Addresses [#12731](https://github.com/Koenkk/zigbee-herdsman-converters/issues/12731) (backlight + calibration missing). No device picture PR since this is a fingerprint addition to an already-documented model.