### PR TITLE
feat: Make Tuya time sync configurable

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1287,6 +1287,17 @@ const tuyaExposes = {
 
 export {tuyaExposes as exposes};
 
+const tuyaOptions = {
+    timeStart: (defaultOption: string) =>
+        e
+            .enum("time_start", ea.SET, ["1970", "2000", "off"])
+            .withDescription(
+                `Reply to Tuya-specific time synchronization requests: "1970" - Reply with seconds since 1970/01/01 (recommended, should stop the device from asking), "2000" - Reply with seconds since 2000/01/01 (use if the weekday is wrong with 1970), "off" - Don't reply (use if replying causes too much traffic). Default for this device: "${defaultOption}"`,
+            ),
+};
+
+export {tuyaOptions as options};
+
 export const skip = {
     // Prevent state from being published when already ON and brightness is also published.
     // This prevents 100% -> X% brightness jumps when the switch is already on
@@ -4488,9 +4499,20 @@ const tuyaModernExtend = {
                     forceTimeUpdate = nextLocalTimeUpdate == null || nextLocalTimeUpdate < Date.now();
                 }
 
-                if (timeStart !== "off" && (msg.type === "commandMcuSyncTime" || forceTimeUpdate)) {
+                let selectedTimeStart = timeStart;
+
+                const timeStartOption = options.time_start as string;
+                if (timeStartOption) {
+                    if (["1970", "2000", "off"].includes(timeStartOption as string)) {
+                        selectedTimeStart = timeStartOption;
+                    } else {
+                        logger.warning(`Invalid option "${timeStartOption}" for ${meta.device.ieeeAddr}.time_start, using default`, NS);
+                    }
+                }
+
+                if (selectedTimeStart !== "off" && (msg.type === "commandMcuSyncTime" || forceTimeUpdate)) {
                     globalStore.putValue(msg.device, "nextLocalTimeUpdate", Date.now() + 3600 * 1000);
-                    const offset = timeStart === "2000" ? constants.OneJanuary2000 : 0;
+                    const offset = selectedTimeStart === "2000" ? constants.OneJanuary2000 : 0;
                     const utcTime = Math.round((Date.now() - offset) / 1000);
                     const localTime = utcTime - new Date().getTimezoneOffset() * 60;
                     const payload = {
@@ -4521,6 +4543,7 @@ const tuyaModernExtend = {
             isModernExtend: true,
             fromZigbee: [fzConverter],
             toZigbee: [],
+            options: [tuyaOptions.timeStart(timeStart)],
         };
 
         if (queryOnConfigure) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -515,6 +515,7 @@ describe("ZHC", () => {
         const ts0601SoilDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_myd45weu", endpoints: []});
         const ts0601Soil = await findByDevice(ts0601SoilDevice);
         expect(ts0601Soil.options.map((t) => t.name)).toStrictEqual([
+            "time_start",
             "temperature_calibration",
             "temperature_precision",
             "soil_moisture_calibration",
@@ -537,6 +538,7 @@ describe("ZHC", () => {
         const ts0111fPlug1Device = mockDevice({modelID: "TS011F", endpoints: []});
         const ts011fPlug1 = await findByDevice(ts0111fPlug1Device);
         expect(ts011fPlug1.options.map((t) => t.name)).toStrictEqual([
+            "time_start",
             "power_calibration",
             "power_precision",
             "current_calibration",


### PR DESCRIPTION
Tuya `timeStart` should be configurable because
- default option is wrong on many devices
- enabling it causes issues on networks with spamming devices
  - https://github.com/Koenkk/zigbee-herdsman-converters/issues/12970
  - https://github.com/Koenkk/zigbee2mqtt/issues/32278

<img width="918" height="302" alt="image" src="https://github.com/user-attachments/assets/4b238851-69a0-4b41-ac03-e524961d0176" />

<img width="317" height="101" alt="image" src="https://github.com/user-attachments/assets/b798f29d-4541-4f67-9628-be8b5cea0523" />

<img width="404" height="79" alt="image" src="https://github.com/user-attachments/assets/bb6c3b13-0802-42d6-a6ba-b32bfed8c66b" />

---

I am wondering if we should enable it for all Tuya devices (default `timeStart` to `1970` instead of `off`). My device asks for the current time every 3 seconds if it doesn't receive a reply.