### PR TITLE
Add Legrand WNRCB46WH (wired 4 scenes control)

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -817,4 +817,18 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(endpoint, coordinatorEndpoint, ["genPowerCfg", "genOnOff", "genLevelCtrl", "genScenes"]);
         },
     },
+    {
+        zigbeeModel: [" Wired Scenes Command\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"],
+        model: "WNRCB46WH",
+        vendor: "Legrand",
+        description: "Wired 4 scenes control",
+        meta: {publishDuplicateTransaction: true},
+        fromZigbee: [fz.identify, fzLocal.command_recall_by_groupid],
+        toZigbee: [],
+        exposes: [e.action(["identify", "button_1", "button_2", "button_3", "button_4"])],
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ["genIdentify", "genScenes"]);
+        },
+    },
 ];


### PR DESCRIPTION
Adds support for the **Legrand WNRCB46WH**, the mains-powered version of the
already-supported **067755** wireless 4-scene switch.

`modelID` is `" Wired Scenes Command"` (NUL-padded to 31 chars), `manufacturerName`
`" Legrand"`. On the wire it is identical to the 067755: each button emits a `genScenes`
`commandRecall` whose **groupid** identifies the button (65517 → `button_1` … 65514 →
`button_4`), so the existing `fzLocal.command_recall_by_groupid` in `legrand.ts` is reused
unchanged.

Differences from the 067755 entry: no `battery()`, no `readInitialBatteryState`, and no
`genPowerCfg`/`genPollCtrl` binding, since this unit is mains powered.
`meta.publishDuplicateTransaction` is kept — like the 067755, the device reuses the ZCL
transaction sequence number across presses, and without it a repeated press of the same
button is swallowed.

Tested on hardware (`sw_version` `003d`), all four buttons:

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5439#issue-5252184227
