### PR TITLE
feat: expose level configuration for Aqara KD-R01D

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -5303,7 +5303,12 @@ export const definitions: DefinitionWithExtend[] = [
             lumiLedIndicator(),
             lumiFlipIndicatorLight(),
             lumiPowerOnBehavior(),
-            m.light({powerOnBehavior: false}),
+            m.light({
+                powerOnBehavior: false,
+                levelConfig: {
+                    features: ["execute_if_off", "on_transition_time", "off_transition_time", "on_level"],
+                },
+            }),
             lumiKnobRotation({withButtonState: false}),
             lumiOperationMode({description: "Decoupled mode for knob"}),
             lumiAction({actionLookup: {hold: 0, single: 1, double: 2, release: 255}}),

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -1293,7 +1293,6 @@ export function light(args: LightArgs = {}): ModernExtend {
         lightExpose.forEach((e) => {
             levelConfig.features ? e.withLevelConfig(levelConfig.features) : e.withLevelConfig();
         });
-        toZigbee.push(tz.level_config);
     }
 
     const exposes: Expose[] = lightExpose;

--- a/test/modernExtend.test.ts
+++ b/test/modernExtend.test.ts
@@ -1,9 +1,10 @@
 import {describe, expect, test, vi} from "vitest";
 import * as fz from "../src/converters/fromZigbee";
+import * as tz from "../src/converters/toZigbee";
 import {findByDevice} from "../src/index";
 import {repInterval} from "../src/lib/constants";
 import {fromZigbee as lumiFz} from "../src/lib/lumi";
-import {electricityMeter, setupAttributes} from "../src/lib/modernExtend";
+import {electricityMeter, light, setupAttributes} from "../src/lib/modernExtend";
 import * as philips from "../src/lib/philips";
 import {assertDefinition, mockDevice, reportingItem} from "./utils";
 
@@ -37,6 +38,11 @@ describe("ModernExtend", () => {
             write: {},
             configureReporting: {},
         });
+    });
+
+    test("light levelConfig includes its toZigbee converter once", () => {
+        const extend = light({levelConfig: {features: ["on_level"]}});
+        expect(extend.toZigbee?.filter((converter) => converter === tz.level_config)).toHaveLength(1);
     });
 
     test("light({colorTemp: {range: undefined}})", async () => {


### PR DESCRIPTION
## Summary

Expose standard `genLevelCtrl` level configuration for the Aqara Dimmer Switch H2 EU (`KD-R01D` / `lumi.switch.agl011`):

- On level
- ON transition time
- OFF transition time
- Execute if off

Also avoid adding the same `tz.level_config` converter twice when `m.light()` is configured with `levelConfig` features.

## Background

The KD-R01D already supports and reports these standard `genLevelCtrl` attributes, but they were not exposed by its definition.

Hardware testing confirmed reading and writing:

- `onLevel`
- `onTransitionTime`
- `offTransitionTime`
- `options`

During testing, a single `level_config` request was observed being handled twice. `m.light()` already includes `tz.level_config` in its base converter list and added it again when level configuration features were enabled. The duplicate insertion has been removed and covered by a regression test.

## Validation

Tested on Aqara KD-R01D hardware.

Commands/checks passed:

- `pnpm run check`
- `pnpm run build`
- Full test suite: 25 files, 801 tests passed
