### PR TITLE
fix(tuya): correct ONENUO TH05Z manufacturerName to _TZE284_qf5mzewi

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3389,7 +3389,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_vvmbj46n",
             "_TZE200_w6n8jeuu",
             "_TZE284_cwyqwqbf",
-            "_TZE2841000000_qf5mzewi", // ONENUO TH05Z - has calibration (DP23/24) instead of DP18
+            "_TZE284_qf5mzewi", // ONENUO TH05Z - has calibration (DP23/24) instead of DP18
         ]),
         model: "ZTH05Z",
         vendor: "Tuya",
@@ -3432,9 +3432,9 @@ export const definitions: DefinitionWithExtend[] = [
                     .withDescription("Temp periodic report"),
             ];
 
-            if (device.manufacturerName !== "_TZE2841000000_qf5mzewi") {
+            if (device.manufacturerName !== "_TZE284_qf5mzewi") {
                 // Original ZTH05Z position for this expose - unchanged.
-                // Not present on the ONENUO TH05Z (_TZE2841000000_qf5mzewi) batch:
+                // Not present on the ONENUO TH05Z (_TZE284_qf5mzewi) batch:
                 // this unit never reports DP18, tested empirically.
                 exps.push(
                     e
@@ -3446,7 +3446,7 @@ export const definitions: DefinitionWithExtend[] = [
                 );
             }
 
-            if (device.manufacturerName === "_TZE2841000000_qf5mzewi") {
+            if (device.manufacturerName === "_TZE284_qf5mzewi") {
                 // ONENUO TH05Z (this specific firmware batch): wider sensitivity
                 // range than other ZTH05Z batches
                 exps.push(
@@ -3488,7 +3488,7 @@ export const definitions: DefinitionWithExtend[] = [
                 );
             }
 
-            if (device.manufacturerName === "_TZE2841000000_qf5mzewi") {
+            if (device.manufacturerName === "_TZE284_qf5mzewi") {
                 // ONENUO TH05Z (this specific firmware batch): has calibration,
                 // which the other ZTH05Z batches don't have. Purely additive -
                 // doesn't move or replace anything for other manufacturerNames.
@@ -3553,7 +3553,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [18, "humidity_periodic_report", tuya.valueConverter.raw],
                 [19, "temperature_sensitivity", tuya.valueConverter.divideBy10],
                 [20, "humidity_sensitivity", tuya.valueConverter.raw],
-                // DP23/24: only present on the ONENUO _TZE2841000000_qf5mzewi
+                // DP23/24: only present on the ONENUO _TZE284_qf5mzewi
                 [23, "temperature_calibration", tuya.valueConverter.divideBy10],
                 [24, "humidity_calibration", tuya.valueConverter.raw],
             ],
@@ -3561,7 +3561,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [
             tuya.whitelabel("ONENUO", "TH05Z", "Temperature & humidity sensor with clock and humidity display", [
                 "_TZE200_vvmbj46n",
-                "_TZE2841000000_qf5mzewi",
+                "_TZE284_qf5mzewi",
             ]),
             tuya.whitelabel("Tuya", "TZE284_cwyqwqbf", "Temperature & humidity sensor with LCD clock", ["_TZE284_cwyqwqbf"]),
         ],


### PR DESCRIPTION
### Problem

The `ZTH05Z` definition currently fingerprints `_TZE2841000000_qf5mzewi`, added in #12935. That
manufacturer name does not appear to correspond to any device seen in the wild — the real hardware
reports **`_TZE284_qf5mzewi`**.

Because the string never matches, the support added in #12935 cannot activate: affected devices
still fall through to "Not supported" with an auto-generated definition. The three behavioural
branches added by that PR (DP18 omission, DP23/24 calibration) are also unreachable for the same
reason.

### Evidence

Koenkk/zigbee2mqtt#31209 (still open) includes a full database entry for this device:

```json
"manufName":"_TZE284_qf5mzewi","modelId":"TS0601","manufId":4417,"powerSource":"Battery"
```

Also reported as `_TZE284_qf5mzewi` in Koenkk/zigbee2mqtt#31784 and Koenkk/zigbee2mqtt#31235.

I have the same sensor here, and it interviews as:

```
modelID:          TS0601
manufacturerName: _TZE284_qf5mzewi
OUI:              Telink Semiconductor (Taipei) Co. Ltd.
```

`_TZE284_qf5mzewi` currently appears **zero** times in `src/devices/tuya.ts`, while
`_TZE2841000000_qf5mzewi` appears seven times.

### Change

Replaces all 7 occurrences of `_TZE2841000000_qf5mzewi` with `_TZE284_qf5mzewi` — the fingerprint,
the three `device.manufacturerName` comparisons that gate the variant behaviour, the two comments,
and the whiteLabel entry. No other changes; the datapoint map and exposes logic from #12935 are
untouched.

### Verification

Tested on hardware with Zigbee2MQTT 2.9.2 via an external converter carrying this definition's
datapoint map. All datapoints decode correctly:

| DP | exposed as | observed |
|----|------------|----------|
| 1  | temperature (divideBy10) | 26.8 °C |
| 2  | humidity (raw) | 58 % |
| 4  | battery (raw) | 100 % |
| 9  | temperature_unit | fahrenheit |

Before: reported as unsupported, no usable entities.
After: temperature, humidity, battery and temperature_unit all populate.

I have not independently confirmed the DP23/24 calibration or DP18 absence described in #12935 —
this PR only corrects the identifier so that logic can actually run.

Closes Koenkk/zigbee2mqtt#31209