### PR TITLE
feat: extend auto-generator with HVAC clusters and more

### DIFF
--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -296,9 +296,11 @@ export async function generateDefinition(device: Zh.Device): Promise<{externalDe
         for (const endpoint of endpointsWithoutGreenPower) {
             endpoints[endpoint.ID.toString()] = endpoint.ID;
         }
-        // create list with all multiEndpointSkip properties from generated extenders
+
+        // Collect multiEndpointSkip from extends that declare it.
         const multiEndpointSkipArr = generatedExtend.flatMap((e) => e.multiEndpointSkip ?? []);
         const multiEndpointSkip = multiEndpointSkipArr.length ? multiEndpointSkipArr : undefined;
+
         // Add to beginning for better visibility.
         generatedExtend.unshift(new ExtendGenerator({extend: m.deviceEndpoints, args: {endpoints, multiEndpointSkip}, source: "deviceEndpoints"}));
         extenders.unshift(generatedExtend[0].getExtend());
@@ -550,6 +552,24 @@ async function extenderThermostat(device: Zh.Device, endpoints: Zh.Endpoint[]): 
         }
 
         generated.push(new ExtendGenerator({extend: m.thermostat, args: thermostatArgs, source: "thermostat"}));
+    }
+
+    // When the thermostat is on only one endpoint but the device has multiple,
+    // declare its properties to be skipped from endpoint suffixing.
+    // This prevents fz.thermostat from producing suffixed keys that clash with
+    // the unsuffixed keys returned by tz.thermostat_* converters.
+    const endpointsWithoutGreenPower = device.endpoints.filter((e) => e.ID !== 242);
+    if (endpoints.length === 1 && endpointsWithoutGreenPower.length > 1) {
+        generated[0].multiEndpointSkip = [
+            "local_temperature",
+            "occupied_heating_setpoint",
+            "occupied_cooling_setpoint",
+            "system_mode",
+            "running_state",
+            "keypad_lockout",
+            "temperature_display_mode",
+            "programming_operation_mode",
+        ];
     }
 
     return generated;

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -474,6 +474,8 @@ async function extenderElectricityMeter(device: Zh.Device, endpoints: Zh.Endpoin
     return [new ExtendGenerator({extend: m.electricityMeter, args, source: "electricityMeter"})];
 }
 
+const THERMOSTAT_CTRL_SEQ_OF_OPER_META = "ctrlSeqeOfOper";
+
 async function extenderThermostat(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
     const generated: GeneratedExtend[] = [];
 
@@ -481,27 +483,51 @@ async function extenderThermostat(device: Zh.Device, endpoints: Zh.Endpoint[]): 
         const isFirstEndpoint = onlyFirstDeviceEnpoint(device, endpoints);
 
         // Read ctrlSeqeOfOper to determine thermostat type
-        // ZCL values: 0=occupied, 1=heating_only, 2=cooling_only, 4=heating_cooling
-        const ctrlSeqeOfOper = await getClusterAttributeValue(endpoint, "hvacThermostat", "ctrlSeqeOfOper", 1);
+        // ZCL values: 0=cooling_only, 1=cooling_with_reheat, 2=heating_only, 3=heating_with_reheat,
+        // 4=heating_cooling_4_pipes, 5=heating_cooling_4_pipes_with_reheat
+        // The value is persisted in device meta, so on subsequent generations (e.g. after a
+        // restart) it is not read from the device again.
+        let ctrlSeqeOfOper: number;
+        const storedCtrlSeqeOfOper = device.meta?.[THERMOSTAT_CTRL_SEQ_OF_OPER_META]?.[endpoint.ID];
+        if (typeof storedCtrlSeqeOfOper === "number") {
+            ctrlSeqeOfOper = storedCtrlSeqeOfOper;
+        } else {
+            const readCtrlSeqeOfOper = await getClusterAttributeValue(endpoint, "hvacThermostat", "ctrlSeqeOfOper", undefined);
+            if (typeof readCtrlSeqeOfOper === "number") {
+                ctrlSeqeOfOper = readCtrlSeqeOfOper;
+                if (!device.meta) device.meta = {};
+                if (typeof device.meta[THERMOSTAT_CTRL_SEQ_OF_OPER_META] !== "object" || device.meta[THERMOSTAT_CTRL_SEQ_OF_OPER_META] === null) {
+                    device.meta[THERMOSTAT_CTRL_SEQ_OF_OPER_META] = {};
+                }
+                device.meta[THERMOSTAT_CTRL_SEQ_OF_OPER_META][endpoint.ID] = readCtrlSeqeOfOper;
+            } else {
+                // Read failed - use the default without persisting, so a transient failure
+                // does not bake the fallback value into the meta.
+                ctrlSeqeOfOper = 2;
+            }
+        }
+
+        const coolingOnly = ctrlSeqeOfOper === 0 || ctrlSeqeOfOper === 1;
+        const heatingAndCooling = ctrlSeqeOfOper === 4 || ctrlSeqeOfOper === 5;
 
         let setpoints: NonNullable<NonNullable<m.ThermostatArgs["setpoints"]>["values"]>;
 
-        if (ctrlSeqeOfOper === 2) {
+        if (coolingOnly) {
             setpoints = {occupiedCoolingSetpoint: {min: 7, max: 30, step: 0.5}};
-        } else if (ctrlSeqeOfOper === 4) {
+        } else if (heatingAndCooling) {
             setpoints = {
                 occupiedHeatingSetpoint: {min: 7, max: 30, step: 0.5},
                 occupiedCoolingSetpoint: {min: 7, max: 30, step: 0.5},
             };
         } else {
-            // heating_only (default, value 1 or unknown)
+            // heating_only (2, 3 or unknown - default)
             setpoints = {occupiedHeatingSetpoint: {min: 7, max: 30, step: 0.5}};
         }
 
         let systemModeValues: constants.ThermostatSystemMode[];
-        if (ctrlSeqeOfOper === 2) {
+        if (coolingOnly) {
             systemModeValues = ["off", "cool"];
-        } else if (ctrlSeqeOfOper === 4) {
+        } else if (heatingAndCooling) {
             systemModeValues = ["off", "heat", "cool", "auto"];
         } else {
             systemModeValues = ["off", "heat"];
@@ -509,7 +535,7 @@ async function extenderThermostat(device: Zh.Device, endpoints: Zh.Endpoint[]): 
 
         const thermostatArgs: m.ThermostatArgs = {
             localTemperature: {},
-            runningState: {values: ctrlSeqeOfOper === 4 ? ["idle", "heat", "cool"] : ctrlSeqeOfOper === 2 ? ["idle", "cool"] : ["idle", "heat"]},
+            runningState: {values: heatingAndCooling ? ["idle", "heat", "cool"] : coolingOnly ? ["idle", "cool"] : ["idle", "heat"]},
             setpoints: {values: setpoints},
             systemMode: {values: systemModeValues},
         };

--- a/src/lib/generateDefinition.ts
+++ b/src/lib/generateDefinition.ts
@@ -3,6 +3,7 @@ import type {Models as ZHModels} from "zigbee-herdsman";
 import {Zcl} from "zigbee-herdsman";
 import type {Cluster} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 
+import type * as constants from "./constants";
 import {logger} from "./logger";
 import * as m from "./modernExtend";
 import * as philips from "./philips";
@@ -112,6 +113,11 @@ const INPUT_EXTENDERS: Extender[] = [
     [["genBinaryOutput"], extenderBinaryOutput],
     [["genAnalogInput"], extenderAnalogInput],
     [["genAnalogOutput"], extenderAnalogOutput],
+    [["hvacThermostat"], extenderThermostat],
+    [["hvacFanCtrl"], extenderFanControl],
+    [["hvacUserInterfaceCfg"], extenderThermostatUi],
+    [["genIdentify"], async (d, eps) => [new ExtendGenerator({extend: m.identify, source: "identify"})]],
+    [["lightingBallastCfg"], async (d, eps) => [new ExtendGenerator({extend: m.lightingBallast, source: "lightingBallast"})]],
 ];
 
 const OUTPUT_EXTENDERS: Extender[] = [
@@ -466,6 +472,89 @@ async function extenderElectricityMeter(device: Zh.Device, endpoints: Zh.Endpoin
     }
 
     return [new ExtendGenerator({extend: m.electricityMeter, args, source: "electricityMeter"})];
+}
+
+async function extenderThermostat(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {
+    const generated: GeneratedExtend[] = [];
+
+    for (const endpoint of endpoints) {
+        const isFirstEndpoint = onlyFirstDeviceEnpoint(device, endpoints);
+
+        // Read ctrlSeqeOfOper to determine thermostat type
+        // ZCL values: 0=occupied, 1=heating_only, 2=cooling_only, 4=heating_cooling
+        const ctrlSeqeOfOper = await getClusterAttributeValue(endpoint, "hvacThermostat", "ctrlSeqeOfOper", 1);
+
+        let setpoints: NonNullable<NonNullable<m.ThermostatArgs["setpoints"]>["values"]>;
+
+        if (ctrlSeqeOfOper === 2) {
+            setpoints = {occupiedCoolingSetpoint: {min: 7, max: 30, step: 0.5}};
+        } else if (ctrlSeqeOfOper === 4) {
+            setpoints = {
+                occupiedHeatingSetpoint: {min: 7, max: 30, step: 0.5},
+                occupiedCoolingSetpoint: {min: 7, max: 30, step: 0.5},
+            };
+        } else {
+            // heating_only (default, value 1 or unknown)
+            setpoints = {occupiedHeatingSetpoint: {min: 7, max: 30, step: 0.5}};
+        }
+
+        let systemModeValues: constants.ThermostatSystemMode[];
+        if (ctrlSeqeOfOper === 2) {
+            systemModeValues = ["off", "cool"];
+        } else if (ctrlSeqeOfOper === 4) {
+            systemModeValues = ["off", "heat", "cool", "auto"];
+        } else {
+            systemModeValues = ["off", "heat"];
+        }
+
+        const thermostatArgs: m.ThermostatArgs = {
+            localTemperature: {},
+            runningState: {values: ctrlSeqeOfOper === 4 ? ["idle", "heat", "cool"] : ctrlSeqeOfOper === 2 ? ["idle", "cool"] : ["idle", "heat"]},
+            setpoints: {values: setpoints},
+            systemMode: {values: systemModeValues},
+        };
+
+        if (!isFirstEndpoint) {
+            thermostatArgs.endpoint = endpoint.ID.toString();
+        }
+
+        // Check if hvacFanCtrl is on the same endpoint - add fanMode if so
+        if (endpoint.supportsInputCluster("hvacFanCtrl")) {
+            thermostatArgs.fanMode = ["off", "low", "medium", "high", "auto"];
+        }
+
+        generated.push(new ExtendGenerator({extend: m.thermostat, args: thermostatArgs, source: "thermostat"}));
+    }
+
+    return generated;
+}
+
+function extenderFanControl(device: Zh.Device, endpoints: Zh.Endpoint[]): GeneratedExtend[] {
+    const generated: GeneratedExtend[] = [];
+    for (const endpoint of endpoints) {
+        // If hvacThermostat is on the same endpoint, fanMode is handled by the thermostat extender
+        if (endpoint.supportsInputCluster("hvacThermostat")) {
+            continue;
+        }
+        let endpointNames: string[] | undefined;
+        if (!onlyFirstDeviceEnpoint(device, endpoints)) {
+            endpointNames = [endpoint.ID.toString()];
+        }
+        generated.push(new ExtendGenerator({extend: m.fanControl, args: {endpointNames}, source: "fanControl"}));
+    }
+    return generated;
+}
+
+function extenderThermostatUi(device: Zh.Device, endpoints: Zh.Endpoint[]): GeneratedExtend[] {
+    const generated: GeneratedExtend[] = [];
+    for (const endpoint of endpoints) {
+        let endpointNames: string[] | undefined;
+        if (!onlyFirstDeviceEnpoint(device, endpoints)) {
+            endpointNames = [endpoint.ID.toString()];
+        }
+        generated.push(new ExtendGenerator({extend: m.thermostatUi, args: {endpointNames}, source: "thermostatUi"}));
+    }
+    return generated;
 }
 
 async function extenderBinaryInput(device: Zh.Device, endpoints: Zh.Endpoint[]): Promise<GeneratedExtend[]> {

--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -658,6 +658,88 @@ export function onOff(args: OnOffArgs = {}): ModernExtend {
     return result;
 }
 
+export interface FanControlArgs<Cl extends string | number = "hvacFanCtrl", _Custom extends TCustomCluster | undefined = undefined> {
+    cluster?: Cl;
+    endpointNames?: string[];
+    reporting?: false | ReportingConfigWithoutAttribute;
+    bind?: boolean;
+}
+export function fanControl<Cl extends string | number = "hvacFanCtrl", Custom extends TCustomCluster | undefined = undefined>(
+    args: FanControlArgs<Cl, Custom> = {},
+): ModernExtend {
+    const {cluster = "hvacFanCtrl" as Cl, endpointNames = undefined, reporting = {min: 0, max: "1_HOUR", change: 0}, bind = true} = args;
+
+    const fanExpose = e.fan().withState("state").withModes(Object.keys(constants.fanMode));
+    const exposes: Expose[] = exposeEndpoints(fanExpose, endpointNames);
+
+    const fromZigbee = [fz.fan];
+    const toZigbee: Tz.Converter[] = [tz.fan_mode];
+
+    const result: ModernExtend = {exposes, fromZigbee, toZigbee, isModernExtend: true};
+
+    const configure: Configure[] = [];
+    if (bind) {
+        configure.push(setupConfigureForBinding(cluster, "input", endpointNames));
+    }
+    if (reporting) {
+        configure.push(
+            setupConfigureForReporting<Cl, Custom>(cluster, "fanMode" as ClusterOrRawAttributeKeys<Cl, Custom>[number], {
+                config: reporting,
+                access: ea.STATE_GET,
+                endpointNames: endpointNames,
+            }),
+        );
+    }
+    result.configure = configure;
+
+    return result;
+}
+
+export interface ThermostatUiArgs<Cl extends string | number = "hvacUserInterfaceCfg", _Custom extends TCustomCluster | undefined = undefined> {
+    cluster?: Cl;
+    endpointNames?: string[];
+    reporting?: false | ReportingConfigWithoutAttribute;
+    bind?: boolean;
+}
+export function thermostatUi<Cl extends string | number = "hvacUserInterfaceCfg", Custom extends TCustomCluster | undefined = undefined>(
+    args: ThermostatUiArgs<Cl, Custom> = {},
+): ModernExtend {
+    const {cluster = "hvacUserInterfaceCfg" as Cl, endpointNames = undefined, reporting = {min: 10, max: "1_HOUR", change: 0}, bind = true} = args;
+
+    const exposes: Expose[] = [
+        ...exposeEndpoints(
+            e.enum("temperature_display_mode", ea.ALL, Object.values(constants.temperatureDisplayMode)).withDescription("Temperature display mode"),
+            endpointNames,
+        ),
+        ...exposeEndpoints(
+            e.enum("keypad_lockout", ea.ALL, Object.values(constants.keypadLockoutMode)).withDescription("Keypad lockout mode"),
+            endpointNames,
+        ),
+    ];
+
+    const fromZigbee = [fz.hvac_user_interface];
+    const toZigbee: Tz.Converter[] = [tz.thermostat_temperature_display_mode, tz.thermostat_keypad_lockout];
+
+    const result: ModernExtend = {exposes, fromZigbee, toZigbee, isModernExtend: true};
+
+    const configure: Configure[] = [];
+    if (bind) {
+        configure.push(setupConfigureForBinding(cluster, "input", endpointNames));
+    }
+    if (reporting) {
+        configure.push(
+            setupConfigureForReporting<Cl, Custom>(cluster, "keypadLockout" as ClusterOrRawAttributeKeys<Cl, Custom>[number], {
+                config: reporting,
+                access: ea.STATE_GET,
+                endpointNames: endpointNames,
+            }),
+        );
+    }
+    result.configure = configure;
+
+    return result;
+}
+
 export interface CommandsOnOffArgs {
     commands?: ("on" | "off" | "toggle")[];
     bind?: boolean;

--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -791,7 +791,7 @@ export default {
         const attributes = {
             hvacThermostat: {
                 attributes: {
-                    ctrlSeqeOfOper: 2,
+                    ctrlSeqeOfOper: 0,
                 },
             },
         };
@@ -819,6 +819,45 @@ export default {
                 1: [
                     ["hvacThermostat", [reportingItem("localTemp", 0, repInterval.HOUR, 10)]],
                     ["hvacThermostat", [reportingItem("occupiedCoolingSetpoint", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("systemMode", 0, repInterval.HOUR, 0)]],
+                    ["hvacThermostat", [reportingItem("runningState", 0, repInterval.HOUR, 0)]],
+                ],
+            },
+        });
+    });
+
+    test("input(hvacThermostat) heating only (ctrlSeqeOfOper=2)", async () => {
+        const attributes = {
+            hvacThermostat: {
+                attributes: {
+                    ctrlSeqeOfOper: 2,
+                },
+            },
+        };
+
+        await assertGeneratedDefinition({
+            device: mockDevice({
+                modelID: "thermo_heat2",
+                endpoints: [{inputClusters: ["hvacThermostat"], outputClusters: [], attributes}],
+            }),
+            meta: {thermostat: {}},
+            fromZigbee: [expect.objectContaining({cluster: "hvacThermostat"})],
+            toZigbee: ["local_temperature", "occupied_heating_setpoint", "system_mode", "running_state"],
+            exposes: ["climate(local_temperature,occupied_heating_setpoint,system_mode,running_state)"],
+            bind: {1: ["hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat"]},
+            read: {
+                1: [
+                    ["hvacThermostat", ["localTemp"]],
+                    ["hvacThermostat", ["occupiedHeatingSetpoint"]],
+                    ["hvacThermostat", ["systemMode"]],
+                    ["hvacThermostat", ["runningState"]],
+                ],
+            },
+            write: {},
+            configureReporting: {
+                1: [
+                    ["hvacThermostat", [reportingItem("localTemp", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("occupiedHeatingSetpoint", 0, repInterval.HOUR, 10)]],
                     ["hvacThermostat", [reportingItem("systemMode", 0, repInterval.HOUR, 0)]],
                     ["hvacThermostat", [reportingItem("runningState", 0, repInterval.HOUR, 0)]],
                 ],
@@ -865,6 +904,22 @@ export default {
                 ],
             },
         });
+    });
+
+    test("input(hvacThermostat) ctrlSeqeOfOper persisted in device meta", async () => {
+        const device = mockDevice({
+            modelID: "thermo_meta",
+            endpoints: [{inputClusters: ["hvacThermostat"], outputClusters: [], read: vi.fn(async () => ({ctrlSeqeOfOper: 2}))}],
+        });
+
+        await findByDevice(device, true);
+        expect(device.endpoints[0].read).toHaveBeenCalled();
+        expect(device.meta.ctrlSeqeOfOper).toEqual({1: 2});
+
+        // Second generation must reuse the persisted value without reading from the device again.
+        vi.mocked(device.endpoints[0].read).mockClear();
+        await findByDevice(device, true);
+        expect(device.endpoints[0].read).not.toHaveBeenCalled();
     });
 
     test("input(hvacThermostat, hvacFanCtrl, hvacUserInterfaceCfg) full HVAC", async () => {

--- a/test/generateDefinition.test.ts
+++ b/test/generateDefinition.test.ts
@@ -688,4 +688,271 @@ export default {
             endpoints: {"10": 10, "11": 11},
         });
     });
+
+    test("input(hvacFanCtrl)", async () => {
+        await assertGeneratedDefinition({
+            device: mockDevice({modelID: "fan", endpoints: [{inputClusters: ["hvacFanCtrl"], outputClusters: []}]}),
+            meta: undefined,
+            fromZigbee: [expect.objectContaining({cluster: "hvacFanCtrl"})],
+            toZigbee: ["fan_mode", "fan_state"],
+            exposes: ["fan(state,mode)"],
+            bind: {1: ["hvacFanCtrl", "hvacFanCtrl"]},
+            read: {1: [["hvacFanCtrl", ["fanMode"]]]},
+            write: {},
+            configureReporting: {
+                1: [["hvacFanCtrl", [reportingItem("fanMode", 0, repInterval.HOUR, 0)]]],
+            },
+        });
+    });
+
+    test("input(hvacUserInterfaceCfg)", async () => {
+        await assertGeneratedDefinition({
+            device: mockDevice({modelID: "thermostat_ui", endpoints: [{inputClusters: ["hvacUserInterfaceCfg"], outputClusters: []}]}),
+            meta: undefined,
+            fromZigbee: [expect.objectContaining({cluster: "hvacUserInterfaceCfg"})],
+            toZigbee: ["temperature_display_mode", "keypad_lockout"],
+            exposes: ["keypad_lockout", "temperature_display_mode"],
+            bind: {1: ["hvacUserInterfaceCfg", "hvacUserInterfaceCfg"]},
+            read: {1: [["hvacUserInterfaceCfg", ["keypadLockout"]]]},
+            write: {},
+            configureReporting: {
+                1: [["hvacUserInterfaceCfg", [reportingItem("keypadLockout", 10, repInterval.HOUR, 0)]]],
+            },
+        });
+    });
+
+    test("input(hvacThermostat) heating only", async () => {
+        await assertGeneratedDefinition({
+            device: mockDevice({
+                modelID: "thermo_heat",
+                endpoints: [{inputClusters: ["hvacThermostat"], outputClusters: []}],
+            }),
+            meta: {thermostat: {}},
+            fromZigbee: [expect.objectContaining({cluster: "hvacThermostat"})],
+            toZigbee: ["local_temperature", "occupied_heating_setpoint", "system_mode", "running_state"],
+            exposes: ["climate(local_temperature,occupied_heating_setpoint,system_mode,running_state)"],
+            bind: {1: ["hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat"]},
+            read: {
+                1: [
+                    ["hvacThermostat", ["ctrlSeqeOfOper"], {disableRecovery: true, sendPolicy: "immediate"}],
+                    ["hvacThermostat", ["localTemp"]],
+                    ["hvacThermostat", ["occupiedHeatingSetpoint"]],
+                    ["hvacThermostat", ["systemMode"]],
+                    ["hvacThermostat", ["runningState"]],
+                ],
+            },
+            write: {},
+            configureReporting: {
+                1: [
+                    ["hvacThermostat", [reportingItem("localTemp", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("occupiedHeatingSetpoint", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("systemMode", 0, repInterval.HOUR, 0)]],
+                    ["hvacThermostat", [reportingItem("runningState", 0, repInterval.HOUR, 0)]],
+                ],
+            },
+        });
+    });
+
+    test("input(hvacThermostat, hvacFanCtrl) on same endpoint", async () => {
+        await assertGeneratedDefinition({
+            device: mockDevice({
+                modelID: "thermo_fan",
+                endpoints: [{inputClusters: ["hvacThermostat", "hvacFanCtrl"], outputClusters: []}],
+            }),
+            meta: {thermostat: {}},
+            fromZigbee: [expect.objectContaining({cluster: "hvacThermostat"})],
+            toZigbee: ["local_temperature", "occupied_heating_setpoint", "system_mode", "running_state", "fan_mode", "fan_state"],
+            exposes: ["climate(local_temperature,occupied_heating_setpoint,system_mode,running_state,fan_mode)"],
+            bind: {1: ["hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacFanCtrl", "hvacFanCtrl"]},
+            read: {
+                1: [
+                    ["hvacThermostat", ["ctrlSeqeOfOper"], {disableRecovery: true, sendPolicy: "immediate"}],
+                    ["hvacThermostat", ["localTemp"]],
+                    ["hvacThermostat", ["occupiedHeatingSetpoint"]],
+                    ["hvacThermostat", ["systemMode"]],
+                    ["hvacThermostat", ["runningState"]],
+                    ["hvacFanCtrl", ["fanMode"]],
+                ],
+            },
+            write: {},
+            configureReporting: {
+                1: [
+                    ["hvacThermostat", [reportingItem("localTemp", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("occupiedHeatingSetpoint", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("systemMode", 0, repInterval.HOUR, 0)]],
+                    ["hvacThermostat", [reportingItem("runningState", 0, repInterval.HOUR, 0)]],
+                    ["hvacFanCtrl", [reportingItem("fanMode", 0, repInterval.HOUR, 0)]],
+                ],
+            },
+        });
+    });
+
+    test("input(hvacThermostat) cooling only", async () => {
+        const attributes = {
+            hvacThermostat: {
+                attributes: {
+                    ctrlSeqeOfOper: 2,
+                },
+            },
+        };
+
+        await assertGeneratedDefinition({
+            device: mockDevice({
+                modelID: "thermo_cool",
+                endpoints: [{inputClusters: ["hvacThermostat"], outputClusters: [], attributes}],
+            }),
+            meta: {thermostat: {}},
+            fromZigbee: [expect.objectContaining({cluster: "hvacThermostat"})],
+            toZigbee: ["local_temperature", "occupied_cooling_setpoint", "system_mode", "running_state"],
+            exposes: ["climate(local_temperature,occupied_cooling_setpoint,system_mode,running_state)"],
+            bind: {1: ["hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat"]},
+            read: {
+                1: [
+                    ["hvacThermostat", ["localTemp"]],
+                    ["hvacThermostat", ["occupiedCoolingSetpoint"]],
+                    ["hvacThermostat", ["systemMode"]],
+                    ["hvacThermostat", ["runningState"]],
+                ],
+            },
+            write: {},
+            configureReporting: {
+                1: [
+                    ["hvacThermostat", [reportingItem("localTemp", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("occupiedCoolingSetpoint", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("systemMode", 0, repInterval.HOUR, 0)]],
+                    ["hvacThermostat", [reportingItem("runningState", 0, repInterval.HOUR, 0)]],
+                ],
+            },
+        });
+    });
+
+    test("input(hvacThermostat) heating and cooling", async () => {
+        const attributes = {
+            hvacThermostat: {
+                attributes: {
+                    ctrlSeqeOfOper: 4,
+                },
+            },
+        };
+
+        await assertGeneratedDefinition({
+            device: mockDevice({
+                modelID: "thermo_both",
+                endpoints: [{inputClusters: ["hvacThermostat"], outputClusters: [], attributes}],
+            }),
+            meta: {thermostat: {}},
+            fromZigbee: [expect.objectContaining({cluster: "hvacThermostat"})],
+            toZigbee: ["local_temperature", "occupied_heating_setpoint", "occupied_cooling_setpoint", "system_mode", "running_state"],
+            exposes: ["climate(local_temperature,occupied_heating_setpoint,occupied_cooling_setpoint,system_mode,running_state)"],
+            bind: {1: ["hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat", "hvacThermostat"]},
+            read: {
+                1: [
+                    ["hvacThermostat", ["localTemp"]],
+                    ["hvacThermostat", ["occupiedHeatingSetpoint"]],
+                    ["hvacThermostat", ["occupiedCoolingSetpoint"]],
+                    ["hvacThermostat", ["systemMode"]],
+                    ["hvacThermostat", ["runningState"]],
+                ],
+            },
+            write: {},
+            configureReporting: {
+                1: [
+                    ["hvacThermostat", [reportingItem("localTemp", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("occupiedHeatingSetpoint", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("occupiedCoolingSetpoint", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("systemMode", 0, repInterval.HOUR, 0)]],
+                    ["hvacThermostat", [reportingItem("runningState", 0, repInterval.HOUR, 0)]],
+                ],
+            },
+        });
+    });
+
+    test("input(hvacThermostat, hvacFanCtrl, hvacUserInterfaceCfg) full HVAC", async () => {
+        await assertGeneratedDefinition({
+            device: mockDevice({
+                modelID: "full_hvac",
+                endpoints: [{inputClusters: ["hvacThermostat", "hvacFanCtrl", "hvacUserInterfaceCfg"], outputClusters: []}],
+            }),
+            meta: {thermostat: {}},
+            fromZigbee: [expect.objectContaining({cluster: "hvacThermostat"}), expect.objectContaining({cluster: "hvacUserInterfaceCfg"})],
+            toZigbee: [
+                "local_temperature",
+                "occupied_heating_setpoint",
+                "system_mode",
+                "running_state",
+                "fan_mode",
+                "fan_state",
+                "temperature_display_mode",
+                "keypad_lockout",
+            ],
+            exposes: [
+                "climate(local_temperature,occupied_heating_setpoint,system_mode,running_state,fan_mode)",
+                "keypad_lockout",
+                "temperature_display_mode",
+            ],
+            bind: {
+                1: [
+                    "hvacThermostat",
+                    "hvacThermostat",
+                    "hvacThermostat",
+                    "hvacThermostat",
+                    "hvacThermostat",
+                    "hvacFanCtrl",
+                    "hvacFanCtrl",
+                    "hvacUserInterfaceCfg",
+                    "hvacUserInterfaceCfg",
+                ],
+            },
+            read: {
+                1: [
+                    ["hvacThermostat", ["ctrlSeqeOfOper"], {disableRecovery: true, sendPolicy: "immediate"}],
+                    ["hvacThermostat", ["localTemp"]],
+                    ["hvacThermostat", ["occupiedHeatingSetpoint"]],
+                    ["hvacThermostat", ["systemMode"]],
+                    ["hvacThermostat", ["runningState"]],
+                    ["hvacFanCtrl", ["fanMode"]],
+                    ["hvacUserInterfaceCfg", ["keypadLockout"]],
+                ],
+            },
+            write: {},
+            configureReporting: {
+                1: [
+                    ["hvacThermostat", [reportingItem("localTemp", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("occupiedHeatingSetpoint", 0, repInterval.HOUR, 10)]],
+                    ["hvacThermostat", [reportingItem("systemMode", 0, repInterval.HOUR, 0)]],
+                    ["hvacThermostat", [reportingItem("runningState", 0, repInterval.HOUR, 0)]],
+                    ["hvacFanCtrl", [reportingItem("fanMode", 0, repInterval.HOUR, 0)]],
+                    ["hvacUserInterfaceCfg", [reportingItem("keypadLockout", 10, repInterval.HOUR, 0)]],
+                ],
+            },
+        });
+    });
+
+    test("input(genIdentify)", async () => {
+        await assertGeneratedDefinition({
+            device: mockDevice({modelID: "identify_device", endpoints: [{inputClusters: ["genIdentify"], outputClusters: []}]}),
+            meta: undefined,
+            fromZigbee: [],
+            toZigbee: ["identify"],
+            exposes: ["identify"],
+            bind: {},
+            read: {},
+            write: {},
+            configureReporting: {},
+        });
+    });
+
+    test("input(lightingBallastCfg)", async () => {
+        await assertGeneratedDefinition({
+            device: mockDevice({modelID: "ballast_device", endpoints: [{inputClusters: ["lightingBallastCfg"], outputClusters: []}]}),
+            meta: undefined,
+            fromZigbee: [expect.objectContaining({cluster: "lightingBallastCfg"})],
+            toZigbee: ["ballast_config", "ballast_minimum_level", "ballast_maximum_level", "ballast_power_on_level"],
+            exposes: ["ballast_maximum_level", "ballast_minimum_level"],
+            bind: {},
+            read: {1: [["lightingBallastCfg", ["minLevel", "maxLevel"]]]},
+            write: {},
+            configureReporting: {},
+        });
+    });
 });


### PR DESCRIPTION
Add support for 5 new clusters in generateDefinition:

- hvacThermostat: intelligent auto-detection via ctrlSeqeOfOper
  (heating_only, cooling_only, heating_cooling) with proper
  setpoints, systemMode, runningState, and fanMode integration
- hvacFanCtrl: standalone fan control with self-check to avoid
  duplication when hvacThermostat is present on same endpoint
- hvacUserInterfaceCfg: temperature_display_mode + keypad_lockout
- genIdentify: identify command support
- lightingBallastCfg: ballast min/max level configuration

New modernExtend functions in modernExtend.ts:
- fanControl(): generic cluster override support
- thermostatUi(): generic cluster override support