### PR TITLE
feat(zigbeetlc): add Tuya TS202PIR1-z (ZP01) support

### DIFF
--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -364,4 +364,51 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         ota: true,
     },
+    /*
+        ZigbeeTLc PIR devices supporting:
+        - Occupancy
+        - Remote On/Off binding (genOnOff state)
+        - PIR timeout
+    */
+    {
+        // Tuya ZP01 (TS0202/_TZ3000_*) with ZigbeeTLc firmware
+        // https://pvvx.github.io/TS0202_TZ3000/
+        zigbeeModel: ["TS202PIR1-z"],
+        model: "TS202PIR1-z",
+        vendor: "Tuya",
+        description: "ZP01 PIR motion sensor (pvvx/ZigbeeTLc)",
+        ota: true,
+        extend: [
+            m.battery({voltage: true}),
+            m.occupancy(),
+            m.onOff({
+                powerOnBehavior: false,
+                description:
+                    'Enable remote On/Off binding. ON: occupancy occupied sends action "on", clear sends action "off". OFF: no occupancy actions.',
+            }),
+            m.enumLookup({
+                name: "power_on_behavior",
+                cluster: "genOnOff",
+                attribute: "startUpOnOff",
+                lookup: {
+                    off: 0,
+                    on: 1,
+                    toggle: 2,
+                    previous: 255,
+                },
+                description: "Power-on behavior for state (remote On/Off enable)",
+            }),
+            m.numeric({
+                name: "pir_timeout",
+                cluster: "msOccupancySensing",
+                attribute: "pirOToUDelay",
+                unit: "s",
+                valueMin: 0,
+                valueMax: 65535,
+                access: "ALL",
+                description: "PIR occupancy timeout in seconds (firmware default ~35s; board R5/R6 may limit minimum)",
+            }),
+            m.commandsOnOff(),
+        ],
+    },
 ];


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5442

## Summary
- Add `TS202PIR1-z` (Tuya ZP01 / TS0202 with pvvx/ZigbeeTLc) to `src/devices/zigbeetlc.ts`
- Exposes: occupancy, battery (+voltage), `state` (remote On/Off binding enable), `power_on_behavior`, `pir_timeout`, on/off commands, OTA
- Docs: https://pvvx.github.io/TS0202_TZ3000/

## Test plan
- [x] Paired as `TS202PIR1-z` after ZigbeeTLc flash
- [x] Occupancy reports
- [x] `pir_timeout` set/get
- [x] `state` ON/OFF controls remote binding actions
- [x] `power_on_behavior` readable/writable
- [x] OTA 0.1.3.8 -> 0.1.3.9