### PR TITLE
fix(SP-EUC01): enable Aqara event mode during configure

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2216,6 +2216,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Aqara",
         extend: [
             lumi.modernExtend.addManuSpecificLumiCluster(),
+            lumiSetEventMode(),
             m.forceDeviceType({type: "Router"}),
             lumiZigbeeOTA(),
             m.poll({

--- a/test/lumi.test.ts
+++ b/test/lumi.test.ts
@@ -6,6 +6,22 @@ import type {Definition, Fz, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 describe("lib/lumi", () => {
+    describe("SP-EUC01 event mode", () => {
+        it("enables event mode during configure", async () => {
+            const device = mockDevice({modelID: "lumi.plug.maeu01", endpoints: [{ID: 1}]});
+            const coordinatorEndpoint = mockDevice({modelID: "coordinator", endpoints: [{ID: 1}]}).getEndpoint(1);
+            const definition = await findByDevice(device);
+
+            await definition.configure?.(device, coordinatorEndpoint, definition);
+
+            expect(device.getEndpoint(1).write).toHaveBeenCalledWith(
+                "manuSpecificLumi",
+                {mode: 1},
+                {manufacturerCode: 0x115f, disableResponse: true},
+            );
+        });
+    });
+
     describe("PS-S04D battery", () => {
         it("decodes battery percentage (tag 24) and voltage (tag 23) from the 0x00F7 struct", () => {
             const extend = lumiModernExtend.lumiBattery({voltageAttribute: 0x0017, percentageAttribute: 0x0018});


### PR DESCRIPTION
## Summary

Fix the Aqara SP-EUC01 (`lumi.plug.maeu01`) configuration by enabling Aqara event mode during device configure.

On the tested device, power and energy worked while voltage, current, and `consumer_connected` remained null. Reads of the standard `haElectricalMeasurement.rmsVoltage` and `rmsCurrent` attributes returned `UNSUPPORTED_ATTRIBUTE`.

Aqara's manufacturer-specific `manuSpecificLumi` cluster (`0xFCC0`), attribute `0x0009`, reported `mode = 0`. Setting it to `mode = 1` immediately enabled voltage, current, and `consumer_connected` telemetry. The existing Lumi converter already decoded these values correctly once event mode was enabled.

This was verified by manually restoring `mode = 0` and running Zigbee2MQTT's normal device configure operation. The mode remained `0`, confirming that the current SP-EUC01 configure path did not enable event mode.

The change reuses the existing `lumiSetEventMode()` helper, which writes `manuSpecificLumi.mode = 1` on endpoint 1 with Aqara manufacturer code `0x115F`, instead of duplicating the manufacturer-specific write. A focused regression test verifies the configure behavior.

## References

- [SP-EUC01 device definition](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/lumi.ts)
- https://github.com/Koenkk/zigbee2mqtt/issues/6861
- https://github.com/Koenkk/zigbee-herdsman-converters/issues/1050
- https://github.com/Koenkk/zigbee2mqtt/issues/13903
- https://www.zigbee2mqtt.io/devices/SP-EUC01.html
