### PR TITLE
fix(NodOn): fix wired input reporting on SIN-4-2-20 endpoint 1

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -559,7 +559,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Lighting relay switch",
         extend: [
             m.identify(),
-            m.deviceEndpoints({endpoints: {default: 1, l1: 1, l2: 2}}),
+            m.deviceEndpoints({endpoints: {l1: 1, l2: 2, default: 1}}),
             m.onOff({endpointNames: ["l1", "l2"]}),
             nodonModernExtend.switchTypeOnOff({endpointName: "l1"}),
             nodonModernExtend.switchTypeOnOff({endpointName: "l2"}),


### PR DESCRIPTION
Fixes [#32802](https://github.com/Koenkk/zigbee2mqtt/issues/32802).

`m.deviceEndpoints({endpoints: {default: 1, l1: 1, l2: 2}})` (added in #12729 for the endpoint 242 fix) gives endpoint 1 two names. `getKey()`, used to label incoming reports, returns the first matching key by insertion order and doesn't special-case `"default"` like Z2M's own `Device.endpointName()` does. Reports on endpoint 1 were published as `state_default`/`power_on_behavior_default` instead of `state_l1`/`power_on_behavior_l1`. Outgoing commands resolve the endpoint by name directly, so were unaffected.

### Fix

```diff
  extend: [
      m.identify(),
-     m.deviceEndpoints({endpoints: {default: 1, l1: 1, l2: 2}}),
+     m.deviceEndpoints({endpoints: {l1: 1, l2: 2, default: 1}}),
      m.onOff({endpointNames: ["l1", "l2"]}),
      nodonModernExtend.switchTypeOnOff({endpointName: "l1"}),
      nodonModernExtend.switchTypeOnOff({endpointName: "l2"}),
  ],
```
