### PR TITLE
feat: Nova Digital ZVL-DUAL: add _TZE284_n41i9jyt fingerprint

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -23086,7 +23086,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_8zizsafo", "_TZE284_iilebqoo"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_8zizsafo", "_TZE284_iilebqoo", "_TZE284_n41i9jyt"]),
         model: "GX03",
         vendor: "GIEX",
         description: "GIEX 2-zone watering timer",
@@ -23131,7 +23131,7 @@ export const definitions: DefinitionWithExtend[] = [
                 [59, "battery", tuya.valueConverter.raw],
             ],
         },
-        whiteLabel: [tuya.whitelabel("Nova Digital", "ZVL-DUAL", "Water Valve with 2 zones", ["_TZE284_iilebqoo"])],
+        whiteLabel: [tuya.whitelabel("Nova Digital", "ZVL-DUAL", "Water Valve with 2 zones", ["_TZE284_iilebqoo", "_TZE284_n41i9jyt"])],
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_eaulras5"]),


### PR DESCRIPTION
Adds the `_TZE284_n41i9jyt` manufacturer code to the existing GIEX `GX03` definition, which already covers the Nova Digital ZVL-DUAL as a white label.

### Device

This unit is sold in Brazil as the **Nova Digital ZVL-DUAL** (dual-zone water valve) — the same product already listed as a white label of `GX03` for `_TZE284_iilebqoo`. It pairs reporting a different manufacturer code:

```
modelID:            TS0601
manufacturerName:   _TZE284_n41i9jyt
type:               EndDevice (battery)
endpoint 1 input:   genBasic, genGroups, genScenes, manuSpecificTuya
endpoint 1 output:  genOta, genTime
```

Since that code is not in the fingerprint list, the device falls back to the auto-generated definition (`supported: false`, only `linkquality` exposed).

### Change

Two lines: the code is added to the `GX03` fingerprint and to the `ZVL-DUAL` white label, so the device is branded as Nova Digital rather than GIEX.

No device picture PR is needed — `ZVL-DUAL` already exists in the documentation.

### Checks

- `pnpm run check` — passed
- `pnpm run build` — passed (4452 definitions)
- `pnpm test` — passed (823 tests, 26 files)

### Note on hardware validation

I own this device and am validating the datapoints on it using an external converter that mirrors this exact definition. I will report back here with the result. Happy to hold the merge until that confirmation if you prefer.
