### PR TITLE
fix(Tongou TOWSMR1): disable respondToMcuVersionResponse to stop commandMcuVersionResponse avalanche

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -20454,8 +20454,10 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.modernExtend.tuyaBase({
                 dp: true,
                 queryOnConfigure: true,
-                queryIntervalSeconds: 10,
-                respondToMcuVersionResponse: true,
+                // respondToMcuVersionResponse omitted (defaults to false): when enabled this MCU emits an
+                // avalanche of commandMcuVersionResponse messages every second. Same fix already applied to
+                // the sibling Tongou TOQCB2-80 breaker below.
+                queryIntervalSeconds: 3 * 60,
             }),
         ],
         whiteLabel: [


### PR DESCRIPTION
**Device:** Tongou TOWSMR1 single-phase multifunction RCBO (DIN module)
**Fingerprints:** `_TZE204_432zhuwe`, `_TZE284_432zhuwe` (the `TOWSMR1` definition also covers `kobbcyum`, `hecsejsb`, `s5vuaadg`, `tuhfx7tf`).

### Problem
With `respondToMcuVersionResponse: true`, this device's MCU avalanches: every time Z2M answers a `commandMcuVersionResponse` the MCU immediately sends another one, producing a flood of `commandMcuVersionResponse` messages roughly once per second, indefinitely. Together with `queryIntervalSeconds: 10` the device is needlessly chatty.

This is the exact behaviour already documented in this file for the sibling **Tongou TOQCB2-80** breaker:

```ts
// Important: respondToMcuVersionResponse should be false otherwise there is an
// avalanche of commandMcuVersionResponse messages every second.
extend: [tuya.modernExtend.tuyaBase({dp: true, queryIntervalSeconds: 3 * 60})],
```

TOWSMR1 is the same Tongou MCU family and behaves the same way, but was left with `respondToMcuVersionResponse: true`.

### Fix
Mirror the TOQCB2-80 treatment: omit `respondToMcuVersionResponse` (it defaults to `false`; the type only permits `true`, so omission is the way to disable it) and slow the poll to `3 * 60` s. Behaviour-only change - no datapoint/expose edits. `queryOnConfigure: true` kept.

### Verification
Ran this change as a local external converter against a live `_TZE204_432zhuwe` unit: the per-second `commandMcuVersionResponse` flood stops entirely, the device stays online, interview completes SUCCESSFUL, and all datapoints (switch, energy, voltage/current, leakage_current, thresholds, reclosers, event) keep reporting and accept writes.
