### PR TITLE
fix: skip external review when PR author is a code owner

### DIFF
--- a/.github/workflows/requires_review.yml
+++ b/.github/workflows/requires_review.yml
@@ -26,6 +26,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
         # Skip if PR already has the approval label
         LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
@@ -62,6 +63,20 @@ jobs:
 
             if [[ $file == $glob ]]; then
               reviewers="${PATTERN_REVIEWERS[$pattern]}"
+
+              # Skip if the PR author is one of the code owners for this file
+              # (owners can't review their own PRs, so don't require it).
+              IS_OWNER=false
+              for owner in $reviewers; do
+                owner_clean="${owner#@}"
+                if [[ "$owner_clean" == "$PR_AUTHOR" ]]; then
+                  IS_OWNER=true
+                  echo "::notice::Skipping '$file' — PR author @$PR_AUTHOR is a code owner"
+                  break
+                fi
+              done
+              $IS_OWNER && continue
+
               echo "::error::Review required for '$file' by '$reviewers'"
               MATCHED_REVIEWERS["$reviewers"]+="$file"$'\n'
               MATCH=true


### PR DESCRIPTION
## Summary

* Skip the external review requirement for PRs authored by a code owner of the modified file.
* Alternatively, if feasible, allow the `CubeZ2mDeveloper` account to add the required review label to PRs.

## Motivation

After being added as code owners, we noticed that PRs submitted by the code owners themselves still trigger the `external-review-required` check.

Since the PR author is already a code owner of the modified files, requiring an additional external review in this specific case may not be necessary.

Currently, we are also unable to add the required review label ourselves, which prevents code-owner-authored PRs from proceeding through the existing review workflow.

## Proposed Changes

Update the `requires_review.yml` workflow to:

* Identify the PR author.
* Check whether the PR author is a code owner for each modified file.
* Skip the external review requirement when the PR author is a code owner.
* Keep the existing external review requirement for files where the PR author is not a code owner.

This change would only affect the external review requirement and would not modify the existing `CODEOWNERS` configuration.

## Alternative Approach

If skipping the external review requirement for code-owner-authored PRs is not preferred, we would also be happy to consider whether the `CubeZ2mDeveloper` account could be granted permission to add the required review label.

However, based on the [GitHub documentation on permission levels for personal account repositories](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository), personal account repositories do not provide the same fine-grained permission controls available in organization repositories. Therefore, it may not be possible to grant only the permission to add labels.

For this reason, if possible, we believe that handling code-owner-authored PRs directly in the `requires_review.yml` workflow may be the simpler and more appropriate approach.

Either approach would allow code-owner-authored PRs to proceed through the existing workflow without requiring an additional external reviewer, while keeping the current external review requirement for other contributors.