### PR TITLE
fix: correct HR-C99C-Z-C045 temperature actions

### DIFF
--- a/src/devices/adeo.ts
+++ b/src/devices/adeo.ts
@@ -4,7 +4,7 @@ import * as exposes from "../lib/exposes";
 import * as m from "../lib/modernExtend";
 import {nodonPilotWire} from "../lib/nodon";
 import * as reporting from "../lib/reporting";
-import type {DefinitionWithExtend, Fz, KeyValueNumberString, Tz} from "../lib/types";
+import type {DefinitionWithExtend, Fz, KeyValueAny, KeyValueNumberString, Tz} from "../lib/types";
 import * as utils from "../lib/utils";
 
 const e = exposes.presets;
@@ -48,6 +48,27 @@ const fzLocal = {
             return payload;
         },
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, ["raw"]>,
+    command_step_color_temperature: {
+        cluster: "lightingColorCtrl",
+        type: "commandStepColorTemp",
+        convert: (model, msg, publish, options, meta) => {
+            if (utils.hasAlreadyProcessedMessage(msg, model)) return;
+            // The physical up/down buttons use the opposite ZCL step modes.
+            const direction = msg.data.stepmode === 3 ? "up" : "down";
+            const payload: KeyValueAny = {
+                action: utils.postfixWithEndpointName(`color_temperature_step_${direction}`, msg, model, meta),
+                action_step_size: msg.data.stepsize,
+                action_color_temperature_delta: direction === "up" ? msg.data.stepsize : -1 * msg.data.stepsize,
+            };
+
+            if (msg.data.transtime !== undefined) {
+                payload.action_transition_time = msg.data.transtime / 10;
+            }
+
+            utils.addActionGroup(payload, msg, model);
+            return payload;
+        },
+    } satisfies Fz.Converter<"lightingColorCtrl", undefined, "commandStepColorTemp">,
 };
 
 const tzLocal = {
@@ -294,7 +315,7 @@ export const definitions: DefinitionWithExtend[] = [
             fz.command_off,
             fz.command_step,
             fz.command_stop,
-            fz.command_step_color_temperature,
+            fzLocal.command_step_color_temperature,
             fz.command_step_hue,
             fz.command_step_saturation,
             fzLocal.color_stop_raw,

--- a/test/adeo.test.ts
+++ b/test/adeo.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from "vitest";
+import {findByDevice} from "../src";
+import type {Fz, KeyValueAny} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+describe("ADEO HR-C99C-Z-C045", () => {
+    const convertStepColorTemperature = async (stepmode: number, sequenceNumber: number) => {
+        const device = mockDevice({
+            modelID: "LXEK-5",
+            manufacturerName: "ADEO",
+            ieeeAddr: "0x086bd7fffe1bc3f2",
+            endpoints: [{ID: 1, outputClusters: ["lightingColorCtrl"]}],
+        });
+        const definition = await findByDevice(device);
+        const converter = definition.fromZigbee.find(
+            (candidate) => candidate.cluster === "lightingColorCtrl" && candidate.type.includes("commandStepColorTemp"),
+        );
+        if (!converter) throw new Error("missing color temperature step converter");
+
+        const msg = {
+            data: {stepmode, stepsize: 22, transtime: 5, minimum: 153, maximum: 370, optionsMask: 0, optionsOverride: 0},
+            endpoint: device.getEndpoint(1),
+            device,
+            meta: {zclTransactionSequenceNumber: sequenceNumber},
+            groupID: null,
+            type: "commandStepColorTemp",
+            cluster: "lightingColorCtrl",
+            linkquality: 25,
+        } as unknown as Fz.Message;
+
+        return converter.convert(definition, msg, () => {}, {}, {device} as unknown as Fz.Meta) as KeyValueAny;
+    };
+
+    it("maps the captured physical up press to color temperature step up", async () => {
+        await expect(convertStepColorTemperature(3, 76)).resolves.toStrictEqual({
+            action: "color_temperature_step_up",
+            action_step_size: 22,
+            action_color_temperature_delta: 22,
+            action_transition_time: 0.5,
+        });
+    });
+
+    it("maps the captured physical down press to color temperature step down", async () => {
+        await expect(convertStepColorTemperature(1, 77)).resolves.toStrictEqual({
+            action: "color_temperature_step_down",
+            action_step_size: 22,
+            action_color_temperature_delta: -22,
+            action_transition_time: 0.5,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add an ADEO-specific color-temperature step converter for `HR-C99C-Z-C045`.
- Map the physical top button to `color_temperature_step_up`.
- Map the physical bottom button to `color_temperature_step_down`.
- Keep the step size, delta, transition time, and action group fields.
- Add regression tests with payloads captured from the device.

## Hardware evidence

A CC2531 radio capture shows that this remote uses the opposite ZCL step modes for its physical temperature buttons:

- Physical top: step mode `3`, step size `22`, transition time `5`.
- Physical bottom: step mode `1`, step size `22`, transition time `5`.

The generic converter maps step mode `1` to up. This gives inverted actions for this device.

The center button is a local mode selector. The center button and the left/right ring buttons in temperature mode send no Zigbee frame, so this PR does not add actions for them.

## Verification

- `pnpm run check`
- `pnpm test` (825 tests passed)
- `pnpm run build`