### PR TITLE
feat(add): MS032Z

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -30227,7 +30227,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE284_rovbuqdo"}],
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_rovbuqdo"]),
         model: "MS032Z",
         vendor: "Tuya",
         description: "LED smart stair light controller (32 steps)",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1950,6 +1950,41 @@ const fzLocal = {
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
 };
 
+// MS032Z stair light controller - DP 125, the six running-light effects.
+const ms032zEffects = {running_water: 1, septum: 2, full_bright: 3, following: 4, colorful: 5, smear: 6};
+
+// MS032Z - DP 103, colour channel order of the addressable strip.
+const ms032zColorOrder = {
+    RGB: tuya.enum(0),
+    RBG: tuya.enum(1),
+    GRB: tuya.enum(2),
+    GBR: tuya.enum(3),
+    BRG: tuya.enum(4),
+    BGR: tuya.enum(5),
+};
+
+// MS032Z - DP 112, LED driver chip. Tuya only names the first three, the rest are
+// numbered. All values have to be listed, otherwise reading a device set to one of
+// the unnamed types throws.
+const ms032zLedChips = {
+    WS2811: tuya.enum(0),
+    DMX512: tuya.enum(1),
+    FW1935: tuya.enum(2),
+    type_3: tuya.enum(3),
+    type_4: tuya.enum(4),
+    type_5: tuya.enum(5),
+    type_6: tuya.enum(6),
+    type_7: tuya.enum(7),
+    type_8: tuya.enum(8),
+    type_9: tuya.enum(9),
+    type_10: tuya.enum(10),
+    type_11: tuya.enum(11),
+    type_12: tuya.enum(12),
+    type_13: tuya.enum(13),
+    type_14: tuya.enum(14),
+    type_15: tuya.enum(15),
+};
+
 export const definitions: DefinitionWithExtend[] = [
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_rjjsib2d"]),
@@ -30188,6 +30223,67 @@ export const definitions: DefinitionWithExtend[] = [
                 [130, "moisture_v1_set", tuya.valueConverter.raw],
                 [131, "moisture_calibration", tuya.valueConverter.divideBy100],
                 [132, "moisture_warning", tuya.valueConverterBasic.lookup({none: tuya.enum(0), low: tuya.enum(1), high: tuya.enum(2)})],
+            ],
+        },
+    },
+    {
+        fingerprint: [{modelID: "TS0601", manufacturerName: "_TZE284_rovbuqdo"}],
+        model: "MS032Z",
+        vendor: "Tuya",
+        description: "LED smart stair light controller (32 steps)",
+        extend: [tuyaBase({dp: true, queryOnConfigure: true, queryOnDeviceAnnounce: true})],
+        exposes: [
+            te.lightBrightness(),
+            e
+                .enum("effect", ea.STATE_SET, Object.keys(ms032zEffects))
+                .withDescription("Running-light effect. Applies to the steps and the side strip together"),
+            e
+                .numeric("speed", ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(100)
+                .withValueStep(1)
+                .withDescription("Speed at which the steps light up one after another"),
+            e.numeric("step_count", ea.STATE_SET).withValueMin(1).withValueMax(32).withValueStep(1).withDescription("Number of steps connected"),
+            e
+                .numeric("light_off_delay", ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(30)
+                .withValueStep(1)
+                .withUnit("s")
+                .withDescription("Time the lights stay on after the motion sensor stops detecting"),
+            e.binary("motion_up", ea.STATE, "ON", "OFF").withDescription("Motion detected by the sensor at the top of the stairs"),
+            e.binary("motion_down", ea.STATE, "ON", "OFF").withDescription("Motion detected by the sensor at the bottom of the stairs"),
+            e
+                .numeric("strip_led_count", ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(1024)
+                .withValueStep(1)
+                .withDescription("Number of LEDs on the addressable strip"),
+            e.enum("rgb_order", ea.STATE_SET, Object.keys(ms032zColorOrder)).withDescription("Colour channel order of the addressable strip"),
+            e.enum("led_chip", ea.STATE_SET, Object.keys(ms032zLedChips)).withDescription("LED driver chip used by the strip"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "state", tvc.onOff],
+                [102, "strip_led_count", tvc.raw],
+                [103, "rgb_order", tuya.valueConverterBasic.lookup(ms032zColorOrder, "unknown")],
+                [112, "led_chip", tuya.valueConverterBasic.lookup(ms032zLedChips, "unknown")],
+                [124, "step_count", tvc.raw],
+                [125, "effect", tuya.valueConverterBasic.lookup(ms032zEffects, "unknown")],
+                [126, "speed", tvc.raw],
+                // The device works in percent, Zigbee2MQTT in 0-254. DP 3 is in the Tuya thing
+                // model but does not exist in this firmware, so brightness lives on DP 127.
+                [127, "brightness", tuya.valueConverterBasic.scale(0, 254, 0, 100)],
+                // Tuya calls DP 128/129 "up_step_test"/"down_step_test", but a capture of the raw
+                // traffic while walking the stairs shows these are what the motion sensors report on.
+                // The sensors cannot be disabled over Zigbee: per the manufacturer manual they are
+                // separately paired wireless sensors (channels R and L on the controller itself).
+                [128, "motion_up", tvc.onOff],
+                [129, "motion_down", tvc.onOff],
+                [134, "light_off_delay", tvc.raw],
+                // DP 116 (value), 132 (value, mirrors 102) and 133 (raw colour) also exist on this
+                // device, but their meaning is unconfirmed and they may be output configuration
+                // parameters, so they are deliberately left out rather than guessed at.
             ],
         },
     },


### PR DESCRIPTION
Adds support for the Tuya `TS0601` / `_TZE284_rovbuqdo` LED smart stair light
controller (32 steps), sold as **MS032Z** (Zigbee variant of the MS032X family by
Guangdong AIPIN Technology) and also as MC032X.

Closes Koenkk/zigbee2mqtt#31390, Koenkk/zigbee2mqtt#31494, Koenkk/zigbee2mqtt#31612, Koenkk/zigbee2mqtt#31703.

## Why this is not based on the Tuya "thing model"

The cloud thing model for this product lists 39 datapoints. That is the template
for the whole product category, not what the hardware implements — several of
those DPs silently do nothing, which is what made earlier external converters
expose controls that had no effect.

Instead the definition below is based on a forced `dataQuery`
(`queryOnConfigure`) against a real device. It reports exactly **14** datapoints,
and repeating the query gives an identical list:

| DP | type | value seen | meaning |
|---:|---|---|---|
| 1 | bool | 1 | on/off |
| 102 | value | 118 | strip LED count |
| 103 | enum | 0 | colour order (RGB) |
| 112 | enum | 6 | LED driver chip |
| 116 | value | 3 | **unknown** |
| 124 | value | 15 | number of steps |
| 125 | value | 4 | effect (following) |
| 126 | value | 65 | speed |
| 127 | value | 18 | brightness (percent) |
| 128 | bool | 0 | motion sensor, top |
| 129 | bool | 0 | motion sensor, bottom |
| 132 | value | 118 | **unknown**, mirrors 102 |
| 133 | raw | `00 ff 00 01` | colour |
| 134 | value | 1 | light-off delay |

A second owner reported the same 14 DPs on the same firmware (appVersion 78) in
Koenkk/zigbee2mqtt#31390. DP 2, 3, 101, 104, 105-108, 118, 122, 130 and 131 do **not** exist on this
device, even though the thing model lists them.

## Notes

- **Brightness is DP 127, not DP 3.** DP 3 is in the thing model but not in the
  firmware, so brightness sliders built on it do nothing.
- **DP 116, 132 and 133 are deliberately left unmapped.** They exist but their
  meaning is unconfirmed, and they may be hardware/output configuration
  parameters, so guessing at them seemed worse than omitting them.
- **The motion sensors cannot be disabled over Zigbee**, and there is no DP for
  it. Per the manufacturer's manual (MS032X, v3.2.0) they are separately paired
  wireless sensors on channels R and L; unpairing is done on the controller.
- **Steps and side strip share one effect, speed and brightness.** There is no
  second set of DPs, so they cannot be configured independently.
- DP 128/129 are named `up_step_test`/`down_step_test` by Tuya, but a capture of
  the raw traffic while walking up and down the stairs shows these are what the
  PIR sensors report on. Two users asked for these DPs in Koenkk/zigbee2mqtt#31390 and never got an
  answer; they are included here.
- Naming (`light_off_delay`, `motion_up`/`motion_down`, `led_chip`) is of course
  open to whatever you prefer.
- Full disclosure on the effect names: the six labels on DP 125 come from the
  external converter in Koenkk/zigbee2mqtt#31494, which several owners of this controller have been
  using since March. I verified that DP 125 accepts and reports values 1-6, but I
  have not independently confirmed that each label matches what the strip does.

## Testing

Running on Zigbee2MQTT 2.13.0 as an external converter against a live device:
on/off, brightness, effect, speed, step count, delay, strip LED count, colour
order and LED chip all read back correctly after a `dataQuery`, and both motion
sensors report while walking the stairs.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
