### PR TITLE
feat(add): Selena SC0002

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -284,6 +284,7 @@ import {definitions as schneiderElectric} from "./schneider_electric";
 import {definitions as schwaiger} from "./schwaiger";
 import {definitions as seastarIntelligence} from "./seastar_intelligence";
 import {definitions as securifi} from "./securifi";
+import {definitions as selena} from "./selena";
 import {definitions as sengled} from "./sengled";
 import {definitions as senoro} from "./senoro";
 import {definitions as sercomm} from "./sercomm";
@@ -667,6 +668,7 @@ const definitions: DefinitionWithExtend[] = [
     ...schwaiger,
     ...seastarIntelligence,
     ...securifi,
+    ...selena,
     ...sengled,
     ...senoro,
     ...sercomm,

--- a/src/devices/selena.ts
+++ b/src/devices/selena.ts
@@ -1,0 +1,12 @@
+import * as m from "../lib/modernExtend";
+import type {DefinitionWithExtend} from "../lib/types";
+
+export const definitions: DefinitionWithExtend[] = [
+    {
+        zigbeeModel: ["SC0002"],
+        model: "SC0002",
+        vendor: "Selena",
+        description: "Desktop environmental monitoring station",
+        extend: [m.temperature(), m.pressure(), m.humidity(), m.illuminance(), m.co2()],
+    },
+];


### PR DESCRIPTION
<!-- Thank you for your contribution!
If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5453

Adds support for the Selena SC0002 desktop environmental monitoring station.

Exposes temperature, pressure, humidity, illuminance, and CO2. Tested as an external converter in Zigbee2MQTT; live readings are reported successfully.