### PR TITLE
Detect _TZ3000_wvedmwyp as TS130F_dual

### DIFF
--- a/src/devices/lonsonho.ts
+++ b/src/devices/lonsonho.ts
@@ -54,6 +54,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_l6iqph4f",
             "_TZ3000_xdo0hj1k",
             "_TZ3000_bmhwnl7s",
+            "_TZ3000_wvedmwyp",
         ]),
         model: "TS130F_dual",
         vendor: "Lonsonho",


### PR DESCRIPTION
This TS130F variant is a dual curtain/shutter switch with closuresWindowCovering on endpoints 1 and 2.

Adds `_TZ3000_wvedmwyp` as a fingerprint for the existing
Lonsonho `TS130F_dual` definition.

Device information:
- Zigbee model: TS130F
- Manufacturer: _TZ3000_wvedmwyp
- Device type: Dual curtain/shutter switch

The device exposes two physical shutter endpoints:

Endpoint 
- genGroups
- genScenes
- genOnOff
- closuresWindowCovering
- manuSpecificTuya3
- genBasic

Endpoint 2:
- genGroups
- genScenes
- genOnOff
- closuresWindowCovering
- manuSpecificTuya3

Zigbee2MQTT currently detects it as the single-channel TS130F,
although both shutter endpoints are present.

The existing TS130F_dual definition already maps:
- left: endpoint 1
- right: endpoint 2
<img width="737" height="296" alt="b5f40e12-c14b-48a3-89b9-402f1409de0d" src="https://github.com/user-attachments/assets/631ff597-6e46-4bf4-8d61-2dba43054eb1" />
<img width="726" height="426" alt="b9584bed-8184-4383-973c-6ad0b25d4df2" src="https://github.com/user-attachments/assets/f1810026-1893-4f6d-9e98-0ba3777dc3e4" />
<img width="402" height="392" alt="ccf69715-7630-4d8a-86b6-ab42f3a84173" src="https://github.com/user-attachments/assets/ccf6933c-d9c4-4dca-9443-ce3aaa589adb" />
