### PR TITLE
fix(detect): Detect `_TZE28C1000000_huu3td85` as AVATTO ZDMS16-1

### DIFF
--- a/src/devices/avatto.ts
+++ b/src/devices/avatto.ts
@@ -384,10 +384,12 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_nqqylykc",
             "_TZE204_huu3td85",
             "_TZE284_huu3td85",
+            "_TZE28C1000000_huu3td85",
         ]),
         model: "ZDMS16-1",
         vendor: "AVATTO",
         description: "Zigbee Module 1 channel Dimmer",
+        whiteLabel: [tuya.whitelabel("NovaDigital", "MS-DM-ZB", "Zigbee Module 1 channel Dimmer", ["_TZE28C1000000_huu3td85"])],
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
             tuya.exposes.lightBrightnessWithMinMax(),


### PR DESCRIPTION
The **NovaDigital MS-DM-ZB** (1 channel Zigbee TRIAC mini dimmer, sold in Brazil) is a rebrand of the AVATTO ZDMS16-1. It reports `TS0601` / `_TZE28C1000000_huu3td85`, which is currently unmatched, so Zigbee2MQTT falls back to an auto-generated definition that exposes nothing but `linkquality`.

The `huu3td85` suffix is already supported under `_TZE204_` and `_TZE284_`; only this prefix variant was missing. The `_TZE28C1000000_` prefix is already used elsewhere in the same family, e.g. `_TZE28C1000000_nqqylykc` on this very definition and `_TZE28C1000000_jtbgusdc` on the ZDMS16-2 (#12476).

All 7 datapoints of the existing ZDMS16-1 definition apply unchanged.

### Testing

Verified on Zigbee2MQTT 2.13.0 (zigbee-herdsman-converters 26.90.0) with a Sonoff ZBDongle-P, by loading the same definition as an external converter against the physical device.

Before:

```
supported: false
model:   TS0601
vendor:  _TZE28C1000000_huu3td85
source:  generated
exposes: linkquality
```

After:

```
supported: true
model:   MS-DM-ZB
vendor:  NovaDigital
exposes: light (state, brightness, min_brightness, max_brightness),
         countdown, switch_type, power_on_behavior, linkquality
```

The device is paired and reporting (`linkquality` 90, `last_seen` current), and the Home Assistant entities are created as expected (`light`, `number.countdown`, `select.switch_type`, `select.power_on_behavior`).

To be explicit about the limits of my testing: I have confirmed detection and the resulting exposes, not yet the physical actuation — the unit is mid-installation here and the values are still `null`, since a TS0601 only pushes datapoints on change. The datapoint mapping is unmodified from the existing ZDMS16-1, so I would not expect it to differ, but I did not want to overstate it. Happy to follow up with an actuation report once the wiring is finished, if you would prefer to hold the PR until then.