### PR TITLE
feat: add STH2Z support to Rti-Tek STHZB

### DIFF
--- a/src/devices/rti_tek.ts
+++ b/src/devices/rti_tek.ts
@@ -13,6 +13,7 @@ const rtiTekFd22 = "rtiTekFd22";
 const rtiTekFd22Id = 0xfd22;
 const fastPollTimeout = 120; // Poll Control uses quarter-seconds, so this is 30 seconds.
 const temperatureUnitMetaKey = "rtiTekTemperatureUnit";
+const productNameMetaKey = "rtiTekProductName";
 
 const faultBits: Record<number, string> = {
     0: "internal_sensor_fault",
@@ -53,6 +54,7 @@ interface RtiTekFd22Cluster {
     attributes: {
         temperatureUnit: number;
         faultCode: number;
+        productName: string;
         internalTemperatureCalibration: number;
         internalHumidityCalibration: number;
         sampleInterval: number;
@@ -62,6 +64,10 @@ interface RtiTekFd22Cluster {
         humidityAlarmLower: number;
         temperatureAlarmStatus: number;
         humidityAlarmStatus: number;
+        sth2zHumidityComfortLower: number;
+        sth2zHumidityComfortUpper: number;
+        sth2zHumidityComfortTemperatureLower: number;
+        sth2zHumidityComfortTemperatureUpper: number;
     };
     commands: never;
     commandResponses: never;
@@ -120,6 +126,25 @@ function setTemperatureUnit(device: Zh.Device | undefined, fahrenheit: boolean) 
     device.save();
 }
 
+function normalizeProductName(value: unknown): string {
+    return Buffer.isBuffer(value)
+        ? value.toString("utf8").trim().toUpperCase()
+        : String(value ?? "")
+              .trim()
+              .toUpperCase();
+}
+
+function isSth2z(device: Zh.Device | DummyDevice | undefined): boolean {
+    return Boolean(device && "meta" in device && device.meta?.[productNameMetaKey] === "STH2Z");
+}
+
+function setProductName(device: Zh.Device | undefined, productName: string) {
+    if (!device) return;
+    device.meta ??= {};
+    device.meta[productNameMetaKey] = productName;
+    device.save();
+}
+
 export function validateAlarmLimits(state: Record<string, number>): void {
     if (
         state.temperature_alarm_lower !== undefined &&
@@ -175,6 +200,7 @@ export function computeHumidityComfort(
 const rtiTekFd22Attributes = {
     temperatureUnit: {ID: 0x0000, type: Zcl.DataType.ENUM8},
     faultCode: {ID: 0x0002, type: Zcl.DataType.UINT32},
+    productName: {ID: 0x0003, type: Zcl.DataType.CHAR_STR},
     internalTemperatureCalibration: {ID: 0xe005, type: Zcl.DataType.INT8},
     internalHumidityCalibration: {ID: 0xe006, type: Zcl.DataType.INT8},
     sampleInterval: {ID: 0xe009, type: Zcl.DataType.UINT16},
@@ -184,6 +210,10 @@ const rtiTekFd22Attributes = {
     humidityAlarmLower: {ID: 0xe00d, type: Zcl.DataType.UINT16},
     temperatureAlarmStatus: {ID: 0xe00e, type: Zcl.DataType.ENUM8},
     humidityAlarmStatus: {ID: 0xe00f, type: Zcl.DataType.ENUM8},
+    sth2zHumidityComfortLower: {ID: 0xe014, type: Zcl.DataType.UINT16},
+    sth2zHumidityComfortUpper: {ID: 0xe015, type: Zcl.DataType.UINT16},
+    sth2zHumidityComfortTemperatureLower: {ID: 0xe016, type: Zcl.DataType.INT16},
+    sth2zHumidityComfortTemperatureUpper: {ID: 0xe017, type: Zcl.DataType.INT16},
 } as const;
 
 const delay = async (milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
@@ -233,12 +263,44 @@ async function readFd22Attributes(endpoint: Zh.Endpoint, attributes: number[]) {
     }
 }
 
+async function readProductName(endpoint: Zh.Endpoint, device: Zh.Device) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            const {productName} = await endpoint.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["productName"]);
+            const normalized = normalizeProductName(productName);
+            if (normalized) {
+                setProductName(device, normalized);
+            } else {
+                logger.warning(`STHZB '${device.ieeeAddr}' did not return product name; using STH1Z-compatible settings`, NS);
+            }
+            return;
+        } catch (error) {
+            logger.debug(`STHZB '${device.ieeeAddr}' product name read failed: ${error}`, NS);
+        }
+        if (attempt < 2) await delay(1000);
+    }
+
+    logger.warning(`STHZB '${device.ieeeAddr}' did not return product name; using STH1Z-compatible settings`, NS);
+}
+
 const comfortStateKeys = {
     humidityLower: "comfort_humidity_lower_limit",
     humidityUpper: "comfort_humidity_upper_limit",
     temperatureLower: "comfort_temperature_lower_limit",
     temperatureUpper: "comfort_temperature_upper_limit",
 } as const;
+
+type ComfortStateKey = (typeof comfortStateKeys)[keyof typeof comfortStateKeys];
+
+const sth2zComfortAttributes = {
+    [comfortStateKeys.humidityLower]: "sth2zHumidityComfortLower",
+    [comfortStateKeys.humidityUpper]: "sth2zHumidityComfortUpper",
+    [comfortStateKeys.temperatureLower]: "sth2zHumidityComfortTemperatureLower",
+    [comfortStateKeys.temperatureUpper]: "sth2zHumidityComfortTemperatureUpper",
+} as const satisfies Record<ComfortStateKey, keyof RtiTekFd22Cluster["attributes"]>;
+
+const sth1zFd22AttributeIds = [0x0000, 0x0002, 0xe005, 0xe006, 0xe009, 0xe00a, 0xe00b, 0xe00c, 0xe00d, 0xe00e, 0xe00f];
+const sth2zComfortAttributeIds = [0xe014, 0xe015, 0xe016, 0xe017];
 
 const alarmStatusLookup = {normal: 0, low: 1, high: 2} as const;
 
@@ -402,23 +464,12 @@ function sth1zDerivedEnvironment(): ModernExtend {
                 );
             },
         } satisfies Fz.Converter<"msRelativeHumidity", undefined, ["attributeReport", "readResponse"]>,
-        {
-            cluster: "genPowerCfg",
-            type: ["attributeReport", "readResponse"],
-            convert: (_model, _msg, _publish, _options, meta) =>
-                deriveEnvironment(
-                    getCelsiusStateNumber(meta.state, "temperature", Number.NaN, isFahrenheit(meta.device)),
-                    Number(meta.state.humidity),
-                    meta.state,
-                    isFahrenheit(meta.device),
-                ),
-        } satisfies Fz.Converter<"genPowerCfg", undefined, ["attributeReport", "readResponse"]>,
     ];
 
     const toZigbee: Tz.Converter[] = [
         {
             key: Object.values(comfortStateKeys),
-            convertSet: (_entity, key, value, meta) => {
+            convertSet: (entity, key, value, meta) => {
                 const fahrenheit = isFahrenheit(meta.device);
                 const displayValue = Number(value);
                 const normalized = isTemperatureKey(key) ? toCelsiusTemperature(displayValue, temperatureKinds[key], fahrenheit) : displayValue;
@@ -439,6 +490,30 @@ function sth1zDerivedEnvironment(): ModernExtend {
                 if (humidityLower >= humidityUpper) throw new Error("comfort humidity lower limit must be below upper limit");
                 if (temperatureLower >= temperatureUpper) throw new Error("comfort temperature lower limit must be below upper limit");
 
+                const attribute = sth2zComfortAttributes[key as ComfortStateKey];
+                if (isSth2z(meta.device) && attribute) {
+                    const raw = isTemperatureKey(key) ? Math.round(normalized * 10) * 10 : Math.round(normalized) * 100;
+                    const deviceValue = raw / 100;
+                    const nextValue = isTemperatureKey(key)
+                        ? round(toDisplayTemperature(deviceValue, temperatureKinds[key], fahrenheit), 1)
+                        : deviceValue;
+                    const nextState = {...meta.state, [key]: nextValue};
+                    return (async () => {
+                        await entity.write<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, {[attribute]: raw} as never);
+                        return {
+                            state: {
+                                [key]: nextValue,
+                                ...deriveEnvironment(
+                                    getCelsiusStateNumber(nextState, "temperature", Number.NaN, fahrenheit),
+                                    Number(nextState.humidity),
+                                    nextState,
+                                    fahrenheit,
+                                ),
+                            },
+                        };
+                    })();
+                }
+
                 const nextValue = isTemperatureKey(key) ? round(toDisplayTemperature(normalized, temperatureKinds[key], fahrenheit), 1) : normalized;
                 const nextState = {...meta.state, [key]: nextValue};
                 return {
@@ -453,7 +528,12 @@ function sth1zDerivedEnvironment(): ModernExtend {
                     },
                 };
             },
-            convertGet: (_entity, key, meta) => {
+            convertGet: async (entity, key, meta) => {
+                const attribute = sth2zComfortAttributes[key as ComfortStateKey];
+                if (isSth2z(meta.device) && attribute) {
+                    await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, [attribute]);
+                    return;
+                }
                 const fallbackKey = Object.entries(comfortStateKeys).find(
                     ([, stateKey]) => stateKey === key,
                 )?.[0] as keyof typeof humidityComfortDefaults;
@@ -462,11 +542,11 @@ function sth1zDerivedEnvironment(): ModernExtend {
                     ? round(toDisplayTemperature(humidityComfortDefaults[fallbackKey], temperatureKinds[key], isFahrenheit(meta.device)), 1)
                     : humidityComfortDefaults[fallbackKey];
                 const value = currentValue === undefined || currentValue === null ? fallbackValue : Number(currentValue);
-                return Promise.resolve({
+                return {
                     state: {
                         [key]: value,
                     },
-                });
+                };
             },
         },
     ];
@@ -494,6 +574,68 @@ function sth1zDerivedEnvironment(): ModernExtend {
     ];
 
     return {exposes: [expose], fromZigbee, toZigbee, isModernExtend: true};
+}
+
+function sthzbProductName(): ModernExtend {
+    const fromZigbee = {
+        cluster: rtiTekFd22,
+        type: ["attributeReport", "readResponse"],
+        convert: (_model, msg, _publish, _options, meta) => {
+            if (msg.data.productName === undefined) return;
+            const productName = normalizeProductName(msg.data.productName);
+            const previousProductName = meta.device.meta?.[productNameMetaKey];
+            setProductName(meta.device, productName);
+            if (previousProductName !== productName) meta.deviceExposesChanged();
+            return {product_name: productName};
+        },
+    } satisfies Fz.Converter<typeof rtiTekFd22, RtiTekFd22Cluster, ["attributeReport", "readResponse"]>;
+
+    const toZigbee: Tz.Converter[] = [
+        {
+            key: ["product_name"],
+            convertGet: async (entity) => {
+                await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["productName"]);
+            },
+        },
+    ];
+
+    return {
+        exposes: [e.text("product_name", ea.STATE_GET).withCategory("diagnostic")],
+        fromZigbee: [fromZigbee],
+        toZigbee,
+        isModernExtend: true,
+    };
+}
+
+function sth2zComfortSettings(): ModernExtend {
+    const fromZigbee = {
+        cluster: rtiTekFd22,
+        type: ["attributeReport", "readResponse"],
+        convert: (_model, msg, _publish, _options, meta) => {
+            if (!isSth2z(meta.device)) return;
+
+            const fahrenheit = isFahrenheit(meta.device);
+            const result: KeyValue = {};
+            for (const [key, attribute] of Object.entries(sth2zComfortAttributes) as [
+                ComfortStateKey,
+                (typeof sth2zComfortAttributes)[ComfortStateKey],
+            ][]) {
+                const raw = msg.data[attribute];
+                if (raw === undefined) continue;
+                const value = Number(raw) / 100;
+                result[key] = isTemperatureKey(key) ? round(toDisplayTemperature(value, temperatureKinds[key], fahrenheit), 1) : Math.round(value);
+            }
+
+            if (Object.keys(result).length === 0) return;
+            const state = {...meta.state, ...result};
+            return {
+                ...result,
+                ...deriveEnvironment(getCelsiusStateNumber(state, "temperature", Number.NaN, fahrenheit), Number(state.humidity), state, fahrenheit),
+            };
+        },
+    } satisfies Fz.Converter<typeof rtiTekFd22, RtiTekFd22Cluster, ["attributeReport", "readResponse"]>;
+
+    return {fromZigbee: [fromZigbee], isModernExtend: true};
 }
 
 function sth1zPrivateSettings(): ModernExtend {
@@ -642,7 +784,7 @@ function sth1zPrivateSettings(): ModernExtend {
 export const definitions: DefinitionWithExtend[] = [
     {
         zigbeeModel: ["STHZB"],
-        model: "STH1Z",
+        model: "STHZB",
         vendor: "Rti-Tek",
         description: "Temperature and humidity sensor",
         ota: true,
@@ -653,6 +795,7 @@ export const definitions: DefinitionWithExtend[] = [
                 attributes: {
                     temperatureUnit: {name: "temperatureUnit", ...rtiTekFd22Attributes.temperatureUnit, write: true, max: 0xff},
                     faultCode: {name: "faultCode", ...rtiTekFd22Attributes.faultCode, max: 0xffffffff},
+                    productName: {name: "productName", ...rtiTekFd22Attributes.productName},
                     internalTemperatureCalibration: {
                         name: "internalTemperatureCalibration",
                         ...rtiTekFd22Attributes.internalTemperatureCalibration,
@@ -682,6 +825,30 @@ export const definitions: DefinitionWithExtend[] = [
                     humidityAlarmLower: {name: "humidityAlarmLower", ...rtiTekFd22Attributes.humidityAlarmLower, write: true, max: 0xffff},
                     temperatureAlarmStatus: {name: "temperatureAlarmStatus", ...rtiTekFd22Attributes.temperatureAlarmStatus, max: 0xff},
                     humidityAlarmStatus: {name: "humidityAlarmStatus", ...rtiTekFd22Attributes.humidityAlarmStatus, max: 0xff},
+                    sth2zHumidityComfortLower: {
+                        name: "sth2zHumidityComfortLower",
+                        ...rtiTekFd22Attributes.sth2zHumidityComfortLower,
+                        write: true,
+                        max: 0xffff,
+                    },
+                    sth2zHumidityComfortUpper: {
+                        name: "sth2zHumidityComfortUpper",
+                        ...rtiTekFd22Attributes.sth2zHumidityComfortUpper,
+                        write: true,
+                        max: 0xffff,
+                    },
+                    sth2zHumidityComfortTemperatureLower: {
+                        name: "sth2zHumidityComfortTemperatureLower",
+                        ...rtiTekFd22Attributes.sth2zHumidityComfortTemperatureLower,
+                        write: true,
+                        min: -32768,
+                    },
+                    sth2zHumidityComfortTemperatureUpper: {
+                        name: "sth2zHumidityComfortTemperatureUpper",
+                        ...rtiTekFd22Attributes.sth2zHumidityComfortTemperatureUpper,
+                        write: true,
+                        min: -32768,
+                    },
                 },
                 commands: {},
                 commandsResponse: {},
@@ -689,7 +856,9 @@ export const definitions: DefinitionWithExtend[] = [
             sth1zTemperatureDisplay(),
             m.humidity({reporting: false}),
             m.battery({percentageReporting: false}),
+            sthzbProductName(),
             sth1zPrivateSettings(),
+            sth2zComfortSettings(),
             sth1zDerivedEnvironment(),
         ],
         configure: async (device) => {
@@ -723,10 +892,9 @@ export const definitions: DefinitionWithExtend[] = [
             ]);
 
             await delay(3000);
-            await readFd22Attributes(
-                endpoint,
-                Object.values(rtiTekFd22Attributes).map((attribute) => attribute.ID),
-            );
+            await readProductName(endpoint, device);
+            await readFd22Attributes(endpoint, sth1zFd22AttributeIds);
+            if (isSth2z(device)) await readFd22Attributes(endpoint, sth2zComfortAttributeIds);
         },
     },
 ];

--- a/src/devices/rti_tek.ts
+++ b/src/devices/rti_tek.ts
@@ -2,37 +2,46 @@ import {Zcl} from "zigbee-herdsman";
 import * as exposes from "../lib/exposes";
 import {logger} from "../lib/logger";
 import * as m from "../lib/modernExtend";
-import * as reporting from "../lib/reporting";
-import type {DefinitionExposesFunction, DefinitionWithExtend, DummyDevice, Expose, Fz, KeyValue, ModernExtend, Tz, Zh} from "../lib/types";
-import * as utils from "../lib/utils";
+import type {DefinitionWithExtend, DummyDevice, Fz, ModernExtend, Tz, Zh} from "../lib/types";
 
 const NS = "zhc:rti-tek";
-const e = exposes.presets;
-const ea = exposes.access;
+const fastPollTimeout = 120;
 const rtiTekFd22 = "rtiTekFd22";
 const rtiTekFd22Id = 0xfd22;
-const fastPollTimeout = 120; // Poll Control uses quarter-seconds, so this is 30 seconds.
 const temperatureUnitMetaKey = "rtiTekTemperatureUnit";
 const productNameMetaKey = "rtiTekProductName";
+const confirmedTemperatureValuesMetaKey = "rtiTekConfirmedTemperatureValues";
+const temperatureWriteThresholdCelsius = 0.1;
 
-const faultBits: Record<number, string> = {
-    0: "internal_sensor_fault",
-    1: "external_sensor_fault",
-    2: "low_battery",
-    3: "poor_battery_status",
-    4: "battery_too_low_for_ota",
+type HumidityComfortLimits = {
+    humidityLower: number;
+    humidityUpper: number;
+    temperatureLower: number;
+    temperatureUpper: number;
 };
 
-const humidityComfortDefaults: Record<"humidityLower" | "humidityUpper" | "temperatureLower" | "temperatureUpper", number> = {
+const humidityComfortDefaults: HumidityComfortLimits = {
     humidityLower: 30,
     humidityUpper: 60,
     temperatureLower: 20,
     temperatureUpper: 26,
-};
+} as const;
 
-type TemperatureKind = "absolute" | "delta";
+const comfortStateKeys = {
+    humidityLower: "comfort_humidity_lower_limit",
+    humidityUpper: "comfort_humidity_upper_limit",
+    temperatureLower: "comfort_temperature_lower_limit",
+    temperatureUpper: "comfort_temperature_upper_limit",
+} as const;
 
-const temperatureKinds = {
+const sth2zComfortAttributes = {
+    [comfortStateKeys.humidityLower]: "sth2zHumidityComfortLower",
+    [comfortStateKeys.humidityUpper]: "sth2zHumidityComfortUpper",
+    [comfortStateKeys.temperatureLower]: "sth2zHumidityComfortTemperatureLower",
+    [comfortStateKeys.temperatureUpper]: "sth2zHumidityComfortTemperatureUpper",
+} as const;
+
+const temperatureStateKinds = {
     temperature: "absolute",
     dew_point: "absolute",
     internal_temperature_calibration: "delta",
@@ -40,162 +49,9 @@ const temperatureKinds = {
     temperature_alarm_lower: "absolute",
     comfort_temperature_lower_limit: "absolute",
     comfort_temperature_upper_limit: "absolute",
-} as const satisfies Record<string, TemperatureKind>;
+} as const;
 
-const fahrenheitCapabilities: Partial<Record<keyof typeof temperatureKinds, {valueMin: number; valueMax: number; valueStep: number}>> = {
-    internal_temperature_calibration: {valueMin: -18, valueMax: 18, valueStep: 0.2},
-    temperature_alarm_upper: {valueMin: -22, valueMax: 140, valueStep: 0.1},
-    temperature_alarm_lower: {valueMin: -22, valueMax: 140, valueStep: 0.1},
-    comfort_temperature_lower_limit: {valueMin: -4, valueMax: 140, valueStep: 0.1},
-    comfort_temperature_upper_limit: {valueMin: -4, valueMax: 140, valueStep: 0.1},
-};
-
-interface RtiTekFd22Cluster {
-    attributes: {
-        temperatureUnit: number;
-        faultCode: number;
-        productName: string;
-        internalTemperatureCalibration: number;
-        internalHumidityCalibration: number;
-        sampleInterval: number;
-        temperatureAlarmUpper: number;
-        temperatureAlarmLower: number;
-        humidityAlarmUpper: number;
-        humidityAlarmLower: number;
-        temperatureAlarmStatus: number;
-        humidityAlarmStatus: number;
-        sth2zHumidityComfortLower: number;
-        sth2zHumidityComfortUpper: number;
-        sth2zHumidityComfortTemperatureLower: number;
-        sth2zHumidityComfortTemperatureUpper: number;
-    };
-    commands: never;
-    commandResponses: never;
-}
-
-export function toDisplayTemperature(value: number, kind: "absolute" | "delta", fahrenheit: boolean): number {
-    if (!fahrenheit) return value;
-    return kind === "delta" ? (value * 9) / 5 : (value * 9) / 5 + 32;
-}
-
-export function toCelsiusTemperature(value: number, kind: "absolute" | "delta", fahrenheit: boolean): number {
-    if (!fahrenheit) return value;
-    return kind === "delta" ? (value * 5) / 9 : ((value - 32) * 5) / 9;
-}
-
-function round(value: number, precision: number): number {
-    return Number(value.toFixed(precision));
-}
-
-function roundToStep(value: number, step: number): number {
-    return Math.round(value / step) * step;
-}
-
-function isFahrenheit(device: Zh.Device | DummyDevice | undefined): boolean {
-    return Boolean(device && "meta" in device && device.meta?.[temperatureUnitMetaKey] === "fahrenheit");
-}
-
-function getTemperatureCapability(
-    key: keyof typeof temperatureKinds,
-    celsiusCapability: {valueMin: number; valueMax: number; valueStep: number},
-    fahrenheit: boolean,
-) {
-    return fahrenheit ? (fahrenheitCapabilities[key] ?? celsiusCapability) : celsiusCapability;
-}
-
-function convertTemperatureState(state: KeyValue, fromFahrenheit: boolean, toFahrenheit: boolean): KeyValue {
-    const converted: KeyValue = {};
-
-    for (const [key, kind] of Object.entries(temperatureKinds)) {
-        const value = state[key];
-        if (value === undefined || value === null || !Number.isFinite(Number(value))) continue;
-        converted[key] = round(toDisplayTemperature(toCelsiusTemperature(Number(value), kind, fromFahrenheit), kind, toFahrenheit), 1);
-    }
-
-    return converted;
-}
-
-function normalizeTemperatureState(state: KeyValue, fahrenheit: boolean): KeyValue {
-    return {...state, ...convertTemperatureState(state, fahrenheit, false)};
-}
-
-function setTemperatureUnit(device: Zh.Device | undefined, fahrenheit: boolean) {
-    if (!device) return;
-    device.meta ??= {};
-    device.meta[temperatureUnitMetaKey] = fahrenheit ? "fahrenheit" : "celsius";
-    device.save();
-}
-
-function normalizeProductName(value: unknown): string {
-    return Buffer.isBuffer(value)
-        ? value.toString("utf8").trim().toUpperCase()
-        : String(value ?? "")
-              .trim()
-              .toUpperCase();
-}
-
-function isSth2z(device: Zh.Device | DummyDevice | undefined): boolean {
-    return Boolean(device && "meta" in device && device.meta?.[productNameMetaKey] === "STH2Z");
-}
-
-function setProductName(device: Zh.Device | undefined, productName: string) {
-    if (!device) return;
-    device.meta ??= {};
-    device.meta[productNameMetaKey] = productName;
-    device.save();
-}
-
-export function validateAlarmLimits(state: Record<string, number>): void {
-    if (
-        state.temperature_alarm_lower !== undefined &&
-        state.temperature_alarm_upper !== undefined &&
-        state.temperature_alarm_upper - state.temperature_alarm_lower < 0.2 - 1e-9
-    ) {
-        throw new Error("temperature alarm upper must be at least 0.2 C above lower");
-    }
-    if (
-        state.humidity_alarm_lower !== undefined &&
-        state.humidity_alarm_upper !== undefined &&
-        state.humidity_alarm_upper - state.humidity_alarm_lower < 2
-    ) {
-        throw new Error("humidity alarm upper must be at least 2 %RH above lower");
-    }
-}
-
-export function formatFaultCode(value: number): string {
-    const raw = value >>> 0;
-    if (raw === 0) return "none";
-    const knownMask = Object.keys(faultBits).reduce((mask, bit) => mask | (1 << Number(bit)), 0);
-    const faults: string[] = Object.entries(faultBits)
-        .filter(([bit]) => (raw & (1 << Number(bit))) !== 0)
-        .map(([, text]) => text);
-    const unknown = (raw & ~knownMask) >>> 0;
-    if (unknown !== 0) faults.push(`unknown_0x${unknown.toString(16).padStart(8, "0")}`);
-    return faults.join(",");
-}
-
-export function computeDewPoint(temperature: number, humidity: number): number | undefined {
-    if (humidity <= 0) return undefined;
-    const rh = Math.min(Math.max(humidity, 0.1), 100);
-    const gamma = Math.log(rh / 100) + (17.62 * temperature) / (243.12 + temperature);
-    return Number(((243.12 * gamma) / (17.62 - gamma)).toFixed(1));
-}
-
-export function computeVpd(temperature: number, humidity: number): number {
-    const rh = Math.min(Math.max(humidity, 0), 100);
-    const svp = 0.6108 * Math.exp((17.27 * temperature) / (temperature + 237.3));
-    return Number(Math.max(0, svp * (1 - rh / 100)).toFixed(2));
-}
-
-export function computeHumidityComfort(
-    temperature: number,
-    humidity: number,
-    defaults = humidityComfortDefaults,
-): "dry" | "comfort" | "wet" | "normal" {
-    if (humidity < defaults.humidityLower) return "dry";
-    if (humidity > defaults.humidityUpper) return "wet";
-    return temperature >= defaults.temperatureLower && temperature <= defaults.temperatureUpper ? "comfort" : "normal";
-}
+type TemperatureKind = "absolute" | "delta";
 
 const rtiTekFd22Attributes = {
     temperatureUnit: {ID: 0x0000, type: Zcl.DataType.ENUM8},
@@ -216,39 +72,160 @@ const rtiTekFd22Attributes = {
     sth2zHumidityComfortTemperatureUpper: {ID: 0xe017, type: Zcl.DataType.INT16},
 } as const;
 
-const delay = async (milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+const requiredFd22AttributeIds = [0x0000, 0x0002, 0xe005, 0xe006, 0xe009, 0xe00a, 0xe00b, 0xe00c, 0xe00d, 0xe00e, 0xe00f];
+const sth2zComfortAttributeIds = [0xe014, 0xe015, 0xe016, 0xe017];
 
-async function configureReporting(endpoint: Zh.Endpoint, cluster: "msTemperatureMeasurement" | "msRelativeHumidity") {
-    const isTemperature = cluster === "msTemperatureMeasurement";
+type RtiTekFd22Attribute = keyof typeof rtiTekFd22Attributes;
+type FzReportTypes = readonly ["attributeReport", "readResponse"];
+type RtiTekFd22Cluster = {
+    attributes: Record<RtiTekFd22Attribute, unknown>;
+    commands: never;
+    commandResponses: never;
+};
+type RawFd22Attributes = Record<number, {value: unknown; type: Zcl.DataType}>;
+type RtiTekFzConverter = Fz.Converter<typeof rtiTekFd22, RtiTekFd22Cluster, FzReportTypes>;
+type TemperatureFzConverter = Fz.Converter<"msTemperatureMeasurement", undefined, FzReportTypes>;
+type HumidityFzConverter = Fz.Converter<"msRelativeHumidity", undefined, FzReportTypes>;
+type ExposeDevice = Zh.Device | DummyDevice;
 
-    await utils.ignoreUnsupportedAttribute(
-        async () =>
-            await endpoint.configureReporting(cluster, [
-                {
-                    attribute: "measuredValue",
-                    minimumReportInterval: 5,
-                    maximumReportInterval: 3600,
-                    reportableChange: isTemperature ? 50 : 200,
-                },
-            ]),
-        `STHZB '${endpoint.deviceIeeeAddress}' ${cluster} reporting configuration`,
-    );
+const faultBits: Record<number, string> = {
+    0: "internal_sensor_fault",
+    1: "external_sensor_fault",
+    2: "low_battery",
+    3: "poor_battery_status",
+    4: "battery_too_low_for_ota",
+};
+
+const alarmStatusLookup = {normal: 0, low: 1, high: 2} as const;
+const e = exposes.presets;
+const ea = exposes.access;
+
+function round(value: number, precision: number): number {
+    return Number(value.toFixed(precision));
 }
 
-async function readFd22Attributes(endpoint: Zh.Endpoint, attributes: number[]) {
-    let remaining = attributes;
+function isFahrenheit(device: ExposeDevice | undefined): boolean {
+    return device !== undefined && !("isDummyDevice" in device) && device.meta?.[temperatureUnitMetaKey] === "fahrenheit";
+}
+
+function setTemperatureUnit(device: Zh.Device | undefined, fahrenheit: boolean) {
+    if (!device) return;
+    device.meta ??= {};
+    device.meta[temperatureUnitMetaKey] = fahrenheit ? "fahrenheit" : "celsius";
+    device.save();
+}
+
+function normalizeProductName(value: unknown): string {
+    return String(value ?? "")
+        .trim()
+        .toUpperCase();
+}
+
+function isSth2z(device: Zh.Device | undefined): boolean {
+    return device?.meta?.[productNameMetaKey] === "STH2Z";
+}
+
+function setProductName(device: Zh.Device | undefined, productName: string) {
+    if (!device) return;
+    device.meta ??= {};
+    device.meta[productNameMetaKey] = productName;
+    device.save();
+}
+
+export function toDisplayTemperature(value: number, fahrenheit: boolean): number;
+export function toDisplayTemperature(value: number, kind: TemperatureKind, fahrenheit: boolean): number;
+export function toDisplayTemperature(value: number, kindOrFahrenheit: TemperatureKind | boolean, fahrenheit?: boolean): number {
+    const kind = typeof kindOrFahrenheit === "boolean" ? "absolute" : kindOrFahrenheit;
+    const useFahrenheit = typeof kindOrFahrenheit === "boolean" ? kindOrFahrenheit : Boolean(fahrenheit);
+    return kind === "delta" ? toDisplayTemperatureDelta(value, useFahrenheit) : useFahrenheit ? (value * 9) / 5 + 32 : value;
+}
+
+export function toCelsiusTemperature(value: number, fahrenheit: boolean): number;
+export function toCelsiusTemperature(value: number, kind: TemperatureKind, fahrenheit: boolean): number;
+export function toCelsiusTemperature(value: number, kindOrFahrenheit: TemperatureKind | boolean, fahrenheit?: boolean): number {
+    const kind = typeof kindOrFahrenheit === "boolean" ? "absolute" : kindOrFahrenheit;
+    const useFahrenheit = typeof kindOrFahrenheit === "boolean" ? kindOrFahrenheit : Boolean(fahrenheit);
+    return kind === "delta" ? toCelsiusTemperatureDelta(value, useFahrenheit) : useFahrenheit ? ((value - 32) * 5) / 9 : value;
+}
+
+function toDisplayTemperatureDelta(value: number, fahrenheit: boolean): number {
+    return fahrenheit ? (value * 9) / 5 : value;
+}
+
+function toCelsiusTemperatureDelta(value: number, fahrenheit: boolean): number {
+    return fahrenheit ? (value * 5) / 9 : value;
+}
+
+function getConfirmedTemperatureValue(device: Zh.Device | undefined, key: string): number | undefined {
+    const values = device?.meta?.[confirmedTemperatureValuesMetaKey];
+    if (values === null || typeof values !== "object") return undefined;
+
+    const value = (values as Record<string, unknown>)[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function setConfirmedTemperatureValue(device: Zh.Device | undefined, key: string, value: number) {
+    if (!device || !Number.isFinite(value)) return;
+
+    const previous = getConfirmedTemperatureValue(device, key);
+    if (previous === value) return;
+
+    device.meta ??= {};
+    const current = device.meta[confirmedTemperatureValuesMetaKey];
+    const values = current !== null && typeof current === "object" ? (current as Record<string, unknown>) : {};
+    device.meta[confirmedTemperatureValuesMetaKey] = {...values, [key]: value};
+    device.save();
+}
+
+export function resolveTemperatureWrite(
+    displayValue: number,
+    fahrenheit: boolean,
+    confirmedDeviceValue: number | undefined,
+    kind: "absolute" | "delta" = "absolute",
+) {
+    const deviceValue = kind === "delta" ? toCelsiusTemperatureDelta(displayValue, fahrenheit) : toCelsiusTemperature(displayValue, fahrenheit);
+    const shouldWrite =
+        !fahrenheit || confirmedDeviceValue === undefined || Math.abs(deviceValue - confirmedDeviceValue) >= temperatureWriteThresholdCelsius - 1e-9;
+
+    return {shouldWrite, deviceValue, stateValue: round(displayValue, 1)};
+}
+
+function delay(milliseconds: number) {
+    return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function isUnsupportedPollControlError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("UNSUPPORTED_ATTRIBUTE") || message.includes("UNSUPPORTED_COMMAND");
+}
+
+async function readFd22AttributeBatch(endpoint: Zh.Endpoint, attributeIds: number[]): Promise<number[]> {
+    try {
+        await endpoint.read(rtiTekFd22Id, attributeIds);
+        return [];
+    } catch (error) {
+        if (attributeIds.length === 1) {
+            logger.debug(`STHZB '${endpoint.deviceIeeeAddress}' FD22 read failed: ${error}`, NS);
+            return attributeIds;
+        }
+
+        const failed: number[] = [];
+        for (const attributeId of attributeIds) {
+            failed.push(...(await readFd22AttributeBatch(endpoint, [attributeId])));
+        }
+        return failed;
+    }
+}
+
+async function readFd22Attributes(endpoint: Zh.Endpoint, ieeeAddress: string, attributeIds = requiredFd22AttributeIds) {
+    let remaining: number[] = [...attributeIds];
 
     for (let attempt = 0; attempt < 3 && remaining.length > 0; attempt++) {
         const failed: number[] = [];
 
         for (let index = 0; index < remaining.length; index += 4) {
             const batch = remaining.slice(index, index + 4);
-            try {
-                await endpoint.read(rtiTekFd22Id, batch);
-            } catch (error) {
-                failed.push(...batch);
-                logger.debug(`STHZB '${endpoint.deviceIeeeAddress}' FD22 read failed: ${error}`, NS);
-            }
+            failed.push(...(await readFd22AttributeBatch(endpoint, batch)));
         }
 
         remaining = failed;
@@ -256,193 +233,197 @@ async function readFd22Attributes(endpoint: Zh.Endpoint, attributes: number[]) {
     }
 
     if (remaining.length > 0) {
-        logger.warning(
-            `STHZB '${endpoint.deviceIeeeAddress}' did not return FD22 attributes: ${remaining.map((id) => `0x${id.toString(16)}`).join(", ")}`,
-            NS,
-        );
+        const attributes = remaining.map((id) => `0x${id.toString(16)}`).join(", ");
+        throw new Error(`STHZB '${ieeeAddress}' did not return required FD22 attributes: ${attributes}`);
     }
 }
 
-async function readProductName(endpoint: Zh.Endpoint, device: Zh.Device) {
+async function readProductName(endpoint: Zh.Endpoint, ieeeAddress: string): Promise<string> {
+    let lastError: unknown;
+
     for (let attempt = 0; attempt < 3; attempt++) {
         try {
-            const {productName} = await endpoint.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["productName"]);
-            const normalized = normalizeProductName(productName);
-            if (normalized) {
-                setProductName(device, normalized);
-            } else {
-                logger.warning(`STHZB '${device.ieeeAddr}' did not return product name; using STH1Z-compatible settings`, NS);
-            }
-            return;
+            const response = await endpoint.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["productName"]);
+            const productName = normalizeProductName(response.productName);
+            if (productName) return productName;
+            lastError = new Error("empty productName response");
         } catch (error) {
-            logger.debug(`STHZB '${device.ieeeAddr}' product name read failed: ${error}`, NS);
+            lastError = error;
         }
+
         if (attempt < 2) await delay(1000);
     }
 
-    logger.warning(`STHZB '${device.ieeeAddr}' did not return product name; using STH1Z-compatible settings`, NS);
+    throw new Error(`STHZB '${ieeeAddress}' did not return required FD22 productName after 3 attempts: ${lastError}`);
 }
 
-const comfortStateKeys = {
-    humidityLower: "comfort_humidity_lower_limit",
-    humidityUpper: "comfort_humidity_upper_limit",
-    temperatureLower: "comfort_temperature_lower_limit",
-    temperatureUpper: "comfort_temperature_upper_limit",
-} as const;
-
-type ComfortStateKey = (typeof comfortStateKeys)[keyof typeof comfortStateKeys];
-
-const sth2zComfortAttributes = {
-    [comfortStateKeys.humidityLower]: "sth2zHumidityComfortLower",
-    [comfortStateKeys.humidityUpper]: "sth2zHumidityComfortUpper",
-    [comfortStateKeys.temperatureLower]: "sth2zHumidityComfortTemperatureLower",
-    [comfortStateKeys.temperatureUpper]: "sth2zHumidityComfortTemperatureUpper",
-} as const satisfies Record<ComfortStateKey, keyof RtiTekFd22Cluster["attributes"]>;
-
-const sth1zFd22AttributeIds = [0x0000, 0x0002, 0xe005, 0xe006, 0xe009, 0xe00a, 0xe00b, 0xe00c, 0xe00d, 0xe00e, 0xe00f];
-const sth2zComfortAttributeIds = [0xe014, 0xe015, 0xe016, 0xe017];
-
-const alarmStatusLookup = {normal: 0, low: 1, high: 2} as const;
-
-const privateNumericSettings = {
-    internal_temperature_calibration: {
-        attribute: "internalTemperatureCalibration",
-        scale: 10,
-        precision: 1,
-        unit: "°C",
-        valueMin: -10,
-        valueMax: 10,
-        valueStep: 0.1,
-    },
-    internal_humidity_calibration: {
-        attribute: "internalHumidityCalibration",
-        scale: 10,
-        precision: 1,
-        unit: "%",
-        valueMin: -10,
-        valueMax: 10,
-        valueStep: 0.1,
-    },
-    sample_interval: {attribute: "sampleInterval", scale: 1, precision: 0, unit: "s", valueMin: 1, valueMax: 3600, valueStep: 1},
-    temperature_alarm_upper: {
-        attribute: "temperatureAlarmUpper",
-        scale: 100,
-        precision: 1,
-        unit: "°C",
-        valueMin: -30,
-        valueMax: 60,
-        valueStep: 0.1,
-    },
-    temperature_alarm_lower: {
-        attribute: "temperatureAlarmLower",
-        scale: 100,
-        precision: 1,
-        unit: "°C",
-        valueMin: -30,
-        valueMax: 60,
-        valueStep: 0.1,
-    },
-    humidity_alarm_upper: {attribute: "humidityAlarmUpper", scale: 100, precision: 0, unit: "%", valueMin: 0, valueMax: 100, valueStep: 1},
-    humidity_alarm_lower: {attribute: "humidityAlarmLower", scale: 100, precision: 0, unit: "%", valueMin: 0, valueMax: 100, valueStep: 1},
-} as const;
-
-type PrivateNumericKey = keyof typeof privateNumericSettings;
-type TemperatureKey = keyof typeof temperatureKinds;
-
-function isTemperatureKey(key: string): key is TemperatureKey {
-    return key in temperatureKinds;
+async function readReportingConfiguration(endpoint: Zh.Endpoint, cluster: string, attribute: string) {
+    try {
+        // These diagnostics span several standard clusters and are intentionally dynamic.
+        const configuration = await endpoint.readReportingConfig(cluster as never, [{attribute}] as never);
+        logger.debug(`STHZB '${endpoint.deviceIeeeAddress}' ${cluster}.${attribute} reporting configuration: ${JSON.stringify(configuration)}`, NS);
+    } catch (error) {
+        logger.warning(`STHZB '${endpoint.deviceIeeeAddress}' failed to read ${cluster}.${attribute} reporting configuration: ${error}`, NS);
+    }
 }
 
-function temperatureExpose(
-    name: TemperatureKey,
-    access: number,
-    celsiusCapability: {valueMin?: number; valueMax?: number; valueStep?: number},
-    device: Zh.Device | DummyDevice,
-    entityCategory?: "config" | "diagnostic",
-) {
-    const fahrenheit = isFahrenheit(device);
-    const capability = getTemperatureCapability(
-        name,
-        {
-            valueMin: celsiusCapability.valueMin ?? -20,
-            valueMax: celsiusCapability.valueMax ?? 60,
-            valueStep: celsiusCapability.valueStep ?? 0.1,
-        },
-        fahrenheit,
-    );
-    let expose = e
-        .numeric(name, access)
-        .withUnit(fahrenheit ? "°F" : "°C")
-        .withValueStep(capability.valueStep);
-    if (celsiusCapability.valueMin !== undefined) expose = expose.withValueMin(capability.valueMin);
-    if (celsiusCapability.valueMax !== undefined) expose = expose.withValueMax(capability.valueMax);
-    if (entityCategory) expose = expose.withCategory(entityCategory);
-    return expose;
+async function writeFd22Attribute(entity: Zh.Endpoint | Zh.Group, attribute: RtiTekFd22Attribute, value: number) {
+    // Runtime registration supplies the FD22 custom-cluster schema to Z2M.
+    const attributes = {[attribute]: value} as unknown as Partial<RtiTekFd22Cluster["attributes"]> & RawFd22Attributes;
+    await entity.write<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, attributes);
 }
 
-function getStateNumber(state: KeyValue, key: string, fallback: number): number {
+async function readFd22Attribute(entity: Zh.Endpoint | Zh.Group, attribute: RtiTekFd22Attribute) {
+    // The public endpoint type cannot infer schemas registered at runtime.
+    await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, [attribute]);
+}
+
+function notifyDeviceExposesChanged(meta: Tz.Meta) {
+    (meta as Tz.Meta & {deviceExposesChanged?: () => void}).deviceExposesChanged?.();
+}
+
+function convertTemperatureState(state: Record<string, unknown>, fromFahrenheit: boolean, toFahrenheit: boolean) {
+    const converted: Record<string, number> = {};
+
+    for (const [key, kind] of Object.entries(temperatureStateKinds)) {
+        const value = Number(state[key]);
+        if (state[key] === undefined || state[key] === null || !Number.isFinite(value)) {
+            continue;
+        }
+
+        const celsius = kind === "delta" ? toCelsiusTemperatureDelta(value, fromFahrenheit) : toCelsiusTemperature(value, fromFahrenheit);
+        converted[key] = round(kind === "delta" ? toDisplayTemperatureDelta(celsius, toFahrenheit) : toDisplayTemperature(celsius, toFahrenheit), 1);
+    }
+
+    return converted;
+}
+
+export function computeDewPoint(temperature: number, humidity: number): number | undefined {
+    if (humidity <= 0) return undefined;
+    const relativeHumidity = Math.min(Math.max(humidity, 0.1), 100);
+    const gamma = Math.log(relativeHumidity / 100) + (17.62 * temperature) / (243.12 + temperature);
+    return round((243.12 * gamma) / (17.62 - gamma), 1);
+}
+
+export function computeVpd(temperature: number, humidity: number): number {
+    const relativeHumidity = Math.min(Math.max(humidity, 0), 100);
+    const saturationVaporPressure = 0.6108 * Math.exp((17.27 * temperature) / (temperature + 237.3));
+    return round(Math.max(0, saturationVaporPressure * (1 - relativeHumidity / 100)), 2);
+}
+
+export function computeHumidityComfort(
+    temperature: number,
+    humidity: number,
+    limits = humidityComfortDefaults,
+): "dry" | "comfort" | "wet" | "normal" {
+    if (humidity < limits.humidityLower) return "dry";
+    if (humidity > limits.humidityUpper) return "wet";
+    return temperature >= limits.temperatureLower && temperature <= limits.temperatureUpper ? "comfort" : "normal";
+}
+
+function getStateNumber(state: Record<string, unknown>, key: string, fallback: number) {
     const value = state[key];
     return value === undefined || value === null ? fallback : Number(value);
 }
 
-function getCelsiusStateNumber(state: KeyValue, key: TemperatureKey, fallback: number, fahrenheit: boolean): number {
-    return toCelsiusTemperature(getStateNumber(state, key, fallback), temperatureKinds[key], fahrenheit);
-}
+function defaultComfortState(state: Record<string, unknown>, fahrenheit: boolean) {
+    const defaults: Record<string, number> = {};
 
-function defaultComfortState(state: KeyValue, fahrenheit: boolean): KeyValue {
-    const defaults: KeyValue = {};
-    for (const [key, defaultValue] of Object.entries(humidityComfortDefaults)) {
+    for (const [key, value] of Object.entries(humidityComfortDefaults)) {
         const stateKey = comfortStateKeys[key as keyof typeof comfortStateKeys];
         if (state[stateKey] !== undefined && state[stateKey] !== null) continue;
-        defaults[stateKey] = isTemperatureKey(stateKey)
-            ? round(toDisplayTemperature(defaultValue, temperatureKinds[stateKey], fahrenheit), 1)
-            : defaultValue;
+        defaults[stateKey] = key.startsWith("temperature") ? round(toDisplayTemperature(value, fahrenheit), 1) : value;
     }
+
     return defaults;
 }
 
-function deriveEnvironment(temperature: number | undefined, humidity: number | undefined, state: KeyValue, fahrenheit: boolean): KeyValue {
+function deriveEnvironment(temperature: number | undefined, humidity: number | undefined, state: Record<string, unknown>, fahrenheit: boolean) {
     const defaults = defaultComfortState(state, fahrenheit);
-    if (!Number.isFinite(temperature) || !Number.isFinite(humidity)) return defaults;
+    if (temperature === undefined || humidity === undefined || !Number.isFinite(temperature) || !Number.isFinite(humidity)) return defaults;
 
-    const comfortLimits = {
+    const limits = {
         humidityLower: getStateNumber(state, comfortStateKeys.humidityLower, humidityComfortDefaults.humidityLower),
         humidityUpper: getStateNumber(state, comfortStateKeys.humidityUpper, humidityComfortDefaults.humidityUpper),
-        temperatureLower: getCelsiusStateNumber(state, comfortStateKeys.temperatureLower, humidityComfortDefaults.temperatureLower, fahrenheit),
-        temperatureUpper: getCelsiusStateNumber(state, comfortStateKeys.temperatureUpper, humidityComfortDefaults.temperatureUpper, fahrenheit),
+        temperatureLower: toCelsiusTemperature(
+            getStateNumber(state, comfortStateKeys.temperatureLower, humidityComfortDefaults.temperatureLower),
+            fahrenheit,
+        ),
+        temperatureUpper: toCelsiusTemperature(
+            getStateNumber(state, comfortStateKeys.temperatureUpper, humidityComfortDefaults.temperatureUpper),
+            fahrenheit,
+        ),
     };
     const dewPoint = computeDewPoint(temperature, humidity);
+
     return {
         ...defaults,
-        ...(dewPoint === undefined ? {} : {dew_point: round(toDisplayTemperature(dewPoint, "absolute", fahrenheit), 1)}),
+        ...(dewPoint === undefined ? {} : {dew_point: round(toDisplayTemperature(dewPoint, fahrenheit), 1)}),
         vpd: computeVpd(temperature, humidity),
-        humidity_comfort: computeHumidityComfort(temperature, humidity, comfortLimits),
+        humidity_comfort: computeHumidityComfort(temperature, humidity, limits),
     };
 }
 
-function validateRange(key: PrivateNumericKey, value: number) {
-    const setting = privateNumericSettings[key];
-    if (value < setting.valueMin || value > setting.valueMax) {
-        throw new Error(`${key} must be between ${setting.valueMin} and ${setting.valueMax}`);
-    }
+function sth2zComfortSettings(): ModernExtend {
+    const fromZigbee: RtiTekFzConverter = {
+        cluster: rtiTekFd22,
+        type: ["attributeReport", "readResponse"],
+        convert: (_model, msg, _publish, _options, meta) => {
+            if (!isSth2z(meta.device)) return;
+            const result: Record<string, number> = {};
+
+            for (const [key, attribute] of Object.entries(sth2zComfortAttributes)) {
+                const raw = msg.data[attribute];
+                if (raw === undefined) continue;
+                const value = Number(raw) / 100;
+                const temperatureSetting = key === comfortStateKeys.temperatureLower || key === comfortStateKeys.temperatureUpper;
+                if (temperatureSetting) setConfirmedTemperatureValue(meta.device, key, value);
+                result[key] = temperatureSetting ? round(toDisplayTemperature(value, isFahrenheit(meta.device)), 1) : round(value, 0);
+            }
+
+            if (Object.keys(result).length === 0) return;
+
+            const state = {...meta.state, ...result};
+            return {
+                ...result,
+                ...deriveEnvironment(
+                    toCelsiusTemperature(Number(state.temperature), isFahrenheit(meta.device)),
+                    Number(state.humidity),
+                    state,
+                    isFahrenheit(meta.device),
+                ),
+            };
+        },
+    };
+
+    return {fromZigbee: [fromZigbee], isModernExtend: true};
 }
 
-function sth1zTemperatureDisplay(): ModernExtend {
-    const converter = {
+function sth1zTemperature(): ModernExtend {
+    const fromZigbee: TemperatureFzConverter = {
         cluster: "msTemperatureMeasurement",
         type: ["attributeReport", "readResponse"],
         convert: (_model, msg, _publish, _options, meta) => {
             if (msg.data.measuredValue === undefined) return;
-            return {temperature: round(toDisplayTemperature(Number(msg.data.measuredValue) / 100, "absolute", isFahrenheit(meta.device)), 1)};
-        },
-    } satisfies Fz.Converter<"msTemperatureMeasurement", undefined, ["attributeReport", "readResponse"]>;
+            const temperature = Number(msg.data.measuredValue) / 100;
 
-    const expose: DefinitionExposesFunction = (device) => [temperatureExpose("temperature", ea.STATE, {}, device)];
-    return {exposes: [expose], fromZigbee: [converter], isModernExtend: true};
+            return {
+                temperature: round(toDisplayTemperature(temperature, isFahrenheit(meta.device)), 1),
+            };
+        },
+    };
+    const expose = (device: ExposeDevice) => [
+        e
+            .numeric("temperature", ea.STATE)
+            .withUnit(isFahrenheit(device) ? "°F" : "°C")
+            .withValueStep(0.1),
+    ];
+
+    return {exposes: [expose], fromZigbee: [fromZigbee], isModernExtend: true};
 }
 
 function sth1zDerivedEnvironment(): ModernExtend {
-    const fromZigbee = [
+    const fromZigbee: [TemperatureFzConverter, HumidityFzConverter] = [
         {
             cluster: "msTemperatureMeasurement",
             type: ["attributeReport", "readResponse"],
@@ -450,77 +431,77 @@ function sth1zDerivedEnvironment(): ModernExtend {
                 if (msg.data.measuredValue === undefined) return;
                 return deriveEnvironment(Number(msg.data.measuredValue) / 100, Number(meta.state.humidity), meta.state, isFahrenheit(meta.device));
             },
-        } satisfies Fz.Converter<"msTemperatureMeasurement", undefined, ["attributeReport", "readResponse"]>,
+        },
         {
             cluster: "msRelativeHumidity",
             type: ["attributeReport", "readResponse"],
             convert: (_model, msg, _publish, _options, meta) => {
                 if (msg.data.measuredValue === undefined) return;
                 return deriveEnvironment(
-                    getCelsiusStateNumber(meta.state, "temperature", Number.NaN, isFahrenheit(meta.device)),
+                    toCelsiusTemperature(Number(meta.state.temperature), isFahrenheit(meta.device)),
                     Number(msg.data.measuredValue) / 100,
                     meta.state,
                     isFahrenheit(meta.device),
                 );
             },
-        } satisfies Fz.Converter<"msRelativeHumidity", undefined, ["attributeReport", "readResponse"]>,
+        },
     ];
-
     const toZigbee: Tz.Converter[] = [
         {
             key: Object.values(comfortStateKeys),
-            convertSet: (entity, key, value, meta) => {
+            convertSet: async (entity, key, value, meta) => {
                 const fahrenheit = isFahrenheit(meta.device);
+                const temperatureSetting = key === comfortStateKeys.temperatureLower || key === comfortStateKeys.temperatureUpper;
                 const displayValue = Number(value);
-                const normalized = isTemperatureKey(key) ? toCelsiusTemperature(displayValue, temperatureKinds[key], fahrenheit) : displayValue;
-                const state = {
-                    ...normalizeTemperatureState(meta.state, fahrenheit),
-                    [key]: normalized,
-                };
-                const humidityLower = getStateNumber(state, comfortStateKeys.humidityLower, humidityComfortDefaults.humidityLower);
-                const humidityUpper = getStateNumber(state, comfortStateKeys.humidityUpper, humidityComfortDefaults.humidityUpper);
-                const temperatureLower = getStateNumber(state, comfortStateKeys.temperatureLower, humidityComfortDefaults.temperatureLower);
-                const temperatureUpper = getStateNumber(state, comfortStateKeys.temperatureUpper, humidityComfortDefaults.temperatureUpper);
+                const decision = temperatureSetting
+                    ? resolveTemperatureWrite(displayValue, fahrenheit, getConfirmedTemperatureValue(meta.device, key))
+                    : {shouldWrite: true, deviceValue: displayValue, stateValue: displayValue};
+                const normalized = temperatureSetting ? decision.deviceValue : displayValue;
+
                 if (
-                    (isTemperatureKey(key) && (normalized < -20 || normalized > 60)) ||
-                    (!isTemperatureKey(key) && (normalized < 0 || normalized > 100))
+                    !Number.isFinite(normalized) ||
+                    (temperatureSetting && (normalized < -20 || normalized > 60)) ||
+                    (!temperatureSetting && (normalized < 0 || normalized > 100))
                 ) {
                     throw new Error(`${key} is outside its supported range`);
                 }
-                if (humidityLower >= humidityUpper) throw new Error("comfort humidity lower limit must be below upper limit");
-                if (temperatureLower >= temperatureUpper) throw new Error("comfort temperature lower limit must be below upper limit");
 
-                const attribute = sth2zComfortAttributes[key as ComfortStateKey];
-                if (isSth2z(meta.device) && attribute) {
-                    const raw = isTemperatureKey(key) ? Math.round(normalized * 10) * 10 : Math.round(normalized) * 100;
-                    const deviceValue = raw / 100;
-                    const nextValue = isTemperatureKey(key)
-                        ? round(toDisplayTemperature(deviceValue, temperatureKinds[key], fahrenheit), 1)
-                        : deviceValue;
-                    const nextState = {...meta.state, [key]: nextValue};
-                    return (async () => {
-                        await entity.write<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, {[attribute]: raw} as never);
-                        return {
-                            state: {
-                                [key]: nextValue,
-                                ...deriveEnvironment(
-                                    getCelsiusStateNumber(nextState, "temperature", Number.NaN, fahrenheit),
-                                    Number(nextState.humidity),
-                                    nextState,
-                                    fahrenheit,
-                                ),
-                            },
-                        };
-                    })();
+                const attribute = isSth2z(meta.device) ? sth2zComfortAttributes[key as keyof typeof sth2zComfortAttributes] : undefined;
+                const rawStep = temperatureSetting ? 10 : 100;
+                const raw = attribute ? Math.round(Math.round(normalized * 100) / rawStep) * rawStep : undefined;
+                const deviceValue = raw === undefined ? normalized : raw / 100;
+                const stateValue = temperatureSetting ? decision.stateValue : deviceValue;
+                const state = {...meta.state, [key]: stateValue};
+                const humidityLower = getStateNumber(state, comfortStateKeys.humidityLower, humidityComfortDefaults.humidityLower);
+                const humidityUpper = getStateNumber(state, comfortStateKeys.humidityUpper, humidityComfortDefaults.humidityUpper);
+                const temperatureLower = toCelsiusTemperature(
+                    getStateNumber(state, comfortStateKeys.temperatureLower, humidityComfortDefaults.temperatureLower),
+                    fahrenheit,
+                );
+                const temperatureUpper = toCelsiusTemperature(
+                    getStateNumber(state, comfortStateKeys.temperatureUpper, humidityComfortDefaults.temperatureUpper),
+                    fahrenheit,
+                );
+
+                if (humidityLower >= humidityUpper) {
+                    throw new Error("comfort humidity lower limit must be below upper limit");
+                }
+                if (temperatureLower >= temperatureUpper) {
+                    throw new Error("comfort temperature lower limit must be below upper limit");
                 }
 
-                const nextValue = isTemperatureKey(key) ? round(toDisplayTemperature(normalized, temperatureKinds[key], fahrenheit), 1) : normalized;
-                const nextState = {...meta.state, [key]: nextValue};
+                if (attribute && raw !== undefined && (!temperatureSetting || decision.shouldWrite)) {
+                    await writeFd22Attribute(entity, attribute, raw);
+                    setConfirmedTemperatureValue(meta.device, key, deviceValue);
+                }
+
+                const nextState = {...meta.state, [key]: stateValue};
+
                 return {
                     state: {
-                        [key]: nextValue,
+                        [key]: stateValue,
                         ...deriveEnvironment(
-                            getCelsiusStateNumber(nextState, "temperature", Number.NaN, fahrenheit),
+                            toCelsiusTemperature(Number(nextState.temperature), fahrenheit),
                             Number(nextState.humidity),
                             nextState,
                             fahrenheit,
@@ -529,19 +510,24 @@ function sth1zDerivedEnvironment(): ModernExtend {
                 };
             },
             convertGet: async (entity, key, meta) => {
-                const attribute = sth2zComfortAttributes[key as ComfortStateKey];
-                if (isSth2z(meta.device) && attribute) {
-                    await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, [attribute]);
+                const attribute = isSth2z(meta.device) ? sth2zComfortAttributes[key as keyof typeof sth2zComfortAttributes] : undefined;
+                if (attribute) {
+                    await readFd22Attribute(entity, attribute);
                     return;
                 }
-                const fallbackKey = Object.entries(comfortStateKeys).find(
+                const defaultKey = Object.entries(comfortStateKeys).find(
                     ([, stateKey]) => stateKey === key,
                 )?.[0] as keyof typeof humidityComfortDefaults;
+                const temperatureSetting = key === comfortStateKeys.temperatureLower || key === comfortStateKeys.temperatureUpper;
+                const fallback = humidityComfortDefaults[defaultKey];
                 const currentValue = meta.state[key];
-                const fallbackValue = isTemperatureKey(key)
-                    ? round(toDisplayTemperature(humidityComfortDefaults[fallbackKey], temperatureKinds[key], isFahrenheit(meta.device)), 1)
-                    : humidityComfortDefaults[fallbackKey];
-                const value = currentValue === undefined || currentValue === null ? fallbackValue : Number(currentValue);
+                const value =
+                    currentValue === undefined || currentValue === null
+                        ? temperatureSetting
+                            ? round(toDisplayTemperature(fallback, isFahrenheit(meta.device)), 1)
+                            : fallback
+                        : Number(currentValue);
+
                 return {
                     state: {
                         [key]: value,
@@ -550,34 +536,105 @@ function sth1zDerivedEnvironment(): ModernExtend {
             },
         },
     ];
+    const expose = (device: ExposeDevice) => {
+        const fahrenheit = isFahrenheit(device);
 
-    const expose: DefinitionExposesFunction = (device) => [
-        temperatureExpose("dew_point", ea.STATE, {}, device),
-        e.numeric("vpd", ea.STATE).withUnit("kPa").withValueStep(0.01),
-        e.enum("humidity_comfort", ea.STATE, ["dry", "comfort", "wet", "normal"]),
-        e
-            .numeric(comfortStateKeys.humidityLower, ea.STATE_SET)
-            .withCategory("config")
-            .withUnit("%")
-            .withValueMin(0)
-            .withValueMax(100)
-            .withValueStep(1),
-        e
-            .numeric(comfortStateKeys.humidityUpper, ea.STATE_SET)
-            .withCategory("config")
-            .withUnit("%")
-            .withValueMin(0)
-            .withValueMax(100)
-            .withValueStep(1),
-        temperatureExpose("comfort_temperature_lower_limit", ea.STATE_SET, {valueMin: -20, valueMax: 60, valueStep: 0.1}, device, "config"),
-        temperatureExpose("comfort_temperature_upper_limit", ea.STATE_SET, {valueMin: -20, valueMax: 60, valueStep: 0.1}, device, "config"),
-    ];
+        return [
+            e
+                .numeric("dew_point", ea.STATE)
+                .withUnit(fahrenheit ? "°F" : "°C")
+                .withValueStep(0.1),
+            e.numeric("vpd", ea.STATE).withUnit("kPa").withValueStep(0.01),
+            e.enum("humidity_comfort", ea.STATE, ["dry", "comfort", "wet", "normal"]),
+            e
+                .numeric(comfortStateKeys.humidityLower, ea.STATE_SET)
+                .withCategory("config")
+                .withUnit("%")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(1),
+            e
+                .numeric(comfortStateKeys.humidityUpper, ea.STATE_SET)
+                .withCategory("config")
+                .withUnit("%")
+                .withValueMin(0)
+                .withValueMax(100)
+                .withValueStep(1),
+            e
+                .numeric(comfortStateKeys.temperatureLower, ea.STATE_SET)
+                .withCategory("config")
+                .withUnit(fahrenheit ? "°F" : "°C")
+                .withValueMin(fahrenheit ? -4 : -20)
+                .withValueMax(fahrenheit ? 140 : 60)
+                .withValueStep(fahrenheit ? 0.2 : 0.1),
+            e
+                .numeric(comfortStateKeys.temperatureUpper, ea.STATE_SET)
+                .withCategory("config")
+                .withUnit(fahrenheit ? "°F" : "°C")
+                .withValueMin(fahrenheit ? -4 : -20)
+                .withValueMax(fahrenheit ? 140 : 60)
+                .withValueStep(fahrenheit ? 0.2 : 0.1),
+        ];
+    };
 
     return {exposes: [expose], fromZigbee, toZigbee, isModernExtend: true};
 }
 
+function sth1zTemperatureUnit(): ModernExtend {
+    const fromZigbee: RtiTekFzConverter = {
+        cluster: rtiTekFd22,
+        type: ["attributeReport", "readResponse"],
+        convert: (_model, msg, _publish, _options, meta) => {
+            if (msg.data.temperatureUnit === undefined) return;
+            const fahrenheit = Number(msg.data.temperatureUnit) === 1;
+            const previousFahrenheit = isFahrenheit(meta.device);
+
+            setTemperatureUnit(meta.device, fahrenheit);
+            if (previousFahrenheit !== fahrenheit) {
+                meta.deviceExposesChanged?.();
+            }
+
+            return {
+                temperature_unit: fahrenheit ? "fahrenheit" : "celsius",
+                ...convertTemperatureState(meta.state ?? {}, previousFahrenheit, fahrenheit),
+            };
+        },
+    };
+    const toZigbee: Tz.Converter[] = [
+        {
+            key: ["temperature_unit"],
+            convertSet: async (entity, _key, value, meta) => {
+                if (value !== "celsius" && value !== "fahrenheit") {
+                    throw new Error("temperature_unit must be celsius or fahrenheit");
+                }
+
+                const fahrenheit = value === "fahrenheit";
+                const previousFahrenheit = isFahrenheit(meta.device);
+                await writeFd22Attribute(entity, "temperatureUnit", fahrenheit ? 1 : 0);
+                setTemperatureUnit(meta.device, fahrenheit);
+                if (previousFahrenheit !== fahrenheit) {
+                    notifyDeviceExposesChanged(meta);
+                }
+
+                return {
+                    state: {
+                        temperature_unit: value,
+                        ...convertTemperatureState(meta.state ?? {}, previousFahrenheit, fahrenheit),
+                    },
+                };
+            },
+            convertGet: async (entity) => {
+                await readFd22Attribute(entity, "temperatureUnit");
+            },
+        },
+    ];
+    const expose = [e.enum("temperature_unit", ea.STATE_SET, ["celsius", "fahrenheit"]).withCategory("config")];
+
+    return {exposes: expose, fromZigbee: [fromZigbee], toZigbee, isModernExtend: true};
+}
+
 function sthzbProductName(): ModernExtend {
-    const fromZigbee = {
+    const fromZigbee: RtiTekFzConverter = {
         cluster: rtiTekFd22,
         type: ["attributeReport", "readResponse"],
         convert: (_model, msg, _publish, _options, meta) => {
@@ -588,14 +645,11 @@ function sthzbProductName(): ModernExtend {
             if (previousProductName !== productName) meta.deviceExposesChanged();
             return {product_name: productName};
         },
-    } satisfies Fz.Converter<typeof rtiTekFd22, RtiTekFd22Cluster, ["attributeReport", "readResponse"]>;
-
+    };
     const toZigbee: Tz.Converter[] = [
         {
             key: ["product_name"],
-            convertGet: async (entity) => {
-                await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["productName"]);
-            },
+            convertGet: async (entity) => readFd22Attribute(entity, "productName"),
         },
     ];
 
@@ -607,67 +661,275 @@ function sthzbProductName(): ModernExtend {
     };
 }
 
-function sth2zComfortSettings(): ModernExtend {
-    const fromZigbee = {
+const calibrationSettings = {
+    internal_temperature_calibration: {
+        attribute: "internalTemperatureCalibration",
+        scale: 10,
+        unit: "°C",
+        valueMin: -10,
+        valueMax: 10,
+        valueStep: 0.1,
+    },
+    internal_humidity_calibration: {
+        attribute: "internalHumidityCalibration",
+        scale: 10,
+        unit: "%",
+        valueMin: -10,
+        valueMax: 10,
+        valueStep: 0.1,
+    },
+    sample_interval: {
+        attribute: "sampleInterval",
+        scale: 1,
+        unit: "s",
+        valueMin: 1,
+        valueMax: 3600,
+        valueStep: 1,
+    },
+} as const;
+
+function sth1zCalibrationSettings(): ModernExtend {
+    const fromZigbee: RtiTekFzConverter = {
         cluster: rtiTekFd22,
         type: ["attributeReport", "readResponse"],
         convert: (_model, msg, _publish, _options, meta) => {
-            if (!isSth2z(meta.device)) return;
+            const result: Record<string, number> = {};
 
-            const fahrenheit = isFahrenheit(meta.device);
-            const result: KeyValue = {};
-            for (const [key, attribute] of Object.entries(sth2zComfortAttributes) as [
-                ComfortStateKey,
-                (typeof sth2zComfortAttributes)[ComfortStateKey],
-            ][]) {
-                const raw = msg.data[attribute];
-                if (raw === undefined) continue;
-                const value = Number(raw) / 100;
-                result[key] = isTemperatureKey(key) ? round(toDisplayTemperature(value, temperatureKinds[key], fahrenheit), 1) : Math.round(value);
-            }
-
-            if (Object.keys(result).length === 0) return;
-            const state = {...meta.state, ...result};
-            return {
-                ...result,
-                ...deriveEnvironment(getCelsiusStateNumber(state, "temperature", Number.NaN, fahrenheit), Number(state.humidity), state, fahrenheit),
-            };
-        },
-    } satisfies Fz.Converter<typeof rtiTekFd22, RtiTekFd22Cluster, ["attributeReport", "readResponse"]>;
-
-    return {fromZigbee: [fromZigbee], isModernExtend: true};
-}
-
-function sth1zPrivateSettings(): ModernExtend {
-    const fromZigbee = {
-        cluster: rtiTekFd22,
-        type: ["attributeReport", "readResponse"],
-        convert: (_model, msg, _publish, _options, meta) => {
-            const result: KeyValue = {};
-            const fahrenheitBeforeUpdate = isFahrenheit(meta.device);
-
-            if (msg.data.temperatureUnit !== undefined) {
-                const fahrenheit = Number(msg.data.temperatureUnit) === 1;
-                setTemperatureUnit(meta.device, fahrenheit);
-                if (fahrenheitBeforeUpdate !== fahrenheit) meta.deviceExposesChanged();
-                result.temperature_unit = fahrenheit ? "fahrenheit" : "celsius";
-                Object.assign(result, convertTemperatureState(meta.state, fahrenheitBeforeUpdate, fahrenheit));
-            }
-
-            for (const [key, setting] of Object.entries(privateNumericSettings) as [
-                PrivateNumericKey,
-                (typeof privateNumericSettings)[PrivateNumericKey],
-            ][]) {
+            for (const [key, setting] of Object.entries(calibrationSettings)) {
                 const raw = msg.data[setting.attribute];
                 if (raw === undefined) continue;
                 const value = Number(raw) / setting.scale;
-                result[key] = round(
-                    toDisplayTemperature(value, isTemperatureKey(key) ? temperatureKinds[key] : "absolute", isFahrenheit(meta.device)),
-                    setting.precision,
-                );
+                if (key === "internal_temperature_calibration") {
+                    setConfirmedTemperatureValue(meta.device, key, value);
+                }
+                result[key] =
+                    key === "internal_temperature_calibration" ? round(toDisplayTemperatureDelta(value, isFahrenheit(meta.device)), 1) : value;
             }
 
-            if (msg.data.faultCode !== undefined) result.fault_status = formatFaultCode(Number(msg.data.faultCode));
+            return Object.keys(result).length === 0 ? undefined : result;
+        },
+    };
+    const toZigbee: Tz.Converter[] = [
+        {
+            key: Object.keys(calibrationSettings),
+            convertSet: async (entity, key, value, meta) => {
+                const setting = calibrationSettings[key as keyof typeof calibrationSettings];
+                const fahrenheit = isFahrenheit(meta.device);
+                const displayValue = Number(value);
+                const temperatureSetting = key === "internal_temperature_calibration";
+                const decision = temperatureSetting
+                    ? resolveTemperatureWrite(displayValue, fahrenheit, getConfirmedTemperatureValue(meta.device, key), "delta")
+                    : {shouldWrite: true, deviceValue: displayValue, stateValue: displayValue};
+                const normalized = temperatureSetting ? decision.deviceValue : displayValue;
+
+                if (!Number.isFinite(normalized) || normalized < setting.valueMin || normalized > setting.valueMax) {
+                    throw new Error(`${key} is outside its supported range`);
+                }
+
+                const raw = Math.round(normalized * setting.scale);
+                if (!temperatureSetting || decision.shouldWrite) {
+                    await writeFd22Attribute(entity, setting.attribute, raw);
+                    if (temperatureSetting) setConfirmedTemperatureValue(meta.device, key, raw / setting.scale);
+                }
+                const stateValue = temperatureSetting ? decision.stateValue : raw / setting.scale;
+
+                return {state: {[key]: stateValue}};
+            },
+            convertGet: async (entity, key) => {
+                await readFd22Attribute(entity, calibrationSettings[key as keyof typeof calibrationSettings].attribute);
+            },
+        },
+    ];
+    const expose = (device: ExposeDevice) => {
+        const fahrenheit = isFahrenheit(device);
+
+        return [
+            e
+                .numeric("internal_temperature_calibration", ea.STATE_SET)
+                .withCategory("config")
+                .withUnit(fahrenheit ? "°F" : "°C")
+                .withValueMin(fahrenheit ? -18 : -10)
+                .withValueMax(fahrenheit ? 18 : 10)
+                .withValueStep(0.1),
+            e
+                .numeric("internal_humidity_calibration", ea.STATE_SET)
+                .withCategory("config")
+                .withUnit("%")
+                .withValueMin(-10)
+                .withValueMax(10)
+                .withValueStep(0.1),
+            e.numeric("sample_interval", ea.STATE_SET).withCategory("config").withUnit("s").withValueMin(1).withValueMax(3600).withValueStep(1),
+        ];
+    };
+
+    return {exposes: [expose], fromZigbee: [fromZigbee], toZigbee, isModernExtend: true};
+}
+
+const alarmSettings = {
+    temperature_alarm_upper: {
+        attribute: "temperatureAlarmUpper",
+        scale: 100,
+        valueMin: -30,
+        valueMax: 60,
+        valueStep: 0.1,
+    },
+    temperature_alarm_lower: {
+        attribute: "temperatureAlarmLower",
+        scale: 100,
+        valueMin: -30,
+        valueMax: 60,
+        valueStep: 0.1,
+    },
+    humidity_alarm_upper: {
+        attribute: "humidityAlarmUpper",
+        scale: 100,
+        valueMin: 0,
+        valueMax: 100,
+        valueStep: 1,
+    },
+    humidity_alarm_lower: {
+        attribute: "humidityAlarmLower",
+        scale: 100,
+        valueMin: 0,
+        valueMax: 100,
+        valueStep: 1,
+    },
+} as const;
+
+function isTemperatureAlarmKey(key: string): key is "temperature_alarm_upper" | "temperature_alarm_lower" {
+    return key === "temperature_alarm_upper" || key === "temperature_alarm_lower";
+}
+
+export function validateAlarmLimits(state: Record<string, number>) {
+    if (
+        state.temperature_alarm_lower !== undefined &&
+        state.temperature_alarm_upper !== undefined &&
+        state.temperature_alarm_upper - state.temperature_alarm_lower < 0.2 - 1e-9
+    ) {
+        throw new Error("temperature alarm upper must be at least 0.2 C above lower");
+    }
+    if (
+        state.humidity_alarm_lower !== undefined &&
+        state.humidity_alarm_upper !== undefined &&
+        state.humidity_alarm_upper - state.humidity_alarm_lower < 2
+    ) {
+        throw new Error("humidity alarm upper must be at least 2 %RH above lower");
+    }
+}
+
+function sth1zAlarmSettings(): ModernExtend {
+    const fromZigbee: RtiTekFzConverter = {
+        cluster: rtiTekFd22,
+        type: ["attributeReport", "readResponse"],
+        convert: (_model, msg, _publish, _options, meta) => {
+            const result: Record<string, number> = {};
+
+            for (const [key, setting] of Object.entries(alarmSettings)) {
+                const raw = msg.data[setting.attribute];
+                if (raw === undefined) continue;
+                const value = Number(raw) / setting.scale;
+                if (isTemperatureAlarmKey(key)) setConfirmedTemperatureValue(meta.device, key, value);
+                result[key] = isTemperatureAlarmKey(key) ? round(toDisplayTemperature(value, isFahrenheit(meta.device)), 1) : value;
+            }
+
+            return Object.keys(result).length === 0 ? undefined : result;
+        },
+    };
+    const toZigbee: Tz.Converter[] = [
+        {
+            key: Object.keys(alarmSettings),
+            convertSet: async (entity, key, value, meta) => {
+                const alarmKey = key as keyof typeof alarmSettings;
+                const setting = alarmSettings[alarmKey];
+                const fahrenheit = isFahrenheit(meta.device);
+                const displayValue = Number(value);
+                const temperatureSetting = isTemperatureAlarmKey(alarmKey);
+                const decision = temperatureSetting
+                    ? resolveTemperatureWrite(displayValue, fahrenheit, getConfirmedTemperatureValue(meta.device, key))
+                    : {shouldWrite: true, deviceValue: displayValue, stateValue: displayValue};
+                const normalized = temperatureSetting ? decision.deviceValue : displayValue;
+
+                if (!Number.isFinite(normalized) || normalized < setting.valueMin || normalized > setting.valueMax) {
+                    throw new Error(`${key} is outside its supported range`);
+                }
+
+                const normalizedState: Record<string, number> = {};
+                for (const stateKey of Object.keys(alarmSettings)) {
+                    const stateValue = meta.state[stateKey];
+                    if (stateValue === undefined || stateValue === null) continue;
+                    normalizedState[stateKey] = isTemperatureAlarmKey(stateKey)
+                        ? toCelsiusTemperature(Number(stateValue), fahrenheit)
+                        : Number(stateValue);
+                }
+                normalizedState[alarmKey] = normalized;
+                validateAlarmLimits(normalizedState);
+
+                const raw = Math.round(normalized * setting.scale);
+                if (!temperatureSetting || decision.shouldWrite) {
+                    await writeFd22Attribute(entity, setting.attribute, raw);
+                    if (temperatureSetting) setConfirmedTemperatureValue(meta.device, key, raw / setting.scale);
+                }
+                const stateValue = temperatureSetting ? decision.stateValue : raw / setting.scale;
+
+                return {state: {[key]: stateValue}};
+            },
+            convertGet: async (entity, key) => {
+                await readFd22Attribute(entity, alarmSettings[key as keyof typeof alarmSettings].attribute);
+            },
+        },
+    ];
+    const expose = (device: ExposeDevice) => {
+        const fahrenheit = isFahrenheit(device);
+
+        return [
+            e
+                .numeric("temperature_alarm_upper", ea.STATE_SET)
+                .withCategory("config")
+                .withUnit(fahrenheit ? "°F" : "°C")
+                .withValueMin(fahrenheit ? -22 : -30)
+                .withValueMax(fahrenheit ? 140 : 60)
+                .withValueStep(0.1),
+            e
+                .numeric("temperature_alarm_lower", ea.STATE_SET)
+                .withCategory("config")
+                .withUnit(fahrenheit ? "°F" : "°C")
+                .withValueMin(fahrenheit ? -22 : -30)
+                .withValueMax(fahrenheit ? 140 : 60)
+                .withValueStep(0.1),
+            e.numeric("humidity_alarm_upper", ea.STATE_SET).withCategory("config").withUnit("%").withValueMin(0).withValueMax(100).withValueStep(1),
+            e.numeric("humidity_alarm_lower", ea.STATE_SET).withCategory("config").withUnit("%").withValueMin(0).withValueMax(100).withValueStep(1),
+        ];
+    };
+
+    return {exposes: [expose], fromZigbee: [fromZigbee], toZigbee, isModernExtend: true};
+}
+
+export function formatFaultCode(value: number): string {
+    const raw = value >>> 0;
+    if (raw === 0) return "none";
+
+    const knownMask = Object.keys(faultBits).reduce((mask, bit) => mask | (1 << Number(bit)), 0);
+    const faults = Object.entries(faultBits)
+        .filter(([bit]) => (raw & (1 << Number(bit))) !== 0)
+        .map(([, text]) => text);
+    const unknown = (raw & ~knownMask) >>> 0;
+    if (unknown !== 0) {
+        faults.push(`unknown_0x${unknown.toString(16).padStart(8, "0")}`);
+    }
+
+    return faults.join(",");
+}
+
+function sth1zDiagnostics(): ModernExtend {
+    const fromZigbee: RtiTekFzConverter = {
+        cluster: rtiTekFd22,
+        type: ["attributeReport", "readResponse"],
+        convert: (_model, msg) => {
+            const result: Record<string, string> = {};
+
+            if (msg.data.faultCode !== undefined) {
+                result.fault_status = formatFaultCode(Number(msg.data.faultCode));
+            }
             if (msg.data.temperatureAlarmStatus !== undefined) {
                 result.temperature_alarm_status =
                     Object.keys(alarmStatusLookup).find(
@@ -681,104 +943,36 @@ function sth1zPrivateSettings(): ModernExtend {
                     ) ?? `unknown_${Number(msg.data.humidityAlarmStatus)}`;
             }
 
-            return Object.keys(result).length > 0 ? result : undefined;
+            return Object.keys(result).length === 0 ? undefined : result;
         },
-    } satisfies Fz.Converter<typeof rtiTekFd22, RtiTekFd22Cluster, ["attributeReport", "readResponse"]>;
-
+    };
     const toZigbee: Tz.Converter[] = [
-        {
-            key: ["temperature_unit"],
-            convertSet: async (entity, _key, value, meta) => {
-                if (value !== "celsius" && value !== "fahrenheit") throw new Error("temperature_unit must be celsius or fahrenheit");
-                const fahrenheit = value === "fahrenheit";
-                const previousFahrenheit = isFahrenheit(meta.device);
-                await entity.write<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, {temperatureUnit: fahrenheit ? 1 : 0});
-                setTemperatureUnit(meta.device, fahrenheit);
-                if (previousFahrenheit !== fahrenheit) meta.deviceExposesChanged?.();
-                return {
-                    state: {
-                        temperature_unit: fahrenheit ? "fahrenheit" : "celsius",
-                        ...convertTemperatureState(meta.state, previousFahrenheit, fahrenheit),
-                    },
-                };
-            },
-            convertGet: async (entity) => {
-                await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["temperatureUnit"]);
-            },
-        },
-        {
-            key: Object.keys(privateNumericSettings),
-            convertSet: async (entity, key, value, meta) => {
-                const setting = privateNumericSettings[key as PrivateNumericKey];
-                const fahrenheit = isFahrenheit(meta.device);
-                const capability = isTemperatureKey(key) ? getTemperatureCapability(key, setting, fahrenheit) : setting;
-                if (!Number.isFinite(Number(value))) throw new Error(`${key} must be a number`);
-                const displayValue = round(roundToStep(Number(value), capability.valueStep), setting.precision);
-                const normalized = isTemperatureKey(key) ? toCelsiusTemperature(displayValue, temperatureKinds[key], fahrenheit) : displayValue;
-                validateRange(key as PrivateNumericKey, normalized);
-                validateAlarmLimits({...normalizeTemperatureState(meta.state, fahrenheit), [key]: normalized} as Record<string, number>);
-                const raw = Math.round(normalized * setting.scale);
-                await entity.write<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, {[setting.attribute]: raw} as never);
-                return {
-                    state: {
-                        [key]: round(
-                            toDisplayTemperature(raw / setting.scale, isTemperatureKey(key) ? temperatureKinds[key] : "absolute", fahrenheit),
-                            setting.precision,
-                        ),
-                    },
-                };
-            },
-            convertGet: async (entity, key) => {
-                await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, [privateNumericSettings[key as PrivateNumericKey].attribute]);
-            },
-        },
         {
             key: ["fault_status"],
             convertGet: async (entity) => {
-                await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["faultCode"]);
+                await readFd22Attribute(entity, "faultCode");
             },
         },
         {
             key: ["temperature_alarm_status"],
             convertGet: async (entity) => {
-                await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["temperatureAlarmStatus"]);
+                await readFd22Attribute(entity, "temperatureAlarmStatus");
             },
         },
         {
             key: ["humidity_alarm_status"],
             convertGet: async (entity) => {
-                await entity.read<typeof rtiTekFd22, RtiTekFd22Cluster>(rtiTekFd22, ["humidityAlarmStatus"]);
+                await readFd22Attribute(entity, "humidityAlarmStatus");
             },
         },
     ];
+    const expose = [
+        e.text("fault_status", ea.STATE_GET).withCategory("diagnostic"),
+        e.enum("temperature_alarm_status", ea.STATE_GET, ["normal", "low", "high"]).withCategory("diagnostic"),
+        e.enum("humidity_alarm_status", ea.STATE_GET, ["normal", "low", "high"]).withCategory("diagnostic"),
+    ];
 
-    const expose: DefinitionExposesFunction = (device) => {
-        const results: Expose[] = [e.enum("temperature_unit", ea.STATE_SET, ["celsius", "fahrenheit"]).withCategory("config")];
-        for (const [key, setting] of Object.entries(privateNumericSettings) as [
-            PrivateNumericKey,
-            (typeof privateNumericSettings)[PrivateNumericKey],
-        ][]) {
-            if (isTemperatureKey(key)) {
-                results.push(temperatureExpose(key, ea.STATE_SET, setting, device, "config"));
-            } else {
-                results.push(
-                    e
-                        .numeric(key, ea.STATE_SET)
-                        .withUnit(setting.unit)
-                        .withValueMin(setting.valueMin)
-                        .withValueMax(setting.valueMax)
-                        .withValueStep(setting.valueStep)
-                        .withCategory("config"),
-                );
-            }
-        }
-        results.push(e.enum("temperature_alarm_status", ea.STATE_GET, ["normal", "low", "high"]).withCategory("diagnostic"));
-        results.push(e.enum("humidity_alarm_status", ea.STATE_GET, ["normal", "low", "high"]).withCategory("diagnostic"));
-        results.push(e.text("fault_status", ea.STATE_GET).withCategory("diagnostic"));
-        return results;
-    };
-
-    return {exposes: [expose], fromZigbee: [fromZigbee], toZigbee, isModernExtend: true};
+    return {exposes: expose, fromZigbee: [fromZigbee], toZigbee, isModernExtend: true};
 }
 
 export const definitions: DefinitionWithExtend[] = [
@@ -788,14 +982,30 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Rti-Tek",
         description: "Temperature and humidity sensor",
         ota: true,
+        // Zigbee2MQTT consumes this OTA policy even though the local converter type has not exposed it yet.
+        meta: {
+            ota_battery_minimum_percentage: 50,
+        } as unknown as DefinitionWithExtend["meta"],
         extend: [
             m.deviceAddCustomCluster(rtiTekFd22, {
                 name: rtiTekFd22,
                 ID: rtiTekFd22Id,
                 attributes: {
-                    temperatureUnit: {name: "temperatureUnit", ...rtiTekFd22Attributes.temperatureUnit, write: true, max: 0xff},
-                    faultCode: {name: "faultCode", ...rtiTekFd22Attributes.faultCode, max: 0xffffffff},
-                    productName: {name: "productName", ...rtiTekFd22Attributes.productName},
+                    temperatureUnit: {
+                        name: "temperatureUnit",
+                        ...rtiTekFd22Attributes.temperatureUnit,
+                        write: true,
+                        max: 0xff,
+                    },
+                    faultCode: {
+                        name: "faultCode",
+                        ...rtiTekFd22Attributes.faultCode,
+                        max: 0xffffffff,
+                    },
+                    productName: {
+                        name: "productName",
+                        ...rtiTekFd22Attributes.productName,
+                    },
                     internalTemperatureCalibration: {
                         name: "internalTemperatureCalibration",
                         ...rtiTekFd22Attributes.internalTemperatureCalibration,
@@ -808,7 +1018,12 @@ export const definitions: DefinitionWithExtend[] = [
                         write: true,
                         min: -128,
                     },
-                    sampleInterval: {name: "sampleInterval", ...rtiTekFd22Attributes.sampleInterval, write: true, max: 0xffff},
+                    sampleInterval: {
+                        name: "sampleInterval",
+                        ...rtiTekFd22Attributes.sampleInterval,
+                        write: true,
+                        max: 0xffff,
+                    },
                     temperatureAlarmUpper: {
                         name: "temperatureAlarmUpper",
                         ...rtiTekFd22Attributes.temperatureAlarmUpper,
@@ -821,10 +1036,28 @@ export const definitions: DefinitionWithExtend[] = [
                         write: true,
                         min: -32768,
                     },
-                    humidityAlarmUpper: {name: "humidityAlarmUpper", ...rtiTekFd22Attributes.humidityAlarmUpper, write: true, max: 0xffff},
-                    humidityAlarmLower: {name: "humidityAlarmLower", ...rtiTekFd22Attributes.humidityAlarmLower, write: true, max: 0xffff},
-                    temperatureAlarmStatus: {name: "temperatureAlarmStatus", ...rtiTekFd22Attributes.temperatureAlarmStatus, max: 0xff},
-                    humidityAlarmStatus: {name: "humidityAlarmStatus", ...rtiTekFd22Attributes.humidityAlarmStatus, max: 0xff},
+                    humidityAlarmUpper: {
+                        name: "humidityAlarmUpper",
+                        ...rtiTekFd22Attributes.humidityAlarmUpper,
+                        write: true,
+                        max: 0xffff,
+                    },
+                    humidityAlarmLower: {
+                        name: "humidityAlarmLower",
+                        ...rtiTekFd22Attributes.humidityAlarmLower,
+                        write: true,
+                        max: 0xffff,
+                    },
+                    temperatureAlarmStatus: {
+                        name: "temperatureAlarmStatus",
+                        ...rtiTekFd22Attributes.temperatureAlarmStatus,
+                        max: 0xff,
+                    },
+                    humidityAlarmStatus: {
+                        name: "humidityAlarmStatus",
+                        ...rtiTekFd22Attributes.humidityAlarmStatus,
+                        max: 0xff,
+                    },
                     sth2zHumidityComfortLower: {
                         name: "sth2zHumidityComfortLower",
                         ...rtiTekFd22Attributes.sth2zHumidityComfortLower,
@@ -853,48 +1086,46 @@ export const definitions: DefinitionWithExtend[] = [
                 commands: {},
                 commandsResponse: {},
             }),
-            sth1zTemperatureDisplay(),
+            sth1zTemperature(),
             m.humidity({reporting: false}),
             m.battery({percentageReporting: false}),
-            sthzbProductName(),
-            sth1zPrivateSettings(),
-            sth2zComfortSettings(),
             sth1zDerivedEnvironment(),
+            sth2zComfortSettings(),
+            sthzbProductName(),
+            sth1zTemperatureUnit(),
+            sth1zCalibrationSettings(),
+            sth1zAlarmSettings(),
+            sth1zDiagnostics(),
         ],
         configure: async (device) => {
             const endpoint = device.getEndpoint(1);
+            if (!endpoint) throw new Error(`STHZB '${device.ieeeAddr}' has no endpoint 1`);
 
             if (endpoint.supportsInputCluster("genPollCtrl")) {
                 try {
                     await endpoint.write("genPollCtrl", {fastPollTimeout});
                 } catch (error) {
-                    logger.warning(`STHZB '${device.ieeeAddr}' fast-poll timeout configuration failed: ${error}`, NS);
+                    if (isUnsupportedPollControlError(error)) {
+                        logger.debug(`STHZB '${device.ieeeAddr}' does not support Poll Control fastPollTimeout`, NS);
+                    } else {
+                        throw error;
+                    }
                 }
             }
 
-            await configureReporting(endpoint, "msTemperatureMeasurement");
-            await configureReporting(endpoint, "msRelativeHumidity");
-            await utils.ignoreUnsupportedAttribute(
-                async () => await reporting.batteryPercentageRemaining(endpoint),
-                `STHZB '${device.ieeeAddr}' battery reporting configuration`,
-            );
-
-            await Promise.all([
-                endpoint
-                    .read("msTemperatureMeasurement", ["measuredValue"])
-                    .catch((error) => logger.debug(`STHZB '${device.ieeeAddr}' temperature read failed: ${error}`, NS)),
-                endpoint
-                    .read("msRelativeHumidity", ["measuredValue"])
-                    .catch((error) => logger.debug(`STHZB '${device.ieeeAddr}' humidity read failed: ${error}`, NS)),
-                endpoint
-                    .read("genPowerCfg", ["batteryVoltage", "batteryPercentageRemaining"])
-                    .catch((error) => logger.debug(`STHZB '${device.ieeeAddr}' battery read failed: ${error}`, NS)),
-            ]);
-
+            await endpoint.read("msTemperatureMeasurement", ["measuredValue"]);
+            await endpoint.read("msRelativeHumidity", ["measuredValue"]);
+            await endpoint.read("genPowerCfg", ["batteryVoltage", "batteryPercentageRemaining"]);
+            await readReportingConfiguration(endpoint, "msTemperatureMeasurement", "measuredValue");
+            await readReportingConfiguration(endpoint, "msRelativeHumidity", "measuredValue");
+            await readReportingConfiguration(endpoint, "genPowerCfg", "batteryPercentageRemaining");
             await delay(3000);
-            await readProductName(endpoint, device);
-            await readFd22Attributes(endpoint, sth1zFd22AttributeIds);
-            if (isSth2z(device)) await readFd22Attributes(endpoint, sth2zComfortAttributeIds);
+            const productName = await readProductName(endpoint, device.ieeeAddr);
+            setProductName(device, productName);
+            await readFd22Attributes(endpoint, device.ieeeAddr);
+            if (isSth2z(device)) {
+                await readFd22Attributes(endpoint, device.ieeeAddr, sth2zComfortAttributeIds);
+            }
         },
     },
 ];

--- a/test/rti_tek.test.ts
+++ b/test/rti_tek.test.ts
@@ -13,7 +13,7 @@ import type {Definition, Fz, KeyValueAny, Tz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 function buildDevice() {
-    return mockDevice({
+    const device = mockDevice({
         modelID: "STHZB",
         manufacturerName: "Rti-Tek",
         endpoints: [
@@ -24,6 +24,12 @@ function buildDevice() {
             },
         ],
     });
+
+    for (const endpoint of device.endpoints) {
+        vi.spyOn(endpoint, "readReportingConfig").mockImplementation(async () => []);
+    }
+
+    return device;
 }
 
 function buildMeta(device: ReturnType<typeof mockDevice>, definition: Definition, overrides?: Partial<Tz.Meta>): Tz.Meta {
@@ -265,14 +271,13 @@ describe("Rti-Tek STHZB converter", () => {
         expect(result).toMatchObject({comfort_humidity_lower_limit: 30, comfort_humidity_upper_limit: 60});
 
         const meta = buildMeta(device, definition);
-        await expect(
-            findTz("comfort_humidity_lower_limit").convertGet?.(device.getEndpoint(1), "comfort_humidity_lower_limit", meta),
-        ).resolves.toStrictEqual({state: {comfort_humidity_lower_limit: 30}});
+        const getResult = await findTz("comfort_humidity_lower_limit").convertGet?.(device.getEndpoint(1), "comfort_humidity_lower_limit", meta);
+        expect(getResult).toStrictEqual({state: {comfort_humidity_lower_limit: 30}});
     });
 
-    it("keeps set comfort humidity limits in %RH when temperature unit is Fahrenheit", () => {
+    it("keeps set comfort humidity limits in %RH when temperature unit is Fahrenheit", async () => {
         device.meta.rtiTekTemperatureUnit = "fahrenheit";
-        const result = findTz("comfort_humidity_lower_limit").convertSet?.(
+        const result = await findTz("comfort_humidity_lower_limit").convertSet?.(
             device.getEndpoint(1),
             "comfort_humidity_lower_limit",
             35,
@@ -282,25 +287,25 @@ describe("Rti-Tek STHZB converter", () => {
         expect(result).toMatchObject({state: {comfort_humidity_lower_limit: 35}});
     });
 
-    it("validates comfort humidity limits against their stored counterpart", () => {
+    it("validates comfort humidity limits against their stored counterpart", async () => {
         const endpoint = device.getEndpoint(1);
 
-        expect(() =>
+        await expect(
             findTz("comfort_humidity_lower_limit").convertSet?.(
                 endpoint,
                 "comfort_humidity_lower_limit",
                 50,
                 buildMeta(device, definition, {state: {comfort_humidity_lower_limit: 30, comfort_humidity_upper_limit: 40}}),
             ),
-        ).toThrow("comfort humidity lower limit must be below upper limit");
-        expect(() =>
+        ).rejects.toThrow("comfort humidity lower limit must be below upper limit");
+        await expect(
             findTz("comfort_humidity_upper_limit").convertSet?.(
                 endpoint,
                 "comfort_humidity_upper_limit",
                 40,
                 buildMeta(device, definition, {state: {comfort_humidity_lower_limit: 50, comfort_humidity_upper_limit: 60}}),
             ),
-        ).toThrow("comfort humidity lower limit must be below upper limit");
+        ).rejects.toThrow("comfort humidity lower limit must be below upper limit");
     });
 
     it("registers the shared STHZB FD22 attributes", async () => {
@@ -308,6 +313,8 @@ describe("Rti-Tek STHZB converter", () => {
         try {
             const configure = definition.configure;
             if (!configure) throw new Error("STH1Z definition is missing configure");
+            const endpoint = device.getEndpoint(1);
+            vi.mocked(endpoint.read).mockImplementation(async (cluster) => (cluster === "rtiTekFd22" ? {productName: "STH1Z"} : {}));
             const configurePromise = configure(device, device.getEndpoint(1), definition);
             await vi.advanceTimersByTimeAsync(3000);
             await configurePromise;
@@ -321,11 +328,12 @@ describe("Rti-Tek STHZB converter", () => {
         }
     });
 
-    it("continues initial reads when the device rejects standard reporting configuration", async () => {
+    it("continues initial reads when standard reporting configuration reads fail", async () => {
         vi.useFakeTimers();
         try {
             const endpoint = device.getEndpoint(1);
-            vi.mocked(endpoint.configureReporting).mockRejectedValueOnce(new Error("UNSUPPORTED_ATTRIBUTE"));
+            vi.mocked(endpoint.read).mockImplementation(async (cluster) => (cluster === "rtiTekFd22" ? {productName: "STH1Z"} : {}));
+            vi.mocked(endpoint.readReportingConfig).mockRejectedValue(new Error("UNSUPPORTED_ATTRIBUTE"));
             const configure = definition.configure;
             if (!configure) throw new Error("STH1Z definition is missing configure");
 
@@ -333,12 +341,7 @@ describe("Rti-Tek STHZB converter", () => {
             await vi.advanceTimersByTimeAsync(3000);
             await expect(configurePromise).resolves.toBeUndefined();
 
-            expect(endpoint.configureReporting).toHaveBeenNthCalledWith(1, "msTemperatureMeasurement", [
-                {attribute: "measuredValue", minimumReportInterval: 5, maximumReportInterval: 3600, reportableChange: 50},
-            ]);
-            expect(endpoint.configureReporting).toHaveBeenNthCalledWith(2, "msRelativeHumidity", [
-                {attribute: "measuredValue", minimumReportInterval: 5, maximumReportInterval: 3600, reportableChange: 200},
-            ]);
+            expect(endpoint.readReportingConfig).toHaveBeenCalledTimes(3);
             expect(endpoint.read).toHaveBeenCalledWith("rtiTekFd22", ["productName"]);
             expect(endpoint.read).toHaveBeenCalledWith(0xfd22, [0x0000, 0x0002, 0xe005, 0xe006]);
             expect(endpoint.read).not.toHaveBeenCalledWith(0xfd22, [0xe014, 0xe015, 0xe016, 0xe017]);
@@ -366,25 +369,13 @@ describe("Rti-Tek STHZB converter", () => {
         }
     });
 
-    it("propagates standard reporting errors so Z2M can retry configuration", async () => {
+    it("propagates measurement read errors so Z2M can retry configuration", async () => {
         const endpoint = device.getEndpoint(1);
-        vi.mocked(endpoint.configureReporting).mockRejectedValueOnce(new Error("TIMEOUT"));
+        vi.mocked(endpoint.read).mockRejectedValueOnce(new Error("TIMEOUT"));
         const configure = definition.configure;
         if (!configure) throw new Error("STH1Z definition is missing configure");
 
         await expect(configure(device, endpoint, definition)).rejects.toThrow("TIMEOUT");
-    });
-
-    it("propagates battery reporting errors so Z2M can retry configuration", async () => {
-        const endpoint = device.getEndpoint(1);
-        vi.mocked(endpoint.configureReporting)
-            .mockResolvedValueOnce(undefined)
-            .mockResolvedValueOnce(undefined)
-            .mockRejectedValueOnce(new Error("NO_ROUTE"));
-        const configure = definition.configure;
-        if (!configure) throw new Error("STH1Z definition is missing configure");
-
-        await expect(configure(device, endpoint, definition)).rejects.toThrow("NO_ROUTE");
     });
 
     it("identifies STH2Z from the FD22 product name", () => {

--- a/test/rti_tek.test.ts
+++ b/test/rti_tek.test.ts
@@ -69,7 +69,7 @@ describe("Rti-Tek STH1Z helpers", () => {
     });
 });
 
-describe("Rti-Tek STH1Z converter", () => {
+describe("Rti-Tek STHZB converter", () => {
     let device: ReturnType<typeof mockDevice>;
     let definition: Definition;
 
@@ -126,7 +126,7 @@ describe("Rti-Tek STH1Z converter", () => {
         });
     });
 
-    it("exposes the complete STH1Z feature set without STH2Z-only controls", () => {
+    it("exposes the shared STHZB feature set", () => {
         const names = definition.exposes(device, {}).map((expose) => expose.name);
 
         expect(names).toEqual(
@@ -145,6 +145,7 @@ describe("Rti-Tek STH1Z converter", () => {
                 "temperature_alarm_status",
                 "humidity_alarm_status",
                 "fault_status",
+                "product_name",
                 "dew_point",
                 "vpd",
                 "humidity_comfort",
@@ -154,23 +155,16 @@ describe("Rti-Tek STH1Z converter", () => {
                 "comfort_temperature_upper_limit",
             ]),
         );
-        expect(names).not.toContain("product_name");
         expect(names).not.toContain("app_action");
         expect(names).not.toContain("child_lock");
     });
 
-    it("refreshes local environmental state when a battery report arrives", () => {
+    it("does not refresh environmental state when a battery report arrives", () => {
         const {result} = runFz("genPowerCfg", {batteryPercentageRemaining: 200}, {temperature: 29.4, humidity: 40.4});
 
-        expect(result).toMatchObject({
-            dew_point: 14.5,
-            vpd: 2.44,
-            humidity_comfort: "normal",
-            comfort_humidity_lower_limit: 30,
-            comfort_humidity_upper_limit: 60,
-            comfort_temperature_lower_limit: 20,
-            comfort_temperature_upper_limit: 26,
-        });
+        expect(result).not.toHaveProperty("dew_point");
+        expect(result).not.toHaveProperty("vpd");
+        expect(result).not.toHaveProperty("humidity_comfort");
     });
 
     it("rejects an invalid alarm pair before writing FD22", async () => {
@@ -309,7 +303,7 @@ describe("Rti-Tek STH1Z converter", () => {
         ).toThrow("comfort humidity lower limit must be below upper limit");
     });
 
-    it("registers only the documented STH1Z FD22 attributes", async () => {
+    it("registers the shared STHZB FD22 attributes", async () => {
         vi.useFakeTimers();
         try {
             const configure = definition.configure;
@@ -320,8 +314,8 @@ describe("Rti-Tek STH1Z converter", () => {
 
             const attributes = device.customClusters.rtiTekFd22.attributes;
             expect(attributes).toMatchObject({temperatureUnit: {ID: 0x0000}, faultCode: {ID: 0x0002}, temperatureAlarmUpper: {ID: 0xe00a}});
-            expect(Object.values(attributes).map((attribute) => attribute.ID)).not.toContain(0xe014);
-            expect(Object.values(attributes).map((attribute) => attribute.ID)).not.toContain(0xe017);
+            expect(attributes).toMatchObject({productName: {ID: 0x0003}, sth2zHumidityComfortLower: {ID: 0xe014}});
+            expect(Object.values(attributes).map((attribute) => attribute.ID)).toContain(0xe017);
         } finally {
             vi.useRealTimers();
         }
@@ -345,7 +339,28 @@ describe("Rti-Tek STH1Z converter", () => {
             expect(endpoint.configureReporting).toHaveBeenNthCalledWith(2, "msRelativeHumidity", [
                 {attribute: "measuredValue", minimumReportInterval: 5, maximumReportInterval: 3600, reportableChange: 200},
             ]);
+            expect(endpoint.read).toHaveBeenCalledWith("rtiTekFd22", ["productName"]);
             expect(endpoint.read).toHaveBeenCalledWith(0xfd22, [0x0000, 0x0002, 0xe005, 0xe006]);
+            expect(endpoint.read).not.toHaveBeenCalledWith(0xfd22, [0xe014, 0xe015, 0xe016, 0xe017]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("reads STH2Z comfort thresholds after identifying the product", async () => {
+        vi.useFakeTimers();
+        try {
+            const endpoint = device.getEndpoint(1);
+            vi.mocked(endpoint.read).mockImplementation(async (cluster) => (cluster === "rtiTekFd22" ? {productName: "STH2Z"} : {}));
+            const configure = definition.configure;
+            if (!configure) throw new Error("STHZB definition is missing configure");
+
+            const configurePromise = configure(device, endpoint, definition);
+            await vi.advanceTimersByTimeAsync(3000);
+            await configurePromise;
+
+            expect(device.meta.rtiTekProductName).toBe("STH2Z");
+            expect(endpoint.read).toHaveBeenCalledWith(0xfd22, [0xe014, 0xe015, 0xe016, 0xe017]);
         } finally {
             vi.useRealTimers();
         }
@@ -370,5 +385,46 @@ describe("Rti-Tek STH1Z converter", () => {
         if (!configure) throw new Error("STH1Z definition is missing configure");
 
         await expect(configure(device, endpoint, definition)).rejects.toThrow("NO_ROUTE");
+    });
+
+    it("identifies STH2Z from the FD22 product name", () => {
+        const {result, meta} = runFz("rtiTekFd22", {productName: "STH2Z"});
+
+        expect(result).toStrictEqual({product_name: "STH2Z"});
+        expect(device.meta.rtiTekProductName).toBe("STH2Z");
+        expect(meta.deviceExposesChanged).toHaveBeenCalledOnce();
+    });
+
+    it("writes STH2Z comfort thresholds to FD22", async () => {
+        device.meta.rtiTekProductName = "STH2Z";
+        const endpoint = device.getEndpoint(1);
+        const meta = buildMeta(device, definition, {state: {comfort_temperature_lower_limit: 20}});
+
+        await findTz("comfort_temperature_upper_limit").convertSet?.(endpoint, "comfort_temperature_upper_limit", 38.6, meta);
+
+        expect(endpoint.write).toHaveBeenCalledWith("rtiTekFd22", {sth2zHumidityComfortTemperatureUpper: 3860});
+    });
+
+    it("refreshes STH2Z environmental state from FD22 comfort reports", () => {
+        device.meta.rtiTekProductName = "STH2Z";
+        const {result} = runFz(
+            "rtiTekFd22",
+            {sth2zHumidityComfortTemperatureUpper: 3860},
+            {
+                temperature: 29.1,
+                humidity: 53.5,
+                comfort_humidity_lower_limit: 0,
+                comfort_humidity_upper_limit: 100,
+                comfort_temperature_lower_limit: 10.8,
+                comfort_temperature_upper_limit: 26,
+            },
+        );
+
+        expect(result).toMatchObject({
+            comfort_temperature_upper_limit: 38.6,
+            humidity_comfort: "comfort",
+            dew_point: 18.7,
+            vpd: 1.87,
+        });
     });
 });


### PR DESCRIPTION
This PR adds STH2Z support to the existing Rti-Tek STHZB definition.

STH1Z and STH2Z use the same Zigbee model ID, so the converter reads the product name from the manufacturer-specific cluster to distinguish the device variant.

STH2Z support includes:

- dynamic product detection
- STH2Z-specific comfort threshold attributes
- temperature unit dependent exposes
- reporting configuration readback
- refreshed derived comfort, dew point and VPD states
- tests for the new STH2Z behavior