### PR TITLE
fix(zemismart): fix date/weather sync for ZMZ609-2

### DIFF
--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -1194,7 +1194,15 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZMZ609-2",
         vendor: "Zemismart",
         description: "Zigbee neutral touchscreen switch 2 gang with power monitoring",
-        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"}), tuya.modernExtend.tuyaWeatherForecast()],
+        extend: [
+            tuya.modernExtend.tuyaBase({
+                dp: true,
+                timeStart: "1970", // needed else date/time doesn't sync with z2m > 2.6.2
+                forceTimeUpdates: true,
+                queryOnConfigure: true,
+            }),
+            tuya.modernExtend.tuyaWeatherForecast(),
+        ],
         fromZigbee: [tuya.fz.datapoints, fzLocal.ignoreTuyaConfigureResponse],
         toZigbee: [tuya.tz.datapoints],
         endpoint: (device) => {

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -5226,7 +5226,7 @@ const tuyaModernExtend = {
 
         const tz_fileds = includeCurrentWeather ? ["temperature_0", "humidity_0", "condition_0"] : [];
 
-        for (let i = 0; i < numberOfForecastDays; ++i) {
+        for (let i = 1; i <= numberOfForecastDays; ++i) {
             tz_fileds.push(`temperature_${i}`);
             tz_fileds.push(`humidity_${i}`);
             tz_fileds.push(`condition_${i}`);
@@ -5268,7 +5268,7 @@ const tuyaModernExtend = {
                 weather_values[TuyaWeatherID.Temperature].push(
                     `temperature_${i}` in meta.state ? (_vCorr(meta.state[`temperature_${i}`] as number) as number) : 0,
                 );
-                weather_values[TuyaWeatherID.Humidity].push(`humidity_${i}` in meta.state ? (meta.state[`humidity${i}`] as number) : 0);
+                weather_values[TuyaWeatherID.Humidity].push(`humidity_${i}` in meta.state ? (meta.state[`humidity_${i}`] as number) : 0);
                 weather_values[TuyaWeatherID.Condition].push(
                     `condition_${i}` in meta.state ? weatherConditionMap[meta.state[`condition_${i}`] as keyof typeof weatherConditionMap] : 0,
                 );

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -6,6 +6,54 @@ import type {Fz} from "../src/lib/types";
 import {mockDevice} from "./utils";
 
 describe("lib/tuya", () => {
+    describe("tuyaWeatherForecast", () => {
+        it("uses forecast fields 1 through 3 and includes their humidity in the payload", async () => {
+            const {toZigbee} = tuya.modernExtend.tuyaWeatherForecast();
+            const converter = toZigbee?.[0];
+            expect(converter?.key).toStrictEqual([
+                "temperature_0",
+                "humidity_0",
+                "condition_0",
+                "temperature_1",
+                "humidity_1",
+                "condition_1",
+                "temperature_2",
+                "humidity_2",
+                "condition_2",
+                "temperature_3",
+                "humidity_3",
+                "condition_3",
+            ]);
+
+            const device = mockDevice({modelID: "TS0601", manufacturerName: "_TZE28C1000000_o409r73p", endpoints: [{ID: 1}]});
+            const definition = await findByDevice(device);
+            const state = {
+                temperature_0: 27,
+                humidity_0: 78,
+                condition_0: "sunny",
+                temperature_1: 31,
+                humidity_1: 80,
+                condition_1: "rain",
+                temperature_2: 29,
+                humidity_2: 75,
+                condition_2: "yin",
+                temperature_3: 28,
+                humidity_3: 85,
+                condition_3: "thunder_shower",
+            };
+            const meta: Tz.Meta = {state, device, message: null, mapped: definition, options: null, publish: null, endpoint_name: null};
+
+            await converter?.convertSet?.(device.endpoints[0], "humidity_3", 85, meta);
+
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("manuSpecificTuya", "tuyaWeatherSync", {
+                payload: Buffer.from([
+                    0x11, 0x00, 0x12, 0x03, 0x13, 0x01, 0x01, 0x00, 27, 0x00, 31, 0x00, 29, 0x00, 28, 0x02, 0x00, 78, 0x00, 80, 0x00, 75, 0x00, 85,
+                    0x03, 100, 118, 114, 143, 0x00,
+                ]),
+            });
+        });
+    });
+
     describe("dpTHZBSettings", () => {
         const {toZigbee, fromZigbee} = tuya.modernExtend.dpTHZBSettings();
 


### PR DESCRIPTION
## Follow-up to #13044

While testing #13044 after merge, I found the device's date and weather display weren't syncing correctly. Root-caused it to:

1. **`ZMZ609-2` missing `forceTimeUpdates`/`queryOnConfigure`** on `tuyaBase()` — same fix already applied to `F3-Pro` for the same symptom ("needed else date/time doesn't sync with z2m > 2.6.2").
2. **Two bugs in `tuyaWeatherForecast()`** (`lib/tuya.ts`), also affecting `M8Pro` and `F3-Pro`:
   - The forecast-day loop for the settable `toZigbee` fields duplicated day 0 and dropped the last forecast day, so it could never be set.
   - `humidity_${i}` was looked up with a typo'd key (`humidity${i}`, no underscore), always resolving to `undefined` — which throws once a forecast day's humidity is actually set, since `Buffer.writeInt16BE` can't write `undefined`.

Added a regression test covering the weather payload generation.

Note: bug 2 was already caught and fixed in #13056, which was closed in favor of a separate community fork rather than merged here. Same fix, re-submitted with the ZMZ609-2 date-sync fix alongside it since both were needed to fully resolve the issue reported against #13044.

### Testing
- `pnpm check` (biome) passes
- `pnpm test` passes (844/844, including the new regression test)
- Pre-commit build hook (tsc + full definitions build) passes
