### PR TITLE
feat(add): MW833P

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -212,6 +212,7 @@ import {definitions as mill} from "./mill";
 import {definitions as mindy} from "./mindy";
 import {definitions as modular} from "./modular";
 import {definitions as moes} from "./moes";
+import {definitions as mowe} from "./mowe";
 import {definitions as msh} from "./msh";
 import {definitions as mullerLicht} from "./muller_licht";
 import {definitions as multir} from "./multir";
@@ -597,6 +598,7 @@ const definitions: DefinitionWithExtend[] = [
     ...mindy,
     ...modular,
     ...moes,
+    ...mowe,
     ...msh,
     ...mullerLicht,
     ...multir,

--- a/src/devices/mowe.ts
+++ b/src/devices/mowe.ts
@@ -1,0 +1,101 @@
+import * as exposes from "../lib/exposes";
+import * as tuya from "../lib/tuya";
+import type {DefinitionWithExtend} from "../lib/types";
+
+const e = exposes.presets;
+const ea = exposes.access;
+
+export const definitions: DefinitionWithExtend[] = [
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE200_ops9sidw"]),
+        model: "MW833P",
+        vendor: "Mowe",
+        description: "Smart presence sensor (24 GHz mmWave radar)",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [
+            e.presence(),
+            e
+                .enum("human_motion_state", ea.STATE, ["none", "peaceful", "motion"])
+                .withDescription("Motion state reported by the radar: nobody, present but still, or moving"),
+            e.illuminance(),
+            e
+                .numeric("body_motion", ea.STATE)
+                .withValueMin(0)
+                .withValueMax(100)
+                .withDescription("Body-motion amplitude, emitted every 5 seconds. 0 means nobody detected"),
+            e
+                .enum("move_direction", ea.STATE, ["none", "close_to", "far_away"])
+                .withDescription("Direction of the detected movement relative to the sensor"),
+            e
+                .numeric("sensitivity", ea.STATE_SET)
+                .withValueMin(1)
+                .withValueMax(3)
+                .withValueStep(1)
+                .withDescription("Radar sensitivity, 1 (least sensitive) to 3 (most sensitive)"),
+            e
+                .enum("scene", ea.STATE_SET, ["default", "area", "toilet", "bedroom", "parlour", "office", "hotel"])
+                .withDescription("Detection profile tuned for the size and use of the room"),
+            e
+                .enum("nobody_time", ea.STATE_SET, ["none", "10s", "30s", "1min", "2min", "5min", "10min", "30min", "1hour"])
+                .withDescription("How long presence is held after the last detection before clearing"),
+            e.binary("radar_self_check", ea.STATE_SET, true, false).withDescription("Start the radar self-check routine").withCategory("config"),
+            e.binary("check_end_flag", ea.STATE, true, false).withDescription("Radar self-check has finished").withCategory("diagnostic"),
+            e
+                .binary("radar_reset_flag", ea.STATE, true, false)
+                .withDescription("Radar reset marker, pushed by the device")
+                .withCategory("diagnostic"),
+            e
+                .text("radar_detection_data", ea.STATE)
+                .withDescription("Self-check output: '1111' confirms a false presence report, '0000' confirms it was genuine")
+                .withCategory("diagnostic"),
+            e.text("hardware_version", ea.STATE).withDescription("Radar hardware version").withCategory("diagnostic"),
+            e.text("soft_version", ea.STATE).withDescription("Radar firmware version").withCategory("diagnostic"),
+            e.text("radar_id", ea.STATE).withDescription("Radar module identifier").withCategory("diagnostic"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [1, "presence", tuya.valueConverter.trueFalseEnum1],
+                [2, "sensitivity", tuya.valueConverter.raw],
+                [101, "radar_reset_flag", tuya.valueConverter.raw],
+                [102, "human_motion_state", tuya.valueConverterBasic.lookup({none: tuya.enum(0), peaceful: tuya.enum(1), motion: tuya.enum(2)})],
+                [103, "illuminance", tuya.valueConverter.raw],
+                [104, "radar_detection_data", tuya.valueConverter.raw],
+                [107, "check_end_flag", tuya.valueConverter.raw],
+                [108, "radar_self_check", tuya.valueConverter.raw],
+                [109, "hardware_version", tuya.valueConverter.raw],
+                [110, "soft_version", tuya.valueConverter.raw],
+                [111, "radar_id", tuya.valueConverter.raw],
+                [
+                    112,
+                    "scene",
+                    tuya.valueConverterBasic.lookup({
+                        default: tuya.enum(0),
+                        area: tuya.enum(1),
+                        toilet: tuya.enum(2),
+                        bedroom: tuya.enum(3),
+                        parlour: tuya.enum(4),
+                        office: tuya.enum(5),
+                        hotel: tuya.enum(6),
+                    }),
+                ],
+                [114, "move_direction", tuya.valueConverterBasic.lookup({none: tuya.enum(0), close_to: tuya.enum(1), far_away: tuya.enum(2)})],
+                [115, "body_motion", tuya.valueConverter.raw],
+                [
+                    131,
+                    "nobody_time",
+                    tuya.valueConverterBasic.lookup({
+                        none: tuya.enum(0),
+                        "10s": tuya.enum(1),
+                        "30s": tuya.enum(2),
+                        "1min": tuya.enum(3),
+                        "2min": tuya.enum(4),
+                        "5min": tuya.enum(5),
+                        "10min": tuya.enum(6),
+                        "30min": tuya.enum(7),
+                        "1hour": tuya.enum(8),
+                    }),
+                ],
+            ],
+        },
+    },
+];


### PR DESCRIPTION
Adds support for the Mowe MW833P, a ceiling-mounted 24 GHz mmWave radar presence sensor.

Over Zigbee the device identifies only as TS0601 / _TZE200_ops9sidw. No existing definition matches that manufacturer name, so Zigbee2MQTT falls back to a generated definition that exposes nothing but linkquality. Reported in Koenkk/zigbee2mqtt#32978.

Nothing on the wire names the vendor, so vendor / model / description are taken from the product itself (MOWE branding on the faceplate, model MW833P on the label).

## Datapoints

Taken from the Tuya "thing data model" for pid=ops9sidw.

| DP | Exposed as | Access | Notes |
|---:|---|---|---|
| 1 | presence | r | verified |
| 2 | sensitivity | rw | verified, range 1-3 |
| 101 | radar_reset_flag | r | |
| 102 | human_motion_state | r | verified - none / peaceful / motion |
| 103 | illuminance | r | verified |
| 104 | radar_detection_data | r | self-check result string |
| 107 | check_end_flag | r | |
| 108 | radar_self_check | rw | |
| 109 | hardware_version | r | |
| 110 | soft_version | r | |
| 111 | radar_id | r | |
| 112 | scene | rw | verified |
| 114 | move_direction | r | verified - none / close_to / far_away |
| 115 | body_motion | r | verified, range 0-100, emitted every 5 s |
| 131 | nobody_time | rw | |

DPs 105, 106 and 113 do not exist on this product.

Seven datapoints were confirmed on a live device (1, 2, 102, 103, 112, 114, 115), including both enums and both writable settings. The remaining ones are mapped from the data model but have not been observed yet: this MCU ignores a Tuya dataQuery (0xEF00 command 0x03), so the read-only diagnostic strings and the self-check flags only populate once the device pushes them of its own accord.

pnpm run build, pnpm run check and pnpm test all pass locally.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5465