### PR TITLE
tuya: add _TZE28C1000000_1fuxihti to TS0601_cover_1

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8808,6 +8808,7 @@ export const definitions: DefinitionWithExtend[] = [
                 "_TZE200_1fuxihti",
                 "_TZE284_1fuxihti",
                 "_TZE204_1fuxihti",
+                "_TZE28C1000000_1fuxihti",
                 "_TZE204_57hjqelq",
                 "_TZE204_vvvtcehj",
                 "_TZE28C1000000_vvvtcehj",


### PR DESCRIPTION
Adds manufacturerName "_TZE28C1000000_1fuxihti" to the TS0601_cover_1 fingerprint.

This is the same curtain motor hardware already covered by "_TZE200_1fuxihti", "_TZE284_1fuxihti" and "_TZE204_1fuxihti" (same suffix, newer Tuya manufacturer ID prefix `_TZE28C1000000_`, which is already used elsewhere in this file, e.g. for the Roximo CRTZ01 curtain motor). Verified working on my own device (interviews as `TS0601` / `_TZE28C1000000_1fuxihti`) using an external converter that reuses the existing `TS0601_cover_1` fromZigbee/toZigbee/exposes — behaves identically to the `_TZE204_1fuxihti` variant.

Not a new device model, so no picture submission needed.