### PR TITLE
Add support for Aqara SJCGQ12LM-ES (engineering test version of T1 water leak sensor)

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -2085,6 +2085,13 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [m.quirkCheckinInterval("1_HOUR"), m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "battery_low"]})],
     },
     {
+        zigbeeModel: ["lumi.flood.agl02\tF\x01"],
+        model: "SJCGQ12LM-ES",
+        vendor: "Aqara",
+        description: "Water leak sensor T1 engineering test version (no specific battery percentage support, not compatible with Aqara Home app)",
+        extend: [m.iasZoneAlarm({zoneType: "water_leak", zoneAttributes: ["alarm_1", "battery_low"]})],
+    },
+    {
         zigbeeModel: ["lumi.flood.agl02"],
         model: "SJCGQ12LM",
         vendor: "Aqara",


### PR DESCRIPTION
This device is an engineering test version of the Aqara T1 water leak sensor (retail model SJCGQ12LM). Unlike the retail version, it is not compatible with the Aqara Home app and has been excluded from official gateway support (it was only available in early test firmware for some gateways).

Key hardware limitation: this device does NOT report battery voltage or percentage; only the battery_low flag is provided via IAS zone status (bit 5). Therefore, we only expose alarm_1 and battery_low using the standard iasZoneAlarm extension, without adding battery meta or fromZigbee custom logic.

This definition is already tested with an external converter and works as expected.
