### PR TITLE
legrand 067797: keep on/off working in dimmer_off (relay) mode

### DIFF
--- a/src/devices/legrand.ts
+++ b/src/devices/legrand.ts
@@ -779,7 +779,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [{vendor: "Legrand", model: "600090A"}],
         ota: true,
         fromZigbee: [fz.identify, fz.lighting_ballast_configuration, fzLegrand.cluster_fc01],
-        toZigbee: [tzLegrand.led_mode, tzLegrand.legrand_device_mode, tzLegrand.identify, tz.ballast_config],
+        toZigbee: [tzLegrand.led_mode, tzLegrand.legrand_device_mode, tzLegrand.identify, tz.ballast_config, tzLegrand.light_state_device_mode_aware],
         exposes: [
             e.numeric("ballast_minimum_level", ea.ALL).withValueMin(1).withValueMax(254).withDescription("Specifies the minimum brightness value"),
             e.numeric("ballast_maximum_level", ea.ALL).withValueMin(1).withValueMax(254).withDescription("Specifies the maximum brightness value"),

--- a/src/lib/legrand.ts
+++ b/src/lib/legrand.ts
@@ -419,6 +419,24 @@ export const tzLegrand = {
             await entity.read("manuSpecificLegrandDevices", [0x0000, 0x0001, 0x0002], legrandOptions);
         },
     } satisfies Tz.Converter,
+    // On dimmer modules that expose `device_mode` (dimmer_on/dimmer_off), the level control
+    // cluster does not respond while the module is in relay mode (`dimmer_off`). `m.light()`
+    // always drives `state` through `tz.light_onoff_brightness`, which uses `genLevelCtrl`, so
+    // in that mode on/off no longer has any effect. This converter keeps the transition-aware
+    // light converter for dimmer mode, and falls back to plain `tz.on_off` in relay mode.
+    light_state_device_mode_aware: {
+        key: ["state"],
+        options: [exposes.options.transition()],
+        convertSet: async (entity, key, value, meta) => {
+            if (meta.state.device_mode === "dimmer_off") {
+                return await tz.on_off.convertSet(entity, key, value, meta);
+            }
+            return await tz.light_onoff_brightness.convertSet(entity, key, value, meta);
+        },
+        convertGet: async (entity, key, meta) => {
+            return await tz.light_onoff_brightness.convertGet(entity, key, meta);
+        },
+    } satisfies Tz.Converter,
     pilot_wire_mode: {
         key: ["pilot_wire_mode"],
         convertSet: async (entity, key, value, meta) => {


### PR DESCRIPTION
\`m.light()\` always drives \`state\` through \`tz.light_onoff_brightness\`, which uses \`genLevelCtrl\`. On the 067797 (and other Legrand dimmer modules exposing \`device_mode\`), the level control cluster does not respond while the module is in relay mode (\`device_mode: dimmer_off\`), so on/off silently stops working in that mode.

Adds a \`device_mode\`-aware \`toZigbee\` converter for \`state\`: it delegates to the transition-aware \`light_onoff_brightness\` in dimmer mode (same behavior as before, including the fix from #13064), and falls back to plain \`tz.on_off\` in relay mode.

Verified locally on a 067797: on/off works in both \`device_mode\` values, transition is still honored in dimmer mode, ballast min/max, LED settings and identify are all unaffected.

Other Legrand dimmer modules with the same \`dimmer_on\`/\`dimmer_off\` pattern (067771, 199182, WNAL50/WNRL50) likely share this issue, but I only own a 067797 so I've kept the fix scoped to that device — happy to extend it if someone can confirm on the others.