### PR TITLE
feat(add): TS0601_TZE284_grxx6qek

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1310,6 +1310,23 @@ const tzLocal = {
             return {state: {sensitivity: value}};
         },
     } satisfies Tz.Converter,
+    // TS0601_TZE284_grxx6qek: DP 2 (on/off) uses this dedicated converter instead of
+    // the generic meta.tuyaDatapoints mapping because tuya.tz.datapoints has no `key`
+    // filter (it runs for every SET) and its onOff lookup does not support TOGGLE.
+    ts0601Grxx6qekState: {
+        key: ["state"],
+        convertSet: async (entity, key, value, meta) => {
+            let newState = value;
+            if (value === "TOGGLE") {
+                newState = meta.state.state === "ON" ? "OFF" : "ON";
+            }
+            await tuya.sendDataPointBool(entity, 2, newState === "ON", "dataRequest", 1);
+            return {state: {state: newState}};
+        },
+        convertGet: async (entity, key, meta) => {
+            await entity.command("manuSpecificTuya", "dataQuery", {});
+        },
+    } satisfies Tz.Converter,    
 };
 
 const fzLocal = {
@@ -1987,6 +2004,40 @@ const fzLocal = {
             return payload;
         },
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
+    // TS0601_TZE284_grxx6qek: answer the MCU time-sync handshake (8-byte payload:
+    // UTC + local time, both as Unix epoch seconds). Without an answer the device
+    // stops reporting after a while.
+    ts0601Grxx6qekMcuSyncTime: {
+        cluster: "manuSpecificTuya",
+        type: ["commandMcuSyncTime"],
+        convert: (model, msg, publish, options, meta) => {
+            const toBytes = (v: number) => [(v >> 24) & 0xff, (v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
+            const now = Math.floor(Date.now() / 1000);
+            msg.endpoint
+                .command(
+                    "manuSpecificTuya",
+                    "mcuSyncTime",
+                    {payloadSize: 8, payload: [...toBytes(now), ...toBytes(now)]},
+                    {
+                        disableDefaultResponse: true,
+                    },
+                )
+                .catch((error) => logger.error(`Failed to sync time with '${msg.device.ieeeAddr}' (${error})`, NS));
+        },
+    } satisfies Fz.Converter<"manuSpecificTuya", undefined, ["commandMcuSyncTime"]>,
+    // TS0601_TZE284_grxx6qek: DP 2 (on/off) reports. Kept out of meta.tuyaDatapoints
+    // together with the SET side (see tzLocal.ts0601Grxx6qekState).
+    ts0601Grxx6qekState: {
+        cluster: "manuSpecificTuya",
+        type: ["commandDataReport", "commandDataResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            for (const dpValue of msg.data.dpValues) {
+                if (dpValue.dp === 2) {
+                    return {state: dpValue.data[0] === 1 ? "ON" : "OFF"};
+                }
+            }
+        },
+    } satisfies Fz.Converter<"manuSpecificTuya", undefined, ["commandDataReport", "commandDataResponse"]>,
 };
 
 // MS032Z stair light controller - DP 125, the six running-light effects.
@@ -27526,6 +27577,24 @@ export const definitions: DefinitionWithExtend[] = [
                         to: (v: string) => ({normal: 0, slight: 1, strong: 2, severe: 3})[v] ?? 0,
                     },
                 ],
+            ],
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_grxx6qek"]),
+        model: "TS0601_TZE284_grxx6qek",
+        vendor: "Tuya",
+        description: "Temperature & humidity smart switch 16A",
+        fromZigbee: [fzLocal.ts0601Grxx6qekMcuSyncTime, fzLocal.ts0601Grxx6qekState, tuya.fz.datapoints],
+        toZigbee: [tzLocal.ts0601Grxx6qekState],
+        configure: tuya.configureMagicPacket,
+        exposes: [e.switch(), e.temperature(), e.humidity()],
+        meta: {
+            tuyaDatapoints: [
+                // DP 2 (state) is handled by the dedicated fzLocal/tzLocal converters above.
+                [27, "temperature", tuya.valueConverter.divideBy10],
+                // DP 28 tracks temperature*1.8+32 (Fahrenheit duplicate of DP 27) - not mapped, redundant.
+                [46, "humidity", tuya.valueConverter.raw],
             ],
         },
     },

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -27534,7 +27534,11 @@ export const definitions: DefinitionWithExtend[] = [
         model: "_TZE284_grxx6qek",
         vendor: "Tuya",
         description: "Temperature & humidity smart switch 16A",
-        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "2000"})],
+        // timeStart "1970": this MCU sanity-checks the mcuSyncTime answer and only
+        // accepts Unix epoch - with the Tuya-2000-epoch answer its sensor reporting
+        // freezes after every device reboot (validated on hardware). With no answer
+        // at all (default "off") it stops reporting as well.
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"})],
         exposes: [e.switch(), e.temperature(), e.humidity()],
         meta: {
             tuyaDatapoints: [

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1310,23 +1310,6 @@ const tzLocal = {
             return {state: {sensitivity: value}};
         },
     } satisfies Tz.Converter,
-    // TS0601_TZE284_grxx6qek: DP 2 (on/off) uses this dedicated converter instead of
-    // the generic meta.tuyaDatapoints mapping because tuya.tz.datapoints has no `key`
-    // filter (it runs for every SET) and its onOff lookup does not support TOGGLE.
-    ts0601Grxx6qekState: {
-        key: ["state"],
-        convertSet: async (entity, key, value, meta) => {
-            let newState = value;
-            if (value === "TOGGLE") {
-                newState = meta.state.state === "ON" ? "OFF" : "ON";
-            }
-            await tuya.sendDataPointBool(entity, 2, newState === "ON", "dataRequest", 1);
-            return {state: {state: newState}};
-        },
-        convertGet: async (entity, key, meta) => {
-            await entity.command("manuSpecificTuya", "dataQuery", {});
-        },
-    } satisfies Tz.Converter,
 };
 
 const fzLocal = {
@@ -2004,40 +1987,6 @@ const fzLocal = {
             return payload;
         },
     } satisfies Fz.Converter<"lightingColorCtrl", undefined, "raw">,
-    // TS0601_TZE284_grxx6qek: answer the MCU time-sync handshake (8-byte payload:
-    // UTC + local time, both as Unix epoch seconds). Without an answer the device
-    // stops reporting after a while.
-    ts0601Grxx6qekMcuSyncTime: {
-        cluster: "manuSpecificTuya",
-        type: ["commandMcuSyncTime"],
-        convert: (model, msg, publish, options, meta) => {
-            const toBytes = (v: number) => [(v >> 24) & 0xff, (v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
-            const now = Math.floor(Date.now() / 1000);
-            msg.endpoint
-                .command(
-                    "manuSpecificTuya",
-                    "mcuSyncTime",
-                    {payloadSize: 8, payload: [...toBytes(now), ...toBytes(now)]},
-                    {
-                        disableDefaultResponse: true,
-                    },
-                )
-                .catch((error) => logger.error(`Failed to sync time with '${msg.device.ieeeAddr}' (${error})`, NS));
-        },
-    } satisfies Fz.Converter<"manuSpecificTuya", undefined, ["commandMcuSyncTime"]>,
-    // TS0601_TZE284_grxx6qek: DP 2 (on/off) reports. Kept out of meta.tuyaDatapoints
-    // together with the SET side (see tzLocal.ts0601Grxx6qekState).
-    ts0601Grxx6qekState: {
-        cluster: "manuSpecificTuya",
-        type: ["commandDataReport", "commandDataResponse"],
-        convert: (model, msg, publish, options, meta) => {
-            for (const dpValue of msg.data.dpValues) {
-                if (dpValue.dp === 2) {
-                    return {state: dpValue.data[0] === 1 ? "ON" : "OFF"};
-                }
-            }
-        },
-    } satisfies Fz.Converter<"manuSpecificTuya", undefined, ["commandDataReport", "commandDataResponse"]>,
 };
 
 // MS032Z stair light controller - DP 125, the six running-light effects.
@@ -27582,16 +27531,26 @@ export const definitions: DefinitionWithExtend[] = [
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_grxx6qek"]),
-        model: "TS0601_TZE284_grxx6qek",
+        model: "_TZE284_grxx6qek",
         vendor: "Tuya",
         description: "Temperature & humidity smart switch 16A",
-        fromZigbee: [fzLocal.ts0601Grxx6qekMcuSyncTime, fzLocal.ts0601Grxx6qekState, tuya.fz.datapoints],
-        toZigbee: [tzLocal.ts0601Grxx6qekState],
-        configure: tuya.configureMagicPacket,
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "2000"})],
         exposes: [e.switch(), e.temperature(), e.humidity()],
         meta: {
             tuyaDatapoints: [
-                // DP 2 (state) is handled by the dedicated fzLocal/tzLocal converters above.
+                [
+                    2,
+                    "state",
+                    {
+                        // Custom converter instead of tuya.valueConverter.onOff to add
+                        // TOGGLE support, resolved against the current state.
+                        from: (v: boolean) => (v ? "ON" : "OFF"),
+                        to: (v: string, meta?: Tz.Meta) => (v === "TOGGLE" ? meta?.state.state !== "ON" : v === "ON"),
+                    },
+                    // The MCU reports DP 2 after every change, so the state comes from the
+                    // device report instead of an optimistic update (avoids publishing "TOGGLE").
+                    {optimistic: false},
+                ],
                 [27, "temperature", tuya.valueConverter.divideBy10],
                 // DP 28 tracks temperature*1.8+32 (Fahrenheit duplicate of DP 27) - not mapped, redundant.
                 [46, "humidity", tuya.valueConverter.raw],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1326,7 +1326,7 @@ const tzLocal = {
         convertGet: async (entity, key, meta) => {
             await entity.command("manuSpecificTuya", "dataQuery", {});
         },
-    } satisfies Tz.Converter,    
+    } satisfies Tz.Converter,
 };
 
 const fzLocal = {


### PR DESCRIPTION
Adds support for a Tuya TS0601 16A/3000W DIN-rail smart switch with an external
temperature & humidity probe (sold e.g. on Banggood as p-2034513).

- Device: TS0601, manufacturerName `_TZE284_grxx6qek`
- Datapoints discovered via debug logging over ~2 days of operation, cross-checked
  against a parallel data logger (temperature/humidity correlation analysis):
  - DP 2: on/off state (bool; the device reports it only on change)
  - DP 27: temperature (°C, raw ÷ 10) -> `tuya.valueConverter.divideBy10`
  - DP 28: **not mapped** - duplicates DP 27 converted to Fahrenheit
    (`temp*1.8+32`, verified with r=0.998 correlation over 2 days of logs),
    not a separate sensor value.
  - DP 46: humidity (%, raw integer, no scaling) -> `tuya.valueConverter.raw`
    - Initially suspected to be a fixed "humidity setpoint" (DP was flat at 64%
      during a short discovery session), but a longer log showed it ranging
      43-82% and anti-correlated with temperature, consistent with real
      ambient relative humidity, not a setpoint.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5469
