### PR TITLE
feat(add): Nova Digital ZCMR-1 (_TZE204_dqy15zxy)

### DIFF
--- a/src/devices/nova_digital.ts
+++ b/src/devices/nova_digital.ts
@@ -1,6 +1,10 @@
+import * as exposes from "../lib/exposes";
 import * as reporting from "../lib/reporting";
 import * as tuya from "../lib/tuya";
 import type {DefinitionWithExtend} from "../lib/types";
+
+const e = exposes.presets;
+const ea = exposes.access;
 
 export const definitions: DefinitionWithExtend[] = [
     {
@@ -30,6 +34,79 @@ export const definitions: DefinitionWithExtend[] = [
             await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genOnOff"]);
             await reporting.onOff(device.getEndpoint(1));
             await reporting.onOff(device.getEndpoint(2));
+        },
+    },
+    {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_dqy15zxy"]),
+        model: "ZCMR-1",
+        vendor: "Nova Digital",
+        description: "Roller blind motor",
+        extend: [
+            tuya.modernExtend.tuyaBase({
+                dp: true,
+                queryOnConfigure: true,
+            }),
+        ],
+        exposes: [
+            e.cover_position().setAccess("position", ea.STATE_SET),
+            e
+                .enum("reverse_direction", ea.STATE_SET, ["forward", "back"])
+                .withDescription("Reverse the motor direction. This resets the upper and lower limits; recalibrate them using border afterwards."),
+            e.enum("border", ea.SET, ["up", "down"]).withDescription("Store the current position as the upper or lower limit"),
+            e
+                .enum("situation_set", ea.STATE, ["fully_open", "fully_close"])
+                .withDescription("Indicates whether 100% represents fully open or fully closed"),
+            e.numeric("travel_time", ea.STATE).withUnit("ms").withDescription("Total calibrated travel time"),
+            e
+                .numeric("position_best", ea.STATE)
+                .withValueMin(0)
+                .withValueMax(100)
+                .withUnit("%")
+                .withDescription("Preset position stored by the motor"),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [
+                    1,
+                    "state",
+                    tuya.valueConverterBasic.lookup({
+                        OPEN: tuya.enum(0),
+                        STOP: tuya.enum(1),
+                        CLOSE: tuya.enum(2),
+                    }),
+                ],
+                [2, "position", tuya.valueConverter.coverPosition],
+                [3, "position", tuya.valueConverter.coverPosition],
+                [
+                    5,
+                    "reverse_direction",
+                    tuya.valueConverterBasic.lookup({
+                        forward: tuya.enum(0),
+                        back: tuya.enum(1),
+                    }),
+                ],
+                [10, "travel_time", tuya.valueConverter.raw],
+                [
+                    11,
+                    "situation_set",
+                    tuya.valueConverterBasic.lookup({
+                        fully_open: tuya.enum(0),
+                        fully_close: tuya.enum(1),
+                    }),
+                ],
+                [
+                    16,
+                    "border",
+                    tuya.valueConverterBasic.lookup({
+                        up: tuya.enum(0),
+                        down: tuya.enum(1),
+                        up_delete: tuya.enum(2),
+                        down_delete: tuya.enum(3),
+                        remove_top_bottom: tuya.enum(4),
+                    }),
+                ],
+                [19, "position_best", tuya.valueConverter.raw],
+            ],
         },
     },
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: [https://github.com/Koenkk/zigbee2mqtt.io/pull/5471](https://github.com/Koenkk/zigbee2mqtt.io/pull/5471)

### Summary

Adds support for the Nova Digital ZCMR-1 tubular roller blind motor with manufacturer _TZE204_dqy15zxy.

### Device information

- Model ID: TS0601
- Manufacturer name: _TZE204_dqy15zxy
- Application version: 74
- Commercial model: Nova Digital ZCMR-1

### Supported features

- Open, close and stop
- Position control and reporting
- Motor direction
- Upper and lower limit configuration
- Total calibrated travel time
- Position orientation status
- Preset position reporting

### Datapoints

- DP 1: open, stop and close
- DP 2: target position
- DP 3: current position
- DP 5: motor direction
- DP 10: total travel time
- DP 11: position orientation
- DP 16: upper and lower limit configuration
- DP 19: preset position

Changing the motor direction resets the upper and lower limits. The description of the expose warns that the limits must be recalibrated afterwards.

The upper and lower limits were verified using DP 16:

- up: stores the current position as the upper limit
- down: stores the current position as the lower limit

Tested successfully with five identical motors on two different instances of Zigbee2MQTT.

Related issue: https://github.com/Koenkk/zigbee2mqtt/issues/30510