### PR TITLE
fix(tuya): select power-on behaviour by predicate result, not option

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -4970,23 +4970,33 @@ const tuyaModernExtend = {
         } else {
             toZigbee.push(tz.on_off);
         }
-        if (powerOutageMemory) {
-            // Legacy, powerOnBehavior is preferred
-            fromZigbee.push(tuyaFz.power_outage_memory);
-            toZigbee.push(tuyaTz.power_on_behavior_1);
-            if (typeof powerOutageMemory === "function") {
-                exposes.push((d) => (powerOutageMemory(d.manufacturerName) ? [tuyaExposes.powerOutageMemory()] : []));
-            } else {
-                exposes.push(tuyaExposes.powerOutageMemory());
+        if (powerOutageMemory || powerOnBehavior2) {
+            // `powerOutageMemory` and `powerOnBehavior2` can both be set, as complementary per-manufacturer
+            // predicates, when one definition covers devices that use either mechanism. The manufacturer is
+            // only known once the exposes are resolved, so both converter sets are registered here and the
+            // lazy exposes decide which key is reachable for a given device. Selecting a branch on the
+            // option itself would always pick the first, since a predicate is truthy regardless of outcome.
+            if (powerOnBehavior2) {
+                // Registered before `power_on_behavior_1` below: both handle the `power_on_behavior` key
+                // and the first match wins, so this must take precedence for the devices that expose it.
+                fromZigbee.push(tuyaFz.power_on_behavior_2);
+                toZigbee.push(tuyaTz.power_on_behavior_2);
+                const expose = args.endpoints ? args.endpoints.map((ee) => e.power_on_behavior().withEndpoint(ee)) : [e.power_on_behavior()];
+                if (typeof powerOnBehavior2 === "function") {
+                    exposes.push((d) => (powerOnBehavior2(d.manufacturerName) ? expose : []));
+                } else {
+                    exposes.push(...expose);
+                }
             }
-        } else if (powerOnBehavior2) {
-            fromZigbee.push(tuyaFz.power_on_behavior_2);
-            toZigbee.push(tuyaTz.power_on_behavior_2);
-            const expose = args.endpoints ? args.endpoints.map((ee) => e.power_on_behavior().withEndpoint(ee)) : [e.power_on_behavior()];
-            if (typeof powerOnBehavior2 === "function") {
-                exposes.push((d) => (powerOnBehavior2(d.manufacturerName) ? expose : []));
-            } else {
-                exposes.push(...expose);
+            if (powerOutageMemory) {
+                // Legacy, powerOnBehavior is preferred
+                fromZigbee.push(tuyaFz.power_outage_memory);
+                toZigbee.push(tuyaTz.power_on_behavior_1);
+                if (typeof powerOutageMemory === "function") {
+                    exposes.push((d) => (powerOutageMemory(d.manufacturerName) ? [tuyaExposes.powerOutageMemory()] : []));
+                } else {
+                    exposes.push(tuyaExposes.powerOutageMemory());
+                }
             }
         } else if (powerOnBehavior3) {
             const endpointList = args.endpoints || [];

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -195,4 +195,45 @@ describe("lib/tuya", () => {
             expect(decode("l1", 1200, 300000, 40000)).toStrictEqual({voltage_l1: 120, current_l1: 300, power_l1: 40000});
         });
     });
+    describe("tuyaOnOff power-on behaviour selection", () => {
+        const resolveExposes = async (manufacturerName: string) => {
+            const device = mockDevice({modelID: "TS0003", manufacturerName, endpoints: [{ID: 1}, {ID: 2}, {ID: 3}]});
+            const definition = await findByDevice(device);
+            const exposes = typeof definition.exposes === "function" ? definition.exposes(device, {}) : definition.exposes;
+            return {definition, properties: exposes.map((expose) => expose.property)};
+        };
+
+        it("exposes power_on_behavior for manufacturers using the manuSpecificTuya3 attribute", async () => {
+            // `TS0003_switch_3_gang_with_backlight` passes `powerOutageMemory` and `powerOnBehavior2` as
+            // complementary predicates. Both are functions, so branching on the option itself always chose
+            // `powerOutageMemory`, whose expose is then gated off for these manufacturers, leaving them with
+            // no power-on control at all.
+            const {properties} = await resolveExposes("_TZ3000_uilitwsy");
+
+            expect(properties).toContain("power_on_behavior_l1");
+            expect(properties).toContain("power_on_behavior_l2");
+            expect(properties).toContain("power_on_behavior_l3");
+            expect(properties).not.toContain("power_outage_memory");
+        });
+
+        it("still exposes power_outage_memory for the legacy manufacturers on the same definition", async () => {
+            const {properties} = await resolveExposes("_TZ3000_nwidmc4n");
+
+            expect(properties).toContain("power_outage_memory");
+            expect(properties).not.toContain("power_on_behavior_l1");
+        });
+
+        it("lets power_on_behavior_2 win the shared power_on_behavior key", async () => {
+            // Both converters answer to `power_on_behavior`; the first match wins, so the manuSpecificTuya3
+            // one has to be registered first or these devices would write moesStartUpOnOff instead.
+            const {definition} = await resolveExposes("_TZ3000_uilitwsy");
+            const keys = definition.toZigbee.map((converter) => converter.key);
+            const powerOnBehavior2 = keys.findIndex((key) => key?.includes("power_on_behavior") && !key.includes("power_outage_memory"));
+            const powerOnBehavior1 = keys.findIndex((key) => key?.includes("power_outage_memory"));
+
+            expect(powerOnBehavior2).toBeGreaterThanOrEqual(0);
+            expect(powerOnBehavior1).toBeGreaterThanOrEqual(0);
+            expect(powerOnBehavior2).toBeLessThan(powerOnBehavior1);
+        });
+    });
 });


### PR DESCRIPTION
### What

`tuyaOnOff` selected between `powerOutageMemory` and `powerOnBehavior2` with:

```ts
if (powerOutageMemory) { ... } else if (powerOnBehavior2) { ... }
```

Both options accept `boolean | ((manufacturerName: string) => boolean)`. A predicate is truthy regardless of what it returns, so whenever a definition supplies **both**, the `powerOutageMemory` branch always won and the `powerOnBehavior2` branch was unreachable.

`TS0003_switch_3_gang_with_backlight` supplies both, as exact complements:

```ts
powerOnBehavior2:  (m) => m !== "_TZ3000_nwidmc4n" && m !== "_TZ3210_ok0ggpk7",
powerOutageMemory: (m) => m === "_TZ3000_nwidmc4n" || m === "_TZ3210_ok0ggpk7",
```

The 10 manufacturers intended to get `powerOnBehavior2` ended up with **no power-on control at all**: the dead branch never registered their converters, and the expose that *was* pushed is gated by `powerOutageMemory(manufacturerName)`, which is false for them. Their `fromZigbee` still parses `moesStartUpOnOff`, so `power_outage_memory_<ep>` appears in state with no matching expose — which is the visible symptom.

Named products affected: Moes MS-104CZ, Lonsonho X703A, Zemismart ZM-L03E-Z, Zemismart KES-606US-L3, AVATTO ZWOT16-W2, Tuya M10Z, Zemismart ZMO-606-S2.

Likely the unresolved remainder of Koenkk/zigbee2mqtt#26452 (closed as stale after 22 comments; backlight and indicator were since fixed, power-on behaviour was not).

### Fix

`manufacturerName` is only available inside the lazy expose callbacks, not when `extend` is built, so the branch cannot be resolved at construction time. Both converter sets are now registered and the lazy exposes decide which key is reachable for a given device.

`power_on_behavior_2` is registered **ahead of** `power_on_behavior_1`: both answer to the `power_on_behavior` key and the first match wins, so this ordering is what makes these devices write `manuSpecificTuya3`/`0xD010` rather than `genOnOff`/`moesStartUpOnOff`. `power_outage_memory` still resolves to `power_on_behavior_1` for the legacy pair.

The code inside each block is unchanged — only the surrounding structure and indentation.

### Scope

I brace-matched every `tuyaOnOff({...})` call site in `src/devices/`: **107 sites, exactly 1 sets more than one power option** — the definition above. No other definition can change behaviour. Definitions setting a single option keep their existing converter and expose order.

### Tests

Three tests added to `test/tuya.test.ts`. Reverting only `src/lib/tuya.ts` fails two of them:

```
× exposes power_on_behavior for manufacturers using the manuSpecificTuya3 attribute
    AssertionError: expected [ undefined, undefined, …(5) ] to include 'power_on_behavior_l1'
× lets power_on_behavior_2 win the shared power_on_behavior key
    AssertionError: expected -1 to be greater than or equal to 0
```

The third asserts `_TZ3000_nwidmc4n` still gets `power_outage_memory` and no `power_on_behavior`; it passes before and after, guarding the legacy half.

`pnpm run build`, `pnpm test` (850 passed) and `pnpm run check` all pass.

### Hardware verification

Zemismart KES-606US-L3 (`_TZ3000_uilitwsy`), 3-gang with neutral. Setting `previous` and reading back returns the value from the device on all three endpoints:

```
Received Zigbee message ... type 'readResponse', cluster 'manuSpecificTuya3', data '{"powerOnBehavior":2}' from endpoint 1
Received Zigbee message ... type 'readResponse', cluster 'manuSpecificTuya3', data '{"powerOnBehavior":2}' from endpoint 2
Received Zigbee message ... type 'readResponse', cluster 'manuSpecificTuya3', data '{"powerOnBehavior":2}' from endpoint 3
```

### Note

Happy to restructure as a definition split in `src/devices/tuya.ts` instead if you'd prefer to keep `tuyaOnOff` untouched — that would need a second `model` name for the two legacy manufacturers, which is why I went this way.

Written with Claude Code; reviewed and tested against real hardware before submitting.
