### PR TITLE
Fix AOYAN AY204T whiteLabel matching

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24805,7 +24805,7 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
-        zigbeeModel: ["ZG-204ZV", "AY204T"],
+        zigbeeModel: ["ZG-204ZV"],
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_uli8wasj", "_TZE200_grgol3xp", "_TZE200_rhgsbacq"]),
         model: "ZG-204ZV",
         vendor: "HOBEIAN",


### PR DESCRIPTION
Moves AY204T out of the parent ZG-204ZV zigbeeModel so it can match the AOYAN whiteLabel entry.