### PR TITLE
Fix: cover_state reversing open/close buttons for coverInverted devices

### DIFF
--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -674,10 +674,7 @@ export const cover_state: Tz.Converter = {
             off: "upOpen" as const,
         };
         utils.assertString(value, key);
-        const invert = utils.getMetaValue(entity, meta.mapped, "coverInverted", "allEqual", false)
-            ? !meta.options.invert_cover
-            : meta.options.invert_cover;
-        const commandLookup = invert ? invertedLookup : lookup;
+        const commandLookup = meta.options.invert_cover ? invertedLookup : lookup;
         await entity.command(
             "closuresWindowCovering",
             utils.getFromLookup(value.toLowerCase(), commandLookup),

--- a/test/toZigbee.test.ts
+++ b/test/toZigbee.test.ts
@@ -407,16 +407,16 @@ describe("toZigbee converters", () => {
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "stop", {}, {});
         });
 
-        test("device-level coverInverted meta swaps commands the same way invert_cover does", async () => {
+        test("device-level coverInverted meta does not affect which raw command is sent", async () => {
             const converter = zhc.toZigbee.cover_state;
             await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({}, {coverInverted: true}));
-            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
         });
 
-        test("invert_cover on a coverInverted device cancels back to the normal commands", async () => {
+        test("invert_cover still swaps commands on a coverInverted device", async () => {
             const converter = zhc.toZigbee.cover_state;
             await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_cover: true}, {coverInverted: true}));
-            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
         });
     });
 

--- a/test/toZigbee.test.ts
+++ b/test/toZigbee.test.ts
@@ -411,12 +411,48 @@ describe("toZigbee converters", () => {
             const converter = zhc.toZigbee.cover_state;
             await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({}, {coverInverted: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
+
+            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta({}, {coverInverted: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
         });
 
         test("invert_cover still swaps commands on a coverInverted device", async () => {
             const converter = zhc.toZigbee.cover_state;
             await converter.convertSet(device.endpoints[0], "state", "open", makeMeta({invert_cover: true}, {coverInverted: true}));
             expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "downClose", {}, {});
+
+            await converter.convertSet(device.endpoints[0], "state", "close", makeMeta({invert_cover: true}, {coverInverted: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
+        });
+
+        test("stop is unaffected by coverInverted meta, with or without invert_cover", async () => {
+            const converter = zhc.toZigbee.cover_state;
+            await converter.convertSet(device.endpoints[0], "state", "stop", makeMeta({}, {coverInverted: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "stop", {}, {});
+
+            await converter.convertSet(device.endpoints[0], "state", "stop", makeMeta({invert_cover: true}, {coverInverted: true}));
+            expect(device.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "stop", {}, {});
+        });
+
+        test("real coverInverted device (Smartwings WM25L-Z) sends unswapped commands by default, through its actual wired-up definition", async () => {
+            const smartwingsDevice = mockDevice({
+                modelID: "WM25/L-Z",
+                endpoints: [{ID: 1, inputClusters: ["closuresWindowCovering", "genPowerCfg"]}],
+            });
+            const definition = await zhc.findByDevice(smartwingsDevice);
+            expect(definition?.meta?.coverInverted).toBe(true);
+
+            const meta: Tz.Meta = {
+                state: {},
+                device: smartwingsDevice,
+                message: null,
+                mapped: definition,
+                options: {},
+                publish: null,
+                endpoint_name: null,
+            };
+            await zhc.toZigbee.cover_state.convertSet(smartwingsDevice.endpoints[0], "state", "open", meta);
+            expect(smartwingsDevice.endpoints[0].command).toHaveBeenCalledWith("closuresWindowCovering", "upOpen", {}, {});
         });
     });
 


### PR DESCRIPTION

## Problem
Since the recent cover inversion changes, pressing "Open" in Home Assistant closes the blind and vice versa — happening seemingly for anyone whose device definition sets coverInverted: true in its meta, regardless of any option they've set themselves.

## Root cause
tz.cover_state — the handler for the raw state: "open"/"close"/"stop" commands (the actual button/service-call path, distinct from percentage-based positioning) — started folding the device-level coverInverted meta into its decision about which raw ZCL command (upOpen/downClose) to send for open/close:

``` python
const invert = utils.getMetaValue(entity, meta.mapped, "coverInverted", "allEqual", false)
    ? !meta.options.invert_cover
    : meta.options.invert_cover;
const commandLookup = invert ? invertedLookup : lookup;
```

Before this, cover_state never considered any inversion at all — it always sent the same fixed command, and that was correct for essentially everyone, coverInverted devices included. coverInverted was introduced to describe a device's percentage reporting being backwards, not the physical direction of its raw open/close commands — those are independent things, and conflating them means every device with that meta flag now has its buttons silently swapped, with no way to opt out, since the flag is baked into the device definition rather than something the user controls.

## Fix
cover_state now keys off only the user's own invert_cover option:

This restores the original, correct-for-everyone default (unaffected by coverInverted), while still letting an individual user flip it via invert_cover on the rare device where the raw command direction genuinely is reversed.

## Testing
tsc --noEmit — clean
pnpm run check (biome) — clean
pnpm run test — full suite passing (847/847), including updated cases for cover_state confirming coverInverted no longer affects which command is sent, and that invert_cover still works standalone.