### PR TITLE
fix: Schneider Electric S520567: restore cover `state`

### DIFF
--- a/src/devices/schneider_electric.ts
+++ b/src/devices/schneider_electric.ts
@@ -2215,15 +2215,7 @@ export const definitions: DefinitionWithExtend[] = [
             })(),
         ],
         fromZigbee: [
-            {
-                ...fz.cover_position_tilt,
-                convert: async (model, msg, publish, options, meta) => {
-                    const result = await fz.cover_position_tilt.convert(model, msg, publish, options, meta);
-                    if (!result) return result;
-                    delete result[postfixWithEndpointName("state", msg, model, meta)];
-                    return result;
-                },
-            },
+            fz.cover_position_tilt,
             {
                 cluster: "closuresWindowCovering",
                 type: ["attributeReport", "readResponse"],

--- a/test/schneider_electric.test.ts
+++ b/test/schneider_electric.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from "vitest";
+import {findByDevice} from "../src/index";
+import type {Fz, KeyValueAny} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+describe("Schneider Electric S520567", () => {
+    const convertReport = async (data: KeyValueAny, type: "attributeReport" | "readResponse" = "attributeReport") => {
+        const device = mockDevice({
+            modelID: "NHPB/SHUTTER/1",
+            manufacturerName: "Schneider Electric",
+            endpoints: [
+                {ID: 5, inputClusters: ["closuresWindowCovering"]},
+                {ID: 21, inputClusters: ["genOnOff"]},
+            ],
+        });
+        const definition = await findByDevice(device);
+        const converter = definition.fromZigbee?.find(
+            (c) => c.cluster === "closuresWindowCovering" && c.type.includes(type) && c.options !== undefined,
+        );
+        if (converter === undefined) throw new Error("no closuresWindowCovering position converter on the definition");
+
+        const msg = {
+            data,
+            endpoint: device.getEndpoint(5),
+            device,
+            meta: null,
+            groupID: null,
+            type,
+            cluster: "closuresWindowCovering",
+            linkquality: 255,
+        } as unknown as Fz.Message<"closuresWindowCovering", undefined, "attributeReport" | "readResponse">;
+
+        const meta = {state: {}, device, deviceExposesChanged: () => {}} as unknown as Fz.Meta;
+        const payload = await converter.convert(definition, msg, () => {}, {}, meta);
+        if (payload === undefined) throw new Error("converter published nothing");
+
+        const exposes = typeof definition.exposes === "function" ? definition.exposes(device, {}) : definition.exposes;
+
+        return {exposes, payload};
+    };
+
+    const convertLiftReport = (currentPositionLiftPercentage: number) => convertReport({currentPositionLiftPercentage});
+
+    it("publishes a value for every property the cover exposes", async () => {
+        const {exposes, payload} = await convertLiftReport(50);
+
+        const cover = exposes.find((expose) => expose.type === "cover");
+        if (cover?.features === undefined) throw new Error("no cover expose on the definition");
+
+        // A lift percentage report carries no tilt, so tilt_cover is expected to
+        // be absent here. Every other declared property must be published,
+        // otherwise the entity has no state in Z2M and Home Assistant.
+        const declared = cover.features.map((feature) => feature.property).filter((property) => property !== "tilt_cover");
+        expect(declared).toContain("state_cover");
+        expect(Object.keys(payload).sort()).toEqual(declared.sort());
+    });
+
+    it("reports state alongside position for a lift percentage report", async () => {
+        expect((await convertLiftReport(50)).payload).toStrictEqual({position_cover: 50, state_cover: "OPEN"});
+        expect((await convertLiftReport(0)).payload).toStrictEqual({position_cover: 0, state_cover: "CLOSE"});
+        expect((await convertLiftReport(100)).payload).toStrictEqual({position_cover: 100, state_cover: "OPEN"});
+    });
+
+    it("reports state on a read response as well as an attribute report", async () => {
+        const {payload} = await convertReport({currentPositionLiftPercentage: 30}, "readResponse");
+        expect(payload).toStrictEqual({position_cover: 30, state_cover: "OPEN"});
+    });
+
+    it("does not derive state from a tilt report", async () => {
+        const {payload} = await convertReport({currentPositionTiltPercentage: 100});
+        expect(payload).toStrictEqual({tilt_cover: 100});
+    });
+});


### PR DESCRIPTION
## What

Restores the `state` property of the Schneider Electric S520567 (Wiser Odace roller shutter) cover, missing since 2.14.0.

## Why

Refs #32997. This does **not** close either open issue, see Scope below.

#12799 moved this device onto named endpoints (`m.deviceEndpoints({endpoints: {cover: 5, switch: 21}})`) and changed its expose to `e.cover_position_tilt().withEndpoint("cover")`. Its properties therefore became endpoint-postfixed: `state_cover`, `position_cover`, `tilt_cover`.

The last commit of that PR (743c8bfa, "Remove auto cover state from state") then wrapped `fz.cover_position_tilt` in a converter that deletes the postfixed `state` key:

```ts
delete result[postfixWithEndpointName("state", msg, model, meta)];
```

`postfixWithEndpointName("state", ...)` resolves to `state_cover` for endpoint 5, so the wrapper deletes exactly the property the exposes list declares. Nothing else on the definition publishes it, so the declared property is never assigned a value.

Affects 2.14.0 (converters v26.90.0 onward), on every report. Zigbee2MQTT publishes `"state_cover": null` on the device topic and `"state": null` on the `<friendly_name>/cover` sub-topic. The Home Assistant cover entity gets no state and no position, renders as `unknown`, and cannot be opened or closed from the UI.

## How

Reverts 743c8bfa: drop the wrapper, use `fz.cover_position_tilt` directly.

That converter is this device's only state source. `currentPositionLiftPercentage` is the sole state-bearing attribute the S520567 reports, and `fz.cover_position_tilt` already derives `state` from it under the definition's existing `meta: {coverInverted: true}`. `coverStateFromTilt` is not set here, so tilt never contributes. This is what the device did before 2.14.0 and what every sibling roller shutter in this file still does: `CCT5015-0001`, `S520530W` and `S520619` all pair plain `fz.cover_position_tilt` with `coverInverted: true`.

Polarity is unchanged from 2.13.x. `invert` is computed once in `fz.cover_position_tilt` and drives both values, so the restored `state` cannot disagree with a `position` users already report as correct.

### Two alternatives I did not take

**Drop `state` from the expose instead, keeping the suppression.** Zigbee2MQTT's Home Assistant discovery builds the cover's state topic from that property, so a cover expose without `state` yields an entity that can never report open or closed.

**Add `multiEndpointSkip: ["position", "tilt", "state"]` and drop `.withEndpoint("cover")`,** as `aeotec.ts` does for its shutter. That is the more ambitious fix: it would restore the state *and* the unpostfixed property names, which would also undo the Home Assistant entity-ID rename that #32999 complains about (`cover.x` to `cover.x_cover`). I left it out deliberately. This definition maps endpoints 5 and 21 with no `default`, so unpostfixed `tz.cover_state` and `tz.cover_position_tilt` writes would have to resolve a target endpoint implicitly. That is a behaviour change on the write path, in a PR whose job is to stop a regression. Happy to do it as a follow-up if you would rather fix both in one go.

## Scope

This PR fixes the missing state only. Two other parts of the 2.14.0 cover breakage are untouched, so neither #32997 nor #32999 should be closed by it:

- **Inverted open/close buttons.** `tz.cover_state` started folding the device-level `coverInverted` meta into its choice of ZCL command, which affects every device carrying that meta rather than this one. #13086 addresses it.
- **The Home Assistant entity-ID rename**, a consequence of the endpoint postfix. See the second alternative above.

## Testing

`test/schneider_electric.test.ts`, four cases:

- `publishes a value for every property the cover exposes` asserts the invariant the bug broke. It reads the property names off the `cover` expose and requires the converter to publish exactly that set. `tilt_cover` is excluded, since a lift-percentage report legitimately carries no tilt.
- `reports state alongside position for a lift percentage report` pins the values: 50 gives `{position_cover: 50, state_cover: "OPEN"}`, 0 gives `CLOSE`, 100 gives `OPEN`.
- `reports state on a read response as well as an attribute report` covers the converter's second declared message type.
- `does not derive state from a tilt report` guards the `coverStateFromTilt` path staying off for this device.

Revert-check. With the tests kept and the fix reverted, three of the four fail on the missing property rather than erroring. The tilt guard passes either way by design:

```
$ git checkout HEAD~1 -- src/devices/schneider_electric.ts
$ pnpm exec vitest run --config ./test/vitest.config.mts test/schneider_electric.test.ts
AssertionError: expected [ 'position_cover' ] to deeply equal [ 'position_cover', 'state_cover' ]
AssertionError: expected { position_cover: 50 } to strictly equal { position_cover: 50, …(1) }
AssertionError: expected { position_cover: 30 } to strictly equal { position_cover: 30, …(1) }
 Tests  3 failed | 1 passed (4)
```

Verified on hardware, on a physical S520567 running Zigbee2MQTT 2.14.0 (converters v26.103.0). Requesting a position read over MQTT returns `position_cover: 0`, `state_cover: null`, `tilt_cover: 0`, and `state: null` on the `/cover` sub-topic, with the shutter confirmed fully closed by eye. The raw lift reading is therefore correct and only the state is missing. Under this change the same reading yields `state_cover: "CLOSE"`, since `state` and `position` are derived from the same `invert` flag. The unpostfixed `position: 50` / `state: "OPEN"` / `tilt: 100` also visible on the root topic are stale values retained from the pre-2.14.0 definition.

Full suite, lint and typecheck on v26.103.0:

```
$ pnpm run test          # 851 passed (27 files); 847 on an unmodified checkout
$ pnpm exec tsc --noEmit # clean
$ pnpm run check         # clean (biome, --error-on-warnings)
```

## Risk

One hunk in one device definition: nine lines removed, one added. No other device resolves to it (`zigbeeModel: ["NHPB/SHUTTER/1"]`). The `postfixWithEndpointName` import stays in use elsewhere in the file.

The definition's own second `closuresWindowCovering` converter writes only `reversed`, a disjoint key set from `fz.cover_position_tilt`, so restoring the standard converter introduces no collision or ordering dependency.

Two things I looked at and left alone, both pre-existing rather than caused by this change:

- `fz.cover_position_tilt` publishes `cover_mode_cover` whenever `windowCoveringMode` arrives, and nothing exposes it, so it lands in MQTT state unexposed. The deleted wrapper never removed it either.
- Users who ran 2.14.0 keep stale unpostfixed `state` and `position` keys in retained Zigbee2MQTT state from the pre-2.14.0 definition. The converter no longer produces them and this change does not clear them.

---
Authored with AI assistance (Claude Code) by @kinorai.
