### PR TITLE
HOBEIAN ZG-IR01: fix temperature scaling when temperature_unit is fahrenheit

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -29172,7 +29172,7 @@ export const definitions: DefinitionWithExtend[] = [
                             return meta.state.temperature_unit === "fahrenheit" ? ((raw - 32) * 5) / 9 : raw;
                         },
                     },
-                ],                
+                ],
                 [110, "humidity", tuya.valueConverter.raw],
                 [112, "battery", tuya.valueConverter.raw],
                 [111, "temperature_unit", tuya.valueConverter.temperatureUnit],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -29158,8 +29158,21 @@ export const definitions: DefinitionWithExtend[] = [
                 [4, "switch4", tuya.valueConverter.onOff],
                 [5, "switch5", tuya.valueConverter.onOff],
                 [6, "switch6", tuya.valueConverter.onOff],
-                [109, "temperature", tuya.valueConverter.divideBy10],
-                [110, "humidity", tuya.valueConverter.raw],
+                [
+                    109,
+                    "temperature",
+                    {
+                        // Device reports the raw value already scaled in the currently selected
+                        // display unit (DP 111), instead of always reporting Celsius. Convert
+                        // back to Celsius here so `temperature` (exposed with a fixed °C unit)
+                        // stays consistent regardless of the device's temperature_unit setting.
+                        // https://github.com/Koenkk/zigbee2mqtt/issues/32984
+                        from: (value: number, meta: Fz.Meta) => {
+                            const raw = value / 10;
+                            return meta.state.temperature_unit === "fahrenheit" ? ((raw - 32) * 5) / 9 : raw;
+                        },
+                    },
+                ],                [110, "humidity", tuya.valueConverter.raw],
                 [112, "battery", tuya.valueConverter.raw],
                 [111, "temperature_unit", tuya.valueConverter.temperatureUnit],
                 [107, "temperature_calibration", tuya.valueConverter.divideBy10],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -29172,7 +29172,8 @@ export const definitions: DefinitionWithExtend[] = [
                             return meta.state.temperature_unit === "fahrenheit" ? ((raw - 32) * 5) / 9 : raw;
                         },
                     },
-                ],                [110, "humidity", tuya.valueConverter.raw],
+                ],                
+                [110, "humidity", tuya.valueConverter.raw],
                 [112, "battery", tuya.valueConverter.raw],
                 [111, "temperature_unit", tuya.valueConverter.temperatureUnit],
                 [107, "temperature_calibration", tuya.valueConverter.divideBy10],


### PR DESCRIPTION
The device's `temperature` DP (109) reports the raw value already
scaled in whatever unit `temperature_unit` (DP 111) is currently
set to, instead of always reporting Celsius. Since the `temperature`
expose always declares a fixed °C unit, this caused a double
conversion downstream (e.g. in Home Assistant): a real 78.6°F/25.9°C
room temperature was reported as 173.5°F after HA converted an
already-Fahrenheit raw value as if it were Celsius.

This adds a conditional DP 109 converter that converts F->C when
`temperature_unit` is currently "fahrenheit", based on `meta.state`,
so the exposed `temperature` value is always genuinely Celsius
regardless of the device's on-device unit setting.

Verified: `tsc --noEmit` and `biome check` pass on the changed file.