### PR TITLE
feat(zigbeetlc): add HOBEIAN ZG-303Z-z (soil moisture) support

### DIFF
--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -365,6 +365,45 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
     },
     /*
+        ZigbeeTLc soil moisture:
+        - Temperature (+calibration)
+        - Humidity (+calibration)
+        - Soil moisture (EP2 as Relative Humidity Measurement)
+        - Measurement interval
+    */
+    {
+        // HOBEIAN / Sonoff ZG-303Z with ZigbeeTLc firmware
+        // https://pvvx.github.io/ZG-303Z/
+        zigbeeModel: ["ZG-303Z-z"],
+        model: "ZG-303Z-z",
+        vendor: "Sonoff",
+        description: "ZG-303Z soil moisture sensor (pvvx/ZigbeeTLc)",
+        extend: [
+            m.deviceEndpoints({endpoints: {1: 1, 2: 2}}),
+            m.battery({voltage: true}),
+            m.identify(),
+            m.temperature({
+                endpointNames: ["1"],
+                reporting: {min: "10_SECONDS", max: "1_HOUR", change: 10},
+            }),
+            m.humidity({
+                endpointNames: ["1"],
+                reporting: {min: "10_SECONDS", max: "1_HOUR", change: 100},
+            }),
+            // FW exposes soil moisture on EP2 as Relative Humidity Measurement
+            m.humidity({
+                name: "soil_moisture",
+                description: "Measured soil moisture",
+                endpointNames: ["2"],
+                reporting: {min: "10_SECONDS", max: "1_HOUR", change: 100},
+            }),
+            extend.temperatureCalibration,
+            extend.humidityCalibration,
+            extend.measurementInterval,
+        ],
+        ota: true,
+    },
+    /*
         ZigbeeTLc PIR devices supporting:
         - Occupancy
         - Remote On/Off binding (genOnOff state)

--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -379,23 +379,30 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "HOBEIAN",
         description: "ZG-303Z soil moisture sensor (pvvx/ZigbeeTLc)",
         extend: [
-            m.deviceEndpoints({endpoints: {1: 1, 2: 2}}),
+            m.deviceEndpoints({
+                endpoints: {1: 1, 2: 2},
+                multiEndpointSkip: ["humidity", "temperature", "soil_moisture"],
+            }),
             m.battery({voltage: true}),
             m.identify(),
-            m.temperature({
-                endpointNames: ["1"],
-                reporting: {min: "10_SECONDS", max: "1_HOUR", change: 10},
-            }),
+            m.temperature({reporting: {min: "10_SECONDS", max: "1_HOUR", change: 10}}),
             m.humidity({
-                endpointNames: ["1"],
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 100},
+                // EP1 air humidity; EP2 also uses RH cluster for soil moisture
+                fzConvert: (_model, msg) => {
+                    if (msg.endpoint.ID !== 1 || msg.data.measuredValue === undefined) return;
+                    return {humidity: msg.data.measuredValue / 100};
+                },
             }),
             // FW exposes soil moisture on EP2 as Relative Humidity Measurement
             m.humidity({
                 name: "soil_moisture",
                 description: "Measured soil moisture",
-                endpointNames: ["2"],
                 reporting: {min: "10_SECONDS", max: "1_HOUR", change: 100},
+                fzConvert: (_model, msg) => {
+                    if (msg.endpoint.ID !== 2 || msg.data.measuredValue === undefined) return;
+                    return {soil_moisture: msg.data.measuredValue / 100};
+                },
             }),
             extend.temperatureCalibration,
             extend.humidityCalibration,

--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -377,7 +377,7 @@ export const definitions: DefinitionWithExtend[] = [
         zigbeeModel: ["ZG-303Z-z"],
         model: "ZG-303Z-z",
         vendor: "HOBEIAN",
-        description: "ZG-303Z soil moisture sensor (pvvx/ZigbeeTLc)",
+        description: "Soil moisture sensor (pvvx/ZigbeeTLc)",
         extend: [
             m.deviceEndpoints({
                 endpoints: {1: 1, 2: 2},

--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -376,7 +376,7 @@ export const definitions: DefinitionWithExtend[] = [
         // https://pvvx.github.io/ZG-303Z/
         zigbeeModel: ["ZG-303Z-z"],
         model: "ZG-303Z-z",
-        vendor: "SONOFF",
+        vendor: "HOBEIAN",
         description: "ZG-303Z soil moisture sensor (pvvx/ZigbeeTLc)",
         extend: [
             m.deviceEndpoints({endpoints: {1: 1, 2: 2}}),

--- a/src/devices/zigbeetlc.ts
+++ b/src/devices/zigbeetlc.ts
@@ -376,7 +376,7 @@ export const definitions: DefinitionWithExtend[] = [
         // https://pvvx.github.io/ZG-303Z/
         zigbeeModel: ["ZG-303Z-z"],
         model: "ZG-303Z-z",
-        vendor: "Sonoff",
+        vendor: "SONOFF",
         description: "ZG-303Z soil moisture sensor (pvvx/ZigbeeTLc)",
         extend: [
             m.deviceEndpoints({endpoints: {1: 1, 2: 2}}),


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5477

## Summary
- Add `ZG-303Z-z` (HOBEIAN/Sonoff ZG-303Z with pvvx/ZigbeeTLc firmware) to `src/devices/zigbeetlc.ts`
- Temperature, air humidity (EP1), soil moisture (EP2 RH cluster), calibrations, measurement interval, identify, battery+voltage, OTA
- No LCD — no display/comfort/smiley exposes
- Firmware page: https://pvvx.github.io/ZG-303Z/

## Test plan
- [x] Paired as `ZG-303Z-z` after ZigbeeTLc flash (`3001-0130`, then OTA to `3001-0139`)
- [x] Temperature / humidity / soil_moisture / battery (+ voltage) report
- [x] temperature_calibration / humidity_calibration (−50…50) and measurement_interval (3…255) work
- [x] Identify flashes LED
- [x] OTA via Z2M to 0.1.3.9