### PR TITLE
feat: make Tuya queryOnDeviceAnnounce configurable

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1294,6 +1294,12 @@ const tuyaOptions = {
             .withDescription(
                 `Reply to Tuya-specific time synchronization requests: "1970" - Reply with seconds since 1970/01/01 (recommended, should stop the device from asking), "2000" - Reply with seconds since 2000/01/01 (use if the weekday is wrong with 1970), "off" - Don't reply (use if replying causes too much traffic). Default for this device: "${defaultOption}"`,
             ),
+    queryOnAnnounce: (defaultOption: boolean) =>
+        e
+            .binary("query_on_announce", ea.SET, true, false)
+            .withDescription(
+                `Query the full device state whenever it re-announces itself on the network. Some devices need this to resume reporting after a rejoin, but on devices that announce frequently this can cause excessive traffic and battery drain. Default for this device: "${defaultOption}"`,
+            ),
 };
 
 export {tuyaOptions as options};
@@ -4550,14 +4556,25 @@ const tuyaModernExtend = {
             result.configure.push(configureBindBasic);
         }
 
+        if (queryOnDeviceAnnounce) {
+            result.options.push(tuyaOptions.queryOnAnnounce(queryOnDeviceAnnounce));
+        }
+
         if (queryOnDeviceAnnounce || queryIntervalSeconds !== undefined) {
             result.onEvent = [
                 (event) => {
                     // Some devices require a dataQuery on deviceAnnounce, otherwise they don't report any data
-                    if (queryOnDeviceAnnounce && event.type === "deviceAnnounce") {
-                        event.data.device.endpoints[0]
-                            .command("manuSpecificTuya", "dataQuery", {})
-                            .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
+                    if (event.type === "deviceAnnounce") {
+                        let effectiveQueryOnAnnounce = queryOnDeviceAnnounce;
+                        const optionValue = event.data.options?.query_on_announce;
+                        if (typeof optionValue === "boolean") {
+                            effectiveQueryOnAnnounce = optionValue;
+                        }
+                        if (effectiveQueryOnAnnounce) {
+                            event.data.device.endpoints[0]
+                                .command("manuSpecificTuya", "dataQuery", {})
+                                .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
+                        }
                     }
 
                     if (queryIntervalSeconds !== undefined) {


### PR DESCRIPTION
## Description
Following the same pattern as #13004 (time_start), this makes
queryOnDeviceAnnounce user-configurable via a new "query_on_announce"
device option, instead of a fixed compile-time choice shared by every
manufacturerName under a given device definition.

## Motivation
Real-world case: the ZTH05Z definition (#12935) has
queryOnDeviceAnnounce: true, shared across all its whiteLabel variants.
On one specific unit (ONENUO TH05Z, _TZE2841000000_qf5mzewi), this
causes a full DP state dump on every deviceAnnounce - and this device
appears to re-announce often, leading to constant last_seen/LQI churn
(observed updating multiple times per second) and abnormally fast
battery drain (~3% consumed in roughly 1 day of normal use).

Removing queryOnDeviceAnnounce entirely (equivalent to the new
query_on_announce: false) on this same unit reduced the churn frequency
noticeably, though occasional communication spikes were still visible.
No clear downside was observed on this unit after the change - reports
still arrive reliably within the configured report interval.

That said, the existing code comment ("Some devices require a dataQuery
on deviceAnnounce, otherwise they don't report any data") suggests other
devices may genuinely depend on this behavior to keep reporting after a
rejoin. Since queryOnDeviceAnnounce currently can only be set per
definition (not per physical unit), there's no way to accommodate both
kinds of devices under a shared whiteLabel definition without this
becoming a runtime, user-configurable option instead.

## Changes
- New `tuyaOptions.queryOnAnnounce()` option (binary, default matches
  the definition's existing queryOnDeviceAnnounce value)
- `tuyaBase()` now pushes this option only when queryOnDeviceAnnounce
  was set to true by the device definition
- The deviceAnnounce handler now checks `event.data.options.query_on_announce`
  before falling back to the compile-time default

## Testing
- [x] pnpm run check passes
- [x] pnpm run test passes - checked test/index.test.ts: none of the
      9 devices currently using queryOnDeviceAnnounce (TS0204, TS020C,
      TS0601_temperature_humidity_sensor_2, ZTH05Z, TS0601_co2_sensor,
      TS0601_co2_temperature_humidity_sensor, RSH-HS06, BLE-YL01,
      TS0601_smart_temperature_switch, MS032Z) are referenced by name
      in that file, and the only two devices with strict options-list
      assertions (ts0601Soil, ts011fPlug1) don't use
      queryOnDeviceAnnounce - so no test file changes are expected to
      be needed.
- [x] Tested against a physical device (ONENUO TH05Z): the underlying
      behavior change (skipping the dataQuery on deviceAnnounce) was
      verified for real by removing queryOnDeviceAnnounce entirely from
      a local external converter running on this unit - confirmed
      reduced last_seen/LQI churn with no observed downside in report
      reliability.
      NOT tested: the new runtime option mechanism itself (reading
      event.data.options.query_on_announce, with the actual patched
      tuyaBase() code) has not been verified end-to-end on real
      hardware - only the equivalent hardcoded-off behavior was. The
      option-resolution logic mirrors #13004 closely, but I'd
      appreciate a second pair of eyes on this part specifically.

## Disclosure
This PR was prepared with AI assistance (Claude).