### PR TITLE
feat(add): Ekaza EKGD-T4085P-4Z

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6358,6 +6358,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE204_gxbdnfrh",
             "_TZE284_g1enhdsi",
             "_TZE284_r731zlxk",
+            "_TZE284_znkkcauq",
         ]),
         model: "TS0601_switch_6_gang",
         vendor: "Tuya",
@@ -6418,6 +6419,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Nova Digital", "FZB-6", "6 gang switch 4x4", ["_TZE204_wskr3up8"]),
             tuya.whitelabel("Nova Digital", "SA-6", "Safira smart switch - 6 gang", ["_TZE204_gxbdnfrh"]),
             tuya.whitelabel("Ekaza", "EKAT-T3074-6WZ", "6 gang switch", ["_TZE284_g1enhdsi"]),
+            tuya.whitelabel("Ekaza", "EKGD-T4085P-4Z", "4 gang switch with 2 gang socket 4x4", ["_TZE284_znkkcauq"]),
         ],
     },
     {


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5484

Adds `_TZE284_znkkcauq` to `TS0601_switch_6_gang` and registers it as an Ekaza white label.

The device is the Ekaza "Interruptor 4x4 Mercúrio Lite" (`EKGD-T4085P-4Z`), sold in Brazil: 4 switch gangs + 2 sockets in a 4x4 box, i.e. 6 gangs total. It is the same hardware family as the already-supported `EKAT-T3074-6WZ` (`_TZE284_g1enhdsi`) and the Nova Digital `NTZB-04-W-B` (`_TZE204_lmgrbuwf`), and its datapoint layout matches `TS0601_switch_6_gang` exactly.

Resolves https://github.com/Koenkk/zigbee2mqtt/issues/32213 (closed by the stale bot without a fix).

**Device signature**

```
modelID:          TS0601
manufacturerName: _TZE284_znkkcauq
endpoint 1  (profile 260, device 81)
  input:  genGroups, genScenes, manuSpecificTuya (0xEF00), genBasic, 0xED00
  output: genOta, genTime
endpoint 242 (profile 41440, device 97)
  output: greenPower
```

**Testing**

Verified on real hardware (zigbee2mqtt 2.14.1, zigbee-herdsman 10.9.2, Sonoff ZBDongle-P) via an external converter with the same fingerprint and datapoint map before preparing this patch:

- DP 1–6 (`state_l1`–`state_l6`) — read and write confirmed for all six gangs; state reports arrive on physical button presses and on relay changes. No "Datapoint N not defined" warnings during several minutes of use.
- DP 15 (`indicator_mode`) — writing `relay` confirmed by observation: the panel LEDs default to `pos` (locator behaviour, lit while the load is OFF), and after the write they follow the load instead. Note the device does not echo setting DPs back, only gang states.
- DP 14 (`power_on_behavior`) — accepted without error; same non-echoing behaviour.
- `tuya.configureMagicPacket` is required, as with the other `_TZE284_` devices in this list.

`pnpm run check`, `pnpm run build` and `test/index.test.ts test/checks.test.ts test/checkDefinition.test.ts` all pass locally.

