### PR TITLE
fix(ikea): prefer hs over xy for KAJPLATS_CWS and VARMBLIXT; add KAJPLATS GU10 CWS 470lm

### DIFF
--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -580,6 +580,7 @@ export const definitions: DefinitionWithExtend[] = [
             "KAJPLATS E27 CWS globe 1055lm",
             "KAJPLATS E14 CWS globe 806lm",
             "KAJPLATS GU10 CWS 575lm",
+            "KAJPLATS GU10 CWS 470lm",
             "KAJPLATS E26 CWS globe 1100lm",
             "KAJPLATS E12 CWS globe 800lm",
         ],
@@ -597,7 +598,7 @@ export const definitions: DefinitionWithExtend[] = [
             {
                 model: "LED2410R5/LED2410R5NA",
                 description: "KAJPLATS GU10 bulb, color/white spectrum, 470/575 lm (Matter)",
-                fingerprint: [{modelID: "KAJPLATS GU10 CWS 575lm"}],
+                fingerprint: [{modelID: "KAJPLATS GU10 CWS 575lm"}, {modelID: "KAJPLATS GU10 CWS 470lm"}],
             },
             {
                 model: "LED2405G8NA",
@@ -616,7 +617,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.light({
                 colorTemp: {range: [153, 555]},
-                color: {modes: ["xy", "hs"], applyRedFix: false, enhancedHue: false},
+                color: {modes: ["hs", "xy"], applyRedFix: false, enhancedHue: false},
                 turnsOffAtBrightness1: true,
                 levelConfig: {features: ["on_off_transition_time", "execute_if_off", "current_level_startup"]},
             }),
@@ -761,7 +762,7 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             m.light({
                 colorTemp: {range: [153, 555]},
-                color: {modes: ["xy", "hs"], applyRedFix: false, enhancedHue: false},
+                color: {modes: ["hs", "xy"], applyRedFix: false, enhancedHue: false},
                 turnsOffAtBrightness1: true,
                 levelConfig: {features: ["on_off_transition_time", "execute_if_off", "current_level_startup"]},
             }),


### PR DESCRIPTION
## What

- `KAJPLATS_CWS` and `VARMBLIXT` (`E2499`): change `color: {modes: ["xy", "hs"], ...}` to `color: {modes: ["hs", "xy"], ...}`.
- `KAJPLATS_CWS`: add the `KAJPLATS GU10 CWS 470lm` model ID (EU variant of the same `LED2410R5` SKU per the CSA product DB; the 575lm string was already there) to `zigbeeModel` and to the `LED2410R5/LED2410R5NA` white-label fingerprint.

## Why

These bulbs clamp out-of-gamut `xy` silently. Pure red (`xy ≈ (0.7006, 0.2993)`) is outside the LED gamut and renders as pink; the bulb's `currentX/currentY` readback echoes the requested values, so logs look fine and only the bulb shows the problem.

They support `MoveToHueAndSaturation` (`enhancedHue: false` in the definition already reflects this), and `hue/saturation` is device-relative so it cannot be clamped. Publishing `{"color":{"hue":0,"saturation":100}}` to `zigbee2mqtt/<device>/set` gives correct red.

Zigbee2MQTT's Home Assistant discovery advertises only one of `xy`/`hs` per light, and picks `xy` unless `color_hs` appears before `color_xy` in the expose (the `preferHS` path added for Osram bulbs in Koenkk/zigbee2mqtt#6402). `Light.withColor()` adds the features in the order given, so listing `hs` first makes discovery advertise `hs`, and HA converts `rgb_color` requests to `hs` instead of `xy`. Other definitions already use `modes: ["hs", "xy"]` for the same reason (lidl, skydance, tuya).

Verified from the built package: both definitions now expose `[..., "color_hs", "color_xy", ...]`, and `KAJPLATS GU10 CWS 470lm` resolves to `LED2410R5/LED2410R5NA`.

## Trade-off

With the current Zigbee2MQTT discovery logic HA will now receive `hs` only for these two definitions, so explicit `xy_color` service calls are converted to `hs` by HA before they reach the bulb. Koenkk/zigbee2mqtt#33025 makes discovery advertise both modes, after which this ordering only matters for older Zigbee2MQTT versions.

`applyRedFix` is left at `false`: untested on these bulbs, and not needed once `hs` is used.

## Checks

- `pnpm run build`, `pnpm run check`, `pnpm test` (844 tests) pass. No snapshot changes were needed.

---
Generated with [Claude Code](https://claude.com/claude-code), reviewed and tested by me. Behaviour on the bulb was verified empirically with a discovery override on a KAJPLATS GU10 CWS 470lm.
