### PR TITLE
feat(add): MS-63A

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -16985,6 +16985,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZ3000_zjchz7pd",
             "_TZ3000_zv6x8bt2",
             "_TZ3000_yi0n4xfd",
+            "_TZ3000_3o7r0mno",
         ]),
         model: "TS011F_with_threshold",
         description: "Din rail switch with power monitoring and threshold settings",
@@ -17085,6 +17086,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Tomzn", "TOB9Z-VAP", "Smart circuit breaker", ["_TZ3000_303avxxt", "_TZ3000_ibefeicf"]),
             tuya.whitelabel("Immax", "07573L", "Smart circuit breaker", ["_TZ3000_zjchz7pd"]),
             tuya.whitelabel("Moes", "A5", "Smart circuit breaker", ["_TZ3000_zv6x8bt2"]),
+            tuya.whitelabel("Nova Digital", "MS-63A", "Smart circuit breaker", ["_TZ3000_3o7r0mno"]),
         ],
     },
     {


### PR DESCRIPTION
Adds support for the Nova Digital MS-63A (`TS011F`, `_TZ3000_3o7r0mno`) as a white label of the existing `TS011F_with_threshold` definition.

Tested with the physical device, including:

- on/off
- voltage, current, power, energy, and temperature reporting
- protection threshold and breaker reporting and configuration

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5485