### PR TITLE
feat: add level_config.couple_color_temp_to_level (dim to warm)

### DIFF
--- a/src/converters/fromZigbee.ts
+++ b/src/converters/fromZigbee.ts
@@ -679,10 +679,12 @@ export const level_config: Fz.Converter<"genLevelCtrl", undefined, ["attributeRe
         // options - 8-bit map
         //   bit 0: ExecuteIfOff - when 0, Move commands are ignored if the device is off;
         //          when 1, CurrentLevel can be changed while the device is off.
-        //   bit 1: CoupleColorTempToLevel - when 1, changes to level also change color temperature.
-        //          (What this means is not defined, but it's most likely to be "dim to warm".)
+        //   bit 1: CoupleColorTempToLevel - when 1, a level change in color temperature mode also moves the
+        //          color temperature between ColorTempPhysicalMaxMireds and CoupleColorTempToLevelMinMireds
+        //          of the Color Control cluster (ZCL "dim to warm").
         if (msg.data.options !== undefined) {
             result[level_config].execute_if_off = !!(Number(msg.data.options) & 1);
+            result[level_config].couple_color_temp_to_level = !!(Number(msg.data.options) & 2);
         }
 
         if (Object.keys(result[level_config]).length > 0) {

--- a/src/converters/toZigbee.ts
+++ b/src/converters/toZigbee.ts
@@ -860,12 +860,19 @@ export const level_config: Tz.Converter = {
         // options - 8-bit map
         //   bit 0: ExecuteIfOff - when 0, Move commands are ignored if the device is off;
         //          when 1, CurrentLevel can be changed while the device is off.
-        //   bit 1: CoupleColorTempToLevel - when 1, changes to level also change color temperature.
-        //          (What this means is not defined, but it's most likely to be "dim to warm".)
-        if (value.execute_if_off != null) {
-            const executeIfOffValue = !!value.execute_if_off;
-            await entity.write("genLevelCtrl", {options: executeIfOffValue ? 1 : 0}, utils.getOptions(meta.mapped, entity));
-            Object.assign(state, {execute_if_off: executeIfOffValue});
+        //   bit 1: CoupleColorTempToLevel - when 1, a level change in color temperature mode also moves the
+        //          color temperature between ColorTempPhysicalMaxMireds and CoupleColorTempToLevelMinMireds
+        //          of the Color Control cluster (ZCL "dim to warm").
+        // Both bits are written together so that setting one does not clear the other; a bit that is not in
+        // the payload keeps its last known value from the state.
+        if (value.execute_if_off != null || value.couple_color_temp_to_level != null) {
+            const current: KeyValueAny = utils.getObjectProperty(meta.state, "level_config", {});
+            const executeIfOffValue = value.execute_if_off != null ? !!value.execute_if_off : !!current.execute_if_off;
+            const coupleColorTempToLevelValue =
+                value.couple_color_temp_to_level != null ? !!value.couple_color_temp_to_level : !!current.couple_color_temp_to_level;
+            const options = (executeIfOffValue ? 1 : 0) | (coupleColorTempToLevelValue ? 2 : 0);
+            await entity.write("genLevelCtrl", {options}, utils.getOptions(meta.mapped, entity));
+            Object.assign(state, {execute_if_off: executeIfOffValue, couple_color_temp_to_level: coupleColorTempToLevelValue});
         }
 
         if (Object.keys(state).length > 0) {

--- a/src/devices/ikea.ts
+++ b/src/devices/ikea.ts
@@ -618,7 +618,7 @@ export const definitions: DefinitionWithExtend[] = [
                 colorTemp: {range: [153, 555]},
                 color: {modes: ["xy", "hs"], applyRedFix: false, enhancedHue: false},
                 turnsOffAtBrightness1: true,
-                levelConfig: {features: ["on_off_transition_time", "execute_if_off", "current_level_startup"]},
+                levelConfig: {features: ["on_off_transition_time", "execute_if_off", "couple_color_temp_to_level", "current_level_startup"]},
             }),
             m.identify(),
         ],

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -451,6 +451,15 @@ export class Light extends Base {
                 ),
             );
         }
+        if (features.includes("couple_color_temp_to_level")) {
+            levelConfig = levelConfig.withFeature(
+                new Binary("couple_color_temp_to_level", access.ALL, true, false)
+                    .withLabel("Couple color temperature to level")
+                    .withDescription(
+                        "Dim to warm: a brightness change in color temperature mode also moves the color temperature between the warmest supported value and the value of the CoupleColorTempToLevelMinMireds attribute",
+                    ),
+            );
+        }
         if (features.includes("on_level")) {
             levelConfig = levelConfig.withFeature(
                 new Numeric("on_level", access.ALL)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -495,6 +495,7 @@ export type LevelConfigFeatures = (
     | "on_transition_time"
     | "off_transition_time"
     | "execute_if_off"
+    | "couple_color_temp_to_level"
     | "on_level"
     | "current_level_startup"
 )[];


### PR DESCRIPTION
The Level Control cluster attribute Options (0x000F) is a bitmap. Bit 0 is ExecuteIfOff, bit 1 is CoupleColorTempToLevel. The ZCL defines bit 1: while it is set and the light is in color temperature mode, a level change also moves the color temperature between ColorTempPhysicalMaxMireds and the Color Control attribute CoupleColorTempToLevelMinMireds (0x400D). The code comment on the converters says the meaning of bit 1 "is not defined", and the bit is not exposed.

I measured the behaviour on an IKEA KAJPLATS GU10 CWS (LED2410R5, firmware 1.1.0, Zigbee mode, Zigbee2MQTT 2.13.0) in two separate runs. With bit 1 set, every level change in color temperature mode sets colorTemperature = 555 - (555 - 370) * level / 254 mired: level 254 gives 370, 200 gives 410, 128 gives 462, 64 gives 509, 10 gives 548, 1 gives 555. The lamp reports 370 for CoupleColorTempToLevelMinMireds and rejected a write to that attribute; 555 is its ColorTempPhysicalMaxMireds. The coupling also applies to the normal `brightness` command from Zigbee2MQTT. It only acts in color temperature mode; a level change in XY mode leaves the color alone. A manual `color_temp` command stays until the next level change. The bit survives a power cycle.

Two things in the converters get in the way of using it:

- `tz.level_config` handles `execute_if_off` by writing the whole byte, `{options: executeIfOffValue ? 1 : 0}`, so every write of `execute_if_off` clears bit 1.
- `fz.level_config` decodes only bit 0, so bit 1 never shows up in the state.

Reproduction on the lamp, all through `zigbee2mqtt/<device>/set`:

1. `{"write":{"cluster":"genLevelCtrl","payload":{"options":2}}}`, then `{"read":{"cluster":"genLevelCtrl","attributes":["options"]}}` returns options 2.
2. `{"level_config":{"execute_if_off":false}}`, then the same read returns options 0.
3. Write options 2 again, then `{"level_config":{"execute_if_off":true}}`. The read returns options 1.

Changes:

- `LevelConfigFeatures` and `withLevelConfig` get a `couple_color_temp_to_level` binary feature. It is not in the default feature list, so no existing device exposes it unless its definition asks for it.
- `tz.level_config` builds the options byte from both bits in one write. A bit present in the payload is used as given. A bit missing from the payload keeps its last known value from `meta.state.level_config`; when the state has no value it is written as 0, which is what the old code did on every write. So a device that only exposes `execute_if_off` sends the same payload as before, except when the device had reported bit 1 set, in which case the old code cleared it and the new code keeps it. `convertGet` already reads `options`, so the state is filled after the first get.
- `fz.level_config` decodes bit 1 as `couple_color_temp_to_level`. Like `execute_if_off`, the key is reported for every device that reads Options, exposed or not.
- The comment about bit 1 is replaced with the ZCL definition.
- `KAJPLATS_CWS` adds `couple_color_temp_to_level` to its `levelConfig` features. I only have the GU10 CWS, so the WS definitions are left alone.

Related: #2284 asked for this coupling in 2021 and was closed as stale. #13100 (hs before xy for `KAJPLATS_CWS`, plus the 470lm model ID) touches the same definition on different lines; the two apply independently in either order.

How to test on a KAJPLATS in Zigbee mode (replace `<device>` with the friendly name):

```
mosquitto_pub -t zigbee2mqtt/<device>/set -m '{"level_config":{"couple_color_temp_to_level":true}}'
mosquitto_pub -t zigbee2mqtt/<device>/set -m '{"read":{"cluster":"genLevelCtrl","attributes":["options"]}}'
```

The read response goes through `fz.level_config`, so the state shows `level_config.couple_color_temp_to_level: true` and the raw value in the read response is 2.

```
mosquitto_pub -t zigbee2mqtt/<device>/set -m '{"level_config":{"execute_if_off":true}}'
mosquitto_pub -t zigbee2mqtt/<device>/set -m '{"read":{"cluster":"genLevelCtrl","attributes":["options"]}}'
```

Before this change the second read returns 1. With it, 3, and both booleans in the state are true.

```
mosquitto_pub -t zigbee2mqtt/<device>/set -m '{"color_temp":250}'
mosquitto_pub -t zigbee2mqtt/<device>/set -m '{"brightness":64}'
mosquitto_pub -t zigbee2mqtt/<device>/set -m '{"read":{"cluster":"lightingColorCtrl","attributes":["colorTemperature"]}}'
```

The GU10 CWS answers 509 mired. With `couple_color_temp_to_level` set back to false, the next `brightness` change leaves `color_temp` where it is.
