### PR TITLE
fix(shelly): fix switch_mode values and switch_type write for Gen4 devices

### DIFF
--- a/src/devices/shelly.ts
+++ b/src/devices/shelly.ts
@@ -1254,7 +1254,7 @@ const shellyModernExtend = {
         // (see SHELLY_RPC_CAN_READ): no convertGet - a device query walks every converter that has
         // one regardless of the access flags - and the exposes say so instead of announcing GET.
         if (twoPMInputEndpoints) {
-            const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
+            const inModeValues = ["momentary", "follow", "flip", "detached", "cycle", "activate"];
             exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
                 if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
                 return Object.keys(shellySwitchInputEndpoints(device, twoPMInputEndpoints)).map((endpoint) =>
@@ -1276,7 +1276,7 @@ const shellyModernExtend = {
             });
         }
         if (featureOnePMInputMode) {
-            const inModeValues = ["follow", "flip", "detached", "cycle", "activation"];
+            const inModeValues = ["momentary", "follow", "flip", "detached", "cycle", "activate"];
             exposes.push((device: Zh.Device | DummyDevice, _options: KeyValue) => {
                 if (utils.isDummyDevice(device) || !device.getEndpoint(SHELLY_ENDPOINT_ID)) return [];
                 return Object.keys(shellySwitchInputEndpoints(device, {sw1: 2})).map((endpoint) =>
@@ -2111,9 +2111,16 @@ const tzLocal = {
     switch_input_type: {
         key: ["switch_type"],
         convertSet: async (entity, key, value, meta) => {
-            const lookup = {toggle: 0, momentary: 1} as const;
-            const ep = determineEndpoint(entity, meta, "genOnOffSwitchCfg");
-            await ep.write("genOnOffSwitchCfg", {switchType: utils.getFromLookup(value as string, lookup)});
+            // The firmware registers genOnOffSwitchCfg.switchType as READ_ONLY
+            // (shelly_zb_on_off_input.cpp), so a direct ZCL write returns
+            // NOT_AUTHORIZED.  Route the write through Input.SetConfig RPC instead.
+            const typeMap = {toggle: "switch", momentary: "button"} as const;
+            const shellyType = utils.getFromLookup(value as string, typeMap);
+            utils.assertEndpoint(entity);
+            const ep = entity.getDevice().getEndpoint(SHELLY_ENDPOINT_ID);
+            if (!ep) throw new Error(`Shelly RPC endpoint ${SHELLY_ENDPOINT_ID} not found`);
+            const switchId = Number(meta.endpoint_name?.replace("sw", "") ?? "1") - 1;
+            await shellyRpcSend(ep, "Input.SetConfig", {id: switchId, config: {type: shellyType}});
             return {state: {switch_type: value}};
         },
         convertGet: async (entity, key, meta) => {


### PR DESCRIPTION
`inModeValues` contains `"activation"` but the firmware only accepts `"activate"`. Setting `switch_mode` to `activation` via Z2M is silently rejected by the device with:

Invalid argument 'in_mode': 'activation' not in allowed values: 'momentary', 'follow', 'flip', 'detached', 'activate'

Since `rpcSend()` is fire-and-forget, the error is never surfaced — Z2M optimistically shows `activation` as applied while the device keeps its previous value.

Affected: Both 1PM and 2PM `inModeValues` arrays (lines 1257, 1279).

### 2. Missing `momentary` in `inModeValues`

The firmware accepts `"momentary"` as a valid `in_mode` (when `input.type` is `button`), but it was not included in the exposed enum values. Users could not select it from Z2M.

### 3. `switch_type` write via ZCL fails with `NOT_AUTHORIZED`

`tzLocal.switch_input_type.convertSet` writes directly to the `genOnOffSwitchCfg.switchType` ZCL attribute. However, the Shelly Gen4 firmware registers this attribute as READ_ONLY, so the ZCL write is rejected with `NOT_AUTHORIZED`.

The correct way to change the input type is through the `Input.SetConfig` RPC method with `{type: "switch"}` or `{type: "button"}`.

**Fix:** Route `switch_type` writes through `Input.SetConfig` RPC on endpoint 239. Reads remain unchanged (ZCL `genOnOffSwitchCfg.switchType` read works correctly).

## Changes

- `src/devices/shelly.ts`:
  - Both `inModeValues` arrays: `"activation"` → `"activate"`, added `"momentary"`
  - `tzLocal.switch_input_type.convertSet`: replaced ZCL `genOnOffSwitchCfg` write with `Input.SetConfig` RPC via `shellyRpcSend()`
  - `convertGet` unchanged (ZCL read still works)

## Tested on

- Shelly 1PM Gen4 (`S4SW-001P16EU`), firmware `2.1.99-dev191815`
- Shelly 1PM Mini Gen4 (`S4SW-001P8EU`), firmware `2.0.0-beta1`
- Zigbee2MQTT 2.13.0 with Ember adapter (SkyConnect)

| Operation                       | Before                                        | After                                                  |
| ------------------------------- | --------------------------------------------- | ------------------------------------------------------ |
| Set `switch_mode` = `activate`  | Sends `activation`, firmware rejects silently | Sends `activate`, firmware accepts                     |
| Set `switch_mode` = `momentary` | Not available in UI                           | Available, firmware accepts (with `input.type=button`) |
| Set `switch_type` = `toggle`    | ZCL write → `NOT_AUTHORIZED`                  | RPC `Input.SetConfig {type: "switch"}` → success       |
| Set `switch_type` = `momentary` | ZCL write → `NOT_AUTHORIZED`                  | RPC `Input.SetConfig {type: "button"}` → success       |
| Get `switch_type`               | ZCL read ✓ (unchanged)                        | ZCL read ✓ (unchanged)                                 |

## Notes

- The `in_mode` / `input.type` / `initial_state` combination validation is enforced by the firmware and is unchanged by this PR. Invalid combinations (e.g. `follow` with `input.type=button`) are correctly rejected by the device.
- The firmware `in_mode` enum values are: `momentary`, `follow`, `flip`, `detached`, `activate` (plus `cycle` on 2PM devices with `SHELLY_SWITCH_CYCLE_MODE`).