### PR TITLE
fix: NodOn SEM-4-3-20: correct zigbeeModel to match real hardware variants

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -339,7 +339,7 @@ export const definitions: DefinitionWithExtend[] = [
         ota: true,
     },
     {
-        zigbeeModel: ["SEM-4-3-20"],
+        zigbeeModel: ["SEM-4-3-20_70A", "SEM-4-3-20_120A"],
         model: "SEM-4-3-20",
         vendor: "NodOn",
         description: "3CT Energy Meter",


### PR DESCRIPTION
#12752 shipped with `zigbeeModel: ["SEM-4-3-20"]`, matching the only variant known to exist at the time. It turns out there is no base SKU: production units announce themselves as `SEM-4-3-20_70A` or `SEM-4-3-20_120A` (named after their CT clamp rating).
