### PR TITLE
fix(XHS2-UE): use correct 3V_2100 voltage curve for battery percentage

### DIFF
--- a/src/devices/universal_electronics_inc.ts
+++ b/src/devices/universal_electronics_inc.ts
@@ -32,7 +32,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Magnetic door & window contact sensor",
         fromZigbee: [fz.ias_contact_alarm_1, fz.temperature, fz.battery],
         toZigbee: [],
-        meta: {battery: {voltageToPercentage: {min: 2500, max: 2800}}},
+        meta: {battery: {voltageToPercentage: "3V_2100"}},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["msTemperatureMeasurement", "genPowerCfg"]);

--- a/test/fromZigbee.test.ts
+++ b/test/fromZigbee.test.ts
@@ -221,14 +221,17 @@ describe("converters/fromZigbee", () => {
         });
     });
 
-    it("XHS2-UE uses voltage curve instead of stale reported battery percentage", async () => {
+    it("XHS2-UE uses voltage curve (3V_2100) instead of stale reported battery percentage", async () => {
         const definition = await findByDevice(mockDevice({modelID: "URC4460BC0-X-R", endpoints: []}));
 
+        // batteryVoltage 29 (2900mV) → 42% on the 3V_2100 curve.
+        // batteryPercentageRemaining 54 → 27% (÷2). The two paths diverge,
+        // so the expected value proves which one won.
         const payload = fromZigbee.battery.convert(
             definition,
             {
                 data: {
-                    batteryVoltage: 28,
+                    batteryVoltage: 29,
                     batteryPercentageRemaining: 54,
                 },
                 endpoint: null,
@@ -247,8 +250,8 @@ describe("converters/fromZigbee", () => {
         );
 
         expect(payload).toStrictEqual({
-            battery: 100,
-            voltage: 2800,
+            battery: 42,
+            voltage: 2900,
         });
     });
 


### PR DESCRIPTION
The existing voltage range `{min: 2500, max: 2800}` causes all XHS2-UE sensors to report 100% battery permanently. CR2 cells in these sensors typically sit around 2900 mV during normal operation — above the 2800 mV ceiling — so the converter always clamps to 100%.

Switching to `"3V_2100"` (the same preset already used by the XHS1-UE, XHK1-UE, and UEHK2AZ0 in this file) gives accurate readings across the discharge curve: 42% at 2900 mV, 27% at 2800 mV.

The existing test is also updated. The previous input (2800 mV with `batteryPercentageRemaining: 54`) coincidentally produced 27% on both the voltage-curve path and the attribute path, so it couldn't actually verify which one ran. The new input (2900 mV) produces 42% via the curve and 27% via the attribute — the two diverge, so `battery: 42` confirms the voltage-curve path is winning.

Related: https://github.com/Koenkk/zigbee2mqtt/issues/21490 and #12985