### PR TITLE
feat: allow Tuya queryOnDeviceAnnounce to be a per-device function

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3609,7 +3609,12 @@ export const definitions: DefinitionWithExtend[] = [
         extend: [
             tuya.modernExtend.tuyaBase({
                 dp: true,
-                queryOnDeviceAnnounce: true,
+                // ONENUO TH05Z (_TZE2841000000_qf5mzewi) appears to re-announce
+                // often; querying its full state on every announce caused
+                // excessive traffic and fast battery drain on that unit, with
+                // no evidence it's actually needed there. Other manufacturerNames
+                // keep the original always-on behavior.
+                queryOnDeviceAnnounce: (device) => device.manufacturerName !== "_TZE2841000000_qf5mzewi",
                 queryOnConfigure: true,
                 timeStart: "1970",
             }),

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -4432,7 +4432,7 @@ const tuyaModernExtend = {
     tuyaBase(
         args: {
             dp?: true;
-            queryOnDeviceAnnounce?: true;
+            queryOnDeviceAnnounce?: true | ((device: Zh.Device) => boolean);
             queryOnConfigure?: true;
             bindBasicOnConfigure?: true;
             queryIntervalSeconds?: number;
@@ -4543,10 +4543,14 @@ const tuyaModernExtend = {
             result.onEvent = [
                 (event) => {
                     // Some devices require a dataQuery on deviceAnnounce, otherwise they don't report any data
-                    if (queryOnDeviceAnnounce && event.type === "deviceAnnounce") {
-                        event.data.device.endpoints[0]
-                            .command("manuSpecificTuya", "dataQuery", {})
-                            .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
+                    if (event.type === "deviceAnnounce") {
+                        const shouldQuery =
+                            typeof queryOnDeviceAnnounce === "function" ? queryOnDeviceAnnounce(event.data.device) : queryOnDeviceAnnounce;
+                        if (shouldQuery) {
+                            event.data.device.endpoints[0]
+                                .command("manuSpecificTuya", "dataQuery", {})
+                                .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
+                        }
                     }
 
                     if (queryIntervalSeconds !== undefined) {


### PR DESCRIPTION
## Description
Following discussion on #13098, this allows
queryOnDeviceAnnounce (tuyaBase()) to be either `true` (unchanged,
unconditional) or a function `(device: Zh.Device) => boolean`,
evaluated per-device at deviceAnnounce time - instead of only a fixed
compile-time boolean shared by every manufacturerName under one
definition.

## Motivation
See #12935 for the concrete case: one specific
manufacturerName sharing the ZTH05Z definition (ONENUO TH05Z,
_TZE2841000000_qf5mzewi) appears to re-announce on the network often,
and querying its full state on every announce caused excessive traffic
and fast battery drain on that unit. Other manufacturerNames sharing
the same definition need the announce-query to keep reporting reliably.
A per-device function lets both cases coexist under one definition.

## Changes
- `tuyaBase()`'s `queryOnDeviceAnnounce` type is now
  `true | ((device: Zh.Device) => boolean)`
- The deviceAnnounce handler resolves the function form (if provided)
  against the actual announcing device before deciding whether to query
- Use it for ONENUO TH05Z _TZE2841000000_qf5mzewi device

## Testing
- [x] pnpm run check passes
- [x] pnpm run test passes
- [ ] NOT tested against a physical device - I won't have access to
      re-test this for a while. The change is a straightforward type
      widening + one ternary resolving the function form; existing
      `true` usages are unaffected. Would appreciate a careful look
      here given I can't verify on hardware right now.

## Disclosure
This PR was prepared with AI assistance (Claude).
