### PR TITLE
feat: Decode Tuya firmware IDs

### DIFF
--- a/src/devices/avatto.ts
+++ b/src/devices/avatto.ts
@@ -13,7 +13,7 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZWSH16",
         vendor: "AVATTO",
         description: "Smart temperature and humidity detector",
-        extend: [tuya.modernExtend.tuyaBase({dp: true, mcuVersionRequestOnConfigure: true})],
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [e.battery(), e.temperature(), e.humidity(), tuya.exposes.temperatureUnit()],
         meta: {
             tuyaDatapoints: [

--- a/src/devices/neo.ts
+++ b/src/devices/neo.ts
@@ -41,7 +41,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("volume", ea.STATE_SET, ["low", "medium", "high"]),
             e.enum("power_type", ea.STATE, ["battery_full", "battery_high", "battery_medium", "battery_low", "usb"]),
         ],
-        extend: [tuya.modernExtend.tuyaBase({forceTimeUpdates: true, queryOnConfigure: true, mcuVersionRequestOnConfigure: true})],
+        extend: [tuya.modernExtend.tuyaBase({forceTimeUpdates: true, queryOnConfigure: true})],
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_t1blo2bj", "_TZE204_t1blo2bj", "_TZE204_q76rtoa9"]),
@@ -63,7 +63,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.enum("volume", ea.STATE_SET, ["low", "medium", "high"]),
             e.numeric("battpercentage", ea.STATE).withUnit("%"),
         ],
-        extend: [tuya.modernExtend.tuyaBase({forceTimeUpdates: true, queryOnConfigure: true, mcuVersionRequestOnConfigure: true})],
+        extend: [tuya.modernExtend.tuyaBase({forceTimeUpdates: true, queryOnConfigure: true})],
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_7hfcudw5"]),
@@ -72,7 +72,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Motion, temperature & humidity sensor",
         fromZigbee: [legacy.fz.neo_nas_pd07, fz.ignore_tuya_set_time],
         toZigbee: [legacy.tz.neo_nas_pd07],
-        extend: [tuya.modernExtend.tuyaBase({mcuVersionRequestOnConfigure: true})],
+        extend: [tuya.modernExtend.tuyaBase()],
         exposes: [
             e.occupancy(),
             e.humidity(),

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -14038,8 +14038,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZWT198/ZWT100-BH",
         vendor: "Tuya",
         description: "Wall thermostat",
-        // Don't enable mcuVersionResponse
-        // https://github.com/Koenkk/zigbee2mqtt/issues/28455#issuecomment-3603696676
         extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "1970"})],
         whiteLabel: [tuya.whitelabel("AVATTO", "WT-100-BH", "Wall thermostat", ["_TZE204_gops3slb", "_TZE284_gops3slb"])],
         exposes: [

--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -399,7 +399,6 @@ export const definitions: DefinitionWithExtend[] = [
         model: "ZM25RX-08/30",
         vendor: "Zemismart",
         description: "Tubular motor",
-        // mcuVersionResponse spsams: https://github.com/Koenkk/zigbee2mqtt/issues/19817
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         options: [exposes.options.invert_cover()],
         exposes: [

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -598,6 +598,19 @@ function convertDecimalValueTo2ByteHexArray(value: number) {
     return [chunk1, chunk2].map((hexVal) => Number.parseInt(hexVal, 16));
 }
 
+/**
+ * Example: 101 = 1×64 + 2×16 + 5×1 -> v1.2.5
+ *
+ * Bits: 7-6 = major, 5-4 = minor, 3-0 = patch
+ */
+function decodeTuyaVersion(value: number) {
+    const major = value >> 6;
+    const minor = (value & 0b00110000) >> 4;
+    const patch = value & 0b00001111;
+
+    return `${major}.${minor}.${patch}`;
+}
+
 // Return `seq` - transaction ID for handling concrete response
 async function sendDataPoints(entity: Zh.Endpoint | Zh.Group, dpValues: Tuya.DpValue[], cmd = "dataRequest", seq?: number) {
     if (seq === undefined) {
@@ -4200,6 +4213,30 @@ const tuyaFz = {
             return result;
         },
     } satisfies Fz.Converter<"ssIasWd", undefined, ["attributeReport", "readResponse"]>,
+    /** Continues tuyaFirmwareId configuration */
+    mcu_version: {
+        cluster: "manuSpecificTuya",
+        type: ["commandMcuVersionResponse"],
+        convert: (model, msg, publish, options, meta) => {
+            if (msg.device.genBasic.swBuildId && !msg.device.meta.hasCustomFirmwareId) {
+                return; // leave default Firmware ID, if it exists
+            }
+
+            const z = msg.device.genBasic.appVersion;
+            const m = msg.data.version;
+
+            if (!z || !m) {
+                return;
+            }
+
+            const zVer = decodeTuyaVersion(z);
+            const mVer = decodeTuyaVersion(m);
+
+            msg.device.genBasic.swBuildId = `Zigbee module: ${zVer}, MCU module: ${mVer}`;
+            msg.device.save();
+            msg.device.meta.hasCustomFirmwareId = true;
+        },
+    } satisfies Fz.Converter<"manuSpecificTuya", undefined, ["commandMcuVersionResponse"]>,
 };
 
 export {tuyaFz as fz};
@@ -4334,6 +4371,30 @@ export interface TuyaDPLightArgs {
     // color?: {dp: number, type: number, scale?: number | [number, number, number, number]},
     endpoint?: string;
 }
+/**
+ * - Decodes "Zigbee module version" from `appVersion`
+ * - Also requests "MCU module version" on TS0601 models
+ * - Populates Firmware ID with the results (if the device does not provide `swBuildId`)
+ */
+const tuyaFirmwareId = async (device: Zh.Device) => {
+    if (device.genBasic.swBuildId && !device.meta.hasCustomFirmwareId) {
+        return; // leave default Firmware ID, if it exists
+    }
+
+    if (device.modelID === "TS0601") {
+        await device.endpoints[0].command("manuSpecificTuya", "mcuVersionRequest", {seq: 0x0002});
+        return; // wait for response, continue in tuyaFz.mcu_version
+    }
+
+    const z = device.genBasic.appVersion;
+    if (!z) {
+        return;
+    }
+
+    device.genBasic.swBuildId = decodeTuyaVersion(z);
+    device.save();
+    device.meta.hasCustomFirmwareId = true;
+};
 
 const tuyaModernExtend = {
     electricityMeasurementPoll(
@@ -4514,7 +4575,7 @@ const tuyaModernExtend = {
         const result: ModernExtend = {
             configure: [configureMagicPacket],
             isModernExtend: true,
-            fromZigbee: [fzConverter],
+            fromZigbee: [fzConverter, tuyaFz.mcu_version],
             toZigbee: [],
             options: [tuyaOptions.timeStart(timeStart)],
         };
@@ -4523,6 +4584,7 @@ const tuyaModernExtend = {
             result.configure.push(configureQuery);
         }
 
+        result.configure.push(tuyaFirmwareId);
 
         if (bindBasicOnConfigure) {
             result.configure.push(configureBindBasic);

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1320,10 +1320,6 @@ export const configureQuery = async (device: Zh.Device, coordinatorEndpoint: Zh.
     await device.getEndpoint(1).command("manuSpecificTuya", "dataQuery", {});
 };
 
-export const configureMcuVersionRequest = async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
-    await device.getEndpoint(1).command("manuSpecificTuya", "mcuVersionRequest", {seq: 0x0002});
-};
-
 export const configureBindBasic = async (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint) => {
     await device.getEndpoint(1).bind("genBasic", coordinatorEndpoint);
 };
@@ -4436,7 +4432,6 @@ const tuyaModernExtend = {
             queryOnConfigure?: true;
             bindBasicOnConfigure?: true;
             queryIntervalSeconds?: number;
-            mcuVersionRequestOnConfigure?: true;
             forceTimeUpdates?: true;
             timeStart?: "2000" | "1970";
         } = {},
@@ -4447,7 +4442,6 @@ const tuyaModernExtend = {
             queryOnConfigure = false,
             bindBasicOnConfigure = false,
             queryIntervalSeconds = undefined,
-            mcuVersionRequestOnConfigure = false,
             // Allow force updating for device with a very bad clock
             // Every hour when a message is received the time will be updated.
             forceTimeUpdates = false,
@@ -4459,7 +4453,6 @@ const tuyaModernExtend = {
             undefined,
             [
                 "commandMcuSyncTime",
-                "commandMcuVersionResponse",
                 "commandMcuGatewayConnectionStatus",
                 "commandDataResponse",
                 "commandDataReport",
@@ -4469,7 +4462,6 @@ const tuyaModernExtend = {
         > = {
             type: [
                 "commandMcuSyncTime",
-                "commandMcuVersionResponse",
                 "commandMcuGatewayConnectionStatus",
                 "commandDataResponse",
                 "commandDataReport",
@@ -4531,9 +4523,6 @@ const tuyaModernExtend = {
             result.configure.push(configureQuery);
         }
 
-        if (mcuVersionRequestOnConfigure) {
-            result.configure.push(configureMcuVersionRequest);
-        }
 
         if (bindBasicOnConfigure) {
             result.configure.push(configureBindBasic);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -231,6 +231,8 @@ export interface DefinitionMeta {
      * Manufacturer specific
      */
     sinopeAlternateBacklightAutoDim?: boolean;
+    /** Indicates if the device does not report `swBuildId`, and a custom one was saved instead */
+    hasCustomFirmwareId?: boolean;
 }
 
 export type Configure = (device: Zh.Device, coordinatorEndpoint: Zh.Endpoint, definition: Definition) => Promise<void> | void;


### PR DESCRIPTION
- continuation of https://github.com/Koenkk/zigbee-herdsman-converters/pull/13027

Tuya devices display one or two versions IDs in the Tuya app.

<img width="40%" src="https://github.com/user-attachments/assets/d85aedf4-f912-4e5f-bb66-db57d0c9ab5a" />
<img width="40%" src="https://github.com/user-attachments/assets/40efd67e-4a6a-4314-9e1c-ea1f294c26cf" />

We are missing those in Z2M, because the `swBuildId` attribute is unsupported.
Instead, we can obtain them during configuration:

- Normal Tuya devices (TS0001, TS0505B etc.) have a single version -> just decode `appVersion` 
(We have it from interview)

- DP-based Tuya devices (TS0601) have two versions -> decode `appVersion` + `mcuVersionResponse`
(We emit `mcuVersionRequest` and wait for reply. This was previously optional, and the reply was not utilized)

- Unofficial Tuya devices (HOBEIAN, ZBEACON) provide `swBuildId` normally -> do nothing

We publish the results under `swBuildId`:

<img width="80%" src="https://github.com/user-attachments/assets/cb13c042-142d-4daa-aebe-6c56c53588d4" />
<img width="80%"  src="https://github.com/user-attachments/assets/cd757a1c-0029-49f7-bd0d-808775d13b90" />

---

Slight issues:
1. If we receive `mcuVersionResponse` after configuration ends, the result is not visible until a Z2M restart (or something that publishes the devices again)
2. Already paired devices don't show the versions (until reconfigured)