### PR TITLE
feat: add Mowe MW781Z and MW783Z as white labels of TS0726

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24523,6 +24523,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [
             tuya.whitelabel("BSEED", "EC-GL86ZPCS11", "1 gang switch with scene and backlight", ["_TZ3002_jn2x20tg"]),
             tuya.whitelabel("BSEED", "EC-SL-FK86ZPCS11", "1 gang switch with scene and backlight (Neutral line optional)", ["_TZ3002_xkxgfxsg"]),
+            tuya.whitelabel("Mowe", "MW781Z", "1 gang switch with scene and backlight", ["_TZ300A_rncj86af"]),
         ],
         fromZigbee: [fzLocal.TS0726_action],
         exposes: [e.action(["scene_1"])],
@@ -24604,6 +24605,7 @@ export const definitions: DefinitionWithExtend[] = [
                 "_TZ3000_r2fgo9ks",
             ]),
             tuya.whitelabel("Zemismart", "KES-606US-L3-EESS", "3 gang switch with neutral", ["_TZ3000_cziew6eu"]),
+            tuya.whitelabel("Mowe", "MW783Z", "3 gang switch with scene and backlight", ["_TZ300A_vqrs45nj"]),
         ],
         fromZigbee: [fzLocal.TS0726_action],
         exposes: [e.action(["scene_1", "scene_2", "scene_3"])],


### PR DESCRIPTION
Adds the MOWE (Möwe Smart Home, Singapore) rebrands of two TS0726 scene switches.

Both manufacturer names are already matched by the existing definitions, so this only attaches the correct vendor and model — no behaviour change:

| manufacturerName | definition | white label |
|---|---|---|
| `_TZ300A_rncj86af` | `TS0726_1_gang_scene_switch` | Mowe MW781Z |
| `_TZ300A_vqrs45nj` | `TS0726_3_gang_scene_switch` | Mowe MW783Z |

Confirmed on hardware: five MW781Z and one MW783Z paired to Zigbee2MQTT 2.x, all interviewing cleanly and working fully on the existing definitions.

The `Mowe` vendor string matches the existing `src/devices/mowe.ts` (MW833P) so both models land on the same vendor page.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
