### PR TITLE
feat: expose switch_inching on TS0726 1 and 3 gang scene switches

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24539,7 +24539,9 @@ export const definitions: DefinitionWithExtend[] = [
                 backlightModeOffOn: true,
                 indicatorModeNoneRelayPos: true,
                 onOffCountdown: true,
+                inchingSwitch: (m) => m === "_TZ300A_rncj86af",
             }),
+            tuya.clusters.addTuyaCommonPrivateCluster(),
         ],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);
@@ -24620,8 +24622,10 @@ export const definitions: DefinitionWithExtend[] = [
                 backlightModeOffOn: true,
                 indicatorModeNoneRelayPos: true,
                 onOffCountdown: true,
+                inchingSwitch: (m) => m === "_TZ300A_vqrs45nj",
                 endpoints: ["l1", "l2", "l3"],
             }),
+            tuya.clusters.addTuyaCommonPrivateCluster(),
         ],
         endpoint: (device) => ({l1: 1, l2: 2, l3: 3}),
         meta: {


### PR DESCRIPTION
Exposes `switch_inching` on `TS0726_1_gang_scene_switch` and `TS0726_3_gang_scene_switch`, using `inchingSwitch` plus `addTuyaCommonPrivateCluster()` (cluster 0xE000, command `setInchingSwitch`), the same shape as the existing `TS0002` definition.

Scoped with manufacturerName predicates, so the other fingerprints sharing these definitions are untouched.

### Verified on hardware

Mowe MW781Z (`_TZ300A_rncj86af`) and MW783Z (`_TZ300A_vqrs45nj`), `appVersion` 68, Zigbee2MQTT 2.14.1.

1 gang, enabled with a 5 s delay then the relay turned on — the device turned itself off 5 s later, unprompted:

```
13:02:53  state=ON     <- commanded
13:02:58  state=OFF    <- device, inching
```

3 gang: the per endpoint encoding was verified by writing all three endpoints and reading the values back from the device. The read path works on both — after a restart each device reports its own persisted `inching` attribute and `fz.inchingSwitch` decodes it.

> Note: testing this surfaced a pre-existing bug in `valueConverter.inchingSwitch`, which corrupts any delay whose low byte is >= 128. Fixed separately in #13119. That fix is independent of this PR, but worth having alongside it, since this PR is what exposes the feature on these devices.

### Changed after review

`smart_light` (switch mode 2) has been **removed**. It was verified only by attribute write and read back, which proves the value is stored, not that the mode does anything distinct. @andrei-lazarov reports values 2 to 5 all behaving like 1 on their hardware, which is consistent with it being inert, so it does not belong in a definition.

Link to picture pull request:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
