### PR TITLE
fix(tuya): inching payload corrupted by utf8 encoding of bytes >= 0x80

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -2781,10 +2781,9 @@ export const valueConverter = {
                     state += 2 ** (i - 1);
                 }
                 const secs: number = Number.parseInt(value[`inching_time_${i}`], 10);
-                const byte1 = secs >> 8; // Equivalent to Math.truc(secs / 256)
-                const byte2 = secs % 256;
-                const ascii = String.fromCharCode(state, byte1, byte2);
-                result += Buffer.from(ascii).toString("base64");
+                // Build the 3 bytes directly: going via String.fromCharCode() and the default utf8
+                // encoding turns any byte >= 0x80 into a 2 byte sequence, corrupting the payload.
+                result += Buffer.from([state, secs >> 8, secs % 256]).toString("base64");
             }
             return result;
         },
@@ -2793,11 +2792,10 @@ export const valueConverter = {
             // break the value into 4 char encoded char which will give 3 char when decoded
             const data: KeyValue = {};
             for (let i = 0; i < value.length; i += 4) {
-                const b64asc = value.substring(i, i + 4);
-                const str = Buffer.from(b64asc, "base64").toString("utf8");
-                const cca0 = str.charCodeAt(0);
-                const cca1 = str.charCodeAt(1);
-                const cca2 = str.charCodeAt(2);
+                const bytes = Buffer.from(value.substring(i, i + 4), "base64");
+                const cca0 = bytes[0];
+                const cca1 = bytes[1];
+                const cca2 = bytes[2];
                 let tmp = 0;
                 let status = "";
                 // first value indicates the endpoint and if it is on or off


### PR DESCRIPTION
`valueConverter.inchingSwitch` corrupts its own payload whenever a byte lands at or above `0x80`.

### Cause

`to()` builds the 3 byte record with `String.fromCharCode(state, byte1, byte2)` and then `Buffer.from(ascii)`, which defaults to **utf8**. Any code point >= 0x80 is encoded as two bytes, so the record becomes 4 bytes and its base64 becomes 8 characters instead of 4. `from()` walks the blob in fixed 4 character chunks, so every record after the first oversized one is read at the wrong offset.

`from()` has the mirror of the same bug: `Buffer.from(b64asc, "base64").toString("utf8")` followed by `charCodeAt`, which turns invalid utf8 into U+FFFD (65533).

Since `byte2 = secs % 256`, this hits **any delay whose low byte is >= 128** — roughly half of all values — plus everything from 32768 s up via the high byte.

```
secs=3600  bytes=[1,14,16]   -> AQ4Q     (4 chars)  ok
secs=3000  bytes=[3,11,184]  -> AwvCuA== (8 chars)  CORRUPT
secs=128   bytes=[1,0,128]   -> AQDCgA== (8 chars)  CORRUPT
```

### Observed on hardware

TS0726 3 gang, writing endpoints 1/2/3 at 3600/3000/2400 s. The 3000 s record is the one that overflows, and everything after it desynchronizes:

```
inching_control_1: ENABLE, inching_time_1: 3600     <- correct
inching_control_2: ENABLE, inching_time_2: 68349    <- wrong, sent 3000
inching_control_3: ENABLE, inching_time_3: 2400     <- correct
inching_control_16: ENABLE, inching_time_16: null   <- phantom
```

Endpoint 16 is U+FFFD going through `Math.trunc(Math.log2(65533)) + 1`.

### Fix

Build and read the record as bytes, never as a string. With the patch applied, a 3000 s write round trips exactly — verified by restarting Zigbee2MQTT so the value is re-read from the device rather than served from cache:

```
inching_control_1: DISABLE, inching_time_1: 3000
```

Link to picture pull request:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
