### PR TITLE
fix: Correct Neo NAS-AB06B2 `alarm_state` enum value

### DIFF
--- a/src/devices/neo.ts
+++ b/src/devices/neo.ts
@@ -99,7 +99,7 @@ export const definitions: DefinitionWithExtend[] = [
         description: "Outdoor solar alarm",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
         exposes: [
-            e.enum("alarm_state", ea.STATE, ["alarm_sound", "alarm_light", "alarm_sound_light", "normal"]).withDescription("Alarm status"),
+            e.enum("alarm_state", ea.STATE, ["alarm_sound", "alarm_light", "alarm_sound_light", "no_alarm"]).withDescription("Alarm status"),
             e.binary("alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable alarm"),
             e.binary("tamper_alarm_switch", ea.STATE_SET, "ON", "OFF").withDescription("Enable tamper alarm"),
             e.binary("tamper_alarm", ea.STATE, "ON", "OFF").withDescription("Indicates whether the device is tampered"),


### PR DESCRIPTION
### What

`alarm_state` on the Neo NAS-AB06B2 declares `normal` as its idle value, but the DP 1 lookup maps `tuya.enum(3)` to `no_alarm`:

```ts
e.enum("alarm_state", ea.STATE, ["alarm_sound", "alarm_light", "alarm_sound_light", "normal"])
...
[1, "alarm_state", tuya.valueConverterBasic.lookup({
    alarm_sound: tuya.enum(0), alarm_light: tuya.enum(1),
    alarm_sound_light: tuya.enum(2), no_alarm: tuya.enum(3),
})],
```

So the device publishes `no_alarm` — a value absent from its own declared enum — and `normal` can never occur.

### Impact

Mostly documentation. The generated [device page](https://www.zigbee2mqtt.io/devices/NAS-AB06B2.html) lists `normal` as a possible state, so an automation written from the docs matching `normal` silently never fires, with no error to explain why. The value that does occur isn't documented at all.

### Why this direction

Changing the *lookup* to emit `normal` would match the docs, but it would silently alter the published state value for every current user of this device and break automations matching `no_alarm`. Aligning the expose to what the converter already emits is non-breaking.

`no_alarm` is also already established elsewhere in the codebase (`src/devices/tuya.ts` returns it in two places). For contrast, the Lincukoo A08-Z10T siren uses an identical enum list and *is* internally consistent (exposes `normal`, maps `normal: 3`) — NAS-AB06B2 is the outlier.

### Verification

Confirmed against a physical `_TZE200_nlrfgpny` (MCU version 80), which reports:

```json
{"alarm_state":"no_alarm","alarm_switch":"OFF","alarm_mode":"alarm_sound_light", ...}
```

`pnpm run check` and `pnpm run build` clean; full suite green (844/844).

> Note: on my machine the suite's default 5s `testTimeout` flakes under parallel load (`tuya.test.ts > tuyaWeatherForecast` and others time out). Those same files pass in isolation both with and without this change, and the full suite passes with `--testTimeout=60000`. Unrelated to this one-line change, but flagging it in case it's worth a look.
