### PR TITLE
feat(add): GKZ-LB431RGBCW-E26

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4396,6 +4396,28 @@ export const definitions: DefinitionWithExtend[] = [
         ],
     },
     {
+        fingerprint: tuya.fingerprint("TS0505B", ["_TZ3210_cnicaghm"]),
+        model: "GKZ-LB431RGBCW-E26",
+        vendor: "Hejhome",
+        description: "Z26 RGB+CCT light bulb",
+        extend: [
+            tuya.modernExtend.tuyaLight({colorTemp: {range: [153, 500]}, color: true}),
+            // This firmware leaves the network after roughly 10 minutes without Basic-cluster keep-alive reads.
+            // GOQUAL documents the same workaround at https://homey.app/en-us/app/com.hejhome.iot/Hejhome/.
+            m.poll({
+                key: "hejhome_z26_app_version_keepalive",
+                defaultIntervalSeconds: 120,
+                poll: async (device) => {
+                    await device.getEndpoint(1).read("genBasic", ["appVersion"]);
+                },
+            }),
+        ],
+        meta: {applyRedFix: true},
+        configure: (device) => {
+            device.getEndpoint(1).saveClusterAttributeKeyValue("lightingColorCtrl", {colorCapabilities: 29});
+        },
+    },
+    {
         zigbeeModel: ["TS0505B"],
         model: "TS0505B_1",
         vendor: "Tuya",


### PR DESCRIPTION
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5490

Adds the Hejhome Z26 RGB+CCT bulb (`GKZ-LB431RGBCW-E26`) with an exact `TS0505B` / `_TZ3210_cnicaghm` match. Two production lots with application version 66 reproduced network leaves after 8m24s and 10m19s without keep-alive.

Uses the existing `m.poll` helper to read endpoint 1 `genBasic.appVersion` every 120 seconds while retaining normal Tuya RGB+CCT behavior. Other TS0505B fingerprints are unaffected. GOQUAL documents the same symptom and attribute in its official Homey changelog, using 30 seconds: https://homey.app/en-us/app/com.hejhome.iot/Hejhome/

The 120-second interval prevented the reproduced self-leave during observed testing, including an approximately 34-hour observation. Continuous long-term reliability and the optimal interval are not established. Technical evidence: https://github.com/mahlernim/hejhome-z26-zigbee2mqtt/blob/main/evidence/observations.md

Validation passed build, Biome, 844 existing tests, benchmarks, and targeted fingerprint and polling-lifecycle checks. The proposed definition was validated locally; hardware evidence comes from the equivalent external converter. No permanent tests were added, following repository guidance for device-definition-only changes.
