### PR TITLE
fix: Tuya TS0224: add back `max_duration`

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -17051,7 +17051,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Tuya",
         description: "Smart light & sound siren",
         extend: [
-            m.iasWarning(),
+            m.iasWarning({maxDuration: true}),
             {
                 exposes: [
                     e.binary("light", ea.STATE_SET, "ON", "OFF").withDescription("Turn the light of the alarm ON/OFF"),


### PR DESCRIPTION
`maxDuration` defaults to false, forgot to enable it on Tuya siren @burmistrzak 

- https://github.com/Koenkk/zigbee-herdsman-converters/pull/12944