### PR TITLE
fix: Fix illuminance 0

### DIFF
--- a/src/lib/modernExtend.ts
+++ b/src/lib/modernExtend.ts
@@ -928,21 +928,23 @@ export function customTimeResponse(start: "1970_UTC" | "2000_LOCAL"): ModernExte
 
 // #region Measurement and Sensing
 
-export function illuminance(args: Partial<NumericArgs<"msIlluminanceMeasurement">> = {}): ModernExtend {
-    const luxScale: ScaleFunction = (value: number, type: "from" | "to") => {
-        let result = value;
-        if (type === "from") {
-            result = 10 ** ((result - 1) / 10000);
-        }
-        return result;
-    };
+const luxScale: ScaleFunction = (value: number, type: "from" | "to") => {
+    let result = value;
+    if (type === "from") {
+        if (result === 0x0000) return 0;
 
+        result = 10 ** ((result - 1) / 10000);
+    }
+    return result;
+};
+
+export function illuminance(args: Partial<NumericArgs<"msIlluminanceMeasurement">> = {}): ModernExtend {
     const result = numeric({
         name: "illuminance",
         cluster: "msIlluminanceMeasurement",
         attribute: "measuredValue",
         reporting: {min: "10_SECONDS", max: "1_HOUR", change: 5}, // 5 lux
-        description: "Measured illuminance",
+        description: "Measured illuminance. 0 = too low to be measured",
         unit: "lx",
         scale: luxScale,
         access: "STATE_GET",


### PR DESCRIPTION
Add the 0 special case (too low to be measured)

Previously it wrongly displayed 1 lx

<img width="50%" src="https://github.com/user-attachments/assets/70b383c2-b867-4822-9e6e-1de2e9300849" />


- part of https://github.com/Koenkk/zigbee-herdsman-converters/pull/11868
- https://github.com/Koenkk/zigbee2mqtt/issues/31431