### PR TITLE
Add _TZE284_lyqazpe6 fingerprint to Tongou TOQCB2-80

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -21910,6 +21910,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_9xstqowh",
             "_TZE284_kv1nvirl",
             "_TZE284_lyqazpe6",
+            "_TZE204_lyqazpe6",
         ]),
         model: "TOQCB2-80",
         vendor: "Tongou",

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -21909,6 +21909,7 @@ export const definitions: DefinitionWithExtend[] = [
             "_TZE284_tzreobvu",
             "_TZE284_9xstqowh",
             "_TZE284_kv1nvirl",
+            "_TZE284_lyqazpe6",
         ]),
         model: "TOQCB2-80",
         vendor: "Tongou",


### PR DESCRIPTION
Adds the `_TZE284_lyqazpe6` manufacturer fingerprint to the existing Tongou TOQCB2-80 definition.

Device model ID: TS0601
Manufacturer name: _TZE284_lyqazpe6

Tested successfully using an external converter based on the existing TOQCB2-80 definition. Switching, electrical measurements and protection settings work correctly.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->