### PR TITLE
feat: make Tuya queryOnDeviceAnnounce configurable (simple version)

### DIFF
--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1294,6 +1294,12 @@ const tuyaOptions = {
             .withDescription(
                 `Reply to Tuya-specific time synchronization requests: "1970" - Reply with seconds since 1970/01/01 (recommended, should stop the device from asking), "2000" - Reply with seconds since 2000/01/01 (use if the weekday is wrong with 1970), "off" - Don't reply (use if replying causes too much traffic). Default for this device: "${defaultOption}"`,
             ),
+    queryOnAnnounce: () =>
+        e
+            .binary("query_on_announce", ea.SET, true, false)
+            .withDescription(
+                `Query the full device state whenever it re-announces itself on the network. Overrides this device's default behavior in either direction. Can be useful to enable on devices that stop reporting after a rejoin, or to disable on devices that announce often and would otherwise generate excessive traffic and battery drain.`,
+            ),
 };
 
 export {tuyaOptions as options};
@@ -4524,7 +4530,7 @@ const tuyaModernExtend = {
             isModernExtend: true,
             fromZigbee: [fzConverter],
             toZigbee: [],
-            options: [tuyaOptions.timeStart(timeStart)],
+            options: [tuyaOptions.timeStart(timeStart), tuyaOptions.queryOnAnnounce()],
         };
 
         if (queryOnConfigure) {
@@ -4539,42 +4545,48 @@ const tuyaModernExtend = {
             result.configure.push(configureBindBasic);
         }
 
-        if (queryOnDeviceAnnounce || queryIntervalSeconds !== undefined) {
-            result.onEvent = [
-                (event) => {
-                    // Some devices require a dataQuery on deviceAnnounce, otherwise they don't report any data
-                    if (event.type === "deviceAnnounce") {
-                        const shouldQuery =
-                            typeof queryOnDeviceAnnounce === "function" ? queryOnDeviceAnnounce(event.data.device) : queryOnDeviceAnnounce;
-                        if (shouldQuery) {
-                            event.data.device.endpoints[0]
-                                .command("manuSpecificTuya", "dataQuery", {})
-                                .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
-                        }
+        result.onEvent = [
+            (event) => {
+                // Some devices require a dataQuery on deviceAnnounce, otherwise they don't report any data
+                if (event.type === "deviceAnnounce") {
+                    const userOverride = event.data.options?.query_on_announce;
+                    let shouldQuery: boolean;
+                    if (typeof userOverride === "boolean") {
+                        shouldQuery = userOverride;
+                    } else if (typeof queryOnDeviceAnnounce === "function") {
+                        shouldQuery = queryOnDeviceAnnounce(event.data.device);
+                    } else {
+                        shouldQuery = queryOnDeviceAnnounce;
                     }
 
-                    if (queryIntervalSeconds !== undefined) {
-                        if (event.type === "stop") {
-                            clearTimeout(globalStore.getValue(event.data.ieeeAddr, "query_interval"));
-                            globalStore.clearValue(event.data.ieeeAddr, "query_interval");
-                        } else if (event.type === "start") {
-                            const setTimer = () => {
-                                const timer = setTimeout(() => {
-                                    event.data.device.endpoints[0]
-                                        .command("manuSpecificTuya", "dataQuery", {})
-                                        .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on interval (${error})`, NS));
-                                    if (globalStore.getValue(event.data.device.ieeeAddr, "query_interval") === timer) {
-                                        setTimer();
-                                    }
-                                }, queryIntervalSeconds * 1000).unref();
-                                globalStore.putValue(event.data.device.ieeeAddr, "query_interval", timer);
-                            };
-                            setTimer();
-                        }
+                    if (shouldQuery) {
+                        event.data.device.endpoints[0]
+                            .command("manuSpecificTuya", "dataQuery", {})
+                            .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
                     }
-                },
-            ];
-        }
+                }
+
+                if (queryIntervalSeconds !== undefined) {
+                    if (event.type === "stop") {
+                        clearTimeout(globalStore.getValue(event.data.ieeeAddr, "query_interval"));
+                        globalStore.clearValue(event.data.ieeeAddr, "query_interval");
+                    } else if (event.type === "start") {
+                        const setTimer = () => {
+                            const timer = setTimeout(() => {
+                                event.data.device.endpoints[0]
+                                    .command("manuSpecificTuya", "dataQuery", {})
+                                    .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on interval (${error})`, NS));
+                                if (globalStore.getValue(event.data.device.ieeeAddr, "query_interval") === timer) {
+                                    setTimer();
+                                }
+                            }, queryIntervalSeconds * 1000).unref();
+                            globalStore.putValue(event.data.device.ieeeAddr, "query_interval", timer);
+                        };
+                        setTimer();
+                    }
+                }
+            },
+        ];
 
         const tuyaGenBasic = tuyaClusters.addTuyaGenBasicCluster();
         const tuyaGenGroups = tuyaClusters.addTuyaGenGroupsCluster();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -516,6 +516,7 @@ describe("ZHC", () => {
         const ts0601Soil = await findByDevice(ts0601SoilDevice);
         expect(ts0601Soil.options.map((t) => t.name)).toStrictEqual([
             "time_start",
+            "query_on_announce",
             "temperature_calibration",
             "temperature_precision",
             "soil_moisture_calibration",
@@ -539,6 +540,7 @@ describe("ZHC", () => {
         const ts011fPlug1 = await findByDevice(ts0111fPlug1Device);
         expect(ts011fPlug1.options.map((t) => t.name)).toStrictEqual([
             "time_start",
+            "query_on_announce",
             "power_calibration",
             "power_precision",
             "current_calibration",
@@ -554,6 +556,56 @@ describe("ZHC", () => {
         const options3 = {current_calibration: -50};
         postProcessConvertedFromZigbeeMessage(ts011fPlug1, payload3, options3, ts0111fPlug1Device);
         expect(payload3).toStrictEqual({current: 0.03});
+    });
+
+    it("applies the query on announce option selected by the user", async () => {
+        const disabledDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE2841000000_qf5mzewi", endpoints: [{}]});
+        const disabledDefinition = await findByDevice(disabledDevice);
+        const disabledCommand = vi.spyOn(disabledDevice.endpoints[0], "command");
+
+        await disabledDefinition.onEvent?.({
+            type: "deviceAnnounce",
+            data: {
+                device: disabledDevice,
+                options: {query_on_announce: true},
+                state: {},
+                deviceExposesChanged: vi.fn(),
+            },
+        });
+
+        expect(disabledCommand).toHaveBeenCalledWith("manuSpecificTuya", "dataQuery", {});
+
+        const enabledDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE284_qf5mzewi", endpoints: [{}]});
+        const enabledDefinition = await findByDevice(enabledDevice);
+        const enabledCommand = vi.spyOn(enabledDevice.endpoints[0], "command");
+
+        await enabledDefinition.onEvent?.({
+            type: "deviceAnnounce",
+            data: {
+                device: enabledDevice,
+                options: {query_on_announce: false},
+                state: {},
+                deviceExposesChanged: vi.fn(),
+            },
+        });
+
+        expect(enabledCommand).not.toHaveBeenCalledWith("manuSpecificTuya", "dataQuery", {});
+
+        const configurableDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_myd45weu", endpoints: [{}]});
+        const configurableDefinition = await findByDevice(configurableDevice);
+        const configurableCommand = vi.spyOn(configurableDevice.endpoints[0], "command");
+
+        await configurableDefinition.onEvent?.({
+            type: "deviceAnnounce",
+            data: {
+                device: configurableDevice,
+                options: {query_on_announce: true},
+                state: {},
+                deviceExposesChanged: vi.fn(),
+            },
+        });
+
+        expect(configurableCommand).toHaveBeenCalledWith("manuSpecificTuya", "dataQuery", {});
     });
 
     it("instantiates list expose of number type", () => {


### PR DESCRIPTION
## Scope

This PR only changes `zigbee-herdsman-converters`.

It exposes `query_on_announce` as a configurable device option. The selected value is used at runtime when the device announces itself.

## Important limitation

This is the simple version (in opposition with #13129):

- the option is available in the UI;
- the user can select `true` or `false`;
- the converter uses the selected value;
- the default is not automatically preselected in the UI;
- the value is not tested on a real Zigbee2MQTT instance.

This PR does not modify Zigbee2MQTT or the frontend.

## Related PRs

This follows the discussion from #13098 and the per-device behavior introduced in #13112.
The original device case comes from #12935.

## Testing

- `pnpm test`
- Not tested on a real Zigbee2MQTT test instance.
- Not tested with a physical device.