### PR TITLE
feat: make Tuya queryOnDeviceAnnounce configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import {
     type KeyValue,
     type OnEvent,
     Option,
+    type OptionFactory,
     Tz,
     type Zh,
 } from "./lib/types";
@@ -253,7 +254,7 @@ function validateDefinition(definition: Definition): asserts definition is Defin
     assert.ok(Array.isArray(definition.exposes) || typeof definition.exposes === "function", "Exposes incorrect");
 }
 
-function processExtensions(definition: DefinitionWithExtend): Definition {
+function processExtensions(definition: DefinitionWithExtend, device?: Zh.Device): Definition {
     if ("extend" in definition) {
         if (!Array.isArray(definition.extend)) {
             assert.fail(`'${definition.model}' has legacy extend which is not supported anymore`);
@@ -291,6 +292,7 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
 
         toZigbee = [...(toZigbee ?? [])];
         fromZigbee = [...(fromZigbee ?? [])];
+        const optionFactories: OptionFactory[] = [];
         options = [...(options ?? [])];
 
         const configures: Configure[] = definitionConfigure ? [definitionConfigure] : [];
@@ -311,6 +313,10 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
 
             if (ext.options) {
                 options.push(...ext.options);
+            }
+
+            if (ext.optionsFactory) {
+                optionFactories.push(ext.optionsFactory);
             }
 
             if (ext.exposes) {
@@ -411,14 +417,17 @@ function processExtensions(definition: DefinitionWithExtend): Definition {
             };
         }
 
+        const optionDevice = device ?? {isDummyDevice: true as const};
+        options.push(...optionFactories.flatMap((factory) => factory(optionDevice)));
+
         return {version: "0.0.0", toZigbee, fromZigbee, exposes, meta, configure, endpoint, onEvent, ota, options, ...definitionWithoutExtend};
     }
 
     return {version: "0.0.0", ...definition};
 }
 
-export function prepareDefinition(definition: DefinitionWithExtend): Definition {
-    const finalDefinition = processExtensions(definition);
+export function prepareDefinition(definition: DefinitionWithExtend, device?: Zh.Device): Definition {
+    const finalDefinition = processExtensions(definition, device);
 
     finalDefinition.toZigbee = [
         toZigbee.scene_store,
@@ -518,7 +527,7 @@ export async function findByDevice(device: Zh.Device, generateForUnknown = false
             }
         }
 
-        return prepareDefinition(definition);
+        return prepareDefinition(definition, device);
     }
 }
 
@@ -599,7 +608,7 @@ export async function generateExternalDefinitionSource(device: Zh.Device): Promi
 export async function generateExternalDefinition(device: Zh.Device): Promise<Definition> {
     const {definition} = await generateDefinition(device);
 
-    return prepareDefinition(definition);
+    return prepareDefinition(definition, device);
 }
 
 function isFingerprintMatch(fingerprint: Fingerprint, device: Zh.Device): boolean {

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -36,6 +36,7 @@ export class Base {
     features?: Feature[];
     category?: "config" | "diagnostic";
     homeassistant?: HomeAssistant;
+    default?: string | number | boolean;
 
     withEndpoint(endpointName: string) {
         this.endpoint = endpointName;
@@ -75,6 +76,11 @@ export class Base {
 
     withDescription(description: string) {
         this.description = description;
+        return this;
+    }
+
+    withDefault(value: string | number | boolean) {
+        this.default = value;
         return this;
     }
 
@@ -138,6 +144,7 @@ export class Base {
         }
         target.category = this.category;
         target.homeassistant = this.homeassistant ? {...this.homeassistant} : undefined;
+        target.default = this.default;
     }
 }
 

--- a/src/lib/tuya.ts
+++ b/src/lib/tuya.ts
@@ -1294,6 +1294,13 @@ const tuyaOptions = {
             .withDescription(
                 `Reply to Tuya-specific time synchronization requests: "1970" - Reply with seconds since 1970/01/01 (recommended, should stop the device from asking), "2000" - Reply with seconds since 2000/01/01 (use if the weekday is wrong with 1970), "off" - Don't reply (use if replying causes too much traffic). Default for this device: "${defaultOption}"`,
             ),
+    queryOnAnnounce: (defaultOption: boolean) =>
+        e
+            .binary("query_on_announce", ea.SET, true, false)
+            .withDefault(defaultOption)
+            .withDescription(
+                `Query the full device state whenever it re-announces itself on the network. Overrides this device's default behavior in either direction. Can be useful to enable on devices that stop reporting after a rejoin, or to disable on devices that announce often and would otherwise generate excessive traffic and battery drain. Default for this device: "${defaultOption}"`,
+            ),
 };
 
 export {tuyaOptions as options};
@@ -4525,6 +4532,15 @@ const tuyaModernExtend = {
             fromZigbee: [fzConverter],
             toZigbee: [],
             options: [tuyaOptions.timeStart(timeStart)],
+            optionsFactory: (device) => {
+                const defaultQueryOnAnnounce =
+                    typeof queryOnDeviceAnnounce === "function" && !utils.isDummyDevice(device)
+                        ? queryOnDeviceAnnounce(device)
+                        : typeof queryOnDeviceAnnounce === "boolean"
+                          ? queryOnDeviceAnnounce
+                          : false;
+                return [tuyaOptions.queryOnAnnounce(defaultQueryOnAnnounce)];
+            },
         };
 
         if (queryOnConfigure) {
@@ -4539,42 +4555,48 @@ const tuyaModernExtend = {
             result.configure.push(configureBindBasic);
         }
 
-        if (queryOnDeviceAnnounce || queryIntervalSeconds !== undefined) {
-            result.onEvent = [
-                (event) => {
-                    // Some devices require a dataQuery on deviceAnnounce, otherwise they don't report any data
-                    if (event.type === "deviceAnnounce") {
-                        const shouldQuery =
-                            typeof queryOnDeviceAnnounce === "function" ? queryOnDeviceAnnounce(event.data.device) : queryOnDeviceAnnounce;
-                        if (shouldQuery) {
-                            event.data.device.endpoints[0]
-                                .command("manuSpecificTuya", "dataQuery", {})
-                                .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
-                        }
+        result.onEvent = [
+            (event) => {
+                // Some devices require a dataQuery on deviceAnnounce, otherwise they don't report any data
+                if (event.type === "deviceAnnounce") {
+                    const userOverride = event.data.options?.query_on_announce;
+                    let shouldQuery: boolean;
+                    if (typeof userOverride === "boolean") {
+                        shouldQuery = userOverride;
+                    } else if (typeof queryOnDeviceAnnounce === "function") {
+                        shouldQuery = queryOnDeviceAnnounce(event.data.device);
+                    } else {
+                        shouldQuery = queryOnDeviceAnnounce;
                     }
 
-                    if (queryIntervalSeconds !== undefined) {
-                        if (event.type === "stop") {
-                            clearTimeout(globalStore.getValue(event.data.ieeeAddr, "query_interval"));
-                            globalStore.clearValue(event.data.ieeeAddr, "query_interval");
-                        } else if (event.type === "start") {
-                            const setTimer = () => {
-                                const timer = setTimeout(() => {
-                                    event.data.device.endpoints[0]
-                                        .command("manuSpecificTuya", "dataQuery", {})
-                                        .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on interval (${error})`, NS));
-                                    if (globalStore.getValue(event.data.device.ieeeAddr, "query_interval") === timer) {
-                                        setTimer();
-                                    }
-                                }, queryIntervalSeconds * 1000).unref();
-                                globalStore.putValue(event.data.device.ieeeAddr, "query_interval", timer);
-                            };
-                            setTimer();
-                        }
+                    if (shouldQuery) {
+                        event.data.device.endpoints[0]
+                            .command("manuSpecificTuya", "dataQuery", {})
+                            .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on device announce (${error})`, NS));
                     }
-                },
-            ];
-        }
+                }
+
+                if (queryIntervalSeconds !== undefined) {
+                    if (event.type === "stop") {
+                        clearTimeout(globalStore.getValue(event.data.ieeeAddr, "query_interval"));
+                        globalStore.clearValue(event.data.ieeeAddr, "query_interval");
+                    } else if (event.type === "start") {
+                        const setTimer = () => {
+                            const timer = setTimeout(() => {
+                                event.data.device.endpoints[0]
+                                    .command("manuSpecificTuya", "dataQuery", {})
+                                    .catch((error) => logger.error(`Failed to query '${event.data.device.ieeeAddr}' on interval (${error})`, NS));
+                                if (globalStore.getValue(event.data.device.ieeeAddr, "query_interval") === timer) {
+                                    setTimer();
+                                }
+                            }, queryIntervalSeconds * 1000).unref();
+                            globalStore.putValue(event.data.device.ieeeAddr, "query_interval", timer);
+                        };
+                        setTimer();
+                    }
+                }
+            },
+        ];
 
         const tuyaGenBasic = tuyaClusters.addTuyaGenBasicCluster();
         const tuyaGenGroups = tuyaClusters.addTuyaGenGroupsCluster();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,7 @@ export type Expose =
     | exposes.Fan
     | exposes.Text;
 export type Option = exposes.Numeric | exposes.Binary | exposes.Composite | exposes.Enum | exposes.List | exposes.Text;
+export type OptionFactory = (device: Zh.Device | DummyDevice) => Option[];
 export interface Fingerprint {
     applicationVersion?: number;
     manufacturerID?: number;
@@ -254,6 +255,7 @@ export interface ModernExtend {
     meta?: Definition["meta"];
     ota?: Definition["ota"];
     options?: Option[];
+    optionsFactory?: OptionFactory;
     onEvent?: Definition["onEvent"][];
     endpoint?: Definition["endpoint"];
     isModernExtend: true;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -516,6 +516,7 @@ describe("ZHC", () => {
         const ts0601Soil = await findByDevice(ts0601SoilDevice);
         expect(ts0601Soil.options.map((t) => t.name)).toStrictEqual([
             "time_start",
+            "query_on_announce",
             "temperature_calibration",
             "temperature_precision",
             "soil_moisture_calibration",
@@ -539,6 +540,7 @@ describe("ZHC", () => {
         const ts011fPlug1 = await findByDevice(ts0111fPlug1Device);
         expect(ts011fPlug1.options.map((t) => t.name)).toStrictEqual([
             "time_start",
+            "query_on_announce",
             "power_calibration",
             "power_precision",
             "current_calibration",
@@ -554,6 +556,68 @@ describe("ZHC", () => {
         const options3 = {current_calibration: -50};
         postProcessConvertedFromZigbeeMessage(ts011fPlug1, payload3, options3, ts0111fPlug1Device);
         expect(payload3).toStrictEqual({current: 0.03});
+    });
+
+    it("shows the query on announce default for the matched Tuya device", async () => {
+        const disabledDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE2841000000_qf5mzewi", endpoints: []});
+        const enabledDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE284_qf5mzewi", endpoints: []});
+        const disabledDefinition = await findByDevice(disabledDevice);
+        const enabledDefinition = await findByDevice(enabledDevice);
+
+        const disabledOption = disabledDefinition.options.find((option) => option.name === "query_on_announce");
+        const enabledOption = enabledDefinition.options.find((option) => option.name === "query_on_announce");
+        expect(disabledOption?.default).toBe(false);
+        expect(enabledOption?.default).toBe(true);
+    });
+
+    it("applies the query on announce option selected by the user", async () => {
+        const disabledDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE2841000000_qf5mzewi", endpoints: [{}]});
+        const disabledDefinition = await findByDevice(disabledDevice);
+        const disabledCommand = vi.spyOn(disabledDevice.endpoints[0], "command");
+
+        await disabledDefinition.onEvent?.({
+            type: "deviceAnnounce",
+            data: {
+                device: disabledDevice,
+                options: {query_on_announce: true},
+                state: {},
+                deviceExposesChanged: vi.fn(),
+            },
+        });
+
+        expect(disabledCommand).toHaveBeenCalledWith("manuSpecificTuya", "dataQuery", {});
+
+        const enabledDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE284_qf5mzewi", endpoints: [{}]});
+        const enabledDefinition = await findByDevice(enabledDevice);
+        const enabledCommand = vi.spyOn(enabledDevice.endpoints[0], "command");
+
+        await enabledDefinition.onEvent?.({
+            type: "deviceAnnounce",
+            data: {
+                device: enabledDevice,
+                options: {query_on_announce: false},
+                state: {},
+                deviceExposesChanged: vi.fn(),
+            },
+        });
+
+        expect(enabledCommand).not.toHaveBeenCalledWith("manuSpecificTuya", "dataQuery", {});
+
+        const configurableDevice = mockDevice({modelID: "TS0601", manufacturerName: "_TZE200_myd45weu", endpoints: [{}]});
+        const configurableDefinition = await findByDevice(configurableDevice);
+        const configurableCommand = vi.spyOn(configurableDevice.endpoints[0], "command");
+
+        await configurableDefinition.onEvent?.({
+            type: "deviceAnnounce",
+            data: {
+                device: configurableDevice,
+                options: {query_on_announce: true},
+                state: {},
+                deviceExposesChanged: vi.fn(),
+            },
+        });
+
+        expect(configurableCommand).toHaveBeenCalledWith("manuSpecificTuya", "dataQuery", {});
     });
 
     it("instantiates list expose of number type", () => {


### PR DESCRIPTION
## Scope

This is the complete implementation across three repositories:

1. `zigbee-herdsman-converters`
2. `zigbee2mqtt` [#33057](https://github.com/Koenkk/zigbee2mqtt/pull/33057)
3. `zigbee2mqtt-frontend` [#2782](https://github.com/nurikk/zigbee2mqtt-frontend/pull/2782)

The option default is calculated for the actual device, propagated through the definition, applied by the backend, and used by the frontend to initialize the control.

## Difference from the simple version #13128

Unlike the simple converter-only version, this implementation:

- provides a real `default` value on the option;
- applies the definition default when no user value is configured;
- preserves the priority of global and device-specific configuration;
- initializes the UI control with the correct `true` or `false` value;
- requires coordinated changes across all three repositories.

## Important limitation

This implementation was not tested against a real Zigbee2MQTT test instance or a physical device.

Validation was limited to:

- `pnpm test` in the converters repository;
- `pnpm test` in Zigbee2MQTT;
- frontend production build;
- unit tests where available.

## Related PRs

This follows:

- #12935: ONENUO TH05Z support;
- #13098: initial configurable `queryOnDeviceAnnounce` proposal;
- #13112: per-device `queryOnDeviceAnnounce` function.

The three PRs in this series should be reviewed and merged together in dependency order.
1. zigbee-herdsman-converters
2. release/update of zigbee-herdsman-converters
3. zigbee2mqtt [#33057](https://github.com/Koenkk/zigbee2mqtt/pull/33057)
4. zigbee2mqtt-frontend [#2782](https://github.com/nurikk/zigbee2mqtt-frontend/pull/2782)