### PR TITLE
feat: add Mowe MW815R as white label of TS0207_water_leak_detector

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4934,6 +4934,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Tuya", "899WZ", "Water leak detector with 80DB Alarm", ["_TZ3000_mugyhz0q"]),
             tuya.whitelabel("Niceboy", "ORBIS Water Sensor", "Water leak sensor", ["_TZ3000_awvmkayh"]),
             tuya.whitelabel("Nous", "E4", "Water Leakage Sensor)", ["_TZ3000_0s9gukzt"]),
+            tuya.whitelabel("Mowe", "MW815R", "Rain sensor", ["_TZ3000_syetgitm"]),
         ],
         toZigbee: [],
         configure: async (device, coordinatorEndpoint) => {


### PR DESCRIPTION
Adds the MOWE (Möwe Smart Home, Singapore) rebrand of the TS0207 water leak detector, sold as the **Zigbee Rain Sensor MW815R**.

`_TZ3000_syetgitm` is already matched by the existing `zigbeeModel: ["TS0207", ...]` entry, so this only attaches the correct vendor, model and description — no behaviour change:

| manufacturerName | definition | white label |
|---|---|---|
| `_TZ3000_syetgitm` | `TS0207_water_leak_detector` | Mowe MW815R |

Confirmed on hardware: one unit paired to Zigbee2MQTT 2.x, interviewing cleanly on the existing definition and reporting `water_leak`, `battery`, `battery_low` and `tamper` correctly. The device is an IAS zone sensor whose rain plate closes the same contact a leak probe would, so the existing converters are exactly right for it — only the branding was generic `Tuya / Water leak detector`.

The `Mowe` vendor string matches the existing `src/devices/mowe.ts` (MW833P) and the MW781Z / MW783Z white labels from #13117, so all Mowe models land on the same vendor page.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
