### PR TITLE
feat: add Mowe MW811D as white label of TS0203

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -2571,6 +2571,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Nous", "E3", "Door sensor", ["_TZ3000_v7chgqso"]),
             tuya.whitelabel("Woox", "R7047", "Smart Door & Window Sensor", ["_TZ3000_timx9ivq"]),
             tuya.whitelabel("Wing", "WZDA1", "Door sensor", ["_TZ3000_rid8lzvo"]),
+            tuya.whitelabel("Mowe", "MW811D", "Door and window sensor", ["_TZ3000_0lvv1d5b"]),
         ],
         exposes: (device, options) => {
             const exps: Expose[] = [e.contact(), e.battery(), e.battery_voltage()];


### PR DESCRIPTION
Adds the MOWE (Möwe Smart Home, Singapore) rebrand of the TS0203 door/window sensor, sold as the **Door / Window Sensor MW811D**.

`_TZ3000_0lvv1d5b` is already matched by the existing `zigbeeModel: ["TS0203", ...]` entry, so this only attaches the correct vendor, model and description — no behaviour change:

| manufacturerName | definition | white label |
|---|---|---|
| `_TZ3000_0lvv1d5b` | `TS0203` | Mowe MW811D |

Confirmed on hardware: two units paired to Zigbee2MQTT 2.x, interviewing cleanly on the existing definition and reporting `contact`, `battery`, `battery_voltage`, `battery_low` and `tamper` correctly. Only the branding was generic `Tuya / Door/window sensor`.

The `Mowe` vendor string matches the existing `src/devices/mowe.ts` (MW833P) and the MW781Z / MW783Z white labels from #13117, so all Mowe models land on the same vendor page.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
