### PR TITLE
feat: add Mowe MW784Z as white label of TS0726_4_gang_scene_switch

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24717,6 +24717,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [
             tuya.whitelabel("BSEED", "EC-GL86ZPCS41", "4 gang switch with scene and backlight", ["_TZ3002_pzao9ls1"]),
             tuya.whitelabel("BSEED", "EC-SL-FK86ZPCS41", "4 gang switch with scene and backlight (Neutral line optional)", ["_TZ3002_eda6eitk"]),
+            tuya.whitelabel("Mowe", "MW784Z", "4 gang switch with scene and backlight", ["_TZ300A_vkflnsl0"]),
         ],
         fromZigbee: [fzLocal.TS0726_action],
         exposes: [e.action(["scene_1", "scene_2", "scene_3", "scene_4"])],


### PR DESCRIPTION
Adds the MOWE (Möwe Smart Home, Singapore) rebrand of the TS0726 4 gang scene switch, sold as the **Mausklick Series Smart Switch MW784Z**.

`_TZ300A_vkflnsl0` is already in this definition's fingerprint list, so this only attaches the correct vendor and model — no behaviour change:

| manufacturerName | definition | white label |
|---|---|---|
| `_TZ300A_vkflnsl0` | `TS0726_4_gang_scene_switch` | Mowe MW784Z |

Confirmed on hardware: one unit paired to Zigbee2MQTT 2.x, interviewing cleanly on the existing definition with all four endpoints (`l1`-`l4`) working.

This completes the Mausklick line alongside MW781Z (1 gang) and MW783Z (3 gang), merged in #13117. The vendor sells it as MW781Z / MW782Z / MW783Z / MW784Z for 1 / 2 / 3 / 4 gang, and serves its product renders named by model, which is where the SKU is confirmed.

The `Mowe` vendor string matches the existing `src/devices/mowe.ts` (MW833P) so all Mowe models land on the same vendor page.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
