### PR TITLE
feat: add Mowe MW786Z as white label of TS0001

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -8378,6 +8378,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Tuya", "ZG-001", "Smart home relay module", ["_TZ3000_g8n1n7lg"]),
             tuya.whitelabel("Nova Digital", "SA-1", "Safira smart light switch - 1 gang", ["_TZ3000_udl7uyd2"]),
             tuya.whitelabel("Moes", "ZS-US1-LN", "Smart light switch - 1 gang", ["_TZ3000_bzzgvet0"]),
+            tuya.whitelabel("Mowe", "MW786Z", "Water heater switch", ["_TZ3000_cb3aangp"]),
         ],
         configure: async (device, coordinatorEndpoint) => {
             await tuya.configureMagicPacket(device, coordinatorEndpoint);


### PR DESCRIPTION
Adds the MOWE (Möwe Smart Home, Singapore) rebrand of the TS0001 switch, sold as the **Mausklick Series Smart Water Heater Switch MW786Z** (30A).

`_TZ3000_cb3aangp` is already matched by the existing `zigbeeModel: ["TS0001"]` entry, so this only attaches the correct vendor, model and description — no behaviour change:

| manufacturerName | definition | white label |
|---|---|---|
| `_TZ3000_cb3aangp` | `TS0001` | Mowe MW786Z |

Confirmed on hardware: two units (one per bathroom) paired to Zigbee2MQTT 2.x, interviewing cleanly on the existing definition and exposing `switch` as expected. Only the branding was generic `Tuya / 1 gang switch`.

The model is published by the vendor at `mowesmarthome.com/product/zigbee-mausklick-series-smart-water-heater-switch/`, whose SKU field reads MW786Z. Note they also sell separate Rocker (MW725Z) and Touch (MW735Z) series water heater switches, which are different products.

It is a water heater isolator rather than a lighting switch, which is why the description differs from the base definition.

The `Mowe` vendor string matches the existing `src/devices/mowe.ts` (MW833P) and the MW781Z / MW783Z white labels from #13117, so all Mowe models land on the same vendor page.

Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
