### PR TITLE
fix: detect Paulmann 291.52 with PIIC5800

### DIFF
--- a/src/devices/paulmann.ts
+++ b/src/devices/paulmann.ts
@@ -386,6 +386,11 @@ export const definitions: DefinitionWithExtend[] = [
             {
                 modelID: "RGBWW",
                 manufacturerName: "Paulmann Licht GmbH",
+                softwareBuildID: "PIIC5800",
+            },
+            {
+                modelID: "RGBWW",
+                manufacturerName: "Paulmann Licht GmbH",
                 softwareBuildID: "PIIC5809",
             },
         ],
@@ -397,6 +402,7 @@ export const definitions: DefinitionWithExtend[] = [
             {
                 vendor: "Paulmann",
                 model: "291.52",
+                fingerprint: [{modelID: "RGBWW", manufacturerName: "Paulmann Licht GmbH", softwareBuildID: "PIIC5800"}],
             },
         ],
     },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -227,6 +227,21 @@ describe("ZHC", () => {
         expect(definition.model).toStrictEqual("TS011F_plug_3");
     });
 
+    it("finds the Paulmann 291.52 white label for PIIC5800 firmware", async () => {
+        const device = mockDevice(
+            {
+                modelID: "RGBWW",
+                manufacturerName: "Paulmann Licht GmbH",
+                softwareBuildID: "PIIC5800",
+                endpoints: [],
+            },
+            "Router",
+        );
+        const definition = await findByDevice(device);
+
+        expect(definition.model).toStrictEqual("291.52");
+    });
+
     it("finds definition by fingerprint - index of size 250+", async () => {
         const device = mockDevice(
             {


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#33041.\n\nAdds the reported \PIIC5800\ firmware fingerprint to the Paulmann E14 definition so it resolves to the 291.52 white label instead of the generated fallback, and covers it with a lookup regression test.