### PR TITLE
feat: expose MW782Z whitelabel for TS0726 2 gang scene switch

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -24625,6 +24625,7 @@ export const definitions: DefinitionWithExtend[] = [
         whiteLabel: [
             tuya.whitelabel("BSEED", "EC-GL86ZPCS21", "2 gang switch with scene and backlight", ["_TZ3002_zjuvw9zf"]),
             tuya.whitelabel("BSEED", "EC-SL-FK86ZPCS21", "2 gang switch with scene and backlight (Neutral line optional)", ["_TZ3002_tlsvxhxc"]),
+            tuya.whitelabel("Mowe", "MW782Z", "2 gang switch with scene and backlight", ["_TZ300A_ohjmifiz"]),
         ],
         fromZigbee: [fzLocal.TS0726_action],
         exposes: [e.action(["scene_1", "scene_2"])],


### PR DESCRIPTION
Adds a Mowe whiteLabel entry for the `TS0726_2_gang_scene_switch` definition, completing the Mausklick series line (1/2/3/4 gang) alongside the already-merged #13117 (MW781Z), #13133 (MW784Z), and the 3-gang MW783Z entry in the same definition block.

Hardware: **Mowe MW781Z .. MW784Z Mausklick series**, confirmed via the vendor's own product page (`mowesmarthome.com/product/mausklick-series-smart-switch/`), whose SKU field lists `MW781Z | MW782Z | MW783Z | MW784Z` for `attribute_gangs` 1/2/3/4 and product renders named `MW782Z-White.jpg` / `MW782Z-Grey.jpg`.

Fingerprint `_TZ300A_ohjmifiz` is already present in this definition's fingerprint list (currently branded generic `Tuya`), confirmed live on my own 2-gang unit — device interviews as `TS0726_2_gang_scene_switch`, `source: native`.

+1/-0 in `src/devices/tuya.ts`.