### PR TITLE
fix: correct ECODO whitelabel identity for TS0502B (_TZ3210_rnj5wxxg)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -7371,7 +7371,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("EcoDim", "ED-10032", "Zigbee LED filament lamp dimmable E27, bulb A60, Smokey 2000K-4000K", ["_TZ3210_09hzmirw"]),
             tuya.whitelabel("Mercator Ikuü", "SMCL01-ZB", "Ikon ceiling light", ["_TZ3000_6dwfra5l"]),
             tuya.whitelabel("LUUMR", "10024773", "Smart LED C35 matt E14 4,2 W", ["_TZ3210_claeh5ds"]),
-            tuya.whitelabel("ECODO", "ECD-SS12", "Sunset smart downlight 12 W, 1800-5700K", ["_TZ3210_rnj5wxxg"]),
+            tuya.whitelabel("ECODO", "PSL-24V/RGBCW/ECD", "All in one 240 W power supply for RGBCW or RGBCCT LED strip", ["_TZ3210_rnj5wxxg"]),
         ],
         extend: [
             tuya.modernExtend.tuyaLight({


### PR DESCRIPTION
Corrects the ECODO whiteLabel entry merged in #13079 — it identified `_TZ3210_rnj5wxxg` as model `ECD-SS12`, "Sunset smart downlight 12 W, 1800-5700K". That is a different ECODO product; the hardware behind this manufacturerName is confirmed to be the **ECODO (All in one) 240 W Power Supply for RGBCW or RGBCCT LED Strip**, SKU `PSL-24V/RGBCW/3-0/240` per the vendor listing, shortened here to `PSL-24V/RGBCW/ECD` as the model string.

Source: https://www.zenterralighting.com/shop/productdetails.aspx?itm_sid=20200902GH7uuVrds56D — lists the product as "ECODO (All in one) 240W Power Supply - ZIGBEE", 24V output, drives 24V RGBCW strip up to 10 m, tunable white 2700-6500K, RGB, Zigbee 3.0/Tuya.

Confirmed on 3 units in production (`_TZ3210_rnj5wxxg`, `TS0502B`, `source: native`) — all report `supported_color_modes: ["color_temp"]` only, consistent with this definition's `tuyaLight({colorTemp: {range: [153, 500]}})` extend: the Zigbee side controls the tunable-white channels, the RGB channels on this all-in-one PSU are not exposed over Zigbee.

+1/-1 in `src/devices/tuya.ts`.