### PR TITLE
SDM01: allow data report duration below 30 seconds

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -18153,7 +18153,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.power_factor().withUnit("%").withDescription("Total power factor"),
             e.power().withDescription("Total active power"),
             e.ac_frequency(),
-            e.numeric("data_report_duration", ea.SET).withValueMin(30).withValueMax(3600),
+            e.numeric("data_report_duration", ea.SET).withValueMin(5).withValueMax(3600),
             tuya.exposes.energyWithPhase("a"),
             tuya.exposes.energyWithPhase("b"),
             tuya.exposes.energyWithPhase("c"),
@@ -18174,7 +18174,7 @@ export const definitions: DefinitionWithExtend[] = [
                     "data_report_duration",
                     {
                         to: (v: number) => {
-                            const value = Math.max(30, Math.min(3600, Math.round(v))) * 2;
+                            const value = Math.max(5, Math.min(3600, Math.round(v))) * 2;
                             // The reporting logic of this device is: for example, if 30 is input, it will report twice within 30 seconds,
                             // Which means reporting once every 15 seconds. Therefore, the input data needs to be multiplied by 2.
                             const byte1 = (value >> 8) & 0xff;


### PR DESCRIPTION
Allow the old-version Tuya SDM01 energy meter to use reporting intervals below 30 seconds.

The current SDM01 converter limits `data_report_duration` to a minimum of 30 seconds. The device accepts lower values, however, and can report measurements at a 5-second interval.

This changes the minimum supported value from 30 to 5 seconds in both the exposed setting and the value converter.

### Device

* Model: `SDM01`
* Manufacturer: `_TZE204_ugekduaj`
* Zigbee model: `TS0601`

### Testing

Tested with Zigbee2MQTT 2.14.1 and `zigbee-herdsman-converters` 26.105.0 using a Zemismart SDM01-TZ0-12-ZM 3-phase energy meter.

With the current implementation, setting:

```json
{"data_report_duration":5}
```

is clamped to 30 seconds and results in a DP18 reporting value of `60` (`0x003C`).

With this change, the same setting produces:

```text
DP18: ..., 8, 1, 0, 10, 9, ...
```

where `10` is `5 × 2`, matching the existing SDM01 reporting-frequency encoding.

The device subsequently reports updated measurements approximately every 5 seconds.

I also verified that the resulting ZCL `dataRequest` and ZNP `dataConfirm` complete successfully.
