### PR TITLE
fix: skip onOff configReport for BASIC-ZB1GSP firmware >= 1.0.5

### DIFF
--- a/src/devices/sonoff.ts
+++ b/src/devices/sonoff.ts
@@ -12126,7 +12126,7 @@ export const definitions: DefinitionWithExtend[] = [
             m.onOff({
                 powerOnBehavior: true,
                 skipDuplicateTransaction: true,
-                configureReporting: true,
+                configureReporting: false,
             }),
             sonoffExtend.inchingControlSet(),
             m.binary<"customClusterEwelink", SonoffEwelink>({
@@ -12343,7 +12343,10 @@ export const definitions: DefinitionWithExtend[] = [
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ["genOnOff", "customClusterEwelink", "seMetering"]);
-            // await reporting.onOff(endpoint, {min: 1, max: 1800, change: 0});
+            // onOff configReport is not supported on firmware >= 1.0.5, device reports proactively
+            if (firmwareSupportFeaturesVersion(device, "1.0.5", "BASIC-ZB1GSP", "lower")) {
+                await reporting.onOff(endpoint, {min: 0, max: 65000, change: 1});
+            }
             await endpoint.read<"customClusterEwelink", SonoffEwelink>(
                 "customClusterEwelink",
                 ["acCurrentCurrentValue", "acCurrentVoltageValue", "acCurrentPowerValue", 0x7003, "outlet_control_protect", "totalEnergyConsumption"],


### PR DESCRIPTION
## Summary

Fix configure failure for SONOFF BASIC-ZB1GSP Zigbee smart plug with power monitoring.

Firmware v1.0.5 and later reports onOff state proactively and no longer supports configuring onOff reporting via ZCL `configReport`. Attempting to do so causes the configure step to fail with `UNSUPPORTED_ATTRIBUTE` after 3 retries.

## Changes

- Disable `configureReporting` in `m.onOff()` to prevent the modern extend from injecting a `genOnOff.configReport` call for the `onOff` attribute.
- Move `reporting.onOff()` into the device's own `configure` function, guarded by a firmware version check so it only runs for firmware earlier than v1.0.5.

Firmware < v1.0.5: `onOff` configReport is configured as before.
Firmware >= v1.0.5: `onOff` configReport is skipped (device reports proactively).

## Testing

Tested with Zigbee2MQTT on SONOFF ZBDongle-E.

- Verified pairing and configure succeeds without `UNSUPPORTED_ATTRIBUTE` error.
- Verified onOff state reporting works correctly.
- Verified power, current, voltage, and energy reporting remains functional.

## Related

- Fixes https://github.com/Koenkk/zigbee2mqtt/issues/33038