### PR TITLE
feat: Add `power_outage_memory` support for Aqara QBKG11LM

### DIFF
--- a/src/devices/lumi.ts
+++ b/src/devices/lumi.ts
@@ -1242,8 +1242,14 @@ export const definitions: DefinitionWithExtend[] = [
             e.energy(),
             e.action(["single", "double", "release", "hold"]),
             e.enum("operation_mode", ea.ALL, ["control_relay", "decoupled"]).withDescription("Decoupled mode"),
+            e.power_outage_memory().withAccess(ea.STATE_SET),
         ],
-        toZigbee: [tz.on_off, lumi.toZigbee.lumi_switch_operation_mode_basic, lumi.toZigbee.lumi_power],
+        toZigbee: [
+            tz.on_off,
+            lumi.toZigbee.lumi_switch_operation_mode_basic,
+            lumi.toZigbee.lumi_power,
+            lumi.toZigbee.lumi_switch_power_outage_memory,
+        ],
         endpoint: (device) => {
             return {system: 1};
         },

--- a/src/lib/lumi.ts
+++ b/src/lib/lumi.ts
@@ -8955,7 +8955,7 @@ export const toZigbee = {
                     {513: {value: value ? 1 : 0, type: 0x10}},
                     manufacturerOptions.lumi,
                 );
-            } else if (["ZNCZ02LM", "QBCZ11LM", "LLKZMK11LM"].includes(meta.mapped.model)) {
+            } else if (["ZNCZ02LM", "QBCZ11LM", "LLKZMK11LM", "QBKG11LM"].includes(meta.mapped.model)) {
                 const payload = value
                     ? [
                           [0xaa, 0x80, 0x05, 0xd1, 0x47, 0x07, 0x01, 0x10, 0x01],


### PR DESCRIPTION
Expose `power_outage_memory` on the QBKG11LM smart wall switch and add the model to the list handled by the `lumi_switch_power_outage_memory` converter, which writes the payload via the basic cluster like the other first-generation Lumi devices (ZNCZ02LM, QBCZ11LM, LLKZMK11LM).



