### PR TITLE
feat: add support for CBE 1443ZK TRV

### DIFF
--- a/src/devices/avatto.ts
+++ b/src/devices/avatto.ts
@@ -282,6 +282,51 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_16m4bgsv"]),
+        model: "1443ZK",
+        vendor: "CBE",
+        description: "Thermostatic radiator valve",
+        extend: [tuya.modernExtend.tuyaBase({dp: true, timeStart: "2000", forceTimeUpdates: true})],
+        exposes: [
+            e.battery(),
+            e.child_lock(),
+            e
+                .climate()
+                .withPreset(["manual", "schedule", "eco", "comfort", "antifrost", "off"])
+                .withLocalTemperature(ea.STATE)
+                .withSetpoint("current_heating_setpoint", 5, 35, 0.5, ea.STATE_SET)
+                .withRunningState(["idle", "heat"], ea.STATE),
+        ],
+        meta: {
+            tuyaDatapoints: [
+                [
+                    2,
+                    "preset",
+                    tuya.valueConverterBasic.lookup({
+                        manual: tuya.enum(0),
+                        schedule: tuya.enum(1),
+                        eco: tuya.enum(2),
+                        comfort: tuya.enum(3),
+                        antifrost: tuya.enum(4),
+                        off: tuya.enum(5),
+                    }),
+                ],
+                [3, "running_state", tuya.valueConverterBasic.lookup({idle: 1, heat: 0})],
+                [
+                    4,
+                    "current_heating_setpoint",
+                    {
+                        from: (value: number) => (value === -1 || value === 0xffffffff ? undefined : value / 10),
+                        to: (value: number) => Math.round(value * 10),
+                    },
+                ],
+                [5, "local_temperature", tuya.valueConverter.divideBy10],
+                [6, "battery", tuya.valueConverter.raw],
+                [7, "child_lock", tuya.valueConverter.lockUnlock],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE204_goecjd1t"]),
         model: "ZWPM16",
         vendor: "AVATTO",


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: https://github.com/Koenkk/zigbee2mqtt.io/pull/5500

Adds support for the CBE 1443ZK thermostatic radiator valve.

Zigbee model: TS0601
Manufacturer: _TZE284_16m4bgsv

Confirmed datapoints:
- DP2: operating mode
- DP3: running state
- DP4: heating setpoint
- DP5: local temperature
- DP6: battery percentage
- DP7: child lock

Operating modes:
- 0 = manual
- 1 = schedule/programming
- 2 = eco
- 3 = comfort
- 4 = antifrost
- 5 = off

Related issue: https://github.com/Koenkk/zigbee2mqtt/issues/30919