### PR TITLE
Namron Edge Thermostat: allow regulator_cycle 0 and thermostat_mode_extra manual

### DIFF
--- a/src/devices/namron.ts
+++ b/src/devices/namron.ts
@@ -809,7 +809,7 @@ const tzEdge = {
         key: ["regulator_cycle"],
         convertSet: async (entity, key, value) => {
             const num = Math.round(Number(value));
-            if (Number.isNaN(num) || num < 1 || num > 30) throw new Error(`Invalid regulator_cycle: ${value}`);
+            if (Number.isNaN(num) || num < 0 || num > 30) throw new Error(`Invalid regulator_cycle: ${value}`);
             await writeEdgeHvac(entity, 0x8007, num, Zcl.DataType.UINT8);
             return {state: {regulator_cycle: num}};
         },
@@ -1079,7 +1079,7 @@ export const definitions: DefinitionWithExtend[] = [
                 .withLocalTemperatureCalibration(-5, 5, 0.5),
             e.numeric("max_heat_temp", ea.ALL).withUnit("°C").withValueMin(15).withValueMax(35).withValueStep(0.5).withLabel("Max heat temperature"),
             e.enum("thermostat_mode", ea.ALL, ["manual", "schedule", "regulator"]).withLabel("Thermostat mode"),
-            e.enum("thermostat_mode_extra", ea.ALL, ["eco", "frost", "holiday"]).withLabel("Special mode"),
+            e.enum("thermostat_mode_extra", ea.ALL, ["eco", "frost", "holiday", "manual"]).withLabel("Special mode"),
             e
                 .enum("sensor_mode", ea.ALL, ["air", "floor", "both", "percent"])
                 .withLabel("Sensor mode")
@@ -1096,7 +1096,7 @@ export const definitions: DefinitionWithExtend[] = [
             e
                 .numeric("regulator_cycle", ea.ALL)
                 .withUnit("min")
-                .withValueMin(1)
+                .withValueMin(0)
                 .withValueMax(30)
                 .withValueStep(1)
                 .withLabel("Regulator cycle duration"),


### PR DESCRIPTION
Title: Namron Edge Thermostat (4566702/4512783): regulator_cycle 0 and thermostat_mode_extra manual should be allowed

Follow-up to #12971 (sensor_mode, merged) and the Edge Thermostat support #12385.
Covers two small expose mismatches found on the same device after 2.14.0:

1) regulator_cycle 0
2) thermostat_mode_extra manual

After #12385 the Edge Thermostat exposes `regulator_cycle` as `1..30 min` (`src/devices/namron.ts:1099` `.withValueMin(1)` and `src/lib/namron.ts:812` `num < 1`). The device itself publishes `0` when not in regulator mode — the Namron firmware uses `0` to mean "regulator idle/off".

Live: zigbee2mqtt 2.14.0, Home Assistant, `number.greenhouse_floorheating_regulator_cycle` is `unknown`, `min:1 max:30`. Mosquitto/zigbee2mqtt publish `{"regulator_cycle":0}` every ~30s, HA logs `Invalid value for number.greenhouse_floorheating_regulator_cycle: 0 (range 1.0 - 30.0)` 2400 times since Sept 6, and the number stays `unknown`. Setting it to `0` via `zigbee2mqtt/Greenhouse Floorheating/set` is rejected with `Invalid regulator_cycle: 0`.

This is the same class as the `boost_time_set` regression noted in #12385: converter stringifies a state the device actually uses. For regulator_cycle the correct idle value is `0` — verified by reading the attribute after a fresh configure (`{"regulator_cycle":""}` → `0`) and by the fact the thermostat's own UI allows `0` (regulator off) before #12385.

Proposed fixes:

1) regulator_cycle — one line each:
- `src/lib/namron.ts:812`: `num < 1` → `num < 0`
- `src/devices/namron.ts:1099`: `.withValueMin(1)` → `.withValueMin(0)`
Purely additive; `0` then means "regulator off" and `1..30` keep their current meaning.

2) thermostat_mode_extra — device publishes `"manual"` when no special mode is active, but expose is `["eco","frost","holiday"]` (`src/devices/namron.ts:1082`):
Live: `select.greenhouse_floorheating_thermostat_mode_extra` stays `unknown`, HA logs every ~30s `Invalid option for select.greenhouse_floorheating_thermostat_mode_extra: 'manual' (valid options: ['eco','frost','holiday'])` (seen continuously since Sept 6 on 2.14.0, e.g. 2026-09-07 18:07:00). Upstream should either include `"manual"` (or `"none"`) in the enum, or map the idle publish to no-op/null so it doesn't error. Same class as (1) — device publishes a state the converter currently rejects.

Happy to open the PR if you prefer, or leave it for the next Edge Thermostat cleanup.

Device: Namron 4512783, firmware 20241017 (OTA 36), zigbee2mqtt 2.14.0, Home Assistant 2026.9.1.
Local workaround for (1) is already in `external_converters/namron_low_temp.js` on this host (`0..30`), which stopped the HA spam (verified 18:07-18:19: 0 `regulator_cycle` errors vs 1 per ~10s before).
