### PR TITLE
feat: Add support for _TZE284_rhocfd6y

### DIFF
--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -442,6 +442,23 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_rhocfd6y"]),
+        model: "07519L",
+        vendor: "Immax",
+        description: "NEO Smart water leak sensor, Zigbee 3.0",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [e.water_leak(), e.battery()],
+        meta: {
+            // DP 101 / DP 102 also appear once (value 0) right after the device connects,
+            // but because their functionaitly is not known, they are intentionally left unmapped.
+            tuyaDatapoints: [
+                // Polarity: device reports 0 while submerged (leak), 1 when dry -> trueFalse0.
+                [1, "water_leak", tuya.valueConverter.trueFalse0],
+                [4, "battery", tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS004F", ["_TZ3000_krwtzhfd"]),
         model: "07767L",
         vendor: "Immax",

--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -452,7 +452,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.battery(),
             e
                 .binary("silent_mode", ea.STATE_SET, "ON", "OFF")
-                .withDescription("Enable or disable buzzer sound on leak detection (does not mute ongoing alarm)")
+                .withDescription("Mute the buzzer on leak detection (does not mute ongoing alarm)")
                 .withCategory("config"),
             e
                 .enum("ringtone", ea.STATE_SET, ["tone_1", "tone_2", "tone_3"])

--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -464,7 +464,7 @@ export const definitions: DefinitionWithExtend[] = [
                 // Polarity: device reports 0 on leakage, 1 when dry -> trueFalse0.
                 [1, "water_leak", tuya.valueConverter.trueFalse0],
                 [4, "battery", tuya.valueConverter.raw],
-                [101, "alarm_sound", tuya.valueConverter.onOffEnumOn1],
+                [101, "silent_mode", tuya.valueConverter.onOffEnumOn0],
                 [
                     102,
                     "ringtone",

--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -451,7 +451,7 @@ export const definitions: DefinitionWithExtend[] = [
             e.water_leak(),
             e.battery(),
             e
-                .binary("alarm_sound", ea.STATE_SET, "ON", "OFF")
+                .binary("silent_mode", ea.STATE_SET, "ON", "OFF")
                 .withDescription("Enable or disable buzzer sound on leak detection (does not mute ongoing alarm)")
                 .withCategory("config"),
             e

--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -450,8 +450,14 @@ export const definitions: DefinitionWithExtend[] = [
         exposes: [
             e.water_leak(),
             e.battery(),
-            e.binary("alarm_sound", ea.STATE_SET, "ON", "OFF").withDescription("Enable or disable buzzer sound on leak detection (does not mute ongoing alarm)").withCategory("config"),
-            e.enum("ringtone", ea.STATE_SET, ["tone_1", "tone_2", "tone_3"]).withDescription("Selected buzzer ringtone for the alarm").withCategory("config"),
+            e
+                .binary("alarm_sound", ea.STATE_SET, "ON", "OFF")
+                .withDescription("Enable or disable buzzer sound on leak detection (does not mute ongoing alarm)")
+                .withCategory("config"),
+            e
+                .enum("ringtone", ea.STATE_SET, ["tone_1", "tone_2", "tone_3"])
+                .withDescription("Selected buzzer ringtone for the alarm")
+                .withCategory("config"),
         ],
         meta: {
             tuyaDatapoints: [

--- a/src/devices/immax.ts
+++ b/src/devices/immax.ts
@@ -447,14 +447,27 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "Immax",
         description: "NEO Smart water leak sensor, Zigbee 3.0",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
-        exposes: [e.water_leak(), e.battery()],
+        exposes: [
+            e.water_leak(),
+            e.battery(),
+            e.binary("alarm_sound", ea.STATE_SET, "ON", "OFF").withDescription("Enable or disable buzzer sound on leak detection (does not mute ongoing alarm)").withCategory("config"),
+            e.enum("ringtone", ea.STATE_SET, ["tone_1", "tone_2", "tone_3"]).withDescription("Selected buzzer ringtone for the alarm").withCategory("config"),
+        ],
         meta: {
-            // DP 101 / DP 102 also appear once (value 0) right after the device connects,
-            // but because their functionaitly is not known, they are intentionally left unmapped.
             tuyaDatapoints: [
-                // Polarity: device reports 0 while submerged (leak), 1 when dry -> trueFalse0.
+                // Polarity: device reports 0 on leakage, 1 when dry -> trueFalse0.
                 [1, "water_leak", tuya.valueConverter.trueFalse0],
                 [4, "battery", tuya.valueConverter.raw],
+                [101, "alarm_sound", tuya.valueConverter.onOffEnumOn1],
+                [
+                    102,
+                    "ringtone",
+                    tuya.valueConverterBasic.lookup({
+                        tone_1: tuya.enum(0),
+                        tone_2: tuya.enum(1),
+                        tone_3: tuya.enum(2),
+                    }),
+                ],
             ],
         },
     },


### PR DESCRIPTION
Adding support for the **Immax Neo Smart Water Leak Sensor (Zigbee 3.0)** 

SN: `07519L`
Ref: https://www.immax.eu/immax-neo-smart-water-leak-sensor-zigbee-3-0-p14936/

Device seems to report following values (verified):
- DP 1 - water leak - tested locally - 0 is leaking, 1 is not-leaking
- DP 4 - battery - looks like it (reports 86% for me, which seems legit)
- DP 101 - alarm_sound - shall it ring on water leakage discovered
- DP 102 - ringtone - three tones

Link to picture pull request: Koenkk/zigbee2mqtt.io#5501

EDIT: Screenshot is outdated, minor changes were made along the way in this PR:
<img width="552" height="567" alt="image" src="https://github.com/user-attachments/assets/741b1e9e-0344-4b75-916f-dfe2ae31a6e9" />

---

Fixes Koenkk/zigbee2mqtt#29614