### PR TITLE
fix: NodOn switchTypeOnOff/switchTypeWindowCovering: give per-channel exposes their own endpoint

### DIFF
--- a/src/devices/nodon.ts
+++ b/src/devices/nodon.ts
@@ -146,7 +146,9 @@ const nodonModernExtend = {
                     semverValid(device.softwareBuildID) &&
                     semverGt(device.softwareBuildID, "3.4.0")
                 ) {
-                    return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription)];
+                    const expose = e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription);
+                    if (args?.endpointName) expose.withEndpoint(args.endpointName);
+                    return [expose];
                 }
                 return [];
             },
@@ -178,7 +180,9 @@ const nodonModernExtend = {
                     semverValid(device.softwareBuildID) &&
                     semverGt(device.softwareBuildID, "3.4.0")
                 ) {
-                    return [e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription)];
+                    const expose = e.enum(resultName, ea.ALL, Object.keys(resultLookup)).withDescription(resultDescription);
+                    if (args?.endpointName) expose.withEndpoint(args.endpointName);
+                    return [expose];
                 }
                 return [];
             },


### PR DESCRIPTION
`switchTypeOnOff` doesn't call `.withEndpoint()`. SIN-4-2-20 and SIN-4-2-20_PRO call it once per channel (l1/l2), so both exposes end up with the same property name and one channel overwrites the other's state.

Fixed `switchTypeWindowCovering` the same way, it has the identical bug even though nothing calls it per channel yet.
