### PR TITLE
fix: make shared breaker phase mapping configurable

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -26,6 +26,21 @@ const ea = exposes.access;
 const te = tuya.exposes;
 const tvc = tuya.valueConverter;
 
+type Phase = "a" | "b" | "c";
+type PhaseMapping = "abc" | "cba";
+
+const phaseMappings: Record<PhaseMapping, Record<6 | 7 | 8, Phase>> = {
+    abc: {6: "a", 7: "b", 8: "c"},
+    cba: {6: "c", 7: "b", 8: "a"},
+};
+
+const phaseVariant = (dp: 6 | 7 | 8): Tuya.ValueConverterSingle => ({
+    from: (value, _meta, options) => {
+        const mapping: PhaseMapping = options?.phase_mapping === "cba" ? "cba" : "abc";
+        return tuya.valueConverter.phaseVariant2WithPhase(phaseMappings[mapping][dp]).from(value);
+    },
+});
+
 const fzZosung = zosung.fzZosung;
 const tzZosung = zosung.tzZosung;
 const ez = zosung.presetsZosung;
@@ -12577,6 +12592,7 @@ export const definitions: DefinitionWithExtend[] = [
         vendor: "SUTON",
         description: "Zigbee DIN RCBO energy meter",
         extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        options: [exposes.options.phase_mapping()],
         exposes: [
             tuya.exposes.switch(),
             e.energy(),
@@ -12659,9 +12675,9 @@ export const definitions: DefinitionWithExtend[] = [
         meta: {
             tuyaDatapoints: [
                 [1, "energy", tuya.valueConverter.divideBy100],
-                [6, null, tuya.valueConverter.phaseVariant2WithPhase("a")],
-                [7, null, tuya.valueConverter.phaseVariant2WithPhase("b")],
-                [8, null, tuya.valueConverter.phaseVariant2WithPhase("c")],
+                [6, null, phaseVariant(6)],
+                [7, null, phaseVariant(7)],
+                [8, null, phaseVariant(8)],
                 [9, "faults", tuya.valueConverter.circuitBreakerFaults],
                 [16, "state", tuya.valueConverter.onOff],
                 [17, null, tuya.valueConverter.threshold_2],
@@ -12690,148 +12706,6 @@ export const definitions: DefinitionWithExtend[] = [
             ],
         },
         whiteLabel: [{vendor: "SUTON", model: "STB3L-125/ZJ"}],
-    },
-    {
-        fingerprint: [
-            {
-                modelID: "TS0601",
-                manufacturerName: "_TZE204_wbhaespm",
-                applicationVersion: 74,
-                hardwareVersion: 1,
-                endpoints: [
-                    {
-                        ID: 1,
-                        profileID: 0x0104,
-                        deviceID: 0x0051,
-                        inputClusters: [0x0000, 0x0004, 0x0005, 0xef00],
-                        outputClusters: [0x000a, 0x0019],
-                    },
-                    {
-                        ID: 242,
-                        profileID: 0xa1e0,
-                        deviceID: 0x0061,
-                        inputClusters: [],
-                        outputClusters: [0x0021],
-                    },
-                ],
-                priority: 1,
-            },
-        ],
-        model: "ZXB3-125",
-        vendor: "SMTONOFF",
-        description: "Three-phase breaker",
-        extend: [tuya.modernExtend.tuyaBase({dp: true})],
-        exposes: [
-            tuya.exposes.switch(),
-            e.energy(),
-            te.circuitBreakerFaults(),
-            tuya.exposes.voltageWithPhase("a"),
-            tuya.exposes.voltageWithPhase("b"),
-            tuya.exposes.voltageWithPhase("c"),
-            tuya.exposes.powerWithPhase("a"),
-            tuya.exposes.powerWithPhase("b"),
-            tuya.exposes.powerWithPhase("c"),
-            tuya.exposes.currentWithPhase("a"),
-            tuya.exposes.currentWithPhase("b"),
-            tuya.exposes.currentWithPhase("c"),
-            e.temperature(),
-            e.binary("leakage_test", ea.STATE_SET, "ON", "OFF").withDescription("Turn ON to perform a leagage test"),
-            e
-                .binary("over_current_breaker", ea.STATE_SET, "ON", "OFF")
-                .withDescription("OFF - alarm only, ON - relay will turn off when threshold reached"),
-            e
-                .numeric("over_current_threshold", ea.STATE_SET)
-                .withUnit("A")
-                .withDescription("Setup the value on the device")
-                .withValueMin(1)
-                .withValueMax(63),
-            e
-                .binary("over_voltage_breaker", ea.STATE_SET, "ON", "OFF")
-                .withDescription("OFF - alarm only, ON - relay will turn off when threshold reached"),
-            e
-                .numeric("over_voltage_threshold", ea.STATE_SET)
-                .withUnit("V")
-                .withDescription("Setup value on the device")
-                .withValueMin(250)
-                .withValueMax(300),
-            e
-                .binary("under_voltage_breaker", ea.STATE_SET, "ON", "OFF")
-                .withDescription("OFF - alarm only, ON - relay will turn off when threshold reached"),
-            e
-                .numeric("under_voltage_threshold", ea.STATE_SET)
-                .withUnit("V")
-                .withDescription("Setup value on the device")
-                .withValueMin(150)
-                .withValueMax(200),
-            e
-                .binary("insufficient_balance_breaker", ea.STATE_SET, "ON", "OFF")
-                .withDescription("OFF - alarm only, ON - relay will turn off when threshold reached"),
-            e
-                .numeric("insufficient_balance_threshold", ea.STATE_SET)
-                .withUnit("kWh")
-                .withDescription("Setup the value on the device")
-                .withValueMin(1)
-                .withValueMax(65535),
-            e
-                .binary("overload_breaker", ea.STATE_SET, "ON", "OFF")
-                .withDescription("OFF - alarm only, ON - relay will turn off when threshold reached"),
-            e
-                .numeric("overload_threshold", ea.STATE_SET)
-                .withUnit("kW")
-                .withDescription("Setup the value on the device")
-                .withValueMin(1)
-                .withValueMax(25),
-            e
-                .binary("leakage_breaker", ea.STATE_SET, "ON", "OFF")
-                .withDescription("OFF - alarm only, ON - relay will turn off when threshold reached"),
-            e
-                .numeric("leakage_threshold", ea.STATE_SET)
-                .withUnit("mA")
-                .withDescription("Setup the value on the device")
-                .withValueMin(10)
-                .withValueMax(90),
-            e
-                .binary("high_temperature_breaker", ea.STATE_SET, "ON", "OFF")
-                .withDescription("OFF - alarm only, ON - relay will turn off when threshold reached"),
-            e
-                .numeric("high_temperature_threshold", ea.STATE_SET)
-                .withUnit("°C")
-                .withDescription("Setup value on the device")
-                .withValueMin(40)
-                .withValueMax(100),
-        ],
-        meta: {
-            tuyaDatapoints: [
-                [1, "energy", tuya.valueConverter.divideBy100],
-                [6, null, tuya.valueConverter.phaseVariant2WithPhase("c")],
-                [7, null, tuya.valueConverter.phaseVariant2WithPhase("b")],
-                [8, null, tuya.valueConverter.phaseVariant2WithPhase("a")],
-                [9, "faults", tuya.valueConverter.circuitBreakerFaults],
-                [16, "state", tuya.valueConverter.onOff],
-                [17, null, tuya.valueConverter.threshold_2],
-                [17, "overload_breaker", tuya.valueConverter.threshold_2],
-                [17, "overload_threshold", tuya.valueConverter.threshold_2],
-                [17, "leakage_threshold", tuya.valueConverter.threshold_2],
-                [17, "leakage_breaker", tuya.valueConverter.threshold_2],
-                [17, "high_temperature_threshold", tuya.valueConverter.threshold_2],
-                [17, "high_temperature_breaker", tuya.valueConverter.threshold_2],
-                [18, null, tuya.valueConverter.threshold_3],
-                [18, "over_current_threshold", tuya.valueConverter.threshold_3],
-                [18, "over_current_breaker", tuya.valueConverter.threshold_3],
-                [18, "over_voltage_threshold", tuya.valueConverter.threshold_3],
-                [18, "over_voltage_breaker", tuya.valueConverter.threshold_3],
-                [18, "under_voltage_threshold", tuya.valueConverter.threshold_3],
-                [18, "under_voltage_breaker", tuya.valueConverter.threshold_3],
-                [18, "insufficient_balance_threshold", tuya.valueConverter.threshold_3],
-                [18, "insufficient_balance_breaker", tuya.valueConverter.threshold_3],
-                [21, "leakage_test", tuya.valueConverter.onOff],
-                [102, "temperature", tuya.valueConverter.divideBy10],
-                [12, null, null],
-                [13, null, null],
-                [14, null, null],
-                [15, null, null],
-            ],
-        },
     },
     {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE200_lsanae15", "_TZE204_lsanae15"]),

--- a/src/lib/exposes.ts
+++ b/src/lib/exposes.ts
@@ -837,6 +837,11 @@ export const options = {
         new Numeric(`${name}_calibration`, access.SET).withDescription(
             `Calibrates the ${name} value (${type} offset), takes into effect on next report of device.`,
         ),
+    phase_mapping: () =>
+        new Enum("phase_mapping", access.SET, ["abc", "cba"])
+            .withLabel("Phase mapping")
+            .withDescription("Maps Tuya DP6/DP7/DP8 to phases. Default abc; select cba only for a verified device variant.")
+            .withCategory("config"),
     precision: (name: string) =>
         new Numeric(`${name}_precision`, access.SET)
             .withValueMin(0)

--- a/test/smtonoff-zxb3.test.ts
+++ b/test/smtonoff-zxb3.test.ts
@@ -1,0 +1,155 @@
+import {describe, expect, it, vi} from "vitest";
+import {findByDevice} from "../src/index";
+import type {Definition, Fz} from "../src/lib/types";
+import {mockDevice} from "./utils";
+
+const sparseEndpoints = [
+    {
+        ID: 1,
+        profileID: 0x0104,
+        deviceID: 0x0051,
+        inputClusterIDs: [0x0000, 0x0004, 0x0005, 0xef00],
+        outputClusterIDs: [0x000a, 0x0019],
+    },
+    {
+        ID: 242,
+        profileID: 0xa1e0,
+        deviceID: 0x0061,
+        inputClusterIDs: [],
+        outputClusterIDs: [0x0021],
+    },
+];
+
+function smtonoffDevice(endpoints = sparseEndpoints) {
+    const device = mockDevice({
+        modelID: "TS0601",
+        manufacturerName: "_TZE204_wbhaespm",
+        applicationVersion: 74,
+        endpoints,
+    });
+    Object.assign(device, {hardwareVersion: 1, stackVersion: 0, zclVersion: 3});
+    vi.spyOn(device, "save").mockImplementation(() => {});
+    return device;
+}
+
+function sutonEd00Endpoints() {
+    return sparseEndpoints.map((endpoint) =>
+        endpoint.ID === 1 ? {...endpoint, inputClusterIDs: [...endpoint.inputClusterIDs, 0xed00]} : {...endpoint},
+    );
+}
+
+function converterFor(definition: Definition, dp: number) {
+    const item = definition.meta?.tuyaDatapoints?.find(([id, property]) => id === dp && property === null);
+    if (!item) throw new Error(`Missing DP${dp}`);
+    return item[2];
+}
+
+function requireDefinition(definition: Definition | undefined): Definition {
+    if (!definition) throw new Error("Expected a matching definition");
+    return definition;
+}
+
+function tuyaMessage(dps: number[]) {
+    return {
+        data: {
+            dpValues: dps.map((dp) => ({dp, datatype: 0, data: Buffer.alloc(0)})),
+        },
+    } as unknown as Fz.Message<"manuSpecificTuya">;
+}
+
+function converterMeta(device: ReturnType<typeof smtonoffDevice>) {
+    return {
+        state: {},
+        device,
+        deviceExposesChanged: vi.fn(),
+    } satisfies Fz.Meta;
+}
+
+function exposeProperties(definition: Definition) {
+    return (typeof definition.exposes === "function" ? definition.exposes(undefined as never, {}) : definition.exposes)
+        .map((expose) => expose.property)
+        .filter((property): property is string => property !== undefined);
+}
+
+const samplePayload = Buffer.from([0x59, 0xd8, 0x00, 0x05, 0xdc, 0x00, 0x04, 0xd2]).toString("base64");
+
+describe("shared _TZE204_wbhaespm phase mapping", () => {
+    it("uses the broad shared definition without a dedicated priority matcher", async () => {
+        const shared = requireDefinition(await findByDevice(smtonoffDevice()));
+        expect(shared).toMatchObject({model: "STB3L-125-ZJ", vendor: "SUTON"});
+        expect(shared.fingerprint?.[0].priority).toBeUndefined();
+        expect(shared.options?.find((option) => option.name === "phase_mapping")).toMatchObject({
+            type: "enum",
+            values: ["abc", "cba"],
+        });
+
+        const suton = await findByDevice(smtonoffDevice(sutonEd00Endpoints()));
+        expect(suton).toMatchObject({model: shared.model, vendor: shared.vendor});
+    });
+
+    it("uses legacy abc mapping by default", async () => {
+        const device = smtonoffDevice();
+        const definition = requireDefinition(await findByDevice(device));
+        const meta = converterMeta(device);
+
+        expect(converterFor(definition, 6).from?.(samplePayload, meta, {}, () => {}, tuyaMessage([6]))).toMatchObject({
+            voltage_a: 2300,
+            current_a: 1.5,
+            power_a: 1234,
+        });
+        expect(converterFor(definition, 7).from?.(samplePayload, meta, {}, () => {}, tuyaMessage([7]))).toMatchObject({
+            voltage_b: 2300,
+            current_b: 1.5,
+            power_b: 1234,
+        });
+        expect(converterFor(definition, 8).from?.(samplePayload, meta, {}, () => {}, tuyaMessage([8]))).toMatchObject({
+            voltage_c: 2300,
+            current_c: 1.5,
+            power_c: 1234,
+        });
+        expect(meta.deviceExposesChanged).not.toHaveBeenCalled();
+        expect(device.save).not.toHaveBeenCalled();
+    });
+
+    it("maps cba devices without changing the stable expose set", async () => {
+        const device = smtonoffDevice();
+        const definition = requireDefinition(await findByDevice(device));
+        const meta = converterMeta(device);
+        const options = {phase_mapping: "cba"};
+
+        expect(converterFor(definition, 6).from?.(samplePayload, meta, options, () => {}, tuyaMessage([6]))).toMatchObject({
+            voltage_c: 2300,
+            current_c: 1.5,
+            power_c: 1234,
+        });
+        expect(converterFor(definition, 7).from?.(samplePayload, meta, options, () => {}, tuyaMessage([7]))).toMatchObject({
+            voltage_b: 2300,
+            current_b: 1.5,
+            power_b: 1234,
+        });
+        expect(converterFor(definition, 8).from?.(samplePayload, meta, options, () => {}, tuyaMessage([8]))).toMatchObject({
+            voltage_a: 2300,
+            current_a: 1.5,
+            power_a: 1234,
+        });
+        const abcExposes = exposeProperties(definition);
+        const cbaExposes = exposeProperties(definition);
+        expect(cbaExposes).toEqual(abcExposes);
+        expect(abcExposes).toEqual(expect.arrayContaining(["power_a", "power_b", "power_c", "current_a", "current_b", "current_c"]));
+        expect(exposeProperties(definition)).not.toContain("power");
+        expect(meta.deviceExposesChanged).not.toHaveBeenCalled();
+        expect(device.save).not.toHaveBeenCalled();
+    });
+
+    it("falls back to abc for an omitted or unknown option", async () => {
+        const definition = requireDefinition(await findByDevice(smtonoffDevice()));
+
+        for (const options of [{}, {phase_mapping: "invalid"}]) {
+            const device = smtonoffDevice();
+            const meta = converterMeta(device);
+            expect(converterFor(definition, 6).from?.(samplePayload, meta, options, () => {}, tuyaMessage([6]))).toMatchObject({
+                power_a: 1234,
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Regression fix for zigbee2mqtt/hassio-zigbee2mqtt#871

### Problem

The static `TS0601 / _TZE204_wbhaespm` Zigbee identity is shared by physically different DIN-rail breaker variants (genuine SUTON `STB3L-125-ZJ`, SMTONOFF `ZXB3-125`, RTX variants, and others). The dedicated priority SMTONOFF matcher introduced by #12972 therefore cannot safely infer the physical product or its phase order from the fingerprint alone, which regressed phase attribution for affected users (#871).

### Fix

Remove the dedicated `ZXB3-125` priority matcher and keep the collision family on the shared `_TZE204_wbhaespm` definition, making the DP6/DP7/DP8 phase order an explicit per-device option:

- default `phase_mapping: abc` — DP6→A, DP7→B, DP8→C. This preserves the historical shared-family behavior and fixes the #871 regression;
- explicit `phase_mapping: cba` — DP6→C, DP7→B, DP8→A. This is the mapping physically verified on the tested SMTONOFF ZXB3-125 three-phase units;
- static A/B/C voltage/current/power exposes in either mode (no dynamic expose switching);
- no runtime phase-count inference, no dynamic exposes, and no new static fingerprint assumptions.

### User configuration

Zigbee2MQTT: **Device → Settings (specific) → Phase mapping**.

Equivalent persisted device configuration:

```yaml
devices:
  '0x...':
    phase_mapping: cba
```

### Evidence

The implementation was physically canary-tested on both installed SMTONOFF ZXB3-125 3P breakers with `phase_mapping: cba`, cross-checked against a Shelly Pro 3EM using one-phase-at-a-time controlled loads:

- DP6 = physical L3/C, DP7 = physical L2/B, DP8 = physical L1/A confirmed repeatedly under load;
- the option persisted across a Zigbee2MQTT restart;
- live phase telemetry remained correct;
- Home Assistant entities and recorder statistics were preserved (no entity churn);
- no unrelated device was captured by the shared definition.

### Validation

RC2 freeze, exact SHA `b278d857df8b8d12888e93f5ed9cb8ea4213ed65`, based on upstream `26.108.1` (`22a4c98f66b60fcc9886334cae47751acf47ec79`):

- scope: exactly one commit, three files (`src/devices/tuya.ts`, `src/lib/exposes.ts`, `test/smtonoff-zxb3.test.ts`);
- fresh CI on the exact SHA: Build ✅, Check ✅, Tests ✅ (28 files / 849 tests, including four focused SMTONOFF regression tests), Bench ✅, autofix ✅.

A physically tested predecessor artifact of the same logical fix exists as the closed fork PR analienx/zigbee-herdsman-converters#6 (RC1).