### PR TITLE
fix(cover): preserve TS130F start position before optimistic update

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1475,9 +1475,10 @@ const tzLocal = {
                 meta.device.manufacturerName === "_TZ3000_yruungrl" &&
                 key === "position" &&
                 utils.isEndpoint(entity) &&
+                utils.isNumber(value) &&
                 utils.isNumber(meta.state.position)
             ) {
-                globalStore.putValue(entity, ts130fPositionKey, {start: meta.state.position});
+                globalStore.putValue(entity, ts130fPositionKey, {start: meta.state.position, target: value});
             }
             return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
         },
@@ -2176,8 +2177,18 @@ const fzLocal = {
 
             if (moving !== 1 /* STOP */) {
                 // Remember the position the movement started from and the position reported while moving.
-                const start = globalStore.getValue(msg.endpoint, ts130fPositionKey)?.start ?? meta.state[property];
-                globalStore.putValue(msg.endpoint, ts130fPositionKey, {start, position, raw: msg.data.currentPositionLiftPercentage});
+                const moved = globalStore.getValue(msg.endpoint, ts130fPositionKey);
+                const start = moved?.start ?? meta.state[property];
+                // For commanded positions, only remember reports that acknowledge the target. A later stale report
+                // of the start position while still moving must not replace the target before the STOP report.
+                if (moved?.target === undefined || position === moved.target) {
+                    globalStore.putValue(msg.endpoint, ts130fPositionKey, {
+                        ...moved,
+                        start,
+                        position,
+                        raw: msg.data.currentPositionLiftPercentage,
+                    });
+                }
                 return result;
             }
 
@@ -2185,7 +2196,7 @@ const fzLocal = {
             globalStore.clearValue(msg.endpoint, ts130fPositionKey);
             // Only correct when the reported position is exactly the one the movement started from,
             // any other position is a legitimate (e.g. manual) stop.
-            if (moved !== undefined && position === moved.start && position !== moved.position) {
+            if (utils.isNumber(moved?.position) && utils.isNumber(moved.raw) && position === moved.start && position !== moved.position) {
                 logger.debug(`Correcting stale position ${position} to ${moved.position}`, NS);
                 result[property] = moved.position;
                 result[postfixWithEndpointName("state", msg, model, meta)] = moved.position === 0 ? "CLOSE" : "OPEN";

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -1464,6 +1464,24 @@ const tzLocal = {
             return {state: {sensitivity: value}};
         },
     } satisfies Tz.Converter,
+    // For B4Z TS130F capture the start position BEFORE the standard converter publishes the target as
+    // optimistic state; the fromZigbee workaround needs the original position to detect a stale STOP report.
+    // https://github.com/Koenkk/zigbee-herdsman-converters/pull/12887
+    // biome-ignore lint/style/useNamingConvention: existing
+    TS130F_cover_position_tilt: {
+        ...tz.cover_position_tilt,
+        convertSet: async (entity, key, value, meta) => {
+            if (
+                meta.device.manufacturerName === "_TZ3000_yruungrl" &&
+                key === "position" &&
+                utils.isEndpoint(entity) &&
+                utils.isNumber(meta.state.position)
+            ) {
+                globalStore.putValue(entity, ts130fPositionKey, {start: meta.state.position});
+            }
+            return await tz.cover_position_tilt.convertSet(entity, key, value, meta);
+        },
+    } satisfies Tz.Converter,
 };
 
 const ts130fPositionKey = "ts130f_position";
@@ -6122,7 +6140,7 @@ export const definitions: DefinitionWithExtend[] = [
         ],
         toZigbee: [
             tz.cover_state,
-            tz.cover_position_tilt,
+            tzLocal.TS130F_cover_position_tilt,
             tuya.tz.cover_calibration,
             tuya.tz.cover_reversal,
             tuya.tz.backlight_indicator_mode_2,

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -127,6 +127,53 @@ describe("lib/tuya", () => {
             const cluster = device.customClusters.closuresWindowCovering;
             expect(cluster.attributes.moesCalibrationTime).toMatchObject({ID: 0xf003, type: Zcl.DataType.UINT16});
         });
+
+        it("corrects a Nous B4Z stale start position after an optimistic position update", async () => {
+            const device = mockDevice({
+                modelID: "TS130F",
+                manufacturerName: "_TZ3000_yruungrl",
+                endpoints: [{ID: 1, inputClusters: ["closuresWindowCovering"]}],
+            });
+            const definition = await findByDevice(device);
+            const endpoint = device.getEndpoint(1);
+            const toConverter = definition.toZigbee.find((converter) => converter.key.includes("position"));
+            const fromConverter = definition.fromZigbee.find((converter) => converter.cluster === "closuresWindowCovering");
+            if (!toConverter?.convertSet || !fromConverter) throw new Error("B4Z cover converters not found");
+
+            const state = {position: 100};
+            const commandResult = await toConverter.convertSet(endpoint, "position", 50, {
+                device,
+                mapped: definition,
+                message: {position: 50},
+                options: {},
+                state,
+                endpoint_name: undefined,
+                publish: () => {},
+            });
+            Object.assign(state, commandResult?.state);
+
+            const convert = (data: {currentPositionLiftPercentage: number; tuyaMovingState: number}) =>
+                fromConverter.convert(
+                    definition,
+                    {
+                        data,
+                        endpoint,
+                        device,
+                        meta: {rawData: Buffer.alloc(0)},
+                        groupID: 0,
+                        type: "attributeReport",
+                        cluster: "closuresWindowCovering",
+                        linkquality: 0,
+                    },
+                    () => {},
+                    {},
+                    {state, device, deviceExposesChanged: () => {}},
+                );
+
+            expect(convert({currentPositionLiftPercentage: 50, tuyaMovingState: 2})).toMatchObject({position: 50});
+            expect(convert({currentPositionLiftPercentage: 100, tuyaMovingState: 1})).toMatchObject({position: 50});
+            expect(endpoint.write).toHaveBeenCalledWith("closuresWindowCovering", {currentPositionLiftPercentage: 50}, expect.anything());
+        });
     });
 
     describe("tuyaOnOff power-on behaviour selection", () => {

--- a/test/tuya.test.ts
+++ b/test/tuya.test.ts
@@ -128,7 +128,7 @@ describe("lib/tuya", () => {
             expect(cluster.attributes.moesCalibrationTime).toMatchObject({ID: 0xf003, type: Zcl.DataType.UINT16});
         });
 
-        it("corrects a Nous B4Z stale start position after an optimistic position update", async () => {
+        const setupB4z = async () => {
             const device = mockDevice({
                 modelID: "TS130F",
                 manufacturerName: "_TZ3000_yruungrl",
@@ -141,17 +141,18 @@ describe("lib/tuya", () => {
             if (!toConverter?.convertSet || !fromConverter) throw new Error("B4Z cover converters not found");
 
             const state = {position: 100};
-            const commandResult = await toConverter.convertSet(endpoint, "position", 50, {
-                device,
-                mapped: definition,
-                message: {position: 50},
-                options: {},
-                state,
-                endpoint_name: undefined,
-                publish: () => {},
-            });
-            Object.assign(state, commandResult?.state);
-
+            const sendPosition = async (position: number) => {
+                const commandResult = await toConverter.convertSet(endpoint, "position", position, {
+                    device,
+                    mapped: definition,
+                    message: {position},
+                    options: {},
+                    state,
+                    endpoint_name: undefined,
+                    publish: () => {},
+                });
+                Object.assign(state, commandResult?.state);
+            };
             const convert = (data: {currentPositionLiftPercentage: number; tuyaMovingState: number}) =>
                 fromConverter.convert(
                     definition,
@@ -170,7 +171,32 @@ describe("lib/tuya", () => {
                     {state, device, deviceExposesChanged: () => {}},
                 );
 
+            return {convert, endpoint, sendPosition};
+        };
+
+        it("corrects a Nous B4Z stale start position after an optimistic position update", async () => {
+            const {convert, endpoint, sendPosition} = await setupB4z();
+            await sendPosition(50);
+
             expect(convert({currentPositionLiftPercentage: 50, tuyaMovingState: 2})).toMatchObject({position: 50});
+            expect(convert({currentPositionLiftPercentage: 100, tuyaMovingState: 1})).toMatchObject({position: 50});
+            expect(endpoint.write).toHaveBeenCalledWith("closuresWindowCovering", {currentPositionLiftPercentage: 50}, expect.anything());
+        });
+
+        it("does not correct a Nous B4Z STOP report before the target was acknowledged", async () => {
+            const {convert, endpoint, sendPosition} = await setupB4z();
+            await sendPosition(50);
+
+            expect(convert({currentPositionLiftPercentage: 100, tuyaMovingState: 1})).toMatchObject({position: 100});
+            expect(endpoint.write).not.toHaveBeenCalled();
+        });
+
+        it("does not replace an acknowledged Nous B4Z target with a stale moving report", async () => {
+            const {convert, endpoint, sendPosition} = await setupB4z();
+            await sendPosition(50);
+
+            expect(convert({currentPositionLiftPercentage: 50, tuyaMovingState: 0})).toMatchObject({position: 50});
+            expect(convert({currentPositionLiftPercentage: 100, tuyaMovingState: 0})).toMatchObject({position: 100});
             expect(convert({currentPositionLiftPercentage: 100, tuyaMovingState: 1})).toMatchObject({position: 50});
             expect(endpoint.write).toHaveBeenCalledWith("closuresWindowCovering", {currentPositionLiftPercentage: 50}, expect.anything());
         });


### PR DESCRIPTION
## Summary
The workaround introduced in PR #12887 corrects stale position reports from _TZ3000_yruungrl covers, which sometimes report the previous position after the cover has moved successfully.

However, it did not account for the optimistic state update performed by the standard converter, causing the target position to be stored as the movement start position. Original fix in #12887 covered this situation but later simplification in commit https://github.com/Koenkk/zigbee-herdsman-converters/pull/12887/commits/ac989a889a03c483ec6a632108b26fd6a4575cb3 broke this and I did not catch that during review.

The problem was discovered while running the dev branch in production for several days where PR #12887 is already applied.

## Solution
Preserve the actual start position before the optimistic update.
