### PR TITLE
fix: add _TZE2841000000_3mzb0sdz fingerprint to Zemismart ZM16B

### DIFF
--- a/src/devices/zemismart.ts
+++ b/src/devices/zemismart.ts
@@ -1138,7 +1138,7 @@ export const definitions: DefinitionWithExtend[] = [
         configure: tuya.configureMagicPacket,
     },
     {
-        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_3mzb0sdz"]),
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE284_3mzb0sdz", "_TZE2841000000_3mzb0sdz"]),
         model: "ZM16B",
         vendor: "Zemismart",
         description: "Tubular motor",


### PR DESCRIPTION
Newer batches of the Zemismart ZM16B tubular motor report manufacturer name `_TZE2841000000_3mzb0sdz` instead of `_TZE284_3mzb0sdz`, so they currently fall back to an auto-generated definition in Zigbee2MQTT. This adds the new manufacturer name to the existing ZM16B fingerprint.

Same Tuya datapoints as the existing definition; verified working (open/close/stop, position, motor direction, cover limits, battery) via an external converter on Zigbee2MQTT 2.14.1 / zigbee-herdsman-converters 26.105.0.

Not a new device, so no picture PR needed (ZM16B image already exists).
