### PR TITLE
feat(add): TS0601_air_quality_sensor_2

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3977,6 +3977,23 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        fingerprint: tuya.fingerprint("TS0601", ["_TZE204_dak2k10o"]),
+        model: "TS0601_air_quality_sensor_2",
+        vendor: "Tuya",
+        description: "Air quality sensor",
+        extend: [tuya.modernExtend.tuyaBase({dp: true})],
+        exposes: [e.temperature(), e.humidity(), e.co2(), e.voc().withUnit("ppb"), e.formaldehyd().withUnit("µg/m³")],
+        meta: {
+            tuyaDatapoints: [
+                [2, "co2", tuya.valueConverter.raw],
+                [18, "temperature", tuya.valueConverter.divideBy10],
+                [19, "humidity", tuya.valueConverter.divideBy10],
+                [21, "voc", tuya.valueConverter.raw],
+                [22, "formaldehyd", tuya.valueConverter.raw],
+            ],
+        },
+    },
+    {
         fingerprint: tuya.fingerprint("TS0601", ["_TZE284_it9utkro"]),
         model: "PM2.5_airbox",
         vendor: "Tuya",


### PR DESCRIPTION
## Description
Adds support for a Tuya TS0601 air quality sensor identified by manufacturerName `_TZE204_dak2k10o` (labeled "Air Detection Box" in the Tuya/Zigbee2MQTT UI).

The existing `TS0601_air_quality_sensor` definition uses the legacy `tuya_air_quality` fromZigbee converter, which only processes the **first** datapoint of a multi-dp Zigbee message (see `firstDpValue` in `src/lib/legacy.ts`). This specific device reports co2/temperature/humidity/v