### PR TITLE
Add eWeLink CK-TLSR8258-L5PI-01(7009) LED bulb

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -4742,6 +4742,20 @@ export const definitions: DefinitionWithExtend[] = [
         },
     },
     {
+        zigbeeModel: ["CK-TLSR8258-L5PI-01(7009)"],
+        model: "CK-TLSR8258-L5PI-01(7009)",
+        vendor: "eWeLink",
+        description: "Zigbee 3.0 18W led light bulb E27 RGBCW",
+        extend: [
+            m.light({
+                colorTemp: {range: [153, 370]},
+                effect: true,
+                powerOnBehavior: true,
+                color: {modes: ["xy", "hs"]},
+            }),
+        ],
+    },
+    {
         zigbeeModel: ["TS0503B"],
         model: "TS0503B",
         vendor: "Tuya",


### PR DESCRIPTION
Adds support for the **eWeLink CK-TLSR8258-L5PI-01(7009)** — a Telink TLSR8258-based Zigbee RGB+CCT LED bulb sold widely on AliExpress. It currently pairs but shows up as *unsupported* (auto-generated definition).

### Device info
- **Vendor:** eWeLink
- **Model ID:** `CK-TLSR8258-L5PI-01(7009)`
- **Type:** Router (mains)
- **Endpoint 1 input clusters:** genBasic, genIdentify, genGroups, genScenes, genOnOff, genLevelCtrl, lightingColorCtrl, touchlink, manuSpecificTuya, 64529, manuSpecificAmazonWWAH
- **Endpoint 242:** greenPower

This is a sibling of the already-supported eWeLink `CK-BL702-AL-01` family and uses the same `modernExtend` `light()` pattern (color temp + xy/hs color + effect + power-on behavior). Color-temp range set to the device-reported `[153, 370]` mireds.

### Where to buy
https://es.aliexpress.com/item/1005010108080390.html

### Verification
Tested end-to-end on real hardware through a `busware.de ESP32 (ZBOSS)` coordinator on Zigbee2MQTT 2.12.0 / zigbee-herdsman 10.4.1:
- on/off ✓
- brightness ✓
- color temperature ✓
- xy / hs color ✓

Local build (`pnpm run build`) and full test suite (`pnpm run test`, 848/848) pass with this definition included.